### PR TITLE
Prevent error in OptOutManager when language is not a string

### DIFF
--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -558,7 +558,7 @@ JS;
             }
         }
 
-        $language = Common::getRequestVar('language', '');
+        $language = Common::getRequestVar('language', '', 'string');
         $lang = APILanguagesManager::getInstance()->isLanguageAvailable($language)
             ? $language
             : LanguagesManager::getLanguageCodeForCurrentUser();


### PR DESCRIPTION
Had the other day close to 80 fatal errors from a scanner where language was not a string which resulted in an error below

> preg_match(): Argument #2 ($subject) must be of type string, array given
> Error: {"message":"preg_match(): Argument #2 ($subject) must be of type string, array given","file":"core\/Filesystem.php","line":79,"request_id":"96ae7","backtrace":" on core\/Filesystem.php(79)\n#0 core\/Filesystem.php(79): preg_match('\/(^[a-zA-Z0-9]+...', Array)\n#1 plugins\/LanguagesManager\/API.php(48): Piwik\\Filesystem::isValidFilename(Array)\n#2 plugins\/CoreAdminHome\/OptOutManager.php(560):

Example URL: `/index.php?action=optOut&backgroundColor=&fontColor=333333&fontFamily=Arial&fontSize=16px&language%5B0%5D=%3Dconvert%28int%2Csys.fn_sqlvarbasetostr%28HashBytes%28%27MD5%27%2C%271476824053%27%29%29%29and+3+in+&language%5B1%5D=3&module=CoreAdminHome`

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
