### PR TITLE
Detect consent managers on the selected site and show a setup link

### DIFF
--- a/plugins/Tour/API.php
+++ b/plugins/Tour/API.php
@@ -48,14 +48,19 @@ class API extends \Piwik\Plugin\API
         $challenges = array();
 
         foreach ($this->challenges->getChallenges() as $challenge) {
-            $challenges[] = array(
+
+            if ($challenge->isDisabled()) {
+                continue;
+            }
+
+            $challenges[] = [
                 'id' => $challenge->getId(),
                 'name' => $challenge->getName(),
                 'description' => $challenge->getDescription(),
                 'isCompleted' => $challenge->isCompleted(),
                 'isSkipped' => $challenge->isSkipped(),
                 'url' => $challenge->getUrl()
-            );
+            ];
         }
 
         return $challenges;

--- a/plugins/Tour/Engagement/Challenge.php
+++ b/plugins/Tour/Engagement/Challenge.php
@@ -26,6 +26,11 @@ abstract class Challenge
 
     private static $settings = null;
 
+    public function __construct()
+    {
+
+    }
+
     /**
      * The human readable name that will be shown in the onboarding widget. Should be max 3 or 4 words and represent an
      * action, like "Add a report"
@@ -52,6 +57,19 @@ abstract class Challenge
     public function isCompleted()
     {
         return $this->hasAttribute(self::APPENDIX_COMPLETED);
+    }
+
+    /**
+     * By default challenges are enabled, if is not appropriate to display a challenge at this time because some condition
+     * has not been met then the challenge can be set as disabled by overriding this method. The constructor code will
+     * still be run every time the challenges are loaded. To disable a challenge based on plugin availablilty it is better
+     * to add a check to the Piwik\Plugins\Tour\Engagement::getChallenges() method
+     *
+     * @return false
+     */
+    public function isDisabled()
+    {
+        return false;
     }
 
     /**

--- a/plugins/Tour/Engagement/ChallengeSetupConsentManager.php
+++ b/plugins/Tour/Engagement/ChallengeSetupConsentManager.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\Tour\Engagement;
+
+use Piwik\Common;
+use Piwik\Http;
+use Piwik\Piwik;
+use Piwik\Site;
+
+class ChallengeSetupConsentManager extends Challenge
+{
+
+    private $consentManagerId = null;
+    private $consentManagerName = null;
+    private $isConnected = false;
+
+    public function __construct($siteData = null)
+    {
+
+        parent::__construct();
+
+        if ($siteData === null) {
+            // Grab the current site main page as a string
+            $idSite = Common::getRequestVar('idSite', null, 'int');
+            if (!$idSite) {
+                return;
+            }
+
+            $url = Site::getMainUrlFor($idSite);
+            if (!$url) {
+                return;
+            }
+
+            $siteData = Http::sendHttpRequestBy('curl', $url, 60, null, null,
+                null, 0, false, true);
+
+        }
+
+        // Loop the consent manager definitions and attempt to detect based on string matching
+        $defs = $this->getConsentManagerDefinitions();
+        foreach ($defs as $consentManagerId => $consentManagerDef) {
+            foreach ($consentManagerDef['detectStrings'] as $dStr) {
+                if (strpos($siteData, $dStr) !== false) {
+                    $this->consentManagerId = $consentManagerId;
+                    break 2;
+                }
+            }
+        }
+
+        // If a consent manager was detected then perform an additional check to see if it has been connected to Matomo
+        if ($this->consentManagerId !== null) {
+
+            if ($defs && array_key_exists($this->consentManagerId, $defs)) {
+
+                $this->consentManagerName = $defs[$this->consentManagerId]['name'];
+
+                foreach ($defs[$this->consentManagerId]['connectedStrings'] as $cStr) {
+                    if (strpos($siteData, $cStr) !== false) {
+                        $this->isConnected = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+    }
+
+    private function getConsentManagerDefinitions() : array
+    {
+        return [
+
+            'osano' => [
+                'name' => 'Osano',
+                'detectStrings' => ['osano.com'],
+                'connectedStrings' => ["Osano.cm.addEventListener('osano-cm-consent-changed', (change) => { console.log('cm-change'); consentSet(change); });"],
+                'url' => 'https://matomo.org/faq/how-to/#using-osano-consent-manager-with-matomo',
+                ],
+
+            'cookiebot' => [
+                'name' => 'Cookiebot',
+                'detectStrings' => ['cookiebot.com'],
+                'connectedStrings' => ["typeof _paq === 'undefined' || typeof Cookiebot === 'undefined'"],
+                'url' => 'https://matomo.org/faq/how-to/#using-cookiebot-consent-manager-with-matomo',
+                ],
+
+            'cookieyes' => [
+                'name' => 'CookieYes',
+                'detectStrings' => ['cookieyes.com'],
+                'connectedStrings' => ['document.addEventListener("cookieyes_consent_update", function (eventData)'],
+                'url' => 'https://matomo.org/faq/how-to/#using-cookieyes-consent-manager-with-matomo',
+                ],
+
+            // Note: tarte au citron pro is configured server side so we cannot tell if it has been connected by
+            // crawling the website, however setup of Matomo with the pro version is automatic, so displaying the guide
+            // link for pro isn't necessary. Only the open source version is detected by this definition.
+            'tarteaucitron' => [
+                'name' => 'Tarte au Citron',
+                'detectStrings' => ['tarteaucitron.js'],
+                'connectedStrings' => ['tarteaucitron.user.matomoHost'],
+                'url' => 'https://matomo.org/faq/how-to/#using-tarte-au-citron-consent-manager-with-matomo',
+                ],
+
+            'klaro' => [
+                'name' => 'Klaro',
+                'detectStrings' => ['klaro.js', 'kiprotect.com'],
+                'connectedStrings' => ['KlaroWatcher()', "title: 'Matomo',"],
+                'url' => 'https://matomo.org/faq/how-to/#using-klaro-consent-manager-with-matomo',
+                ],
+
+            'complianz' => [
+                'name' => 'Complianz',
+                'detectStrings' => ['complianz-gdpr'],
+                'connectedStrings' => ["if (!cmplz_in_array( 'statistics', consentedCategories )) {
+		_paq.push(['forgetCookieConsentGiven']);"],
+                'url' => 'https://matomo.org/faq/how-to/#using-complianz-for-wordpress-consent-manager-with-matomo',
+                ],
+            ];
+    }
+
+    public function getName()
+    {
+        return Piwik::translate('Tour_ConnectConsentManager', [$this->consentManagerName]);
+    }
+
+    public function getDescription()
+    {
+        return Piwik::translate('Tour_ConnectConsentManagerIntro', [$this->consentManagerName]);
+    }
+
+    public function getId()
+    {
+        return 'setup_consent_manager';
+    }
+
+    public function getConsentManagerId()
+    {
+        return $this->consentManagerId;
+    }
+
+    public function isCompleted()
+    {
+
+        if (!$this->consentManagerName) {
+            return true;
+        }
+
+        return $this->isConnected;
+    }
+
+    public function isDisabled()
+    {
+        return ($this->consentManagerId === null);
+    }
+
+    public function getUrl()
+    {
+        if ($this->consentManagerId === null) {
+            return '';
+        }
+
+        return $this->getConsentManagerDefinitions()[$this->consentManagerId]['url'];
+
+    }
+
+}

--- a/plugins/Tour/Engagement/ChallengeSetupConsentManager.php
+++ b/plugins/Tour/Engagement/ChallengeSetupConsentManager.php
@@ -20,7 +20,10 @@ class ChallengeSetupConsentManager extends Challenge
     private $consentManagerName = null;
     private $isConnected = false;
 
-    public function __construct($siteData = null)
+    /**
+     * @param string|null $siteData    String of site content, content of the current site will be retrieved if left blank
+     */
+    public function __construct(?string $siteData = null)
     {
 
         parent::__construct();
@@ -37,9 +40,16 @@ class ChallengeSetupConsentManager extends Challenge
                 return;
             }
 
-            $siteData = Http::sendHttpRequestBy('curl', $url, 60, null, null,
-                null, 0, false, true);
+            try {
+                $siteData = Http::sendHttpRequestBy('curl', $url, 60, null, null,
+                    null, 0, false, true);
+            } catch (\Exception $e) {
+            }
 
+        }
+
+        if ($siteData === null) {
+            return;
         }
 
         // Loop the consent manager definitions and attempt to detect based on string matching
@@ -71,6 +81,11 @@ class ChallengeSetupConsentManager extends Challenge
 
     }
 
+    /**
+     * Return an array of consent manager definitions which can be used to detect their prescence and show guide links
+     *
+     * @return array[]
+     */
     private function getConsentManagerDefinitions() : array
     {
         return [

--- a/plugins/Tour/Engagement/ChallengeSetupConsentManager.php
+++ b/plugins/Tour/Engagement/ChallengeSetupConsentManager.php
@@ -30,6 +30,9 @@ class ChallengeSetupConsentManager extends Challenge
 
         if ($siteData === null) {
             // Grab the current site main page as a string
+            if (!isset($_REQUEST['idSite'])) {
+                return;
+            }
             $idSite = Common::getRequestVar('idSite', null, 'int');
             if (!$idSite) {
                 return;

--- a/plugins/Tour/Engagement/Challenges.php
+++ b/plugins/Tour/Engagement/Challenges.php
@@ -38,8 +38,10 @@ class Challenges
     {
         /** @var Challenge[] $challenges */
         $challenges = array(
-            StaticContainer::get(ChallengeTrackingCode::class),
+           StaticContainer::get(ChallengeTrackingCode::class),
         );
+
+        $challenges[] = StaticContainer::get(ChallengeSetupConsentManager::class);
 
         if ($this->isActivePlugin('Goals')) {
             $challenges[] = StaticContainer::get(ChallengeCreatedGoal::class);

--- a/plugins/Tour/lang/en.json
+++ b/plugins/Tour/lang/en.json
@@ -50,6 +50,8 @@
         "Part2Title": "Keep it up %1$s. You’re well on your way to becoming a Matomo expert.",
         "Part3Title": "You are on the right track %1$s. Continue, and become a Matomo expert.",
         "Part4Title": "Great progress %1$s. Only a few more challenges to complete.",
-        "OnlyVisibleToSuperUser": "Only you as a %1$ssuperuser%2$s can see this widget."
+        "OnlyVisibleToSuperUser": "Only you as a %1$ssuperuser%2$s can see this widget.",
+        "ConnectConsentManager": "Connect %1$s consent manager",
+        "ConnectConsentManagerIntro": "%1$s consent manager was detected on your website, learn how to connect %1$s and Matomo so they can work together."
     }
 }

--- a/plugins/Tour/tests/System/ConsentManagerDetectionTest.php
+++ b/plugins/Tour/tests/System/ConsentManagerDetectionTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\Tour\tests\System;
+
+use Piwik\Plugins\Tour\Engagement\ChallengeSetupConsentManager;
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
+
+/**
+ * @group ConsentManagerDetectionTest
+ * @group TourTest
+ * @group Plugins
+ */
+class ConsentManagerDetectionTest extends SystemTestCase
+{
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function test_detectConsentManager_disableWhenNotDetected()
+    {
+        $siteData = '';
+        $challenge = new ChallengeSetupConsentManager($siteData);
+        $this->assertTrue($challenge->isDisabled());
+    }
+
+    public function test_detectConsentManager_detectedButNotConnected()
+    {
+        $siteData = '<html><head><script src="https://osano.com/uhs9879874hthg.js"></script></head><body>A site</body></html>';
+        $challenge = new ChallengeSetupConsentManager($siteData);
+        $this->assertFalse($challenge->isDisabled());
+        $this->assertFalse($challenge->isCompleted());
+        $this->assertEquals('osano', $challenge->getConsentManagerId());
+    }
+
+    public function test_detectConsentManager_detectedAndConnected()
+    {
+        $siteData = "<html><head><script src='https://osano.com/uhs9879874hthg.js'></script><script>Osano.cm.addEventListener('osano-cm-consent-changed', (change) => { console.log('cm-change'); consentSet(change); });</script></head><body>A site</body></html>";
+        $challenge = new ChallengeSetupConsentManager($siteData);
+        $this->assertFalse($challenge->isDisabled());
+        $this->assertTrue($challenge->isCompleted());
+        $this->assertEquals('osano', $challenge->getConsentManagerId());
+    }
+
+}


### PR DESCRIPTION
### Description:

This PR adds a new 'challenge' to the 'Become a Matomo Expert' widget which is part of the Tour plugin. It will check for popular consent managers installed on the currently selected site and if detected will show a link to an FAQ showing how to integrate them with Matomo. Additionally it will check to see if the integration code is present on the website and if so automatically mark the challenge as complete.

A bit more detail:

When the Challenge object is constructed it will perform a simple cURL request to grab the current site main URL into a string and then check this against a known list of consent manager identifiers.

There are three possible outcomes:

 -  No consent manager is detected on the website - if this happens the challenge constructor will use the new Challenge::isDisabled() method to disable itself and it will not be shown on the widget.
 - A consent manager is detected, but no integration code was detected - the challenge will be shown on the widget as uncompleted.
 - A consent manager is detected and the integration code is detected - the challenge will be shown on the widget as completed.

The known consent managers are stored in a assoc array with detection strings and the URL for the guide, this can easily be extended in the future to cover more consent managers.

Currently supported: Osano, Cookiebot, CookieYes, Tarte au Citron, Klaro and Complianz GDPR for WordPress.

The linked guides are not public yet, but the included URLs will point to the correct location when they published.

One issue to consider is that this will cause a page load hit to the tracked website every time the widget is loaded. We could possibly soften this by adding a 'last checked' timestamp somewhere to ensure that we never check more frequently than say every 5 minutes. Another tweak could be to set the last checked timestamp a week(?) into the future if either no consent manager is detected or the consent manager is detected and is connected. Additionally we might want the cURL page load to use a user agent that avoids tracking or at least identifies as a robot of some sort.

Thoughts on this much appreciated!

Ref: DEV-3004

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
