### PR TITLE
Adds update script to remove broken scheduled reports from db

### DIFF
--- a/core/Updates/4.10.0-b1.php
+++ b/core/Updates/4.10.0-b1.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+use Piwik\Updater\Migration;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
+
+/**
+ * Update for version 4.10.0-b1
+ */
+class Updates_4_10_0_b1 extends PiwikUpdates
+{
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    /**
+     * @param Updater $updater
+     *
+     * @return Migration[]
+     */
+    public function getMigrations(Updater $updater)
+    {
+        $table        = Common::prefixTable('report');
+        $invalidCount = Db::fetchOne(
+            "SELECT COUNT(*) FROM $table WHERE reports = ? OR parameters = ?",
+            ['Array', 'Array']
+        );
+
+        if (0 === (int) $invalidCount) {
+            return [];
+        }
+
+        return [
+            $this->migration->db->sql('DELETE FROM ' . $table . ' WHERE reports = "Array" OR parameters = "Array"')
+        ];
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
+    }
+}

--- a/core/Updates/4.10.0-b1.php
+++ b/core/Updates/4.10.0-b1.php
@@ -50,7 +50,7 @@ class Updates_4_10_0_b1 extends PiwikUpdates
         }
 
         return [
-            $this->migration->db->sql('DELETE FROM ' . $table . ' WHERE reports = "Array" OR parameters = "Array"')
+            $this->migration->db->sql("DELETE FROM " . $table . " WHERE reports = 'Array' OR parameters = 'Array'")
         ];
     }
 

--- a/core/Version.php
+++ b/core/Version.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -20,7 +21,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    const VERSION = '4.9.0-rc1';
+    const VERSION = '4.10.0-b1';
 
     const MAJOR_VERSION = 4;
 


### PR DESCRIPTION
### Description:

In a former version of Matomo scheduled reports were stored in a broken state. Instead of the json_encoded data, the string `Array` was stored in the database. As those reports can't be used nor restored it should be better to simply remove them.

fixes #19047

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
