### PR TITLE
Refactor 'user info changed' emails away from the generic Mail class

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -18,8 +18,6 @@ use Piwik\Common;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
-use Piwik\IP;
-use Piwik\Mail;
 use Piwik\Metrics\Formatter;
 use Piwik\NoAccessException;
 use Piwik\Option;
@@ -27,9 +25,9 @@ use Piwik\Piwik;
 use Piwik\Plugin;
 use Piwik\Plugins\CoreAdminHome\Emails\UserCreatedEmail;
 use Piwik\Plugins\Login\PasswordVerifier;
+use Piwik\Plugins\UsersManager\Emails\UserInfoChangedEmail;
 use Piwik\Site;
 use Piwik\Tracker\Cache;
-use Piwik\View;
 use Piwik\Plugins\CoreAdminHome\Emails\UserDeletedEmail;
 
 /**
@@ -1511,23 +1509,10 @@ class API extends \Piwik\Plugin\API
     {
         $deviceDescription = $this->getDeviceDescription();
 
-        $view = new View('@UsersManager/_userInfoChangedEmail.twig');
-        $view->type = $type;
-        $view->accountName = Common::sanitizeInputValue($user['login']);
-        $view->newEmail = Common::sanitizeInputValue($newValue);
-        $view->ipAddress = IP::getIpFromHeader();
-        $view->deviceDescription = $deviceDescription;
-
-        $mail = new Mail();
+        $mail = new UserInfoChangedEmail($type, $newValue, $deviceDescription, $user['login']);
 
         $mail->addTo($emailTo, $user['login']);
         $mail->setSubject(Piwik::translate($subject));
-        $mail->setDefaultFromPiwik();
-        $mail->setWrappedHtmlBody($view);
-
-        $replytoEmailName = Config::getInstance()->General['login_password_recovery_replyto_email_name'];
-        $replytoEmailAddress = Config::getInstance()->General['login_password_recovery_replyto_email_address'];
-        $mail->addReplyTo($replytoEmailAddress, $replytoEmailName);
 
         $mail->send();
     }

--- a/plugins/UsersManager/Emails/UserInfoChangedEmail.php
+++ b/plugins/UsersManager/Emails/UserInfoChangedEmail.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Piwik\Plugins\UsersManager\Emails;
+
+use Piwik\Common;
+use Piwik\Config;
+use Piwik\IP;
+use Piwik\Mail;
+use Piwik\View;
+
+class UserInfoChangedEmail extends Mail
+{
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $changedNewValue;
+
+    /**
+     * @var string
+     */
+    private $deviceDescription;
+
+    /**
+     * @var string
+     */
+    private $login;
+
+    public function __construct($type, $changedNewValue, $deviceDescription, $login)
+    {
+        parent::__construct();
+        $this->type = $type;
+        $this->changedNewValue = $changedNewValue;
+        $this->deviceDescription = $deviceDescription;
+        $this->login = $login;
+        $this->setUpEmail();
+    }
+
+
+    private function setUpEmail()
+    {
+        $this->setDefaultFromPiwik();
+        $this->setWrappedHtmlBody($this->getDefaultBodyView());
+
+        $replytoEmailName = Config::getInstance()->General['login_password_recovery_replyto_email_name'];
+        $replytoEmailAddress = Config::getInstance()->General['login_password_recovery_replyto_email_address'];
+        $this->addReplyTo($replytoEmailAddress, $replytoEmailName);
+    }
+
+
+    /**
+     * @return View
+     */
+    protected function getDefaultBodyView()
+    {
+        $deviceDescription = $this->deviceDescription;
+
+        $view = new View('@UsersManager/_userInfoChangedEmail.twig');
+        $view->type = $this->type;
+        $view->accountName = Common::sanitizeInputValue($this->login);
+        $view->newEmail = Common::sanitizeInputValue($this->changedNewValue);
+        $view->ipAddress = IP::getIpFromHeader();
+        $view->deviceDescription = $deviceDescription;
+        return $view;
+    }
+}


### PR DESCRIPTION
### Description:

Issue: DEV-2501

This refactors the emails produced by the `UserManager` plugin into their own sub-class of Mail. Before this it simply composed emails from the generic class.

This will allow subscribers of the `Mail.shouldSend` hook to better differentiate between what emails are being sent.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
