### PR TITLE
[Vue] Add update to regenerate tagmanager containers with preview releases so new vue code will be present.

### DIFF
--- a/core/Updates/4.9.0-b1.php
+++ b/core/Updates/4.9.0-b1.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Piwik;
+use Piwik\Plugin\Manager;
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+use Piwik\Updater\Migration;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
+
+/**
+ * Update for version 4.9.0-b1
+ */
+class Updates_4_9_0_b1 extends PiwikUpdates
+{
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    /**
+     * Here you can define one or multiple SQL statements that should be executed during the update.
+     *
+     * @param Updater $updater
+     *
+     * @return Migration[]
+     */
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = [];
+
+        if (Manager::getInstance()->isPluginActivated('TagManager')) {
+            $migrations[] = new Migration\Custom(function () {
+                $onlyWithPreviewRelease = true;
+                Piwik::postEvent('TagManager.regenerateContainerReleases', [$onlyWithPreviewRelease]);
+            }, 'php ./console tagmanager:regenerate-released-containers --only-with-preview-release');
+        }
+
+        return $migrations;
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
+    }
+
+}

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    const VERSION = '4.8.0';
+    const VERSION = '4.9.0-b1';
 
     const MAJOR_VERSION = 4;
 


### PR DESCRIPTION
### Description:

Depends on https://github.com/matomo-org/tag-manager/pull/432

After that PR is merged, tag manager containers will still have angularjs code which will no longer work. So the containers are regenerated in the update.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
