### PR TITLE
Ensure required translations are loaded for Goal management

### DIFF
--- a/plugins/Goals/Goals.php
+++ b/plugins/Goals/Goals.php
@@ -402,5 +402,6 @@ class Goals extends \Piwik\Plugin
         $translationKeys[] = 'Events_EventCategory';
         $translationKeys[] = 'Events_EventName';
         $translationKeys[] = 'Goals_YouCanEnableEcommerceReports';
+        $translationKeys[] = 'General_Description';
     }
 }


### PR DESCRIPTION
### Description:

As reported on the forum (https://forum.matomo.org/t/the-string-general-description-was-not-loaded-in-javascript/45513) it might happen that a translation string is not available in javascript. This ist most likely the case as all other plugins that might already load it are disabled.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
