### PR TITLE
Abstract locking functions to allow support for additional database engines

### DIFF
--- a/core/ArchiveProcessor/LoaderLock.php
+++ b/core/ArchiveProcessor/LoaderLock.php
@@ -37,12 +37,14 @@ class LoaderLock
 
     public function setLock()
     {
-        Db::fetchOne('SELECT GET_LOCK(?,?)', array($this->id, self::MAX_LOCK_TIME));
+        $db = Db::get();
+        $db->getLock($this->id, self::MAX_LOCK_TIME);
     }
 
     public function unLock()
     {
-        Db::query('DO RELEASE_LOCK(?)', array($this->id));
+        $db = Db::get();
+        $db->releaseLock($this->id);
     }
 
     public function getId()
@@ -51,15 +53,17 @@ class LoaderLock
     }
 
     /**
-     * @description check if the lock is available to user
+     * Check if the lock is available to user
+     *
      * @param string $key
      * @return bool
+     *
      * @throws \Exception
      */
     public static function isLockAvailable($key)
     {
-        return (bool)Db::fetchOne('SELECT IS_FREE_LOCK(?)', [$key]);
-
+        $db = Db::get();
+        return $db->isLockAvailable($key);
     }
 
 }

--- a/core/Concurrency/Lock.php
+++ b/core/Concurrency/Lock.php
@@ -108,6 +108,11 @@ class Lock
         return $this->lockValue === $this->backend->get($this->lockKey);
     }
 
+    public function isLockedByAnyProcess()
+    {
+        return (bool) $this->backend->get($this->lockKey);
+    }
+
     public function unlock()
     {
         if ($this->lockValue) {

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -330,4 +330,110 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
 
         return parent::_dsn();
     }
+
+    /**
+     * Get a database lock
+     *
+     * @param string $lockName
+     * @param int    $maxRetries
+     *
+     * @return bool true if a lock was obtained
+     */
+    public function getLock(string $lockName, int $maxRetries = 30) : bool
+    {
+        if (strlen($lockName) > 64) {
+            throw new \Exception('DB lock name has to be 64 characters or less for MySQL 5.7 compatibility.');
+        }
+
+        /*
+         * the server (e.g., shared hosting) may have a low wait timeout
+         * so instead of a single GET_LOCK() with a 30 second timeout,
+         * we use a 1 second timeout and loop, to avoid losing our MySQL
+         * connection
+         */
+        $sql = 'SELECT GET_LOCK(?, 1)';
+
+        while ($maxRetries > 0) {
+            $result = $this->fetchOne($sql, [$lockName]);
+            if ($result == '1') {
+                return true;
+            }
+            $maxRetries--;
+        }
+
+        return false;
+    }
+
+    /**
+     * Release a database lock
+     *
+     * @param string $lockName
+     *
+     * @return bool True if the lock was released
+     */
+    public function releaseLock(string $lockName) : bool
+    {
+        return $this->fetchOne('SELECT RELEASE_LOCK(?)', [$lockName]) == '1';
+    }
+
+    /**
+     * Check if a database lock is available
+     *
+     * @param string $lockName
+     *
+     * @return bool  True if the lock is available
+     */
+    public function isLockAvailable(string $lockName) : bool
+    {
+        return (bool)$this->fetchOne('SELECT IS_FREE_LOCK(?)', [$lockName]);
+    }
+
+    /**
+     * Locks the supplied table or tables.
+     *
+     * **NOTE:** Matomo does not require the `LOCK TABLES` privilege to be available, it
+     * should still work if this has not been granted.
+     *
+     * @param string|array $tablesToRead The table or tables to obtain 'read' locks on. Table names must
+     *                                   be prefixed (see {@link Piwik\Common::prefixTable()}).
+     * @param string|array $tablesToWrite The table or tables to obtain 'write' locks on. Table names must
+     *                                    be prefixed (see {@link Piwik\Common::prefixTable()}).
+     *
+     * @return bool  True if the lock statement completed successfully
+     */
+    public function lockTables($tablesToRead, $tablesToWrite = []) : bool
+    {
+        if (!is_array($tablesToRead)) {
+            $tablesToRead = array($tablesToRead);
+        }
+
+        if (!is_array($tablesToWrite)) {
+            $tablesToWrite = array($tablesToWrite);
+        }
+
+        $lockExprs = array();
+        foreach ($tablesToWrite as $table) {
+            $lockExprs[] = $table . " WRITE";
+        }
+
+        foreach ($tablesToRead as $table) {
+            $lockExprs[] = $table . " READ";
+        }
+
+        return self::fetchOne("LOCK TABLES " . implode(', ', $lockExprs)) == '1';
+    }
+
+    /**
+     * Releases all table locks.
+     *
+     * **NOTE:** Matomo does not require the `LOCK TABLES` privilege to be available. It
+     * should still work if this has not been granted.
+     *
+     * @return bool  True if the unlock statement completed successfully
+     */
+    public function unlockAllTables() : bool
+    {
+        return self::fetchOne("UNLOCK TABLES") == '1';
+    }
+
 }

--- a/core/Db/AdapterInterface.php
+++ b/core/Db/AdapterInterface.php
@@ -65,6 +65,60 @@ interface AdapterInterface
     public function isErrNo($e, $errno);
 
     /**
+     * Get a database lock
+     *
+     * @param string $lockName
+     * @param int    $maxRetries
+     *
+     * @return bool True if a lock was obtained
+     */
+    public function getLock(string $lockName, int $maxRetries = 30) : bool;
+
+    /**
+     * Release a database lock
+     *
+     * @param string $lockName
+     *
+     * @return bool True if the lock was released
+     */
+    public function releaseLock(string $lockName) : bool;
+
+    /**
+     * Check if a database lock is available
+     *
+     * @param string $lockName
+     *
+     * @return bool  True if the lock is available
+     */
+    public function isLockAvailable(string $lockName) : bool;
+
+
+    /**
+     * Locks the supplied table or tables.
+     *
+     * **NOTE:** Matomo does not require the `LOCK TABLES` privilege to be available, it
+     * should still work if this has not been granted.
+     *
+     * @param string|array $tablesToRead The table or tables to obtain 'read' locks on. Table names must
+     *                                   be prefixed (see {@link Piwik\Common::prefixTable()}).
+     * @param string|array $tablesToWrite The table or tables to obtain 'write' locks on. Table names must
+     *                                    be prefixed (see {@link Piwik\Common::prefixTable()}).
+     *
+     * @return bool  True if the lock statement completed successfully
+     */
+    public function lockTables($tablesToRead, $tablesToWrite = []) : bool;
+
+    /**
+     * Releases all table locks.
+     *
+     * **NOTE:** Matomo does not require the `LOCK TABLES` privilege to be available. It
+     * should still work if this has not been granted.
+     *
+     * @return bool  True if the unlock statement completed successfully
+     */
+    public function unlockAllTables() : bool;
+
+    /**
      * Is the connection character set equal to utf8?
      *
      * @return bool


### PR DESCRIPTION
### Description:

Abstracts all code that performs database locking to use functions defined in `AdapterInterface` which are then implemented separately in individual database adapter classes. This will allow different database engines to handle locking in their own way and remove the assumption that MySQL locking is being used.

Fixes #19643 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
