### PR TITLE
Posting to new activity to track console report invalidation requests

### DIFF
--- a/plugins/CoreAdminHome/Commands/InvalidateReportData.php
+++ b/plugins/CoreAdminHome/Commands/InvalidateReportData.php
@@ -106,6 +106,22 @@ class InvalidateReportData extends ConsoleCommand
                         }
                         $logger->info($message);
                     } else {
+                        /**
+                         * Trigger the activity that tracks when a customer requests invalidation.
+                         * Having the post here results in multiple activity logs if there are multiple segments and/or
+                         * periods, but all of the dates and other fields are pretty much in the right format.
+                         */
+                        Piwik::postEvent('InvalidateReports.invalidateReports', [[
+                            'idSites' => is_array($sites) ? implode(',', $sites) : $sites,
+                            'dates' => is_array($dates) ? implode(',', $dates) : $dates,
+                            'period' => $periodType,
+                            'segment' => $segment,
+                            'cascadeDown' => $cascade,
+                            '_forceInvalidateNonexistant' => false,
+                            'plugin' => $plugin,
+                            'ignoreLogDeletionLimit' => $ignoreLogDeletionLimit
+                        ]]);
+
                         $invalidationResult = $invalidator->markArchivesAsInvalidated($sites, $dates, $periodType, $segment, $cascade,
                             false, $plugin, $ignoreLogDeletionLimit);
 


### PR DESCRIPTION
### Description:

Posting to new activity to track when a customer requests report invalidation via the console. This is part of DEV-2669. There's a PR in the ActivityLog plugin to add the new activity so that it can be tracked.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
