### PR TITLE
 filtering a user's permissions, capabilities fixes

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -641,7 +641,7 @@ class API extends \Piwik\Plugin\API
             $limit,
             $offset,
             $filter_search,
-            null,
+            $filter_access,
             $idSites
         );
         foreach ($sites as &$siteAccess) {

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -645,10 +645,8 @@ class API extends \Piwik\Plugin\API
             $idSites
         );
         foreach ($sites as &$siteAccess) {
-            [
-              $siteAccess['role'],
-              $siteAccess['capabilities']
-            ] = $this->getRoleAndCapabilitiesFromAccess($siteAccess['access']);
+            $siteAccess['role'] = $this->roleProvider->getAllRoleIds();
+            $siteAccess['capabilities'] = $this->capabilityProvider->getAllCapabilityIds();
             $siteAccess['role'] = empty($siteAccess['role']) ? 'noaccess' : reset($siteAccess['role']);
             unset($siteAccess['access']);
         }

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -641,12 +641,14 @@ class API extends \Piwik\Plugin\API
             $limit,
             $offset,
             $filter_search,
-            $filter_access,
+            null,
             $idSites
         );
         foreach ($sites as &$siteAccess) {
-            $siteAccess['role'] = $this->roleProvider->getAllRoleIds();
-            $siteAccess['capabilities'] = $this->capabilityProvider->getAllCapabilityIds();
+            [
+              $siteAccess['role'],
+              $siteAccess['capabilities']
+            ] = $this->getRoleAndCapabilitiesFromAccess($siteAccess['access']);
             $siteAccess['role'] = empty($siteAccess['role']) ? 'noaccess' : reset($siteAccess['role']);
             unset($siteAccess['access']);
         }

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -205,7 +205,7 @@ class Model
         $selector = "a.access";
         if ($access) {
             $selector = 'b.access';
-            $joins .= " LEFT JOIN matomo_access b on a.idsite = b.idsite AND a.login = b.login";
+            $joins .= " LEFT JOIN ". Common::prefixTable('access') ." b on a.idsite = b.idsite AND a.login = b.login";
         }
 
         $sql = 'SELECT SQL_CALC_FOUND_ROWS s.idsite as idsite, s.name as site_name, GROUP_CONCAT('.$selector.' SEPARATOR "|") as access

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -202,7 +202,13 @@ class Model
             }
         }
 
-        $sql = 'SELECT SQL_CALC_FOUND_ROWS s.idsite as idsite, s.name as site_name, GROUP_CONCAT(a.access SEPARATOR "|") as access
+        $selector = "a.access";
+        if ($access) {
+            $selector = 'b.access';
+            $joins .= " LEFT JOIN matomo_access b on a.idsite = b.idsite AND a.login = b.login";
+        }
+
+        $sql = 'SELECT SQL_CALC_FOUND_ROWS s.idsite as idsite, s.name as site_name, GROUP_CONCAT('.$selector.' SEPARATOR "|") as access
                   FROM ' . Common::prefixTable('access') . " a
                 $joins
                 $where

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -854,6 +854,17 @@ class APITest extends IntegrationTestCase
         $this->assertEquals($expected, $access);
     }
 
+    public function testGetUserCapabilitiesAfterFilter()
+    {
+        $this->addUserWithAccess('userLoginCapabilities', 'view', 1, 'searchTextdef@email.com');
+        $this->api->addCapabilities('userLoginCapabilities','tagmanager_write',1);
+
+        $access = $this->api->getSitesAccessForUser('userLoginCapabilities', null, 1, null, 'view');
+
+        $this->assertEquals(['tagmanager_write'], $access[0]['capabilities']);
+
+    }
+
     public function testGetSitesAccessForUserShouldIgnoreOffsetIfLimitNotSupplied()
     {
         $this->api->setUserAccess('userLogin', 'admin', [1]);

--- a/plugins/UsersManager/tests/UI/UsersManager_spec.js
+++ b/plugins/UsersManager/tests/UI/UsersManager_spec.js
@@ -625,6 +625,8 @@ describe("UsersManager", function () {
             await page.evaluate(function () {
               $('.access-filter select').val('string:admin').change();
             });
+            await page.waitForTimeout(500); // wait for animation
+
             await page.mouse.move(-10, -10);
 
             expect(await page.screenshotSelector('.usersManager')).to.matchImage('admin_filter_permissions');

--- a/plugins/UsersManager/tests/UI/UsersManager_spec.js
+++ b/plugins/UsersManager/tests/UI/UsersManager_spec.js
@@ -621,6 +621,15 @@ describe("UsersManager", function () {
             expect(await page.screenshotSelector('.usersManager')).to.matchImage('admin_edit_permissions');
         });
 
+      it('should filter editing user permissions by access', async function () {
+            await page.evaluate(function () {
+              $('.access-filter select').val('string:admin').change();
+            });
+            await page.mouse.move(-10, -10);
+
+            expect(await page.screenshotSelector('.usersManager')).to.matchImage('admin_filter_permissions');
+      });
+
         it('should show the add existing user modal', async function () {
             await page.click('.userEditForm .entityCancelLink');
 

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_filter_permissions.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_filter_permissions.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb453b03fee48156bc24ef4f77e48ca8ebc6cf40c09fa456c846b9600008f7e3
-size 75621
+oid sha256:59b6d818e54cc5ed14b1f777f55697926499343a498439fcb472ec9adc67ae6d
+size 54531

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_filter_permissions.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_admin_view_admin_filter_permissions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb453b03fee48156bc24ef4f77e48ca8ebc6cf40c09fa456c846b9600008f7e3
+size 75621


### PR DESCRIPTION
### Description:

Fixes: #19679 

The problem is caused by matomo_access table, Capabilities and access are in one column when the filter is by where it cleans the other access

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
