### PR TITLE
Remove team check from release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,21 +44,6 @@ jobs:
         with:
           script: |
               core.setFailed('Release password didn\'t match')
-      - name: "Check if user is in group"
-        run: |
-          MEMBER=$( curl -s \
-                 --request GET \
-                 --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-                 --header 'content-type: application/json' \
-                 --url https://api.github.com/orgs/matomo-org/teams/release-team/members \
-                 | jq '.[] | select(.login == "${{ github.actor }}")' )
-
-          if [[ -z "$MEMBER" ]]
-          then
-           echo "Action was not triggered by a member with release permission"
-           exit 1;
-          fi
-        shell: bash
       - uses: actions/checkout@v2
         with:
           lfs: false


### PR DESCRIPTION
### Description:

`GITHUB_TOKEN` doesn't have access to the members of public team so the release-team member check fails. Removing the check means we will rely on the password only which may be sufficient anyway.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
