### PR TITLE
Apply max execution query time to Live.getCounters API and queryAdjacentVisitorId method

### DIFF
--- a/plugins/Live/Controller.php
+++ b/plugins/Live/Controller.php
@@ -14,6 +14,7 @@ use Piwik\Config;
 use Piwik\Piwik;
 use Piwik\DataTable;
 use Piwik\Plugins\Goals\API as APIGoals;
+use Piwik\Plugins\Live\Exception\MaxExecutionTimeExceededException;
 use Piwik\Plugins\Live\Visualizations\VisitorLog;
 use Piwik\Url;
 use Piwik\View;
@@ -116,20 +117,35 @@ class Controller extends \Piwik\Plugin\Controller
     private function setCounters($view)
     {
         $segment = Request::getRawSegmentFromRequest();
-        $last30min = Request::processRequest('Live.getCounters', [
-            'idSite' => $this->idSite,
-            'lastMinutes' => 30,
-            'segment' => $segment,
-            'showColumns' => 'visits,actions',
-        ], $default = []);
-        $last30min = $last30min[0];
-        $today = Request::processRequest('Live.getCounters', [
-            'idSite' => $this->idSite,
-            'lastMinutes' => 24 * 60,
-            'segment' => $segment,
-            'showColumns' => 'visits,actions',
-        ], $default = []);
-        $today = $today[0];
+        $executeTodayQuery = true;
+        try {
+            $last30min = Request::processRequest('Live.getCounters', [
+                'idSite' => $this->idSite,
+                'lastMinutes' => 30,
+                'segment' => $segment,
+                'showColumns' => 'visits,actions',
+            ], $default = []);
+            $last30min = $last30min[0];
+        } catch (MaxExecutionTimeExceededException $e) {
+            $last30min = ['visits' => '-', 'actions' => '-'];
+            $today = ['visits' => '-', 'actions' => '-'];
+            $executeTodayQuery = false; // if query for last 30 min failed, we also expect the 24 hour query to fail
+        }
+
+        try {
+            if ($executeTodayQuery) {
+                $today = Request::processRequest('Live.getCounters', [
+                    'idSite' => $this->idSite,
+                    'lastMinutes' => 24 * 60,
+                    'segment' => $segment,
+                    'showColumns' => 'visits,actions',
+                ], $default = []);
+                $today = $today[0];
+            }
+        } catch (MaxExecutionTimeExceededException $e) {
+            $today = ['visits' => '-', 'actions' => '-'];
+        }
+
         $view->visitorsCountHalfHour = $last30min['visits'];
         $view->visitorsCountToday = $today['visits'];
         $view->pisHalfhour = $last30min['actions'];

--- a/plugins/Live/Controller.php
+++ b/plugins/Live/Controller.php
@@ -118,6 +118,8 @@ class Controller extends \Piwik\Plugin\Controller
     {
         $segment = Request::getRawSegmentFromRequest();
         $executeTodayQuery = true;
+        $view->countErrorToday = '';
+        $view->countErrorHalfHour = '';
         try {
             $last30min = Request::processRequest('Live.getCounters', [
                 'idSite' => $this->idSite,
@@ -129,6 +131,8 @@ class Controller extends \Piwik\Plugin\Controller
         } catch (MaxExecutionTimeExceededException $e) {
             $last30min = ['visits' => '-', 'actions' => '-'];
             $today = ['visits' => '-', 'actions' => '-'];
+            $view->countErrorToday = $e->getMessage();
+            $view->countErrorHalfHour = $e->getMessage();
             $executeTodayQuery = false; // if query for last 30 min failed, we also expect the 24 hour query to fail
         }
 
@@ -144,6 +148,7 @@ class Controller extends \Piwik\Plugin\Controller
             }
         } catch (MaxExecutionTimeExceededException $e) {
             $today = ['visits' => '-', 'actions' => '-'];
+            $view->countErrorToday = $e->getMessage();
         }
 
         $view->visitorsCountHalfHour = $last30min['visits'];

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -404,7 +404,7 @@ class Model
         try {
             $numVisitors = $readerDb->fetchOne($query['sql'], $query['bind']);
         } catch (Exception $e) {
-            $this->handleMaxExecutionTimeError($readerDb, $e, $segment, $startDate, Date::now(), null, 0, $query);
+            $this->handleMaxExecutionTimeError($readerDb, $e, $segment->getOriginalString(), $startDate, Date::now(), null, 0, $query);
             throw $e;
         }
 

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -399,6 +399,11 @@ class Model
         $query   = $segment->getSelectQuery($select, $from, $where, $bind);
 
         $query['sql'] = DbHelper::addMaxExecutionTimeHintToQuery($query['sql'], $this->getLiveQueryMaxExecutionTime());
+        $query['sql'] = trim($query['sql']);
+
+        if (0 === stripos($query['sql'], 'SELECT')) {
+            $query['sql'] = 'SELECT /* Live.getCounters */' . mb_substr($query['sql'], strlen('SELECT'));
+        }
 
         $readerDb = Db::getReader();
         try {

--- a/plugins/Live/Reports/GetSimpleLastVisitCount.php
+++ b/plugins/Live/Reports/GetSimpleLastVisitCount.php
@@ -14,6 +14,7 @@ use Piwik\Piwik;
 use Piwik\Plugin\Report;
 use Piwik\Plugins\Live\Controller;
 use Piwik\API\Request;
+use Piwik\Plugins\Live\Exception\MaxExecutionTimeExceededException;
 use Piwik\Report\ReportWidgetFactory;
 use Piwik\View;
 use Piwik\Widget\WidgetsList;
@@ -38,16 +39,26 @@ class GetSimpleLastVisitCount extends Base
         $lastMinutes = Config::getInstance()->General[Controller::SIMPLE_VISIT_COUNT_WIDGET_LAST_MINUTES_CONFIG_KEY];
 
         $params    = array('lastMinutes' => $lastMinutes, 'showColumns' => array('visits', 'visitors', 'actions'));
-        $lastNData = Request::processRequest('Live.getCounters', $params);
+        $refereshAfterSeconds = Config::getInstance()->General['live_widget_refresh_after_seconds'];
+
+        $error = '';
+        try {
+            $lastNData = Request::processRequest('Live.getCounters', $params);
+        } catch (MaxExecutionTimeExceededException $e) {
+            $error = $e->getMessage();
+            $lastNData = [0 => ['visitors' => '-', 'visits' => '-', 'actions' => '-']];
+            $refereshAfterSeconds = 999999999; // we don't want it to refresh again any time soon as same issue would happen again
+        }
 
         $formatter = new Formatter();
 
         $view = new View('@Live/getSimpleLastVisitCount');
+        $view->error = $error;
         $view->lastMinutes = $lastMinutes;
         $view->visitors    = $formatter->getPrettyNumber($lastNData[0]['visitors']);
         $view->visits      = $formatter->getPrettyNumber($lastNData[0]['visits']);
         $view->actions     = $formatter->getPrettyNumber($lastNData[0]['actions']);
-        $view->refreshAfterXSecs = Config::getInstance()->General['live_widget_refresh_after_seconds'];
+        $view->refreshAfterXSecs = $refereshAfterSeconds;
         $view->translations = array(
             'one_visitor' => Piwik::translate('Live_NbVisitor'),
             'visitors'    => Piwik::translate('Live_NbVisitors'),

--- a/plugins/Live/templates/_totalVisitors.twig
+++ b/plugins/Live/templates/_totalVisitors.twig
@@ -16,13 +16,13 @@
         <tbody>
         <tr class="">
             <td class="label column">{{ 'Live_LastHours'|translate(24) }}</td>
-            <td class="column">{{ visitorsCountToday|number }}</td>
-            <td class="column">{{ pisToday|number }}</td>
+            <td class="column" {% if countErrorToday %}title="{{ countErrorToday|e('html_attr') }}"{% endif %}>{{ visitorsCountToday|number }}</td>
+            <td class="column" {% if countErrorToday %}title="{{ countErrorToday|e('html_attr') }}"{% endif %}>{{ pisToday|number }}</td>
         </tr>
         <tr class="">
             <td class="label column">{{ 'Live_LastMinutes'|translate(30) }}</td>
-            <td class="column">{{ visitorsCountHalfHour|number }}</td>
-            <td class="column">{{ pisHalfhour|number }}</td>
+            <td class="column" {% if countErrorHalfHour %}title="{{ countErrorHalfHour|e('html_attr') }}"{% endif %}>{{ visitorsCountHalfHour|number }}</td>
+            <td class="column" {% if countErrorHalfHour %}title="{{ countErrorHalfHour|e('html_attr') }}"{% endif %}>{{ pisHalfhour|number }}</td>
         </tr>
         </tbody>
     </table>

--- a/plugins/Live/templates/getSimpleLastVisitCount.twig
+++ b/plugins/Live/templates/getSimpleLastVisitCount.twig
@@ -3,6 +3,7 @@
         <div>{{ visitors }}</div>
     </div>
     <br/>
+    {% if error is not empty %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
 
     <div class='simple-realtime-elaboration'>
         {% set visitsMessage %}

--- a/plugins/Live/tests/Integration/ModelTest.php
+++ b/plugins/Live/tests/Integration/ModelTest.php
@@ -18,6 +18,7 @@ use Piwik\Plugins\Live\Model;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\Tests\Integration\SegmentTest;
 
 /**
@@ -120,6 +121,10 @@ class ModelTest extends IntegrationTestCase
 
     public function test_getLastMinutesCounterForQuery_maxExecutionTime()
     {
+        if (SystemTestCase::isMysqli()) {
+            $this->markTestSkipped('max_execution_time not supported on mysqli');
+            return;
+        }
         $this->expectException(MaxExecutionTimeExceededException::class);
         $this->expectExceptionMessage('Live_QueryMaxExecutionTimeExceeded');
         $this->setLowestMaxExecutionTime();
@@ -133,6 +138,10 @@ class ModelTest extends IntegrationTestCase
 
     public function test_queryAdjacentVisitorId_maxExecutionTime()
     {
+        if (SystemTestCase::isMysqli()) {
+            $this->markTestSkipped('max_execution_time not supported on mysqli');
+            return;
+        }
         $this->expectException(MaxExecutionTimeExceededException::class);
         $this->expectExceptionMessage('Live_QueryMaxExecutionTimeExceeded');
         $this->setLowestMaxExecutionTime();

--- a/plugins/Live/tests/Integration/ModelTest.php
+++ b/plugins/Live/tests/Integration/ModelTest.php
@@ -124,6 +124,8 @@ class ModelTest extends IntegrationTestCase
         $this->expectExceptionMessage('Live_QueryMaxExecutionTimeExceeded');
         $this->setLowestMaxExecutionTime();
 
+        $this->trackPageView();
+
         $model = new Model();
         $model->queryAndWhereSleepTestsOnly = true;
         $model->getNumVisits(1, 999999, '');
@@ -135,6 +137,7 @@ class ModelTest extends IntegrationTestCase
         $this->expectExceptionMessage('Live_QueryMaxExecutionTimeExceeded');
         $this->setLowestMaxExecutionTime();
 
+        $this->trackPageView();
         $model = new Model();
         $model->queryAndWhereSleepTestsOnly = true;
         $model->queryAdjacentVisitorId(1, '1234567812345678', Date::yesterday()->getDatetime(), '', true);
@@ -528,5 +531,15 @@ class ModelTest extends IntegrationTestCase
         $general = $config->General;
         $general['live_query_max_execution_time'] = $time;
         $config->General = $general;
+    }
+
+    private function trackPageView(): void
+    {
+        // Needed for the tests that may execute a sleep() to test max execution time. Otherwise if the table is empty
+        // the sleep would not be executed making the tests fail randomly
+        $t = Fixture::getTracker(1, Date::now()->getDatetime(), $defaultInit = true);
+        $t->setTokenAuth(Fixture::getTokenAuth());
+        $t->setVisitorId(substr(sha1('X4F66G776HGI'), 0, 16));
+        $t->doTrackPageView('foo');
     }
 }


### PR DESCRIPTION
### Description:

Noticed the max execution query configuration is not applied to live counters which it is now. When the query takes too long, then it will show a `dash` and a tooltip explaining that it took too long to get the data. The message may vary depending if a segment is selected or not 
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/273120/155805776-efb11a8a-4f66-41d6-9035-db082bf842e3.png">

For queryAdjacentVisitorId if there's a timeout we simply assume that no next or previous visitor was found.

Checked https://matomo.org/faq/how-to/how-can-i-automatically-stop-long-running-database-queries/ which doesn't need to be updated by the looks.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
