### PR TITLE
show Development language again when development mode is enabled

### DIFF
--- a/plugins/LanguagesManager/API.php
+++ b/plugins/LanguagesManager/API.php
@@ -389,11 +389,12 @@ class API extends \Piwik\Plugin\API
 
     private function enableDevelopmentLanguageInDevEnvironment(&$languages)
     {
-        if (!Development::isEnabled()) {
-            $key = array_search(DevelopmentLoader::LANGUAGE_ID, $languages);
-            if ($key) {
-                unset($languages[$key]);
-            }
+        $key = array_search(DevelopmentLoader::LANGUAGE_ID, $languages);
+        if (!Development::isEnabled() && $key) {
+            unset($languages[$key]);
+        }
+        if (Development::isEnabled() && !$key) {
+            $languages[] = DevelopmentLoader::LANGUAGE_ID;
         }
     }
 }


### PR DESCRIPTION
### Description:

I am not sure if this broke with my changes and the weblate migration or before, but I can't see any place in `getAvailableLanguages()` `dev` is added to the list.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
