### PR TITLE
Fix for undefined array index error when rendering sparklines.

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/Sparklines.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines.php
@@ -289,7 +289,10 @@ class Sparklines extends ViewDataTable
 
                 $metrics = [];
                 foreach ($values as $i => $value) {
-                    if ($columnMetrics[$column[$i]]) {
+                    if (!isset($column[$i])) {
+                        continue;
+                    }
+                    if (isset($columnMetrics[$column[$i]]) && $columnMetrics[$column[$i]]) {
                         $value = $columnMetrics[$column[$i]]->format($value, $metricFormatter);
                     } elseif (strpos($column[$i], 'revenue') !== false && $idSite > 0) {
                         $value = $metricFormatter->getPrettyMoney($value, $idSite);


### PR DESCRIPTION
### Description:

Fixes #19275 

Adds an array index check for the columnMetric array when formatting sparkline visualizations.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
