### PR TITLE
Clear general cache less often when launching the archiving

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -271,10 +271,6 @@ class ArchiveInvalidator
 
         $invalidationInfo = new InvalidationResult();
 
-        // when browser archiving is used then to be safe we always want to invalidate the general cache as otherwise
-        // invalidating of today might not happen.
-        $requiresGeneralCacheInvalidation = Rules::isBrowserTriggerEnabled();
-
         // quick fix for #15086, if we're only invalidating today's date for a site, don't add the site to the list of sites
         // to reprocess.
         $hasMoreThanJustToday = [];
@@ -288,11 +284,6 @@ class ArchiveInvalidator
             ) {
                 // date is for today
                 $hasMoreThanJustToday[$idSite] = false;
-            } else {
-                // date is not for today. this means we need to invalidate the general cache so a new tracking request
-                // for the same date can set the flag again that another archive invalidation is needed.
-                // this behaviour is not needed for today as we always force archiving of "yesterday" anyway.
-                $requiresGeneralCacheInvalidation = true;
             }
         }
 
@@ -341,7 +332,7 @@ class ArchiveInvalidator
             }
         }
 
-        if ($clearCache && $requiresGeneralCacheInvalidation) {
+        if ($clearCache) {
             Cache::clearCacheGeneral();
         }
 

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -205,8 +205,10 @@ class ArchiveInvalidator
     public function forgetRememberedArchivedReportsToInvalidateForSite($idSite)
     {
         $id = $this->buildRememberArchivedReportIdForSite($idSite) . '_';
-        $this->deleteOptionLike($id);
-        Cache::clearCacheGeneral();
+        $hasDeletedSomething = $this->deleteOptionLike($id);
+        if ($hasDeletedSomething) {
+            Cache::clearCacheGeneral();
+        }
     }
 
     /**
@@ -220,9 +222,14 @@ class ArchiveInvalidator
 
         // The process pid is added to the end of the entry in order to support multiple concurrent transactions.
         //  So this must be a deleteLike call to get all the entries, where there used to only be one.
-        $this->deleteOptionLike($id);
+        return $this->deleteOptionLike($id);
     }
 
+    /**
+     * @param $id
+     * @return bool true if a record was deleted, false otherwise.
+     * @throws \Zend_Db_Statement_Exception
+     */
     private function deleteOptionLike($id)
     {
         // we're not using deleteLike since it maybe could cause deadlocks see https://github.com/matomo-org/matomo/issues/15545
@@ -230,7 +237,7 @@ class ArchiveInvalidator
         $keys = Option::getLike('%' . str_replace('_', '\_', $id) . '%');
 
         if (empty($keys)) {
-            return;
+            return false;
         }
 
         $keys = array_keys($keys);
@@ -238,7 +245,8 @@ class ArchiveInvalidator
         $placeholders = Common::getSqlStringFieldsArray($keys);
 
         $table = Common::prefixTable('option');
-        Db::query('DELETE FROM `' . $table . '` WHERE `option_name` IN (' . $placeholders . ')', $keys);
+        $db = Db::query('DELETE FROM `' . $table . '` WHERE `option_name` IN (' . $placeholders . ')', $keys);
+        return (bool) $db->rowCount();
     }
 
     /**
@@ -251,12 +259,11 @@ class ArchiveInvalidator
      * @param string $name null to make sure every plugin is archived when this invalidation is processed by core:archive,
      *                     or a plugin name to only archive the specific plugin.
      * @param bool $ignorePurgeLogDataDate
-     * @param bool $clearCache
      * @return InvalidationResult
      * @throws \Exception
      */
     public function markArchivesAsInvalidated(array $idSites, array $dates, $period, Segment $segment = null, $cascadeDown = false,
-                                              $forceInvalidateNonexistantRanges = false, $name = null, $ignorePurgeLogDataDate = false, $clearCache = true)
+                                              $forceInvalidateNonexistantRanges = false, $name = null, $ignorePurgeLogDataDate = false)
     {
         $plugin = null;
         if ($name && strpos($name, '.') !== false) {
@@ -269,7 +276,9 @@ class ArchiveInvalidator
             throw new \Exception("Plugin is not activated: '$plugin'");
         }
 
+        $anySiteRequiresGeneralCache = false;
         $invalidationInfo = new InvalidationResult();
+        $isBrowserTriggerEnabled = Rules::isBrowserTriggerEnabled();
 
         // quick fix for #15086, if we're only invalidating today's date for a site, don't add the site to the list of sites
         // to reprocess.
@@ -284,6 +293,11 @@ class ArchiveInvalidator
             ) {
                 // date is for today
                 $hasMoreThanJustToday[$idSite] = false;
+            } else {
+                // invalidation is not for today.
+                // this means we need to try to invalidate the general cache so a new tracking request for the same date can set the flag again that another archive invalidation is needed. this behaviour is not needed for today as we always force archiving of "yesterday" anyway.
+                $anySiteRequiresGeneralCache = $anySiteRequiresGeneralCache // a previous site required a general cache clear but because of the 4s interval we might not have executed it just yet. We carry this "true" flag forward until the 4seconds have past or it's the end of the function to make sure it will be executed at some point
+                    || $isBrowserTriggerEnabled;  // when browser archiving is used then to be safe we always want to invalidate the general cache as otherwise invalidating of today might not happen.
             }
         }
 
@@ -318,22 +332,25 @@ class ArchiveInvalidator
 
         $isInvalidatingDays = $period == 'day' || $cascadeDown || empty($period);
         $isNotInvalidatingSegment = empty($segment) || empty($segment->getString());
+
         if ($isInvalidatingDays
             && $isNotInvalidatingSegment
         ) {
+
+            $hasDeleted = true;
             foreach ($idSites as $idSite) {
                 foreach ($dates as $date) {
                     if (is_string($date)) {
                         $date = Date::factory($date);
                     }
 
-                    $this->forgetRememberedArchivedReportsToInvalidate($idSite, $date);
+                    $hasDeleted = $this->forgetRememberedArchivedReportsToInvalidate($idSite, $date) || $hasDeleted;
                 }
             }
-        }
 
-        if ($clearCache) {
-            Cache::clearCacheGeneral();
+            if ($anySiteRequiresGeneralCache && $hasDeleted) {
+                Cache::clearCacheGeneral();
+            }
         }
 
         return $invalidationInfo;

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -330,23 +330,15 @@ class ArchiveInvalidator
             && $isNotInvalidatingSegment
         ) {
 
-            $isBrowserTriggerEnabled = Rules::isBrowserTriggerEnabled();
             $hasDeletedAny = false;
 
             foreach ($idSites as $idSite) {
-                $tz = Site::getTimezoneFor($idSite);
-
                 foreach ($dates as $date) {
                     if (is_string($date)) {
                         $date = Date::factory($date);
                     }
-                    $isToday = ((string)$date) == ((string)Date::factoryInTimezone('today', $tz));
 
-                    if (!$isToday || $isBrowserTriggerEnabled) {
-                        // invalidation is not for today. this means we need to try to invalidate the general cache so a new tracking request for the same date can set the flag again that another archive invalidation is needed. this behaviour is not needed for today as we always force archiving of "yesterday" anyway.
-                        // when browser archiving is used, to be safe, we always want to invalidate the general cache as otherwise invalidating of today might not happen.
-                        $hasDeletedAny = $this->forgetRememberedArchivedReportsToInvalidate($idSite, $date) || $hasDeletedAny;
-                    }
+                    $hasDeletedAny = $this->forgetRememberedArchivedReportsToInvalidate($idSite, $date) || $hasDeletedAny;
                 }
             }
 

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -250,11 +250,13 @@ class ArchiveInvalidator
      * @param bool $forceInvalidateNonexistantRanges set true to force inserting rows for ranges in archive_invalidations
      * @param string $name null to make sure every plugin is archived when this invalidation is processed by core:archive,
      *                     or a plugin name to only archive the specific plugin.
+     * @param bool $ignorePurgeLogDataDate
+     * @param bool $clearCache
      * @return InvalidationResult
      * @throws \Exception
      */
     public function markArchivesAsInvalidated(array $idSites, array $dates, $period, Segment $segment = null, $cascadeDown = false,
-                                              $forceInvalidateNonexistantRanges = false, $name = null, $ignorePurgeLogDataDate = false)
+                                              $forceInvalidateNonexistantRanges = false, $name = null, $ignorePurgeLogDataDate = false, $clearCache = true)
     {
         $plugin = null;
         if ($name && strpos($name, '.') !== false) {
@@ -328,7 +330,10 @@ class ArchiveInvalidator
                 }
             }
         }
-        Cache::clearCacheGeneral();
+
+        if ($clearCache) {
+            Cache::clearCacheGeneral();
+        }
 
         return $invalidationInfo;
     }

--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -442,10 +442,11 @@ class Loader
                 $dateToInvalidate = Date::factory($date);
                 $idSite = $this->params->getSite()->getId();
                 $timezone = Site::getTimezoneFor($idSite);
+                $isDateToday = ((string)$dateToInvalidate) == ((string)Date::factoryInTimezone('today', $timezone));
 
                 $anySiteRequiresGeneralCache = $anySiteRequiresGeneralCache // a previous site required a general cache clear but because of the 4s interval we might not have executed it just yet. We carry this "true" flag forward until the 4seconds have past or it's the end of the function to make sure it will be executed at some point
                     || $isBrowserTriggerEnabled  // when browser archiving is used then to be safe we always want to invalidate the general cache as otherwise invalidating of today might not happen.
-                    || ((string)$dateToInvalidate) != ((string)Date::factoryInTimezone('today', $timezone));  // date is not for today. this means we need to invalidate the general cache so a new tracking request for the same date can set the flag again that another archive invalidation is needed. this behaviour is not needed for today as we always force archiving of "yesterday" anyway.
+                    || !$isDateToday;  // invalidation is not for today. this means we need to invalidate the general cache so a new tracking request for the same date can set the flag again that another archive invalidation is needed. this behaviour is not needed for today as we always force archiving of "yesterday" anyway.
 
                 if (time() - $timeCacheLastCleared >= 4 && $anySiteRequiresGeneralCache) {
                     // for performance reason we don't want to clear the cache for every site but only once per 4 seconds.

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
@@ -498,12 +498,14 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
         $this->rememberReportsForManySitesAndDates();
 
         // site does not match
-        $this->invalidator->forgetRememberedArchivedReportsToInvalidate(10, Date::factory('2014-04-05'));
+        $hasDeleted = $this->invalidator->forgetRememberedArchivedReportsToInvalidate(10, Date::factory('2014-04-05'));
+        $this->assertFalse($hasDeleted);
         $reports = $this->invalidator->getRememberedArchivedReportsThatShouldBeInvalidated();
         $this->assertSameReports($this->getRememberedReportsByDate(), $reports);
 
         // date does not match
-        $this->invalidator->forgetRememberedArchivedReportsToInvalidate(7, Date::factory('2012-04-05'));
+        $hasDeleted = $this->invalidator->forgetRememberedArchivedReportsToInvalidate(7, Date::factory('2012-04-05'));
+        $this->assertFalse($hasDeleted);
         $reports = $this->invalidator->getRememberedArchivedReportsThatShouldBeInvalidated();
         $this->assertSameReports($this->getRememberedReportsByDate(), $reports);
     }
@@ -512,7 +514,8 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
     {
         $this->rememberReportsForManySitesAndDates();
 
-        $this->invalidator->forgetRememberedArchivedReportsToInvalidate(2, Date::factory('2014-04-05'));
+        $hasDeleted = $this->invalidator->forgetRememberedArchivedReportsToInvalidate(2, Date::factory('2014-04-05'));
+        $this->assertTrue($hasDeleted);
         $reports = $this->invalidator->getRememberedArchivedReportsThatShouldBeInvalidated();
 
         $expected = array(
@@ -526,7 +529,8 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
 
         unset($expected['2014-05-08']);
 
-        $this->invalidator->forgetRememberedArchivedReportsToInvalidate(7, Date::factory('2014-05-08'));
+        $hasDeleted = $this->invalidator->forgetRememberedArchivedReportsToInvalidate(7, Date::factory('2014-05-08'));
+        $this->assertTrue($hasDeleted);
         $reports = $this->invalidator->getRememberedArchivedReportsThatShouldBeInvalidated();
         $this->assertSameReports($expected, $reports);
     }


### PR DESCRIPTION
### Description:

fix DEV-2707

Since Matomo 4.7 we noticed that we often have thousands of general cache invalidations within a minute. Around 100 general cache invalidations within approx 4 seconds but depends on how many archives there are to be invalidated. It causes one general cache invalidation per site every time we call `prepareArchive`. Aka if you have thousands of sites, and run heaps of archives, and all sites have regular traffic, this can cause a huge massive amount of invalidations.

<img width="175" alt="image" src="https://user-images.githubusercontent.com/273120/160057473-791dbb59-6345-4520-8796-c1fbb456e987.png">


All these cache invalidations are also particularly a problem as we're constantly clearing the cache, and also constantly populate the tracker cache every ms as there are concurrent tracking requests happening. 

The problem is coming from this backtrace which is called once per site when preparing an archive run. So this can be called very often this logic and cause a huge amount of invalidations.

```

#0  Piwik\Tracker\Cache::clearCacheGeneral() called at [core/Archive/ArchiveInvalidator.php:332]
#1  Piwik\Archive\ArchiveInvalidator->markArchivesAsInvalidated() called at [plugins/CoreAdminHome/API.php:166]
#2  Piwik\Plugins\CoreAdminHome\API->invalidateArchivedReports() called at [core/CronArchive.php:928]
#3  Piwik\CronArchive->invalidateWithSegments() called at [core/CronArchive.php:873]
#4  Piwik\CronArchive->invalidateArchivedReportsForSitesThatNeedToBeArchivedAgainImpl() called at [core/CronArchive.php:808]
#5  Piwik\CronArchive->Piwik\{closure}() called at [core/Tracker/Cache.php:302]
#6  Piwik\Tracker\Cache::withDelegatedCacheClears() called at [core/CronArchive.php:809]
#7  Piwik\CronArchive->invalidateArchivedReportsForSitesThatNeedToBeArchivedAgain() called at [core/CronArchive/QueueConsumer.php:182]
#8  Piwik\CronArchive\QueueConsumer->getNextArchivesToProcess() called at [core/CronArchive.php:394]
#9  Piwik\CronArchive->run() called at [core/CronArchive.php:280]
#10 Piwik\CronArchive->Piwik\{closure}() called at [core/Access.php:661]
#11 Piwik\Access::doAsSuperUser() called at [core/CronArchive.php:286]
#12 Piwik\CronArchive->main() called at [plugins/CoreConsole/Commands/CoreArchiver.php:32]
#13 Piwik\Plugins\CoreConsole\Commands\CoreArchiver->execute() called at [vendor/symfony/console/Symfony/Component/Console/Command/Command.php:257]
#14 Symfony\Component\Console\Command\Command->run() called at [vendor/symfony/console/Symfony/Component/Console/Application.php:874]
#15 Symfony\Component\Console\Application->doRunCommand() called at [vendor/symfony/console/Symfony/Component/Console/Application.php:195]
#16 Symfony\Component\Console\Application->doRun()
```

To improve the situation my thought was to invalidate the general cache only every 4 seconds. We could technically only clear the cache after marking all archives as invalid. However, this could take a while depending on the number of archives to invalidate and the number of sites. 

If it takes a few minutes between marking an archive as invalid and calling `clearGeneralCache`, then we risk that the given date won't be re-archived later under circumstances since the tracker wouldn't know we have invalidated the archive and therefore it wouldn't call `rememberToInvalidateArchivedReportsLater` and then we wouldn't archive that date again under some circumstances. It's bit hard to explain but generally we need a general cache clear ideally immediately after marking an archiving as invalid.

My trade-off was that it's unlikely that the only tracking request for the given date happens during those 5 seconds. And for today periods we always archive the date again the next day after midnight so it shouldn't be an issue.

Any thoughts on this? I haven't fully tested it yet but wanted to check for thoughts first.

There could be other solutions like having the information to `rememberToInvalidateArchivedReportsLater` in a tracker site cache but thinking this can make things worse as we can't optimise it as well as this one and causes again a lot of invalidations.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
