### PR TITLE
Force Travis to use PHP 8.0.9 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,14 +66,14 @@ matrix:
       sudo: false
       addons: false
     # All tests after another
-    - php: 8.0
+    - php: 8.0.9
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI ALLTEST_EXTRA_OPTIONS="--run-first-half-only" SKIP_COMPOSER_INSTALL=1
       sudo: required
       before_install:
         - composer install --ignore-platform-reqs
         - composer remove --dev phpunit/phpunit
         - composer require --dev phpunit/phpunit ~9.3 --ignore-platform-reqs
-    - php: 8.0
+    - php: 8.0.9
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI ALLTEST_EXTRA_OPTIONS="--run-second-half-only" SKIP_COMPOSER_INSTALL=1
       sudo: required
       before_install:


### PR DESCRIPTION
### Description:

We should at a later step consider to switch to PHP 8.1. But it seems currently the tests would fail there.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
