### PR TITLE
Enable brute force detection for user invitation

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -16,6 +16,7 @@ use Piwik\Common;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
+use Piwik\IP;
 use Piwik\Log;
 use Piwik\Nonce;
 use Piwik\Piwik;
@@ -542,6 +543,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
         // if no user matches the invite token
         if (!$user) {
+            $this->bruteForceDetection->addFailedAttempt(IP::getIpFromHeader());
             throw new Exception(Piwik::translate('Login_InvalidUsernameEmail'));
         }
 
@@ -644,6 +646,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
         // if no user matches the invite token
         if (!$user) {
+            $this->bruteForceDetection->addFailedAttempt(IP::getIpFromHeader());
             throw new Exception(Piwik::translate('Login_InvalidOrExpiredToken'));
         }
 

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -55,6 +55,8 @@ class Login extends \Piwik\Plugin
             'Controller.Login.resetPassword'   => 'beforeLoginCheckBruteForceForUserPwdLogin',
             'Controller.Login.login'           => 'beforeLoginCheckBruteForceForUserPwdLogin',
             'Controller.TwoFactorAuth.loginTwoFactorAuth' => 'beforeLoginCheckBruteForce',
+            'Controller.Login.acceptInvitation' => 'beforeLoginCheckBruteForce',
+            'Controller.Login.declineInvitation' => 'beforeLoginCheckBruteForce',
             'Login.authenticate.successful'    => 'beforeLoginCheckBruteForce',
             'Login.beforeLoginCheckAllowed'  => 'beforeLoginCheckBruteForceForUserPwdLogin', // record any failed attempt in UI
             'Login.recordFailedLoginAttempt'  => 'onFailedLoginRecordAttempt', // record any failed attempt in UI


### PR DESCRIPTION
### Description:

This will enable brute force detection for `acceptInvitation` and `declineInvitation` actions of Login controller. Failed attempts will be added each time any of those actions will be called with an invalid token.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
