### PR TITLE
Minor performance improvement for archive invalidator

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -30,7 +30,6 @@ use Piwik\Segment;
 use Piwik\SettingsServer;
 use Piwik\Site;
 use Piwik\Tracker\Cache;
-use Piwik\Tracker\Model as TrackerModel;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -227,7 +227,7 @@ class ArchiveInvalidator
     {
         // we're not using deleteLike since it maybe could cause deadlocks see https://github.com/matomo-org/matomo/issues/15545
         // we want to reduce number of rows scanned and only delete specific primary key
-        $keys = Option::getLike(str_replace('_', '\_', $id) . '%');
+        $keys = Option::getLike('%' . str_replace('_', '\_', $id) . '%');
 
         if (empty($keys)) {
             return;

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -30,6 +30,7 @@ use Piwik\Segment;
 use Piwik\SettingsServer;
 use Piwik\Site;
 use Piwik\Tracker\Cache;
+use Piwik\Tracker\Model as TrackerModel;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -96,7 +97,7 @@ class ArchiveInvalidator
         // we do not really have to get the value first. we could simply always try to call set() and it would update or
         // insert the record if needed but we do not want to lock the table (especially since there are still some
         // MyISAM installations)
-        $values = Option::getLike('%' . $this->rememberArchivedReportIdStart . '%');
+        $values = Option::getLike(str_replace('_', '\_', $this->rememberArchivedReportIdStart) . '%');
 
         $all = [];
         foreach ($values as $name => $value) {
@@ -154,7 +155,7 @@ class ArchiveInvalidator
 
     public function getRememberedArchivedReportsThatShouldBeInvalidated()
     {
-        $reports = Option::getLike('%' . $this->rememberArchivedReportIdStart . '%_%');
+        $reports = Option::getLike(str_replace('_', '\_', $this->rememberArchivedReportIdStart) . '%\_%');
 
         $sitesPerDay = array();
 
@@ -204,7 +205,7 @@ class ArchiveInvalidator
 
     public function forgetRememberedArchivedReportsToInvalidateForSite($idSite)
     {
-        $id = $this->buildRememberArchivedReportIdForSite($idSite) . '\_';
+        $id = $this->buildRememberArchivedReportIdForSite($idSite) . '_';
         $this->deleteOptionLike($id);
         Cache::clearCacheGeneral();
     }
@@ -227,7 +228,7 @@ class ArchiveInvalidator
     {
         // we're not using deleteLike since it maybe could cause deadlocks see https://github.com/matomo-org/matomo/issues/15545
         // we want to reduce number of rows scanned and only delete specific primary key
-        $keys = Option::getLike('%' . $id . '%');
+        $keys = Option::getLike(str_replace('_', '\_', $id) . '%');
 
         if (empty($keys)) {
             return;

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -97,7 +97,7 @@ class ArchiveInvalidator
         // we do not really have to get the value first. we could simply always try to call set() and it would update or
         // insert the record if needed but we do not want to lock the table (especially since there are still some
         // MyISAM installations)
-        $values = Option::getLike(str_replace('_', '\_', $this->rememberArchivedReportIdStart) . '%');
+        $values = Option::getLike('%' . str_replace('_', '\_', $this->rememberArchivedReportIdStart) . '%');
 
         $all = [];
         foreach ($values as $name => $value) {
@@ -122,7 +122,7 @@ class ArchiveInvalidator
             // we do not really have to get the value first. we could simply always try to call set() and it would update or
             // insert the record if needed but we do not want to lock the table (especially since there are still some
             // MyISAM installations)
-            $value = Option::getLike('%' . $key . '%');
+            $value = Option::getLike('%' . str_replace('_', '\_', $key) . '%');
         }
 
         // getLike() returns an empty array rather than 'false'
@@ -155,7 +155,7 @@ class ArchiveInvalidator
 
     public function getRememberedArchivedReportsThatShouldBeInvalidated()
     {
-        $reports = Option::getLike(str_replace('_', '\_', $this->rememberArchivedReportIdStart) . '%\_%');
+        $reports = Option::getLike('%' . str_replace('_', '\_', $this->rememberArchivedReportIdStart) . '%\_%');
 
         $sitesPerDay = array();
 


### PR DESCRIPTION
### Description:

We did queries like `where option_name like '%report_to_invalidate_%'`. However, `_` would match any character and makes the matching more resource intense. It technically also improves security slightly although there wasn't any issue.

refs https://forum.matomo.org/t/matomo-on-premise-scaling/45262 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
