### PR TITLE
[Bug] Cant not Copy User Dashboard to another user

### DIFF
--- a/plugins/Dashboard/javascripts/dashboard.js
+++ b/plugins/Dashboard/javascripts/dashboard.js
@@ -103,16 +103,13 @@ function copyDashboardToUser() {
     var ajaxRequest = new ajaxHelper();
     ajaxRequest.addParams({
         module: 'API',
-        method: 'UsersManager.getUsers',
+        method: 'UsersManager.getSiteAccessUsers',
         format: 'json',
-        filter_limit: '-1'
+        filter_limit: '-1',
     }, 'get');
     ajaxRequest.setCallback(
         function (availableUsers) {
             $(makeSelectorLastId('copyDashboardUser')).empty();
-            $(makeSelectorLastId('copyDashboardUser')).append(
-                $('<option></option>').val(piwik.userLogin).text(piwik.userLogin)
-            );
             $.each(availableUsers, function (index, user) {
                 if (user.login != 'anonymous' && user.login != piwik.userLogin) {
                     $(makeSelectorLastId('copyDashboardUser')).append(

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1444,6 +1444,21 @@ class API extends \Piwik\Plugin\API
         return $result;
     }
 
+    public function getSiteAccessUsers($idSite)
+    {
+        Piwik::checkUserHasAdminAccess($idSite);
+        $logins = $this->model->getSiteUsers($idSite);
+
+        if (empty($logins)) {
+            return array();
+        }
+
+        $logins = $this->userFilter->filterLogins($logins);
+        $logins = implode(',', $logins);
+
+        return $this->getUsers($logins);
+    }
+
     private function isUserHasAdminAccessTo($idSite)
     {
         try {

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -132,7 +132,21 @@ class Model
     {
         $db = $this->getDb();
         $users = $db->fetchAll("SELECT login FROM " . Common::prefixTable("access")
-                               . " WHERE idsite = ? AND access = ?", array($idSite, $access));
+                               . " WHERE idsite = ? AND access in (?)", array($idSite, $access));
+
+        $logins = array();
+        foreach ($users as $user) {
+            $logins[] = $user['login'];
+        }
+
+        return $logins;
+    }
+
+    public function getSiteUsers($idSite)
+    {   $db = $this->getDb();
+        $users = $db->fetchAll("SELECT login FROM " . Common::prefixTable("access")
+          . " WHERE idsite = ?", $idSite);
+
 
         $logins = array();
         foreach ($users as $user) {


### PR DESCRIPTION
### Description:

Fixes: #18692 
 
Cant not Copy User Dashboard for different sites with different access. 

My guess was the getUser API endpoints, do have related param site Id, when site selector changes, getUser still return default site sitting maybe.

Question: do we allow users to copy the dashboard to themselves? 




### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
