### PR TITLE
When verifying a nonce, an empty referrer should be allowed. even though expectedReferrerHost is specified

### DIFF
--- a/core/Nonce.php
+++ b/core/Nonce.php
@@ -115,18 +115,22 @@ class Nonce
             return Piwik::translate('Login_InvalidNonceToken');
         }
 
-        // validate referrer
+        // Validate referrer if present and non-local
         $referrer = Url::getReferrer();
-        if (empty($expectedReferrerHost) && !empty($referrer) && !Url::isLocalUrl($referrer)) {
-            return Piwik::translate('Login_InvalidNonceReferrer', array(
-              '<a target="_blank" rel="noreferrer noopener" href="https://matomo.org/faq/how-to-install/faq_98">',
-              '</a>'
-              )) . $additionalErrors;
-        }
 
-        //referrer is different expected host
-        if (!empty($expectedReferrerHost) && !self::isReferrerHostValid($referrer, $expectedReferrerHost)) {
-            return Piwik::translate('Login_InvalidNonceUnexpectedReferrer') . $additionalErrors;
+        if (!empty($referrer) && !Url::isLocalUrl($referrer)) {
+            // validate referrer
+            if (empty($expectedReferrerHost)) {
+                return Piwik::translate('Login_InvalidNonceReferrer', array(
+                        '<a target="_blank" rel="noreferrer noopener" href="https://matomo.org/faq/how-to-install/faq_98">',
+                        '</a>'
+                    )) . $additionalErrors;
+            }
+
+            //referrer is different expected host
+            if (!empty($expectedReferrerHost) && !self::isReferrerHostValid($referrer, $expectedReferrerHost)) {
+                return Piwik::translate('Login_InvalidNonceUnexpectedReferrer') . $additionalErrors;
+            }
         }
 
         // validate origin

--- a/core/Nonce.php
+++ b/core/Nonce.php
@@ -65,31 +65,33 @@ class Nonce
      *
      * @param string $id The nonce's unique ID. See {@link getNonce()}.
      * @param string $cnonce Nonce sent from client.
-     * @param null|string $expectedReferrerHost The expected referrer host for the HTTP referrer URL.
+     * @param null|string $allowedReferrerHost The allowed referrer host for the HTTP referrer URL.
      * @return bool `true` if valid; `false` otherwise.
      */
-    public static function verifyNonce($id, $cnonce, $expectedReferrerHost = null)
+    public static function verifyNonce($id, $cnonce, $allowedReferrerHost = null)
     {
         // load error with message function.
-        $error = self::verifyNonceWithErrorMessage($id, $cnonce, $expectedReferrerHost);
+        $error = self::verifyNonceWithErrorMessage($id, $cnonce, $allowedReferrerHost);
         return $error === "";
     }
 
     /**
-     * Returns error message
+     * Returns an error message, if any of the individual checks fails.
      *
-     * A nonce is valid if it matches the current nonce and if the current nonce
-     * has not expired.
+     * A nonce must match the current nonce and must not be expired.
      *
-     * The request is valid if the referrer is a local URL (see {@link Url::isLocalUrl()})
-     * and if the HTTP origin is valid (see {@link getAcceptableOrigins()}).
+     * If a referrer is present, it must match $allowedReferrerHost. The exception is a referrer that resolves to local,
+     * which is allowed if $allowedReferrerHost is empty.
+     * If a referrer is not present, then $allowedReferrerHost is ignored.
+     *
+     * The HTTP origin must be valid (see {@link getAcceptableOrigins()}).
      *
      * @param string $id The nonce's unique ID. See {@link getNonce()}.
      * @param string $cnonce Nonce sent from client.
-     * @param null $expectedReferrerHost The expected referrer host for the HTTP referrer URL.
+     * @param string|null $allowedReferrerHost The allowed referrer for the HTTP referrer URL. See method description.
      * @return string if empty is valid otherwise return error message
      */
-    public static function verifyNonceWithErrorMessage($id, $cnonce, $expectedReferrerHost = null)
+    public static function verifyNonceWithErrorMessage($id, $cnonce, $allowedReferrerHost = null)
     {
         $ns = new SessionNamespace($id);
         $nonce = $ns->nonce;
@@ -118,17 +120,17 @@ class Nonce
         // Validate referrer if present
         $referrer = Url::getReferrer();
         if (!empty($referrer)) {
-            // Allow localhost, if no specific referrer is expected
-            if (empty($expectedReferrerHost) && !Url::isLocalUrl($referrer)) {
+            // Allow the instance host by default, if no allowedReferrerHost is specified
+            if (empty($allowedReferrerHost) && !Url::isLocalUrl($referrer)) {
                 return Piwik::translate('Login_InvalidNonceReferrer', array(
                         '<a target="_blank" rel="noreferrer noopener" href="https://matomo.org/faq/how-to-install/faq_98">',
                         '</a>'
                     )) . $additionalErrors;
             }
 
-            // Test that referrer matches what was expected
-            if (!empty($expectedReferrerHost) && !self::isReferrerHostValid($referrer, $expectedReferrerHost)) {
-                return Piwik::translate('Login_InvalidNonceUnexpectedReferrer') . $additionalErrors;
+            // Test that referrer matches what was allowed
+            if (!empty($allowedReferrerHost) && !self::isReferrerHostValid($referrer, $allowedReferrerHost)) {
+                return Piwik::translate('Login_InvalidNonceUnallowedReferrer') . $additionalErrors;
             }
         }
 
@@ -145,14 +147,14 @@ class Nonce
     }
 
     // public for tests
-    public static function isReferrerHostValid($referrer, $expectedReferrerHost)
+    public static function isReferrerHostValid($referrer, $allowedReferrerHost)
     {
         if (empty($referrer)) {
             return false;
         }
 
         $referrerHost = Url::getHostFromUrl($referrer);
-        return preg_match('/(^|\.)' . preg_quote($expectedReferrerHost) . '$/i', $referrerHost);
+        return preg_match('/(^|\.)' . preg_quote($allowedReferrerHost) . '$/i', $referrerHost);
     }
 
     /**
@@ -229,13 +231,13 @@ class Nonce
      *                           **nonce** query parameter is used.
      * @throws \Exception if the nonce is invalid. See {@link verifyNonce()}.
      */
-    public static function checkNonce($nonceName, $nonce = null, $expectedReferrerHost = null)
+    public static function checkNonce($nonceName, $nonce = null, $allowedReferrerHost = null)
     {
         if ($nonce === null) {
             $nonce = Common::getRequestVar('nonce', null, 'string');
         }
 
-        if (!self::verifyNonce($nonceName, $nonce, $expectedReferrerHost)) {
+        if (!self::verifyNonce($nonceName, $nonce, $allowedReferrerHost)) {
             throw new \Exception(Piwik::translate('General_ExceptionNonceMismatch'));
         }
 

--- a/core/Nonce.php
+++ b/core/Nonce.php
@@ -120,7 +120,7 @@ class Nonce
         // Validate referrer if present
         $referrer = Url::getReferrer();
         if (!empty($referrer)) {
-            // Allow the instance host by default, if no allowedReferrerHost is specified
+            // Allow the instance host by default, if no allowedReferrerHost is specified.
             if (empty($allowedReferrerHost) && !Url::isLocalUrl($referrer)) {
                 return Piwik::translate('Login_InvalidNonceReferrer', array(
                         '<a target="_blank" rel="noreferrer noopener" href="https://matomo.org/faq/how-to-install/faq_98">',
@@ -128,7 +128,7 @@ class Nonce
                     )) . $additionalErrors;
             }
 
-            // Test that referrer matches what was allowed
+            // Test that referrer matches what is allowed.
             if (!empty($allowedReferrerHost) && !self::isReferrerHostValid($referrer, $allowedReferrerHost)) {
                 return Piwik::translate('Login_InvalidNonceUnallowedReferrer') . $additionalErrors;
             }

--- a/core/Nonce.php
+++ b/core/Nonce.php
@@ -118,9 +118,9 @@ class Nonce
         // Validate referrer if present and non-local
         $referrer = Url::getReferrer();
 
-        if (!empty($referrer) && !Url::isLocalUrl($referrer)) {
+        if (!empty($referrer)) {
             // validate referrer
-            if (empty($expectedReferrerHost)) {
+            if (empty($expectedReferrerHost) && !Url::isLocalUrl($referrer)) {
                 return Piwik::translate('Login_InvalidNonceReferrer', array(
                         '<a target="_blank" rel="noreferrer noopener" href="https://matomo.org/faq/how-to-install/faq_98">',
                         '</a>'

--- a/core/Nonce.php
+++ b/core/Nonce.php
@@ -115,11 +115,10 @@ class Nonce
             return Piwik::translate('Login_InvalidNonceToken');
         }
 
-        // Validate referrer if present and non-local
+        // Validate referrer if present
         $referrer = Url::getReferrer();
-
         if (!empty($referrer)) {
-            // validate referrer
+            // Allow localhost, if no specific referrer is expected
             if (empty($expectedReferrerHost) && !Url::isLocalUrl($referrer)) {
                 return Piwik::translate('Login_InvalidNonceReferrer', array(
                         '<a target="_blank" rel="noreferrer noopener" href="https://matomo.org/faq/how-to-install/faq_98">',
@@ -127,7 +126,7 @@ class Nonce
                     )) . $additionalErrors;
             }
 
-            //referrer is different expected host
+            // Test that referrer matches what was expected
             if (!empty($expectedReferrerHost) && !self::isReferrerHostValid($referrer, $expectedReferrerHost)) {
                 return Piwik::translate('Login_InvalidNonceUnexpectedReferrer') . $additionalErrors;
             }

--- a/core/Nonce.php
+++ b/core/Nonce.php
@@ -238,7 +238,7 @@ class Nonce
         }
 
         if (!self::verifyNonce($nonceName, $nonce, $allowedReferrerHost)) {
-            throw new \Exception(Piwik::translate('General_ExceptionNonceMismatch'));
+            throw new \Exception(Piwik::translate('General_ExceptionSecurityCheckFailed'));
         }
 
         self::discardNonce($nonceName);

--- a/tests/PHPUnit/Integration/NonceTest.php
+++ b/tests/PHPUnit/Integration/NonceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration;
+
+use Piwik\Nonce;
+use Piwik\Session\SessionNamespace;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group TrackerTest
+ * @group Tracker
+ */
+class NonceTest extends IntegrationTestCase
+{
+    protected $preTestServerHttpReferrer;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $ns = new SessionNamespace(1);
+        $ns->nonce = 'abc';
+
+        $this->preTestServerHttpReferrer = $_SERVER['HTTP_REFERER'];
+    }
+
+    public function tearDown(): void
+    {
+        $this->setReferrer($this->preTestServerHttpReferrer);
+        parent::tearDown();
+    }
+
+    protected function setReferrer(string $referrer): void
+    {
+        $_SERVER['HTTP_REFERER'] = $referrer;
+    }
+
+    public function testVerifyNonceWithErrorMessage_invalidNonce_expectErrorString()
+    {
+        $this->assertSame(
+            'Login_InvalidNonceToken',
+            Nonce::verifyNonceWithErrorMessage(1, 'abcd')
+        );
+    }
+
+    public function testVerifyNonceWithErrorMessage__validNonceAndExpectedReferrerWithNoReferrer_expectEmptyString()
+    {
+        $this->assertSame(
+            '',
+            Nonce::verifyNonceWithErrorMessage(1, 'abc', 'example.com')
+        );
+    }
+
+    public function testVerifyNonceWithErrorMessage_validNonceAndExpectedReferrerWithMatchingReferrer_expectEmptyString()
+    {
+        $this->setReferrer('https://example.com');
+        $this->assertSame(
+            '',
+            Nonce::verifyNonceWithErrorMessage(1, 'abc', 'example.com')
+        );
+    }
+
+    public function testVerifyNonceWithErrorMessage_validNonceAndExpectedReferrerWithMismatchedReferrer_expectErrorString()
+    {
+        $this->setReferrer('https://example.net');
+        $this->assertSame(
+            'Login_InvalidNonceUnexpectedReferrer',
+            Nonce::verifyNonceWithErrorMessage(1, 'abc', 'example.com')
+        );
+    }
+}

--- a/tests/PHPUnit/Integration/NonceTest.php
+++ b/tests/PHPUnit/Integration/NonceTest.php
@@ -67,6 +67,15 @@ class NonceTest extends IntegrationTestCase
         );
     }
 
+    public function testVerifyNonceWithErrorMessage_validNonceAndNoExpectedReferrerWithReferrer_expectErrorString()
+    {
+        $this->setReferrer('https://example.net');
+        $this->assertSame(
+            'Login_InvalidNonceReferrer',
+            Nonce::verifyNonceWithErrorMessage(1, 'abc')
+        );
+    }
+
     public function testVerifyNonceWithErrorMessage_validNonceAndExpectedReferrerWithMismatchedReferrer_expectErrorString()
     {
         $this->setReferrer('https://example.net');

--- a/tests/PHPUnit/Integration/NonceTest.php
+++ b/tests/PHPUnit/Integration/NonceTest.php
@@ -50,7 +50,7 @@ class NonceTest extends IntegrationTestCase
         );
     }
 
-    public function testVerifyNonceWithErrorMessage__validNonceAndExpectedReferrerWithNoReferrer_expectEmptyString()
+    public function testVerifyNonceWithErrorMessage__validNonceAndAllowedReferrerWithNoReferrer_expectEmptyString()
     {
         $this->assertSame(
             '',
@@ -58,7 +58,7 @@ class NonceTest extends IntegrationTestCase
         );
     }
 
-    public function testVerifyNonceWithErrorMessage_validNonceAndExpectedReferrerWithMatchingReferrer_expectEmptyString()
+    public function testVerifyNonceWithErrorMessage_validNonceAndAllowedReferrerWithMatchingReferrer_expectEmptyString()
     {
         $this->setReferrer('https://example.com');
         $this->assertSame(
@@ -67,7 +67,7 @@ class NonceTest extends IntegrationTestCase
         );
     }
 
-    public function testVerifyNonceWithErrorMessage_validNonceAndNoExpectedReferrerWithReferrer_expectErrorString()
+    public function testVerifyNonceWithErrorMessage_validNonceAndNoAllowedReferrerWithReferrer_expectErrorString()
     {
         $this->setReferrer('https://example.net');
         $this->assertSame(
@@ -76,11 +76,20 @@ class NonceTest extends IntegrationTestCase
         );
     }
 
-    public function testVerifyNonceWithErrorMessage_validNonceAndExpectedReferrerWithMismatchedReferrer_expectErrorString()
+    public function testVerifyNonceWithErrorMessage_validNonceAndLocalReferrerWithNoAllowedReferrer_expectEmptyString()
+    {
+        $this->setReferrer('http://app'); // The "local" host when running via CLI.
+        $this->assertSame(
+            '',
+            Nonce::verifyNonceWithErrorMessage(1, 'abc')
+        );
+    }
+
+    public function testVerifyNonceWithErrorMessage_validNonceAndAllowedReferrerWithMismatchedReferrer_expectErrorString()
     {
         $this->setReferrer('https://example.net');
         $this->assertSame(
-            'Login_InvalidNonceUnexpectedReferrer',
+            'Login_InvalidNonceUnallowedReferrer',
             Nonce::verifyNonceWithErrorMessage(1, 'abc', 'example.com')
         );
     }


### PR DESCRIPTION
### Description:

if an expectedReferrerHost is passed, the nonce-check will fail, if there is no referrer. This was introduced in #17228, as a fix when using GoogleAnalyticsImporter.
While using GoogleAnalyticsImporter, we are seeing a referrer being sent by the browser, so this this will cause the check to fail, as the empty referrer doesn't match google.com.

This fix allows empty referrers again, while also doing expectedReferrerHost and/or localhost, when referrer is specified.

Tests added as integration tests.
./console tests:run --testsuite integration --filter NonceTest

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
