### PR TITLE
Fix PHP8.2 deprecation messages

### DIFF
--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -63,6 +63,10 @@ class Loader
      */
     private $dataAccessModel;
 
+    /**
+     * @var bool
+     */
+    private $invalidateBeforeArchiving;
 
     public function __construct(Parameters $params, $invalidateBeforeArchiving = false)
     {

--- a/core/Concurrency/Lock.php
+++ b/core/Concurrency/Lock.php
@@ -92,7 +92,6 @@ class Lock
         $locked    = $this->backend->setIfNotExists($this->lockKey, $lockValue, $ttlInSeconds);
         if ($locked) {
             $this->lockValue = $lockValue;
-            $this->ttlUsed = $ttlInSeconds;
             $this->lastExpireTime = Date::getNowTimestamp();
         }
 

--- a/core/Segment/SegmentExpression.php
+++ b/core/Segment/SegmentExpression.php
@@ -54,6 +54,12 @@ class SegmentExpression
     const SQL_WHERE_DO_NOT_MATCH_ANY_ROW = "(1 = 0)";
     const SQL_WHERE_MATCHES_ALL_ROWS = "(1 = 1)";
 
+    protected $string;
+    protected $joins = [];
+    protected $valuesBind = [];
+    protected $tree = [];
+    protected $parsedSubExpressions = [];
+
     public function __construct($string)
     {
         $this->string = $string;
@@ -70,10 +76,6 @@ class SegmentExpression
         return count($this->tree) == 0;
     }
 
-    protected $joins = array();
-    protected $valuesBind = array();
-    protected $tree = array();
-    protected $parsedSubExpressions = array();
 
     public function getSubExpressionCount()
     {
@@ -397,7 +399,7 @@ class SegmentExpression
         if (false !== strpos($str, '_')) {
             $str = str_replace("_", "\_", $str);
         }
-        
+
         return $str;
     }
 

--- a/plugins/PrivacyManager/DoNotTrackHeaderChecker.php
+++ b/plugins/PrivacyManager/DoNotTrackHeaderChecker.php
@@ -21,6 +21,8 @@ use Piwik\Tracker\IgnoreCookie;
  */
 class DoNotTrackHeaderChecker
 {
+    protected $config;
+
     /**
      * @param Config $config
      */


### PR DESCRIPTION
### Description:

solves deprecations reported here: https://github.com/matomo-org/matomo/issues/19343#issuecomment-1292876547

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
