### PR TITLE
Fix for unhandled datatable maps in custom dimensions

### DIFF
--- a/plugins/CustomDimensions/API.php
+++ b/plugins/CustomDimensions/API.php
@@ -63,22 +63,9 @@ class API extends \Piwik\Plugin\API
 
         if (!empty($idSubtable) && $dataTable->getRowsCount()) {
             $parentTable = Archive::createDataTableFromArchive($record, $idSite, $period, $date, $segment);
-
-            $parentValue = null;
-            if ($parentTable instanceof Map) {
-                $row = $parentTable->getRowFromIdSubDataTable($idSubtable);
-                if ($row) {
-                    $parentValue = $row->getColumn('label');
-                }
-            } else {
-                foreach ($parentTable->getRows() as $row) {
-                    if ($row->getIdSubDataTable() == $idSubtable) {
-                        $parentValue = $row->getColumn('label');
-                        break;
-                    }
-                }
-            }
-            if ($parentValue) {
+            $row = $parentTable->getRowFromIdSubDataTable($idSubtable);
+            if ($row) {
+                $parentValue = $row->getColumn('label');
                 $dataTable->filter('Piwik\Plugins\CustomDimensions\DataTable\Filter\AddSubtableSegmentMetadata', array($idDimension, $parentValue));
             }
 

--- a/plugins/CustomDimensions/API.php
+++ b/plugins/CustomDimensions/API.php
@@ -12,7 +12,6 @@ use Piwik\Common;
 
 use Piwik\Archive;
 use Piwik\DataTable;
-use Piwik\DataTable\Map;
 use Piwik\Filesystem;
 use Piwik\Piwik;
 use Piwik\Plugins\CustomDimensions\Dao\Configuration;


### PR DESCRIPTION
### Description:

If the `Archive::createDataTableFromArchive()` method returns a `DataTable\Map` instead of a `DataTable` object then `getCustomDimension()` tries to use it as a single DataTable object resulting in errors. This fix checks if the returned object is a `DataTable\Map` and if so uses a different method to retrieve the required data.

Fixes #20043

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
