### PR TITLE
Fix array to string conversion warning in userOptOut

### DIFF
--- a/plugins/PrivacyManager/Controller.php
+++ b/plugins/PrivacyManager/Controller.php
@@ -130,7 +130,6 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
     public function usersOptOut()
     {
         Piwik::checkUserHasSomeAdminAccess();
-        $language = LanguagesManager::getLanguageCodeForCurrentUser();
 
         $doNotTrackOptions = [
             ['key' => '1',
@@ -153,7 +152,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         }
 
         return $this->renderTemplate('usersOptOut', [
-            'language' => $language,
+            'language' => LanguagesManager::getLanguageCodeForCurrentUser(),
             'currentLanguageCode' => LanguagesManager::getLanguageCodeForCurrentUser(),
             'languageOptions' => $languageOptions,
             'doNotTrackOptions' => $doNotTrackOptions,


### PR DESCRIPTION
### Description:

Fixes an array to string conversion bug caused by variable naming collision.

Fixes  #19852 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
