### PR TITLE
Fix command to disable 2fa for a user

### DIFF
--- a/plugins/TwoFactorAuth/Commands/Disable2FAForUser.php
+++ b/plugins/TwoFactorAuth/Commands/Disable2FAForUser.php
@@ -1,8 +1,9 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
- * @link https://matomo.org
+ * @link    https://matomo.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
@@ -20,7 +21,10 @@ class Disable2FAForUser extends ConsoleCommand
     protected function configure()
     {
         $this->setName('twofactorauth:disable-2fa-for-user');
-        $this->setDescription('Disable two-factor authentication for a user. Useful if a user loses the device that was used for two-factor authentication. After it was disabled, the user will be able to set it up again.');
+        $this->setDescription(
+            'Disable two-factor authentication for a user. Useful if a user loses the device that was used for'
+            . ' two-factor authentication. After it was disabled, the user will be able to set it up again.'
+        );
         $this->addOption('login', null, InputOption::VALUE_REQUIRED, 'Login of an existing user');
     }
 

--- a/plugins/TwoFactorAuth/Commands/Disable2FAForUser.php
+++ b/plugins/TwoFactorAuth/Commands/Disable2FAForUser.php
@@ -8,8 +8,9 @@
 
 namespace Piwik\Plugins\TwoFactorAuth\Commands;
 
-use Piwik\API\Request;
+use Piwik\Container\StaticContainer;
 use Piwik\Plugin\ConsoleCommand;
+use Piwik\Plugins\TwoFactorAuth\TwoFactorAuthentication;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -28,9 +29,10 @@ class Disable2FAForUser extends ConsoleCommand
         $this->checkAllRequiredOptionsAreNotEmpty($input);
         $login = $input->getOption('login');
 
-        Request::processRequest('TwoFactorAuth.resetTwoFactorAuth', array(
-            'userLogin' => $login
-        ));
+        // Note: We can't use API here, as the API method would require a password confirmation
+        $t2f = StaticContainer::get(TwoFactorAuthentication::class);
+        $t2f->disable2FAforUser($login);
+
         $message = sprintf('<info>Disabled two-factor authentication for user: %s</info>', $login);
         $output->writeln($message);
     }


### PR DESCRIPTION
### Description:

fixes #18947

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
