### PR TITLE
Goal visits log query performance improvement - don't execute the query when no idVisits

### DIFF
--- a/plugins/Goals/VisitorDetails.php
+++ b/plugins/Goals/VisitorDetails.php
@@ -60,6 +60,9 @@ class VisitorDetails extends VisitorDetailsAbstract
      */
     protected function queryGoalConversionsForVisits($idVisits)
     {
+        if (empty($idVisits)) {
+            return [];
+        }
         $sql = "
 				SELECT
 						log_conversion.idvisit,


### PR DESCRIPTION
We earlier so a high CPU usage on database which seems to have happened because there were maybe on idvisits given

```
... WHERE log_conversion.idvisit IN ('') ...
```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
