### PR TITLE
Add mechanism to initialize vue components outside of angularjs

### DIFF
--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -150,6 +150,68 @@ window.piwikHelper = {
         return angular.element(document).injector().get(dependency);
     },
 
+    // initial call for 'body' later in this file
+    compileVueEntryComponents: function (selector) {
+      function toKebabCase(arg) {
+        return arg.substring(0, 1).toLowerCase() + arg.substring(1)
+          .replace(/[A-Z]/g, function (s) { return '-' + s.toLowerCase(); });
+      }
+
+      $('[vue-entry]', selector).each(function () {
+        var entry = $(this).attr('vue-entry');
+
+        var parts = entry.split('.');
+        if (parts.length !== 2) {
+          throw new Error('Expects vue-entry to have format Plugin.Component, where Component is exported Vue component. Got: ' + entry);
+        }
+
+        var createVNode = Vue.createVNode;
+        var createVueApp = CoreHome.createVueApp;
+        var plugin = window[parts[0]];
+        if (!plugin) {
+          throw new Error('Unknown plugin in vue-entry: ' + plugin);
+        }
+
+        var component = plugin[parts[1]];
+        if (!component) {
+          throw new Error('Unknown component in vue-entry: ' + entry);
+        }
+
+        var componentParams = {};
+        $.each(this.attributes, function () {
+          if (this.name === 'vue-entry') {
+            return;
+          }
+
+          var value = this.value;
+          try {
+            value = JSON.parse(this.value);
+          } catch (e) {
+            // pass
+          }
+
+          componentParams[toKebabCase(this.name)] = value;
+        });
+
+        var app = createVueApp({
+          render: function () {
+            return createVNode(component, componentParams);
+          },
+        });
+        app.mount(this);
+
+        this.addEventListener('matomoVueDestroy', function () {
+          app.unmount();
+        });
+      });
+    },
+
+    destroyVueComponent: function (selector) {
+      $('[vue-entry]', selector).each(function () {
+        this.dispatchEvent(new CustomEvent('matomoVueDestroy'));
+      });
+    },
+
     /**
      * As we still have a lot of old jQuery code and copy html from node to node we sometimes have to trigger the
      * compiling of angular components manually.
@@ -648,3 +710,9 @@ try {
 
 } catch (e) {}
 }(jQuery));
+
+(function ($) {
+  $(function () {
+    piwikHelper.compileVueEntryComponents('body');
+  });
+}(jQuery))


### PR DESCRIPTION
### Description:

This PR introduces a method to initialize entry Vue components without angularjs. Add the `vue-entry="Plugin.Component"` attribute to an element in a twig template and the Vue component will be initialized. Currently the attributes are only handled on the initial page load. Vue components used in old vanilla controller action results will need to have the new `piwikHelper.compileVueEntryComponents()` method called on the HTML. This method should not be mixed with `piwikHelper.compileAngularComponents()`. Other HTML attributes are used as input props to the component. The attributes can be JSON encoded.

Used in last tag-manager pull request.

Changes:
* Add piwikHelper.compileVueEntryComponents() which initializes elements w/ vue-entry as the Vue components the attribute references.
* Call the above function once on document ready.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
