### PR TITLE
Setting prepare callback before validation

### DIFF
--- a/core/Settings/FieldConfig.php
+++ b/core/Settings/FieldConfig.php
@@ -191,6 +191,20 @@ class FieldConfig
     public $inlineHelp = null;
 
     /**
+     * A closure that prepares the setting value. If supplied, this closure will be executed before
+     * the setting has been validated.
+     *
+     * **Example**
+     *
+     *     $setting->prepare = function ($value, Setting $setting) {
+     *         return mb_strtolower($value);
+     *     }
+     *
+     * @var null|\Closure
+     */
+    public $prepare = null;
+
+    /**
      * A closure that does some custom validation on the setting before the setting is persisted.
      *
      * The closure should take two arguments: the setting value and the {@link Setting} instance being

--- a/core/Settings/Setting.php
+++ b/core/Settings/Setting.php
@@ -221,6 +221,10 @@ class Setting
 
         $config = $this->configureField();
 
+        if ($config->prepare && $config->prepare instanceof \Closure) {
+            $value = call_user_func($config->prepare, $value, $this);
+        }
+
         $this->validateValue($value);
 
         if ($config->transform && $config->transform instanceof \Closure) {


### PR DESCRIPTION
### Description:

Along with existing `transform` callback that runs **after** validation would be applicable to add `prepare` callback that runs **before** validation

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
