### PR TITLE
Fix comparison for conversion reports

### DIFF
--- a/plugins/API/Filter/DataComparisonFilter.php
+++ b/plugins/API/Filter/DataComparisonFilter.php
@@ -298,6 +298,10 @@ class DataComparisonFilter
                 'format_metrics' => 0,
                 'label' => '',
                 'flat' => Common::getRequestVar('flat', 0, 'int', $this->request),
+                'filter_add_columns_when_show_all_columns' => Common::getRequestVar('filter_add_columns_when_show_all_columns', '', 'string', $this->request),
+                'filter_update_columns_when_show_all_goals' => Common::getRequestVar('filter_update_columns_when_show_all_goals', '', 'string', $this->request),
+                'filter_show_goal_columns_process_goals' => Common::getRequestVar('filter_show_goal_columns_process_goals', '', 'string', $this->request),
+                'idGoal' => Common::getRequestVar('idGoal', '', 'string', $this->request),
             ],
             $paramsToModify
         );

--- a/tests/UI/expected-screenshots/Comparison_goals_table.png
+++ b/tests/UI/expected-screenshots/Comparison_goals_table.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:205c3a5c96bd29a40a3d9b3e8770db001effe5578765d55290a89567d8d71dd2
-size 144169
+oid sha256:05f877c6c566eb09aad6ac404d4a0f272703d1c731a40dd77b2649c7ec43b9ec
+size 147925

--- a/tests/UI/expected-screenshots/Comparison_goals_table_specific.png
+++ b/tests/UI/expected-screenshots/Comparison_goals_table_specific.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:522d360bfec1df54f6eafa68cb389f3a580c265b86a95fc78d4abaaf37da3596
+size 167427

--- a/tests/UI/specs/Comparison_spec.js
+++ b/tests/UI/specs/Comparison_spec.js
@@ -241,10 +241,16 @@ describe("Comparison", function () {
         expect(await dialog.screenshot()).to.matchImage('segmented_visitorlog');
     });
 
-    it('should show the goals table correctly when comparing segments and period', async () => {
+    it('should show the goals overview table correctly when comparing segments and period', async () => {
         await page.goto(goalsTableUrl);
         await page.waitForNetworkIdle();
         expect(await page.screenshot({ fullPage: true })).to.matchImage('goals_table');
+    });
+
+    it('should show a specific goals table correctly when comparing segments and period', async () => {
+        await page.goto(goalsTableUrl + '&idGoal=1');
+        await page.waitForNetworkIdle();
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('goals_table_specific');
     });
 
     it('should load a widgetized sparklines visualization correctly', async () => {


### PR DESCRIPTION
### Description:

The goal specific query parameters were not forwarded when fetching the compared reports, which caused the goal metrics to be unavailable.

fixes #18869

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
