### PR TITLE
Handle case only file name updates on case insensitive file systems

### DIFF
--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -314,7 +314,7 @@ class Filesystem
             return str_replace($target, '', $file);
         }, $targetFiles);
 
-        if (FileSystem::isFileSystemCaseSensitive()) {
+        if (FileSystem::isFileSystemCaseInsensitive()) {
             $diff = array_udiff($targetFiles, $sourceFiles, 'strcasecmp');
         } else {
             $diff = array_diff($targetFiles, $sourceFiles);
@@ -566,7 +566,7 @@ class Filesystem
      *
      * @return bool
      */
-    public static function isFileSystemCaseSensitive() : bool
+    public static function isFileSystemCaseInsensitive() : bool
     {
         $testFileName = 'caseSensitivityTest.txt';
         $pathTmp = StaticContainer::get('path.tmp');

--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -314,7 +314,11 @@ class Filesystem
             return str_replace($target, '', $file);
         }, $targetFiles);
 
-        $diff = array_diff($targetFiles, $sourceFiles);
+        if (FileSystem::isFileSystemCaseSensitive()) {
+            $diff = array_udiff($targetFiles, $sourceFiles, 'strcasecmp');
+        } else {
+            $diff = array_diff($targetFiles, $sourceFiles);
+        }
 
         return array_values($diff);
     }
@@ -555,6 +559,23 @@ class Filesystem
         $pathIsTmp = StaticContainer::get('path.tmp');
         $isPathWithinTmpFolder = strpos($path, $pathIsTmp) === 0;
         return $isPathWithinTmpFolder;
+    }
+
+    /**
+     * Check if the filesystem is case sensitive by writing a temporary file
+     *
+     * @return bool
+     */
+    public static function isFileSystemCaseSensitive() : bool
+    {
+        $testFileName = 'caseSensitivityTest.txt';
+        $pathTmp = StaticContainer::get('path.tmp');
+        @file_put_contents($pathTmp.'/'.$testFileName, 'Nothing to see here.');
+        if (\file_exists($pathTmp.'/'.strtolower($testFileName))) {
+             // Wrote caseSensitivityTest.txt but casesensitivitytest.txt exists, so case insensitive
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/tests/PHPUnit/Unit/FilesystemTest.php
+++ b/tests/PHPUnit/Unit/FilesystemTest.php
@@ -327,9 +327,6 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
     private function createCaseInsensitiveSourceFiles()
     {
         $source = $this->createEmptySource();
-        Filesystem::mkdir($source . '/CoreHome');
-        Filesystem::mkdir($source . '/CoreHome/vue');
-        Filesystem::mkdir($source . '/CoreHome/vue/src');
         Filesystem::mkdir($source . '/CoreHome/vue/src/MenuDropdown');
 
         file_put_contents($source . '/CoreHome/vue/src/MenuDropdown/MenuDropdown.vue', '');

--- a/tests/PHPUnit/Unit/FilesystemTest.php
+++ b/tests/PHPUnit/Unit/FilesystemTest.php
@@ -14,6 +14,7 @@ use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
 /**
  * @group Core
+ * @group FileSystem
  */
 class FilesystemTest extends \PHPUnit\Framework\TestCase
 {
@@ -193,6 +194,22 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(), $result);
     }
 
+    public function test_unlockTargetFilesNotPresentInSource_shouldUnlinkCaseInsensitiveFiles()
+    {
+        $sourceInsensitive = $this->createCaseInsensitiveSourceFiles();
+        $targetInsensitive = $this->createCaseInsensitiveTargetFiles();
+
+        // make sure there is a difference between those folders
+        $result = Filesystem::directoryDiff($sourceInsensitive, $targetInsensitive);
+        $this->assertNotEmpty($result);
+
+        Filesystem::unlinkTargetFilesNotPresentInSource($sourceInsensitive, $targetInsensitive);
+
+        // make sure there is no longer a difference
+        $result = Filesystem::directoryDiff($sourceInsensitive, $targetInsensitive);
+        $this->assertEquals(array(), $result);
+    }
+
     private function createSourceFiles()
     {
         $source = $this->createEmptySource();
@@ -263,6 +280,46 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
         Filesystem::mkdir($this->testPath . '/target');
 
         return $this->testPath . '/target';
+    }
+
+    private function createEmptyCaseInsensitiveSource()
+    {
+        Filesystem::mkdir($this->testPath . '/Source');
+
+        return $this->testPath . '/Source';
+    }
+
+    private function createEmptyCaseInsensitiveTarget()
+    {
+        Filesystem::mkdir($this->testPath . '/Target');
+
+        return $this->testPath . '/Target';
+    }
+
+    private function createCaseInsensitiveTargetFiles()
+    {
+        $target = $this->createEmptyCaseInsensitiveTarget();
+        Filesystem::mkdir($target . '/CoreHome');
+        Filesystem::mkdir($target . '/CoreHome/vue');
+        Filesystem::mkdir($target . '/CoreHome/vue/src');
+        Filesystem::mkdir($target . '/CoreHome/vue/src/Menudropdown');
+
+        file_put_contents($target . '/CoreHome/vue/src/Menudropdown/Menudropdown.vue', '');
+
+        return $target;
+    }
+
+    private function createCaseInsensitiveSourceFiles()
+    {
+        $source = $this->createEmptyCaseInsensitiveSource();
+        Filesystem::mkdir($source . '/CoreHome');
+        Filesystem::mkdir($source . '/CoreHome/vue');
+        Filesystem::mkdir($source . '/CoreHome/vue/src');
+        Filesystem::mkdir($source . '/CoreHome/vue/src/MenuDropdown');
+
+        file_put_contents($source . '/CoreHome/vue/src/MenuDropdown/MenuDropdown.vue', '');
+
+        return $source;
     }
 
     public function test_getFileSize_ZeroSize()

--- a/tests/PHPUnit/Unit/FilesystemTest.php
+++ b/tests/PHPUnit/Unit/FilesystemTest.php
@@ -314,9 +314,6 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
     private function createCaseInsensitiveTargetFiles()
     {
         $target = $this->createEmptyTarget();
-        Filesystem::mkdir($target . '/CoreHome');
-        Filesystem::mkdir($target . '/CoreHome/vue');
-        Filesystem::mkdir($target . '/CoreHome/vue/src');
         Filesystem::mkdir($target . '/CoreHome/vue/src/Menudropdown');
 
         file_put_contents($target . '/CoreHome/vue/src/Menudropdown/Menudropdown.vue', '');

--- a/tests/PHPUnit/Unit/FilesystemTest.php
+++ b/tests/PHPUnit/Unit/FilesystemTest.php
@@ -204,7 +204,7 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
 
         $result = Filesystem::directoryDiff($sourceInsensitive, $targetInsensitive);
 
-        if (Filesystem::isFileSystemCaseSensitive()) {
+        if (Filesystem::isFileSystemCaseInsensitive()) {
 
             // Case insensitive filesystem:
             // Since the target and source will be treated as the same file then we do not want directoryDiff() to


### PR DESCRIPTION
### Description:

Fixes #18724

## Background

During an update, any files that already exist in the installation destination but no longer exist in the update package will be identified and removed.

The process is:
1) Copy the new files.
2) Check for obsolete files that exist in the installation target but are no longer part of the package.
3) Delete the obsolete files.

This causes a problem when a file is renamed with only a change in case, eg. `Myfile` to `MyFile`. 

For case sensitive systems this works:
1) The new `MyFile` is copied without interfering with the old `Myfile`
2) `Myfile` is identified as not being in the source package and noted for deletion.
3) The obsolete `Myfile` is correctly unlinked without interfering with the new `MyFile`.

For case insensitive system this fails:
1) The new `MyFile` is copied and overwrites the old `Myfile` as the name is treated as the same.
2) `Myfile` is identified as not being in the source package and noted for deletion.
3) The new `MyFile` is incorrectly deleted as the name is treated as the same, this results in a missing file.

## Fix 
To fix this a new method has been added which checks if the file system is case insensitive by writing a file with one case and checking if it exists using another case. If the file is reported to exist under a differently cased filename then the file system is assumed to be case insensitive.

When checking for files which exist in the installation but not in the source package and a case insensitive file system is detected then the file name comparison will be performed in a case insensitive manner, this results in the following behaviour:

1) The new `MyFile` is copied and overwrites the old `Myfile` as the name is treated as the same.
2) `MyFile` in the source package is compared case insensitively with the existing `Myfile` and considered to exist in the source package, so it is not noted for deletion.
3)  No attempt is made to delete `Myfile` and as it has been overwritten with the new `MyFile`, resulting in the new file in the correct place.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
