### PR TITLE
Remove no longer needed method in UsersManager

### DIFF
--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -68,11 +68,6 @@ class Controller extends ControllerAdmin
         parent::__construct();
     }
 
-    static function orderByName($a, $b)
-    {
-        return strcmp($a['name'], $b['name']);
-    }
-
     /**
      * The "Manage Users and Permissions" Admin UI screen
      */


### PR DESCRIPTION
Avoids fatal errors like "Too few arguments to function Piwik\\Plugins\\UsersManager\\Controller::orderByName(), 0 passed and exactly 2 expected" when opening 
 `/index.php?module=UsersManager&action=orderByName`. I couldn't find usage of this method. If it was still used, we could make it private.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
