### PR TITLE
Fix issue where date ranges might include too many subperiods 

### DIFF
--- a/core/Period/Range.php
+++ b/core/Period/Range.php
@@ -263,7 +263,7 @@ class Range extends Period
             if (strpos($strDateEnd, '-') === false) {
                 $timezone = $this->timezone;
             }
-            $endDate = Date::factory($strDateEnd, $timezone);
+            $endDate = Date::factory($strDateEnd, $timezone)->setTime("00:00:00");
         } else {
             throw new Exception($this->translator->translate('General_ExceptionInvalidDateRange', array($this->strDate, ' \'lastN\', \'previousN\', \'YYYY-MM-DD,YYYY-MM-DD\'')));
         }

--- a/tests/PHPUnit/Unit/Period/RangeTest.php
+++ b/tests/PHPUnit/Unit/Period/RangeTest.php
@@ -20,6 +20,12 @@ use Piwik\Period\Year;
  */
 class RangeTest extends BasePeriodTest
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        Date::$now = null;
+    }
+
     /**
      * @dataProvider getDateXPeriodsAgoProvider
      */
@@ -185,11 +191,37 @@ class RangeTest extends BasePeriodTest
     // test range date1,date2
     public function testRangeComma4_EndDateIncludesTodayWithTimezone()
     {
+        Date::$now = strtotime('2020-08-01 03:00:00');
         $range = new Range('day', '2008-01-01,today', 'Europe/Berlin');
         $subPeriods = $range->getSubperiods();
         $this->assertEquals('2008-01-01', $subPeriods[0]->toString());
         $this->assertEquals('2008-01-02', $subPeriods[1]->toString());
         $this->assertEquals('2008-01-03', $subPeriods[2]->toString());
+        $this->assertEquals('2020-08-01', end($subPeriods)->toString());
+    }
+
+    // test range date1,date2
+    public function testRangeComma5_EndDateIncludesTodayWithTimezoneAfterCurrentUTCDate()
+    {
+        Date::$now = strtotime('2020-08-01 03:00:00');
+        $range = new Range('day', '2008-01-01,today', 'Pacific/Auckland');
+        $subPeriods = $range->getSubperiods();
+        $this->assertEquals('2008-01-01', $subPeriods[0]->toString());
+        $this->assertEquals('2008-01-02', $subPeriods[1]->toString());
+        $this->assertEquals('2008-01-03', $subPeriods[2]->toString());
+        $this->assertEquals('2020-08-01', end($subPeriods)->toString());
+    }
+
+    // test range date1,date2
+    public function testRangeComma6_EndDateIncludesTodayWithTimezoneBeforeCurrentUTCDate()
+    {
+        Date::$now = strtotime('2020-08-01 03:00:00');
+        $range = new Range('day', '2008-01-01,today', 'America/New_York');
+        $subPeriods = $range->getSubperiods();
+        $this->assertEquals('2008-01-01', $subPeriods[0]->toString());
+        $this->assertEquals('2008-01-02', $subPeriods[1]->toString());
+        $this->assertEquals('2008-01-03', $subPeriods[2]->toString());
+        $this->assertEquals('2020-07-31', end($subPeriods)->toString());
     }
 
     // test range date1,date2

--- a/tests/PHPUnit/Unit/Period/RangeTest.php
+++ b/tests/PHPUnit/Unit/Period/RangeTest.php
@@ -183,6 +183,16 @@ class RangeTest extends BasePeriodTest
     }
 
     // test range date1,date2
+    public function testRangeComma4_EndDateIncludesTodayWithTimezone()
+    {
+        $range = new Range('day', '2008-01-01,today', 'Europe/Berlin');
+        $subPeriods = $range->getSubperiods();
+        $this->assertEquals('2008-01-01', $subPeriods[0]->toString());
+        $this->assertEquals('2008-01-02', $subPeriods[1]->toString());
+        $this->assertEquals('2008-01-03', $subPeriods[2]->toString());
+    }
+
+    // test range date1,date2
     public function testRangeWeekcomma1()
     {
         $range = new Range('week', '2007-12-22,2008-01-03');


### PR DESCRIPTION
### Description:

When using a magic keyword (like `today`) as end of a period and providing a timezone other than `UTC`, the array of subperiods could actually hold too many periods.

*For debugging purpose:*
The start and end date for the range are initialized here:
https://github.com/matomo-org/matomo/blob/dde206cdfd68a1638aebbe3ae1335e92e6375065/core/Period/Range.php#L256-L267

When using `today` and a timezone like `Europe/Berlin` the `$endDate` would hold a date like `2022-03-24 01:00:00` (without setting the time to `00:00:00`). The start date would be used as provided, but with time `00:00:00`
When generating the the subperiods here:
https://github.com/matomo-org/matomo/blob/dde206cdfd68a1638aebbe3ae1335e92e6375065/core/Period/Range.php#L417-L422
The compare in the while would actually match once more as expected, as the time of the dates differs (`00:00:00` < `01:00:00`) and thus one more date than expected is added.

fixes #18992

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
