### PR TITLE
Adds Microsoft and Yandex click ids to default query parameters exclusion list

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -938,7 +938,7 @@ default_time_one_page_visit = 0
 
 ; Comma separated list of URL query string variable names that will be removed from your tracked URLs
 ; By default, Matomo will remove the most common parameters which are known to change often (eg. session ID parameters)
-url_query_parameter_to_exclude_from_url = "gclid,fbclid,fb_xd_fragment,fb_comment_id,phpsessid,jsessionid,sessionid,aspsessionid,doing_wp_cron,sid,pk_vid"
+url_query_parameter_to_exclude_from_url = "gclid,fbclid,msclkid,yclid,fb_xd_fragment,fb_comment_id,phpsessid,jsessionid,sessionid,aspsessionid,doing_wp_cron,sid,pk_vid"
 
 ; If set to 1, Matomo will use the default provider if no other provider is configured.
 ; In addition the default provider will be used as a fallback when the configure provider does not return any results.

--- a/tests/PHPUnit/Integration/Tracker/ActionTest.php
+++ b/tests/PHPUnit/Integration/Tracker/ActionTest.php
@@ -170,6 +170,37 @@ class ActionTest extends IntegrationTestCase
         $this->assertEquals($filteredUrl[0], PageUrl::excludeQueryParametersFromUrl($url, $idSite));
     }
 
+    public function getTestAdvertisingClickIdUrls()
+    {
+        return [
+            ['https://www.example.com?gclid=1234', 'https://www.example.com'],
+            ['https://www.example.com?fbclid=1234', 'https://www.example.com'],
+            ['https://www.example.com?msclkid=1234', 'https://www.example.com'],
+            ['https://www.example.com?yclid=1234', 'https://www.example.com'],
+            ['https://www.example.com/path1?gclid=1234', 'https://www.example.com/path1'],
+            ['https://www.example.com/path2?fbclid=1234', 'https://www.example.com/path2'],
+            ['https://www.example.com/path3?msclkid=1234', 'https://www.example.com/path3'],
+            ['https://www.example.com/path4?yclid=1234', 'https://www.example.com/path4'],
+            ['https://www.example.com?random=1234', 'https://www.example.com?random=1234'],
+            ['https://www.example.com?random=1234&yclid=qwerty', 'https://www.example.com?random=1234'],
+        ];
+    }
+
+    /**
+     * No excluded query parameters specified, apart from the standard "session" parameters, always excluded
+     *
+     * @dataProvider getTestAdvertisingClickIdUrls
+     */
+    public function testExcludeQueryParametersAdvertisingClickIds($url, $filteredUrl)
+    {
+        $this->setUpRootAccess();
+        $idSite = API::getInstance()->addSite("site1", array('http://example.org'), $ecommerce = 0,
+            $siteSearch = 1, $searchKeywordParameters = null, $searchCategoryParameters = null,
+            $excludedIps = '', $excludedQueryParameters = '', $timezone = null, $currency = null,
+            $group = null, $startDate = null, $excludedUserAgents = null, $keepURLFragments = 1);
+        $this->assertEquals($filteredUrl, PageUrl::excludeQueryParametersFromUrl($url, $idSite));
+    }
+
     public function getTestUrlsHashtag()
     {
         $urls = array(


### PR DESCRIPTION

### Description:

Added code to exclude Microsoft and Yandex click from query parameters.
Fixes: #DEV-2774

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
