### PR TITLE
Fix for Http class header parse error

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -742,7 +742,7 @@ class Http
                 }
                 $response = '';
             } else {
-                $header = '';
+                $header = [];
                 // redirects are included in the output html, so we look for the last line that starts w/ HTTP/...
                 // to split the response
                 while (substr($response, 0, 5) == "HTTP/") {

--- a/core/Http.php
+++ b/core/Http.php
@@ -742,7 +742,7 @@ class Http
                 }
                 $response = '';
             } else {
-                $header = [];
+                $header = '';
                 // redirects are included in the output html, so we look for the last line that starts w/ HTTP/...
                 // to split the response
                 while (substr($response, 0, 5) == "HTTP/") {
@@ -752,7 +752,7 @@ class Http
                         [$header, $response] = $split;
                     } else {
                         $response = '';
-                        $header = $split;
+                        $header = reset($split);
                     }
                 }
 


### PR DESCRIPTION
### Description:

Fixes #20077

When a non-boolean response is received by the `core/Http::sendHttpRequestBy()` method and no redirect header is found the `explode()` method attempts to execute against a string instead of an array causing a fatal error.

This PR changes the default value for the header variable in this code block from string to array.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
