### PR TITLE
Refactor emails about password reset into a Mail sub-class

### DIFF
--- a/plugins/Login/Emails/PasswordResetEmail.php
+++ b/plugins/Login/Emails/PasswordResetEmail.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\Login\Emails;
+
+use Piwik\Common;
+use Piwik\Config;
+use Piwik\Mail;
+use Piwik\Piwik;
+
+class PasswordResetEmail extends Mail
+{
+    /**
+     * @var string
+     */
+    private $login;
+
+    /**
+     * @var string
+     */
+    private $ip;
+
+    /**
+     * @var string
+     */
+    private $resetUrl;
+
+    public function __construct($login, $ip, $resetUrl)
+    {
+        parent::__construct();
+
+        $this->login = $login;
+        $this->ip = $ip;
+        $this->resetUrl = $resetUrl;
+
+        $this->setUpEmail();
+    }
+
+    private function setUpEmail()
+    {
+        $replytoEmailName = Config::getInstance()->General['login_password_recovery_replyto_email_name'];
+        $replytoEmailAddress = Config::getInstance()->General['login_password_recovery_replyto_email_address'];
+
+        $this->setSubject($this->getDefaultSubject());
+        $this->addReplyTo($replytoEmailAddress, $replytoEmailName);
+        $this->setWrappedHtmlBody($this->getDefaultBodyText());
+    }
+
+    private function getDefaultSubject()
+    {
+        return Piwik::translate('Login_MailTopicPasswordChange');
+    }
+
+    private function getDefaultBodyText()
+    {
+        return '<p>' . str_replace(
+            "\n\n",
+            "</p><p>",
+            Piwik::translate('Login_MailPasswordChangeBody2', [Common::sanitizeInputValue($this->login), Common::sanitizeInputValue($this->ip), Common::sanitizeInputValue($this->resetUrl)])
+        ) . "</p>";
+    }
+}

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -11,11 +11,10 @@ use Exception;
 use Piwik\Access;
 use Piwik\Auth\Password;
 use Piwik\Common;
-use Piwik\Config;
 use Piwik\IP;
-use Piwik\Mail;
 use Piwik\Option;
 use Piwik\Piwik;
+use Piwik\Plugins\Login\Emails\PasswordResetEmail;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\Plugins\UsersManager\UsersManager;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
@@ -440,25 +439,14 @@ class PasswordResetter
             . "&resetToken=" . urlencode($resetToken);
 
         // send email with new password
-        $mail = new Mail();
+        $mail = new PasswordResetEmail($login, $ip, $url);
         $mail->addTo($email, $login);
-        $mail->setSubject(Piwik::translate('Login_MailTopicPasswordChange'));
-        $bodyText = '<p>' . str_replace(
-                "\n\n",
-                "</p><p>",
-                Piwik::translate('Login_MailPasswordChangeBody2', [Common::sanitizeInputValue($login), Common::sanitizeInputValue($ip), Common::sanitizeInputValue($url)])
-            ) . "</p>";
-        $mail->setWrappedHtmlBody($bodyText);
 
         if ($this->emailFromAddress || $this->emailFromName) {
             $mail->setFrom($this->emailFromAddress, $this->emailFromName);
         } else {
             $mail->setDefaultFromPiwik();
         }
-
-        $replytoEmailName = Config::getInstance()->General['login_password_recovery_replyto_email_name'];
-        $replytoEmailAddress = Config::getInstance()->General['login_password_recovery_replyto_email_address'];
-        $mail->addReplyTo($replytoEmailAddress, $replytoEmailName);
 
         @$mail->send();
     }


### PR DESCRIPTION
### Description:

Ref: DEV-2501

Summary: Refactor emails about password reset into a Mail sub-class.

This refactors the emails produced by the PasswordResetter into their own sub-class of Mail. Before this it simply composed emails from the generic Mail class.

This will allow subscribers of the `Mail.shouldSend` hook to better differentiate between what emails are being sent.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
