### PR TITLE
Remve '3' as Morpheus is also the default theme of Matomo 4

### DIFF
--- a/plugins/Morpheus/plugin.json
+++ b/plugins/Morpheus/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "Morpheus",
-    "description": "Morpheus is the default theme of Matomo 3 designed to help you focus on your analytics. In Greek mythology, Morpheus is the God of dreams. In the Matrix movie, Morpheus is the leader of the rebel forces who fight to awaken humans from a dreamlike reality called The Matrix. ",
+    "description": "Morpheus is the default theme of Matomo designed to help you focus on your analytics. In Greek mythology, Morpheus is the God of dreams. In the Matrix movie, Morpheus is the leader of the rebel forces who fight to awaken humans from a dreamlike reality called The Matrix. ",
     "theme": true,
     "stylesheet": "stylesheets/main.less"
 }


### PR DESCRIPTION
### Description:

The description of Morpheus still listed it as (only) the default theme of 'Matomo 3'. As it is also the default theme of Matomo 4, I guess it makes sense to simply remove the '3'.

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [x] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [x] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [x] Existing documentation updated if needed