### PR TITLE
Compatibility fixes for PHP 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,14 +66,14 @@ matrix:
       sudo: false
       addons: false
     # All tests after another
-    - php: 8.0.9
+    - php: 8.1
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI ALLTEST_EXTRA_OPTIONS="--run-first-half-only" SKIP_COMPOSER_INSTALL=1
       sudo: required
       before_install:
         - composer install --ignore-platform-reqs
         - composer remove --dev phpunit/phpunit
         - composer require --dev phpunit/phpunit ~9.3 --ignore-platform-reqs
-    - php: 8.0.9
+    - php: 8.1
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI ALLTEST_EXTRA_OPTIONS="--run-second-half-only" SKIP_COMPOSER_INSTALL=1
       sudo: required
       before_install:

--- a/core/Db/Adapter/Mysqli.php
+++ b/core/Db/Adapter/Mysqli.php
@@ -82,6 +82,11 @@ class Mysqli extends Zend_Db_Adapter_Mysqli implements AdapterInterface
             return;
         }
 
+        // The default error reporting of mysqli changed in PHP 8.1. To circumvent problems in our error handling we set
+        // the erroring reporting to the default that was used prior PHP 8.1
+        // See https://php.watch/versions/8.1/mysqli-error-mode for more details
+        mysqli_report(MYSQLI_REPORT_OFF);
+
         parent::_connect();
 
         $this->_connection->query('SET sql_mode = "' . Db::SQL_MODE . '"');

--- a/core/ReportRenderer/Pdf.php
+++ b/core/ReportRenderer/Pdf.php
@@ -169,7 +169,7 @@ class Pdf extends ReportRenderer
 
     public function getRenderedReport()
     {
-        return $this->TCPDF->Output(null, 'S');
+        return $this->TCPDF->Output('', 'S');
     }
 
     public function renderFrontPage($reportTitle, $prettyDate, $description, $reportMetadata, $segment)

--- a/core/Site.php
+++ b/core/Site.php
@@ -438,7 +438,7 @@ class Site
         }
         $validIds = array();
         foreach ($ids as $id) {
-            $id = trim($id);
+            $id = is_string($id) ? trim($id) : $id;
             if (!empty($id) && is_numeric($id) && $id > 0) {
                 $validIds[] = $id;
             }

--- a/core/Tracker/Db/Mysqli.php
+++ b/core/Tracker/Db/Mysqli.php
@@ -105,6 +105,11 @@ class Mysqli extends Db
             $timer = $this->initProfiler();
         }
 
+        // The default error reporting of mysqli changed in PHP 8.1. To circumvent problems in our error handling we set
+        // the erroring reporting to the default that was used prior PHP 8.1
+        // See https://php.watch/versions/8.1/mysqli-error-mode for more details
+        mysqli_report(MYSQLI_REPORT_OFF);
+
         $this->connection = mysqli_init();
 
 

--- a/libs/Authenticator/TwoFactorAuthenticator.php
+++ b/libs/Authenticator/TwoFactorAuthenticator.php
@@ -132,7 +132,7 @@ class TwoFactorAuthenticator
             $x = "";
             if (!in_array($secret[$i], $base32chars)) return false;
             for ($j = 0; $j < 8; $j++) {
-                $x .= str_pad(base_convert(@$base32charsFlipped[@$secret[$i + $j]], 10, 2), 5, '0', STR_PAD_LEFT);
+                $x .= str_pad(base_convert($base32charsFlipped[@$secret[$i + $j]] ?? '', 10, 2), 5, '0', STR_PAD_LEFT);
             }
             $eightBits = str_split($x, 8);
             for ($z = 0; $z < count($eightBits); $z++) {

--- a/plugins/CoreAdminHome/Commands/ConfigDelete.php
+++ b/plugins/CoreAdminHome/Commands/ConfigDelete.php
@@ -77,7 +77,7 @@ NOTES:
             'value' => $input->getOption('value'),
         ]);
 
-        $argument = trim($input->getArgument('argument'));
+        $argument = trim($input->getArgument('argument') ?? '');
 
         // Sanity check inputs.
         switch (true) {

--- a/plugins/CoreAdminHome/Commands/ConfigGet.php
+++ b/plugins/CoreAdminHome/Commands/ConfigGet.php
@@ -89,7 +89,7 @@ NOTES:
             $format = self::OUTPUT_FORMAT_DEFAULT;
         }
 
-        $argument = trim($input->getArgument('argument'));
+        $argument = trim($input->getArgument('argument') ?? '');
 
         // If there are multiple arguments, just use the last one.
         $argument = array_slice(explode(' ', $argument), -1)[0];

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -281,7 +281,7 @@ class PasswordResetter
             $expiryTimestamp = $this->getDefaultExpiryTime();
         }
 
-        $expiry = strftime('%Y%m%d%H', $expiryTimestamp);
+        $expiry = date('YmdH', $expiryTimestamp);
         $token = $this->generateSecureHash(
             $expiry . $user['login'] . $user['email'] . $user['ts_password_modified'] . $keySuffix,
             $user['password']

--- a/plugins/Marketplace/Api/Service.php
+++ b/plugins/Marketplace/Api/Service.php
@@ -132,7 +132,7 @@ class Service
 
         $response = $this->download($url);
 
-        $result = json_decode($response, true);
+        $result = json_decode($response ?? '', true);
 
         if (is_null($result)) {
             $message = sprintf('There was an error reading the response from the Marketplace: Please try again later.');

--- a/plugins/PrivacyManager/tests/Fixtures/MultipleSitesMultipleVisitsFixture.php
+++ b/plugins/PrivacyManager/tests/Fixtures/MultipleSitesMultipleVisitsFixture.php
@@ -478,7 +478,7 @@ class MultipleSitesMultipleVisitsFixture extends Fixture
     private function trackVisit($userId, $referrer, $idGoal = null, $hoursAgo = null)
     {
         $this->initTracker($userId, $hoursAgo);
-        $this->tracker->setUrlReferrer($referrer);
+        $this->tracker->setUrlReferrer($referrer ?? false);
         $this->tracker->setUrl('http://www.helloworld.com/hello/world' . $userId);
         $this->tracker->doTrackPageView('Hello World ');
 

--- a/plugins/Referrers/Columns/Base.php
+++ b/plugins/Referrers/Columns/Base.php
@@ -633,7 +633,7 @@ abstract class Base extends VisitDimension
     protected function hasReferrerColumnChanged(Visitor $visitor, $information, $infoName)
     {
         $existing = mb_strtolower($visitor->getVisitorColumn($infoName) ?? '');
-        $new = mb_strtolower($information[$infoName]);
+        $new = mb_strtolower($information[$infoName] ?? '');
 
         $result = $existing != $new;
         if ($result) {

--- a/plugins/UserLanguage/functions.php
+++ b/plugins/UserLanguage/functions.php
@@ -48,7 +48,7 @@ function languageTranslate($label)
  */
 function languageTranslateWithCode($label)
 {
-    $ex = explode('-', $label);
+    $ex = explode('-', $label ?? '');
     $lang = languageTranslate($ex[0]);
 
     if (count($ex) == 2 && $ex[0] != $ex[1]) {

--- a/tests/PHPUnit/Fixtures/ManyVisitsWithMockLocationProvider.php
+++ b/tests/PHPUnit/Fixtures/ManyVisitsWithMockLocationProvider.php
@@ -175,7 +175,7 @@ class ManyVisitsWithMockLocationProvider extends Fixture
 
             // one visit to root url
             $t->setUrl("http://piwik.net/$visitorCounter/");
-            $t->setUrlReferrer(null);
+            $t->setUrlReferrer(false);
             $t->setForceVisitDateTime($visitDate->getDatetime());
             $t->setCustomDimension('' . $this->customDimensionId, $i * 5);
             $this->trackAction($t, $actionType, $visitorCounter, null);
@@ -195,7 +195,7 @@ class ManyVisitsWithMockLocationProvider extends Fixture
                 if (!is_null($referrers)) {
                     $t->setUrlReferrer($referrers[$actionIdx]);
                 } else {
-                    $t->setUrlReferrer(null);
+                    $t->setUrlReferrer(false);
                 }
 
                 if (!is_null($customVars)) {

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -1,10 +1,12 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
  * @link https://matomo.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
+
 namespace Piwik\Tests\Framework;
 
 use Piwik\Access;
@@ -104,8 +106,8 @@ class Fixture extends \PHPUnit\Framework\Assert
     public $printToScreen = false;
 
     public $testCaseClass = false;
-    public $extraPluginsToLoad = array();
-    public $extraDiEnvironments = array();
+    public $extraPluginsToLoad = [];
+    public $extraDiEnvironments = [];
 
     public $testEnvironment = null;
 
@@ -115,9 +117,9 @@ class Fixture extends \PHPUnit\Framework\Assert
      *
      * @var array
      */
-    public $extraDefinitions = array();
+    public $extraDefinitions = [];
 
-    public $extraTestEnvVars = array();
+    public $extraTestEnvVars = [];
 
     /**
      * @var Environment
@@ -150,7 +152,7 @@ class Fixture extends \PHPUnit\Framework\Assert
         $cliPhp = new CliPhp();
         $php = $cliPhp->findPhpBinary();
 
-        $command = $php . ' ' . PIWIK_INCLUDE_PATH .'/tests/PHPUnit/proxy/console ';
+        $command = $php . ' ' . PIWIK_INCLUDE_PATH . '/tests/PHPUnit/proxy/console ';
 
         if (!empty($_SERVER['HTTP_HOST'])) {
             $command .= '--matomo-domain=' . $_SERVER['HTTP_HOST'];
@@ -249,7 +251,8 @@ class Fixture extends \PHPUnit\Framework\Assert
         try {
             static::connectWithoutDatabase();
 
-            if ($this->dropDatabaseInSetUp
+            if (
+                $this->dropDatabaseInSetUp
                 || $this->resetPersistedFixture
             ) {
                 $this->dropDatabase();
@@ -268,7 +271,6 @@ class Fixture extends \PHPUnit\Framework\Assert
             DbHelper::recordInstallVersion();
 
             self::getPluginManager()->unloadPlugins();
-
         } catch (Exception $e) {
             static::fail("TEST INITIALIZATION FAILED: " . $e->getMessage() . "\n" . $e->getTraceAsString());
         }
@@ -291,7 +293,7 @@ class Fixture extends \PHPUnit\Framework\Assert
         self::updateDatabase();
         self::installAndActivatePlugins($testEnvironment);
 
-        $_GET = $_REQUEST = array();
+        $_GET = $_REQUEST = [];
         $_SERVER['HTTP_REFERER'] = '';
 
         FakeAccess::$superUserLogin = 'superUserLogin';
@@ -327,7 +329,8 @@ class Fixture extends \PHPUnit\Framework\Assert
         // In some cases the Factory might be filled with settings that contain an invalid database connection
         StaticContainer::getContainer()->set('Piwik\Settings\Storage\Factory', new \Piwik\Settings\Storage\Factory());
 
-        if ($this->overwriteExisting
+        if (
+            $this->overwriteExisting
             || !$this->isFixtureSetUp()
         ) {
             $this->setUp();
@@ -407,18 +410,18 @@ class Fixture extends \PHPUnit\Framework\Assert
         PiwikCache::getLazyCache()->flushAll();
         ArchiveTableCreator::clear();
         EventDispatcher::getInstance()->clearCache();
-        \Piwik\Plugins\ScheduledReports\API::$cache = array();
+        \Piwik\Plugins\ScheduledReports\API::$cache = [];
         Singleton::clearAll();
-        PluginsArchiver::$archivers = array();
+        PluginsArchiver::$archivers = [];
         \Piwik\Notification\Manager::cancelAllNotifications();
 
         Plugin\API::unsetAllInstances();
-        $_GET = $_REQUEST = array();
+        $_GET = $_REQUEST = [];
         if ($resetTranslations) {
             self::resetTranslations();
         }
 
-        self::getConfig()->Plugins; // make sure Plugins exists in a config object for next tests that use Plugin\Manager
+        self::getConfig()->Plugins; // make sure Plugins exists in config object for next tests that use Plugin\Manager
         // since Plugin\Manager uses getFromGlobalConfig which doesn't init the config object
     }
 
@@ -437,7 +440,7 @@ class Fixture extends \PHPUnit\Framework\Assert
     {
         $config = self::getConfig();
         $installed = $config->PluginsInstalled;
-        $installed['PluginsInstalled'] = array();
+        $installed['PluginsInstalled'] = [];
         $config->PluginsInstalled = $installed;
     }
 
@@ -454,8 +457,11 @@ class Fixture extends \PHPUnit\Framework\Assert
      * @param bool|false $testCaseClass Ignored.
      * @param array $extraPluginsToLoad Ignoerd.
      */
-    public static function loadAllPlugins(TestingEnvironmentVariables $testEnvironment = null, $testCaseClass = false, $extraPluginsToLoad = array())
-    {
+    public static function loadAllPlugins(
+        TestingEnvironmentVariables $testEnvironment = null,
+        $testCaseClass = false,
+        $extraPluginsToLoad = []
+    ) {
         DbHelper::createTables();
         DbHelper::recordInstallVersion();
         self::getPluginManager()->loadActivatedPlugins();
@@ -467,12 +473,12 @@ class Fixture extends \PHPUnit\Framework\Assert
 
         // Install plugins
         $messages = $pluginsManager->installLoadedPlugins();
-        if(!empty($messages)) {
+        if (!empty($messages)) {
             Log::info("Plugin loading messages: %s", implode(" --- ", $messages));
         }
 
         // Activate them
-        foreach($pluginsManager->getLoadedPlugins() as $plugin) {
+        foreach ($pluginsManager->getLoadedPlugins() as $plugin) {
             $name = $plugin->getPluginName();
             if (!$pluginsManager->isPluginActivated($name)) {
                 $pluginsManager->activatePlugin($name);
@@ -530,19 +536,29 @@ class Fixture extends \PHPUnit\Framework\Assert
      * @param null|string $excludedParameters
      * @return int    idSite of website created
      */
-    public static function createWebsite($dateTime, $ecommerce = 0, $siteName = false, $siteUrl = false,
-                                         $siteSearch = 1, $searchKeywordParameters = null,
-                                         $searchCategoryParameters = null, $timezone = null, $type = null,
-                                         $excludeUnknownUrls = 0, $excludedParameters = null)
-    {
-        if($siteName === false) {
+    public static function createWebsite(
+        $dateTime,
+        $ecommerce = 0,
+        $siteName = false,
+        $siteUrl = false,
+        $siteSearch = 1,
+        $searchKeywordParameters = null,
+        $searchCategoryParameters = null,
+        $timezone = null,
+        $type = null,
+        $excludeUnknownUrls = 0,
+        $excludedParameters = null
+    ) {
+        if ($siteName === false) {
             $siteName = self::DEFAULT_SITE_NAME;
         }
         $idSite = APISitesManager::getInstance()->addSite(
             $siteName,
             $siteUrl === false ? "http://piwik.net/" : $siteUrl,
             $ecommerce,
-            $siteSearch, $searchKeywordParameters, $searchCategoryParameters,
+            $siteSearch,
+            $searchKeywordParameters,
+            $searchCategoryParameters,
             $ips = null,
             $excludedQueryParameters = $excludedParameters,
             $timezone,
@@ -557,8 +573,9 @@ class Fixture extends \PHPUnit\Framework\Assert
         );
 
         // Manually set the website creation date to a day earlier than the earliest day we record stats for
-        Db::get()->update(Common::prefixTable("site"),
-            array('ts_created' => Date::factory($dateTime)->subDay(1)->getDatetime()),
+        Db::get()->update(
+            Common::prefixTable("site"),
+            ['ts_created' => Date::factory($dateTime)->subDay(1)->getDatetime()],
             "idsite = $idSite"
         );
 
@@ -581,8 +598,8 @@ class Fixture extends \PHPUnit\Framework\Assert
         $piwikUri = $config->tests['request_uri'];
         $piwikPort = $config->tests['port'];
 
-        if($piwikUri == '@REQUEST_URI@') {
-            throw new Exception("Piwik is mis-configured. Remove (or fix) the 'request_uri' entry below [tests] section in your config.ini.php. ");
+        if ($piwikUri == '@REQUEST_URI@') {
+            throw new Exception("Matomo is mis-configured. Remove (or fix) the 'request_uri' entry below [tests] section in your config.ini.php. ");
         }
 
         if (!empty($piwikPort)) {
@@ -609,7 +626,7 @@ class Fixture extends \PHPUnit\Framework\Assert
         $piwikUrl = str_replace("https://", "http://", $piwikUrl);
 
         // append REQUEST_URI (eg. when Piwik runs at http://localhost/piwik/)
-        if($piwikUri != '/') {
+        if ($piwikUri != '/') {
             $piwikUrl .= $piwikUri;
         }
 
@@ -679,8 +696,7 @@ class Fixture extends \PHPUnit\Framework\Assert
             . "\n If you are stuck, you can enable [Tracker] debug=1; in config.ini.php to get more debug info."
             . "\n\n Also, please try to restart your webserver, and run the test again, this may help!"
             . base64_encode($response)
-            . $url
-        );
+            . $url);
     }
 
     public static function checkTrackingFailureResponse($response)
@@ -704,10 +720,10 @@ class Fixture extends \PHPUnit\Framework\Assert
     {
         $data = json_decode($response, true);
         if (!is_array($data) || empty($response)) {
-            throw new Exception("Bulk tracking response (".$response.") is not an array: " . var_export($data, true) . "\n");
+            throw new Exception("Bulk tracking response (" . $response . ") is not an array: " . var_export($data, true) . "\n");
         }
-        if(!isset($data['status'])) {
-            throw new Exception("Returned data didn't have a status: " . var_export($data,true));
+        if (!isset($data['status'])) {
+            throw new Exception("Returned data didn't have a status: " . var_export($data, true));
         }
 
         self::assertArrayHasKey('status', $data);
@@ -716,12 +732,12 @@ class Fixture extends \PHPUnit\Framework\Assert
 
     public static function makeLocation($city, $region, $country, $lat = null, $long = null, $isp = null)
     {
-        return array(LocationProvider::CITY_NAME_KEY    => $city,
+        return [LocationProvider::CITY_NAME_KEY    => $city,
                      LocationProvider::REGION_CODE_KEY  => $region,
                      LocationProvider::COUNTRY_CODE_KEY => $country,
                      LocationProvider::LATITUDE_KEY     => $lat,
                      LocationProvider::LONGITUDE_KEY    => $long,
-                     LocationProvider::ISP_KEY          => $isp);
+                     LocationProvider::ISP_KEY          => $isp];
     }
 
     /**
@@ -761,7 +777,7 @@ class Fixture extends \PHPUnit\Framework\Assert
         }
         try {
             if (!$model->getUserByTokenAuth(self::ADMIN_USER_TOKEN)) {
-                $model->addTokenAuth($login,self::ADMIN_USER_TOKEN, 'Admin user token', Date::now()->getDatetime());
+                $model->addTokenAuth($login, self::ADMIN_USER_TOKEN, 'Admin user token', Date::now()->getDatetime());
             }
         } catch (Exception $e) {
             // duplicate entry errors are expected
@@ -793,7 +809,7 @@ class Fixture extends \PHPUnit\Framework\Assert
         // retrieve available reports
         $availableReportMetadata = APIScheduledReports::getReportMetadata($idSite, ScheduledReports::EMAIL_TYPE);
 
-        $availableReportIds = array();
+        $availableReportIds = [];
         foreach ($availableReportMetadata as $reportMetadata) {
             $availableReportIds[] = $reportMetadata['uniqueId'];
         }
@@ -808,7 +824,7 @@ class Fixture extends \PHPUnit\Framework\Assert
             ScheduledReports::EMAIL_TYPE,
             ReportRenderer::HTML_FORMAT, // overridden in getApiForTestingScheduledReports()
             $availableReportIds,
-            array(ScheduledReports::DISPLAY_FORMAT_PARAMETER => ScheduledReports::DISPLAY_FORMAT_TABLES_ONLY)
+            [ScheduledReports::DISPLAY_FORMAT_PARAMETER => ScheduledReports::DISPLAY_FORMAT_TABLES_ONLY]
         );
 
         // set-up sms report for one website
@@ -819,8 +835,8 @@ class Fixture extends \PHPUnit\Framework\Assert
             0,
             MobileMessaging::MOBILE_TYPE,
             MobileMessaging::SMS_FORMAT,
-            array("MultiSites_getOne"),
-            array("phoneNumbers" => array())
+            ["MultiSites_getOne"],
+            ["phoneNumbers" => []]
         );
 
         // set-up sms report for all websites
@@ -831,8 +847,8 @@ class Fixture extends \PHPUnit\Framework\Assert
             0,
             MobileMessaging::MOBILE_TYPE,
             MobileMessaging::SMS_FORMAT,
-            array("MultiSites_getAll"),
-            array("phoneNumbers" => array())
+            ["MultiSites_getAll"],
+            ["phoneNumbers" => []]
         );
 
         if (self::canImagesBeIncludedInScheduledReports()) {
@@ -845,7 +861,7 @@ class Fixture extends \PHPUnit\Framework\Assert
                 ScheduledReports::EMAIL_TYPE,
                 ReportRenderer::HTML_FORMAT, // overridden in getApiForTestingScheduledReports()
                 $availableReportIds,
-                array(ScheduledReports::DISPLAY_FORMAT_PARAMETER => ScheduledReports::DISPLAY_FORMAT_TABLES_AND_GRAPHS)
+                [ScheduledReports::DISPLAY_FORMAT_PARAMETER => ScheduledReports::DISPLAY_FORMAT_TABLES_AND_GRAPHS]
             );
 
             // set-up mail report with one row evolution based png graph
@@ -856,11 +872,11 @@ class Fixture extends \PHPUnit\Framework\Assert
                 0,
                 ScheduledReports::EMAIL_TYPE,
                 ReportRenderer::HTML_FORMAT,
-                array('Actions_getPageTitles'),
-                array(
+                ['Actions_getPageTitles'],
+                [
                      ScheduledReports::DISPLAY_FORMAT_PARAMETER => ScheduledReports::DISPLAY_FORMAT_GRAPHS_ONLY,
                      ScheduledReports::EVOLUTION_GRAPH_PARAMETER => 'true',
-                ),
+                ],
                 false
             );
             APIScheduledReports::getInstance()->addReport(
@@ -870,11 +886,11 @@ class Fixture extends \PHPUnit\Framework\Assert
                 0,
                 ScheduledReports::EMAIL_TYPE,
                 ReportRenderer::HTML_FORMAT,
-                array('Actions_getPageTitles'),
-                array(
+                ['Actions_getPageTitles'],
+                [
                     ScheduledReports::DISPLAY_FORMAT_PARAMETER => ScheduledReports::DISPLAY_FORMAT_GRAPHS_ONLY,
                     ScheduledReports::EVOLUTION_GRAPH_PARAMETER => 'true',
-                ),
+                ],
                 false,
                 'prev',
                 10
@@ -886,11 +902,11 @@ class Fixture extends \PHPUnit\Framework\Assert
                 0,
                 ScheduledReports::EMAIL_TYPE,
                 ReportRenderer::HTML_FORMAT,
-                array('Actions_getPageTitles'),
-                array(
+                ['Actions_getPageTitles'],
+                [
                     ScheduledReports::DISPLAY_FORMAT_PARAMETER => ScheduledReports::DISPLAY_FORMAT_GRAPHS_ONLY,
                     ScheduledReports::EVOLUTION_GRAPH_PARAMETER => 'true',
-                ),
+                ],
                 false,
                 'each'
             );
@@ -902,15 +918,15 @@ class Fixture extends \PHPUnit\Framework\Assert
      */
     public static function canImagesBeIncludedInScheduledReports()
     {
-        if(!function_exists('gd_info')) {
+        if (!function_exists('gd_info')) {
             echo "GD is not installed so cannot run these tests. please enable GD in PHP!\n";
             return false;
         }
         $gdInfo = gd_info();
         return
             stristr(php_uname(), self::IMAGES_GENERATED_ONLY_FOR_OS) &&
-            strpos( phpversion(), self::IMAGES_GENERATED_FOR_PHP) !== false &&
-            strpos( $gdInfo['GD Version'], self::IMAGES_GENERATED_FOR_GD) !== false;
+            strpos(phpversion(), self::IMAGES_GENERATED_FOR_PHP) !== false &&
+            strpos($gdInfo['GD Version'], self::IMAGES_GENERATED_FOR_GD) !== false;
     }
 
     public static function executeLogImporter($logFile, $options, $allowFailure = false)
@@ -926,7 +942,7 @@ class Fixture extends \PHPUnit\Framework\Assert
 
         foreach ($options as $name => $values) {
             if (!is_array($values)) {
-                $values = array($values);
+                $values = [$values];
             }
 
             foreach ($values as $value) {
@@ -947,7 +963,8 @@ class Fixture extends \PHPUnit\Framework\Assert
         }
 
         exec($cmd, $output, $result);
-        if ($result !== 0
+        if (
+            $result !== 0
             && !$allowFailure
         ) {
             throw new Exception("log importer failed: " . implode("\n", $output) . "\n\ncommand used: $cmd");
@@ -958,12 +975,12 @@ class Fixture extends \PHPUnit\Framework\Assert
 
     public static function siteCreated($idSite)
     {
-        return Db::fetchOne("SELECT COUNT(*) FROM " . Common::prefixTable('site') . " WHERE idsite = ?", array($idSite)) != 0;
+        return Db::fetchOne("SELECT COUNT(*) FROM " . Common::prefixTable('site') . " WHERE idsite = ?", [$idSite]) != 0;
     }
 
     public static function goalExists($idSite, $idGoal)
     {
-        return Db::fetchOne("SELECT COUNT(*) FROM " . Common::prefixTable('goal') . " WHERE idgoal = ? AND idsite = ?", array($idGoal, $idSite)) != 0;
+        return Db::fetchOne("SELECT COUNT(*) FROM " . Common::prefixTable('goal') . " WHERE idgoal = ? AND idsite = ?", [$idGoal, $idSite]) != 0;
     }
 
     /**
@@ -989,8 +1006,9 @@ class Fixture extends \PHPUnit\Framework\Assert
         $iniReader = new IniReader();
         $config = $iniReader->readFile(PIWIK_INCLUDE_PATH . '/config/config.ini.php');
         $originalDbName = $config['database']['dbname'];
-        if ($dbName == $originalDbName
-            && $dbName != 'piwik_tests' && $dbName !='matomo_tests'
+        if (
+            $dbName == $originalDbName
+            && $dbName != 'piwik_tests' && $dbName != 'matomo_tests'
         ) { // santity check
             throw new \Exception("Trying to drop original database '$originalDbName'. Something's wrong w/ the tests.");
         }
@@ -1027,7 +1045,8 @@ class Fixture extends \PHPUnit\Framework\Assert
         }
 
         $result = $updater->updateComponents($componentsWithUpdateFile);
-        if (!empty($result['coreError'])
+        if (
+            !empty($result['coreError'])
             || !empty($result['warnings'])
             || !empty($result['errors'])
         ) {
@@ -1044,7 +1063,7 @@ class Fixture extends \PHPUnit\Framework\Assert
      */
     public function provideContainerConfig()
     {
-        return array();
+        return [];
     }
 
     public function createEnvironmentInstance()

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -76,6 +76,7 @@ use ReflectionClass;
 class Fixture extends \PHPUnit\Framework\Assert
 {
     const IMAGES_GENERATED_ONLY_FOR_OS = 'linux';
+    const IMAGES_GENERATED_FOR_PHP = '7.2';
     const IMAGES_GENERATED_FOR_GD = '2.1.0';
     const DEFAULT_SITE_NAME = 'Piwik test';
 
@@ -908,6 +909,7 @@ class Fixture extends \PHPUnit\Framework\Assert
         $gdInfo = gd_info();
         return
             stristr(php_uname(), self::IMAGES_GENERATED_ONLY_FOR_OS) &&
+            strpos( phpversion(), self::IMAGES_GENERATED_FOR_PHP) !== false &&
             strpos( $gdInfo['GD Version'], self::IMAGES_GENERATED_FOR_GD) !== false;
     }
 

--- a/tests/PHPUnit/Integration/FrontControllerTest.php
+++ b/tests/PHPUnit/Integration/FrontControllerTest.php
@@ -23,7 +23,7 @@ class FrontControllerTest extends IntegrationTestCase
     public function test_fatalErrorStackTracesReturned()
     {
         $url = Fixture::getRootUrl() . '/tests/resources/trigger-fatal.php?format=json';
-        $response = Http::sendHttpRequest($url, self::isTravisCI() ? 5 : 20);
+        $response = Http::sendHttpRequest($url, self::isTravisCI() ? 2 : 20);
 
         $response = json_decode($response, $isAssoc = true);
         $response['message'] = $this->cleanMessage($response['message']);
@@ -31,7 +31,7 @@ class FrontControllerTest extends IntegrationTestCase
         $this->assertEquals('error', $response['result']);
 
         $expectedFormat = <<<FORMAT
-Allowed memory size of %s bytes exhausted (tried to allocate %s bytes) on {includePath}/tests/resources/trigger-fatal.php(22) #0 {includePath}/tests/resources/trigger-fatal.php(35): MyClass-&gt;triggerError(arg1=&quot;argval&quot;, arg2=&quot;another&quot;) #1 {includePath}/tests/resources/trigger-fatal.php(51): MyDerivedClass::staticMethod() #2 {includePath}/tests/resources/trigger-fatal.php(57): myFunction()
+Allowed memory size of %s bytes exhausted (tried to allocate %s bytes) on {includePath}/tests/resources/trigger-fatal.php(23) #0 {includePath}/tests/resources/trigger-fatal.php(36): MyClass-&gt;triggerError(arg1=&quot;argval&quot;, arg2=&quot;another&quot;) #1 {includePath}/tests/resources/trigger-fatal.php(52): MyDerivedClass::staticMethod() #2 {includePath}/tests/resources/trigger-fatal.php(58): myFunction()
 FORMAT;
 
         $this->assertStringMatchesFormat($expectedFormat, $response['message']);

--- a/tests/PHPUnit/Integration/FrontControllerTest.php
+++ b/tests/PHPUnit/Integration/FrontControllerTest.php
@@ -23,7 +23,7 @@ class FrontControllerTest extends IntegrationTestCase
     public function test_fatalErrorStackTracesReturned()
     {
         $url = Fixture::getRootUrl() . '/tests/resources/trigger-fatal.php?format=json';
-        $response = Http::sendHttpRequest($url, self::isTravisCI() ? 2 : 20);
+        $response = Http::sendHttpRequest($url, self::isTravisCI() ? 5 : 20);
 
         $response = json_decode($response, $isAssoc = true);
         $response['message'] = $this->cleanMessage($response['message']);

--- a/tests/resources/trigger-fatal.php
+++ b/tests/resources/trigger-fatal.php
@@ -1,5 +1,6 @@
 <?php
 
+ini_set('display_errors', 0);
 define('PIWIK_PRINT_ERROR_BACKTRACE', true);
 define('PIWIK_ENABLE_DISPATCH', false);
 


### PR DESCRIPTION
### Description:

This PR will run the AllTests on PHP 8.1 and includes

* various fixes for deprecation notices on PHP 8.1
* couple of test fixes for PHP 8.1
* fix for possible problems for PHP 8.1 using MySQLi connector
* fix for PHP 8.0.17 / 8.0.18 & 8.1.4 / 8.1.5 using `zlib.output_compression = On`

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
