### PR TITLE
Fix error when setting license key from command line

### DIFF
--- a/plugins/Marketplace/Commands/SetLicenseKey.php
+++ b/plugins/Marketplace/Commands/SetLicenseKey.php
@@ -12,7 +12,7 @@ use Piwik\Plugin\ConsoleCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Piwik\Plugins\Marketplace\Api;
+use Piwik\Plugins\Marketplace\API;
 
 /**
  * marketplace:set-license-key console command
@@ -31,12 +31,12 @@ class SetLicenseKey extends ConsoleCommand
         $licenseKey = $input->getOption('license-key');
 
         if (empty(trim($licenseKey))) {
-            Api::getInstance()->deleteLicenseKey();
+            API::getInstance()->deleteLicenseKey();
             $output->writeln("License key removed.");
             return;
         }
 
-        Api::getInstance()->saveLicenseKey($licenseKey);
+        API::getInstance()->saveLicenseKey($licenseKey);
         $output->writeln("License key set.");
     }
 }


### PR DESCRIPTION
### Description:

Attempting to set a plugin license key with `./console marketplace:set-license-key --license-key="xxx"` results in the error 
```
Uncaught exception: Error: Class "Piwik\Plugins\Marketplace\Api" not found in 
/var/www/matomo/plugins/Marketplace/Commands/SetLicenseKey.php:39
```
(Debian 11 running PHP 8.1.1)

This error appears to be caused by case sensitivity on the referenced class name, where the class name is `API` but the the referenced class is `Api` which is not PSR-4 compliant. Changing the referenced class name to `API` fixes the error.

Ref L3-258

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
