### PR TITLE
Prevent archiving of data for time periods that start in the future

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -610,8 +610,6 @@ class Archive implements ArchiveQuery
      */
     private function cacheArchiveIdsAfterLaunching($archiveGroups, $plugins)
     {
-        $today = Date::today();
-
         foreach ($this->params->getPeriods() as $period) {
             $twoDaysAfterPeriod = $period->getDateEnd()->addDay(2);
 
@@ -633,6 +631,9 @@ class Archive implements ArchiveQuery
                         $idSite, $period->getLabel(), $period->getPrettyString());
                     continue;
                 }
+
+                // Allow for site timezone, local time may have started a new day ahead of UTC
+                $today = \Piwik\Date::factory('now', $site->getTimezone());
 
                 // if the starting date is in the future we know there are no visits
                 if ($period->getDateStart()->isLater($today)) {

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -613,7 +613,6 @@ class Archive implements ArchiveQuery
         $today = Date::today();
 
         foreach ($this->params->getPeriods() as $period) {
-            $twoDaysBeforePeriod = $period->getDateStart()->subDay(2);
             $twoDaysAfterPeriod = $period->getDateEnd()->addDay(2);
 
             foreach ($this->params->getIdSites() as $idSite) {
@@ -635,8 +634,8 @@ class Archive implements ArchiveQuery
                     continue;
                 }
 
-                // if the starting date is in the future we know there is no visiidsite = ?t
-                if ($twoDaysBeforePeriod->isLater($today)) {
+                // if the starting date is in the future we know there are no visits
+                if ($period->getDateStart()->isLater($today)) {
                     Log::debug("Archive site %s, %s (%s) skipped, archive is after today.",
                         $idSite, $period->getLabel(), $period->getPrettyString());
                     continue;

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -273,9 +273,9 @@ class ArchiveTest extends IntegrationTestCase
 
         // archive range and day
         Rules::setBrowserTriggerArchiving(true);
-        API::getInstance()->get(1, 'day', '2020-03-04');
-        API::getInstance()->get(1, 'day', '2020-03-05');
-        API::getInstance()->get(1, 'day', '2020-03-06');
+        API::getInstance()->get($idSite, 'day', '2020-03-04');
+        API::getInstance()->get($idSite, 'day', '2020-03-05');
+        API::getInstance()->get($idSite, 'day', '2020-03-06');
 
         // check expected archives were created
         $archives = Db::fetchAll("SELECT date1, date2, name, period, value FROM " . Common::prefixTable('archive_numeric_2020_03')
@@ -283,6 +283,61 @@ class ArchiveTest extends IntegrationTestCase
         $expected = [
             ['date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'period' => 1, 'value' => '1'],
             ['date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'period' => 1, 'value' => '1']
+        ];
+        $this->assertEquals($expected, $archives);
+
+        Date::$now = time();
+    }
+
+    public function test_shouldArchivePeriodsStartingInTheFuture_IfWebSiteLocalTimeIsInNextDay()
+    {
+        // Create a site with a timezone ahead of UTC
+        $idSite = Fixture::createWebsite('2014-05-06', 1, false, false,
+            1, null, null, 'Pacific/Auckland');
+
+        self::$fixture->getTestEnvironment()->overrideConfig('General', 'browser_archiving_disabled_enforce', 0);
+        self::$fixture->getTestEnvironment()->overrideConfig('General', 'archiving_range_force_on_browser_request', 1);
+        self::$fixture->getTestEnvironment()->save();
+
+        Config::getInstance()->General['browser_archiving_disabled_enforce'] = 0;
+        Config::getInstance()->General['archiving_range_force_on_browser_request'] = 1;
+
+        // track some visits
+        $t = Fixture::getTracker($idSite, '2020-03-04 05:05:05');
+        $t->setUrl('http://abc.com/mypage');
+        Fixture::checkResponse($t->doTrackPageView('page title'));
+
+        $t->setForceVisitDateTime('2020-03-05 06:06:06');
+        $t->setUrl('http://abc.com/myotherpage');
+        Fixture::checkResponse($t->doTrackPageView('another page'));
+
+        $t->setForceVisitDateTime('2020-03-06 07:07:07');
+        $t->setUrl('http://abc.com/myotherpageagain');
+        Fixture::checkResponse($t->doTrackPageView('another page again'));
+
+        // Set the current UTC date to a time only 3hrs until midnight, this will ensure that the website with
+        // it's local timezone will be in the next day
+        Date::$now = strtotime('2020-03-05 21:00:00');
+
+        // clear invalidations from above tracking
+        $cronArchive = new CronArchive();
+        $cronArchive->init();
+        $cronArchive->invalidateArchivedReportsForSitesThatNeedToBeArchivedAgain(1);
+
+        // archive range and day
+        Rules::setBrowserTriggerArchiving(true);
+        API::getInstance()->get($idSite, 'day', '2020-03-04');
+        API::getInstance()->get($idSite, 'day', '2020-03-05');
+        API::getInstance()->get($idSite, 'day', '2020-03-06');
+        API::getInstance()->get($idSite, 'day', '2020-03-07');
+
+        // check expected archives were created
+        $archives = Db::fetchAll("SELECT date1, date2, name, period, value FROM " . Common::prefixTable('archive_numeric_2020_03')
+            . " WHERE `name` IN ('done', 'done.VisitsSummary')");
+        $expected = [
+            ['date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'period' => 1, 'value' => '1'],
+            ['date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'period' => 1, 'value' => '1'],
+            ['date1' => '2020-03-06', 'date2' => '2020-03-06', 'name' => 'done', 'period' => 1, 'value' => '1'],
         ];
         $this->assertEquals($expected, $archives);
 

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -26,6 +26,9 @@ use Piwik\Site;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
+/**
+ * @group ArchiveTest
+ */
 class ArchiveTest extends IntegrationTestCase
 {
     protected static function beforeTableDataCached()
@@ -235,6 +238,55 @@ class ArchiveTest extends IntegrationTestCase
             ['idarchive' => '18', 'date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => '1'],
         ];
         $this->assertEquals($expected, $archives);
+    }
+
+    public function test_shouldNotArchivePeriodsStartingInTheFuture()
+    {
+        $idSite = 1;
+
+        self::$fixture->getTestEnvironment()->overrideConfig('General', 'browser_archiving_disabled_enforce', 0);
+        self::$fixture->getTestEnvironment()->overrideConfig('General', 'archiving_range_force_on_browser_request', 1);
+        self::$fixture->getTestEnvironment()->save();
+
+        Config::getInstance()->General['browser_archiving_disabled_enforce'] = 0;
+        Config::getInstance()->General['archiving_range_force_on_browser_request'] = 1;
+
+        // track some visits
+        $t = Fixture::getTracker($idSite, '2020-03-04 05:05:05');
+        $t->setUrl('http://abc.com/mypage');
+        Fixture::checkResponse($t->doTrackPageView('page title'));
+
+        $t->setForceVisitDateTime('2020-03-05 06:06:06');
+        $t->setUrl('http://abc.com/myotherpage');
+        Fixture::checkResponse($t->doTrackPageView('another page'));
+
+        $t->setForceVisitDateTime('2020-03-06 07:07:07');
+        $t->setUrl('http://abc.com/myotherpageagain');
+        Fixture::checkResponse($t->doTrackPageView('another page again'));
+
+        Date::$now = strtotime('2020-03-05 12:00:00');
+
+        // clear invalidations from above tracking
+        $cronArchive = new CronArchive();
+        $cronArchive->init();
+        $cronArchive->invalidateArchivedReportsForSitesThatNeedToBeArchivedAgain(1);
+
+        // archive range and day
+        Rules::setBrowserTriggerArchiving(true);
+        API::getInstance()->get(1, 'day', '2020-03-04');
+        API::getInstance()->get(1, 'day', '2020-03-05');
+        API::getInstance()->get(1, 'day', '2020-03-06');
+
+        // check expected archives were created
+        $archives = Db::fetchAll("SELECT date1, date2, name, period, value FROM " . Common::prefixTable('archive_numeric_2020_03')
+            . " WHERE `name` IN ('done', 'done.VisitsSummary')");
+        $expected = [
+            ['date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'period' => 1, 'value' => '1'],
+            ['date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'period' => 1, 'value' => '1']
+        ];
+        $this->assertEquals($expected, $archives);
+
+        Date::$now = time();
     }
 
     public function test_archivingInvalidWeekWithSegment_doesReprocessInvalidDayWIthSegment()

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -344,6 +344,61 @@ class ArchiveTest extends IntegrationTestCase
         Date::$now = time();
     }
 
+    public function test_shouldNotArchivePeriodsStartingInTheFuture_IfWebSiteLocalTimeIsInPreviousDay()
+    {
+
+        // Create a site with a timezone behind of UTC
+        $idSite = Fixture::createWebsite('2014-05-06', 1, false, false,
+            1, null, null, 'America/Vancouver'); // -8hrs
+
+        self::$fixture->getTestEnvironment()->overrideConfig('General', 'browser_archiving_disabled_enforce', 0);
+        self::$fixture->getTestEnvironment()->overrideConfig('General', 'archiving_range_force_on_browser_request', 1);
+        self::$fixture->getTestEnvironment()->save();
+
+        Config::getInstance()->General['browser_archiving_disabled_enforce'] = 0;
+        Config::getInstance()->General['archiving_range_force_on_browser_request'] = 1;
+
+        // track some visits
+        $t = Fixture::getTracker($idSite, '2020-03-04 05:05:05');
+        $t->setUrl('http://abc.com/mypage');
+        Fixture::checkResponse($t->doTrackPageView('page title'));
+
+        $t->setForceVisitDateTime('2020-03-05 06:06:06');
+        $t->setUrl('http://abc.com/myotherpage');
+        Fixture::checkResponse($t->doTrackPageView('another page'));
+
+        $t->setForceVisitDateTime('2020-03-06 07:07:07');
+        $t->setUrl('http://abc.com/myotherpageagain');
+        Fixture::checkResponse($t->doTrackPageView('another page again'));
+
+        // Set the current UTC date to a time only 3hrs from midnight, this will ensure that the website with
+        // it's local timezone will be in the previous day
+        Date::$now = strtotime('2020-03-05 03:00:00');
+
+        // clear invalidations from above tracking
+        $cronArchive = new CronArchive();
+        $cronArchive->init();
+        $cronArchive->invalidateArchivedReportsForSitesThatNeedToBeArchivedAgain(1);
+
+        // archive range and day
+        Rules::setBrowserTriggerArchiving(true);
+        API::getInstance()->get($idSite, 'day', '2020-03-04');
+        API::getInstance()->get($idSite, 'day', '2020-03-05');
+        API::getInstance()->get($idSite, 'day', '2020-03-06');
+        API::getInstance()->get($idSite, 'day', '2020-03-07');
+
+        // check expected archives were created
+        $archives = Db::fetchAll("SELECT date1, date2, name, period, value FROM " . Common::prefixTable('archive_numeric_2020_03')
+            . " WHERE `name` IN ('done', 'done.VisitsSummary')");
+
+        $expected = [
+            ['date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'period' => 1, 'value' => '1']
+        ];
+        $this->assertEquals($expected, $archives);
+
+        Date::$now = time();
+    }
+
     public function test_archivingInvalidWeekWithSegment_doesReprocessInvalidDayWIthSegment()
     {
         $idSite = 1;


### PR DESCRIPTION
### Description:

Fixes #18773 

When archiving a week, month or year some sub-periods may fall in the future (eg. it's Thursday so we want to archive this week, but Friday, Saturday and Sunday are in the future).

Writing blank archive data for the future causes problems (and is inefficient) so the code in Archive.php#L629-L643 skips any archives for periods with a start date in the future or before the website was created. However for some reason it only skips archives with start dates two days greater than the current date, this causes blank archives to be written for today+1 and today+2.

This is a simple fix to skip any periods which start on a date later than the current date.

Prior to this change a running `./console core:archive` command would result in `Archive::prepareArchive()` being called for dates two days into the future, after the change the method is only called up to and include the current date.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
