### PR TITLE
Respect enable_required_directories_diagnostic option in server info diagnostics

### DIFF
--- a/plugins/Diagnostics/Diagnostic/ServerInformational.php
+++ b/plugins/Diagnostics/Diagnostic/ServerInformational.php
@@ -8,6 +8,7 @@
 namespace Piwik\Plugins\Diagnostics\Diagnostic;
 
 use Piwik\Translation\Translator;
+use Piwik\Config\GeneralConfig;
 use Piwik\SettingsPiwik;
 
 /**

--- a/plugins/Diagnostics/Diagnostic/ServerInformational.php
+++ b/plugins/Diagnostics/Diagnostic/ServerInformational.php
@@ -32,13 +32,18 @@ class ServerInformational implements Diagnostic
         if (!empty($_SERVER['SERVER_SOFTWARE'])) {
 
             $isGlobalConfigIniAccessible = true; // Assume true if not installed yet
+            
+            // Only attempt to check file accessibility if the config setting allows it
+            $disableFileAccessCheck = (GeneralConfig::getConfigValue('enable_required_directories_diagnostic') == 0);
 
-            if (SettingsPiwik::isMatomoInstalled()) {
-                $rpd = new RequiredPrivateDirectories($this->translator);
-                $isGlobalConfigIniAccessible = $rpd->isGlobalConfigIniAccessible();
+            if(!$disableFileAccessCheck) {
+                if (SettingsPiwik::isMatomoInstalled()) {
+                    $rpd = new RequiredPrivateDirectories($this->translator);
+                    $isGlobalConfigIniAccessible = $rpd->isGlobalConfigIniAccessible();
+                }
             }
 
-            if (strpos(strtolower($_SERVER['SERVER_SOFTWARE']), 'nginx') !== false && $isGlobalConfigIniAccessible) {
+            if (strpos(strtolower($_SERVER['SERVER_SOFTWARE']), 'nginx') !== false && $isGlobalConfigIniAccessible && !$disableFileAccessCheck) {
 
                 $comment = $_SERVER['SERVER_SOFTWARE']."<br><br>";
                 $comment .= $this->translator->translate('Diagnostics_HtaccessWarningNginx', [


### PR DESCRIPTION
### Description:

I found another location where the accessibility of the `global.ini.php` is checked despite the `enable_required_directories_diagnostic` option is disabled in the config (the other case was fixed in #19031).
I just copied the changes over from #19031 to here.

Fixes #18967

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
