### PR TITLE
Fixes too large buttons padding for mobile

### DIFF
--- a/plugins/Morpheus/stylesheets/ui/_buttons.less
+++ b/plugins/Morpheus/stylesheets/ui/_buttons.less
@@ -72,5 +72,12 @@ input[type="submit"].btn,
 }
 
 .btn, .btn-large, .btn-small, .btn-flat {
-    padding: 0 2rem;
+  padding: 0 2rem;
+  height: auto;
+}
+
+@media (max-width: 1199px) {
+  .btn, .btn-large, .btn-small, .btn-flat {
+    padding: 0 0.5em;
+  }
 }


### PR DESCRIPTION
### Description:

**Actual**

![image](https://user-images.githubusercontent.com/32728904/176870835-a586431a-30e8-4efb-b675-9a61b86866f6.png)

**Expected**

![image](https://user-images.githubusercontent.com/32728904/176874167-ed3c8612-b51f-4697-b684-deccc89819f6.png)

How to build plugin `Morpheus`?

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
