### PR TITLE
Fix number formatting in additional Y axis in (evolution) charts

### DIFF
--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -123,11 +123,18 @@ function rowEvolutionGetMetricNameFromRow(tr)
                             formatString: '%s',
                             formatter: $.jqplot.NumberFormatter
                         }
-                    }
+                    },
                 }
             };
 
             this.jqplotParams = $.extend(true, {}, defaultParams, params);
+
+            for (var i = 2; typeof this.jqplotParams.axes['y' + i + 'axis'] != 'undefined'; i++) {
+                this.jqplotParams.axes['y' + i + 'axis'].tickOptions = $.extend(true, {}, {
+                  formatString: '%s',
+                  formatter: $.jqplot.NumberFormatter
+                }, this.jqplotParams.axes['y' + i + 'axis'].tickOptions);
+            }
 
             this._setColors();
         },

--- a/tests/UI/expected-screenshots/EvolutionGraph_bounce_rate.png
+++ b/tests/UI/expected-screenshots/EvolutionGraph_bounce_rate.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:acd073900f58d1bff4aa3fb68b1987c658e0b2c53f6f0bfb7aaf5f8956e2f14d
-size 107634
+oid sha256:f7111399d9c3755037d20a36a10a6c661a326f37cfd36e6f182eb4c2aabfca9b
+size 107910


### PR DESCRIPTION
### Description:

While reviewing another PR I saw that the additional y axis values in evolution charts were not formatted:

![image](https://user-images.githubusercontent.com/1579355/173858860-e8c259c8-b8f9-4638-ac38-f75a4c7a443a.png)

This PR will change the behavior, so the number formatter is set for all available y axis.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
