### PR TITLE
Fix for current year not processed for new custom reports

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1054,9 +1054,16 @@ class CronArchive
                 continue;
             }
 
-            // archive is for week that is over two months, we don't need to care about the month
+            // archive is for a week that is over two months, we don't need to care about the month
             if ($label == 'month'
                 && Date::factory($archiveToProcess['date1'])->toString('m') != Date::factory($archiveToProcess['date2'])->toString('m')
+            ) {
+                continue;
+            }
+
+            // archive is for a week that is over two years, we don't need to care about the year
+            if ($label == 'year'
+                && Date::factory($archiveToProcess['date1'])->toString('y') != Date::factory($archiveToProcess['date2'])->toString('y')
             ) {
                 continue;
             }

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -305,6 +305,7 @@ class CronArchiveTest extends IntegrationTestCase
             [
                 [
                     ['idarchive' => 1, 'idsite' => 1, 'period' => 2, 'date1' => '2021-12-27', 'date2' => '2022-01-02', 'name' => 'done', 'report' => null, 'ts_invalidated' => '2022-03-04 01:00:00'],
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 4, 'date1' => '2022-01-01', 'date2' => '2022-12-31', 'name' => 'done', 'report' => null, 'ts_invalidated' => '2022-03-04 01:00:00'],
                 ],
                 ['idarchive' => 1, 'idsite' => 1, 'period' => 2, 'date1' => '2021-12-27', 'date2' => '2022-01-02', 'name' => 'done', 'report' => null, 'ts_invalidated' => '2022-03-04 01:00:00'],
                 [
@@ -319,7 +320,7 @@ class CronArchiveTest extends IntegrationTestCase
                         'ts_invalidated' => '2022-03-04 01:00:00',
                     ),
                     array (
-                        'idarchive' => NULL,
+                        'idarchive' => 1,
                         'idsite' => '1',
                         'period' => '4',
                         'date1' => '2022-01-01',

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -300,6 +300,36 @@ class CronArchiveTest extends IntegrationTestCase
                     ),
                 ],
             ],
+
+            // week split across two years - make sure the year invalidation isn't changed to the week start year
+            [
+                [
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 2, 'date1' => '2021-12-27', 'date2' => '2022-01-02', 'name' => 'done', 'report' => null, 'ts_invalidated' => '2022-03-04 01:00:00'],
+                ],
+                ['idarchive' => 1, 'idsite' => 1, 'period' => 2, 'date1' => '2021-12-27', 'date2' => '2022-01-02', 'name' => 'done', 'report' => null, 'ts_invalidated' => '2022-03-04 01:00:00'],
+                [
+                    array (
+                        'idarchive' => '1',
+                        'idsite' => '1',
+                        'period' => '2',
+                        'date1' => '2021-12-27',
+                        'date2' => '2022-01-02',
+                        'name' => 'done',
+                        'report' => NULL,
+                        'ts_invalidated' => '2022-03-04 01:00:00',
+                    ),
+                    array (
+                        'idarchive' => NULL,
+                        'idsite' => '1',
+                        'period' => '4',
+                        'date1' => '2022-01-01',
+                        'date2' => '2022-12-31',
+                        'name' => 'done',
+                        'report' => NULL,
+                        'ts_invalidated' => '2022-03-04 01:00:00',
+                    ),
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
### Description:

Steps to recreate:
1) Create a new custom report, add any dimension/metric
2) Run `./console core:archive`
3) Check the output for `period = year` - only the previous year is processed, not the current year.

When archiving starts for a custom report, a check is done for any existing archives and if missing then invalidations are created for each period in the current year: days, weeks, months and year. These are created correctly with one invalidation for the current year (2022).

After processing each period the `core/CronArchive::repairInvalidationsIfNeeded` method is run to make sure any higher level invalidations exist (eg. if a week was just updated then make sure the higher level month and year are invalidated as those figures will have changed)

This doesn't cause any problems for day periods as every processed day will be in the current year, months also never span years.

However if there is a week which spans the previous and current year (eg. Monday 2021-12-27 to Sunday 2022-01-02) then `repairInvalidationIfNeeded` will look for a year invalidation for 2021 (the week's start date year) and when it fails to find one it will replace the previously created 2022 year invalidation with a 2021 year invalidation.

This results in no archive for the current year and an unnecessary archive for the previous year.

This PR adds a simple check to skip any attempt to repair a year validation if the week spans more than one year, a similar check already exists for weeks that span two months. (https://github.com/matomo-org/matomo/pull/16886#discussion_r537920138)

As `repairInvalidationIfNeeded` is part of the main archiving process this issue likely affects all archiving and is not specific to Custom Reports.

Ref L3-290
Also looks like it Fixes #18343

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
