### PR TITLE
[Vue] do not use button element in piwikHelper.modalConfirm() if it belongs to another nested modal

### DIFF
--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -270,6 +270,14 @@ window.piwikHelper = {
 
         $('[role]', domElem).each(function(){
             var $button = $(this);
+
+            // skip this button if it's part of another modal, the current modal can launch
+            // (which is true if there are more than one parent elements w/ css class ui-confirm)
+            const uiConfirm = $button.parents('.ui-confirm');
+            if (uiConfirm.length > 1) {
+              return;
+            }
+
             var role  = $button.attr('role');
             var title = $button.attr('title');
             var text  = $button.val();

--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -272,8 +272,11 @@ window.piwikHelper = {
             var $button = $(this);
 
             // skip this button if it's part of another modal, the current modal can launch
-            // (which is true if there are more than one parent elements w/ css class ui-confirm)
-            const uiConfirm = $button.parents('.ui-confirm');
+            // (which is true if there are more than one parent elements contained in domElem,
+            // w/ css class ui-confirm)
+            const uiConfirm = $button.parents('.ui-confirm').filter(function () {
+              return domElem[0] === this || $.contains(domElem[0], this);
+            });
             if (uiConfirm.length > 1) {
               return;
             }


### PR DESCRIPTION
### Description:

piwikHelper.modalConfirm() uses every button w/ `[role]` even if it belongs to a nested modal. This doesn't appear to be an issue w/ angularjs code due to the timing in when angularjs processes templates/materialize creates modal content. With vue, the HTML appears to show up quicker.

To reproduce, check out https://github.com/matomo-org/tag-manager/pull/404 and try to import a version. In the modal, you'll see "Yes"/"No" buttons which actually belong to the #confirmImportContainerVersion modal stored in the import version directive.

Fixed by checking for the number of .ui-confirm parents contained in the modal contents and skipping the button if it's more than 1.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
