### PR TITLE
Skip web server error logs for unsupported browser exceptions

### DIFF
--- a/core/ExceptionHandler.php
+++ b/core/ExceptionHandler.php
@@ -146,7 +146,12 @@ class ExceptionHandler
             }
         }
 
-        $result = Piwik_GetErrorMessagePage($message, $debugTrace, true, true, $logoHeaderUrl, $logoFaviconUrl);
+        // Unsupported browser errors shouldn't be written to the web server log. At DEBUG logging level this error will
+        // be written to the application log instead
+        $writeErrorLog = !($ex instanceof \Piwik\Exception\NotSupportedBrowserException);
+
+        $result = Piwik_GetErrorMessagePage($message, $debugTrace, true, true, $logoHeaderUrl,
+                                            $logoFaviconUrl, null, $writeErrorLog);
 
         try {
             /**

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -109,12 +109,15 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
      * @param bool $optionalLinkBack If true, displays a link to go back
      * @param bool|string $logoUrl The URL to the logo to use.
      * @param bool|string $faviconUrl The URL to the favicon to use.
+     * @param bool $writeErrorLog If true then a webserver error log will be written, defaults to true
      * @return string
      */
     function Piwik_GetErrorMessagePage($message, $optionalTrace = false, $optionalLinks = false, $optionalLinkBack = false,
-                                       $logoUrl = false, $faviconUrl = false, $isCli = null)
+                                       $logoUrl = false, $faviconUrl = false, $isCli = null, bool $writeErrorLog = true)
     {
-        error_log(sprintf("Error in Matomo: %s", str_replace("\n", " ", strip_tags($message))));
+        if ($writeErrorLog) {
+            error_log(sprintf("Error in Matomo: %s", str_replace("\n", " ", strip_tags($message))));
+        }
 
         if (!headers_sent()) {
             header('Content-Type: text/html; charset=utf-8');


### PR DESCRIPTION
### Description:

Fixes #17738 

Checks for the `NotSupportedBrowserException` type on the error message page and avoids writing a web server error log for these exception. (they can be captured in the application log instead if logging is set to `debug`)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
