### PR TITLE
Full width field in settings

### DIFF
--- a/core/Settings/FieldConfig.php
+++ b/core/Settings/FieldConfig.php
@@ -147,6 +147,14 @@ class FieldConfig
     public $uiControlAttributes = array();
 
     /**
+     * Makes field full width.
+     * Useful for `$field->uiControl = FieldConfig::UI_CONTROL_MULTI_TUPLE;`
+     *
+     * @var bool
+     */
+    public $fullWidth = false;
+
+    /**
      * The list of all available values for this setting. If null, the setting can have any value.
      *
      * If supplied, this field should be an array mapping available values with their prettified

--- a/core/Settings/FieldConfig/MultiPair.php
+++ b/core/Settings/FieldConfig/MultiPair.php
@@ -14,7 +14,7 @@ namespace Piwik\Settings\FieldConfig;
  *
  * Usage:
  *
- * $field->uiControl = FieldConfig::UI_CONTROL_MULTI_PAIR;
+ * $field->uiControl = FieldConfig::UI_CONTROL_MULTI_TUPLE;
  * $field1 = new FieldConfig\MultiPair('Index', 'index', FieldConfig::UI_CONTROL_TEXT);
  * $field2 = new FieldConfig\MultiPair('Value', 'value', FieldConfig::UI_CONTROL_TEXT);
  * $field->uiControlAttributes['field1'] = $field1->toArray();

--- a/plugins/CoreHome/vue/src/MultiPairField/MultiPairField.less
+++ b/plugins/CoreHome/vue/src/MultiPairField/MultiPairField.less
@@ -7,14 +7,13 @@
   }
 
   .multiPairFieldTable {
-    
+
     &.has1Fields {
       .fieldUiControl1{
-        width: ~"calc(100% - 60px)";
         padding-right: 0.75rem;
       }
     }
-  
+
     &:not(.has1Fields) {
       .fieldUiControl {
         display: inline-block;
@@ -23,38 +22,56 @@
     }
 
     &.has2Fields {
-      .fieldUiControl1 {
-        width: 160px;
-      }
       .fieldUiControl2 {
-        width: ~"calc(100% - 190px)";
         padding: 0.75rem;
-      }
-    }
-  
-    &.has3Fields {
-      .fieldUiControl1 {
-        width: 120px;
-      }
-      .fieldUiControl2,
-      .fieldUiControl3 {
-        width: 220px;
-      }
-    }
-  
-    &.has4Fields {
-      .fieldUiControl1 {
-        width: 120px;
-      }
-      .fieldUiControl2,
-      .fieldUiControl3,
-      .fieldUiControl4 {
-        width: 148px;
       }
     }
   }
 
   .icon-minus {
     cursor: pointer;
+  }
+}
+
+.col.m6 {
+  .multiPairField {
+    .multiPairFieldTable {
+
+      &.has1Fields {
+        .fieldUiControl1{
+          width: ~"calc(100% - 60px)";
+        }
+      }
+
+      &.has2Fields {
+        .fieldUiControl1 {
+          width: 160px;
+        }
+        .fieldUiControl2 {
+          width: ~"calc(100% - 190px)";
+        }
+      }
+
+      &.has3Fields {
+        .fieldUiControl1 {
+          width: 120px;
+        }
+        .fieldUiControl2,
+        .fieldUiControl3 {
+          width: 220px;
+        }
+      }
+
+      &.has4Fields {
+        .fieldUiControl1 {
+          width: 120px;
+        }
+        .fieldUiControl2,
+        .fieldUiControl3,
+        .fieldUiControl4 {
+          width: 148px;
+        }
+      }
+    }
   }
 }

--- a/plugins/CorePluginsAdmin/SettingsMetadata.php
+++ b/plugins/CorePluginsAdmin/SettingsMetadata.php
@@ -128,6 +128,7 @@ class SettingsMetadata
             'templateFile' => $config->customUiControlTemplateFile,
             'introduction' => $config->introduction,
             'condition' => $config->condition,
+            'fullWidth' => $config->fullWidth,
         );
 
         if ($config->customFieldComponent) {

--- a/plugins/Morpheus/templates/demo.twig
+++ b/plugins/Morpheus/templates/demo.twig
@@ -396,6 +396,14 @@
      ui-control-attributes='{"field1":{"key":"index","title":"Index","uiControl":"text","availableValues":null},"field2":{"key":"value","title":"Value","uiControl":"text","availableValues":null},"field3":{"key":"value2","title":"Value","uiControl":"text","availableValues":null},"field4":{"key":"value3","title":"Value","uiControl":"text","availableValues":null}}'>
 </div>
 
+<div piwik-field uicontrol="multituple" name="multitupletextfullwidth"
+     data-title="Multiple values full width (four)"
+     full-width="true"
+     value="[]"
+     inline-help="Multi Tuple text and text full width"
+     ui-control-attributes='{"field1":{"key":"index","title":"Index","uiControl":"text","availableValues":null},"field2":{"key":"value","title":"Value","uiControl":"text","availableValues":null},"field3":{"key":"value2","title":"Value","uiControl":"text","availableValues":null},"field4":{"key":"value3","title":"Value","uiControl":"text","availableValues":null}}'>
+</div>
+
 <div piwik-field uicontrol="multituple" name="multitupletextvalue"
      data-title="Multiple values with values (four)"
      value='[{"index": "test", "value":"myfoo"},{"index": "test 2", "value":"myfoo 2"}]'


### PR DESCRIPTION
### Description:

Allows configure full width field through template parameters.

`plugins/CorePluginsAdmin/vue/src/FormField/FormField.vue` already have this ability but it used only in frontend.

As `FieldMultituple` allows to use up to 4 subfields, it would be nice to have ability to extend it to full width.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
