### PR TITLE
PHP8 fix - Ensure data retention settings are respected 

### DIFF
--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -452,9 +452,9 @@ class PrivacyManager extends Plugin
     /**
      * Returns the settings for the data purging feature.
      *
-     * @return array
+     * @return array<string, int>
      */
-    public static function getPurgeDataSettings()
+    public static function getPurgeDataSettings(): array
     {
         $settings = [];
 
@@ -462,7 +462,7 @@ class PrivacyManager extends Plugin
         $config = PiwikConfig::getInstance();
         foreach (self::$purgeDataOptions as $configKey => $configSection) {
             $values = $config->$configSection;
-            $settings[$configKey] = $values[$configKey];
+            $settings[$configKey] = (int) $values[$configKey];
         }
 
         if (!Controller::isDataPurgeSettingsEnabled()) {
@@ -473,7 +473,7 @@ class PrivacyManager extends Plugin
         foreach (self::$purgeDataOptions as $configName => $configSection) {
             $value = Option::get($configName);
             if ($value !== false) {
-                $settings[$configName] = $value;
+                $settings[$configName] = (int) $value;
             }
         }
 
@@ -489,7 +489,7 @@ class PrivacyManager extends Plugin
     {
         foreach (self::$purgeDataOptions as $configName => $configSection) {
             if (isset($settings[$configName])) {
-                Option::set($configName, $settings[$configName]);
+                Option::set($configName, (int) $settings[$configName]);
             }
         }
 


### PR DESCRIPTION
### Description:

On PHP 8, the settings if log and report data should be deleted might not be respected correctly.

The reason for this is, that the API converts the setting to a boolean e.g. here:
https://github.com/matomo-org/matomo/blob/6cc723685d3c1c9b399b09e9b691b9f2dba80bce/plugins/PrivacyManager/API.php#L295

But as the value is then stored in an option in the database, it gets converted to a string again.
So the resulting database value is either `1` (string value of `true`) or an empty string (string value of `false`).

When the value is later checked in the task this is done this way:
https://github.com/matomo-org/matomo/blob/2ea1411560d1942057fb97c94e334bfbd797a817/plugins/PrivacyManager/PrivacyManager.php#L523

That used to work smoothly for PHP 7. But for PHP 8 the result of that compare changed. The result of comparing an empty string against `0` changed. See https://3v4l.org/v4p2U

That means that removing log and report data is actually always enabled on PHP 8 once the settings in the UI had been saved.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
