### PR TITLE
Improve check for provider plugin

### DIFF
--- a/plugins/UserCountry/LocationProvider/DefaultProvider.php
+++ b/plugins/UserCountry/LocationProvider/DefaultProvider.php
@@ -62,6 +62,7 @@ class DefaultProvider extends LocationProvider
     {
         if (
             !Manager::getInstance()->isPluginInstalled('Provider')
+            || !class_exists('Piwik\Plugins\Provider\Provider')
             || Common::getRequestVar('dp', 0, 'int') === 1
         ) {
             return false;


### PR DESCRIPTION
### Description:

If, for some reason, the provider plugin is marked as installed, but not available in the file system, a fatal error might occur while tracking if the default geolocation provider is used.

Check if the class we are trying to use actually exists solves this issue.

refs #19602

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
