### PR TITLE
remove deprecated dollar brace string interpolation

### DIFF
--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -127,7 +127,7 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
         bool $writeErrorLog = true
     ) {
         if ($writeErrorLog) {
-            error_log(sprintf("${errorLogPrefix}Error in Matomo: %s", str_replace("\n", " ", strip_tags($message))));
+            error_log(sprintf("{$errorLogPrefix}Error in Matomo: %s", str_replace("\n", " ", strip_tags($message))));
         }
 
         if (!headers_sent()) {


### PR DESCRIPTION
see #19343

This seems to be the only change that is strictly required for Matomo to be mostly useable in PHP 8.2