### PR TITLE
[Vue] Allow modals to be identified by attribute in case it isnt desired to add .ui-confirm styles.

### DIFF
--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -339,7 +339,7 @@ window.piwikHelper = {
             // skip this button if it's part of another modal, the current modal can launch
             // (which is true if there are more than one parent elements contained in domElem,
             // w/ css class ui-confirm)
-            const uiConfirm = $button.parents('.ui-confirm').filter(function () {
+            const uiConfirm = $button.parents('.ui-confirm,[ui-confirm]').filter(function () {
               return domElem[0] === this || $.contains(domElem[0], this);
             });
             if (uiConfirm.length > 1) {


### PR DESCRIPTION
### Description:

TagManager modals sometimes use .tag-ui-confirm because it is not desired to use the .ui-confirm styles. However in core .ui-confirm is used to check whether a modal button belongs to a nested modal, so buttons that appear to other modals can be detected for some tag manager modals. Fixed by allowing detection via `[ui-confirm]` as well.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
