### PR TITLE
Move guessing location country by provider to default location provider

### DIFF
--- a/plugins/UserCountry/Columns/Country.php
+++ b/plugins/UserCountry/Columns/Country.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -6,19 +7,16 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  *
  */
+
 namespace Piwik\Plugins\UserCountry\Columns;
 
 use Piwik\Columns\DimensionSegmentFactory;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
-use Piwik\Intl\Data\Provider\RegionDataProvider;
 use Piwik\Metrics\Formatter;
-use Matomo\Network\IP;
 use Piwik\Piwik;
-use Piwik\Plugin\Manager;
 use Piwik\Plugin\Segment;
-use Piwik\Plugins\Provider\Provider as ProviderProvider;
 use Piwik\Plugins\UserCountry\LocationProvider;
 use Piwik\Segment\SegmentsList;
 use Piwik\Tracker\Visit;
@@ -53,8 +51,8 @@ class Country extends Base
         $segment->setNeedsMostFrequentValues(false);
         $regionDataProvider = StaticContainer::get('Piwik\Intl\Data\Provider\RegionDataProvider');
         $countryList = $regionDataProvider->getCountryList();
-        array_walk($countryList, function(&$item, $key) {
-            $item = Piwik::translate('Intl_Country_'.strtoupper($key), [], 'en');
+        array_walk($countryList, function (&$item, $key) {
+            $item = Piwik::translate('Intl_Country_' . strtoupper($key), [], 'en');
         });
 
         $segment->setSqlFilterValue(function ($val) use ($countryList) {
@@ -97,53 +95,7 @@ class Country extends Base
             return strtolower($country);
         }
 
-        $country = $this->getCountryUsingProviderExtensionIfValid($userInfo['ip']);
-
-        if (!empty($country)) {
-            return $country;
-        }
-
         return Visit::UNKNOWN_CODE;
-    }
-
-    private function getCountryUsingProviderExtensionIfValid($ipAddress)
-    {
-        if (!Manager::getInstance()->isPluginInstalled('Provider')) {
-            return false;
-        }
-
-        $hostname = $this->getHost($ipAddress);
-        $hostnameExtension = ProviderProvider::getCleanHostname($hostname);
-
-        $hostnameDomain = substr($hostnameExtension, 1 + strrpos($hostnameExtension, '.'));
-        if ($hostnameDomain == 'uk') {
-            $hostnameDomain = 'gb';
-        }
-
-        /** @var RegionDataProvider $regionDataProvider */
-        $regionDataProvider = StaticContainer::get('Piwik\Intl\Data\Provider\RegionDataProvider');
-
-        if (array_key_exists($hostnameDomain, $regionDataProvider->getCountryList())) {
-            return $hostnameDomain;
-        }
-
-        return false;
-    }
-
-    /**
-     * Returns the hostname given the IP address string
-     *
-     * @param string $ipStr IP Address
-     * @return string hostname (or human-readable IP address)
-     */
-    private function getHost($ipStr)
-    {
-        $ip = IP::fromStringIP($ipStr);
-
-        $host = $ip->getHostname();
-        $host = ($host === null ? $ipStr : $host);
-
-        return trim(strtolower($host));
     }
 
     /**
@@ -175,8 +127,6 @@ class Country extends Base
         $enableLanguageToCountryGuess = Config::getInstance()->Tracker['enable_language_to_country_guess'];
         $locationIp = $visitor->getVisitorColumn('location_ip');
 
-        $country = Common::getCountry($browserLanguage, $enableLanguageToCountryGuess, $locationIp);
-
-        return $country;
+        return Common::getCountry($browserLanguage, $enableLanguageToCountryGuess, $locationIp);
     }
 }

--- a/plugins/UserCountry/LocationProvider/DefaultProvider.php
+++ b/plugins/UserCountry/LocationProvider/DefaultProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -6,11 +7,18 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  *
  */
+
 namespace Piwik\Plugins\UserCountry\LocationProvider;
 
+use Matomo\Network\IP;
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
+use Piwik\Intl\Data\Provider\RegionDataProvider;
 use Piwik\Piwik;
+use Piwik\Plugin\Manager;
+use Piwik\Plugins\PrivacyManager\Config as PrivacyManagerConfig;
+use Piwik\Plugins\Provider\Provider as ProviderProvider;
 use Piwik\Plugins\UserCountry\LocationProvider;
 use Piwik\Tracker\TrackerConfig;
 
@@ -32,17 +40,72 @@ class DefaultProvider extends LocationProvider
      */
     public function getLocation($info)
     {
-        $enableLanguageToCountryGuess = Config::getInstance()->Tracker['enable_language_to_country_guess'];
+        $country = $this->getCountryUsingProviderExtensionIfAvailable($info['ip']);
 
-        if (empty($info['lang'])) {
-            $info['lang'] = Common::getBrowserLanguage();
+        if (empty($country)) {
+            $enableLanguageToCountryGuess = Config::getInstance()->Tracker['enable_language_to_country_guess'];
+
+            if (empty($info['lang'])) {
+                $info['lang'] = Common::getBrowserLanguage();
+            }
+            $country = Common::getCountry($info['lang'], $enableLanguageToCountryGuess, $info['ip']);
         }
-        $country = Common::getCountry($info['lang'], $enableLanguageToCountryGuess, $info['ip']);
 
-        $location = array(parent::COUNTRY_CODE_KEY => $country);
+        $location = [parent::COUNTRY_CODE_KEY => $country];
         $this->completeLocationResult($location);
 
         return $location;
+    }
+
+
+    private function getCountryUsingProviderExtensionIfAvailable($ipAddress)
+    {
+        if (
+            !Manager::getInstance()->isPluginInstalled('Provider')
+            || Common::getRequestVar('dp', 0, 'int') !== 1
+        ) {
+            return false;
+        }
+
+        $privacyConfig = new PrivacyManagerConfig();
+
+        // when using anonymized ip for enrichment we skip this check
+        if ($privacyConfig->useAnonymizedIpForVisitEnrichment) {
+            return false;
+        }
+
+        $hostname = $this->getHost($ipAddress);
+        $hostnameExtension = ProviderProvider::getCleanHostname($hostname);
+
+        $hostnameDomain = substr($hostnameExtension, 1 + strrpos($hostnameExtension, '.'));
+        if ($hostnameDomain == 'uk') {
+            $hostnameDomain = 'gb';
+        }
+
+        /** @var RegionDataProvider $regionDataProvider */
+        $regionDataProvider = StaticContainer::get('Piwik\Intl\Data\Provider\RegionDataProvider');
+
+        if (array_key_exists($hostnameDomain, $regionDataProvider->getCountryList())) {
+            return $hostnameDomain;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the hostname given the IP address string
+     *
+     * @param string $ipStr IP Address
+     * @return string hostname (or human-readable IP address)
+     */
+    private function getHost($ipStr)
+    {
+        $ip = IP::fromStringIP($ipStr);
+
+        $host = $ip->getHostname();
+        $host = ($host === null ? $ipStr : $host);
+
+        return trim(strtolower($host));
     }
 
     /**
@@ -92,10 +155,10 @@ class DefaultProvider extends LocationProvider
      */
     public function getSupportedLocationInfo()
     {
-        return array(self::CONTINENT_CODE_KEY => true,
+        return [self::CONTINENT_CODE_KEY => true,
                      self::CONTINENT_NAME_KEY => true,
                      self::COUNTRY_CODE_KEY   => true,
-                     self::COUNTRY_NAME_KEY   => true);
+                     self::COUNTRY_NAME_KEY   => true];
     }
 
     /**
@@ -112,22 +175,23 @@ class DefaultProvider extends LocationProvider
     public function getInfo()
     {
         $desc = '<p>' . Piwik::translate('UserCountry_DefaultLocationProviderDesc1') . ' '
-            . Piwik::translate('UserCountry_DefaultLocationProviderDesc2',
-                array('<strong>', '', '', '</strong>'))
+            . Piwik::translate(
+                'UserCountry_DefaultLocationProviderDesc2',
+                ['<strong>', '', '', '</strong>']
+            )
             . '</p><p><a href="https://matomo.org/faq/how-to/#faq_163" rel="noreferrer noopener"  target="_blank">'
             . Piwik::translate('UserCountry_HowToInstallGeoIPDatabases')
             . '</a></p>';
-        return array('id' => self::ID, 'title' => self::TITLE, 'description' => $desc, 'order' => 1);
+        return ['id' => self::ID, 'title' => self::TITLE, 'description' => $desc, 'order' => 1];
     }
 
     public function getUsageWarning(): ?string
     {
         $comment = Piwik::translate('UserCountry_DefaultLocationProviderDesc1') . ' ';
-        $comment .= Piwik::translate('UserCountry_DefaultLocationProviderDesc2', array(
+        $comment .= Piwik::translate('UserCountry_DefaultLocationProviderDesc2', [
             '<a href="https://matomo.org/docs/geo-locate/" rel="noreferrer noopener" target="_blank">', '', '', '</a>'
-        ));
+        ]);
 
         return $comment;
     }
 }
-

--- a/plugins/UserCountry/LocationProvider/DefaultProvider.php
+++ b/plugins/UserCountry/LocationProvider/DefaultProvider.php
@@ -62,7 +62,7 @@ class DefaultProvider extends LocationProvider
     {
         if (
             !Manager::getInstance()->isPluginInstalled('Provider')
-            || Common::getRequestVar('dp', 0, 'int') !== 1
+            || Common::getRequestVar('dp', 0, 'int') === 1
         ) {
             return false;
         }
@@ -98,7 +98,7 @@ class DefaultProvider extends LocationProvider
      * @param string $ipStr IP Address
      * @return string hostname (or human-readable IP address)
      */
-    private function getHost($ipStr)
+    protected function getHost($ipStr)
     {
         $ip = IP::fromStringIP($ipStr);
 

--- a/plugins/UserCountry/tests/Integration/DefaultLocationProviderTest.php
+++ b/plugins/UserCountry/tests/Integration/DefaultLocationProviderTest.php
@@ -7,12 +7,24 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\UserCountry\tests\Unit;
+namespace Piwik\Plugins\UserCountry\tests\Integration;
 
+use Piwik\Plugin\Manager;
 use Piwik\Plugins\UserCountry\LocationProvider\DefaultProvider;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
-class DefaultLocationProviderTest extends \PHPUnit\Framework\TestCase
+/**
+ * @group bla
+ */
+class DefaultLocationProviderTest extends IntegrationTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Manager::getInstance()->activatePlugin('Provider');
+    }
+
     public function testGetCountryFromProvider()
     {
         $locationProvider = $this->getMockBuilder(DefaultProvider::class)->onlyMethods(['getHost'])->getMock();
@@ -25,7 +37,7 @@ class DefaultLocationProviderTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        self::assertEquals('DE', $result[DefaultProvider::COUNTRY_CODE_KEY]);
+        self::assertEquals('de', $result[DefaultProvider::COUNTRY_CODE_KEY]);
     }
 
     public function testGetCountryFromLanguageIfProviderNotAvailable()
@@ -40,6 +52,6 @@ class DefaultLocationProviderTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        self::assertEquals('FR', $result[DefaultProvider::COUNTRY_CODE_KEY]);
+        self::assertEquals('fr', $result[DefaultProvider::COUNTRY_CODE_KEY]);
     }
 }

--- a/plugins/UserCountry/tests/Unit/DefaultLocationProviderTest.php
+++ b/plugins/UserCountry/tests/Unit/DefaultLocationProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UserCountry\tests\Unit;
+
+use Piwik\Plugins\UserCountry\LocationProvider\DefaultProvider;
+
+class DefaultLocationProviderTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetCountryFromProvider()
+    {
+        $locationProvider = $this->getMockBuilder(DefaultProvider::class)->onlyMethods(['getHost'])->getMock();
+        $locationProvider->expects($this->once())->method('getHost')->willReturn('p573a336f.dip0.t-ipconnect.de');
+
+        $result = $locationProvider->getLocation(
+            [
+                'ip' => '123.123.123.123',
+                'lang' => 'fr',
+            ]
+        );
+
+        self::assertEquals('DE', $result[DefaultProvider::COUNTRY_CODE_KEY]);
+    }
+
+    public function testGetCountryFromLanguageIfProviderNotAvailable()
+    {
+        $locationProvider = $this->getMockBuilder(DefaultProvider::class)->onlyMethods(['getHost'])->getMock();
+        $locationProvider->expects($this->once())->method('getHost')->willReturn('123.123.123.123');
+
+        $result = $locationProvider->getLocation(
+            [
+                'ip' => '123.123.123.123',
+                'lang' => 'fr',
+            ]
+        );
+
+        self::assertEquals('FR', $result[DefaultProvider::COUNTRY_CODE_KEY]);
+    }
+}

--- a/tests/PHPUnit/Integration/LogImporterTest.php
+++ b/tests/PHPUnit/Integration/LogImporterTest.php
@@ -183,9 +183,6 @@ class LogImporterTest extends IntegrationTestCase
         $this->assertEquals('matomo.org/äöüß§$%', $name);
     }
 
-    /**
-     * @group bla
-     */
     public function testOutputOption()
     {
         $file = StaticContainer::get('path.tmp') . '/logs/import_log.log';


### PR DESCRIPTION
### Description:

As discussed in #17033, it's actually not expected that the country might be automatically guessed if the provider plugin is active, but the chosen location provider does not serve a result.

This PR kind of replaces #17033. The last thing that would be missing or could be improved is to add a check if the provided IP might already have been anonymized. Otherwise IPs like `123.123.0.0` might get passed to `gethostbyaddr`, which can't have a result, so we could prevent that. But that might be not that much important right now.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
