### PR TITLE
add Live.initializeVisitorActions event to allow plugins to collapse actions in visitor log if they need to

### DIFF
--- a/plugins/Live/javascripts/visitorActions.js
+++ b/plugins/Live/javascripts/visitorActions.js
@@ -142,6 +142,10 @@ function initializeVisitorActions(elem) {
         });
     });
 
+    // must be here before the logic to toggle the expanders so if plugins collapse items, the actions will
+    // be correctly counted
+    window.CoreHome.Matomo.postEvent('Live.initializeVisitorActions', elem);
+
     // hide expanders if content collapsing removed enough items
     $("ol.actionList", elem).each(function () {
         var actionsToDisplayCollapsed = +piwik.visitorLogActionsToDisplayCollapsed;
@@ -191,4 +195,3 @@ function initializeVisitorActions(elem) {
         $list.children(':not(.actionsForPageExpander):not(.duplicate)').removeClass('last-action').last().addClass('last-action');
     }
 }
-


### PR DESCRIPTION
### Description:

Adds a client side events so plugins can collapse actions or do other things if they need to.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
