### PR TITLE
[Vue] Ignore warning from browserslist of old caniuse data (since this is u…

### DIFF
--- a/plugins/CoreVue/Commands/Build.php
+++ b/plugins/CoreVue/Commands/Build.php
@@ -90,7 +90,8 @@ class Build extends ConsoleCommand
 
     private function watch($plugins, $printBuildCommand, OutputInterface $output)
     {
-        $commandSingle = "FORCE_COLOR=1 MATOMO_CURRENT_PLUGIN=%1\$s " . self::getVueCliServiceBin() . ' build --mode=development --target lib --name '
+        $commandSingle = "BROWSERSLIST_IGNORE_OLD_DATA=1 FORCE_COLOR=1 MATOMO_CURRENT_PLUGIN=%1\$s "
+            . self::getVueCliServiceBin() . ' build --mode=development --target lib --name '
             . "%1\$s --filename=%1\$s.development --no-clean ./plugins/%1\$s/vue/src/index.ts --dest ./plugins/%1\$s/vue/dist --watch &";
 
         $command = '';
@@ -107,7 +108,8 @@ class Build extends ConsoleCommand
 
     private function buildFiles(OutputInterface $output, $plugin, $printBuildCommand)
     {
-        $command = "FORCE_COLOR=1 MATOMO_CURRENT_PLUGIN=$plugin " . self::getVueCliServiceBin() . ' build --target lib --name ' . $plugin
+        $command = "BROWSERSLIST_IGNORE_OLD_DATA=1 FORCE_COLOR=1 MATOMO_CURRENT_PLUGIN=$plugin "
+            . self::getVueCliServiceBin() . ' build --target lib --name ' . $plugin
             . " ./plugins/$plugin/vue/src/index.ts --dest ./plugins/$plugin/vue/dist";
 
         if ($printBuildCommand) {


### PR DESCRIPTION
…pdated on major matomo releases only).

### Description:

Run vue:build w/o it to see the problem.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
