### PR TITLE
Prevent possible errors when exporting datasets in GDPR tool

### DIFF
--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -6,6 +7,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  *
  */
+
 namespace Piwik\Plugins\PrivacyManager\Model;
 
 use Piwik\Columns\Dimension;
@@ -50,7 +52,7 @@ class DataSubjects
     public function deleteDataSubjectsForDeletedSites($allExistingIdSites)
     {
         if (empty($allExistingIdSites)) {
-            return array();
+            return [];
         }
 
         $allExistingIdSites = array_map('intval', $allExistingIdSites);
@@ -67,15 +69,15 @@ class DataSubjects
         if (empty($idSitesNoLongerExisting)) {
             // nothing to be deleted... if there is no entry for that table in log_visit or log_link_visit_action
             // then there shouldn't be anything to be deleted in other tables either
-            return array();
+            return [];
         }
 
         $logTables = $this->getLogTablesToDeleteFrom();
         // It's quicker to call the delete queries one site at a time instead of using the IN operator and potentially
         // creating a huge result set
         foreach ($idSitesNoLongerExisting as $idSiteNoLongerExisting) {
-            $r = $this->deleteLogDataFrom($logTables, function($tableToSelectFrom) use ($idSiteNoLongerExisting) {
-                return [$tableToSelectFrom . '.idsite = '. $idSiteNoLongerExisting, []];
+            $r = $this->deleteLogDataFrom($logTables, function ($tableToSelectFrom) use ($idSiteNoLongerExisting) {
+                return [$tableToSelectFrom . '.idsite = ' . $idSiteNoLongerExisting, []];
             });
             foreach ($r as $k => $v) {
                 if (!array_key_exists($k, $results)) {
@@ -92,16 +94,16 @@ class DataSubjects
     public function deleteDataSubjects($visits)
     {
         if (empty($visits)) {
-            return array();
+            return [];
         }
 
-        $results = array();
+        $results = [];
 
         /**
          * Lets you delete data subjects to make your plugin GDPR compliant.
          * This can be useful if you have developed a plugin which stores any data for visits but doesn't
          * use any core logic to store this data. If core API's are used, for example log tables, then the data may
-         * be deleted automatically. 
+         * be deleted automatically.
          *
          * **Example**
          *
@@ -115,7 +117,7 @@ class DataSubjects
          * @param array &$visits An array with multiple visit entries containing an idvisit and idsite each. The data
          *                       for these visits is requested to be deleted.
          */
-        Piwik::postEvent('PrivacyManager.deleteDataSubjects', array(&$results, $visits));
+        Piwik::postEvent('PrivacyManager.deleteDataSubjects', [&$results, $visits]);
 
         $datesToInvalidateByIdSite = $this->getDatesToInvalidate($visits);
 
@@ -142,16 +144,16 @@ class DataSubjects
 
     private function getDatesToInvalidate($visits)
     {
-        $idVisitsByIdSites = array();
+        $idVisitsByIdSites = [];
         foreach ($visits as $visit) {
             $idSite = (int)$visit['idsite'];
             if (!isset($idVisitsByIdSites[$idSite])) {
-                $idVisitsByIdSites[$idSite] = array();
+                $idVisitsByIdSites[$idSite] = [];
             }
             $idVisitsByIdSites[$idSite][] = (int)$visit['idvisit'];
         }
 
-        $datesToInvalidate = array();
+        $datesToInvalidate = [];
         foreach ($idVisitsByIdSites as $idSite => $idVisits) {
             $timezone = Site::getTimezoneFor($idSite);
 
@@ -160,7 +162,7 @@ class DataSubjects
                 . ' AND idvisit IN (' . implode(',', $idVisits) . ')';
 
             $resultSet = Db::fetchAll($sql);
-            $dates = array();
+            $dates = [];
             foreach ($resultSet as $row) {
                 $date = Date::factory($row['visit_last_action_time'], $timezone);
                 $dates[$date->toString('Y-m-d')] = 1;
@@ -195,14 +197,14 @@ class DataSubjects
         foreach ($logTables as $logTable) {
             $logTableName = $logTable->getName();
 
-            $from = array($logTableName);
+            $from = [$logTableName];
             $tableToSelect = $this->findNeededTables($logTable, $from);
 
             if (!$tableToSelect) {
                 throw new \Exception('Cannot join table ' . $logTable->getName());
             }
 
-            list($where, $bind) = $generateWhere($tableToSelect);
+            [$where, $bind] = $generateWhere($tableToSelect);
 
             $sql = "DELETE $logTableName FROM " . $this->makeFromStatement($from) . " WHERE $where";
 
@@ -230,11 +232,11 @@ class DataSubjects
             $bName = $b->getName();
             if ($bName === 'log_visit') {
                 return -1;
-            } else if ($aName === 'log_visit') {
+            } elseif ($aName === 'log_visit') {
                 return 1;
-            } else if ($bName === 'log_link_visit_action') {
+            } elseif ($bName === 'log_link_visit_action') {
                 return -1;
-            } else if ($aName === 'log_link_visit_action') {
+            } elseif ($aName === 'log_link_visit_action') {
                 return 1;
             }
 
@@ -268,7 +270,7 @@ class DataSubjects
     public function exportDataSubjects($visits)
     {
         if (empty($visits)) {
-            return array();
+            return [];
         }
 
         $logTables = $this->logTablesProvider->getAllLogTables();
@@ -278,7 +280,7 @@ class DataSubjects
 
         $dimensions = Dimension::getAllDimensions();
 
-        $results = array();
+        $results = [];
 
         foreach ($logTables as $logTable) {
             $logTableName = $logTable->getName();
@@ -286,7 +288,7 @@ class DataSubjects
                 continue; // we export these entries further below
             }
 
-            $from = array($logTableName);
+            $from = [$logTableName];
             $tableToSelect = $this->findNeededTables($logTable, $from);
 
             if (!$tableToSelect) {
@@ -295,14 +297,14 @@ class DataSubjects
                 continue;
             }
 
-            list($where, $bind) = $this->visitsToWhereAndBind($tableToSelect, $visits);
+            [$where, $bind] = $this->visitsToWhereAndBind($tableToSelect, $visits);
 
-            $select = array();
+            $select = [];
             $cols = DbHelper::getTableColumns(Common::prefixTable($logTableName));
             ksort($cols); // make sure test results will be always in same order
 
-            $binaryFields = array();
-            $dimensionPerCol = array();
+            $binaryFields = [];
+            $dimensionPerCol = [];
             foreach ($cols as $col => $config) {
                 foreach ($dimensions as $dimension) {
                     if (
@@ -333,7 +335,7 @@ class DataSubjects
             $idFields = $logTable->getIdColumn();
             if (!empty($idFields)) {
                 if (!is_array($idFields)) {
-                    $idFields = array($idFields);
+                    $idFields = [$idFields];
                 }
                 $sql .= ' ORDER BY ';
                 foreach ($idFields as $field) {
@@ -396,10 +398,10 @@ class DataSubjects
             $dimensionLogTable = $this->logTablesProvider->getLogTable($dimensionTable);
 
             if ($join && $join instanceof ActionNameJoin && $dimensionColumn && $dimensionTable && $dimensionLogTable && $dimensionLogTable->getColumnToJoinOnIdVisit()) {
-                $from = array('log_action', array('table' => $dimensionTable, 'joinOn' => "log_action.idaction = `$dimensionTable`.`$dimensionColumn`"));
+                $from = ['log_action', ['table' => $dimensionTable, 'joinOn' => "log_action.idaction = `$dimensionTable`.`$dimensionColumn`"]];
 
                 $tableToSelect = $this->findNeededTables($dimensionLogTable, $from);
-                list($where, $bind) = $this->visitsToWhereAndBind($tableToSelect, $visits);
+                [$where, $bind] = $this->visitsToWhereAndBind($tableToSelect, $visits);
                 $from = $this->makeFromStatement($from);
 
                 $sql = "SELECT log_action.idaction, log_action.name, log_action.url_prefix FROM $from WHERE $where";
@@ -418,7 +420,7 @@ class DataSubjects
                     usort($result, function ($a1, $a2) {
                         return $a1['idaction'] > $a2['idaction'] ? 1 : -1;
                     });
-                    $results['log_action_' . $dimensionTable.'_' . $dimensionColumn] = $result;
+                    $results['log_action_' . $dimensionTable . '_' . $dimensionColumn] = $result;
                 }
             }
         }
@@ -443,7 +445,7 @@ class DataSubjects
          * @param array &$visits An array with multiple visit entries containing an idvisit and idsite each. The data
          *                       for these visits is requested to be exported.
          */
-        Piwik::postEvent('PrivacyManager.exportDataSubjects', array(&$results, $visits));
+        Piwik::postEvent('PrivacyManager.exportDataSubjects', [&$results, $visits]);
 
         krsort($results); // make sure test results are always in same order
 
@@ -457,12 +459,12 @@ class DataSubjects
         if ($logTable->getColumnToJoinOnIdVisit()) {
             $tableToSelect = 'log_visit';
             if ($logTableName !== 'log_visit') {
-                $from[] = array('table' => 'log_visit', 'joinOn' => sprintf('%s.%s = %s.%s', $logTableName, $logTable->getColumnToJoinOnIdVisit(), 'log_visit', 'idvisit'));
+                $from[] = ['table' => 'log_visit', 'joinOn' => sprintf('%s.%s = %s.%s', $logTableName, $logTable->getColumnToJoinOnIdVisit(), 'log_visit', 'idvisit')];
             }
         } elseif ($logTable->getColumnToJoinOnIdAction()) {
             $tableToSelect = 'log_link_visit_action';
             if ($logTableName !== 'log_link_visit_action') {
-                $from[] = array('table' => 'log_link_visit_action', 'joinOn' => sprintf('%s.%s = %s.%s', $logTableName, $logTable->getColumnToJoinOnIdAction(), 'log_link_visit_action', 'idaction_url'));
+                $from[] = ['table' => 'log_link_visit_action', 'joinOn' => sprintf('%s.%s = %s.%s', $logTableName, $logTable->getColumnToJoinOnIdAction(), 'log_link_visit_action', 'idaction_url')];
             }
         } else {
             $tableToSelect = $this->joinNonCoreTable($logTable, $from);
@@ -487,15 +489,20 @@ class DataSubjects
 
     private function visitsToWhereAndBind($tableToSelect, $visits)
     {
-        $where = array();
-        $bind = array();
-        $in = array();
+        $where = [];
+        $bind = [];
+        $in = [];
         foreach ($visits as $visit) {
             if (empty($visit['idsite'])) {
                 $in[] = (int) $visit['idvisit'];
             } else {
-                $where[] = sprintf('(%s.idsite = %d AND %s.idvisit = %d)',
-                    $tableToSelect, (int) $visit['idsite'], $tableToSelect, (int) $visit['idvisit']);
+                $where[] = sprintf(
+                    '(%s.idsite = %d AND %s.idvisit = %d)',
+                    $tableToSelect,
+                    (int) $visit['idsite'],
+                    $tableToSelect,
+                    (int) $visit['idvisit']
+                );
             }
         }
         $where = implode(' OR ', $where);
@@ -503,10 +510,10 @@ class DataSubjects
             if (!empty($where)) {
                 $where .= ' OR ';
             }
-            $where .= $tableToSelect . '.idvisit in (' . implode(',',$in) . ')';
+            $where .= $tableToSelect . '.idvisit in (' . implode(',', $in) . ')';
         }
 
-        return array($where, $bind);
+        return [$where, $bind];
     }
 
     private function joinNonCoreTable(LogTable $logTable, &$from)
@@ -522,26 +529,26 @@ class DataSubjects
             $joinTable = $this->logTablesProvider->getLogTable($tableName);
 
             if ($joinTable->getColumnToJoinOnIdVisit()) {
-                $from[] = array(
+                $from[] = [
                     'table' => $joinTable->getName(),
                     'joinOn' => sprintf('%s.%s = %s.%s', $logTableName, $joinColumn, $joinTable->getName(), $joinColumn)
-                );
+                ];
                 if ($joinTable->getName() !== 'log_visit') {
-                    $from[] = array(
+                    $from[] = [
                         'table' => 'log_visit',
                         'joinOn' => sprintf('%s.%s = %s.%s', $joinTable->getName(), $joinTable->getColumnToJoinOnIdVisit(), 'log_visit', $joinTable->getColumnToJoinOnIdVisit())
-                    );
+                    ];
                 }
                 $tableToSelect = 'log_visit';
                 return $tableToSelect;
             } else {
-                $subFroms = array();
+                $subFroms = [];
                 $tableToSelect = $this->joinNonCoreTable($joinTable, $subFroms);
                 if ($tableToSelect) {
-                    $from[] = array(
+                    $from[] = [
                         'table' => $joinTable->getName(),
                         'joinOn' => sprintf('%s.%s = %s.%s', $logTableName, $joinColumn, $joinTable->getName(), $joinColumn)
-                    );
+                    ];
                     foreach ($subFroms as $subFrom) {
                         $from[] = $subFrom;
                     }
@@ -549,7 +556,6 @@ class DataSubjects
                 }
             }
         }
-
     }
 
     /**
@@ -565,5 +571,4 @@ class DataSubjects
         });
         return $deleteCounts;
     }
-
 }


### PR DESCRIPTION
### Description:

When exporting datasets in the GDPR tool we try to format all columns that are exported.
This is done by checking for matching dimensions. In some cases this causes problems, as the dimensions actually don't have a format method that can format the raw column value (as they define a sql segment that should be applied).

This currently happens e.g. when exporting a dataset that contains some media actions, as the `Hour` dimension is used for `server_time` column.

This PR drops using dimensions for formatting if they define a special sql segment.
In addition it catches possible exceptions thrown while formatting and using the unformatted raw value instead. Possible exceptions will be logged so we still might notice possible problems.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
