### PR TITLE
Fix failing UserId tests

### DIFF
--- a/plugins/UserId/tests/Fixtures/TrackFewVisitsAndCreateUsers.php
+++ b/plugins/UserId/tests/Fixtures/TrackFewVisitsAndCreateUsers.php
@@ -38,12 +38,6 @@ class TrackFewVisitsAndCreateUsers extends Fixture
             for ($numVisits = 0; $numVisits < ($key+1) * 10; $numVisits++) {
                 $t->setUserId($userId);
                 $t->setVisitorId(str_pad($numVisits.$key, 16, 'a'));
-                if ($numVisits % 5 == 0) {
-                    $t->doTrackSiteSearch('some search term');
-                }
-                if ($numVisits % 4 == 0) {
-                    $t->doTrackEvent('Event action', 'event cat');
-                }
                 $t->setForceNewVisit();
                 $t->setUrl('http://example.org/my/dir/page' . ($numVisits % 4));
 
@@ -51,6 +45,18 @@ class TrackFewVisitsAndCreateUsers extends Fixture
                 $t->setForceVisitDateTime($visitDateTime);
 
                 self::assertTrue($t->doTrackPageView('incredible title ' . ($numVisits % 3)));
+
+                if ($numVisits && $numVisits % 5 == 0) {
+                    $visitDateTime = Date::factory($this->dateTime)->addDay($numVisits)->addHour(0.02)->getDatetime();
+                    $t->setForceVisitDateTime($visitDateTime);
+                    self::assertTrue($t->doTrackSiteSearch('some search term'));
+                }
+                if ($numVisits && $numVisits % 4 == 0) {
+                    $visitDateTime = Date::factory($this->dateTime)->addDay($numVisits)->addHour(0.04)->getDatetime();
+                    $t->setForceVisitDateTime($visitDateTime);
+                    self::assertTrue($t->doTrackEvent('Event action', 'event cat'));
+                }
+
             }
         }
 

--- a/plugins/UserId/tests/System/expected/test___UserId.getUsers_day.xml
+++ b/plugins/UserId/tests/System/expected/test___UserId.getUsers_day.xml
@@ -3,11 +3,11 @@
 	<row>
 		<label>user1</label>
 		<nb_uniq_visitors>1</nb_uniq_visitors>
-		<nb_visits>2</nb_visits>
-		<nb_actions>3</nb_actions>
+		<nb_visits>1</nb_visits>
+		<nb_actions>1</nb_actions>
 		<nb_users>1</nb_users>
-		<max_actions>2</max_actions>
-		<sum_visit_length>1</sum_visit_length>
+		<max_actions>1</max_actions>
+		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		

--- a/plugins/UserId/tests/System/expected/test___UserId.getUsers_range.xml
+++ b/plugins/UserId/tests/System/expected/test___UserId.getUsers_range.xml
@@ -2,11 +2,11 @@
 <result>
 	<row>
 		<label>user3</label>
-		<nb_visits>31</nb_visits>
-		<nb_actions>44</nb_actions>
-		<max_actions>4</max_actions>
-		<sum_visit_length>11</sum_visit_length>
-		<bounce_count>20</bounce_count>
+		<nb_visits>30</nb_visits>
+		<nb_actions>42</nb_actions>
+		<max_actions>3</max_actions>
+		<sum_visit_length>1307</sum_visit_length>
+		<bounce_count>19</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>30</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>30</sum_daily_nb_users>
@@ -15,11 +15,11 @@
 	</row>
 	<row>
 		<label>user2</label>
-		<nb_visits>21</nb_visits>
-		<nb_actions>29</nb_actions>
-		<max_actions>3</max_actions>
-		<sum_visit_length>7</sum_visit_length>
-		<bounce_count>14</bounce_count>
+		<nb_visits>20</nb_visits>
+		<nb_actions>27</nb_actions>
+		<max_actions>2</max_actions>
+		<sum_visit_length>799</sum_visit_length>
+		<bounce_count>13</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>20</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>20</sum_daily_nb_users>
@@ -28,10 +28,10 @@
 	</row>
 	<row>
 		<label>user1</label>
-		<nb_visits>11</nb_visits>
-		<nb_actions>15</nb_actions>
+		<nb_visits>10</nb_visits>
+		<nb_actions>13</nb_actions>
 		<max_actions>2</max_actions>
-		<sum_visit_length>4</sum_visit_length>
+		<sum_visit_length>363</sum_visit_length>
 		<bounce_count>7</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>

--- a/plugins/UserId/tests/System/expected/test_ascSortOrder__UserId.getUsers_day.xml
+++ b/plugins/UserId/tests/System/expected/test_ascSortOrder__UserId.getUsers_day.xml
@@ -29,11 +29,11 @@
 	<row>
 		<label>user1</label>
 		<nb_uniq_visitors>1</nb_uniq_visitors>
-		<nb_visits>2</nb_visits>
-		<nb_actions>3</nb_actions>
+		<nb_visits>1</nb_visits>
+		<nb_actions>1</nb_actions>
 		<nb_users>1</nb_users>
-		<max_actions>2</max_actions>
-		<sum_visit_length>1</sum_visit_length>
+		<max_actions>1</max_actions>
+		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		

--- a/plugins/UserId/tests/System/expected/test_ascSortOrder__UserId.getUsers_range.xml
+++ b/plugins/UserId/tests/System/expected/test_ascSortOrder__UserId.getUsers_range.xml
@@ -2,10 +2,10 @@
 <result>
 	<row>
 		<label>user1</label>
-		<nb_visits>11</nb_visits>
-		<nb_actions>15</nb_actions>
+		<nb_visits>10</nb_visits>
+		<nb_actions>13</nb_actions>
 		<max_actions>2</max_actions>
-		<sum_visit_length>4</sum_visit_length>
+		<sum_visit_length>363</sum_visit_length>
 		<bounce_count>7</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
@@ -15,11 +15,11 @@
 	</row>
 	<row>
 		<label>user2</label>
-		<nb_visits>21</nb_visits>
-		<nb_actions>29</nb_actions>
-		<max_actions>3</max_actions>
-		<sum_visit_length>7</sum_visit_length>
-		<bounce_count>14</bounce_count>
+		<nb_visits>20</nb_visits>
+		<nb_actions>27</nb_actions>
+		<max_actions>2</max_actions>
+		<sum_visit_length>799</sum_visit_length>
+		<bounce_count>13</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>20</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>20</sum_daily_nb_users>
@@ -28,11 +28,11 @@
 	</row>
 	<row>
 		<label>user3</label>
-		<nb_visits>31</nb_visits>
-		<nb_actions>44</nb_actions>
-		<max_actions>4</max_actions>
-		<sum_visit_length>11</sum_visit_length>
-		<bounce_count>20</bounce_count>
+		<nb_visits>30</nb_visits>
+		<nb_actions>42</nb_actions>
+		<max_actions>3</max_actions>
+		<sum_visit_length>1307</sum_visit_length>
+		<bounce_count>19</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>30</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>30</sum_daily_nb_users>

--- a/plugins/UserId/tests/System/expected/test_limit__UserId.getUsers_range.xml
+++ b/plugins/UserId/tests/System/expected/test_limit__UserId.getUsers_range.xml
@@ -2,11 +2,11 @@
 <result>
 	<row>
 		<label>user2</label>
-		<nb_visits>21</nb_visits>
-		<nb_actions>29</nb_actions>
-		<max_actions>3</max_actions>
-		<sum_visit_length>7</sum_visit_length>
-		<bounce_count>14</bounce_count>
+		<nb_visits>20</nb_visits>
+		<nb_actions>27</nb_actions>
+		<max_actions>2</max_actions>
+		<sum_visit_length>799</sum_visit_length>
+		<bounce_count>13</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>20</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>20</sum_daily_nb_users>
@@ -15,10 +15,10 @@
 	</row>
 	<row>
 		<label>user1</label>
-		<nb_visits>11</nb_visits>
-		<nb_actions>15</nb_actions>
+		<nb_visits>10</nb_visits>
+		<nb_actions>13</nb_actions>
 		<max_actions>2</max_actions>
-		<sum_visit_length>4</sum_visit_length>
+		<sum_visit_length>363</sum_visit_length>
 		<bounce_count>7</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>

--- a/plugins/UserId/tests/System/expected/test_searchByUserId__UserId.getUsers_range.xml
+++ b/plugins/UserId/tests/System/expected/test_searchByUserId__UserId.getUsers_range.xml
@@ -2,11 +2,11 @@
 <result>
 	<row>
 		<label>user2</label>
-		<nb_visits>21</nb_visits>
-		<nb_actions>29</nb_actions>
-		<max_actions>3</max_actions>
-		<sum_visit_length>7</sum_visit_length>
-		<bounce_count>14</bounce_count>
+		<nb_visits>20</nb_visits>
+		<nb_actions>27</nb_actions>
+		<max_actions>2</max_actions>
+		<sum_visit_length>799</sum_visit_length>
+		<bounce_count>13</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>20</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>20</sum_daily_nb_users>


### PR DESCRIPTION
### Description:

The UserId tests were actually failing due to this change: #18636

The reason for that seems to be the weird tracking done for the UserId tests, causing the tracked data to be slightly different.
I'll add some comments in the code to make that a bit more clear what the issue was.

refs #18082 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
