### PR TITLE
[tests] add random number fields in tests to skip some random number failed

### DIFF
--- a/tests/PHPUnit/Framework/TestRequest/ApiTestConfig.php
+++ b/tests/PHPUnit/Framework/TestRequest/ApiTestConfig.php
@@ -120,7 +120,7 @@ class ApiTestConfig
      * returns the super table of the API method being tested. If set, TestRequest\Collection will look for the
      * first valid idSubtable value to use in the test request. Since these values are assigned dynamically,
      * there's no other way to set idSubtable.
-     * 
+     *
      * @var string|bool eg, `"Referrers.getWebsites"`
      */
     public $supertableApi = false;
@@ -175,6 +175,15 @@ class ApiTestConfig
      * @param string[]|false
      */
     public $xmlFieldsToRemove = false;
+
+    /**
+     * An array of number fields that generate differently depend on the request.
+     * These fields should be fields that change on every test execution and have
+     * to be replaced by x to pass the tests.
+     *
+     * @param string[]|false
+     */
+    public $randomNumberFields = false;
 
     /**
      * If true, Date times XML fields that change on each request for Live API methods are retained.

--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -227,7 +227,7 @@ class Response
     private function randomNumberFields($input, $randomNumberFields = false)
     {
         if ($randomNumberFields === false) {
-            $fieldsToRemove = @$this->params['randomNumberFields'];
+            $randomNumberFields = @$this->params['randomNumberFields'];
         }
 
         if (!is_array($randomNumberFields)) {
@@ -246,8 +246,8 @@ class Response
         $testNotSmallAfter = strlen($input > 100) && $testNotSmallAfter;
 
         $oldInput = $input;
-        $input = preg_replace('/(<' . $xmlElement . '>.+?<\/' . $xmlElement . '>)/', 'x', $input);
-        $input = str_replace('<' . $xmlElement . ' />', 'x', $input);
+        $search = "/(?<=".$xmlElement.">)(.*)(?=<\/".$xmlElement.")/";
+        $input = preg_replace($search, 'x', $input);
 
         // check we didn't delete the whole string
         if ($testNotSmallAfter && $input != $oldInput) {

--- a/tests/PHPUnit/System/BlobReportLimitingTest.php
+++ b/tests/PHPUnit/System/BlobReportLimitingTest.php
@@ -85,6 +85,7 @@ class BlobReportLimitingTest extends SystemTestCase
                     // in this test, we only care to check that the result is being limited/aggregated correctly, so we can remove these
                     // when comparing.
                     'xmlFieldsToRemove' => ['label', 'segment', 'url', 'exit_nb_visits', 'exit_rate', 'bounce_count', 'bounce_rate'],
+                    'randomNumberFields' => ['nb_visits', 'nb_uniq_visitors', 'nb_hits']
                 ),
             ),
 


### PR DESCRIPTION
### Description:

add random number fields in tests to skip some random number failed
eg:
```
- <nb_visits>1</nb_visits>
+ <nb_visits>2</nb_visits>

```

will be  `<nb_visits>x</nb_visits>`

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
