### PR TITLE
[Vue] change modal callbacks option type to allow any key value

### DIFF
--- a/plugins/CoreVue/types/index.d.ts
+++ b/plugins/CoreVue/types/index.d.ts
@@ -59,11 +59,7 @@ declare global {
 
   let Piwik_Popover: PiwikPopoverGlobal;
 
-  interface ModalConfirmCallbacks {
-    yes?: () => void;
-    no?: () => void;
-    validation?: () => void;
-  }
+  type ModalConfirmCallbacks = Record<string, () => void>;
 
   interface ModalConfirmOptions {
     onCloseEnd: () => void;


### PR DESCRIPTION
### Description:

For modalConfirm(), the callback key names can be any value that matches an `<input>`'s role attribute. It's not limited to `yes`,`no`,`validation`. This PR allows any key to be specified in TypeScript.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
