### PR TITLE
[Vue] retry vue:build if we notice a typescript compiler race condition occurs

### DIFF
--- a/plugins/CoreVue/Commands/Build.php
+++ b/plugins/CoreVue/Commands/Build.php
@@ -22,6 +22,7 @@ class Build extends ConsoleCommand
 {
     const RECOMMENDED_NODE_VERSION = '16.0.0';
     const RECOMMENDED_NPM_VERSION = '7.0.0';
+    const RETRY_COUNT = 2;
 
     protected function configure()
     {
@@ -144,13 +145,25 @@ class Build extends ConsoleCommand
         if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
             passthru($command);
         } else {
-            exec($command, $cmdOutput, $returnCode);
-            if ($returnCode != 0
-                || stripos(implode("\n", $cmdOutput), 'warning') !== false
-            ) {
-                $output->writeln("<error>Failed:</error>\n");
-                $output->writeln($cmdOutput);
-                $output->writeln("");
+            $attempts = 0;
+            while ($attempts < self::RETRY_COUNT) {
+                exec($command, $cmdOutput, $returnCode);
+
+                $concattedOutput = implode("\n", $cmdOutput);
+                if ($this->isTypeScriptRaceConditionInOutput($plugin, $concattedOutput)) {
+                    $output->writeln("<comment>The TypeScript compiler encountered a race condition when compiling "
+                        . "files (files that exist were not found), retrying.</comment>");
+                }
+
+                if ($returnCode != 0
+                    || stripos($concattedOutput, 'warning') !== false
+                ) {
+                    $output->writeln("<error>Failed:</error>\n");
+                    $output->writeln($cmdOutput);
+                    $output->writeln("");
+                }
+
+                ++$attempts;
             }
         }
 
@@ -251,5 +264,17 @@ class Build extends ConsoleCommand
                 . "command %s</comment>",
                 self::RECOMMENDED_NPM_VERSION, $npmVersion, 'npm install -g npm@latest'));
         }
+    }
+
+    private function isTypeScriptRaceConditionInOutput($plugin, $concattedOutput)
+    {
+        if (!preg_match('/^TS2307: Cannot find module \'([^\']+)\' or its corresponding type declarations./', $concattedOutput, $matches)) {
+            return false;
+        }
+
+        $file = $matches[1];
+        $filePath = PIWIK_INCLUDE_PATH . '/plugins/' . $plugin . '/vue/src/' . $file;
+        $isTypeScriptCompilerBug = file_exists($filePath);
+        return $isTypeScriptCompilerBug;
     }
 }


### PR DESCRIPTION
### Description:

This should hopefully prevent the vue build github action from failing without making builds too slow.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
