### PR TITLE
Fix placing series / series picker in charts

### DIFF
--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -1221,7 +1221,7 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
         var plot = this;
         $(seriesPicker).bind('placeSeriesPicker', function () {
             this.domElem.css('margin-left', plot._gridPadding.left + 'px');
-            $('.jqplot-legend-canvas').css({paddingLeft: '34px'});
+            $('.jqplot-legend-canvas', $('#' + target)).css({paddingLeft: '34px'});
             plot.baseCanvas._elem.before(this.domElem);
         });
 

--- a/plugins/Goals/tests/UI/GoalsPages_spec.js
+++ b/plugins/Goals/tests/UI/GoalsPages_spec.js
@@ -51,6 +51,7 @@ describe("GoalsPages", function () {
 
     await page.waitForSelector('.ui-dialog');
     await page.waitForNetworkIdle();
+    await page.waitForTimeout(200);
 
     const dialog = await page.$('.ui-dialog');
     expect(await dialog.screenshot()).to.matchImage('overview_row_evolution_reloaded');
@@ -103,6 +104,7 @@ describe("GoalsPages", function () {
 
     await page.waitForSelector('.ui-dialog');
     await page.waitForNetworkIdle();
+    await page.waitForTimeout(200);
 
     const dialog = await page.$('.ui-dialog');
     expect(await dialog.screenshot()).to.matchImage('individual_row_evolution_reloaded');

--- a/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_individual_row_evolution_reloaded.png
+++ b/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_individual_row_evolution_reloaded.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a554ae7a8249dd867010724260abf32dd65351433f28c2c07ff4fac309b1f4ae
-size 59883
+oid sha256:bd0af5841ad6cf391fae350c0212f1e1c149e3f3e70b367e84930e70d15be7f7
+size 59765


### PR DESCRIPTION
### Description:

I've investigate why one of our UI test is randomly failing all the time:

![GoalsPages_individual_row_evolution_reloaded](https://user-images.githubusercontent.com/1579355/182179414-bacb505c-3ba9-47ba-a5ca-221e0a714104.png)

vs

![GoalsPages_individual_row_evolution_reloaded](https://user-images.githubusercontent.com/1579355/182178808-26023d96-46ad-491e-ab0e-259b4669418b.png)

The reason for this random failure actually turned out to be kind of a bug. The series in the chart needs to be placed more right, if a series picker icon is shown. While this is not the case for the chart on the UI test, there is a chart on the page that is loaded in the background of the popover. As the selector to adjust the placement was global, it also affected the one on the UI test. So the test used to fail depending on the loading speed of the reports in background.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
