### PR TITLE
[Vue] add intermediate proxy script for Vue CLI bin that fixes typescript error lines

### DIFF
--- a/plugins/CoreVue/Commands/Build.php
+++ b/plugins/CoreVue/Commands/Build.php
@@ -111,7 +111,7 @@ class Build extends ConsoleCommand
     private function watch($plugins, $printBuildCommand, OutputInterface $output)
     {
         $commandSingle = "BROWSERSLIST_IGNORE_OLD_DATA=1 FORCE_COLOR=1 MATOMO_CURRENT_PLUGIN=%1\$s "
-            . self::getVueCliServiceBin() . ' build --mode=development --target lib --name '
+            . 'node ' . self::getVueCliServiceProxyBin() . ' build --mode=development --target lib --name '
             . "%1\$s --filename=%1\$s.development --no-clean ./plugins/%1\$s/vue/src/index.ts --dest ./plugins/%1\$s/vue/dist --watch &";
 
         $command = '';
@@ -123,13 +123,14 @@ class Build extends ConsoleCommand
             $output->writeln("<comment>$command</comment>");
             return;
         }
-        passthru($command);
+
+        passthru($commandSingle);
     }
 
     private function buildFiles(OutputInterface $output, $plugin, $printBuildCommand)
     {
         $command = "BROWSERSLIST_IGNORE_OLD_DATA=1 FORCE_COLOR=1 MATOMO_CURRENT_PLUGIN=$plugin "
-            . self::getVueCliServiceBin() . ' build --target lib --name ' . $plugin
+            . 'node ' . self::getVueCliServiceProxyBin() . ' build --target lib --name ' . $plugin
             . " ./plugins/$plugin/vue/src/index.ts --dest ./plugins/$plugin/vue/dist";
 
         if ($printBuildCommand) {
@@ -141,7 +142,7 @@ class Build extends ConsoleCommand
 
         $output->writeln("<comment>Building $plugin...</comment>");
         if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
-            passthru($command, $returnCode);
+            passthru($command);
         } else {
             exec($command, $cmdOutput, $returnCode);
             if ($returnCode != 0
@@ -204,6 +205,11 @@ class Build extends ConsoleCommand
     public static function getVueCliServiceBin()
     {
         return PIWIK_INCLUDE_PATH . "/node_modules/@vue/cli-service/bin/vue-cli-service.js";
+    }
+
+    public static function getVueCliServiceProxyBin()
+    {
+        return PIWIK_INCLUDE_PATH . "/plugins/CoreVue/scripts/cli-service-proxy.js";
     }
 
     public static function checkVueCliServiceAvailable()

--- a/plugins/CoreVue/Commands/Build.php
+++ b/plugins/CoreVue/Commands/Build.php
@@ -124,7 +124,7 @@ class Build extends ConsoleCommand
             return;
         }
 
-        passthru($commandSingle);
+        passthru($command);
     }
 
     private function buildFiles(OutputInterface $output, $plugin, $printBuildCommand)

--- a/plugins/CoreVue/scripts/cli-service-proxy.js
+++ b/plugins/CoreVue/scripts/cli-service-proxy.js
@@ -1,0 +1,49 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+const fs = require('fs');
+const readline = require('readline');
+
+const middlePositions = {};
+function getMiddlePosition(file) {
+  if (!middlePositions[file] && fs.existsSync(file)) {
+    const fileContents = fs.readFileSync(file).toString('utf-8');
+    const scriptIndex = fileContents.indexOf('<script lang="ts"');
+    if (scriptIndex !== -1) {
+      middlePositions[file] = (fileContents.substring(0, scriptIndex).match(/\n/g) || []).length;
+    }
+  }
+  return middlePositions[file];
+}
+
+function interceptWrite(originalWrite) {
+  return function (chunk, encoding, cb) {
+    if (typeof chunk === 'string' && /tsl.*?ERROR/.test(chunk)) {
+      chunk = chunk.replace(/(\/(?:.(?!\())+.)\((\d+)(,\d+\))/g, (m, file, line, rest) => {
+        if (/.vue.ts$/.test(file)) {
+          file = file.substring(0, file.length - 3);
+          const middleLine = getMiddlePosition(file);
+          return `${file}(${middleLine + parseInt(line, 10)}${rest}`;
+        }
+        return m;
+      });
+    }
+
+    return originalWrite.call(this, chunk, encoding, cb);
+  };
+}
+
+process.stdout.clearLine = readline.clearLine.bind(null, process.stdout);
+process.stdout.cursorTo = readline.cursorTo.bind(null, process.stdout);
+
+process.stderr.clearLine = readline.clearLine.bind(null, process.stderr);
+process.stderr.cursorTo = readline.cursorTo.bind(null, process.stderr);
+
+process.stdout.write = interceptWrite(process.stdout.write);
+process.stderr.write = interceptWrite(process.stderr.write);
+
+require('../../../node_modules/@vue/cli-service/bin/vue-cli-service.js');


### PR DESCRIPTION
### Description:

When processing .vue files, Vue CLI bin will find the `<script lang="ts">` element, and feed its contents into the typescript compiler. The line numbers for errors are specific to that chunk of text and not the entire .vue file. This PR adds an intermediate script that corrects the line numbers in those errors.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
