### PR TITLE
Fix some "Passing null to parameter" warnings (PHP8.1)

### DIFF
--- a/core/Twig.php
+++ b/core/Twig.php
@@ -360,6 +360,11 @@ class Twig
     protected function addFilter_safeDecodeRaw()
     {
         $rawSafeDecoded = new TwigFilter('rawSafeDecoded', function ($string) {
+
+            if (!$string) {
+                return '';
+            }
+
             $string = str_replace('+', '%2B', $string);
             $string = str_replace('&nbsp;', html_entity_decode('&nbsp;', ENT_COMPAT | ENT_HTML401, 'UTF-8'), $string);
 

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -361,7 +361,7 @@ class Twig
     {
         $rawSafeDecoded = new TwigFilter('rawSafeDecoded', function ($string) {
 
-            if (!$string) {
+            if ($string === null) {
                 return '';
             }
 

--- a/libs/HTML/QuickForm2/Rule/Nonempty.php
+++ b/libs/HTML/QuickForm2/Rule/Nonempty.php
@@ -93,7 +93,7 @@ class HTML_QuickForm2_Rule_Nonempty extends HTML_QuickForm2_Rule
         } elseif (is_array($value)) {
             return count(array_filter($value, 'strlen')) >= $this->getConfig();
         } else {
-            return (bool)strlen($value);
+            return (bool)strlen($value ?? '');
         }
     }
 

--- a/plugins/Referrers/Columns/Base.php
+++ b/plugins/Referrers/Columns/Base.php
@@ -477,7 +477,7 @@ abstract class Base extends VisitDimension
      */
     protected function getParameterValueFromReferrerUrl($adsenseReferrerParameter)
     {
-        $value = trim(urldecode(UrlHelper::getParameterFromQueryString($this->referrerUrlParse['query'], $adsenseReferrerParameter)));
+        $value = trim(urldecode(UrlHelper::getParameterFromQueryString($this->referrerUrlParse['query'], $adsenseReferrerParameter) ?? ''));
         return $value;
     }
 
@@ -522,7 +522,7 @@ abstract class Base extends VisitDimension
             return false;
         }
 
-        $this->keywordReferrerAnalyzed = mb_strtolower($this->keywordReferrerAnalyzed);
+        $this->keywordReferrerAnalyzed = mb_strtolower($this->keywordReferrerAnalyzed ?? '');
         $this->nameReferrerAnalyzed = mb_strtolower($this->nameReferrerAnalyzed);
         return true;
     }

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -207,7 +207,7 @@ class Model
 
         $access = $db->fetchAll($sql, $bind);
         foreach ($access as &$entry) {
-            $entry['access'] = explode('|', $entry['access']);
+            $entry['access'] = explode('|', $entry['access'] ?? '');
         }
 
         $count = $db->fetchOne("SELECT FOUND_ROWS()");
@@ -659,7 +659,7 @@ class Model
 
         $users = $db->fetchAll($sql, $bind);
         foreach ($users as &$user) {
-            $user['access'] = explode('|', $user['access']);
+            $user['access'] = explode('|', $user['access'] ?? '');
         }
 
         $count = $db->fetchOne("SELECT FOUND_ROWS()");


### PR DESCRIPTION
This fixes:
```
WARNING Referrers
plugins/Referrers/Columns/Base.php(525): 
Deprecated - mb_strtolower(): Passing null to parameter #1 ($string) of type string is deprecated

WARNING Referrers
plugins/Referrers/Columns/Base.php(478): 
Deprecated - urldecode(): Passing null to parameter #1 ($string) of type string is deprecated

WARNING Events
core/Twig.php(363): Deprecated - str_replace(): 
Passing null to parameter #3 ($subject) of type array|string is deprecated

WARNING UsersManager
plugins/UsersManager/Model.php(662): Deprecated - explode():
Passing null to parameter #2 ($string) of type string is deprecated

WARNING UsersManager
plugins/UsersManager/Model.php(210):
Deprecated - explode(): Passing null to parameter #2 ($string) of type string is deprecated

WARNING Login
libs/HTML/QuickForm2/Rule/Nonempty.php(96): 
Deprecated - strlen(): Passing null to parameter #1 ($string) of type string is deprecated
```
First priority was to keep the existing behavior to avoid creating any bugs. 