### PR TITLE
Fix for page overlay sidebar authentication failure

### DIFF
--- a/plugins/Overlay/Overlay.php
+++ b/plugins/Overlay/Overlay.php
@@ -18,7 +18,8 @@ class Overlay extends \Piwik\Plugin
     {
         return array(
             'AssetManager.getJavaScriptFiles'        => 'getJsFiles',
-            'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys'
+            'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
+            'Platform.initialized'                   => 'handleIframeMissingCookie'
         );
     }
 
@@ -36,5 +37,18 @@ class Overlay extends \Piwik\Plugin
     {
         $translationKeys[] = 'General_OverlayRowActionTooltipTitle';
         $translationKeys[] = 'General_OverlayRowActionTooltip';
+    }
+
+    /**
+     * The Overlay.notifyParentIframe call is sometimes made without a session cookie due to an iframe related race
+     * condition, this results in a new session being created which logs the current user out.
+     * As a hacky workaround we detect this condition here and remove the set cookie header from the response to
+     * protect the session
+     */
+    public function handleIframeMissingCookie()
+    {
+        if ($_GET['action'] == 'notifyParentIframe' && count($_COOKIE) == 0) {
+            header_remove('Set-Cookie');
+        }
     }
 }

--- a/plugins/Overlay/templates/notifyParentIframe.twig
+++ b/plugins/Overlay/templates/notifyParentIframe.twig
@@ -9,10 +9,7 @@
     var piwikWindow = window.parent.parent;
     // notify piwik of location change
     // the location has been passed as the hash part of the url from the overlay session
-
-    setTimeout(function() {
-        piwikWindow.Piwik_Overlay.setCurrentUrl(window.location.hash.substring(1));
-    }, 500);
+    piwikWindow.Piwik_Overlay.setCurrentUrl(window.location.hash.substring(1));
 
 </script>
 </body>

--- a/plugins/Overlay/templates/notifyParentIframe.twig
+++ b/plugins/Overlay/templates/notifyParentIframe.twig
@@ -9,7 +9,11 @@
     var piwikWindow = window.parent.parent;
     // notify piwik of location change
     // the location has been passed as the hash part of the url from the overlay session
-    piwikWindow.Piwik_Overlay.setCurrentUrl(window.location.hash.substring(1));
+
+    setTimeout(function() {
+        piwikWindow.Piwik_Overlay.setCurrentUrl(window.location.hash.substring(1));
+    }, 500);
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
### Description:

Fixes #18538 

When using the page overlay feature, the `notifyParentIframe` call intermittently gets sent without a session cookie. This is quite random and only occurs approximately once in every 20-30 calls. It appears to be a race condition related iframe access to cookies. 

Because there is no session cookie then a new session is started and the response to the `notifyParentIframe` sets a new session cookie which invalidates the session, this is apparent when the `loadSidebar` call is made shortly after and the `token_auth` is rejected and the user is forcibly logged out.

Without a solution to the race condition issue this PR is a workaround to prevent the session breaking. It's not possible to check the session cookie via javascript so a server side check is implemented which will remove the `set-cookie` header when responding to a `notifyParentIframe` without any cookies.

To recreate:
1) Create some visits to a test site clicking between one or two pages.
2) Open the page overlay view
3) Set the browser console to view network requested filtered by `notifyParentIframe`
4) Click back and forth between the pages that were tracked
5) Eventually the sidebar will show a 'session expired' error.
6) Check the last `notifyParentIframe` call in the console, it will be missing a request session cookie and will receive a set cookie for a new session

With this fix the `notifyParentIframe` call will still be made without a session cookie, but no set cookie will be returned in the response and the session will not break.

See also L3-197

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
