### PR TITLE
Pseudolocalization for Development

### DIFF
--- a/core/Translation/Loader/DevelopmentLoader.php
+++ b/core/Translation/Loader/DevelopmentLoader.php
@@ -17,6 +17,66 @@ class DevelopmentLoader implements LoaderInterface
     public const LANGUAGE_ID = 'dev';
 
     /**
+     * from https://github.com/tryggvigy/pseudo-localization/blob/master/src/localize.js
+     * by Tryggvi Gylfason
+     * MIT license
+     */
+    const MAP = [
+        "a" => 'ȧ',
+        "A" => 'Ȧ',
+        "b" => 'ƀ',
+        "B" => 'Ɓ',
+        "c" => 'ƈ',
+        "C" => 'Ƈ',
+        "d" => 'ḓ',
+        "D" => 'Ḓ',
+        "e" => 'ḗ',
+        "E" => 'Ḗ',
+        "f" => 'ƒ',
+        "F" => 'Ƒ',
+        "g" => 'ɠ',
+        "G" => 'Ɠ',
+        "h" => 'ħ',
+        "H" => 'Ħ',
+        "i" => 'ī',
+        "I" => 'Ī',
+        "j" => 'ĵ',
+        "J" => 'Ĵ',
+        "k" => 'ķ',
+        "K" => 'Ķ',
+        "l" => 'ŀ',
+        "L" => 'Ŀ',
+        "m" => 'ḿ',
+        "M" => 'Ḿ',
+        "n" => 'ƞ',
+        "N" => 'Ƞ',
+        "o" => 'ǿ',
+        "O" => 'Ǿ',
+        "p" => 'ƥ',
+        "P" => 'Ƥ',
+        "q" => 'ɋ',
+        "Q" => 'Ɋ',
+        "r" => 'ř',
+        "R" => 'Ř',
+//        "s" => 'ş', // avoid breaking format strings
+        "S" => 'Ş',
+        "t" => 'ŧ',
+        "T" => 'Ŧ',
+        "v" => 'ṽ',
+        "V" => 'Ṽ',
+        "u" => 'ŭ',
+        "U" => 'Ŭ',
+        "w" => 'ẇ',
+        "W" => 'Ẇ',
+        "x" => 'ẋ',
+        "X" => 'Ẋ',
+        "y" => 'ẏ',
+        "Y" => 'Ẏ',
+        "z" => 'ẑ',
+        "Z" => 'Ẑ',
+    ];
+
+    /**
      * Decorated loader.
      *
      * @var LoaderInterface
@@ -45,7 +105,7 @@ class DevelopmentLoader implements LoaderInterface
             return $this->loader->load($language, $directories);
         }
 
-        return $this->getDevelopmentTranslations($directories);
+        return $this->getPseudoLocale($directories);
     }
 
     private function getDevelopmentTranslations(array $directories)
@@ -53,12 +113,28 @@ class DevelopmentLoader implements LoaderInterface
         $fallbackTranslations = $this->loader->load($this->fallbackLanguage, $directories);
 
         $translations = array();
-
         foreach ($fallbackTranslations as $section => $sectionFallbackTranslations) {
             $translationIds = array_keys($sectionFallbackTranslations);
             $sectionTranslations = $this->prefixTranslationsWithSection($section, $translationIds);
 
             $translations[$section] = array_combine($translationIds, $sectionTranslations);
+        }
+
+        return $translations;
+    }
+
+    private function getPseudoLocale(array $directories)
+    {
+        $fallbackTranslations = $this->loader->load($this->fallbackLanguage, $directories);
+
+        $translations = array();
+        foreach ($fallbackTranslations as $section => $sectionFallbackTranslations) {
+
+            $translations[$section] = array_map(function ($translation) {
+                $accented = strtr($translation, self::MAP);
+                return "[" . $accented . "]";
+
+            }, $sectionFallbackTranslations);
         }
 
         return $translations;

--- a/core/Translation/Loader/DevelopmentLoader.php
+++ b/core/Translation/Loader/DevelopmentLoader.php
@@ -10,18 +10,13 @@
 namespace Piwik\Translation\Loader;
 
 /**
- * Loads a pseudo-language for developers where translation are equal to translation ids.
+ * Loads a pseudo-language for developers.
  */
 class DevelopmentLoader implements LoaderInterface
 {
     public const LANGUAGE_ID = 'dev';
 
-    /**
-     * from https://github.com/tryggvigy/pseudo-localization/blob/master/src/localize.js
-     * by Tryggvi Gylfason
-     * MIT license
-     */
-    const MAP = [
+    private const MAP = [
         "a" => 'ȧ',
         "A" => 'Ȧ',
         "b" => 'ƀ',
@@ -58,7 +53,7 @@ class DevelopmentLoader implements LoaderInterface
         "Q" => 'Ɋ',
         "r" => 'ř',
         "R" => 'Ř',
-//        "s" => 'ş', // avoid breaking format strings
+        "s" => 'ş',
         "S" => 'Ş',
         "t" => 'ŧ',
         "T" => 'Ŧ',
@@ -77,8 +72,6 @@ class DevelopmentLoader implements LoaderInterface
     ];
 
     /**
-     * Decorated loader.
-     *
      * @var LoaderInterface
      */
     private $loader;
@@ -96,9 +89,6 @@ class DevelopmentLoader implements LoaderInterface
         $this->loader = $loader;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function load($language, array $directories)
     {
         if ($language !== self::LANGUAGE_ID) {
@@ -108,22 +98,11 @@ class DevelopmentLoader implements LoaderInterface
         return $this->getPseudoLocale($directories);
     }
 
-    private function getDevelopmentTranslations(array $directories)
-    {
-        $fallbackTranslations = $this->loader->load($this->fallbackLanguage, $directories);
-
-        $translations = array();
-        foreach ($fallbackTranslations as $section => $sectionFallbackTranslations) {
-            $translationIds = array_keys($sectionFallbackTranslations);
-            $sectionTranslations = $this->prefixTranslationsWithSection($section, $translationIds);
-
-            $translations[$section] = array_combine($translationIds, $sectionTranslations);
-        }
-
-        return $translations;
-    }
-
-    private function getPseudoLocale(array $directories)
+    /**
+     * @param string[] $directories
+     * @return array<string, array<string, string>>
+     */
+    private function getPseudoLocale(array $directories): array
     {
         $fallbackTranslations = $this->loader->load($this->fallbackLanguage, $directories);
 
@@ -134,19 +113,39 @@ class DevelopmentLoader implements LoaderInterface
                 continue;
             }
 
-            $translations[$section] = array_map(function ($translation) {
-                $accented = strtr($translation, self::MAP);
-                return "[" . $accented . "]";
-            }, $sectionFallbackTranslations);
+            $sectionTranslations = [];
+            foreach ($sectionFallbackTranslations as $key => $translation) {
+                $sectionTranslations[$key] = $this->pseudoLocalize($translation);
+            }
+
+            $translations[$section] = $sectionTranslations;
         }
 
         return $translations;
     }
 
-    private function prefixTranslationsWithSection($section, $translationIds)
+    private function pseudoLocalize(string $translation): string
     {
-        return array_map(function ($translation) use ($section) {
-            return $section . '_' . $translation;
-        }, $translationIds);
+        $protectedTokens = [];
+        $tokenized = preg_replace_callback(
+            "/<[^>]+>|&[A-Za-z0-9#]+;|%%|%(?:[0-9]+[$])?[+\\-0'#]*[0-9]*(?:\\.[0-9]+)?[bcdeEfFgGosuxX]/",
+            function ($matches) use (&$protectedTokens) {
+                $token = "\x1D" . count($protectedTokens) . "\x1E";
+                $protectedTokens[$token] = $matches[0];
+                return $token;
+            },
+            $translation
+        );
+
+        if ($tokenized === null) {
+            $tokenized = $translation;
+        }
+
+        $accented = strtr($tokenized, self::MAP);
+        if (!empty($protectedTokens)) {
+            $accented = strtr($accented, $protectedTokens);
+        }
+
+        return "[" . $accented . "]";
     }
 }

--- a/core/Translation/Loader/DevelopmentLoader.php
+++ b/core/Translation/Loader/DevelopmentLoader.php
@@ -127,13 +127,16 @@ class DevelopmentLoader implements LoaderInterface
     {
         $fallbackTranslations = $this->loader->load($this->fallbackLanguage, $directories);
 
-        $translations = array();
+        $translations = [];
         foreach ($fallbackTranslations as $section => $sectionFallbackTranslations) {
+            if ($section === 'Intl') {
+                $translations[$section] = $sectionFallbackTranslations;
+                continue;
+            }
 
             $translations[$section] = array_map(function ($translation) {
                 $accented = strtr($translation, self::MAP);
                 return "[" . $accented . "]";
-
             }, $sectionFallbackTranslations);
         }
 

--- a/core/Translation/Loader/JsonFileLoader.php
+++ b/core/Translation/Loader/JsonFileLoader.php
@@ -16,9 +16,6 @@ use Piwik\Common;
  */
 class JsonFileLoader implements LoaderInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function load($language, array $directories)
     {
         if (empty($language)) {
@@ -43,7 +40,10 @@ class JsonFileLoader implements LoaderInterface
         return $translations;
     }
 
-    private function loadFile($filename)
+    /**
+     * @return array<string, array<string, string>>
+     */
+    private function loadFile(string $filename): array
     {
         $data = file_get_contents($filename);
         $translations = json_decode($data, true);
@@ -57,7 +57,7 @@ class JsonFileLoader implements LoaderInterface
         }
 
         if (!is_array($translations)) {
-            return array();
+            return [];
         }
 
         return $translations;

--- a/core/Translation/Loader/LoaderInterface.php
+++ b/core/Translation/Loader/LoaderInterface.php
@@ -16,9 +16,9 @@ interface LoaderInterface
 {
     /**
      * @param string $language
-     * @param mixed[] $directories Directories containing translation files.
+     * @param string[] $directories Directories containing translation files.
+     * @return array<string, array<string, string>> Translations.
      * @throws \Exception The translation file was not found
-     * @return string[] Translations.
      */
     public function load($language, array $directories);
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2329,16 +2329,6 @@ parameters:
 			path: core/Tracker/VisitorRecognizer.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function array_keys expects array, string given\\.$#"
-			count: 1
-			path: core/Translation/Loader/DevelopmentLoader.php
-
-		-
-			message: "#^Parameter \\#1 \\$keys of function array_combine expects array, null given\\.$#"
-			count: 1
-			path: core/Translation/Loader/DevelopmentLoader.php
-
-		-
 			message: "#^Variable \\$translationId on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: core/Translation/Translator.php

--- a/tests/PHPUnit/Unit/Translation/Loader/DevelopmentLoaderTest.php
+++ b/tests/PHPUnit/Unit/Translation/Loader/DevelopmentLoaderTest.php
@@ -16,13 +16,31 @@ use Piwik\Translation\Loader\DevelopmentLoader;
  */
 class DevelopmentLoaderTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var array<string, array<string, string>>
+     */
     private $translations = array(
         'General' => array(
             'translationId' => 'Hello',
+            'withPlaceholder' => 'Items: %1$d',
+            'withHtml' => '<strong>Save</strong>',
+            'withEntity' => 'Fish &amp; Chips',
+            'withPercentLiteral' => '100% free',
+            'withStringPlaceholderAdjacentText' => '%sBy clicking',
+            'withMultipleStringPlaceholders' => '%1$s from %2$s to %3$s',
+            'withIntPlaceholder' => '%d results',
+            'withNumberedIntPlaceholder' => '%2$d of %1$d',
+            'withFloatPrecisionPlaceholder' => 'Rate: %.2f%% complete',
+            'withPaddedIntPlaceholder' => '%04d items',
+            'withPercentAndPositionalPlaceholders' => '%1$s%% from %2$s to %3$s',
+            'withSignedPositionalFloatPlaceholder' => 'Delta: %1$+08.2f units',
+        ),
+        'Intl' => array(
+            'OriginalLanguageName' => 'English',
         ),
     );
 
-    public function testShouldReturnTranslationIdsIfDevelopmentLanguage()
+    public function testShouldReturnPseudoLocalizedTranslationsIfDevelopmentLanguage(): void
     {
         $wrappedLoader = $this->getMockForAbstractClass('Piwik\Translation\Loader\LoaderInterface');
         $loader = new DevelopmentLoader($wrappedLoader);
@@ -36,14 +54,29 @@ class DevelopmentLoaderTest extends \PHPUnit\Framework\TestCase
 
         $expected = array(
             'General' => array(
-                'translationId' => 'General_translationId',
+                'translationId' => '[Ħḗŀŀǿ]',
+                'withPlaceholder' => '[Īŧḗḿş: %1$d]',
+                'withHtml' => '[<strong>Şȧṽḗ</strong>]',
+                'withEntity' => '[Ƒīşħ &amp; Ƈħīƥş]',
+                'withPercentLiteral' => '[100% ƒřḗḗ]',
+                'withStringPlaceholderAdjacentText' => '[%sƁẏ ƈŀīƈķīƞɠ]',
+                'withMultipleStringPlaceholders' => '[%1$s ƒřǿḿ %2$s ŧǿ %3$s]',
+                'withIntPlaceholder' => '[%d řḗşŭŀŧş]',
+                'withNumberedIntPlaceholder' => '[%2$d ǿƒ %1$d]',
+                'withFloatPrecisionPlaceholder' => '[Řȧŧḗ: %.2f%% ƈǿḿƥŀḗŧḗ]',
+                'withPaddedIntPlaceholder' => '[%04d īŧḗḿş]',
+                'withPercentAndPositionalPlaceholders' => '[%1$s%% ƒřǿḿ %2$s ŧǿ %3$s]',
+                'withSignedPositionalFloatPlaceholder' => '[Ḓḗŀŧȧ: %1$+08.2f ŭƞīŧş]',
+            ),
+            'Intl' => array(
+                'OriginalLanguageName' => 'English',
             ),
         );
 
         $this->assertEquals($expected, $translations);
     }
 
-    public function testShouldUseDecoratedLoaderIfNotDevelopmentLanguage()
+    public function testShouldUseDecoratedLoaderIfNotDevelopmentLanguage(): void
     {
         $wrappedLoader = $this->getMockForAbstractClass('Piwik\Translation\Loader\LoaderInterface');
         $loader = new DevelopmentLoader($wrappedLoader);


### PR DESCRIPTION
Inspired by https://netflixtechblog.com/pseudo-localization-netflix-12fff76fbcbe and others.
I think this helps a lot during testing. Unlike the "dev" language it is not completely unreadable and one can test features with it. Untranslated text immediately sticks out and issues with non-ASCII character should be more noticable than with English text.

Expanding the text by a factor (e.g. by duplicating every chacter with an n% chance) could also be added.

This is just a rough draft to show that the idea works. Of course it should become its separate language from the existing "dev".

![grafik](https://user-images.githubusercontent.com/6266037/184542374-7e281548-b1ee-4488-81c0-7975fdac888a.png)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
