### PR TITLE
Fix for datatable row sum warning message

### DIFF
--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -678,6 +678,9 @@ class Row extends \ArrayObject
         if (is_array($columnToSumValue)) {
             $newValue = $thisColumnValue;
             foreach ($columnToSumValue as $arrayIndex => $arrayValue) {
+                if (!is_numeric($arrayIndex) && !$this->isSummableColumn($arrayIndex)) {
+                    continue;
+                }
                 if (!isset($newValue[$arrayIndex])) {
                     $newValue[$arrayIndex] = false;
                 }


### PR DESCRIPTION
### Description:

Fixes #18468

This is a follow up to the earlier #18500 fix to ensure that when summing up datatable row array columns that each of the array keys is checked against the unsummable columns list and is not summed if present there. This should prevent attempts to sum up the `ts_archived` string date value in the row `_metadata` array column and subsequent warning messages.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
