### PR TITLE
Adds GitHub action to automatically update our Intl data from CLDR

### DIFF
--- a/.github/workflows/update-intl.yml
+++ b/.github/workflows/update-intl.yml
@@ -1,0 +1,122 @@
+name: Update Intl data
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 10 1 * *"
+
+permissions:
+  actions: read
+  checks: none
+  contents: write
+  deployments: none
+  issues: read
+  packages: none
+  pull-requests: write
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Fetch latest CLDR version"
+        id: cldr
+        run: |
+          CLDRRELEASES=$( curl \
+                 --request GET \
+                 --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+                 --header 'content-type: application/json' \
+                 --url https://api.github.com/repos/unicode-org/cldr-json/releases?per_page=15 )
+          for row in $(echo "${CLDRRELEASES}" | jq -r '.[] | @base64'); do
+            _jq() {
+              echo ${row} | base64 --decode | jq -r ${1}
+            }
+            if [[ $(_jq '.prerelease') == false ]]
+            then
+              echo ::set-output name=cldr-version::$(_jq '.tag_name')
+              break
+            fi
+          done
+        shell: bash
+      - name: "Check CLDR version"
+        if: steps.cldr.outputs.cldr-version == ''
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Unable to find current CLDR version')
+      - uses: actions/checkout@v2
+        with:
+          lfs: false
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer install --prefer-dist
+      - name: Quick Matomo Install
+        run: |
+          cat <<-EOF > ./config/config.ini.php
+          [General]
+          always_load_commands_from_plugin=Intl
+
+          [Development]
+          enabled = 1
+          EOF
+
+          cat ./config/config.ini.php
+      - name: Prepare git config
+        run: |
+          cat <<- EOF > $HOME/.netrc
+            machine github.com
+            login $GITHUB_ACTOR
+            password $GITHUB_TOKEN
+            machine api.github.com
+            login $GITHUB_ACTOR
+            password $GITHUB_TOKEN
+          EOF
+          chmod 600 $HOME/.netrc
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --global user.name "$GITHUB_ACTOR"
+          git push origin --delete update-intl || true
+          git branch -D update-intl || true
+          git branch update-intl
+          git checkout -f update-intl
+      - name: Update Intl data
+        run: php ./console translations:generate-intl-data --cldr-version="${{ steps.cldr.outputs.cldr-version }}"
+      - name: Push changes
+        id: push
+        run: |
+          if [[ $( git diff --numstat plugins/Intl/lang/*.json ) ]]
+          then
+            cd $GITHUB_WORKSPACE
+            git add plugins/Intl/lang/*.json
+            git commit -m "Updates Intl data from CLDR ${{ steps.cldr.outputs.cldr-version }}"
+            git push --set-upstream origin update-intl
+            echo ::set-output name=updated::1
+          fi
+      - name: Create PR
+        run: |
+          curl \
+             --request POST \
+             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+             --header 'content-type: application/json' \
+             --data '{
+              "title":"[automatic Intl data updates from CLDR ${{ steps.cldr.outputs.cldr-version }}]",
+              "body":"Updated Intl plugin data with changes from CLDR ${{ steps.cldr.outputs.cldr-version }}",
+              "head":"update-intl",
+              "base":"4.x-dev"
+              }' \
+             --url https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls
+        shell: bash
+        if: steps.push.outputs.updated

--- a/plugins/Intl/Commands/GenerateIntl.php
+++ b/plugins/Intl/Commands/GenerateIntl.php
@@ -41,6 +41,7 @@ class GenerateIntl extends ConsoleCommand
     {
         $this->setName('translations:generate-intl-data')
             ->addOption('language', 'l', InputOption::VALUE_OPTIONAL, 'language that should be fetched')
+            ->addOption('cldr-version', '', InputOption::VALUE_OPTIONAL, 'CLDR version to use for update')
             ->setDescription('Generates Intl-data for Piwik');
     }
 
@@ -71,14 +72,16 @@ class GenerateIntl extends ConsoleCommand
             $matomoLanguages = [$input->getOption('language')];
         }
 
+        if ($input->getOption('cldr-version')) {
+            $this->CLDRVersion = $input->getOption('cldr-version');
+        }
+
         $aliasesUrl = 'https://raw.githubusercontent.com/unicode-org/cldr-json/%s/cldr-json/cldr-core/supplemental/aliases.json';
         $aliasesData = Http::fetchRemoteFile(sprintf($aliasesUrl, $this->CLDRVersion));
         $aliasesData = json_decode($aliasesData, true);
-        $aliasesData = $aliasesData['supplemental']['metadata']['alias']['languageAlias'];
+        $aliasesData = $aliasesData['supplemental']['metadata']['alias']['languageAlias'] ?? [];
 
         $this->checkCurrencies($output);
-
-        $writePath = Filesystem::getPathToPiwikRoot() . '/plugins/Intl/lang/%s.json';
 
         foreach ($matomoLanguages AS $langCode) {
 
@@ -151,7 +154,7 @@ class GenerateIntl extends ConsoleCommand
 
         $currencyData = Http::fetchRemoteFile(sprintf($currencyDataUrl, $this->CLDRVersion, 'en'));
         $currencyData = json_decode($currencyData, true);
-        $currencyData = $currencyData['supplemental']['currencyData']['region'];
+        $currencyData = $currencyData['supplemental']['currencyData']['region'] ?? [];
 
         $cldrCurrencies = array();
         foreach ($currencyData as $region) {
@@ -188,7 +191,7 @@ class GenerateIntl extends ConsoleCommand
             if (empty($languageData)) {
                 $languageData = Http::fetchRemoteFile(sprintf($languageDataUrl, $this->CLDRVersion, 'en'));
                 $languageData = json_decode($languageData, true);
-                $languageData = $languageData['main']['en']['localeDisplayNames']['languages'];
+                $languageData = $languageData['main']['en']['localeDisplayNames']['languages'] ?? [];
             }
 
             if (array_key_exists($code, $languageData) && $languageData[$code] != $code) {
@@ -213,7 +216,7 @@ class GenerateIntl extends ConsoleCommand
                 try {
                     $territoryData = Http::fetchRemoteFile(sprintf($territoryDataUrl, $this->CLDRVersion, 'en'));
                     $territoryData = json_decode($territoryData, true);
-                    $territoryData = $territoryData['main']['en']['localeDisplayNames']['territories'];
+                    $territoryData = $territoryData['main']['en']['localeDisplayNames']['territories'] ?? [];
 
                     if (array_key_exists($territory, $territoryData)) {
                         $englishName .= ' ('.$territoryData[$territory].')';
@@ -242,7 +245,7 @@ class GenerateIntl extends ConsoleCommand
         try {
             $languageData = Http::fetchRemoteFile(sprintf($languageDataUrl, $this->CLDRVersion, $requestLangCode));
             $languageData = json_decode($languageData, true);
-            $languageData = $languageData['main'][$requestLangCode]['localeDisplayNames']['languages'];
+            $languageData = $languageData['main'][$requestLangCode]['localeDisplayNames']['languages'] ?? [];
 
             if (empty($languageData)) {
                 throw new \Exception();
@@ -274,7 +277,7 @@ class GenerateIntl extends ConsoleCommand
         try {
             $layoutData = Http::fetchRemoteFile(sprintf($layoutDirectionUrl, $this->CLDRVersion, $requestLangCode));
             $layoutData = json_decode($layoutData, true);
-            $layoutData = $layoutData['main'][$requestLangCode]['layout']['orientation'];
+            $layoutData = $layoutData['main'][$requestLangCode]['layout']['orientation'] ?? [];
 
             if (empty($layoutData)) {
                 throw new \Exception();
@@ -312,7 +315,7 @@ class GenerateIntl extends ConsoleCommand
         try {
             $territoryData = Http::fetchRemoteFile(sprintf($territoryDataUrl, $this->CLDRVersion, $requestLangCode));
             $territoryData = json_decode($territoryData, true);
-            $territoryData = $territoryData['main'][$requestLangCode]['localeDisplayNames']['territories'];
+            $territoryData = $territoryData['main'][$requestLangCode]['localeDisplayNames']['territories'] ?? [];
 
             if (empty($territoryData)) {
                 throw new \Exception();
@@ -343,7 +346,7 @@ class GenerateIntl extends ConsoleCommand
         try {
             $calendarData = Http::fetchRemoteFile(sprintf($calendarDataUrl, $this->CLDRVersion, $requestLangCode));
             $calendarData = json_decode($calendarData, true);
-            $calendarData = $calendarData['main'][$requestLangCode]['dates']['calendars']['gregorian'];
+            $calendarData = $calendarData['main'][$requestLangCode]['dates']['calendars']['gregorian'] ?? [];
 
             if (empty($calendarData)) {
                 throw new \Exception();
@@ -419,7 +422,7 @@ class GenerateIntl extends ConsoleCommand
         try {
             $dateFieldData = Http::fetchRemoteFile(sprintf($dateFieldsUrl, $this->CLDRVersion, $requestLangCode));
             $dateFieldData = json_decode($dateFieldData, true);
-            $dateFieldData = $dateFieldData['main'][$requestLangCode]['dates']['fields'];
+            $dateFieldData = $dateFieldData['main'][$requestLangCode]['dates']['fields'] ?? [];
 
             if (empty($dateFieldData)) {
                 throw new \Exception();
@@ -446,7 +449,7 @@ class GenerateIntl extends ConsoleCommand
         try {
             $timeZoneData = Http::fetchRemoteFile(sprintf($timeZoneDataUrl, $this->CLDRVersion, $requestLangCode));
             $timeZoneData = json_decode($timeZoneData, true);
-            $timeZoneData = $timeZoneData['main'][$requestLangCode]['dates']['timeZoneNames'];
+            $timeZoneData = $timeZoneData['main'][$requestLangCode]['dates']['timeZoneNames'] ?? [];
 
             if (empty($timeZoneData)) {
                 throw new \Exception();
@@ -509,7 +512,7 @@ class GenerateIntl extends ConsoleCommand
         try {
             $unitsData = Http::fetchRemoteFile(sprintf($unitsUrl, $this->CLDRVersion, $requestLangCode));
             $unitsData = json_decode($unitsData, true);
-            $unitsData = $unitsData['main'][$requestLangCode]['numbers'];
+            $unitsData = $unitsData['main'][$requestLangCode]['numbers'] ?? [];
 
             if (empty($unitsData)) {
                 throw new \Exception();
@@ -539,7 +542,7 @@ class GenerateIntl extends ConsoleCommand
         try {
             $unitsData = Http::fetchRemoteFile(sprintf($unitsUrl, $this->CLDRVersion, $requestLangCode));
             $unitsData = json_decode($unitsData, true);
-            $unitsData = $unitsData['main'][$requestLangCode]['units'];
+            $unitsData = $unitsData['main'][$requestLangCode]['units'] ?? [];
 
             if (empty($unitsData)) {
                 throw new \Exception();
@@ -597,7 +600,7 @@ class GenerateIntl extends ConsoleCommand
         try {
             $currencyData = Http::fetchRemoteFile(sprintf($currenciesUrl, $this->CLDRVersion, $requestLangCode));
             $currencyData = json_decode($currencyData, true);
-            $currencyData = $currencyData['main'][$requestLangCode]['numbers']['currencies'];
+            $currencyData = $currencyData['main'][$requestLangCode]['numbers']['currencies'] ?? [];
 
             if (empty($currencyData)) {
                 throw new \Exception();


### PR DESCRIPTION
### Description:

The action will automatically run on the 1st of every month. In additition is can be triggered manually if needed.

The action first fetches the list of releases of CLDR to determine the version to use for updates. It will only use stable releases.
If updates are available a PR will be automatically created.

fixes #18833

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
