### PR TITLE
[Vue] ignore linkSync errors in custom chai assertion to avoid error if expected file does not exist

### DIFF
--- a/tests/lib/screenshot-testing/support/chai-extras.js
+++ b/tests/lib/screenshot-testing/support/chai-extras.js
@@ -92,7 +92,11 @@ module.exports = function makeChaiImageAssert(comparisonCommand = 'compare') {
 
                     // copy to diff dir for ui tests viewer (we don't generate diffs w/ compare since it slows the tests a bit)
                     if (!fs.existsSync(diffPath)) {
-                        fs.linkSync(expectedPath, diffPath);
+                        try {
+                          fs.linkSync(expectedPath, diffPath);
+                        } catch (e) {
+                          console.log(`Failed to copy ${expectedPath} to ${diffPath}`);
+                        }
                     }
                 }
 


### PR DESCRIPTION
### Description:

The error message in this PR is a bit easier to understand than the ENOENT error from node.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
