### PR TITLE
Visits Overview accessibility improvement - remove redundant information

### DIFF
--- a/plugins/CoreVisualizations/templates/macros.twig
+++ b/plugins/CoreVisualizations/templates/macros.twig
@@ -15,8 +15,8 @@
     {% endif %}
 
     <span class="metricEvolution" title="{{ evolution.tooltip|rawSafeDecoded|e('html_attr') }}">
-    <img style="padding-right:4px" src="plugins/MultiSites/images/{{ evolutionIcon }}"/>
-    <strong class="{{ evolutionClass }}">{{ evolutionPretty }}</strong></span>
+    <img style="padding-right:4px" src="plugins/MultiSites/images/{{ evolutionIcon }}" alt="" />
+    <strong class="{{ evolutionClass }}" aria-hidden="true">{{ evolutionPretty }}</strong></span>
 {% endmacro %}
 
 {% macro singleSparkline(sparkline, allMetricsDocumentation, areSparklinesLinkable) %}


### PR DESCRIPTION
This PR is related to issue #19807.

### Description:

On several places of the admin, assistive technologies users will get redundant information due to duplicate info between text and title attributes, etc.

This PR aims to fix this issue on the Visites Overview widget.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
