### PR TITLE
Run scheduled report tests on any PHP version

### DIFF
--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -78,7 +78,6 @@ use ReflectionClass;
 class Fixture extends \PHPUnit\Framework\Assert
 {
     const IMAGES_GENERATED_ONLY_FOR_OS = 'linux';
-    const IMAGES_GENERATED_FOR_PHP = '7.2';
     const IMAGES_GENERATED_FOR_GD = '2.1.0';
     const DEFAULT_SITE_NAME = 'Piwik test';
 
@@ -911,7 +910,6 @@ class Fixture extends \PHPUnit\Framework\Assert
         $gdInfo = gd_info();
         return
             stristr(php_uname(), self::IMAGES_GENERATED_ONLY_FOR_OS) &&
-            strpos( phpversion(), self::IMAGES_GENERATED_FOR_PHP) !== false &&
             strpos( $gdInfo['GD Version'], self::IMAGES_GENERATED_FOR_GD) !== false;
     }
 


### PR DESCRIPTION
### Description:

We have a couple of scheduled report tests that are only executed on certain systems:
https://github.com/matomo-org/matomo/blob/9fa38fe3cc31632e2a6a0e916c5df7185c872e0d/tests/PHPUnit/Framework/TestCase/SystemTestCase.php#L251-L273
https://github.com/matomo-org/matomo/blob/9fa38fe3cc31632e2a6a0e916c5df7185c872e0d/tests/PHPUnit/Framework/TestCase/SystemTestCase.php#L315-L396

If I remember correctly we had some issues when running those tests on PHP 5 and PHP 7, as the results differed back then.
It seems that isn't a problem anymore when running them on PHP 7 and PHP 8. At least there are no tests failing.
But based on the number of test cases it looks like they are executed.

refs #18499