### PR TITLE
Added a config option to specify database error codes to ignore during updates

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -45,6 +45,10 @@ ssl_no_verify =
 ; Matomo should work correctly without this setting but we recommend to have a charset set.
 charset = utf8
 
+; Database error codes to ignore during updates
+;
+;ignore_error_codes[] = 1105
+
 ; If configured, the following queries will be executed on the reader instead of the writer.
 ; * archiving queries that hit a log table
 ; * live queries that hit a log table
@@ -155,6 +159,7 @@ always_archive_data_range = 0;
 ; NOTE: you must also set [log] log_writers[] = "screen" to enable the profiler to print on screen
 enable_sql_profiler = 0
 
+[Debug]
 ; If set to 1, all requests to matomo.php will be forced to be 'new visitors'
 tracker_always_new_visitor = 0
 

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -159,7 +159,6 @@ always_archive_data_range = 0;
 ; NOTE: you must also set [log] log_writers[] = "screen" to enable the profiler to print on screen
 enable_sql_profiler = 0
 
-[Debug]
 ; If set to 1, all requests to matomo.php will be forced to be 'new visitors'
 tracker_always_new_visitor = 0
 

--- a/core/Updater/Migration/Db/Sql.php
+++ b/core/Updater/Migration/Db/Sql.php
@@ -43,7 +43,7 @@ class Sql extends DbMigration
         }
 
         $this->sql = $sql;
-        $globalErrorCodesToIgnore = Config::getInstance()->database['ignore_error_codes'];
+        $globalErrorCodesToIgnore = Config::getInstance()->database['ignore_error_codes'] ?? [];
         $this->errorCodesToIgnore = array_merge($errorCodesToIgnore, (is_array($globalErrorCodesToIgnore) ? $globalErrorCodesToIgnore : []));
     }
 

--- a/core/Updater/Migration/Db/Sql.php
+++ b/core/Updater/Migration/Db/Sql.php
@@ -7,6 +7,7 @@
  */
 namespace Piwik\Updater\Migration\Db;
 use Piwik\Common;
+use Piwik\Config;
 use Piwik\Db;
 use Piwik\Updater\Migration\Db as DbMigration;
 
@@ -31,6 +32,7 @@ class Sql extends DbMigration
 
     /**
      * Sql constructor.
+     *
      * @param string $sql
      * @param int|int[] $errorCodesToIgnore  If no error should be ignored use an empty array.
      */
@@ -41,7 +43,8 @@ class Sql extends DbMigration
         }
 
         $this->sql = $sql;
-        $this->errorCodesToIgnore = $errorCodesToIgnore;
+        $globalErrorCodesToIgnore = Config::getInstance()->database['ignore_error_codes'];
+        $this->errorCodesToIgnore = array_merge($errorCodesToIgnore, (is_array($globalErrorCodesToIgnore) ? $globalErrorCodesToIgnore : []));
     }
 
     public function shouldIgnoreError($exception)


### PR DESCRIPTION
### Description:

Added a new `config.ini.php` option `ignore_error_codes` to specify database error codes that should always be ignored during database updates.

Fixes #19572

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
