### PR TITLE
Fix failures link to Learn More

### DIFF
--- a/plugins/CoreAdminHome/vue/src/TrackingFailures/FailureRow.vue
+++ b/plugins/CoreAdminHome/vue/src/TrackingFailures/FailureRow.vue
@@ -4,7 +4,7 @@
   <td>{{ failure.solution }} <a
     v-show="failure.solution_url"
     rel="noopener noreferrer"
-    ::href="failure.solution_url"
+    :href="failure.solution_url"
   >{{ translate('CoreAdminHome_LearnMore') }}</a></td>
   <td class="datetime">{{ failure.pretty_date_first_occurred }}</td>
   <td>{{ failure.url }}</td>


### PR DESCRIPTION
Extra colon (`:href`) prevents clicking on the link in Chromium.

```
<a rel="noopener noreferrer" :href="https://matomo.org/faq/how-to/faq_30838/">Learn more</a>
```

