### PR TITLE
Force period type to 'range' if date is a range when checking chart incomplete periods

### DIFF
--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -387,7 +387,7 @@ function rowEvolutionGetMetricNameFromRow(tr)
                 var period = this.param.period;
                 // If date is actually a range then adjust the period type for the containsToday check
                 if (period === 'day' && this.param.date.indexOf(',') !== -1) {
-                    period = 'range'
+                    period = 'range';
                 }
                 if (piwikPeriods.parse(period, this.param.date).containsToday()) {
                     this.jqplotParams['incompleteDataPoints'] = 1;

--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -386,11 +386,11 @@ function rowEvolutionGetMetricNameFromRow(tr)
 
                 var period = this.param.period;
                 // If date is actually a range then adjust the period type for the containsToday check
-                if (period === 'day' && this.param.date.indexOf(',') !== false) {
+                if (period === 'day' && this.param.date.indexOf(',') !== -1) {
                     period = 'range'
                 }
                 if (piwikPeriods.parse(period, this.param.date).containsToday()) {
-                  this.jqplotParams['incompleteDataPoints'] = 1;
+                    this.jqplotParams['incompleteDataPoints'] = 1;
                 }
 
                 var plot = self._plot = $.jqplot(targetDivId, this.data, this.jqplotParams);

--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -383,8 +383,14 @@ function rowEvolutionGetMetricNameFromRow(tr)
                 this.jqplotParams['incompleteDataPoints'] = 0;
 
                 var piwikPeriods = piwikHelper.getAngularDependency('piwikPeriods');
-                if (piwikPeriods.parse(this.param.period, this.param.date).containsToday()) {
-                    this.jqplotParams['incompleteDataPoints'] = 1;
+
+                var period = this.param.period;
+                // If date is actually a range then adjust the period type for the containsToday check
+                if (period === 'day' && this.param.date.indexOf(',') !== false) {
+                    period = 'range'
+                }
+                if (piwikPeriods.parse(period, this.param.date).containsToday()) {
+                  this.jqplotParams['incompleteDataPoints'] = 1;
                 }
 
                 var plot = self._plot = $.jqplot(targetDivId, this.data, this.jqplotParams);


### PR DESCRIPTION
### Description:

As part of the recent Visual indication of incomplete periods on charts change (#18086), a check is performed on the currently selected period and date to determine if the period contains the current date. (eg. Period = 'week', Date = '2022-01-20'). This check is called by `jqplot.js` and executed by the periods service.

The A/B testing plugin for some internal reason needs to set the period to 'day' but the date to a range (eg. '2021-01-20,2021-01-27). This causes the `containsToday` check to fail as a valid date cannot be parsed from a date range.

This PR adds a simple check before calling attempting to parse the date period, if the date is a range then the period type will be forced to type 'range' for the purposes of the `containsToday` check only.

Ref L3-205

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
