### PR TITLE
[Vue] patch vue compiler so it does not decode &nbsp; entities

### DIFF
--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -1083,7 +1083,9 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
                 || strpos($file, 'vendor/mayflower/mo4-coding-standard/') !== false
                 || strpos($file, 'vendor/symfony/polyfill-iconv/') !== false
                 || strpos($file, 'plugins/CoreVue/polyfills/dist/MatomoPolyfills.min.js') !== false
-                || strpos($file, 'plugins/VisitorGenerator/vendor/fzaninotto/faker/src/Faker/Provider/') !== false) {
+                || strpos($file, 'plugins/VisitorGenerator/vendor/fzaninotto/faker/src/Faker/Provider/') !== false
+                || preg_match('/plugins\/[a-zA-Z0-9]+\/vue\/dist\/[a-zA-Z0-9]+.umd(.min)?.js/', $file)
+            ) {
                 continue;
             }
 

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -1083,9 +1083,7 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
                 || strpos($file, 'vendor/mayflower/mo4-coding-standard/') !== false
                 || strpos($file, 'vendor/symfony/polyfill-iconv/') !== false
                 || strpos($file, 'plugins/CoreVue/polyfills/dist/MatomoPolyfills.min.js') !== false
-                || strpos($file, 'plugins/VisitorGenerator/vendor/fzaninotto/faker/src/Faker/Provider/') !== false
-                || preg_match('/plugins\/[a-zA-Z0-9]+\/vue\/dist\/[a-zA-Z0-9]+.umd(.min)?.js/', $file)
-            ) {
+                || strpos($file, 'plugins/VisitorGenerator/vendor/fzaninotto/faker/src/Faker/Provider/') !== false) {
                 continue;
             }
 

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,18 @@
 const fs = require('fs');
 const path = require('path');
 
+const { parserOptions } = require('@vue/compiler-dom');
+
+// overwrite decodeEntities function in @vue/compiler-dom so it does not decode the &nbsp;
+// entity. ReleaseChecklistTest will not allow those characters in JS files.
+const oldDecodeEntities = parserOptions.decodeEntities;
+const NBSP_DECODED = oldDecodeEntities('&nbsp;');
+
+parserOptions.decodeEntities = (rawText) => {
+  const result = oldDecodeEntities(...arguments);
+  return result.replaceAll(NBSP_DECODED, '&nbsp;');
+};
+
 const pluginExternals = scanPluginExternals();
 
 function scanPluginExternals() {


### PR DESCRIPTION
### Description:

As title. I thought of skipping the UMD files, but I'm not sure why the test was originally added, and it looked related to security. Since `&nbsp;` could be easily needed in the future it also doesn't seem acceptable to just never use it.

I found the place where this happens in the vue compiler and found a way to patch it.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
