### PR TITLE
With multi_server_environment enable maintain won't send 503 as response

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -639,7 +639,7 @@ assume_secure_protocol = 0
 ; By enabling this flag we will for example not allow the installation of a plugin via the UI as a plugin would be only
 ; installed on one server or a config one change would be only made on one server instead of all servers.
 ; This flag doesn't need to be enabled when the config file is on a shared filesystem such as NFS or EFS.
-; During maintenance mode, multiple environment will continue return 200 as response on API request.
+; When enabled, Matomo will return the response code 200 instead of 503 in maintenance mode.
 multi_server_environment = 0
 
 ; List of proxy headers for client IP addresses

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -639,6 +639,7 @@ assume_secure_protocol = 0
 ; By enabling this flag we will for example not allow the installation of a plugin via the UI as a plugin would be only
 ; installed on one server or a config one change would be only made on one server instead of all servers.
 ; This flag doesn't need to be enabled when the config file is on a shared filesystem such as NFS or EFS.
+; During maintenance mode, multiple environment will continue return 200 as response on API request.
 multi_server_environment = 0
 
 ; List of proxy headers for client IP addresses

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -11,6 +11,7 @@ namespace Piwik;
 
 use Exception;
 use Piwik\API\Request;
+use Piwik\Config\GeneralConfig;
 use Piwik\Container\StaticContainer;
 use Piwik\DataTable\Manager;
 use Piwik\Exception\AuthenticationFailedException;
@@ -493,12 +494,12 @@ class FrontController extends Singleton
 
     protected function handleMaintenanceMode()
     {
-        if ((Config::getInstance()->General['maintenance_mode'] != 1) || Common::isPhpCliMode() ) {
+        if ((GeneralConfig::getConfigValue('maintenance_mode') != 1) || Common::isPhpCliMode() ) {
             return;
         }
 
         // as request matomo behind load balancer should not return 503. https://github.com/matomo-org/matomo/issues/18054
-        if (Config::getInstance()->General['multi_server_environment'] != 1) {
+        if (GeneralConfig::getConfigValue('multi_server_environment') != 1) {
             Common::sendResponseCode(503);
         }
 

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -493,11 +493,14 @@ class FrontController extends Singleton
 
     protected function handleMaintenanceMode()
     {
-        // as request matomo behind load balancer should not return 503. https://github.com/matomo-org/matomo/issues/18054
-        if ((Config::getInstance()->General['maintenance_mode'] != 1) || Common::isPhpCliMode() || Config::getInstance()->General['multi_server_environment']) {
+        if ((Config::getInstance()->General['maintenance_mode'] != 1) || Common::isPhpCliMode() ) {
             return;
         }
-        Common::sendResponseCode(503);
+
+        // as request matomo behind load balancer should not return 503. https://github.com/matomo-org/matomo/issues/18054
+        if (Config::getInstance()->General['multi_server_environment'] != 1) {
+            Common::sendResponseCode(503);
+        }
 
         $logoUrl = 'plugins/Morpheus/images/logo.svg';
         $faviconUrl = 'plugins/CoreHome/images/favicon.png';

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -493,7 +493,8 @@ class FrontController extends Singleton
 
     protected function handleMaintenanceMode()
     {
-        if ((Config::getInstance()->General['maintenance_mode'] != 1) || Common::isPhpCliMode()) {
+        // as request matomo behind load balancer should not return 503. https://github.com/matomo-org/matomo/issues/18054
+        if ((Config::getInstance()->General['maintenance_mode'] != 1) || Common::isPhpCliMode() || Config::getInstance()->General['multi_server_environment']) {
             return;
         }
         Common::sendResponseCode(503);


### PR DESCRIPTION
### Description:
Fixes: #18054 

With multi_server_environment enable maintain won't send 503 as a response. Missing tests

Docs update
https://matomo.org/faq/how-to/faq_20278/
 ```
+ When Matomo is maintenance_mode, the API will return `503`, unless Matomo is configured behind a load balancer, with `General` config `multi_server_environment=1`, should return http status code `200` 
```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
