### PR TITLE
Add exception for invalid limit before grouping

### DIFF
--- a/core/RankingQuery.php
+++ b/core/RankingQuery.php
@@ -96,6 +96,7 @@ class RankingQuery
      */
     public function __construct($limit = 0)
     {
+        $limit = intval($limit);
         if (is_int($limit) && $limit > 0) {
             $this->setLimit($limit);
         }

--- a/core/RankingQuery.php
+++ b/core/RankingQuery.php
@@ -92,12 +92,11 @@ class RankingQuery
     /**
      * Constructor.
      *
-     * @param int $limit The result row limit. See {@link setLimit()}.
+     * @param int|false $limit The result row limit. See {@link setLimit()}.
      */
-    public function __construct($limit = 0)
+    public function __construct($limit = false)
     {
-        $limit = (int)$limit;
-        if ($limit > 0) {
+        if ($limit !==false) {
             $this->setLimit($limit);
         }
     }

--- a/core/RankingQuery.php
+++ b/core/RankingQuery.php
@@ -96,7 +96,7 @@ class RankingQuery
      */
     public function __construct($limit = 0)
     {
-        if ($limit) {
+        if (is_int($limit) && $limit > 0) {
             $this->setLimit($limit);
         }
     }

--- a/core/RankingQuery.php
+++ b/core/RankingQuery.php
@@ -92,11 +92,11 @@ class RankingQuery
     /**
      * Constructor.
      *
-     * @param int|false $limit The result row limit. See {@link setLimit()}.
+     * @param int $limit The result row limit. See {@link setLimit()}.
      */
-    public function __construct($limit = false)
+    public function __construct($limit = 0)
     {
-        if ($limit !== false) {
+        if ($limit) {
             $this->setLimit($limit);
         }
     }

--- a/core/RankingQuery.php
+++ b/core/RankingQuery.php
@@ -96,7 +96,7 @@ class RankingQuery
      */
     public function __construct($limit = 0)
     {
-        $limit = intval($limit);
+        $limit = (int)$limit;
         if ($limit > 0) {
             $this->setLimit($limit);
         }

--- a/core/RankingQuery.php
+++ b/core/RankingQuery.php
@@ -97,7 +97,7 @@ class RankingQuery
     public function __construct($limit = 0)
     {
         $limit = intval($limit);
-        if (is_int($limit) && $limit > 0) {
+        if ($limit > 0) {
             $this->setLimit($limit);
         }
     }

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -298,7 +298,7 @@ class API extends \Piwik\Plugin\API
         $types[Action::TYPE_OUTLINK] = 'outlinks';
         $types[Action::TYPE_DOWNLOAD] = 'downloads';
 
-        $rankingQuery = new RankingQuery($limitBeforeGrouping ? $limitBeforeGrouping : $this->limitBeforeGrouping);
+        $rankingQuery = new RankingQuery($limitBeforeGrouping ?? $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
         $rankingQuery->addLabelColumn(array('name', 'url_prefix'));
         $rankingQuery->partitionResultIntoMultipleGroups('type', array_keys($types));
@@ -343,7 +343,7 @@ class API extends \Piwik\Plugin\API
             throw new Exception('limitBeforeGrouping has to be an integer.');
         }
 
-        $rankingQuery = new RankingQuery($limitBeforeGrouping ? $limitBeforeGrouping : $this->limitBeforeGrouping);
+        $rankingQuery = new RankingQuery($limitBeforeGrouping ?? $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
 
         // we generate a single column that contains the interesting data for each referrer.
@@ -425,7 +425,7 @@ class API extends \Piwik\Plugin\API
         if ($limitBeforeGrouping && !is_numeric($limitBeforeGrouping)) {
             throw new Exception('limitBeforeGrouping has to be an integer.');
         }
-        $rankingQuery = new RankingQuery($limitBeforeGrouping ? $limitBeforeGrouping : $this->limitBeforeGrouping);
+        $rankingQuery = new RankingQuery($limitBeforeGrouping ?? $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
         $rankingQuery->addLabelColumn(array('name', 'url_prefix'));
         $rankingQuery->setColumnToMarkExcludedRows('is_self');

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -69,6 +69,7 @@ class API extends \Piwik\Plugin\API
             throw new Exception('PeriodNotAllowed');
         }
 
+        $limitBeforeGrouping = intval($limitBeforeGrouping);
         if ($limitBeforeGrouping && !is_int($limitBeforeGrouping)) {
             throw new Exception('limitBeforeGrouping has to be an integer.');
         }

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -69,7 +69,7 @@ class API extends \Piwik\Plugin\API
             throw new Exception('PeriodNotAllowed');
         }
 
-        if ($limitBeforeGrouping && !is_numeric($limitBeforeGrouping)) {
+        if ($limitBeforeGrouping && !is_int($limitBeforeGrouping)) {
             throw new Exception('limitBeforeGrouping has to be an integer.');
         }
         // get idaction of the requested action

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -215,11 +215,15 @@ class API extends \Piwik\Plugin\API
      * @param $report
      * @param $idaction
      * @param string $actionType
-     * @param $limitBeforeGrouping
+     * @param int $limitBeforeGrouping
      * @param boolean $includeLoops
      */
-    private function addFollowingActions($logAggregator, &$report, $idaction, $actionType, $limitBeforeGrouping, $includeLoops = false)
+    private function addFollowingActions($logAggregator, &$report, $idaction, $actionType, $limitBeforeGrouping, $includeLoops = 0)
     {
+        if ($limitBeforeGrouping && !is_numeric($limitBeforeGrouping)) {
+            throw new Exception('limitBeforeGrouping has to be an integer.');
+        }
+
         $data = $this->queryFollowingActions(
             $idaction, $actionType, $logAggregator, $limitBeforeGrouping, $includeLoops);
 
@@ -234,12 +238,12 @@ class API extends \Piwik\Plugin\API
      * @param $idaction
      * @param $actionType
      * @param LogAggregator $logAggregator
-     * @param $limitBeforeGrouping
+     * @param  $limitBeforeGrouping
      * @param $includeLoops
      * @return array(followingPages:DataTable, outlinks:DataTable, downloads:DataTable)
      */
     protected function queryFollowingActions($idaction, $actionType, LogAggregator $logAggregator,
-                                          $limitBeforeGrouping = false, $includeLoops = false)
+                                          $limitBeforeGrouping = 0, $includeLoops = false)
     {
         $types = array();
 
@@ -329,11 +333,16 @@ class API extends \Piwik\Plugin\API
      * @param $idaction
      * @param $actionType
      * @param LogAggregator $logAggregator
-     * @param $limitBeforeGrouping
+     * @param int $limitBeforeGrouping
      * @return DataTable
+     * @throws Exception
      */
-    protected function queryExternalReferrers($idaction, $actionType, $logAggregator, $limitBeforeGrouping = false)
+    protected function queryExternalReferrers($idaction, $actionType, $logAggregator, $limitBeforeGrouping = 0)
     {
+        if ($limitBeforeGrouping && !is_numeric($limitBeforeGrouping)) {
+            throw new Exception('limitBeforeGrouping has to be an integer.');
+        }
+
         $rankingQuery = new RankingQuery($limitBeforeGrouping ? $limitBeforeGrouping : $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
 
@@ -404,15 +413,18 @@ class API extends \Piwik\Plugin\API
      * @param $idaction
      * @param $actionType
      * @param LogAggregator $logAggregator
-     * @param $limitBeforeGrouping
+     * @param int $limitBeforeGrouping
      * @return array(previousPages:DataTable, loops:integer)
      */
-    protected function queryInternalReferrers($idaction, $actionType, $logAggregator, $limitBeforeGrouping = false)
+    protected function queryInternalReferrers($idaction, $actionType, $logAggregator, $limitBeforeGrouping = 0)
     {
         $keyIsOther = 0;
         $keyIsPageUrlAction = 1;
         $keyIsSiteSearchAction = 2;
 
+        if ($limitBeforeGrouping && !is_numeric($limitBeforeGrouping)) {
+            throw new Exception('limitBeforeGrouping has to be an integer.');
+        }
         $rankingQuery = new RankingQuery($limitBeforeGrouping ? $limitBeforeGrouping : $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
         $rankingQuery->addLabelColumn(array('name', 'url_prefix'));

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -339,10 +339,8 @@ class API extends \Piwik\Plugin\API
      */
     protected function queryExternalReferrers($idaction, $actionType, $logAggregator, $limitBeforeGrouping = 0)
     {
-        if ($limitBeforeGrouping && !is_numeric($limitBeforeGrouping)) {
-            throw new Exception('limitBeforeGrouping has to be an integer.');
-        }
 
+        $limitBeforeGrouping = intval($limitBeforeGrouping);
         $rankingQuery = new RankingQuery($limitBeforeGrouping ?? $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
 
@@ -422,6 +420,7 @@ class API extends \Piwik\Plugin\API
         $keyIsPageUrlAction = 1;
         $keyIsSiteSearchAction = 2;
 
+        $limitBeforeGrouping = intval($limitBeforeGrouping);
         $rankingQuery = new RankingQuery($limitBeforeGrouping ?? $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
         $rankingQuery->addLabelColumn(array('name', 'url_prefix'));

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -65,6 +65,10 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasViewAccess($idSite);
 
+        if ($limitBeforeGrouping && !is_int($limitBeforeGrouping)) {
+            throw new Exception('LimitBeforeGroupingIsInvalid');
+        }
+
         if (!$this->isPeriodAllowed($idSite, $period, $date)) {
             throw new Exception('PeriodNotAllowed');
         }

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -55,13 +55,13 @@ class API extends \Piwik\Plugin\API
      * @param $period
      * @param $date
      * @param bool $segment
-     * @param bool $limitBeforeGrouping
+     * @param int $limitBeforeGrouping
      * @param string $parts
      * @return array
      * @throws Exception
      */
     public function getTransitionsForAction($actionName, $actionType, $idSite, $period, $date,
-                                            $segment = false, $limitBeforeGrouping = false, $parts = 'all')
+                                            $segment = false, $limitBeforeGrouping = 0, $parts = 'all')
     {
         Piwik::checkUserHasViewAccess($idSite);
 

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -69,10 +69,9 @@ class API extends \Piwik\Plugin\API
             throw new Exception('PeriodNotAllowed');
         }
 
+        //convert string to int
         $limitBeforeGrouping = intval($limitBeforeGrouping);
-        if ($limitBeforeGrouping && !is_int($limitBeforeGrouping)) {
-            throw new Exception('limitBeforeGrouping has to be an integer.');
-        }
+
         // get idaction of the requested action
         $idaction = $this->deriveIdAction($actionName, $actionType);
         if ($idaction < 0) {
@@ -423,9 +422,6 @@ class API extends \Piwik\Plugin\API
         $keyIsPageUrlAction = 1;
         $keyIsSiteSearchAction = 2;
 
-        if ($limitBeforeGrouping && !is_numeric($limitBeforeGrouping)) {
-            throw new Exception('limitBeforeGrouping has to be an integer.');
-        }
         $rankingQuery = new RankingQuery($limitBeforeGrouping ?? $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
         $rankingQuery->addLabelColumn(array('name', 'url_prefix'));

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -70,7 +70,7 @@ class API extends \Piwik\Plugin\API
         }
 
         if ($limitBeforeGrouping && !is_numeric($limitBeforeGrouping)) {
-            throw new Exception('LimitBeforeGroupingIsInvalid');
+            throw new Exception('limitBeforeGrouping has to be an integer.');
         }
         // get idaction of the requested action
         $idaction = $this->deriveIdAction($actionName, $actionType);

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -69,6 +69,9 @@ class API extends \Piwik\Plugin\API
             throw new Exception('PeriodNotAllowed');
         }
 
+        if ($limitBeforeGrouping && !is_numeric($limitBeforeGrouping)) {
+            throw new Exception('limitBeforeGrouping has to be an integer.');
+        }
         //convert string to int
         $limitBeforeGrouping = intval($limitBeforeGrouping);
 
@@ -218,11 +221,8 @@ class API extends \Piwik\Plugin\API
      * @param int $limitBeforeGrouping
      * @param boolean $includeLoops
      */
-    private function addFollowingActions($logAggregator, &$report, $idaction, $actionType, $limitBeforeGrouping, $includeLoops = 0)
+    private function addFollowingActions($logAggregator, &$report, $idaction, $actionType, $limitBeforeGrouping = 0, $includeLoops = 0)
     {
-        if ($limitBeforeGrouping && !is_numeric($limitBeforeGrouping)) {
-            throw new Exception('limitBeforeGrouping has to be an integer.');
-        }
 
         $data = $this->queryFollowingActions(
             $idaction, $actionType, $logAggregator, $limitBeforeGrouping, $includeLoops);
@@ -340,7 +340,6 @@ class API extends \Piwik\Plugin\API
     protected function queryExternalReferrers($idaction, $actionType, $logAggregator, $limitBeforeGrouping = 0)
     {
 
-        $limitBeforeGrouping = intval($limitBeforeGrouping);
         $rankingQuery = new RankingQuery($limitBeforeGrouping ?? $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
 
@@ -420,7 +419,6 @@ class API extends \Piwik\Plugin\API
         $keyIsPageUrlAction = 1;
         $keyIsSiteSearchAction = 2;
 
-        $limitBeforeGrouping = intval($limitBeforeGrouping);
         $rankingQuery = new RankingQuery($limitBeforeGrouping ?? $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
         $rankingQuery->addLabelColumn(array('name', 'url_prefix'));

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -36,12 +36,12 @@ use Piwik\Tracker\TableLogAction;
  */
 class API extends \Piwik\Plugin\API
 {
-    public function getTransitionsForPageTitle($pageTitle, $idSite, $period, $date, $segment = false, $limitBeforeGrouping = false)
+    public function getTransitionsForPageTitle($pageTitle, $idSite, $period, $date, $segment = false, $limitBeforeGrouping = 0)
     {
         return $this->getTransitionsForAction($pageTitle, 'title', $idSite, $period, $date, $segment, $limitBeforeGrouping);
     }
 
-    public function getTransitionsForPageUrl($pageUrl, $idSite, $period, $date, $segment = false, $limitBeforeGrouping = false)
+    public function getTransitionsForPageUrl($pageUrl, $idSite, $period, $date, $segment = false, $limitBeforeGrouping = 0)
     {
         return $this->getTransitionsForAction($pageUrl, 'url', $idSite, $period, $date, $segment, $limitBeforeGrouping);
     }

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -73,7 +73,7 @@ class API extends \Piwik\Plugin\API
             throw new Exception('limitBeforeGrouping has to be an integer.');
         }
         //convert string to int
-        $limitBeforeGrouping = intval($limitBeforeGrouping);
+        $limitBeforeGrouping = (int)$limitBeforeGrouping;
 
         // get idaction of the requested action
         $idaction = $this->deriveIdAction($actionName, $actionType);
@@ -221,7 +221,7 @@ class API extends \Piwik\Plugin\API
      * @param int $limitBeforeGrouping
      * @param boolean $includeLoops
      */
-    private function addFollowingActions($logAggregator, &$report, $idaction, $actionType, $limitBeforeGrouping = 0, $includeLoops = 0)
+    private function addFollowingActions($logAggregator, &$report, $idaction, $actionType, $limitBeforeGrouping = 0, $includeLoops = false)
     {
 
         $data = $this->queryFollowingActions(
@@ -298,7 +298,7 @@ class API extends \Piwik\Plugin\API
         $types[Action::TYPE_OUTLINK] = 'outlinks';
         $types[Action::TYPE_DOWNLOAD] = 'downloads';
 
-        $rankingQuery = new RankingQuery($limitBeforeGrouping ?? $this->limitBeforeGrouping);
+        $rankingQuery = new RankingQuery($limitBeforeGrouping ? $limitBeforeGrouping: $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
         $rankingQuery->addLabelColumn(array('name', 'url_prefix'));
         $rankingQuery->partitionResultIntoMultipleGroups('type', array_keys($types));
@@ -340,7 +340,7 @@ class API extends \Piwik\Plugin\API
     protected function queryExternalReferrers($idaction, $actionType, $logAggregator, $limitBeforeGrouping = 0)
     {
 
-        $rankingQuery = new RankingQuery($limitBeforeGrouping ?? $this->limitBeforeGrouping);
+        $rankingQuery = new RankingQuery($limitBeforeGrouping ? $limitBeforeGrouping: $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
 
         // we generate a single column that contains the interesting data for each referrer.
@@ -419,7 +419,7 @@ class API extends \Piwik\Plugin\API
         $keyIsPageUrlAction = 1;
         $keyIsSiteSearchAction = 2;
 
-        $rankingQuery = new RankingQuery($limitBeforeGrouping ?? $this->limitBeforeGrouping);
+        $rankingQuery = new RankingQuery($limitBeforeGrouping ? $limitBeforeGrouping: $this->limitBeforeGrouping);
         $rankingQuery->setOthersLabel('Others');
         $rankingQuery->addLabelColumn(array('name', 'url_prefix'));
         $rankingQuery->setColumnToMarkExcludedRows('is_self');

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -65,14 +65,13 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        if ($limitBeforeGrouping && !is_int($limitBeforeGrouping)) {
-            throw new Exception('LimitBeforeGroupingIsInvalid');
-        }
-
         if (!$this->isPeriodAllowed($idSite, $period, $date)) {
             throw new Exception('PeriodNotAllowed');
         }
 
+        if ($limitBeforeGrouping && !is_numeric($limitBeforeGrouping)) {
+            throw new Exception('LimitBeforeGroupingIsInvalid');
+        }
         // get idaction of the requested action
         $idaction = $this->deriveIdAction($actionName, $actionType);
         if ($idaction < 0) {

--- a/plugins/Transitions/lang/en.json
+++ b/plugins/Transitions/lang/en.json
@@ -25,7 +25,6 @@
         "NoDataForAction": "No data for %s",
         "NoDataForActionDetails": "Either the action had no pageviews during the period, or it is invalid.",
         "PeriodNotAllowed": "Select a valid time period",
-        "LimitBeforeGroupingIsInvalid": "Limit Before Group has to be an integer.",
         "PeriodNotAllowedDetails": "Try selecting a period with fewer days for this feature.",
         "OutgoingTraffic": "Outgoing traffic",
         "PluginDescription": "Reports previous and following actions for each page URL in a new \"Transitions\" report, available in the \"Actions\" reports via a new icon.",

--- a/plugins/Transitions/lang/en.json
+++ b/plugins/Transitions/lang/en.json
@@ -25,6 +25,7 @@
         "NoDataForAction": "No data for %s",
         "NoDataForActionDetails": "Either the action had no pageviews during the period, or it is invalid.",
         "PeriodNotAllowed": "Select a valid time period",
+        "LimitBeforeGroupingIsInvalid": "Limit Before Group has to be an integer.",
         "PeriodNotAllowedDetails": "Try selecting a period with fewer days for this feature.",
         "OutgoingTraffic": "Outgoing traffic",
         "PluginDescription": "Reports previous and following actions for each page URL in a new \"Transitions\" report, available in the \"Actions\" reports via a new icon.",

--- a/plugins/Transitions/tests/Integration/TransitionsMaxAllowedPeriodTest.php
+++ b/plugins/Transitions/tests/Integration/TransitionsMaxAllowedPeriodTest.php
@@ -82,6 +82,21 @@ class TransitionsMaxAllowedPeriodTest extends IntegrationTestCase
         }
     }
 
+    public function test_ShouldThrowException_IfInvalidLimitBeforeGroup()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('limitBeforeGrouping has to be an integer.');
+        $this->api->getTransitionsForAction('http://example.org/page/one.html', 'url', 1,
+            'range', '2012-08-09,2012-08-10', false, 'all');
+    }
+
+    public function test_ShouldPass_IfLimitBeforeGroupPassingIntAsString()
+    {
+        $report = $this->api->getTransitionsForAction('http://example.org/page/one.html', 'url', 1,
+            'range', '2012-08-09,2012-08-10', false, '100');
+        $this->assertIsArray($report);
+    }
+
     public function test_ShouldThrowException_IfRangeDayCountIsLargerThanDayPeriod()
     {
         Config::setSetting('Transitions_1', 'max_period_allowed', 'day');

--- a/plugins/Transitions/tests/Integration/TransitionsMaxAllowedPeriodTest.php
+++ b/plugins/Transitions/tests/Integration/TransitionsMaxAllowedPeriodTest.php
@@ -85,7 +85,7 @@ class TransitionsMaxAllowedPeriodTest extends IntegrationTestCase
     public function test_ShouldThrowException_IfInvalidLimitBeforeGroup()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('LimitBeforeGroupingIsInvalid');
+        $this->expectExceptionMessage('limitBeforeGrouping has to be an integer.');
         $this->api->getTransitionsForAction('http://example.org/page/one.html', 'url', 1,
             'range','2012-08-09,2012-08-10',false,'all');
     }

--- a/plugins/Transitions/tests/Integration/TransitionsMaxAllowedPeriodTest.php
+++ b/plugins/Transitions/tests/Integration/TransitionsMaxAllowedPeriodTest.php
@@ -82,31 +82,6 @@ class TransitionsMaxAllowedPeriodTest extends IntegrationTestCase
         }
     }
 
-    public function test_ShouldThrowException_IfInvalidLimitBeforeGroup()
-    {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('limitBeforeGrouping has to be an integer.');
-        $this->api->getTransitionsForAction('http://example.org/page/one.html', 'url', 1,
-            'range','2012-08-09,2012-08-10',false,'all');
-    }
-
-    public function test_ShouldThrowException_IfInvalidLimitBeforeGroupWithGetTransitionsForPageTitle()
-    {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('limitBeforeGrouping has to be an integer.');
-        $this->api->getTransitionsForPageTitle('test', 1, 1,
-            'range','2012-08-09,2012-08-10','all');
-    }
-
-    public function test_ShouldThrowException_IfInvalidLimitBeforeGroupWithGetTransitionsForPageUrl()
-    {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('limitBeforeGrouping has to be an integer.');
-        $this->api->getTransitionsForPageUrl('test', 1, 1,
-            'range','2012-08-09,2012-08-10','all');
-    }
-
-
     public function test_ShouldThrowException_IfRangeDayCountIsLargerThanDayPeriod()
     {
         Config::setSetting('Transitions_1', 'max_period_allowed', 'day');

--- a/plugins/Transitions/tests/Integration/TransitionsMaxAllowedPeriodTest.php
+++ b/plugins/Transitions/tests/Integration/TransitionsMaxAllowedPeriodTest.php
@@ -90,6 +90,23 @@ class TransitionsMaxAllowedPeriodTest extends IntegrationTestCase
             'range','2012-08-09,2012-08-10',false,'all');
     }
 
+    public function test_ShouldThrowException_IfInvalidLimitBeforeGroupWithGetTransitionsForPageTitle()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('limitBeforeGrouping has to be an integer.');
+        $this->api->getTransitionsForPageTitle('test', 1, 1,
+            'range','2012-08-09,2012-08-10','all');
+    }
+
+    public function test_ShouldThrowException_IfInvalidLimitBeforeGroupWithGetTransitionsForPageUrl()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('limitBeforeGrouping has to be an integer.');
+        $this->api->getTransitionsForPageUrl('test', 1, 1,
+            'range','2012-08-09,2012-08-10','all');
+    }
+
+
     public function test_ShouldThrowException_IfRangeDayCountIsLargerThanDayPeriod()
     {
         Config::setSetting('Transitions_1', 'max_period_allowed', 'day');

--- a/plugins/Transitions/tests/Integration/TransitionsMaxAllowedPeriodTest.php
+++ b/plugins/Transitions/tests/Integration/TransitionsMaxAllowedPeriodTest.php
@@ -82,6 +82,14 @@ class TransitionsMaxAllowedPeriodTest extends IntegrationTestCase
         }
     }
 
+    public function test_InvalideLimitBeforeGroup()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('LimitBeforeGroupingIsInvalid');
+        $this->api->getTransitionsForAction('http://example.org/page/one.html', 'url', 1,
+            'range','2012-08-09,2012-08-10',false,'all');
+    }
+
     public function test_ShouldThrowException_IfRangeDayCountIsLargerThanDayPeriod()
     {
         Config::setSetting('Transitions_1', 'max_period_allowed', 'day');

--- a/plugins/Transitions/tests/Integration/TransitionsMaxAllowedPeriodTest.php
+++ b/plugins/Transitions/tests/Integration/TransitionsMaxAllowedPeriodTest.php
@@ -82,7 +82,7 @@ class TransitionsMaxAllowedPeriodTest extends IntegrationTestCase
         }
     }
 
-    public function test_InvalideLimitBeforeGroup()
+    public function test_ShouldThrowException_IfInvalidLimitBeforeGroup()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('LimitBeforeGroupingIsInvalid');

--- a/plugins/Transitions/tests/System/TransitionsTest.php
+++ b/plugins/Transitions/tests/System/TransitionsTest.php
@@ -17,7 +17,7 @@ use Piwik\Tests\Fixtures\SomeVisitsManyPageviewsWithTransitions;
  * @group Plugins
  */
 class TransitionsTest extends SystemTestCase
-{   
+{
     public static $fixture = null; // initialized below class definition
 
     /**

--- a/tests/PHPUnit/Unit/RankingQueryTest.php
+++ b/tests/PHPUnit/Unit/RankingQueryTest.php
@@ -89,6 +89,13 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
 		";
 
         $this->checkQuery($query, $innerQuery, $expected);
+
+        $query = new RankingQuery('20');
+        $query->setOthersLabel('Others');
+        $query->addLabelColumn('label');
+        $query->setColumnToMarkExcludedRows('exclude_marker');
+        $this->checkQuery($query, $innerQuery, $expected);
+
     }
 
     /**

--- a/tests/PHPUnit/Unit/RankingQueryTest.php
+++ b/tests/PHPUnit/Unit/RankingQueryTest.php
@@ -176,16 +176,15 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
 		";
 
         $this->checkQuery($query, $innerQuery, $expected);
-        $query = new RankingQuery(-10);
+        $query = new RankingQuery(0.11);
         $query->setOthersLabel('Others');
         $query->addLabelColumn('label');
         $query->addColumn('column');
         $query->addColumn('columnSum', 'sum');
         $this->checkQuery($query, $innerQuery, $expected);
 
-
         $this->checkQuery($query, $innerQuery, $expected);
-        $query = new RankingQuery(-10.4);
+        $query = new RankingQuery(-10);
         $query->setOthersLabel('Others');
         $query->addLabelColumn('label');
         $query->addColumn('column');

--- a/tests/PHPUnit/Unit/RankingQueryTest.php
+++ b/tests/PHPUnit/Unit/RankingQueryTest.php
@@ -134,6 +134,58 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
 
         $this->checkQuery($query, $innerQuery, $expected);
     }
+    public function testInvalidFormatLimit()
+    {
+        $query = new RankingQuery('all');
+        $query->setOthersLabel('Others');
+        $query->addLabelColumn('label');
+        $query->addColumn('column');
+        $query->addColumn('columnSum', 'sum');
+
+        $innerQuery = "SELECT label, column, columnSum FROM myTable";
+
+        $expected = "
+			SELECT
+				CASE
+					WHEN counter = 6 THEN 'Others'
+					ELSE `label`
+				END AS `label`,
+				`column`,
+				sum(`columnSum`) AS `columnSum`
+			FROM (
+				SELECT
+					`label`,
+					CASE
+						WHEN @counter = 6 THEN 6
+						ELSE @counter:=@counter+1
+					END AS counter,
+					`column`,
+					`columnSum`
+				FROM
+					( SELECT @counter:=0 ) initCounter,
+					( SELECT label, column, columnSum FROM myTable ) actualQuery
+			 ) AS withCounter
+			GROUP BY counter
+		";
+
+        $this->checkQuery($query, $innerQuery, $expected);
+        $query = new RankingQuery(-10);
+        $query->setOthersLabel('Others');
+        $query->addLabelColumn('label');
+        $query->addColumn('column');
+        $query->addColumn('columnSum', 'sum');
+        $this->checkQuery($query, $innerQuery, $expected);
+
+
+        $this->checkQuery($query, $innerQuery, $expected);
+        $query = new RankingQuery(-10.4);
+        $query->setOthersLabel('Others');
+        $query->addLabelColumn('label');
+        $query->addColumn('column');
+        $query->addColumn('columnSum', 'sum');
+        $this->checkQuery($query, $innerQuery, $expected);
+
+    }
 
     /**
      * @param RankingQuery $rankingQuery

--- a/tests/PHPUnit/Unit/RankingQueryTest.php
+++ b/tests/PHPUnit/Unit/RankingQueryTest.php
@@ -58,6 +58,7 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
      */
     public function testExcludeRows()
     {
+
         $query = new RankingQuery(20);
         $query->setOthersLabel('Others');
         $query->addLabelColumn('label');
@@ -95,7 +96,6 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
         $query->addLabelColumn('label');
         $query->setColumnToMarkExcludedRows('exclude_marker');
         $this->checkQuery($query, $innerQuery, $expected);
-
     }
 
     /**
@@ -140,57 +140,6 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
 		";
 
         $this->checkQuery($query, $innerQuery, $expected);
-    }
-    public function testInvalidFormatLimit()
-    {
-        $query = new RankingQuery('all');
-        $query->setOthersLabel('Others');
-        $query->addLabelColumn('label');
-        $query->addColumn('column');
-        $query->addColumn('columnSum', 'sum');
-
-        $innerQuery = "SELECT label, column, columnSum FROM myTable";
-
-        $expected = "
-			SELECT
-				CASE
-					WHEN counter = 6 THEN 'Others'
-					ELSE `label`
-				END AS `label`,
-				`column`,
-				sum(`columnSum`) AS `columnSum`
-			FROM (
-				SELECT
-					`label`,
-					CASE
-						WHEN @counter = 6 THEN 6
-						ELSE @counter:=@counter+1
-					END AS counter,
-					`column`,
-					`columnSum`
-				FROM
-					( SELECT @counter:=0 ) initCounter,
-					( SELECT label, column, columnSum FROM myTable ) actualQuery
-			 ) AS withCounter
-			GROUP BY counter
-		";
-
-        $this->checkQuery($query, $innerQuery, $expected);
-        $query = new RankingQuery(0.11);
-        $query->setOthersLabel('Others');
-        $query->addLabelColumn('label');
-        $query->addColumn('column');
-        $query->addColumn('columnSum', 'sum');
-        $this->checkQuery($query, $innerQuery, $expected);
-
-        $this->checkQuery($query, $innerQuery, $expected);
-        $query = new RankingQuery(-10);
-        $query->setOthersLabel('Others');
-        $query->addLabelColumn('label');
-        $query->addColumn('column');
-        $query->addColumn('columnSum', 'sum');
-        $this->checkQuery($query, $innerQuery, $expected);
-
     }
 
     /**


### PR DESCRIPTION

### Description:
Fixes: #19867
Add an exception for invalid limit before grouping. When URL passing `limitBeforeGrouping=all` will throw an exception.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
