### PR TITLE
[Vue] fix retry loop in vue:build command

### DIFF
--- a/plugins/CoreVue/Commands/Build.php
+++ b/plugins/CoreVue/Commands/Build.php
@@ -153,6 +153,9 @@ class Build extends ConsoleCommand
                 if ($this->isTypeScriptRaceConditionInOutput($plugin, $concattedOutput)) {
                     $output->writeln("<comment>The TypeScript compiler encountered a race condition when compiling "
                         . "files (files that exist were not found), retrying.</comment>");
+
+                    ++$attempts;
+                    continue;
                 }
 
                 if ($returnCode != 0
@@ -163,7 +166,7 @@ class Build extends ConsoleCommand
                     $output->writeln("");
                 }
 
-                ++$attempts;
+                break;
             }
         }
 


### PR DESCRIPTION
### Description:

The retry loop was broken, should only retry if the typescript race condition is found.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
