### PR TITLE
[Vue] make sure chunk assets can be removed

### DIFF
--- a/core/AssetManager.php
+++ b/core/AssetManager.php
@@ -279,10 +279,40 @@ class AssetManager extends Singleton
                 } else {
                     $assetsToRemove[] = $this->getMergedNonCoreJSAsset();
                 }
+
+                $assetFetcher = $this->getPluginUmdJScriptFetcher();
+                foreach ($assetFetcher->getChunkFiles() as $chunk) {
+                    $files = $chunk->getFiles();
+
+                    $foundInChunk = false;
+                    foreach ($files as $file) {
+                        if (strpos($file, "/$pluginName.umd.") !== false) {
+                            $foundInChunk = true;
+                        }
+                    }
+
+                    if ($foundInChunk) {
+                        $outputFile = $chunk->getOutputFile();
+                        $asset = $this->getMergedUIAsset($outputFile);
+                        if ($asset->exists()) {
+                            $assetsToRemove[] = $asset;
+                        }
+                        break;
+                    }
+                }
             }
         } else {
             $assetsToRemove[] = $this->getMergedCoreJSAsset();
             $assetsToRemove[] = $this->getMergedNonCoreJSAsset();
+
+            $assetFetcher = $this->getPluginUmdJScriptFetcher();
+            foreach ($assetFetcher->getChunkFiles() as $chunk) {
+                $outputFile = $chunk->getOutputFile();
+                $asset = $this->getMergedUIAsset($outputFile);
+                if ($asset->exists()) {
+                    $assetsToRemove[] = $asset;
+                }
+            }
         }
 
         $this->removeAssets($assetsToRemove);

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -55,8 +55,8 @@ class Manager
 
     protected $doLoadPlugins = true;
 
-    protected static $pluginsToPathCache = array();
-    protected static $pluginsToWebRootDirCache = array();
+    public static $pluginsToPathCache = array();
+    public static $pluginsToWebRootDirCache = array();
 
     private $pluginsLoadedAndActivated;
 

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -55,8 +55,8 @@ class Manager
 
     protected $doLoadPlugins = true;
 
-    public static $pluginsToPathCache = array();
-    public static $pluginsToWebRootDirCache = array();
+    protected static $pluginsToPathCache = array();
+    protected static $pluginsToWebRootDirCache = array();
 
     private $pluginsLoadedAndActivated;
 

--- a/tests/PHPUnit/Integration/.gitignore
+++ b/tests/PHPUnit/Integration/.gitignore
@@ -1,0 +1,1 @@
+/plugins

--- a/tests/PHPUnit/Integration/AssetManager/UIAssetFetcher/PluginUmdAssetFetcherTest.php
+++ b/tests/PHPUnit/Integration/AssetManager/UIAssetFetcher/PluginUmdAssetFetcherTest.php
@@ -91,6 +91,8 @@ class PluginUmdAssetFetcherTest extends UnitTestCase
         putenv("MATOMO_PLUGIN_DIRS=" . self::TEST_PLUGINS_DIR . ';'
             . str_replace(PIWIK_INCLUDE_PATH, '', self::TEST_PLUGINS_DIR));
         unset($GLOBALS['MATOMO_PLUGIN_DIRS']);
+        Manager::$pluginsToPathCache = [];
+        Manager::$pluginsToWebRootDirCache = [];
         Manager::initPluginDirectories();
     }
 
@@ -101,7 +103,10 @@ class PluginUmdAssetFetcherTest extends UnitTestCase
         clearstatcache(true);
 
         putenv("MATOMO_PLUGIN_DIRS=");
+        $this->assertEquals('', getenv('MATOMO_PLUGIN_DIRS')); // sanity check
         unset($GLOBALS['MATOMO_PLUGIN_DIRS']);
+        Manager::$pluginsToPathCache = [];
+        Manager::$pluginsToWebRootDirCache = [];
         Manager::initPluginDirectories();
     }
 

--- a/tests/PHPUnit/Integration/AssetManager/UIAssetFetcher/PluginUmdAssetFetcherTest.php
+++ b/tests/PHPUnit/Integration/AssetManager/UIAssetFetcher/PluginUmdAssetFetcherTest.php
@@ -37,6 +37,9 @@ class PluginUmdAssetFetcherTest extends UnitTestCase
         'TestPlugin5' => ['TestPlugin1', 'TestPlugin3'],
     ];
 
+    private $oldPluginDirsEnvVar;
+    private $oldPluginDirsGlobal;
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
@@ -84,6 +87,9 @@ class PluginUmdAssetFetcherTest extends UnitTestCase
 
     public function setUp(): void
     {
+        $this->oldPluginDirsEnvVar = getenv('MATOMO_PLUGIN_DIRS');
+        $this->oldPluginDirsGlobal = $GLOBALS['MATOMO_PLUGIN_DIRS'];
+
         parent::setUp();
 
         clearstatcache(true);
@@ -91,8 +97,6 @@ class PluginUmdAssetFetcherTest extends UnitTestCase
         putenv("MATOMO_PLUGIN_DIRS=" . self::TEST_PLUGINS_DIR . ';'
             . str_replace(PIWIK_INCLUDE_PATH, '', self::TEST_PLUGINS_DIR));
         unset($GLOBALS['MATOMO_PLUGIN_DIRS']);
-        Manager::$pluginsToPathCache = [];
-        Manager::$pluginsToWebRootDirCache = [];
         Manager::initPluginDirectories();
     }
 
@@ -102,11 +106,8 @@ class PluginUmdAssetFetcherTest extends UnitTestCase
 
         clearstatcache(true);
 
-        putenv("MATOMO_PLUGIN_DIRS=");
-        $this->assertEquals('', getenv('MATOMO_PLUGIN_DIRS')); // sanity check
-        unset($GLOBALS['MATOMO_PLUGIN_DIRS']);
-        Manager::$pluginsToPathCache = [];
-        Manager::$pluginsToWebRootDirCache = [];
+        putenv("MATOMO_PLUGIN_DIRS={$this->oldPluginDirsEnvVar}");
+        $GLOBALS['MATOMO_PLUGIN_DIRS'] = $this->oldPluginDirsGlobal;
         Manager::initPluginDirectories();
     }
 

--- a/tests/PHPUnit/Integration/AssetManagerTest.php
+++ b/tests/PHPUnit/Integration/AssetManagerTest.php
@@ -46,6 +46,9 @@ class AssetManagerTest extends IntegrationTestCase
     const CORE_PLUGIN_WITH_ONLY_UMD_NAME = 'MockCorePluginOnlyUmd';
     const NON_CORE_PLUGIN_WITH_ONLY_UMD_NAME = 'MockNonCorePluginOnlyUmd';
 
+    private $oldPluginDirsEnvVar;
+    private $oldPluginDirsGlobal;
+
     /**
      * @var AssetManager
      */
@@ -107,6 +110,9 @@ class AssetManagerTest extends IntegrationTestCase
 
     private function setUpPluginsDirectory()
     {
+        $this->oldPluginDirsEnvVar = getenv('MATOMO_PLUGIN_DIRS');
+        $this->oldPluginDirsGlobal = $GLOBALS['MATOMO_PLUGIN_DIRS'];
+
         parent::setUpBeforeClass();
 
         $pluginsWithUmds = [
@@ -144,8 +150,6 @@ class AssetManagerTest extends IntegrationTestCase
         putenv("MATOMO_PLUGIN_DIRS=" . self::TEST_PLUGINS_DIR . ';'
             . str_replace(PIWIK_INCLUDE_PATH, '', self::TEST_PLUGINS_DIR));
         unset($GLOBALS['MATOMO_PLUGIN_DIRS']);
-        Manager::$pluginsToPathCache = [];
-        Manager::$pluginsToWebRootDirCache = [];
         Manager::initPluginDirectories();
     }
 
@@ -155,11 +159,8 @@ class AssetManagerTest extends IntegrationTestCase
 
         clearstatcache(true);
 
-        putenv("MATOMO_PLUGIN_DIRS=");
-        $this->assertEquals('', getenv('MATOMO_PLUGIN_DIRS')); // sanity check
-        unset($GLOBALS['MATOMO_PLUGIN_DIRS']);
-        Manager::$pluginsToPathCache = [];
-        Manager::$pluginsToWebRootDirCache = [];
+        putenv("MATOMO_PLUGIN_DIRS={$this->oldPluginDirsEnvVar}");
+        $GLOBALS['MATOMO_PLUGIN_DIRS'] = $this->oldPluginDirsGlobal;
         Manager::initPluginDirectories();
     }
 

--- a/tests/PHPUnit/Integration/AssetManagerTest.php
+++ b/tests/PHPUnit/Integration/AssetManagerTest.php
@@ -13,6 +13,7 @@ use Piwik\AssetManager\UIAsset;
 use Piwik\AssetManager;
 use Piwik\AssetManager\UIAssetFetcher\StaticUIAssetFetcher;
 use Piwik\Config;
+use Piwik\Filesystem;
 use Piwik\Plugin;
 use Piwik\Plugin\Manager;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -28,6 +29,8 @@ class AssetManagerTest extends IntegrationTestCase
 {
     // todo Theme->rewriteAssetPathIfOverridesFound is not tested
 
+    const TEST_PLUGINS_DIR = __DIR__ . '/plugins';
+
     const ASSET_MANAGER_TEST_DIR = 'tests/PHPUnit/Unit/AssetManager/';
 
     const FIRST_CACHE_BUSTER_JS = 'first-cache-buster-js';
@@ -40,6 +43,8 @@ class AssetManagerTest extends IntegrationTestCase
     const NON_CORE_PLUGIN_NAME = 'MockNonCorePlugin';
     const CORE_THEME_PLUGIN_NAME = 'CoreThemePlugin';
     const NON_CORE_THEME_PLUGIN_NAME = 'NonCoreThemePlugin';
+    const CORE_PLUGIN_WITH_ONLY_UMD_NAME = 'MockCorePluginOnlyUmd';
+    const NON_CORE_PLUGIN_WITH_ONLY_UMD_NAME = 'MockNonCorePluginOnlyUmd';
 
     /**
      * @var AssetManager
@@ -65,6 +70,8 @@ class AssetManagerTest extends IntegrationTestCase
     {
         parent::setUp();
 
+        $this->setUpPluginsDirectory();
+
         $this->setUpConfig();
 
         $this->activateMergedAssets();
@@ -82,6 +89,8 @@ class AssetManagerTest extends IntegrationTestCase
 
     public function tearDown(): void
     {
+        $this->removePluginsDirectory();
+
         if ($this->assetManager !== null) {
             $this->assetManager->removeMergedAssets();
         }
@@ -94,6 +103,59 @@ class AssetManagerTest extends IntegrationTestCase
         return array(
             'Piwik\Plugin\Manager' => \DI\autowire('Piwik\Tests\Unit\AssetManager\PluginManagerMock')
         );
+    }
+
+    private function setUpPluginsDirectory()
+    {
+        parent::setUpBeforeClass();
+
+        $pluginsWithUmds = [
+            self::CORE_PLUGIN_NAME,
+            self::NON_CORE_PLUGIN_NAME,
+            self::CORE_PLUGIN_WITH_ONLY_UMD_NAME,
+            self::NON_CORE_PLUGIN_WITH_ONLY_UMD_NAME,
+        ];
+
+        // setup plugin test directories
+        Filesystem::unlinkRecursive(self::TEST_PLUGINS_DIR, true);
+        foreach ($pluginsWithUmds as $pluginName) {
+            $vueDir = self::TEST_PLUGINS_DIR . '/' . $pluginName . '/vue/dist';
+            $vueSrcDir = self::TEST_PLUGINS_DIR . '/' . $pluginName . '/vue/src';
+
+            Filesystem::mkdir($vueDir);
+            Filesystem::mkdir($vueSrcDir);
+
+            $umdDependencies = [
+                "dependsOn" => [],
+            ];
+            $umdDependenciesPath = $vueDir . '/umd.metadata.json';
+
+            file_put_contents($umdDependenciesPath, json_encode($umdDependencies));
+
+            $umdPath = $vueDir . '/' . $pluginName . '.umd.min.js';
+            $umdContent = "// begin $pluginName\n";
+            $umdContent .= "// end $pluginName\n";
+
+            file_put_contents($umdPath, $umdContent);
+        }
+
+        clearstatcache(true);
+
+        putenv("MATOMO_PLUGIN_DIRS=" . self::TEST_PLUGINS_DIR . ';'
+            . str_replace(PIWIK_INCLUDE_PATH, '', self::TEST_PLUGINS_DIR));
+        unset($GLOBALS['MATOMO_PLUGIN_DIRS']);
+        Manager::initPluginDirectories();
+    }
+
+    private function removePluginsDirectory()
+    {
+        Filesystem::unlinkRecursive(self::TEST_PLUGINS_DIR, true);
+
+        clearstatcache(true);
+
+        putenv("MATOMO_PLUGIN_DIRS=");
+        unset($GLOBALS['MATOMO_PLUGIN_DIRS']);
+        Manager::initPluginDirectories();
     }
 
     private function activateMergedAssets()
@@ -142,7 +204,9 @@ class AssetManagerTest extends IntegrationTestCase
                  $this->getNonCoreTheme()->getPlugin(),
                  $this->getCorePlugin(),
                  $this->getCorePluginWithoutUIAssets(),
-                 $this->getNonCorePlugin()
+                 $this->getNonCorePlugin(),
+                 $this->getCorePluginWithOnlyUmd(),
+                 $this->getNonCorePluginWithOnlyUmd(),
             )
         );
 
@@ -177,6 +241,16 @@ class AssetManagerTest extends IntegrationTestCase
         $corePlugin->setCssCustomization('/* customization via event */');
 
         return $corePlugin;
+    }
+
+    private function getCorePluginWithOnlyUmd()
+    {
+        return new PluginMock(self::CORE_PLUGIN_WITH_ONLY_UMD_NAME);
+    }
+
+    private function getNonCorePluginWithOnlyUmd()
+    {
+        return new PluginMock(self::NON_CORE_PLUGIN_WITH_ONLY_UMD_NAME);
     }
 
     /**
@@ -277,6 +351,15 @@ class AssetManagerTest extends IntegrationTestCase
     private function triggerGetMergedNonCoreJavaScript()
     {
         $this->mergedAsset = $this->assetManager->getMergedNonCoreJavaScript();
+    }
+
+    private function triggerGetMergedChunkJavaScript()
+    {
+        $chunks = [];
+        for ($i = 0; $i < AssetManager\UIAssetFetcher\PluginUmdAssetFetcher::getDefaultChunkCount(); ++$i) {
+            $chunks[] = $this->assetManager->getMergedJavaScriptChunk($i);
+        }
+        return $chunks;
     }
 
     private function triggerGetMergedStylesheet()
@@ -413,7 +496,7 @@ class AssetManagerTest extends IntegrationTestCase
     }
 
     /**
-     * @return UIAsset[]
+     * @return array
      */
     private function generateAllMergedAssets()
     {
@@ -430,7 +513,13 @@ class AssetManagerTest extends IntegrationTestCase
         $this->assertTrue($coreJsAsset->exists());
         $this->assertTrue($nonCoreJsAsset->exists());
 
-        return array($stylesheetAsset, $coreJsAsset, $nonCoreJsAsset);
+        $chunks = $this->triggerGetMergedChunkJavaScript();
+        $this->assertCount(3, $chunks);
+        $this->assertTrue($chunks[0]->exists());
+        $this->assertTrue($chunks[1]->exists());
+        $this->assertTrue($chunks[2]->exists());
+
+        return array($stylesheetAsset, $coreJsAsset, $nonCoreJsAsset, $chunks);
     }
 
     /**
@@ -611,7 +700,11 @@ class AssetManagerTest extends IntegrationTestCase
             '<script type="text/javascript" src="tests/PHPUnit/Unit/AssetManager/scripts/SimpleObject.js"></script>' . "\n" .
             '<script type="text/javascript" src="tests/PHPUnit/Unit/AssetManager/scripts/SimpleArray.js"></script>' . "\n" .
             '<script type="text/javascript" src="tests/PHPUnit/Unit/AssetManager/scripts/SimpleComments.js"></script>' . "\n" .
-            '<script type="text/javascript" src="tests/PHPUnit/Unit/AssetManager/scripts/SimpleAlert.js"></script>' . "\n";
+            '<script type="text/javascript" src="tests/PHPUnit/Unit/AssetManager/scripts/SimpleAlert.js"></script>' . "\n" .
+            '<script type="text/javascript" src="tests/PHPUnit/Integration/plugins/MockCorePlugin/vue/dist/MockCorePlugin.umd.min.js"></script>' . "\n" .
+            '<script type="text/javascript" src="tests/PHPUnit/Integration/plugins/MockNonCorePlugin/vue/dist/MockNonCorePlugin.umd.min.js"></script>' . "\n" .
+            '<script type="text/javascript" src="tests/PHPUnit/Integration/plugins/MockCorePluginOnlyUmd/vue/dist/MockCorePluginOnlyUmd.umd.min.js"></script>' . "\n" .
+            '<script type="text/javascript" src="tests/PHPUnit/Integration/plugins/MockNonCorePluginOnlyUmd/vue/dist/MockNonCorePluginOnlyUmd.umd.min.js"></script>' . "\n";
 
         $this->assertEquals($expectedJsInclusionDirective, $this->assetManager->getJsInclusionDirective());
     }
@@ -624,7 +717,10 @@ class AssetManagerTest extends IntegrationTestCase
         $expectedJsInclusionDirective =
             $this->getJsTranslationScript() .
             '<script type="text/javascript" src="index.php?module=Proxy&action=getCoreJs"></script>' . "\n" .
-            '<script type="text/javascript" src="index.php?module=Proxy&action=getNonCoreJs"></script>' . "\n";
+            '<script type="text/javascript" src="index.php?module=Proxy&action=getNonCoreJs"></script>' . "\n" .
+            '<script type="text/javascript" src="index.php?module=Proxy&action=getUmdJs&chunk=0" defer></script>' . "\n" .
+            '<script type="text/javascript" src="index.php?module=Proxy&action=getUmdJs&chunk=1" defer></script>' . "\n" .
+            '<script type="text/javascript" src="index.php?module=Proxy&action=getUmdJs&chunk=2" defer></script>' . "\n";
 
         $this->assertEquals($expectedJsInclusionDirective, $this->assetManager->getJsInclusionDirective());
     }
@@ -656,13 +752,18 @@ class AssetManagerTest extends IntegrationTestCase
      */
     public function test_removeMergedAssets()
     {
-        list($stylesheetAsset, $coreJsAsset, $nonCoreJsAsset) = $this->generateAllMergedAssets();
+        list($stylesheetAsset, $coreJsAsset, $nonCoreJsAsset, $chunks) = $this->generateAllMergedAssets();
 
         $this->assetManager->removeMergedAssets();
 
         $this->assertFalse($stylesheetAsset->exists());
         $this->assertFalse($coreJsAsset->exists());
         $this->assertFalse($nonCoreJsAsset->exists());
+
+        $this->assertCount(3, $chunks);
+        $this->assertFalse($chunks[0]->exists());
+        $this->assertFalse($chunks[1]->exists());
+        $this->assertFalse($chunks[2]->exists());
     }
 
     /**
@@ -670,13 +771,18 @@ class AssetManagerTest extends IntegrationTestCase
      */
     public function test_removeMergedAssets_PluginNameSpecified_PluginWithoutAssets()
     {
-        list($stylesheetAsset, $coreJsAsset, $nonCoreJsAsset) = $this->generateAllMergedAssets();
+        list($stylesheetAsset, $coreJsAsset, $nonCoreJsAsset, $chunks) = $this->generateAllMergedAssets();
 
         $this->assetManager->removeMergedAssets(self::CORE_PLUGIN_WITHOUT_ASSETS_NAME);
 
         $this->assertFalse($stylesheetAsset->exists());
         $this->assertTrue($coreJsAsset->exists());
         $this->assertTrue($nonCoreJsAsset->exists());
+
+        $this->assertCount(3, $chunks);
+        $this->assertTrue($chunks[0]->exists());
+        $this->assertTrue($chunks[1]->exists());
+        $this->assertTrue($chunks[2]->exists());
     }
 
     /**
@@ -684,13 +790,18 @@ class AssetManagerTest extends IntegrationTestCase
      */
     public function test_removeMergedAssets_PluginNameSpecified_CorePlugin()
     {
-        list($stylesheetAsset, $coreJsAsset, $nonCoreJsAsset) = $this->generateAllMergedAssets();
+        list($stylesheetAsset, $coreJsAsset, $nonCoreJsAsset, $chunks) = $this->generateAllMergedAssets();
 
         $this->assetManager->removeMergedAssets(self::CORE_PLUGIN_NAME);
 
         $this->assertFalse($stylesheetAsset->exists());
         $this->assertFalse($coreJsAsset->exists());
         $this->assertTrue($nonCoreJsAsset->exists());
+
+        $this->assertCount(3, $chunks);
+        $this->assertFalse($chunks[0]->exists());
+        $this->assertTrue($chunks[1]->exists());
+        $this->assertTrue($chunks[2]->exists());
     }
 
     /**
@@ -698,12 +809,17 @@ class AssetManagerTest extends IntegrationTestCase
      */
     public function test_removeMergedAssets_PluginNameSpecified_NonCoreThemeWithAssets()
     {
-        list($stylesheetAsset, $coreJsAsset, $nonCoreJsAsset) = $this->generateAllMergedAssets();
+        list($stylesheetAsset, $coreJsAsset, $nonCoreJsAsset, $chunks) = $this->generateAllMergedAssets();
 
         $this->assetManager->removeMergedAssets(self::NON_CORE_THEME_PLUGIN_NAME);
 
         $this->assertFalse($stylesheetAsset->exists());
         $this->assertTrue($coreJsAsset->exists());
         $this->assertFalse($nonCoreJsAsset->exists());
+
+        $this->assertCount(3, $chunks);
+        $this->assertTrue($chunks[0]->exists());
+        $this->assertTrue($chunks[1]->exists());
+        $this->assertTrue($chunks[2]->exists());
     }
 }

--- a/tests/PHPUnit/Integration/AssetManagerTest.php
+++ b/tests/PHPUnit/Integration/AssetManagerTest.php
@@ -144,6 +144,8 @@ class AssetManagerTest extends IntegrationTestCase
         putenv("MATOMO_PLUGIN_DIRS=" . self::TEST_PLUGINS_DIR . ';'
             . str_replace(PIWIK_INCLUDE_PATH, '', self::TEST_PLUGINS_DIR));
         unset($GLOBALS['MATOMO_PLUGIN_DIRS']);
+        Manager::$pluginsToPathCache = [];
+        Manager::$pluginsToWebRootDirCache = [];
         Manager::initPluginDirectories();
     }
 
@@ -154,7 +156,10 @@ class AssetManagerTest extends IntegrationTestCase
         clearstatcache(true);
 
         putenv("MATOMO_PLUGIN_DIRS=");
+        $this->assertEquals('', getenv('MATOMO_PLUGIN_DIRS')); // sanity check
         unset($GLOBALS['MATOMO_PLUGIN_DIRS']);
+        Manager::$pluginsToPathCache = [];
+        Manager::$pluginsToWebRootDirCache = [];
         Manager::initPluginDirectories();
     }
 


### PR DESCRIPTION
### Description:

The current asset removal functionality does not take into account JS chunks, this PR fixes that. This lead to inaccurate JS chunk file sizes when switching between branches, which I noticed.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
