### PR TITLE
tweak QueryParameters type in index.d.ts to better match arbitrary object types

### DIFF
--- a/.github/workflows/buildvue.yml
+++ b/.github/workflows/buildvue.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           git fetch --depth=1 origin ${{ steps.vars.outputs.base }}
 
-          VUE_FILES_MODIFIED=$(git diff --name-only ${{ steps.vars.outputs.base }} -- plugins/*/vue/**/* | wc -l)
+          VUE_FILES_MODIFIED=$(git diff --name-only ${{ steps.vars.outputs.base }} -- plugins/*/vue/**/* plugins/CoreVue/types | wc -l)
 
           if [[ $VUE_FILES_MODIFIED == "0" ]]
           then

--- a/plugins/CoreVue/types/index.d.ts
+++ b/plugins/CoreVue/types/index.d.ts
@@ -11,7 +11,7 @@ import { ExtendedKeyboardEvent } from 'mousetrap';
 
 declare global {
   type QueryParameterValue = string | number | null | undefined | QueryParameterValue[];
-  type QueryParameters = {[name: string]: QueryParameterValue | QueryParameters};
+  type QueryParameters = Record<string, QueryParameterValue | QueryParameters>;
 
   interface WrappedEventListener extends Function {
     wrapper?: (evt: Event) => void;


### PR DESCRIPTION
### Description:

This avoids typescript errors when casting certain arbitrary objects to the QueryParameters type. I was specifically having trouble with this one:

```
{
  example: string;
  name: string;
  types: {
    name: string;
    value: string;
  }[];
  value: string;
}[]
```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
