### PR TITLE
Fix PHP 8.1 deprecation notice

### DIFF
--- a/plugins/Actions/API.php
+++ b/plugins/Actions/API.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -6,6 +7,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  *
  */
+
 namespace Piwik\Plugins\Actions;
 
 use Exception;
@@ -59,16 +61,18 @@ class API extends \Piwik\Plugin\API
         $requestedColumns = Piwik::getArrayFromApiParameter($columns);
         $columns = $report->getMetricsRequiredForReport($allColumns = null, $requestedColumns);
 
-        $inDbColumnNames = array_map(function ($value) { return 'Actions_' . $value; }, $columns);
+        $inDbColumnNames = array_map(function ($value) {
+            return 'Actions_' . $value;
+        }, $columns);
         $dataTable = $archive->getDataTableFromNumeric($inDbColumnNames);
 
         $dataTable->deleteColumns(array_diff($requestedColumns, $columns));
 
         $newNameMapping = array_combine($inDbColumnNames, $columns);
-        $dataTable->filter('ReplaceColumnNames', array($newNameMapping));
+        $dataTable->filter('ReplaceColumnNames', [$newNameMapping]);
 
         $columnsToShow = $requestedColumns ?: $report->getAllMetrics();
-        $dataTable->queueFilter('ColumnDelete', array($columnsToRemove = array(), $columnsToShow));
+        $dataTable->queueFilter('ColumnDelete', [$columnsToRemove = [], $columnsToShow]);
 
         return $dataTable;
     }
@@ -85,9 +89,16 @@ class API extends \Piwik\Plugin\API
      *
      * @return DataTable|DataTable\Map
      */
-    public function getPageUrls($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false,
-                                $depth = false, $flat = false)
-    {
+    public function getPageUrls(
+        $idSite,
+        $period,
+        $date,
+        $segment = false,
+        $expanded = false,
+        $idSubtable = false,
+        $depth = false,
+        $flat = false
+    ) {
         Piwik::checkUserHasViewAccess($idSite);
 
         $dataTable = Archive::createDataTableFromArchive('Actions_actions_url', $idSite, $period, $date, $segment, $expanded, $flat, $idSubtable, $depth);
@@ -95,11 +106,11 @@ class API extends \Piwik\Plugin\API
         $this->filterActionsDataTable($dataTable, Action::TYPE_PAGE_URL);
 
         if ($flat) {
-            $dataTable->filter(function(DataTable $dataTable) {
+            $dataTable->filter(function (DataTable $dataTable) {
                 foreach ($dataTable->getRows() as $row) {
                     $label = $row->getColumn('label');
                     if (substr($label, 0, 1) !== '/' && $label != Piwik::translate('General_NotDefined', Piwik::translate('Actions_ColumnPageURL'))) {
-                        $row->setColumn('label', '/'.$label);
+                        $row->setColumn('label', '/' . $label);
                     }
                 }
             });
@@ -152,12 +163,12 @@ class API extends \Piwik\Plugin\API
     protected function keepPagesFollowingSearch($dataTable)
     {
         // Keep only pages which are following site search
-        $dataTable->filter('ColumnCallbackDeleteRow', array(
+        $dataTable->filter('ColumnCallbackDeleteRow', [
             PiwikMetrics::INDEX_PAGE_IS_FOLLOWING_SITE_SEARCH_NB_HITS,
             function ($value) {
                 return $value <= 0;
             }
-        ));
+        ]);
     }
 
     /**
@@ -190,7 +201,7 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $callBackParameters = array('Actions_actions_url', $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable = null);
+        $callBackParameters = ['Actions_actions_url', $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable = null];
         $dataTable = $this->getFilterPageDatatableSearch($callBackParameters, $pageUrl, Action::TYPE_PAGE_URL);
         $this->addPageProcessedMetrics($dataTable);
         $this->filterActionsDataTable($dataTable, Action::TYPE_PAGE_URL);
@@ -212,9 +223,15 @@ class API extends \Piwik\Plugin\API
      * Returns a DataTable with analytics information for every unique entry page title
      * for the given site, time period & segment.
      */
-    public function getEntryPageTitles($idSite, $period, $date, $segment = false, $expanded = false,
-                                       $idSubtable = false, $flat = false)
-    {
+    public function getEntryPageTitles(
+        $idSite,
+        $period,
+        $date,
+        $segment = false,
+        $expanded = false,
+        $idSubtable = false,
+        $flat = false
+    ) {
         Piwik::checkUserHasViewAccess($idSite);
 
         $dataTable = $this->getPageTitles($idSite, $period, $date, $segment, $expanded, $idSubtable, $flat);
@@ -226,9 +243,15 @@ class API extends \Piwik\Plugin\API
      * Returns a DataTable with analytics information for every unique exit page title
      * for the given site, time period & segment.
      */
-    public function getExitPageTitles($idSite, $period, $date, $segment = false, $expanded = false,
-                                      $idSubtable = false, $flat = false)
-    {
+    public function getExitPageTitles(
+        $idSite,
+        $period,
+        $date,
+        $segment = false,
+        $expanded = false,
+        $idSubtable = false,
+        $flat = false
+    ) {
         Piwik::checkUserHasViewAccess($idSite);
 
         $dataTable = $this->getPageTitles($idSite, $period, $date, $segment, $expanded, $idSubtable, $flat);
@@ -240,7 +263,7 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $callBackParameters = array('Actions_actions', $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable = null);
+        $callBackParameters = ['Actions_actions', $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable = null];
         $dataTable = $this->getFilterPageDatatableSearch($callBackParameters, $pageName, Action::TYPE_PAGE_TITLE);
         $this->addPageProcessedMetrics($dataTable);
         $this->filterActionsDataTable($dataTable, Action::TYPE_PAGE_TITLE);
@@ -260,7 +283,7 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $callBackParameters = array('Actions_downloads', $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable = null);
+        $callBackParameters = ['Actions_downloads', $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable = null];
         $dataTable = $this->getFilterPageDatatableSearch($callBackParameters, $downloadUrl, Action::TYPE_DOWNLOAD);
         $this->filterActionsDataTable($dataTable, Action::TYPE_DOWNLOAD);
         return $dataTable;
@@ -279,7 +302,7 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $callBackParameters = array('Actions_outlink', $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable = null);
+        $callBackParameters = ['Actions_outlink', $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable = null];
         $dataTable = $this->getFilterPageDatatableSearch($callBackParameters, $outlinkUrl, Action::TYPE_OUTLINK);
         $this->filterActionsDataTable($dataTable, Action::TYPE_OUTLINK);
         return $dataTable;
@@ -293,7 +316,7 @@ class API extends \Piwik\Plugin\API
         $dataTable->deleteColumn(PiwikMetrics::INDEX_SITE_SEARCH_HAS_NO_RESULT);
         $this->filterActionsDataTable($dataTable, Action::TYPE_SITE_SEARCH);
         $dataTable->filter('ReplaceColumnNames');
-        $dataTable->filter('AddSegmentByLabel', array('siteSearchKeyword'));
+        $dataTable->filter('AddSegmentByLabel', ['siteSearchKeyword']);
         $this->addPagesPerSearchColumn($dataTable);
         return $dataTable;
     }
@@ -306,7 +329,7 @@ class API extends \Piwik\Plugin\API
      */
     protected function addPagesPerSearchColumn($dataTable, $columnToRead = 'nb_hits')
     {
-        $dataTable->filter('ColumnCallbackAddColumnQuotient', array('nb_pages_per_search', $columnToRead, 'nb_visits', $precision = 1));
+        $dataTable->filter('ColumnCallbackAddColumnQuotient', ['nb_pages_per_search', $columnToRead, 'nb_visits', $precision = 1]);
     }
 
     protected function getSiteSearchKeywordsRaw($idSite, $period, $date, $segment)
@@ -321,17 +344,19 @@ class API extends \Piwik\Plugin\API
 
         $dataTable = $this->getSiteSearchKeywordsRaw($idSite, $period, $date, $segment);
         // Delete all rows that have some results
-        $dataTable->filter('ColumnCallbackDeleteRow',
-            array(
+        $dataTable->filter(
+            'ColumnCallbackDeleteRow',
+            [
                 PiwikMetrics::INDEX_SITE_SEARCH_HAS_NO_RESULT,
                 function ($value) {
                     return $value < 1;
                 }
-            ));
+            ]
+        );
         $dataTable->deleteRow(DataTable::ID_SUMMARY_ROW);
         $dataTable->deleteColumn(PiwikMetrics::INDEX_SITE_SEARCH_HAS_NO_RESULT);
         $this->filterActionsDataTable($dataTable, $isPageTitleType = false);
-        $dataTable->filter('AddSegmentByLabel', array('siteSearchKeyword'));
+        $dataTable->filter('AddSegmentByLabel', ['siteSearchKeyword']);
         $dataTable->filter('ReplaceColumnNames');
         $this->addPagesPerSearchColumn($dataTable);
         return $dataTable;
@@ -418,7 +443,7 @@ class API extends \Piwik\Plugin\API
             }
 
             // nothing found in all sub tables
-            $result = new DataTable;
+            $result = new DataTable();
             $subTables = $table->getDataTables();
             if (count($subTables) > 0) {
                 // use the first subtable's metadata to ensure basic metadata like `period` is available in response
@@ -435,7 +460,7 @@ class API extends \Piwik\Plugin\API
             $row = $table->getRowFromLabel($search);
             if ($row === false) {
                 // not found
-                $result = new DataTable;
+                $result = new DataTable();
                 $result->setAllTableMetadata($table->getAllTableMetadata());
                 return $result;
             }
@@ -478,7 +503,7 @@ class API extends \Piwik\Plugin\API
         // Must be applied before Sort in this case, since the DataTable can contain both int and strings indexes
         // (in the transition period between pre 1.2 and post 1.2 datatable structure)
 
-        $dataTable->filter('Piwik\Plugins\Actions\DataTable\Filter\Actions', array($isPageTitleType));
+        $dataTable->filter('Piwik\Plugins\Actions\DataTable\Filter\Actions', [$isPageTitleType]);
 
         return $dataTable;
     }
@@ -490,12 +515,14 @@ class API extends \Piwik\Plugin\API
      */
     private function filterNonEntryActions($dataTable)
     {
-        $dataTable->filter('ColumnCallbackDeleteRow',
-            array(PiwikMetrics::INDEX_PAGE_ENTRY_NB_VISITS,
-                  function ($visits) {
-                      return !strlen($visits);
-                  }
-            )
+        $dataTable->filter(
+            'ColumnCallbackDeleteRow',
+            [
+                PiwikMetrics::INDEX_PAGE_ENTRY_NB_VISITS,
+                function ($visits) {
+                    return !strlen($visits);
+                }
+            ]
         );
     }
 
@@ -506,18 +533,21 @@ class API extends \Piwik\Plugin\API
      */
     private function filterNonExitActions($dataTable)
     {
-        $dataTable->filter('ColumnCallbackDeleteRow',
-            array(PiwikMetrics::INDEX_PAGE_EXIT_NB_VISITS,
-                  function ($visits) {
-                      return !strlen($visits);
-                  })
+        $dataTable->filter(
+            'ColumnCallbackDeleteRow',
+            [
+                PiwikMetrics::INDEX_PAGE_EXIT_NB_VISITS,
+                function ($visits) {
+                    return !strlen($visits);
+                }
+            ]
         );
     }
 
     private function addPageProcessedMetrics(DataTable\DataTableInterface $dataTable)
     {
         $dataTable->filter(function (DataTable $table) {
-            $extraProcessedMetrics = $table->getMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME);
+            $extraProcessedMetrics = $table->getMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME) ?: [];
             $extraProcessedMetrics[] = new AverageTimeOnPage();
             $extraProcessedMetrics[] = new BounceRate();
             $extraProcessedMetrics[] = new ExitRate();


### PR DESCRIPTION
### Description:

Came across this error while testing:

```
Deprecated: Automatic conversion of false to array is deprecated in /matomo/plugins/Actions/API.php on line 521
```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
