### PR TITLE
Improve performance when deleting data for multiple sites

### DIFF
--- a/plugins/PrivacyManager/tests/Integration/Model/DataSubjectsTest.php
+++ b/plugins/PrivacyManager/tests/Integration/Model/DataSubjectsTest.php
@@ -24,6 +24,7 @@ use Piwik\Plugins\SitesManager\API as SitesManagerAPI;
 /**
  * Class DataSubjectsTest
  *
+ * @group DataSubjectsTest
  * @group Plugins
  */
 class DataSubjectsTest extends IntegrationTestCase


### PR DESCRIPTION
### Description:

Fixes #18618

This PR slightly changes the way the `deleteLogDataForDeletedSites` scheduled task deletes data. 

Currently this function attempts to delete data in each table for multiple sites with a single query using the IN operator, this can result in a very large data set being selected and a join buffer being used which can cause the query to take a very long time to complete.

This has been changed use one query per site / table pair which will result in a simpler query and faster completion.

There are existing tests that cover this functionality.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
