### PR TITLE
add convenience command to minify tracker JS during development

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -31,6 +31,16 @@ The js/ folder contains:
 
 ## Deployment
 
+To minify core JavaScript you may run the following command (with Development Mode enabled):
+
+  ```bash
+  $ ./console development:build-tracker-js
+  ```
+
+(Note: this command can also be used to minify plugin tracker JavaScript.)
+
+To manually minify the file:
+
 * piwik.js is minified using YUICompressor 2.4.8.
   To install YUICompressor run:
  

--- a/plugins/CoreConsole/Commands/BuildTracker.php
+++ b/plugins/CoreConsole/Commands/BuildTracker.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreConsole\Commands;
+
+use Piwik\Http;
+use Piwik\Plugin\ConsoleCommand;
+use Piwik\Plugin\Manager;
+use Piwik\Unzip;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BuildTracker extends ConsoleCommand
+{
+    const YUI_COMPRESSOR_URL = 'https://github.com/yui/yuicompressor/releases/download/v2.4.8/yuicompressor-2.4.8.zip';
+
+    protected function configure()
+    {
+        $this->setName('development:build-tracker-js');
+        $this->setDescription('Minifies tracker JavaScript for Matomo core or a single plugin.');
+        $this->addOption('plugin', null, InputOption::VALUE_REQUIRED, 'The plugin to minify. If not supplied, minifies core tracker JS.');
+    }
+
+    public function isEnabled()
+    {
+        return \Piwik\Development::isEnabled();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $plugin = $input->getOption('plugin');
+        if ($plugin && !Manager::getInstance()->isPluginInFilesystem($plugin)) {
+            throw new \InvalidArgumentException("Invalid plugin '$plugin'");
+        }
+
+        $this->installYuiCompressorIfNeeded($output);
+        $this->compress($plugin, $output);
+    }
+
+    private function compress($plugin, OutputInterface $output)
+    {
+        $output->writeln("Minifying...");
+
+        $jsPath = PIWIK_INCLUDE_PATH . '/js';
+        if (!$plugin) {
+            $command = "cd $jsPath && sed '/<DEBUG>/,/<\\/DEBUG>/d' < piwik.js | sed 's/eval/replacedEvilString/' | java -jar yuicompressor-2.4.8.jar --type js --line-break 1000 | sed 's/replacedEvilString/eval/' | sed 's/^[/][*]/\\/*!/' > piwik.min.js && cp piwik.min.js ../piwik.js && cp piwik.min.js ../matomo.js";
+            if ($output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
+                $output->writeln("Command: $command");
+            }
+            passthru($command);
+            return;
+        }
+
+        $pluginTrackerJs = PIWIK_INCLUDE_PATH . '/plugins/' . $plugin . '/tracker.js';
+        $pluginTrackerMinJs = PIWIK_INCLUDE_PATH . '/plugins/' . $plugin . '/tracker.min.js';
+
+        $command = "cd $jsPath && cat $pluginTrackerJs | java -jar yuicompressor-2.4.8.jar --type js --line-break 1000 | sed 's/^[/][*]/\\/*!/' > $pluginTrackerMinJs";
+        if ($output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
+            $output->writeln("Command: $command");
+        }
+        passthru($command);
+
+        $output->writeln("Done.");
+    }
+
+    private function installYuiCompressorIfNeeded(OutputInterface $output)
+    {
+        $zipPath = PIWIK_INCLUDE_PATH . '/js/yuicompressor-2.4.8.zip';
+        $jarPath = PIWIK_INCLUDE_PATH . '/js/yuicompressor-2.4.8.jar';
+        if (is_file($jarPath)) {
+            return;
+        }
+
+        $output->writeln("Downloading YUI compressor...");
+        Http::fetchRemoteFile(self::YUI_COMPRESSOR_URL, $zipPath);
+
+        $unzip = Unzip::factory('PclZip', $zipPath);
+        $unzip->extract(PIWIK_INCLUDE_PATH . '/js/');
+    }
+}


### PR DESCRIPTION
### Description:

I'm working on a plugin that has some custom tracker JS code and noticed there's no instructions for minifying tracker JS. So I wrote this command which uses the instructions for minifying the core tracker JS to minify either that file, or the tracker JS for a plugin. Mostly for convenience.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
