### PR TITLE
Avoid loading goals data multiple times for goal metrics

### DIFF
--- a/plugins/Goals/Columns/Metrics/GoalSpecificProcessedMetric.php
+++ b/plugins/Goals/Columns/Metrics/GoalSpecificProcessedMetric.php
@@ -71,7 +71,9 @@ abstract class GoalSpecificProcessedMetric extends ProcessedMetric
         }
     }
 
-    protected function getGoalName()
+    protected static $goalsCache = [];
+
+    protected function getGoalName(): string
     {
         if ($this->idGoal == Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER) {
             return Piwik::translate('Goals_EcommerceOrder');
@@ -80,15 +82,20 @@ abstract class GoalSpecificProcessedMetric extends ProcessedMetric
         }
 
         if (isset($this->idSite)) {
-            $allGoals = Request::processRequest('Goals.getGoals', ['idSite' => $this->idSite, 'filter_limit' => '-1'], $default = []);
-            $goalName = @$allGoals[$this->idGoal]['name'];
-            return $goalName;
+            if (!isset(self::$goalsCache[$this->idSite])) {
+                self::$goalsCache[$this->idSite] = Request::processRequest(
+                    'Goals.getGoals',
+                    ['idSite' => $this->idSite, 'filter_limit' => '-1'],
+                    $default = []
+                );
+            }
+            return self::$goalsCache[$this->idSite][$this->idGoal]['name'] ?? '';
         } else {
-            return "";
+            return '';
         }
     }
 
-    protected function getGoalNameForDocs()
+    protected function getGoalNameForDocs(): string
     {
         $goalName = $this->getGoalName();
         if ($goalName == Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER) {


### PR DESCRIPTION
### Description:

Currently when a report showing goal specific metrics is loaded, each metric will trigger a request to `Goals.getGoals` to fetch the goals details in order to find the name.
This might depending on the number of goals decrease the performance. On a goals overview page, with six configured goals, the API method is currently called 54 times. 
With this PR the API is only called once per requested report. So the number of calls is lowered to only 2!

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
