### PR TITLE
Ensure client hints are always returned as array

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -635,12 +635,14 @@ class Request
         return Common::getRequestVar('ua', $default, 'string', $this->params);
     }
 
-    public function getClientHints()
+    public function getClientHints(): array
     {
         // use headers as default if no data was send with the tracking request
         $default = Http::getClientHintsFromServerVariables();
 
-        return Common::getRequestVar('uadata', $default, 'json', $this->params);
+        $clientHints = Common::getRequestVar('uadata', $default, 'json', $this->params);
+
+        return is_array($clientHints) ? $clientHints : [];
     }
 
     public function shouldUseThirdPartyCookie()


### PR DESCRIPTION
### Description:

client hints are expected to be an array when used in places like here:

https://github.com/matomo-org/matomo/blob/ecae3ead0294d744b6a5fbd23d2f78a7f1ec1562/core/Tracker/VisitExcluded.php#L193

fixes #19849

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
