### PR TITLE
Create assets folder if it is missing when writing Report

### DIFF
--- a/core/ReportRenderer.php
+++ b/core/ReportRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -6,6 +7,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  *
  */
+
 namespace Piwik;
 
 use Exception;
@@ -40,12 +42,12 @@ abstract class ReportRenderer extends BaseFactory
 
     protected $report;
 
-    private static $availableReportRenderers = array(
+    private static $availableReportRenderers = [
         self::PDF_FORMAT,
         self::HTML_FORMAT,
         self::CSV_FORMAT,
         self::TSV_FORMAT,
-    );
+    ];
 
     /**
      * Sets the site id
@@ -71,7 +73,7 @@ abstract class ReportRenderer extends BaseFactory
     {
         return Piwik::translate(
             'General_ExceptionInvalidReportRendererFormat',
-            array(self::normalizeRendererType($rendererType), implode(', ', self::$availableReportRenderers))
+            [self::normalizeRendererType($rendererType), implode(', ', self::$availableReportRenderers)]
         );
     }
 
@@ -155,7 +157,7 @@ abstract class ReportRenderer extends BaseFactory
     protected static function makeFilenameWithExtension($filename, $extension)
     {
         // the filename can be used in HTTP headers, remove new lines to prevent HTTP header injection
-        $filename = str_replace(array("\n", "\t"), " ", $filename);
+        $filename = str_replace(["\n", "\t"], " ", $filename);
 
         return $filename . "." . $extension;
     }
@@ -178,7 +180,7 @@ abstract class ReportRenderer extends BaseFactory
 
         @chmod($outputFilename, 0600);
 
-        if(file_exists($outputFilename)){
+        if (file_exists($outputFilename)) {
             @unlink($outputFilename);
         }
 
@@ -241,16 +243,16 @@ abstract class ReportRenderer extends BaseFactory
                 }
             }
 
-            $reportColumns = array(
+            $reportColumns = [
                 'label' => Piwik::translate('General_Name'),
                 'value' => Piwik::translate('General_Value'),
-            );
+            ];
         }
 
-        return array(
+        return [
             $finalReport,
             $reportColumns,
-        );
+        ];
     }
 
     public static function getStaticGraph($reportMetadata, $width, $height, $evolution, $segment)

--- a/core/ReportRenderer.php
+++ b/core/ReportRenderer.php
@@ -169,7 +169,12 @@ abstract class ReportRenderer extends BaseFactory
      */
     protected static function getOutputPath($filename)
     {
-        $outputFilename = StaticContainer::get('path.tmp') . '/assets/' . $filename;
+        $baseAssetsDir = StaticContainer::get('path.tmp') . '/assets/';
+        $outputFilename = $baseAssetsDir . $filename;
+
+        if (!is_dir($baseAssetsDir)) {
+            Filesystem::mkdir($baseAssetsDir);
+        }
 
         @chmod($outputFilename, 0600);
 


### PR DESCRIPTION
### Description:

We are receiving errors such as:
- `Scheduler: Error Unable to create output file`
- `Scheduler: Error ReportRenderer: Could not write to file`

This appears to happen when the `assets` directory doesn't exist in the `tmp` folder when the Scheduled reports task is run via `./console core:run-scheduled-task`. This has been observed for `pdf` and `csv`. 

It appears you can recreate this as such:
- Create a report that can be generated
- breakpoint `if ($shouldExecuteTask)` in `Scheduler.php`
- Set `$shouldExecuteTask` to true.
- if `tmp/assets` is missing at `\Piwik\ReportRenderer::writeFile` then the error will occur. This will also occur at `$this->Error('Unable to create output file: '.$name);` in `tcpdf` 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
