### PR TITLE
Fix cookies with session lifetime

### DIFF
--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -146,7 +146,10 @@ class Cookie
             }
         }
 
-        $Expires = $this->formatExpireTime($Expires);
+        // Format expire time only for non session cookies
+        if (0 !== $Expires) {
+            $Expires = $this->formatExpireTime($Expires);
+        }
 
         $header = 'Set-Cookie: ' . rawurlencode($Name) . '=' . rawurlencode($Value)
             . (empty($Expires) ? '' : '; expires=' . $Expires)


### PR DESCRIPTION
### Description:

As a regression from https://github.com/matomo-org/matomo/pull/18179 cookies with session lifetime don't work anymore.

As stated in the Cookie class an expire of `0` should indicate a session cookie:
https://github.com/matomo-org/matomo/blob/9c666ab8cf4c591ba26cd7d992972ef47d5369a2/core/Cookie.php#L81-L82

But that doesn't work anymore as the lifetime will be always converted to a datetime, resulting in `01-Jan-1970 00:00:00 UTC`, causing the cookie to be never set.

fixes #18819

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
