### PR TITLE
Improve performance of some archiving queries

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -282,8 +282,7 @@ class LogAggregator
         if (defined('PIWIK_TEST_MODE') && PIWIK_TEST_MODE) {
             $engine = 'ENGINE=MEMORY';
         }
-        $tempTableIdVisitColumn = 'idvisit  BIGINT(10) UNSIGNED NOT NULL';
-        $createTableSql = 'CREATE TEMPORARY TABLE ' . $table . ' (' . $tempTableIdVisitColumn . ') ' . $engine;
+        $createTableSql = 'CREATE TEMPORARY TABLE ' . $table . ' (idvisit  BIGINT(10) UNSIGNED NOT NULL, PRIMARY KEY (`idvisit`)) ' . $engine;
         // we do not insert the data right away using create temporary table ... select ...
         // to avoid metadata lock see eg https://www.percona.com/blog/2018/01/10/why-avoid-create-table-as-select-statement/
 
@@ -293,23 +292,7 @@ class LogAggregator
         } catch (\Exception $e) {
             if ($readerDb->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_TABLE_EXISTS)) {
                 return;
-            } elseif ($readerDb->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_REQUIRES_PRIMARY_KEY)
-                || $readerDb->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_UNABLE_CREATE_TABLE_WITHOUT_PRIMARY_KEY
-                    || stripos($e->getMessage(), 'requires a primary key') !== false
-                    || stripos($e->getMessage(), 'table without a primary key') !== false)
-            ) {
-                $createTableSql = str_replace($tempTableIdVisitColumn, $tempTableIdVisitColumn . ', PRIMARY KEY (`idvisit`)', $createTableSql);
-
-                try {
-                    $readerDb->query($createTableSql);
-                } catch (\Exception $e) {
-                    if ($readerDb->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_TABLE_EXISTS)) {
-                        return;
-                    } else {
-                        throw $e;
-                    }
-                }
-            } else {
+            }  else {
                 throw $e;
             }
         }


### PR DESCRIPTION
### Description:

We had an issue where a custom reports query took longer than 45 minutes to execute every single time and then archiving gets aborted.

Noticed there wasn't crazy much data on the instance (log_visit 5.5M, log_link_visit_action 15M, log_action 300K). And the query usually without a segment runs very fast. With a segment applied in the query it runs fast as well. Once we join it with the temporary table then it is VERY slow and aborts after 45 minutes. After adding the primary key, then the query executed fast (in one minute). 

I don't know why I didn't add the primary key initially. I assume I was thinking it shouldn't be needed as the index would contain same information as the table and when it's not needed then it's faster to not do it. However, seeing in that case now that it's clearly faster to have that index. I haven't tested any other query, but would assume some other archive queries would get faster as well for segments.

Queries I used to reproduce

```sql
-- drop temporary table logtmpsegment010ccc0a9e16636173df1de1bfc6a263;
create temporary table logtmpsegment010ccc0a9e16636173df1de1bfc6a263 (idvisit  BIGINT(10) UNSIGNED NOT NULL);
-- create temporary table logtmpsegment010ccc0a9e16636173df1de1bfc6a263 (idvisit  BIGINT(10) UNSIGNED NOT NULL, PRIMARY KEY (`idvisit`));

insert into logtmpsegment010ccc0a9e16636173df1de1bfc6a263 (idvisit) select idvisit from log_visit where  idsite=1 and visit_last_action_time >= '2022-02-06 23:00:00' and visit_last_action_time < '2022-02-07 23:00:00'; 


SELECT SQL_NO_CACHE        CASE      WHEN counter = 50001 THEN '__mtm_ranking_query_others__'      ELSE `CoreHome.VisitLastActionDayOfMonth`     END AS `CoreHome.VisitLastActionDayOfMonth`         , `sum_events_totalevents`    FROM (     SELECT     `CoreHome.VisitLastActionDayOfMonth`,         CASE     WHEN @counter = 50001 THEN 50001     ELSE @counter:=@counter+1    END    AS counter     , `sum_events_totalevents`    FROM     ( SELECT @counter:=0 ) initCounter,     ( SELECT    DAYOFMONTH(log_inner.visit_last_action_time) AS 'CoreHome.VisitLastActionDayOfMonth', sum(log_inner.visit_total_events) AS 'sum_events_totalevents'    FROM       (  SELECT     log_visit.visit_last_action_time,  log_visit.visit_total_events    FROM      logtmpsegment010ccc0a9e16636173df1de1bfc6a263 INNER JOIN log_visit AS log_visit ON log_visit.idvisit = logtmpsegment010ccc0a9e16636173df1de1bfc6a263.idvisit RIGHT JOIN log_link_visit_action AS log_link_visit_action  ON  logtmpsegment010ccc0a9e16636173df1de1bfc6a263.idvisit = log_link_visit_action.idvisit  LEFT JOIN log_action AS log_action_idaction_event_category ON log_link_visit_action.idaction_event_category = log_action_idaction_event_category.idaction    WHERE     (log_action_idaction_event_category.type = "10" and log_link_visit_action.idsite = 1)   GROUP BY     DAYOFMONTH(log_visit.visit_last_action_time), `log_visit`.`idvisit`    ORDER BY     NULL  ) AS log_inner    GROUP BY     DAYOFMONTH(log_inner.visit_last_action_time)    ORDER BY     sum_events_totalevents ) actualQuery    ) AS withCounter    GROUP BY counter
```

### Explain when the primary key is there (query fast)

<img width="1519" alt="image" src="https://user-images.githubusercontent.com/273120/153993096-b3faab95-b935-489c-9a73-b97d0c079293.png">

### Explain when the primary key is not there (query slow)

notice the `56497021392` rows

<img width="1523" alt="image" src="https://user-images.githubusercontent.com/273120/153993122-92024580-346b-4b1f-a515-cd9e9c6967e8.png">

### Performance change for insert query

The `insert into logtmpsegment010ccc0a9e16636173df1de1bfc6a263` had no big performance difference whether index was there or not for this data amount. It was inserting only 160K visits though. The performance difference was around 15%. Without index the query took usually around 1.1s vs with index around 1.3seconds.
This is probably why we didn't add it initially to save this 15% of time.

On a different table where 450K visits were inserted it slowed it weirdly always took 3.1 seconds no mater with index or without. On a result set of 2M visits (rows) it slowed it down from 9.3 seconds to 9.8 seconds.

I executed the same queries every time many times to get an average.

Generally, with segments the rows are often smaller since the segment filters out many visits so I don't think this is any real issue.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
