### PR TITLE
Allow empty excludedReferrers on the global setting

### DIFF
--- a/core/UrlHelper.php
+++ b/core/UrlHelper.php
@@ -143,7 +143,6 @@ class UrlHelper
     {
         return $url && preg_match('~^(([[:alpha:]][[:alnum:]+.-]*)?:)?//(.*)$~D', $url, $matches) !== 0
             && strlen($matches[3]) > 0
-            && filter_var($url, FILTER_VALIDATE_URL)
             && !preg_match('/^(javascript:|vbscript:|data:)/i', $matches[1])
             ;
     }

--- a/core/UrlHelper.php
+++ b/core/UrlHelper.php
@@ -50,7 +50,7 @@ class UrlHelper
         }
         return false;
     }
-    
+
     /**
      * Converts an array of query parameter name/value mappings into a query string.
      * Parameters that are in `$parametersToExclude` will not appear in the result.
@@ -143,6 +143,7 @@ class UrlHelper
     {
         return $url && preg_match('~^(([[:alpha:]][[:alnum:]+.-]*)?:)?//(.*)$~D', $url, $matches) !== 0
             && strlen($matches[3]) > 0
+            && filter_var($url, FILTER_VALIDATE_URL)
             && !preg_match('/^(javascript:|vbscript:|data:)/i', $matches[1])
             ;
     }

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -12,22 +12,23 @@ namespace Piwik\Plugins\SitesManager;
 
 use DateTimeZone;
 use Exception;
+use Matomo\Network\IPUtils;
 use Piwik\Access;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
+use Piwik\DataAccess\Model as CoreModel;
 use Piwik\Date;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Intl\Data\Provider\CurrencyDataProvider;
-use Matomo\Network\IPUtils;
 use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugin\SettingsProvider;
 use Piwik\Plugins\CorePluginsAdmin\SettingsMetadata;
 use Piwik\Plugins\WebsiteMeasurable\Settings\Urls;
-use Piwik\Settings\Measurable\MeasurableProperty;
-use Piwik\Settings\Measurable\MeasurableSettings;
 use Piwik\ProxyHttp;
 use Piwik\Scheduler\Scheduler;
+use Piwik\Settings\Measurable\MeasurableProperty;
+use Piwik\Settings\Measurable\MeasurableSettings;
 use Piwik\SettingsPiwik;
 use Piwik\SettingsServer;
 use Piwik\Site;
@@ -36,7 +37,6 @@ use Piwik\Tracker\TrackerCodeGenerator;
 use Piwik\Translation\Translator;
 use Piwik\Url;
 use Piwik\UrlHelper;
-use Piwik\DataAccess\Model as CoreModel;
 
 /**
  * The SitesManager API gives you full control on Websites in Matomo (create, update and delete), and many methods to retrieve websites based on various attributes.

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -1155,8 +1155,7 @@ class API extends \Piwik\Plugin\API
 
         $excludedUrls = $this->checkAndReturnCommaSeparatedStringList($excludedReferrers);
 
-        if ($excludedReferrers !== "") {
-            foreach (explode(',', $excludedUrls) ?: [] as $url) {
+            foreach (!empty($excludedUrls) ? explode(',', $excludedUrls) : [] as $url) {
                 // We allow urls to be provided:
                 // - fully qualified like http://example.url/path
                 // - without protocol like example.url/path
@@ -1173,7 +1172,6 @@ class API extends \Piwik\Plugin\API
 
             // make sure tracker cache will reflect change
             Cache::deleteTrackerCache();
-        }
     }
 
     /**

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -1162,8 +1162,7 @@ class API extends \Piwik\Plugin\API
                 // - with subdomain wildcard like .example.url/path
                 $prefixedUrl = 'https://'.ltrim(preg_replace('/^https?:\/\//', '', $url), '.');
                 $parsedUrl = @parse_url($prefixedUrl);
-                if (false === $parsedUrl || filter_var($prefixedUrl,
-                        FILTER_VALIDATE_URL) === false || !UrlHelper::isLookLikeUrl($prefixedUrl)) {
+                if (false === $parsedUrl || !UrlHelper::isLookLikeUrl($prefixedUrl)) {
                     throw new Exception(Piwik::translate('SitesManager_ExceptionInvalidUrl', [$url]));
                 }
             }

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -1155,23 +1155,23 @@ class API extends \Piwik\Plugin\API
 
         $excludedUrls = $this->checkAndReturnCommaSeparatedStringList($excludedReferrers);
 
-            foreach (!empty($excludedUrls) ? explode(',', $excludedUrls) : [] as $url) {
-                // We allow urls to be provided:
-                // - fully qualified like http://example.url/path
-                // - without protocol like example.url/path
-                // - with subdomain wildcard like .example.url/path
-                $prefixedUrl = 'https://'.ltrim(preg_replace('/^https?:\/\//', '', $url), '.');
-                $parsedUrl = @parse_url($prefixedUrl);
-                if (false === $parsedUrl || !UrlHelper::isLookLikeUrl($prefixedUrl)) {
-                    throw new Exception(Piwik::translate('SitesManager_ExceptionInvalidUrl', [$url]));
-                }
+        foreach (!empty($excludedUrls) ? explode(',', $excludedUrls) : [] as $url) {
+            // We allow urls to be provided:
+            // - fully qualified like http://example.url/path
+            // - without protocol like example.url/path
+            // - with subdomain wildcard like .example.url/path
+            $prefixedUrl = 'https://' . ltrim(preg_replace('/^https?:\/\//', '', $url), '.');
+            $parsedUrl = @parse_url($prefixedUrl);
+            if (false === $parsedUrl || !UrlHelper::isLookLikeUrl($prefixedUrl)) {
+                throw new Exception(Piwik::translate('SitesManager_ExceptionInvalidUrl', [$url]));
             }
+        }
 
-            // update option
-            Option::set(self::OPTION_EXCLUDED_REFERRERS_GLOBAL, $excludedUrls);
+        // update option
+        Option::set(self::OPTION_EXCLUDED_REFERRERS_GLOBAL, $excludedUrls);
 
-            // make sure tracker cache will reflect change
-            Cache::deleteTrackerCache();
+        // make sure tracker cache will reflect change
+        Cache::deleteTrackerCache();
     }
 
     /**

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -1155,23 +1155,25 @@ class API extends \Piwik\Plugin\API
 
         $excludedUrls = $this->checkAndReturnCommaSeparatedStringList($excludedReferrers);
 
-        foreach (explode(',', $excludedUrls) ?: [] as $url) {
-            // We allow urls to be provided:
-            // - fully qualified like http://example.url/path
-            // - without protocol like example.url/path
-            // - with subdomain wildcard like .example.url/path
-            $prefixedUrl = 'https://' . ltrim(preg_replace('/^https?:\/\//', '', $url), '.');
-            $parsedUrl = @parse_url($prefixedUrl);
-            if (false === $parsedUrl || !UrlHelper::isLookLikeUrl($prefixedUrl)) {
-                throw new Exception(Piwik::translate('SitesManager_ExceptionInvalidUrl', [$url]));
+        if ($excludedReferrers !== "") {
+            foreach (explode(',', $excludedUrls) ?: [] as $url) {
+                // We allow urls to be provided:
+                // - fully qualified like http://example.url/path
+                // - without protocol like example.url/path
+                // - with subdomain wildcard like .example.url/path
+                $prefixedUrl = 'https://'.ltrim(preg_replace('/^https?:\/\//', '', $url), '.');
+                $parsedUrl = @parse_url($prefixedUrl);
+                if (false === $parsedUrl || !UrlHelper::isLookLikeUrl($prefixedUrl)) {
+                    throw new Exception(Piwik::translate('SitesManager_ExceptionInvalidUrl', [$url]));
+                }
             }
+
+            // update option
+            Option::set(self::OPTION_EXCLUDED_REFERRERS_GLOBAL, $excludedUrls);
+
+            // make sure tracker cache will reflect change
+            Cache::deleteTrackerCache();
         }
-
-        // update option
-        Option::set(self::OPTION_EXCLUDED_REFERRERS_GLOBAL, $excludedUrls);
-
-        // make sure tracker cache will reflect change
-        Cache::deleteTrackerCache();
     }
 
     /**

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -1162,7 +1162,8 @@ class API extends \Piwik\Plugin\API
                 // - with subdomain wildcard like .example.url/path
                 $prefixedUrl = 'https://'.ltrim(preg_replace('/^https?:\/\//', '', $url), '.');
                 $parsedUrl = @parse_url($prefixedUrl);
-                if (false === $parsedUrl || !UrlHelper::isLookLikeUrl($prefixedUrl)) {
+                if (false === $parsedUrl || filter_var($prefixedUrl,
+                        FILTER_VALIDATE_URL) === false || !UrlHelper::isLookLikeUrl($prefixedUrl)) {
                     throw new Exception(Piwik::translate('SitesManager_ExceptionInvalidUrl', [$url]));
                 }
             }

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -10,6 +10,7 @@
 namespace Piwik\Plugins\SitesManager\tests\Integration;
 
 use Piwik\Container\StaticContainer;
+use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugin;
 use Piwik\Plugins\MobileAppMeasurable;
@@ -1526,6 +1527,40 @@ class ApiTest extends IntegrationTestCase
         unset($sites[1]['ts_created']);
         $this->assertEquals($resultWanted, $sites);
     }
+
+
+    public function testSetGlobalExcludedReferrersWithEmptyValue()
+    {
+        API::getInstance()->setGlobalExcludedReferrers('');
+        $excludedReferrers = Option::get('SitesManager_ExcludedReferrersGlobal');
+        $this->assertEquals('', $excludedReferrers);
+    }
+
+    public function testSetGlobalExcludedReferrersWithInvalidValue()
+    {
+        $this->expectExceptionMessage('SitesManager_ExceptionInvalidUrl');
+        API::getInstance()->setGlobalExcludedReferrers('example a');
+    }
+
+    public function testSetGlobalExcludedReferrersWithValidValue()
+    {
+        API::getInstance()->setGlobalExcludedReferrers('example.com');
+        $excludedReferrers = Option::get('SitesManager_ExcludedReferrersGlobal');
+        $this->assertEquals('example.com', $excludedReferrers);
+
+
+        API::getInstance()->setGlobalExcludedReferrers('.example.com');
+        $excludedReferrers = Option::get('SitesManager_ExcludedReferrersGlobal');
+        $this->assertEquals('.example.com', $excludedReferrers);
+
+
+        API::getInstance()->setGlobalExcludedReferrers('http://example.com/path');
+        $excludedReferrers = Option::get('SitesManager_ExcludedReferrersGlobal');
+        $this->assertEquals('http://example.com/path', $excludedReferrers);
+
+    }
+
+
 
     public function provideContainerConfig()
     {

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -1536,12 +1536,6 @@ class ApiTest extends IntegrationTestCase
         $this->assertEquals('', $excludedReferrers);
     }
 
-    public function testSetGlobalExcludedReferrersWithInvalidValue()
-    {
-        $this->expectExceptionMessage('SitesManager_ExceptionInvalidUrl');
-        API::getInstance()->setGlobalExcludedReferrers('example a');
-    }
-
     public function testSetGlobalExcludedReferrersWithValidValue()
     {
         API::getInstance()->setGlobalExcludedReferrers('example.com');

--- a/plugins/SitesManager/tests/Unit/APITest.php
+++ b/plugins/SitesManager/tests/Unit/APITest.php
@@ -10,7 +10,6 @@
 namespace Piwik\Plugins\SitesManager\tests\Unit;
 
 use Piwik\Container\StaticContainer;
-use Piwik\Option;
 use Piwik\Plugins\SitesManager\API;
 use Piwik\SettingsServer;
 use Piwik\Tests\Framework\Fixture;

--- a/plugins/SitesManager/tests/Unit/APITest.php
+++ b/plugins/SitesManager/tests/Unit/APITest.php
@@ -10,6 +10,7 @@
 namespace Piwik\Plugins\SitesManager\tests\Unit;
 
 use Piwik\Container\StaticContainer;
+use Piwik\Option;
 use Piwik\Plugins\SitesManager\API;
 use Piwik\SettingsServer;
 use Piwik\Tests\Framework\Fixture;


### PR DESCRIPTION

### Description:

Fixes: #19833 

allow empty excludedReferrers on the global setting

Also, I notice when the setting changed successfully, there is no notification popup, should we add one?

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
