### PR TITLE
Ignore duplicate entry error when creating a sequence

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -82,7 +82,7 @@ class Model
                     break;
                 }
 
-                list($idarchive, $value) = explode('.', $pair);
+                [$idarchive, $value] = explode('.', $pair);
 
                 array_shift($duplicateArchives);
 
@@ -99,7 +99,7 @@ class Model
                         break;
                     }
 
-                    list($idarchive, $value) = explode('.', $pair);
+                    [$idarchive, $value] = explode('.', $pair);
                     $archiveIds[] = $idarchive; // does not matter what the value is, the latest is usable so older archives can be purged
                 }
             }
@@ -157,7 +157,7 @@ class Model
 
         if (!empty($name)) {
             if (strpos($name, '.') !== false) {
-                list($plugin, $name) = explode('.', $name, 2);
+                [$plugin, $name] = explode('.', $name, 2);
             } else {
                 $plugin = $name;
                 $name = null;
@@ -512,7 +512,14 @@ class Model
             $idarchive = $sequence->getNextId();
         } catch (Exception $e) {
             // edge case: sequence was not found, create it now
-            $sequence->create();
+            try {
+                $sequence->create();
+            } catch (Exception $ex) {
+                // Ignore duplicate entry error, as that means another request might have already created the sequence
+                if (!Db::get()->isErrNo($ex, \Piwik\Updater\Migration\Db::ERROR_CODE_DUPLICATE_ENTRY)) {
+                    throw $ex;
+                }
+            }
 
             $idarchive = $sequence->getNextId();
         }


### PR DESCRIPTION
### Description:

In the past the CronArchiving tests sometimes failed with the error:

```
Got invalid response from API request: ?module=API&method=CoreAdminHome.archiveReports&idSite=1&period=day&date=2019-12-10&format=json&segment=actions%3E%3D2&trigger=archivephp. Response was '{"result":"error","message":"SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'archive_numeric_2019_12' for key 'PRIMARY' 
#0 \/home\/travis\/build\/matomo-org\/matomo\/libs\/Zend\/Db\/Statement.php(300): Zend_Db_Statement_Pdo-&gt;_execute(Array) 
#1 \/home\/travis\/build\/matomo-org\/matomo\/libs\/Zend\/Db\/Adapter\/Abstract.php(479): Zend_Db_Statement-&gt;execute(Array) 
#2 \/home\/travis\/build\/matomo-org\/matomo\/libs\/Zend\/Db\/Adapter\/Pdo\/Abstract.php(238): Zend_Db_Adapter_Abstract-&gt;query('INSERT INTO `se...', Array) 
#3 \/home\/travis\/build\/matomo-org\/matomo\/core\/Db\/Adapter\/Pdo\/Mysql.php(310): Zend_Db_Adapter_Pdo_Abstract-&gt;query('INSERT INTO `se...', Array) 
#4 \/home\/travis\/build\/matomo-org\/matomo\/libs\/Zend\/Db\/Adapter\/Abstract.php(575): Piwik\\Db\\Adapter\\Pdo\\Mysql-&gt;query('INSERT INTO `se...', Array) 
#5 \/home\/travis\/build\/matomo-org\/matomo\/core\/Sequence.php(67): Zend_Db_Adapter_Abstract-&gt;insert('sequence', Array) 
#6 \/home\/travis\/build\/matomo-org\/matomo\/core\/DataAccess\/Model.php(515): Piwik\\Sequence-&gt;create() 
#7 \/home\/travis\/build\/matomo-org\/matomo\/core\/DataAccess\/ArchiveWriter.php(195): Piwik\\DataAccess\\Model-&gt;allocateNewArchiveId('archive_numeric...') 
#8 \/home\/travis\/build\/matomo-org\/matomo\/core\/DataAccess\/ArchiveWriter.php(157): Piwik\\DataAccess\\ArchiveWriter-&gt;allocateNewArchiveId() 
#9 \/home\/travis\/build\/matomo-org\/matomo\/core\/ArchiveProcessor\/PluginsArchiver.php(68): Piwik\\DataAccess\\ArchiveWriter-&gt;initNewArchive() 
#10 \/home\/travis\/build\/matomo-org\/matomo\/core\/ArchiveProcessor\/Loader.php(273): Piwik\\ArchiveProcessor\\PluginsArchiver-&gt;__construct(Object(Piwik\\ArchiveProcessor\\Parameters)) 
#11 \/home\/travis\/build\/matomo-org\/matomo\/core\/ArchiveProcessor\/Loader.php(176): Piwik\\ArchiveProcessor\\Loader-&gt;prepareAllPluginsArchive(false, false) 
#12 \/home\/travis\/build\/matomo-org\/matomo\/core\/ArchiveProcessor\/Loader.php(159): Piwik\\ArchiveProcessor\\Loader-&gt;insertArchiveData(false, false) 
#13 \/home\/travis\/build\/matomo-org\/matomo\/core\/ArchiveProcessor\/Loader.php(99): Piwik\\ArchiveProcessor\\Loader-&gt;prepareArchiveImpl(false) 
#14 \/home\/travis\/build\/matomo-org\/matomo\/core\/Context.php(75): Piwik\\ArchiveProcessor\\Loader-&gt;Piwik\\ArchiveProcessor\\{closure}() 
#15 \/home\/travis\/build\/matomo-org\/matomo\/core\/ArchiveProcessor\/Loader.php(103): Piwik\\Context::changeIdSite(1, Object(Closure)) 
#16 \/home\/travis\/build\/matomo-org\/matomo\/plugins\/CoreAdminHome\/API.php(278): Piwik\\ArchiveProcessor\\Loader-&gt;prepareArchive(false) 
#17 [internal function]: Piwik\\Plugins\\CoreAdminHome\\API-&gt;archiveReports('1', Object(Piwik\\Period\\Day), '2019-12-10', 'actions%3E%3D2', false, false) 
#18 \/home\/travis\/build\/matomo-org\/matomo\/core\/API\/Proxy.php(244): call_user_func_array(Array, Array) 
#19 \/home\/travis\/build\/matomo-org\/matomo\/core\/Context.php(28): Piwik\\API\\Proxy-&gt;Piwik\\API\\{closure}() 
#20 \/home\/travis\/build\/matomo-org\/matomo\/core\/API\/Proxy.php(335): Piwik\\Context::executeWithQueryParameters(Array, Object(Closure)) 
#21 \/home\/travis\/build\/matomo-org\/matomo\/core\/API\/Request.php(266): Piwik\\API\\Proxy-&gt;call('\\\\Piwik\\\\Plugins\\\\...', 'archiveReports', Array) 
#22 \/home\/travis\/build\/matomo-org\/matomo\/plugins\/API\/Controller.php(46): Piwik\\API\\Request-&gt;process() 
#23 [internal function]: Piwik\\Plugins\\API\\Controller-&gt;index() 
#24 \/home\/travis\/build\/matomo-org\/matomo\/core\/FrontController.php(619): call_user_func_array(Array, Array) 
#25 \/home\/travis\/build\/matomo-org\/matomo\/core\/FrontController.php(168): Piwik\\FrontController-&gt;doDispatch('API', false, Array) 
#26 \/home\/travis\/build\/matomo-org\/matomo\/core\/dispatch.php(32): Piwik\\FrontController-&gt;dispatch() 
#27 \/home\/travis\/build\/matomo-org\/matomo\/index.php(25): require_once('\/home\/travis\/bu...') 
#28 \/home\/travis\/build\/matomo-org\/matomo\/tests\/PHPUnit\/proxy\/index.php(15): include('\/home\/travis\/bu...') 
#29 \/home\/travis\/build\/matomo-org\/matomo\/core\/CliMulti\/RequestCommand.php(79): require_once('\/home\/travis\/bu...') 
#30 \/home\/travis\/build\/matomo-org\/matomo\/vendor\/symfony\/console\/Symfony\/Component\/Console\/Command\/Command.php(257): Piwik\\CliMulti\\RequestCommand-&gt;execute(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput)) 
#31 \/home\/travis\/build\/matomo-org\/matomo\/vendor\/symfony\/console\/Symfony\/Component\/Console\/Application.php(874): Symfony\\Component\\Console\\Command\\Command-&gt;run(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput)) 
#32 \/home\/travis\/build\/matomo-org\/matomo\/vendor\/symfony\/console\/Symfony\/Component\/Console\/Application.php(195): Symfony\\Component\\Console\\Application-&gt;doRunCommand(Object(Piwik\\CliMulti\\RequestCommand), Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput)) #33 [internal function]: Symfony\\Component\\Console\\Application-&gt;doRun(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput)) 
#34 \/home\/travis\/build\/matomo-org\/matomo\/core\/Console.php(135): call_user_func(Array, Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput)) 
#35 \/home\/travis\/build\/matomo-org\/matomo\/core\/Access.php(670): Piwik\\Console-&gt;Piwik\\{closure}() 
#36 \/home\/travis\/build\/matomo-org\/matomo\/core\/Console.php(136): P ... ild\/matomo-org\/matomo\/console(32): Symfony\\Component\\Console\\Application->run()\n#41 {main}"}'
```

See e.g. https://app.travis-ci.com/github/matomo-org/matomo/jobs/554673498

Looking at the code it seems the reason might be a rase condition, where either the first call to `getNextId` fails for a temporary reason or where two archiving requests try to create a sequence simultaneously. 
Ignoring the duplicate entry error should be safe in that case, as it means the record already exists and the following `getNextId` should work as expected nevertheless.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
