### PR TITLE
Add new event Segment.filterSegments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 
 * The config setting `enable_default_location_provider` in `Tracker` has been added. By setting this option to 0, you can disable the default location provider. This can be used to prevent the geolocator to guess the country based on the users language, if the configured provider doesn't provide any results.
 
+#### New PHP events
+
+* Added new event `Segment.filterSegments`. Plugins can use this to filter segment definitions.
+
 ## Matomo 4.7.0
 
 ### Deprecated APIs

--- a/core/Segment/SegmentsList.php
+++ b/core/Segment/SegmentsList.php
@@ -132,6 +132,20 @@ class SegmentsList
             $dimension->configureSegments($list, new DimensionSegmentFactory($dimension));
         }
 
+        /**
+         * Triggered to filter segment definitions.
+         *
+         * **Example**
+         *
+         *     public function filterSegments(&$segmentList)
+         *     {
+         *         $segmentList->remove('Category');
+         *     }
+         *
+         * @param SegmentsList $list An instance of the SegmentsList.
+         */
+        Piwik::postEvent('Segment.filterSegments', array($list));
+        
         $cache->save($cacheKey, $list);
 
         return $list;


### PR DESCRIPTION
### Description:

For many other `*.add*` events we also have matching `*.filter*` events. Eg we have this for `Access.Capability.filterCapabilities`, `Dimension.filterDimensions`, `Metric.filterMetrics`, `Report.filterReports`.

However, it doesn't seem to be the case for segments. This be useful in a plugin right now. 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
