### PR TITLE
Fix PHP8 Trim Error

### DIFF
--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -561,8 +561,10 @@ class GoalManager
 
         foreach ($cleanedItems as $item) {
             $actionsToLookup = array();
-            list($sku, $name, $category, $price, $quantity) = $item;
+            list($sku_check, $name_check, $category, $price, $quantity) = $item;
+            $sku = is_array($sku_check) ? join(',', $sku_check) : $sku_check;
             $actionsToLookup[] = array(trim($sku), Action::TYPE_ECOMMERCE_ITEM_SKU);
+            $name = is_array($name_check) ? join(',', $name_check) : $name_check;
             $actionsToLookup[] = array(trim($name), Action::TYPE_ECOMMERCE_ITEM_NAME);
 
             // Only one category

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -125,6 +125,26 @@ class TrackerTest extends IntegrationTestCase
         $this->assertActionEquals('scary <> movies', $conversionItems[0]['idaction_category']);
     }
 
+    public function test_trackingEcommerceOrder_WithNameAndSKUArrays()
+    {
+        // item sku, item name, item category, item price, item quantity
+        $ecItems = array(array(["sku1", "sku2"], ["name1", "name2"], 'category1', 12.99, 1));
+
+        $urlToTest = $this->getEcommerceItemsUrl($ecItems);
+
+        $response = $this->sendTrackingRequestByCurl($urlToTest);
+        Fixture::checkResponse($response);
+
+        $this->assertEquals(1, $this->getCountOfConversions());
+
+        $conversionItems = $this->getConversionItems();
+        $this->assertEquals(1, count($conversionItems));
+
+        $this->assertActionEquals('sku1,sku2', $conversionItems[0]['idaction_sku']);
+        $this->assertActionEquals('name1,name2', $conversionItems[0]['idaction_name']);
+        $this->assertActionEquals('category1', $conversionItems[0]['idaction_category']);
+    }
+
     public function test_trackingEcommerceOrder_DoesNotFail_WhenEmptyEcommerceItemsParamUsed()
     {
         // item sku, item name, item category, item price, item quantity


### PR DESCRIPTION
### Description:

An error happens if sites if names or skus are arrays in PHP 8 (was just a warning in PHP 7)

> Uncaught exception in core/Tracker/GoalManager.php line 567:
> trim(): Argument #1 ($string) must be of type string, array given

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
