### PR TITLE
[Vue] only write vue metadata JSON file if there is a src file in the vue plugin

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -23,6 +23,7 @@ if (!process.env.MATOMO_CURRENT_PLUGIN) {
   console.log("The MATOMO_CURRENT_PLUGIN environment variable is not set!");
 }
 
+const srcPath = `plugins/${process.env.MATOMO_CURRENT_PLUGIN}/vue/src/`;
 const publicPath = `plugins/${process.env.MATOMO_CURRENT_PLUGIN}/vue/dist/`;
 
 // hack to get publicPath working for lib build target (see https://github.com/vuejs/vue-cli/issues/4896#issuecomment-569001811)
@@ -54,8 +55,10 @@ OutputDetectedDependentPluginsPlugin.prototype.apply = function (compiler) {
     const metadata = {
       dependsOn: detectedDependentPlugins,
     };
-    fs.mkdirSync(path.dirname(metadataPath), { recursive: true });
-    fs.writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
+    if (fs.existsSync(path.join(srcPath))) {
+      fs.mkdirSync(path.dirname(metadataPath), {recursive: true});
+      fs.writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
+    }
   });
 };
 


### PR DESCRIPTION
### Description:

This makes it less annoying when switching branches while vue:build --watch is running, where one branch has a vue folder and the other doesn't.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
