### PR TITLE
Prepare github actions for Matomo 5

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: '4.x-dev'
+        ref: '5.x-dev'
         lfs: false
     - name: Install composer dependencies
       run: composer install
@@ -48,8 +48,8 @@ jobs:
 
           git push origin --delete composer-update || true
           git branch -D composer-update || true
-          git fetch upstream 4.x-dev
-          git checkout -f upstream/4.x-dev
+          git fetch upstream 5.x-dev
+          git checkout -f upstream/5.x-dev
           git branch composer-update
           git checkout -f composer-update
     - name: Update composer dependencies
@@ -88,7 +88,7 @@ jobs:
                   "title":"[automatic composer updates]",
                   "body":${{ steps.update.outputs.message }},
                   "head":"composer-update",
-                  "base":"4.x-dev"
+                  "base":"5.x-dev"
                   }' \
                  --url https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
 
             if ! [[ ${GITHUB_REF#refs/heads/} =~ ^[4-9]\.x-dev$ || ${GITHUB_REF#refs/heads/} == "next_release" ]]
             then
-              echo "A tag can only be created from branches '4.x-dev' and 'next_release'. Please create the tag manually if a release needs to be built from another branch."
+              echo "A tag can only be created from branches '5.x-dev' and 'next_release'. Please create the tag manually if a release needs to be built from another branch."
               exit 1
             fi
 

--- a/.github/workflows/submodules.yml
+++ b/.github/workflows/submodules.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: '4.x-dev'
+        ref: '5.x-dev'
         lfs: false
     - name: Prepare branches
       run: | 
@@ -46,14 +46,14 @@ jobs:
 
           git push origin --delete submodules || true
           git branch -D submodules || true
-          git fetch upstream 4.x-dev
-          git checkout -f upstream/4.x-dev
+          git fetch upstream 5.x-dev
+          git checkout -f upstream/5.x-dev
           git branch submodules
           git checkout -f submodules
     - name: Checkout submodules
       run: git submodule update --init --force
     - name: Update all submodules
-      run: git submodule foreach "git checkout 4.x-dev || git checkout master; git pull --ff-only"
+      run: git submodule foreach "git checkout 5.x-dev || git checkout master; git pull --ff-only"
     - name: Check for changes
       id: changes
       continue-on-error: true
@@ -95,7 +95,7 @@ jobs:
                   "title":"[automatic submodule updates]",
                   "body":"${{ steps.changes.outputs.message }}",
                   "head":"submodules",
-                  "base":"4.x-dev"
+                  "base":"5.x-dev"
                   }' \
                  --url https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls
       shell: bash

--- a/.github/workflows/update-intl.yml
+++ b/.github/workflows/update-intl.yml
@@ -115,7 +115,7 @@ jobs:
               "title":"[automatic Intl data updates from CLDR ${{ steps.cldr.outputs.cldr-version }}]",
               "body":"Updated Intl plugin data with changes from CLDR ${{ steps.cldr.outputs.cldr-version }}",
               "head":"update-intl",
-              "base":"4.x-dev"
+              "base":"5.x-dev"
               }' \
              --url https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls
         shell: bash

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Code Status
 
-[![Build Status](https://travis-ci.com/matomo-org/matomo.svg?branch=4.x-dev)](https://app.travis-ci.com/matomo-org/matomo/branches)
+[![Build Status](https://travis-ci.com/matomo-org/matomo.svg?branch=5.x-dev)](https://app.travis-ci.com/matomo-org/matomo/branches)
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/matomo-org/matomo.svg)](http://isitmaintained.com/project/matomo-org/matomo "Percentage of issues still open")
 
 ## Description

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,6 +1,6 @@
 ## Legal notice
 
-See the [LEGALNOTICE file](https://github.com/matomo-org/matomo/blob/4.x-dev/LEGALNOTICE).
+See the [LEGALNOTICE file](https://github.com/matomo-org/matomo/blob/5.x-dev/LEGALNOTICE).
 
 ## Matomo modifications to libs/
 


### PR DESCRIPTION
### Description:

Before releasing Matomo 5 we will soon switch the base branch from `4.x-dev` to `5.x-dev`. Some of our actions are automatically running on the base branch. For this purpose we need to update the used branch for some actions.
Should be safe to already merge this, as the changes here should first be used when the base branch was changed.

But it should meanwhile already be possible to trigger the actions manually for `5.x-dev` after this was merged.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
