### PR TITLE
add global types for datatable row action classes/code

### DIFF
--- a/plugins/CoreVue/types/index.d.ts
+++ b/plugins/CoreVue/types/index.d.ts
@@ -147,6 +147,7 @@ declare global {
      */
     siteName: string;
     currentSiteName: string;
+    siteMainUrl?: string;
     period?: string;
     currentDateString?: string;
     startDateString?: string;

--- a/plugins/CoreVue/types/index.d.ts
+++ b/plugins/CoreVue/types/index.d.ts
@@ -13,6 +13,19 @@ declare global {
   type QueryParameterValue = string | number | null | undefined | QueryParameterValue[];
   type QueryParameters = Record<string, QueryParameterValue | QueryParameters>;
 
+  class DataTable_RowAction {
+    protected dataTable: any;
+    public actionName: string;
+    public trEventName: string;
+
+    constructor(dataTable: any);
+
+    openPopover(apiAction: string, idSubtable: string|number, extraParams: QueryParameters);
+    trigger(tr: HTMLElement|JQuery, originalEvent: Event, subTableLabel: string);
+    performAction(idSubtable: string|number, tr: HTMLElement|JQuery, originalEvent: Event);
+    doOpenPopover(urlParam: string);
+  }
+
   interface WrappedEventListener extends Function {
     wrapper?: (evt: Event) => void;
   }
@@ -206,6 +219,20 @@ declare global {
     show(apiMethod: string, segment: string, extraParams: Record<string|number, unknown>): void;
   }
 
+  interface RowAction {
+    name: string;
+    dataTableIcon: string;
+    order: number;
+    dataTableIconTooltip?: string[];
+    isAvailableOnReport(dataTableParams: QueryParameters, tr: HTMLElement|JQuery): boolean;
+    isAvailableOnRow(dataTableParams: QueryParameters, tr: HTMLElement|JQuery): boolean;
+    createInstance(dataTable: any, urlParam: string): DataTable_RowAction;
+  }
+
+  interface DataTableRowActionsRegisteryService {
+    register(rowAction: RowAction);
+  }
+
   interface Window {
     angular: IAngularStatic;
     globalAjaxQueue: GlobalAjaxQueue;
@@ -221,6 +248,7 @@ declare global {
     NumberFormatter: NumberFormatter;
     Piwik_Transitions: TransitionsGlobal;
     SegmentedVisitorLog: SegmentedVisitorLogService;
+    DataTable_RowActions_Registry: DataTableRowActionsRegisteryService;
 
     _pk_translate(translationStringId: string, values: (string|number|boolean)[]): string;
     require(p: string): any;


### PR DESCRIPTION
### Description:

So it's possible to add row actions in typescript.

Also added a property to PiwikGlobal for `siteMainUrl`.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
