### PR TITLE
[Vue] use absolute path for @types output directory

### DIFF
--- a/plugins/MobileMessaging/vue/dist/umd.metadata.json
+++ b/plugins/MobileMessaging/vue/dist/umd.metadata.json
@@ -1,6 +1,7 @@
 {
   "dependsOn": [
     "CoreHome",
-    "CorePluginsAdmin"
+    "CorePluginsAdmin",
+    "ScheduledReports"
   ]
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -110,7 +110,7 @@ module.exports = {
           options.compilerOptions = {
             declaration: true,
             noEmit: false,
-            outDir: `@types/${process.env.MATOMO_CURRENT_PLUGIN}`,
+            outDir: `${__dirname}/@types/${process.env.MATOMO_CURRENT_PLUGIN}`,
           };
           return options;
         });


### PR DESCRIPTION
### Description:

...so it does not change if plugins define their own tsconfig.json.

Also fix the MobileMessaging umd.metadata.json file, which should have a dependency for ScheduledReports.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
