### PR TITLE
[Vue] Fix vue-directive selector, make sure to select root node if it has vue-directive, not vue-entry

### DIFF
--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -258,8 +258,11 @@ window.piwikHelper = {
     },
 
     compileVueDirectives: function (selector) {
-      $('[vue-directive]', selector).add($(selector).filter('[vue-entry]')).each(function () {
+      $('[vue-directive]', selector).add($(selector).filter('[vue-directive]')).each(function () {
         var vueDirectiveName = $(this).attr('vue-directive');
+        if (!vueDirectiveName) {
+          return;
+        }
 
         var parts = vueDirectiveName.split('.');
         if (parts.length !== 2) {


### PR DESCRIPTION
### Description:

As title. Can cause problems when vue-entry is used within a widget.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
