### PR TITLE
Ensure plugin updates are executed when setting up UITestFixture

### DIFF
--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -60,6 +60,8 @@ class EventDispatcher
 
     private $pluginHooks = array();
 
+    public static $_SKIP_EVENTS_IN_TESTS = false;
+
     /**
      * Constructor.
      */
@@ -87,6 +89,10 @@ class EventDispatcher
      */
     public function postEvent($eventName, $params, $pending = false, $plugins = null)
     {
+        if (self::$_SKIP_EVENTS_IN_TESTS) {
+            return;
+        }
+
         if ($pending) {
             $this->pendingEvents[] = array($eventName, $params);
         }

--- a/tests/PHPUnit/Fixtures/UITestFixture.php
+++ b/tests/PHPUnit/Fixtures/UITestFixture.php
@@ -10,13 +10,11 @@
 namespace Piwik\Tests\Fixtures;
 
 use Exception;
-use Piwik\Access;
 use Piwik\API\Proxy;
 use Piwik\API\Request;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\Columns\Dimension;
 use Piwik\Common;
-use Piwik\Config;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 use Piwik\Date;
@@ -43,7 +41,6 @@ use Piwik\Plugins\SitesManager\API as SitesManagerAPI;
 use Piwik\Plugins\UsersManager\UserUpdater;
 use Piwik\Plugins\VisitsSummary\API as VisitsSummaryAPI;
 use Piwik\ReportRenderer;
-use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\XssTesting;
 use Piwik\Plugins\ScheduledReports\API as APIScheduledReports;
 use Psr\Container\ContainerInterface;
@@ -77,6 +74,8 @@ class UITestFixture extends SqlDump
     {
         parent::setUp();
 
+        // We need to disable events for running updates below.
+        // Otherwise PHP will run into a segfault when trying to execute updates for plugins.
         EventDispatcher::$_SKIP_EVENTS_IN_TESTS = true;
 
         // fetch the installed versions of all plugins from options table

--- a/tests/PHPUnit/Fixtures/UITestFixture.php
+++ b/tests/PHPUnit/Fixtures/UITestFixture.php
@@ -22,6 +22,7 @@ use Piwik\DataTable\Row;
 use Piwik\Date;
 use Piwik\Db;
 use Piwik\DbHelper;
+use Piwik\EventDispatcher;
 use Piwik\Filesystem;
 use Piwik\FrontController;
 use Piwik\Option;
@@ -76,6 +77,8 @@ class UITestFixture extends SqlDump
     {
         parent::setUp();
 
+        EventDispatcher::$_SKIP_EVENTS_IN_TESTS = true;
+
         // fetch the installed versions of all plugins from options table
         $pluginVersions = Option::getLike('version_%');
         $plugins = [];
@@ -94,6 +97,8 @@ class UITestFixture extends SqlDump
         self::installAndActivatePlugins($this->getTestEnvironment());
 
         self::updateDatabase();
+
+        EventDispatcher::$_SKIP_EVENTS_IN_TESTS = false;
 
         // make sure site has an early enough creation date (for period selector tests)
         Db::get()->update(

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -436,11 +436,11 @@ class Fixture extends \PHPUnit\Framework\Assert
         Manager::getInstance()->loadPluginTranslations();
     }
 
-    protected static function resetPluginsInstalledConfig()
+    protected static function resetPluginsInstalledConfig($plugins = [])
     {
         $config = self::getConfig();
         $installed = $config->PluginsInstalled;
-        $installed['PluginsInstalled'] = [];
+        $installed['PluginsInstalled'] = $plugins;
         $config->PluginsInstalled = $installed;
     }
 


### PR DESCRIPTION
### Description:

Currently when setting up the UITestFixture, updates for plugin are not executed.
That is caused by resetting the details about which plugins are installed and trying to install them again.
If an update e.g. modified a table, installing the table again won't update it. But as the installed plugin version will be updated to the latest version after it was installed, update script won't be executed afterwards.

Preserving the database information which version was installed when database dump was created fixes this.
For some reason doing that only runs into a PHP segfault when executing the updates.
Disabling the events while performing such updates solves that problem.

When merging such changes to 5.x-dev, we should consider reverting the database changes in the fixture done in #19746

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
