### PR TITLE
Fix importing logs consisting of nasty strings (#19069)

### DIFF
--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -184,6 +184,7 @@ class Model
         $sql   = "INSERT INTO $table (name, hash, type, url_prefix) VALUES (?,CRC32(?),?,?)";
 
         $db = $this->getDb();
+        $name = iconv('UTF-8', 'ASCII//TRANSLIT', $name);
         $db->query($sql, array($name, $name, $type, $urlPrefix));
 
         $actionId = $db->lastInsertId();


### PR DESCRIPTION
Some UTF8 strings may stop the import. Webserver's error-log reveals:
[php7:notice] [...] Mysqli statement execute error : Incorrect string [...].

Converting the string to ASCII before importing fixes the issue so that
importing the logs runs successfully.

Fixes #19069.
