### PR TITLE
hide widget when not found

### DIFF
--- a/plugins/Dashboard/javascripts/dashboardWidget.js
+++ b/plugins/Dashboard/javascripts/dashboardWidget.js
@@ -230,7 +230,7 @@
         },
 
         /**
-         * Creaates the widget markup for the given uniqueId
+         * Creates the widget markup for the given uniqueId
          *
          * @param {String} uniqueId
          */
@@ -240,6 +240,8 @@
 
             widgetsHelper.getWidgetNameFromUniqueId(uniqueId, function(widgetName) {
                 if (!widgetName) {
+                    // when widget not found hide it.
+                    $(".sortable[widgetid="+uniqueId+"]").hide();
                     widgetName = _pk_translate('Dashboard_WidgetNotFound');
                 }
 

--- a/plugins/Dashboard/javascripts/dashboardWidget.js
+++ b/plugins/Dashboard/javascripts/dashboardWidget.js
@@ -241,7 +241,7 @@
             widgetsHelper.getWidgetNameFromUniqueId(uniqueId, function(widgetName) {
                 if (!widgetName) {
                     // when widget not found hide it.
-                    $(".sortable[widgetid="+uniqueId+"]").hide();
+                    self.destroy();
                     widgetName = _pk_translate('Dashboard_WidgetNotFound');
                 }
 

--- a/plugins/Dashboard/javascripts/dashboardWidget.js
+++ b/plugins/Dashboard/javascripts/dashboardWidget.js
@@ -241,8 +241,8 @@
             widgetsHelper.getWidgetNameFromUniqueId(uniqueId, function(widgetName) {
                 if (!widgetName) {
                     // when widget not found hide it.
-                    self.destroy();
-                    widgetName = _pk_translate('Dashboard_WidgetNotFound');
+                    $('[widgetId="' + uniqueId + '"]').remove();
+                    return;
                 }
 
                 var title = self.options.title === null ? $('<span/>').text(widgetName) : self.options.title;

--- a/plugins/Dashboard/javascripts/dashboardWidget.js
+++ b/plugins/Dashboard/javascripts/dashboardWidget.js
@@ -241,8 +241,8 @@
             widgetsHelper.getWidgetNameFromUniqueId(uniqueId, function(widgetName) {
                 if (!widgetName) {
                     // when widget not found hide it.
-                    $('[widgetId="' + uniqueId + '"]').remove();
-                    return;
+                    $('[widgetId="' + uniqueId + '"]').hide();
+                    widgetName = _pk_translate('Dashboard_WidgetNotFound');
                 }
 
                 var title = self.options.title === null ? $('<span/>').text(widgetName) : self.options.title;


### PR DESCRIPTION

### Description:

Fixes: #9969 
hide widget when not found

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
