### PR TITLE
Fixed error due to non-array values

### DIFF
--- a/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
+++ b/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
@@ -100,7 +100,7 @@ class CalculateConversionPageRate extends BaseFilter
 
         foreach ($goalIds as $idGoal => $g) {
             $total = $archive->getNumeric(GoalsArchiver::getRecordName('nb_conversions', $idGoal));
-            if (count($total)) {
+            if (!empty($total) && count($total)) {
                 $goalTotals[$idGoal] = reset($total);
             }
         }

--- a/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
+++ b/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
@@ -100,8 +100,10 @@ class CalculateConversionPageRate extends BaseFilter
 
         foreach ($goalIds as $idGoal => $g) {
             $total = $archive->getNumeric(GoalsArchiver::getRecordName('nb_conversions', $idGoal));
-            if (!empty($total) && count($total)) {
+            if (is_array($total) && count($total)) {
                 $goalTotals[$idGoal] = reset($total);
+            } else if(is_numeric($total)) {
+                $goalTotals[$idGoal] = $total;
             }
         }
 

--- a/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
+++ b/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
@@ -102,7 +102,7 @@ class CalculateConversionPageRate extends BaseFilter
             $total = $archive->getNumeric(GoalsArchiver::getRecordName('nb_conversions', $idGoal));
             if (is_array($total) && count($total)) {
                 $goalTotals[$idGoal] = reset($total);
-            } else if(is_numeric($total)) {
+            } else if (is_numeric($total)) {
                 $goalTotals[$idGoal] = $total;
             }
         }


### PR DESCRIPTION
### Description:

Due to #18221 changes, we are getting a error "count(): Parameter must be an array or an object that implements Countable".
This was noticed in this [build](https://app.travis-ci.com/github/matomo-org/plugin-GoogleAnalyticsImporter/jobs/572187699) of GAImporter Plugin

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
