### PR TITLE
Ensure referrer spam list will be update to date in new releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "matomo/ini": "~3.0",
         "matomo/matomo-php-tracker": "^3.0",
         "matomo/network": "~2.0",
-        "matomo/referrer-spam-list": "~4.0.0",
+        "matomo/referrer-spam-list": "dev-master",
         "matomo/searchengine-and-social-list": "~3.0",
         "monolog/monolog": "~1.11",
         "mustangostang/spyc": "~0.6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7594badf335be345564cc3259be6940e",
+    "content-hash": "9f6dbec89d3c3357d4208cdf4be7ce74",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -695,22 +695,23 @@
         },
         {
             "name": "matomo/referrer-spam-list",
-            "version": "4.0.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/referrer-spam-list.git",
-                "reference": "afe4c1ea107ee7a8915a0d5eb0031cf0366608a8"
+                "reference": "980999af6f2f42c715066ef6b8ea289d34ae88ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/afe4c1ea107ee7a8915a0d5eb0031cf0366608a8",
-                "reference": "afe4c1ea107ee7a8915a0d5eb0031cf0366608a8",
+                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/980999af6f2f42c715066ef6b8ea289d34ae88ee",
+                "reference": "980999af6f2f42c715066ef6b8ea289d34ae88ee",
                 "shasum": ""
             },
             "replace": {
                 "matomo/referrer-spam-blacklist": "*",
                 "piwik/referrer-spam-blacklist": "*"
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -719,9 +720,9 @@
             "description": "Community-contributed list of referrer spammers",
             "support": {
                 "issues": "https://github.com/matomo-org/referrer-spam-list/issues",
-                "source": "https://github.com/matomo-org/referrer-spam-list/tree/4.0.0"
+                "source": "https://github.com/matomo-org/referrer-spam-list/tree/master"
             },
-            "time": "2020-08-10T19:54:07+00:00"
+            "time": "2022-02-12T02:36:05+00:00"
         },
         {
             "name": "matomo/searchengine-and-social-list",
@@ -4592,6 +4593,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "matomo/referrer-spam-list": 20,
         "lox/xhprof": 20
     },
     "prefer-stable": false,


### PR DESCRIPTION
### Description:

As we actually aren't publishing any new releases for https://github.com/matomo-org/referrer-spam-list, the list is only updated through the scheduled task within Matomo. If Internet connection is disabled that won't work and the list won't be updated.

As the scheduled task fetches the latest version from `master` branch, I've updated the composer requirement to do the same.
This should ensure that every automatic composer update will also update to the latest list.

fixes #18768

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
