### PR TITLE
Improve GA/consent manager detection by not restricting to curl and caching result

### DIFF
--- a/core/SiteContentDetector.php
+++ b/core/SiteContentDetector.php
@@ -9,7 +9,6 @@
 namespace Piwik;
 
 use Matomo\Cache\Lazy;
-use Piwik\Container\StaticContainer;
 
 /**
  * This class provides detection functions for specific content on a site. It can be used to easily detect the

--- a/tests/PHPUnit/Framework/Mock/FakeSiteContentDetector.php
+++ b/tests/PHPUnit/Framework/Mock/FakeSiteContentDetector.php
@@ -12,19 +12,17 @@ class FakeSiteContentDetector extends SiteContentDetector
     public function __construct($mockData = [])
     {
         $this->mockData = $mockData;
+        parent::__construct(null);
     }
 
     public function detectContent(array $detectContent = [SiteContentDetector::ALL_CONTENT],
-                                  ?int $idSite = null, ?string $siteData = null, int $timeOut = 60)
+                                  ?int $idSite = null, ?string $siteData = null, int $timeOut = 60): void
     {
-
         foreach ($this->mockData as $property => $value) {
             if (property_exists($this, $property)) {
                $this->{$property} = $value;
             }
         }
-
-        return true;
     }
 
 }

--- a/tests/PHPUnit/Unit/SiteContentDetectorTest.php
+++ b/tests/PHPUnit/Unit/SiteContentDetectorTest.php
@@ -21,7 +21,7 @@ class SiteContentDetectorTest extends \PHPUnit\Framework\TestCase
     {
         $siteData = '<html lang="en"><head><title>A site</title></head><script src="https://osano.com/uhs9879874hthg.js"></script></head><body>A site</body></html>';
 
-        $scd = SiteContentDetector::getInstance();
+        $scd = new SiteContentDetector();
         $scd->detectContent([SiteContentDetector::ALL_CONTENT], null, $siteData);
 
         $this->assertEquals('osano', $scd->consentManagerId);
@@ -31,7 +31,7 @@ class SiteContentDetectorTest extends \PHPUnit\Framework\TestCase
     public function test_detectsConsentManager_Connected()
     {
         $siteData = "<html lang='en'><head><title>A site</title></head><script src='https://osano.com/uhs9879874hthg.js'></script><script>Osano.cm.addEventListener('osano-cm-consent-changed', (change) => { console.log('cm-change'); consentSet(change); });</script></><body>A site</body></html>";
-        $scd = SiteContentDetector::getInstance();
+        $scd = new SiteContentDetector();
         $scd->detectContent([SiteContentDetector::ALL_CONTENT], null, $siteData);
 
         $this->assertEquals('osano', $scd->consentManagerId);
@@ -48,7 +48,7 @@ class SiteContentDetectorTest extends \PHPUnit\Framework\TestCase
                      ga('create', 'UA-xxxxxxxx-x', 'xxxxxx.com');
                      ga('send', 'pageview');
                      </script></head><body>A site</body></html>";
-        $scd = SiteContentDetector::getInstance();
+        $scd = new SiteContentDetector();
         $scd->detectContent([SiteContentDetector::GA3], null, $siteData);
 
         $this->assertEmpty($scd->consentManagerId);
@@ -68,7 +68,7 @@ class SiteContentDetectorTest extends \PHPUnit\Framework\TestCase
                             gtag('config', 'GA_TRACKING_ID');
                     </script>
                     </head><body>A site</body></html>";
-        $scd = SiteContentDetector::getInstance();
+        $scd = new SiteContentDetector();
         $scd->detectContent([SiteContentDetector::GA4], null, $siteData);
 
         $this->assertFalse($scd->ga3);
@@ -87,7 +87,7 @@ class SiteContentDetectorTest extends \PHPUnit\Framework\TestCase
                      })(window,document,'script','dataLayer','GTM-NRTVJJC');</script>
                      <!-- End Google Tag Manager -->                     
                      </head><body>A site</body></html>";
-        $scd = SiteContentDetector::getInstance();
+        $scd = new SiteContentDetector();
         $scd->detectContent([SiteContentDetector::GTM], null, $siteData);
 
         $this->assertFalse($scd->ga3);
@@ -98,7 +98,7 @@ class SiteContentDetectorTest extends \PHPUnit\Framework\TestCase
     public function test_doesNotDetectsGA_IfNotPresent()
     {
         $siteData = "<html lang=\"en\"><head><title>A site</title><script><script>console.log('abc');</script></head><body>A site</body></html>";
-        $scd = SiteContentDetector::getInstance();
+        $scd = new SiteContentDetector();
         $scd->detectContent([SiteContentDetector::ALL_CONTENT], null, $siteData);
 
         $this->assertFalse($scd->ga3);


### PR DESCRIPTION
### Description:

Changes the Site Content Detector class to use lazy caching for detected site properties so that site content will only be checked at most once per week. A lower cache lifetime than four weeks was used so that existing Matomo users who add a content manager to their site can see the setup guide links within a few days.

Explicit curl usage has been replaced with `getHTTPTransport()` as a parameter to `sendHttpRequestBy()` so that there is no restriction to just using curl, but invalid SSL certificates can still be ignored.

Fixes #20000

(Remember to turn off development mode in config.ini.php for cache testing! :slightly_smiling_face: )

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
