### PR TITLE
Avoid double formatting of conversion rate in comparison mode

### DIFF
--- a/plugins/Goals/Reports/Get.php
+++ b/plugins/Goals/Reports/Get.php
@@ -140,15 +140,18 @@ class Get extends Base
             ]);
 
             // Adding conversion rate as extra processed metrics ensures it will be formatted
-            $view->config->filters[] = function (DataTable $t) {
-                $extraProcessedMetrics = $t->getMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME);
+            // This is not done when comparing, as comparison does its own formatting
+            if (!$view->isComparing()) {
+                $view->config->filters[] = function (DataTable $t) {
+                    $extraProcessedMetrics = $t->getMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME);
 
-                if (empty($extraProcessedMetrics)) {
-                    $extraProcessedMetrics = [];
-                }
-                $extraProcessedMetrics[] = new ConversionRate();
-                $t->setMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME, $extraProcessedMetrics);
-            };
+                    if (empty($extraProcessedMetrics)) {
+                        $extraProcessedMetrics = [];
+                    }
+                    $extraProcessedMetrics[] = new ConversionRate();
+                    $t->setMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME, $extraProcessedMetrics);
+                };
+            }
 
             $allowMultiple = Common::getRequestVar('allow_multiple', 0, 'int');
 


### PR DESCRIPTION
### Description:

When viewing a goals report in comparison mode I got the following error in log:

```
WARNING CoreHome[2022-11-08 13:38:15 UTC] [871ee] /srv/matomo/core/Metrics/Formatter.php(161): Notice - A non well formed numeric value encountered - Matomo 4.12.3 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already) #0/core/Metrics/Formatter.php(161),#1/plugins/CoreHome/Columns/Metrics/ConversionRate.php(42),#2/plugins/CoreVisualizations/Visualizations/Sparklines.php(259),#3/plugins/CoreVisualizations/Visualizations/Sparklines.php(108),#4/core/Plugin/Report.php(320),#5/plugins/CoreHome/Controller.php(60),[internal function]: Piwik\Plugins\CoreHome\Controller->renderReportWidget(),#7/core/FrontController.php(631),#8/core/FrontController.php(169),#9/core/dispatch.php(32)
```

Turned out, that in comparison mode, the values seem to be formatted twice. That actually caused the numbers to be incorrect. Instead of 1,8% it was displayed as 100%

Might be related to #19954

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
