### PR TITLE
Try to reduce failed cache write random UI test failures

### DIFF
--- a/config/environment/ui-test.php
+++ b/config/environment/ui-test.php
@@ -21,6 +21,7 @@ return array(
                 while ($attempts < $retryCount) {
                     try {
                         parent::write($key, $content);
+                        return;
                     } catch (\Exception $ex) {
                         if (!preg_match('/^Failed to write cache file/', $ex->getMessage())) {
                             throw $ex;

--- a/config/environment/ui-test.php
+++ b/config/environment/ui-test.php
@@ -23,7 +23,7 @@ return array(
                         parent::write($key, $content);
                     } catch (\Exception $ex) {
                         if (!preg_match('/^Failed to write cache file/', $ex->getMessage())) {
-                            throw;
+                            throw $ex;
                         }
 
                         usleep(50);

--- a/config/environment/ui-test.php
+++ b/config/environment/ui-test.php
@@ -10,6 +10,30 @@ return array(
     'tests.ui.url_normalizer_blacklist.api' => array(),
     'tests.ui.url_normalizer_blacklist.controller' => array(),
 
+    'twig.cache' => function (\Psr\Container\ContainerInterface $container) {
+        $templatesPath = $container->get('path.tmp.templates');
+        return new class($templatesPath) extends \Twig\Cache\FilesystemCache {
+            public function write(string $key, string $content): void
+            {
+                $retryCount = 3;
+
+                $attempts = 0;
+                while ($attempts < $retryCount) {
+                    try {
+                        parent::write($key, $content);
+                    } catch (\Exception $ex) {
+                        if (!preg_match('/^Failed to write cache file/', $ex->getMessage())) {
+                            throw;
+                        }
+
+                        usleep(50);
+                        ++$attempts;
+                    }
+                }
+            }
+        };
+    },
+
     'Piwik\Config' => \DI\decorate(function (\Piwik\Config $config) {
         $config->General['cors_domains'][] = '*';
         $config->General['trusted_hosts'][] = '127.0.0.1';

--- a/config/global.php
+++ b/config/global.php
@@ -35,6 +35,8 @@ return array(
 
     'view.clearcompiledtemplates.enable' => true,
 
+    'twig.cache' => DI\string('path.tmp.templates'),
+
     'Matomo\Cache\Eager' => function (ContainerInterface $c) {
         $backend = $c->get('Matomo\Cache\Backend');
         $cacheId = $c->get('cache.eager.cache_id');

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -134,13 +134,13 @@ class Twig
         $chainLoader = new ChainLoader($loaders);
 
         // Create new Twig Environment and set cache dir
-        $templatesCompiledPath = StaticContainer::get('path.tmp.templates');
+        $cache = StaticContainer::get('twig.cache');
 
         $this->twig = new Environment($chainLoader,
             array(
                  'debug'            => true, // to use {{ dump(var) }} in twig templates
                  'strict_variables' => true, // throw an exception if variables are invalid
-                 'cache'            => $templatesCompiledPath,
+                 'cache'            => $cache,
             )
         );
         $this->twig->addExtension(new DebugExtension());


### PR DESCRIPTION
### Description:

For UI tests only adds a special FilesystemCache instance that retries the operation if it fails.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
