### PR TITLE
Fix for zero average order value on charts

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -105,7 +105,8 @@ class Request
                 $defaultRequest['segment'] = $requestRaw['segment'];
             }
 
-            if (!isset($defaultRequest['format_metrics'])) {
+            // Only default to formatting metrics if the request doesn't contain the format metrics parameter
+            if (!isset($defaultRequest['format_metrics']) && !isset($request['format_metrics'])) {
                 $defaultRequest['format_metrics'] = 'bc';
             }
         }

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -105,8 +105,10 @@ class Request
                 $defaultRequest['segment'] = $requestRaw['segment'];
             }
 
-            $defaultRequest['format_metrics'] = 'bc';
-
+            // Only default to formatting metrics if the request doesn't already contain the format metrics parameter
+            if (!isset($defaultRequest['format_metrics']) && !isset($request['format_metrics'])) {
+                $defaultRequest['format_metrics'] = 'bc';
+            }
         }
 
         $requestArray = $defaultRequest;

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -105,10 +105,8 @@ class Request
                 $defaultRequest['segment'] = $requestRaw['segment'];
             }
 
-            // Only default to formatting metrics if the request doesn't contain the format metrics parameter
-            if (!isset($defaultRequest['format_metrics']) && !isset($request['format_metrics'])) {
-                $defaultRequest['format_metrics'] = 'bc';
-            }
+            $defaultRequest['format_metrics'] = 'bc';
+
         }
 
         $requestArray = $defaultRequest;

--- a/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
@@ -52,7 +52,7 @@ class Chart
         $this->axes['xaxis']['onclick'] = & $onClick;
     }
 
-    public function setAxisYValues(&$values, $seriesMetadata = null)
+    public function setAxisYValues(&$values, $seriesMetadata = null, ?array $seriesUnits = null)
     {
         foreach ($values as $label => &$data) {
             $seriesInfo = array(
@@ -65,9 +65,13 @@ class Chart
             }
 
             $this->series[] = $seriesInfo;
+            $unit = (isset($seriesUnits[$label]) ? $seriesUnits[$label] : null);
 
-            array_walk($data, function (&$v) {
+            array_walk($data, function (&$v) use ($unit) {
                 $v = (float) Common::forceDotAsSeparatorForDecimalPoint($v);
+                if ($unit === '%') {
+                    $v = $v * 100;
+                }
             });
             $this->data[] = & $data;
         }
@@ -90,7 +94,12 @@ class Chart
 
         // generate jqplot axes config
         foreach ($axesIds as $unit => $axisId) {
-            $this->axes[$axisId]['tickOptions']['formatString'] = '%s' . $unit;
+            if ($unit === '%') {
+                $this->axes[$axisId]['tickOptions']['formatString'] = '%s' . $unit;
+            } else {
+                $this->axes[$axisId]['tickOptions']['formatString'] = $unit . '%s';
+            }
+
         }
 
         // map each series to appropriate yaxis

--- a/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
@@ -9,6 +9,8 @@
 namespace Piwik\Plugins\CoreVisualizations\JqplotDataGenerator;
 
 use Piwik\Common;
+use Piwik\Container\StaticContainer;
+use Piwik\NumberFormatter;
 use Piwik\ProxyHttp;
 
 /**
@@ -103,6 +105,20 @@ class Chart
         foreach ($axesIds as $unit => $axisId) {
             if ($unit === '$' || $unit === '£') {
                 $this->axes[$axisId]['tickOptions']['formatString'] = $unit . '%s';
+            } else {
+                $this->axes[$axisId]['tickOptions']['formatString'] = '%s' . $unit;
+            }
+        }
+
+        $currencies = StaticContainer::get('Piwik\Intl\Data\Provider\CurrencyDataProvider')->getCurrencyList();
+        $currencies = array_column($currencies, 0);
+
+        // generate jqplot axes config
+        foreach ($axesIds as $unit => $axisId) {
+            if ($unit === '%') {
+                $this->axes[$axisId]['tickOptions']['formatString'] = str_replace('0', '%s', NumberFormatter::getInstance()->formatPercent(0, 0, 0));
+            } else if (in_array($unit, $currencies)) {
+                $this->axes[$axisId]['tickOptions']['formatString'] = str_replace('0', '%s', NumberFormatter::getInstance()->formatCurrency(0, $unit, 0));
             } else {
                 $this->axes[$axisId]['tickOptions']['formatString'] = '%s' . $unit;
             }

--- a/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
@@ -52,6 +52,13 @@ class Chart
         $this->axes['xaxis']['onclick'] = & $onClick;
     }
 
+    /**
+     * Set the series values
+     *
+     * @param            $values
+     * @param null       $seriesMetadata
+     * @param array|null $seriesUnits     If the series units array is passed then the values will be formatted
+     */
     public function setAxisYValues(&$values, $seriesMetadata = null, ?array $seriesUnits = null)
     {
         foreach ($values as $label => &$data) {

--- a/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
@@ -94,12 +94,11 @@ class Chart
 
         // generate jqplot axes config
         foreach ($axesIds as $unit => $axisId) {
-            if ($unit === '%') {
-                $this->axes[$axisId]['tickOptions']['formatString'] = '%s' . $unit;
-            } else {
+            if ($unit === '$' || $unit === '£') {
                 $this->axes[$axisId]['tickOptions']['formatString'] = $unit . '%s';
+            } else {
+                $this->axes[$axisId]['tickOptions']['formatString'] = '%s' . $unit;
             }
-
         }
 
         // map each series to appropriate yaxis

--- a/plugins/CoreVisualizations/JqplotDataGenerator/Evolution.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator/Evolution.php
@@ -89,7 +89,7 @@ class Evolution extends JqplotDataGenerator
         $visualization->dataTable = $dataTable;
         $visualization->properties = $this->properties;
 
-        $visualization->setAxisYValues($allSeriesData, $seriesMetadata);
+        $visualization->setAxisYValues($allSeriesData, $seriesMetadata, $seriesUnits);
         $visualization->setAxisYUnits($seriesUnits);
 
         $xLabelStrs = [];

--- a/plugins/CoreVisualizations/JqplotDataGenerator/Evolution.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator/Evolution.php
@@ -89,7 +89,11 @@ class Evolution extends JqplotDataGenerator
         $visualization->dataTable = $dataTable;
         $visualization->properties = $this->properties;
 
-        $visualization->setAxisYValues($allSeriesData, $seriesMetadata, $seriesUnits);
+        $units = null;
+        if ($visualization->properties['request_parameters_to_modify']['format_metrics'] === 0) {
+            $units = $seriesUnits;
+        }
+        $visualization->setAxisYValues($allSeriesData, $seriesMetadata, $units);
         $visualization->setAxisYUnits($seriesUnits);
 
         $xLabelStrs = [];

--- a/plugins/CoreVisualizations/Visualizations/Graph.php
+++ b/plugins/CoreVisualizations/Visualizations/Graph.php
@@ -62,7 +62,10 @@ abstract class Graph extends Visualization
             $this->requestConfig->request_parameters_to_modify['filter_truncate'] = $this->config->max_graph_elements - 1;
         }
 
-        $this->requestConfig->request_parameters_to_modify['format_metrics'] = 1;
+        // Only default to formatting metrics if the request hasn't already been set to not format metrics
+        if (!isset($this->requestConfig->request_parameters_to_modify['format_metrics'])) {
+            $this->requestConfig->request_parameters_to_modify['format_metrics'] = 1;
+        }
 
         // if addTotalRow was called in GenerateGraphHTML, add a row containing totals of
         // different metrics

--- a/plugins/Goals/Controller.php
+++ b/plugins/Goals/Controller.php
@@ -22,6 +22,7 @@ use Piwik\Plugins\Referrers\API as APIReferrers;
 use Piwik\Translation\Translator;
 use Piwik\View;
 use Piwik\ViewDataTable\Factory as ViewDataTableFactory;
+use Piwik\Plugins\CoreVisualizations\Visualizations\jqplotGraph\Evolution;
 
 /**
  *
@@ -203,7 +204,7 @@ class Controller extends \Piwik\Plugin\Controller
         if (empty($idGoal)) {
             $idGoal = Common::getRequestVar('idGoal', '', 'string');
         }
-        $view = $this->getLastUnitGraph($this->pluginName, __FUNCTION__, 'Goals.get');
+        $view = $this->getLastUnitGraph($this->pluginName, __FUNCTION__, 'Goals.get', ['format_metrics' => 0]);
         $view->requestConfig->request_parameters_to_modify['idGoal'] = $idGoal;
         $view->requestConfig->request_parameters_to_modify['showAllGoalSpecificMetrics'] = 1;
 
@@ -250,6 +251,10 @@ class Controller extends \Piwik\Plugin\Controller
 
         $langString = $idGoal ? 'Goals_SingleGoalOverviewDocumentation' : 'Goals_GoalsOverviewDocumentation';
         $view->config->documentation = $this->translator->translate($langString, '<br />');
+
+        if ($view instanceof Evolution) {
+            $view->requestConfig->request_parameters_to_modify['format_metrics'] = 0;
+        }
 
         return $this->renderView($view);
     }

--- a/plugins/Goals/Reports/Get.php
+++ b/plugins/Goals/Reports/Get.php
@@ -245,7 +245,8 @@ class Get extends Base
                     'forceView' => null,
                     'viewDataTable' => null,
                     'showtitle' => null,
-                    'random' => null
+                    'random' => null,
+                    'format_metrics' => 0
                 ]);
             }
 

--- a/tests/UI/expected-screenshots/RowEvolution_row_evolution_ecommerce_item.png
+++ b/tests/UI/expected-screenshots/RowEvolution_row_evolution_ecommerce_item.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e4cbdf9d2183e35dec47741a2848033e17d61d453281a63512ce5a0b68d869e
-size 76591
+oid sha256:d795ac0da7f19b00a30a94874c0fe2a1e328c7e0d96aea6270826a3a8ada2770
+size 76788


### PR DESCRIPTION
### Description:

Fixes #15262 

The average order value on the evolution overview charts was always shown as zero, this was caused by pre-formatted values in the datatable breaking the jqplot data generation.

This fix attempts to solve this by:
- Respecting evolution chart visualization calls which set `format_metrics = 0` (only setting a `format_metrics` default value if there are no request override parameters)
- Having evolution charts set `format_metrics = 0`
- Passing the series units to the jqplot data generation `setAxisYValues` method
- If the series unit is a percent then convert chart data values to display percentages.
- jqplot chart number formatting currently doesn't fully support internationalization (eg. forcing a dot as a decimal point separator), all series formatting units were being added as a postfix, I added a minor tweak to show dollar and pound currency symbols as prefixes. This is obviously not ideal but should be a slight improvement for some people, if we had a reliable way to determine the currency symbol position then we could possibly add that as metadata to `core/Metrics::getUnit()` and make it available to the jqplot formatting code.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
