### PR TITLE
Add 429 (rate limited) response code

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -1137,6 +1137,7 @@ class Common
             401 => 'Unauthorized',
             403 => 'Forbidden',
             404 => 'Not Found',
+            429 => 'Too Many Requests',
             500 => 'Internal Server Error',
             503 => 'Service Unavailable',
         );

--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -52,9 +52,7 @@ class Adapter
             try {
                 $adapter->getConnection();
 
-                if (!Zend_Db_Table::getDefaultAdapter()) {
-                    Zend_Db_Table::setDefaultAdapter($adapter);
-                }
+                Zend_Db_Table::setDefaultAdapter($adapter);
                 // we don't want the connection information to appear in the logs
                 $adapter->resetConfig();
             } catch(\Exception $e) {

--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -52,7 +52,9 @@ class Adapter
             try {
                 $adapter->getConnection();
 
-                Zend_Db_Table::setDefaultAdapter($adapter);
+                if (!Zend_Db_Table::getDefaultAdapter()) {
+                    Zend_Db_Table::setDefaultAdapter($adapter);
+                }
                 // we don't want the connection information to appear in the logs
                 $adapter->resetConfig();
             } catch(\Exception $e) {


### PR DESCRIPTION
### Description:

This PR adds a 429 response code to `Common::sendResponseCode()`. ~~and wraps the `Zend_Db_Table::setDefaultAdapter($adapter);` in a conditional This helps prevent a reference being kept, making it easier to close a DB connection if required.~~

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
