### PR TITLE
Update ReportsProvider.php

### DIFF
--- a/core/Plugin/ReportsProvider.php
+++ b/core/Plugin/ReportsProvider.php
@@ -153,7 +153,7 @@ class ReportsProvider
              *     public function filterReports(&$reports)
              *     {
              *         foreach ($reports as $index => $report) {
-             *              if ($report->getCategory() === 'Actions') {}
+             *              if ($report->getCategoryId() === 'General_Actions') {
              *                  unset($reports[$index]); // remove all reports having this action
              *              }
              *         }


### PR DESCRIPTION
Copying this from the docs caused

> Unmatched '}'

and fixing it caused

> Call to undefined method Piwik\Plugins\API\Reports\Get::getCategory()

and logging `getCategoryId()` shows that `Actions` is not correct either. But using `General_Actions` doesn't remove any menus either, even though `unset` is called.

I feel like the first person using these APIs (refs #19389)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
