### PR TITLE
Improve performance of calculating evolution trend metric value

### DIFF
--- a/plugins/CoreHome/Columns/Metrics/EvolutionMetric.php
+++ b/plugins/CoreHome/Columns/Metrics/EvolutionMetric.php
@@ -60,6 +60,8 @@ class EvolutionMetric extends ProcessedMetric
      */
     private $currentData;
 
+    private $isLowerBetter = false;
+
     /**
      * The list of labels leading to the current subtable being processed. Used to get the proper subtable in
      * $pastData.
@@ -83,6 +85,7 @@ class EvolutionMetric extends ProcessedMetric
                                 ?DataTable $currentData = null)
     {
         $this->wrapped = $wrapped;
+        $this->isLowerBetter = Metrics::isLowerValueBetter($this->wrapped);
         $this->pastData = $pastData;
         $this->currentData = $currentData;
 
@@ -119,8 +122,7 @@ class EvolutionMetric extends ProcessedMetric
 
     public function getTrendValue($computedValue = 0)
     {
-        $isLowerBetter = Metrics::isLowerValueBetter($this->wrapped);
-        if ($isLowerBetter) {
+        if ($this->isLowerBetter) {
             return ($computedValue < 0 ? 1 : ($computedValue > 0 ? -1 : 0));
         }
 


### PR DESCRIPTION
### Description:

This will avoid calling `Metrics::isLowerValueBetter` each time the trend value for a row is calculated, which can be easily hundreds or thousands of calls depending on the datatable size.

refs L3-241

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
