### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/plugins/Actions/javascripts/actionsDataTable.js
+++ b/plugins/Actions/javascripts/actionsDataTable.js
@@ -19,7 +19,7 @@
 
         var currentLevelIndex = style.indexOf('level');
         if (currentLevelIndex >= 0) {
-            currentLevel = Number(style.substr(currentLevelIndex + 5, 1));
+            currentLevel = Number(style.slice(currentLevelIndex + 5, currentLevelIndex + 6));
         }
         return currentLevel;
     }

--- a/plugins/CoreHome/angularjs/anchorLinkFix.js
+++ b/plugins/CoreHome/angularjs/anchorLinkFix.js
@@ -75,8 +75,8 @@
 
     function handleScrollToAnchorIfPresentOnPageLoad()
     {
-        if (location.hash.substr(0, 2) == '#/') {
-            var hash = location.hash.substr(2);
+        if (location.hash.slice(0, 2) == '#/') {
+            var hash = location.hash.slice(2);
             scrollToAnchorIfPossible(hash, null);
         }
     }
@@ -102,7 +102,7 @@
                     return;
                 }
 
-                var hash = newUrl.substr(hashPos + 2);
+                var hash = newUrl.slice(hashPos + 2);
 
                 scrollToAnchorIfPossible(hash, event);
             }

--- a/plugins/CoreHome/angularjs/common/directives/autocomplete-matched.js
+++ b/plugins/CoreHome/angularjs/common/directives/autocomplete-matched.js
@@ -46,7 +46,7 @@
                     var startTerm = content.toLowerCase().indexOf(searchTerm.toLowerCase());
 
                     if (-1 !== startTerm) {
-                        var word = content.substr(startTerm, searchTerm.length);
+                        var word = content.slice(startTerm, startTerm + searchTerm.length);
                         var escapedword = $sanitize(piwik.helper.htmlEntities(word));
                         content = content.replace(word, '<span class="autocompleteMatched">' + escapedword + '</span>');
                         element.html(content);

--- a/plugins/CoreHome/angularjs/common/directives/field-condition.js
+++ b/plugins/CoreHome/angularjs/common/directives/field-condition.js
@@ -38,7 +38,7 @@
             } else if (element.prop('tagName').toLowerCase() === 'select') {
                 var name = element.val();
                 if (name.indexOf('string:') === 0) {
-                    return name.substr('string:'.length);
+                    return name.slice('string:'.length);
                 }
 
                 return name;

--- a/plugins/CoreHome/angularjs/common/filters/ucfirst.js
+++ b/plugins/CoreHome/angularjs/common/filters/ucfirst.js
@@ -15,7 +15,7 @@
             }
 
             var firstLetter = (value + '').charAt(0).toUpperCase();
-            return firstLetter + value.substr(1);
+            return firstLetter + value.slice(1);
         };
     }
 })();

--- a/plugins/CoreHome/angularjs/http404check.js
+++ b/plugins/CoreHome/angularjs/http404check.js
@@ -42,7 +42,7 @@
                     -1 !== rejection.config.url.indexOf('plugins')) {
 
                     var posEndUrl = rejection.config.url.indexOf('.html') + 5;
-                    var url       = rejection.config.url.substr(0, posEndUrl);
+                    var url       = rejection.config.url.slice(0, posEndUrl);
 
                     var message = 'Please check your server configuration. You may want to whitelist "*.html" files from the "plugins" directory.';
                     message    += ' The HTTP status code is ' + rejection.status + ' for URL "' + url + '"';

--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -100,7 +100,7 @@ var broadcast = {
 
         // hash doesn't contain the first # character.
         if (hash && 0 === (''+hash).indexOf('/')) {
-            hash = (''+hash).substr(1);
+            hash = (''+hash).slice(1);
         }
 
 
@@ -773,8 +773,8 @@ var broadcast = {
      */
     getValueFromHash: function (param, url) {
         var hashStr = broadcast.getHashFromUrl(url);
-        if (hashStr.substr(0, 1) == '#') {
-            hashStr = hashStr.substr(1);
+        if (hashStr.slice(0, 1) == '#') {
+            hashStr = hashStr.slice(1);
         }
         hashStr = hashStr.split('#')[0];
 
@@ -795,7 +795,7 @@ var broadcast = {
         var lookFor = param + '=';
 
         if (url.indexOf('?') >= 0) {
-            url = url.substr(url.indexOf('?')+1);
+            url = url.slice(url.indexOf('?')+1);
         }
 
         var urlPieces = url.split('&');

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -805,7 +805,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
         $.each(patternsToReplace, function (index, pattern) {
             if (0 === currentPattern.indexOf(pattern.to)) {
-                currentPattern = pattern.from + currentPattern.substr(2);
+                currentPattern = pattern.from + currentPattern.slice(2);
             }
         });
 
@@ -881,7 +881,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
             $.each(patternsToReplace, function (index, pattern) {
                 if (0 === keyword.indexOf(pattern.from)) {
-                    keyword = pattern.to + keyword.substr(1);
+                    keyword = pattern.to + keyword.slice(1);
                 }
             });
 

--- a/plugins/CoreHome/vue/dist/CoreHome.umd.js
+++ b/plugins/CoreHome/vue/dist/CoreHome.umd.js
@@ -367,7 +367,7 @@ Matomo_piwik.updateDateInTitle = function updateDateInTitle(date, period) {
 
   if (originalTitle.indexOf(Matomo_piwik.siteName) === 0) {
     var dateString = " - ".concat(Periods_Periods.parse(period, date).getPrettyString(), " ");
-    document.title = "".concat(Matomo_piwik.siteName).concat(dateString).concat(originalTitle.substr(Matomo_piwik.siteName.length));
+    document.title = "".concat(Matomo_piwik.siteName).concat(dateString).concat(originalTitle.slice(Matomo_piwik.siteName.length));
   }
 };
 
@@ -3191,10 +3191,10 @@ var ShowSensitiveData_window = window,
     var protectedData = '';
 
     if (showCharacters > 0) {
-      protectedData += sensitiveData.substr(0, showCharacters);
+      protectedData += sensitiveData.slice(0, showCharacters);
     }
 
-    protectedData += sensitiveData.substr(showCharacters).replace(/./g, '*');
+    protectedData += sensitiveData.slice(showCharacters).replace(/./g, '*');
     element.html(protectedData);
 
     function onClickHandler() {
@@ -6973,7 +6973,7 @@ function scrollFirstElementIntoView(element) {
 
         if (category && category.lastIndexOf('\n') !== -1) {
           // remove "\n\nMenu"
-          category = category.substr(0, category.lastIndexOf('\n')).trim();
+          category = category.slice(0, category.lastIndexOf('\n')).trim();
         }
 
         window.$(element).find('li .item').each(function (i, subElement) {

--- a/plugins/CoreHome/vue/src/Matomo/Matomo.ts
+++ b/plugins/CoreHome/vue/src/Matomo/Matomo.ts
@@ -24,7 +24,7 @@ piwik.updateDateInTitle = function updateDateInTitle(date: string, period: strin
 
   if (originalTitle.indexOf(piwik.siteName) === 0) {
     const dateString = ` - ${Periods.parse(period, date).getPrettyString()} `;
-    document.title = `${piwik.siteName}${dateString}${originalTitle.substr(piwik.siteName.length)}`;
+    document.title = `${piwik.siteName}${dateString}${originalTitle.slice(piwik.siteName.length)}`;
   }
 };
 

--- a/plugins/CoreHome/vue/src/QuickAccess/QuickAccess.vue
+++ b/plugins/CoreHome/vue/src/QuickAccess/QuickAccess.vue
@@ -443,7 +443,7 @@ export default defineComponent({
 
         if (category && category.lastIndexOf('\n') !== -1) {
           // remove "\n\nMenu"
-          category = category.substr(0, category.lastIndexOf('\n')).trim();
+          category = category.slice(0, category.lastIndexOf('\n')).trim();
         }
 
         window.$(element).find('li .item').each((i, subElement) => {

--- a/plugins/CoreHome/vue/src/ShowSensitiveData/ShowSensitiveData.ts
+++ b/plugins/CoreHome/vue/src/ShowSensitiveData/ShowSensitiveData.ts
@@ -38,9 +38,9 @@ export default {
 
     let protectedData = '';
     if (showCharacters > 0) {
-      protectedData += sensitiveData.substr(0, showCharacters);
+      protectedData += sensitiveData.slice(0, showCharacters);
     }
-    protectedData += sensitiveData.substr(showCharacters).replace(/./g, '*');
+    protectedData += sensitiveData.slice(showCharacters).replace(/./g, '*');
     element.html(protectedData);
 
     function onClickHandler() {

--- a/plugins/CustomDimensions/javascripts/rowactions.js
+++ b/plugins/CustomDimensions/javascripts/rowactions.js
@@ -17,8 +17,8 @@ $(function () {
             },
             trigger: function (tr, e, subTableLabel) {
                 var label = this.getLabelFromTr(tr);
-                if (label && label.substr(0, 1) === '@') {
-                    label = label.substr(1);
+                if (label && label.slice(0, 1) === '@') {
+                    label = label.slice(1);
                 }
 
                 var subtable = tr.closest('table');
@@ -42,8 +42,8 @@ $(function () {
             onClick: function (actionA, tr, e) {
                 var segment;
                 var link = this.getLabelFromTr(tr);
-                if (link && link.substr(0, 1) === '@') {
-                    link = link.substr(1);
+                if (link && link.slice(0, 1) === '@') {
+                    link = link.slice(1);
                 }
 
                 link = 'http://' + unescape(link);

--- a/plugins/CustomDimensions/vue/src/utilities.ts
+++ b/plugins/CustomDimensions/vue/src/utilities.ts
@@ -6,5 +6,5 @@
  */
 
 export function ucfirst(s: string): string {
-  return `${s[0].toUpperCase()}${s.substr(1)}`;
+  return `${s[0].toUpperCase()}${s.slice(1)}`;
 }

--- a/plugins/Goals/vue/src/ManageGoals/ManageGoals.vue
+++ b/plugins/Goals/vue/src/ManageGoals/ManageGoals.vue
@@ -701,10 +701,10 @@ export default defineComponent({
       }
     },
     lcfirst(s: string) {
-      return `${s.substr(0, 1).toLowerCase()}${s.substr(1)}`;
+      return `${s.slice(0, 1).toLowerCase()}${s.slice(1)}`;
     },
     ucfirst(s: string) {
-      return `${s.substr(0, 1).toUpperCase()}${s.substr(1)}`;
+      return `${s.slice(0, 1).toUpperCase()}${s.slice(1)}`;
     },
   },
   computed: {

--- a/plugins/Marketplace/vue/src/PluginName/PluginName.ts
+++ b/plugins/Marketplace/vue/src/PluginName/PluginName.ts
@@ -13,8 +13,8 @@ window.broadcast.addPopoverHandler('browsePluginDetail', (value) => {
   let activeTab = null;
 
   if (value.indexOf('!') !== -1) {
-    activeTab = value.substr(value.indexOf('!') + 1);
-    pluginName = value.substr(0, value.indexOf('!'));
+    activeTab = value.slice(value.indexOf('!') + 1);
+    pluginName = value.slice(0, value.indexOf('!'));
   }
 
   let url = `module=Marketplace&action=pluginDetails&pluginName=${encodeURIComponent(pluginName)}`;

--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -380,7 +380,7 @@ var Piwik_Overlay = (function () {
                 var currentHashStr = broadcast.getHash();
 
                 if (currentHashStr.charAt(0) == '?') {
-                    currentHashStr = currentHashStr.substr(1);
+                    currentHashStr = currentHashStr.slice(1);
                 }
 
                 currentHashStr = broadcast.updateParamValue('l=' + newFrameLocation, currentHashStr);

--- a/plugins/Overlay/templates/startOverlaySession.twig
+++ b/plugins/Overlay/templates/startOverlaySession.twig
@@ -12,7 +12,7 @@
         var match = false;
         var parser = document.createElement('a');
 
-        var urlToRedirect = window.location.hash.substr(1);
+        var urlToRedirect = window.location.hash.slice(1);
         parser.href = urlToRedirect;
         var hostToRedirect = parser.hostname;
 

--- a/plugins/PrivacyManager/vue/src/OptOutCustomizer/OptOutCustomizer.vue
+++ b/plugins/PrivacyManager/vue/src/OptOutCustomizer/OptOutCustomizer.vue
@@ -181,7 +181,7 @@ export default defineComponent({
       return !!this.piwikurl
         && this.backgroundColor === ''
         && this.fontColor !== ''
-        && nearlyWhite(this.fontColor.substr(1));
+        && nearlyWhite(this.fontColor.slice(1));
     },
     iframeUrl(): string {
       if (this.piwikurl) {
@@ -189,8 +189,8 @@ export default defineComponent({
           module: 'CoreAdminHome',
           action: 'optOut',
           language: this.language,
-          backgroundColor: this.backgroundColor.substr(1),
-          fontColor: this.fontColor.substr(1),
+          backgroundColor: this.backgroundColor.slice(1),
+          fontColor: this.fontColor.slice(1),
           fontSize: this.fontSizeWithUnit,
           fontFamily: this.fontFamily,
         });

--- a/plugins/Referrers/vue/src/CampaignBuilder/CampaignBuilder.vue
+++ b/plugins/Referrers/vue/src/CampaignBuilder/CampaignBuilder.vue
@@ -213,8 +213,8 @@ export default defineComponent({
 
       let urlHash = '';
       if (urlHashPos >= 0) {
-        urlHash = generatedUrl.substr(urlHashPos);
-        generatedUrl = generatedUrl.substr(0, urlHashPos);
+        urlHash = generatedUrl.slice(urlHashPos);
+        generatedUrl = generatedUrl.slice(0, urlHashPos);
       }
 
       if (generatedUrl.indexOf('/', 10) < 0 && generatedUrl.indexOf('?') < 0) {

--- a/plugins/SegmentEditor/vue/src/SegmentGenerator/SegmentGenerator.vue
+++ b/plugins/SegmentEditor/vue/src/SegmentGenerator/SegmentGenerator.vue
@@ -216,13 +216,13 @@ function findAndExplodeByMatch(metric: string) {
   if (minPos < metric.length) {
     // sth found - explode
     if (singleChar === true) {
-      newMetric.segment = metric.substr(0, minPos);
-      newMetric.matches = metric.substr(minPos, 1);
-      newMetric.value = decodeURIComponent(metric.substr(minPos + 1));
+      newMetric.segment = metric.slice(0, minPos);
+      newMetric.matches = metric.slice(minPos, minPos + 1);
+      newMetric.value = decodeURIComponent(metric.slice(minPos + 1));
     } else {
-      newMetric.segment = metric.substr(0, minPos);
-      newMetric.matches = metric.substr(minPos, 2);
-      newMetric.value = decodeURIComponent(metric.substr(minPos + 2));
+      newMetric.segment = metric.slice(0, minPos);
+      newMetric.matches = metric.slice(minPos, minPos + 2);
+      newMetric.value = decodeURIComponent(metric.slice(minPos + 2));
     }
 
     // if value is only '' -> change to empty string

--- a/plugins/Transitions/javascripts/transitions.js
+++ b/plugins/Transitions/javascripts/transitions.js
@@ -459,7 +459,7 @@ Piwik_Transitions.prototype.renderCenterBox = function () {
             el.addClass('Transitions_Value0');
         } else {
             self.addTooltipShowingPercentageOfAllPageviews(el, modelProperty);
-            var groupName = cssClass.charAt(0).toLowerCase() + cssClass.substr(1);
+            var groupName = cssClass.charAt(0).toLowerCase() + cssClass.slice(1);
             el.hover(function () {
                 self.highlightGroup(groupName, highlightCurveOnSide);
             }, function () {
@@ -792,7 +792,7 @@ Piwik_Transitions.prototype.highlightGroup = function (groupName, side) {
     this.highlightedGroup = groupName;
     this.highlightedGroupSide = side;
 
-    var cssClass = 'Transitions_' + groupName.charAt(0).toUpperCase() + groupName.substr(1);
+    var cssClass = 'Transitions_' + groupName.charAt(0).toUpperCase() + groupName.slice(1);
     this.highlightedGroupCenterEl = this.canvas.container.find('.' + cssClass);
     this.highlightedGroupCenterEl.addClass('Transitions_Highlighted');
 

--- a/plugins/UserCountryMap/javascripts/realtime-map.js
+++ b/plugins/UserCountryMap/javascripts/realtime-map.js
@@ -586,7 +586,7 @@
                 }
             }
 
-            updateMap(location.hash && (location.hash == '#world' || location.hash.match(/^#[A-Z]{2,3}$/)) ? location.hash.substr(1) : 'world'); // TODO: restore last state
+            updateMap(location.hash && (location.hash == '#world' || location.hash.match(/^#[A-Z]{2,3}$/)) ? location.hash.slice(1) : 'world'); // TODO: restore last state
 
             // clicking on map background zooms out
             $('.RealTimeMap_map', this.$element).off('click').click(function () {
@@ -643,7 +643,7 @@
                     var ds = new Date().getTime() / 1000 - el.data('actiontime');
                     el.html(relativeTime(ds));
                 });
-                var d = new Date(), datetime = d.toTimeString().substr(0, 8);
+                var d = new Date(), datetime = d.toTimeString().slice(0, 8);
                 $('.realTimeMap_datetime').html(datetime);
             }, 1000);
         },

--- a/plugins/UserCountryMap/javascripts/visitor-map.js
+++ b/plugins/UserCountryMap/javascripts/visitor-map.js
@@ -192,7 +192,7 @@
 
                 if (val == 1 && metric == 'nb_visits') v = _.one_visit;
 
-                if (metric.substr(0, 3) == 'nb_' && metric != 'nb_actions_per_visit') {
+                if (metric.slice(0, 3) == 'nb_' && metric != 'nb_actions_per_visit') {
                     var total;
                     if (id.length == 3) total = UserCountryMap.countriesByIso[id][metric];
                     else if (id == 'world') total = self.config.visitsSummary[metric];
@@ -761,12 +761,12 @@
 
                             function regionCode(region) {
                                 var key = UserCountryMap.keys[iso] || 'fips';
-                                return key.substr(0, 4) == "fips" ? (region[key] || "").substr(2) : region[key];  // cut first two letters from fips code (=country code)
+                                return key.slice(0, 4) == "fips" ? (region[key] || "").slice(2) : region[key];  // cut first two letters from fips code (=country code)
                             }
 
                             function regionExistsInMap(code) {
                                 var key = UserCountryMap.keys[iso] || 'fips', q = {};
-                                q[key] = key.substr(0, 4) == 'fips' ? UserCountryMap.countriesByIso[iso].fips + code : code;
+                                q[key] = key.slice(0, 4) == 'fips' ? UserCountryMap.countriesByIso[iso].fips + code : code;
                                 if (map.getLayer('regions').getPaths(q).length === 0) {
                                     return false;
                                 }
@@ -783,7 +783,7 @@
                                     };
 
                                     if (map.getLayer('regions').getPaths(q).length) {
-                                        region = map.getLayer('regions').getPaths(q)[0].data.fips.substr(2);
+                                        region = map.getLayer('regions').getPaths(q)[0].data.fips.slice(2);
                                     }
                                 }
 

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -3188,7 +3188,7 @@ function PiwikTest() {
         equal(tracker.getVisitorId(), visitorId, "After tracking an action and updating the ID cookie, the visitor ID is still the same.");
 
         // Visitor ID is by default set to a UUID fingerprint
-        var hashUserId = tracker.hook.test._sha1(userIdString).substr(0, 16);
+        var hashUserId = tracker.hook.test._sha1(userIdString).slice(0, 16);
         notEqual(hashUserId, tracker.getVisitorId(), "Visitor ID " + tracker.getVisitorId() + " is not yet the hash of User ID " + hashUserId);
         notEqual("", tracker.getVisitorId(), "Visitor ID is not empty");
         ok( tracker.getVisitorId().length === 16, "Visitor ID is 16 chars string");
@@ -3231,7 +3231,7 @@ function PiwikTest() {
         // Set User ID and verify it was set
         tracker.setUserId(userIdString);
         equal(userIdString, tracker.getUserId(), "getUserId() returns User Id");
-            notEqual(tracker.hook.test._sha1(userIdString).substr(0, 16), tracker.getVisitorId(), "Visitor ID is not the sha1 of User ID (it used to be)");
+            notEqual(tracker.hook.test._sha1(userIdString).slice(0, 16), tracker.getVisitorId(), "Visitor ID is not the sha1 of User ID (it used to be)");
             equal(tracker.getVisitorId(), tracker2.getVisitorId(), "After setting a User ID, Visitor ID does not change");
 
             // Set the User ID and verify nothing's changed
@@ -3657,7 +3657,7 @@ if ($mysql) {
 
         var piwikUrl = location.href;
         if (piwikUrl.indexOf('?') > 0) {
-            piwikUrl = piwikUrl.substr(0, piwikUrl.indexOf('?'));
+            piwikUrl = piwikUrl.slice(0, piwikUrl.indexOf('?'));
         }
         equal(tracker.getPiwikUrl(), piwikUrl, "getPiwikUrl, relative tracker url" );
 
@@ -4968,7 +4968,7 @@ if ($mysql) {
         strictEqual(tracker.hasRememberedConsent(), true, "rememberConsentGiven, sets cookie to remember consent" );
         var rememberedConsent = tracker.getRememberedConsent();
         strictEqual(String(rememberedConsent).length, 13, "getRememberedConsent, returns the data in milliseconds eg '1522200406749'" );
-        strictEqual(String(rememberedConsent).substr(0, 2), '16', "getRememberedConsent, starts with correct data" );
+        strictEqual(String(rememberedConsent).slice(0, 2), '16', "getRememberedConsent, starts with correct data" );
 
         tracker.requireConsent();
         strictEqual(tracker.hasConsent(), true, "when requiring consent, and we remembered consent, consent should be given" );

--- a/tests/javascript/jash/Jash.js
+++ b/tests/javascript/jash/Jash.js
@@ -1116,7 +1116,7 @@ Jash.Indenter = {
 				if (tagLevel === -1) {
 					level--;
 				}
-				arr = this.indentAndAdd(level,source.substr(startedAt,tagLength),arr);
+				arr = this.indentAndAdd(level,source.slice(startedAt,startedAt+tagLength),arr);
 				if (tagLevel === 1) {
 					level++;
 				}
@@ -1129,7 +1129,7 @@ Jash.Indenter = {
 					}
 					if (source.charAt(position) === '<') {
 						tagLength = position-startedAt;
-						arr = this.indentAndAdd(level,source.substr(startedAt,tagLength),arr);
+						arr = this.indentAndAdd(level,source.slice(startedAt,startedAt+tagLength),arr);
 					}
 				} else {
 					position++;
@@ -1455,7 +1455,7 @@ Jash.TabComplete = function() {
 		fragLength++;
 		matches = this.doAllStringsInArrayHaveSameCharacterAtIndex(fragLength,arr);
 	    }
-	    return arr[0].substr(0,fragLength);
+	    return arr[0].slice(0,fragLength);
 	}
 	/**
 	* Attempt to complete an element id or class name based on what is available in all
@@ -1535,7 +1535,7 @@ Jash.TabComplete = function() {
 					/* tokenize classes into array */
 					var classes = els[i].className.split(/\s/);
 					for(var ii = 0; ii < classes.length; ii++) {
-						if(classes[ii].indexOf(lastSelector.substr(1)) == 0 || lastSelector == ".") {
+						if(classes[ii].indexOf(lastSelector.slice(1)) == 0 || lastSelector == ".") {
 							/* prevent duplicate entries */
 							if(matches.join("***").indexOf(classes[ii]) == -1) {
 								matches.push("." + classes[ii]);
@@ -1547,7 +1547,7 @@ Jash.TabComplete = function() {
 		/* id */
 		} else if (lastSelector.match(/^#/)) {
 			for(var i = 0; i<els.length; i++) {
-				if(els[i].id && els[i].id.indexOf(lastSelector.substr(1)) == 0) {
+				if(els[i].id && els[i].id.indexOf(lastSelector.slice(1)) == 0) {
 					matches.push("#" + els[i].id);
 				}
 			}

--- a/tests/javascript/jslint/jslint.js
+++ b/tests/javascript/jslint/jslint.js
@@ -951,7 +951,7 @@ var JSLINT = (function () {
             var c, pos = 0, r = '', result;
 
             function hex(n) {
-                var i = parseInt(source_row.substr(pos + 1, n), 16);
+                var i = parseInt(source_row.slice(pos + 1, pos + 1 + n), 16);
                 pos += n;
                 if (i >= 32 && i <= 126 &&
                         i !== 34 && i !== 92 && i !== 39) {

--- a/tests/lib/screenshot-testing/support/chai-extras.js
+++ b/tests/lib/screenshot-testing/support/chai-extras.js
@@ -237,7 +237,7 @@ function assumeFileIsImageIfNotSpecified(filename) {
 
 function endsWith(string, needle)
 {
-    return string.substr(-1 * needle.length, needle.length) === needle;
+    return needle.length === 0 || string.slice(-needle.length) === needle;
 }
 
 // other automatically run assertions


### PR DESCRIPTION
### Description:

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [x] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
