### PR TITLE
Segmented visits log might show incorrect title

### DIFF
--- a/plugins/Live/javascripts/SegmentedVisitorLog.js
+++ b/plugins/Live/javascripts/SegmentedVisitorLog.js
@@ -110,7 +110,15 @@ var SegmentedVisitorLog = function() {
 
             // remove title returned from the server
             var title = box.find('h2[piwik-enriched-headline]');
-            var defaultTitle = title.text();
+
+            // if the enriched headline has been already parsed, there might be additional content,
+            // so we prefer using the original title, which is placed in div with class "title"
+            // @see plugins/CoreHome/vue/src/EnrichedHeadline/EnrichedHeadline.vue
+            if (title.find('.title')) {
+                var defaultTitle = title.find('.title').text();
+            } else {
+                var defaultTitle = title.text();
+            }
 
             if (title.length) {
                 title.remove();


### PR DESCRIPTION
### Description:

fixes #18775

I guess this might be a regression of the vue migration.

Steps to reproduce:
- Go to any goal page
- Click the link "Show Visits Log segmented by this Goal"
- The title of the opened popover will contain some text of the rate feature

![image](https://user-images.githubusercontent.com/1579355/153870657-01eeebcc-ad50-4e00-bf1c-bbae39f60aeb.png)


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
