### PR TITLE
Enrich log_visit table index by a third column

### DIFF
--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -191,7 +191,7 @@ class Mysql implements SchemaInterface
                                 PRIMARY KEY(idvisit),
                                 INDEX index_idsite_config_datetime (idsite, config_id, visit_last_action_time),
                                 INDEX index_idsite_datetime (idsite, visit_last_action_time),
-                                INDEX index_idsite_idvisitor (idsite, idvisitor)
+                                INDEX index_idsite_idvisitor (idsite, idvisitor, visit_last_action_time DESC)
                               ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 

--- a/core/Updates/5.0.0-b1.php
+++ b/core/Updates/5.0.0-b1.php
@@ -39,9 +39,7 @@ class Updates_5_0_0_b1 extends PiwikUpdates
 
     public function doUpdate(Updater $updater)
     {
-        if ($this->requiresUpdatedLogVisitTableIndex()) {
-            $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
-        }
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 
     public function getMigrations(Updater $updater)

--- a/core/Updates/5.0.0-b1.php
+++ b/core/Updates/5.0.0-b1.php
@@ -1,16 +1,11 @@
 <?php
+
 /**
- * Copyright (C) InnoCraft Ltd - All rights reserved.
+ * Matomo - free/libre analytics platform
  *
- * NOTICE:  All information contained herein is, and remains the property of InnoCraft Ltd.
- * The intellectual and technical concepts contained herein are protected by trade secret or copyright law.
- * Redistribution of this information or reproduction of this material is strictly forbidden
- * unless prior written permission is obtained from InnoCraft Ltd.
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  *
- * You shall use this code only in accordance with the license agreement obtained from InnoCraft Ltd.
- *
- * @link https://www.innocraft.com/
- * @license For license details see https://www.innocraft.com/license
  */
 
 namespace Piwik\Updates;
@@ -60,7 +55,7 @@ class Updates_5_0_0_b1 extends Updates
             }
         }
     }
-    
+
     private function requiresUpdatedLogVisitTableIndex()
     {
         $sql = "SHOW INDEX FROM {$this->tableName} WHERE Key_name = '{$this->indexName}'";

--- a/core/Updates/5.0.0-b1.php
+++ b/core/Updates/5.0.0-b1.php
@@ -14,8 +14,6 @@ use Piwik\Db;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updater\Migration\Db as DbAlias;
-use Piwik\Updater\Migration\Db\DropIndex;
-use Piwik\Updater\Migration\Db\Sql;
 use Piwik\Updater\Migration\Factory;
 use Piwik\Updates as PiwikUpdates;
 
@@ -42,8 +40,17 @@ class Updates_5_0_0_b1 extends PiwikUpdates
     public function doUpdate(Updater $updater)
     {
         if ($this->requiresUpdatedLogVisitTableIndex()) {
-            $updater->executeMigrations(__FILE__, $this->getLogVisitTableMigrations());
+            $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
         }
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        if ($this->requiresUpdatedLogVisitTableIndex()) {
+            return $this->getLogVisitTableMigrations();
+        }
+
+        return [];
     }
 
     private function getLogVisitTableMigrations()

--- a/core/Updates/5.0.0-b1.php
+++ b/core/Updates/5.0.0-b1.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright (C) InnoCraft Ltd - All rights reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains the property of InnoCraft Ltd.
+ * The intellectual and technical concepts contained herein are protected by trade secret or copyright law.
+ * Redistribution of this information or reproduction of this material is strictly forbidden
+ * unless prior written permission is obtained from InnoCraft Ltd.
+ *
+ * You shall use this code only in accordance with the license agreement obtained from InnoCraft Ltd.
+ *
+ * @link https://www.innocraft.com/
+ * @license For license details see https://www.innocraft.com/license
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Db;
+use Piwik\Common;
+use Piwik\Updater;
+use Piwik\Updater\Migration\Db as DbAlias;
+use Piwik\Updater\Migration\Db\DropIndex;
+use Piwik\Updater\Migration\Db\Sql;
+use Piwik\Updates;
+
+/**
+ * Update for version 5.0.0-b1
+ */
+class Updates_5_0_0_b1 extends Updates
+{
+    private $tableName;
+    private $indexName;
+
+    public function __construct()
+    {
+        $this->tableName = Common::prefixTable('log_visit');
+        $this->indexName = 'index_idsite_idvisitor';
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+        if ($this->requiresUpdatedLogVisitTableIndex()) {
+            $this->updateLogVisitTableIndex();
+        }
+    }
+
+    private function updateLogVisitTableIndex()
+    {
+        try {
+            $dropIndex = new DropIndex($this->tableName, $this->indexName);
+            $dropIndex->exec();
+
+            // Using the base `Sql` class instead of the AddIndex class as it doesn't support DESC collation
+            $sql = "ALTER TABLE `{$this->tableName}` ADD INDEX `{$this->indexName}` (`idsite`, `idvisitor`, `visit_last_action_time` DESC)";
+            $addIndex = new Sql($sql, [DbAlias::ERROR_CODE_DUPLICATE_KEY, DbAlias::ERROR_CODE_KEY_COLUMN_NOT_EXISTS]);
+            $addIndex->exec();
+        } catch (\Exception $e) {
+            if (!$dropIndex->shouldIgnoreError($e)) {
+                throw $e;
+            }
+        }
+    }
+    
+    private function requiresUpdatedLogVisitTableIndex()
+    {
+        $sql = "SHOW INDEX FROM {$this->tableName} WHERE Key_name = '{$this->indexName}'";
+
+        $result = Db::fetchAll($sql);
+
+        return empty($result);
+    }
+}


### PR DESCRIPTION
### Description:

**Issue:** [dev-2431](https://innocraft.atlassian.net/browse/DEV-2431)

This PR improves the existing log_visit table index by including a third column within the index. The schema change will allow all new installations to benefit from the improved index, while the update script is earmarked for the 5.0.0 release.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
