### PR TITLE
[Vue] Fix regression in plugin order determination, new param keepUnresolved is not used in function.

### DIFF
--- a/core/AssetManager/UIAssetFetcher/PluginUmdAssetFetcher.php
+++ b/core/AssetManager/UIAssetFetcher/PluginUmdAssetFetcher.php
@@ -230,6 +230,7 @@ class PluginUmdAssetFetcher extends UIAssetFetcher
                 // check if dependency is not activated
                 if (!in_array($pluginDependency, $plugins)
                     && !in_array($pluginDependency, $result)
+                    && !$keepUnresolved
                 ) {
                     return;
                 }

--- a/tests/PHPUnit/Integration/AssetManager/UIAssetFetcher/PluginUmdAssetFetcherTest.php
+++ b/tests/PHPUnit/Integration/AssetManager/UIAssetFetcher/PluginUmdAssetFetcherTest.php
@@ -315,6 +315,26 @@ class PluginUmdAssetFetcherTest extends UnitTestCase
         $this->assertEquals($expectedAssets, $assets);
     }
 
+    public function test_orderPluginsByPluginDependencies()
+    {
+        $pluginList = PluginUmdAssetFetcher::orderPluginsByPluginDependencies([
+            'TestPlugin4',
+            'TestPlugin1',
+            'TestPlugin2',
+        ]);
+        $this->assertEquals(['TestPlugin4', 'TestPlugin1', 'TestPlugin2'], $pluginList);
+    }
+
+    public function test_orderPluginsByPluginDependencies_whenKeepUnresolvedIsFalse()
+    {
+        $pluginList = PluginUmdAssetFetcher::orderPluginsByPluginDependencies([
+            'TestPlugin4',
+            'TestPlugin1',
+            'TestPlugin2',
+        ], $keepUnresolved = false);
+        $this->assertEquals(['TestPlugin1', 'TestPlugin2'], $pluginList);
+    }
+
     private static function getUmdFile(string $pluginName)
     {
         $relativeRoot = str_replace(PIWIK_INCLUDE_PATH, '', self::TEST_PLUGINS_DIR);


### PR DESCRIPTION
### Description:

Refs #18761 

This causes the vue:build command to fail. Added tests for this as well.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
