### PR TITLE
Speed up sparklines when larger periods are selected and improve detection of trends as well as fix comparison of dates

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -443,6 +443,7 @@
         "StatisticsAreNotRecorded": "Matomo Visitor Tracking is currently disabled! Re-enable tracking by setting record_statistics = 1 in your config/config.ini.php file.",
         "Subtotal": "Subtotal",
         "Summary": "Summary",
+        "SparklineTooltipUsedPeriod": "Each data point in the sparkline represents a %s.",
         "Table": "Table",
         "TagCloud": "Tag Cloud",
         "Tax": "Tax",

--- a/plugins/CoreVisualizations/Visualizations/Sparklines.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines.php
@@ -13,18 +13,15 @@ namespace Piwik\Plugins\CoreVisualizations\Visualizations;
 use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\DataTable;
-use Piwik\Date;
 use Piwik\Metrics;
 use Piwik\Metrics\Formatter as MetricFormatter;
-use Piwik\Period;
 use Piwik\Period\Factory;
-use Piwik\Period\Range;
 use Piwik\Plugin\Report;
 use Piwik\Plugin\ReportsProvider;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\API\Filter\DataComparisonFilter;
+use Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines\SparklinePeriodSelector;
 use Piwik\SettingsPiwik;
-use Piwik\Site;
 use Piwik\View;
 
 /**
@@ -236,8 +233,9 @@ class Sparklines extends ViewDataTable
             $comparePeriods = $data->getMetadata('comparePeriods');
             $compareDates = $data->getMetadata('compareDates');
 
-            $comparisonPeriods = $this->getComparisonPeriodObjects($comparePeriods, $compareDates);
-            $sparklineUrlParams = $this->setSparklineDatePeriodIfNeeded($sparklineUrlParams, $periodObj, $comparisonPeriods);
+            $periodSelector = new SparklinePeriodSelector($this->config);
+            $comparisonPeriods = $periodSelector->getComparisonPeriodObjects($comparePeriods, $compareDates);
+            $sparklineUrlParams = $periodSelector->setSparklineDatePeriods($sparklineUrlParams, $periodObj, $comparisonPeriods);
 
             if ($isComparing) {
                 $sparklineUrlParams['compareSegments'] = [];
@@ -326,85 +324,6 @@ class Sparklines extends ViewDataTable
                 $this->config->addSparkline($sparklineUrlParams, $metrics, $desc = null, $evolution, $order, $title = null, $group = $sparklineMetricIndex, $seriesIndices = null, $graphParams);
             }
         }
-    }
-
-    private function getComparisonPeriodObjects($comparePeriods, $compareDates)
-    {
-        $periods = [];
-        if (!empty($comparePeriods)) {
-            foreach ($comparePeriods as $periodIndex => $period) {
-                if ($periodIndex === 0) {
-                    continue; // this is the original period
-                }
-                $date = $compareDates[$periodIndex];
-                $periods[] = Factory::build($period, $date);
-            }
-        }
-        return $periods;
-    }
-
-    private function getHighestPeriodInCommon(Period $originalPeriod, $comparisonPeriods)
-    {
-        $lowestNumDaysInRange = $this->getNumDaysDifference($originalPeriod->getDateStart(), $originalPeriod->getDateEnd());
-
-        if (!empty($comparisonPeriods)) {
-            foreach ($comparisonPeriods as $period) {
-                $numDaysInRange = $this->getNumDaysDifference($period->getDateStart(), $period->getDateEnd());
-                if ($numDaysInRange < $lowestNumDaysInRange) {
-                    $lowestNumDaysInRange = $numDaysInRange;
-                }
-            }
-        }
-
-        $periodToUse = 'day';
-        if ($lowestNumDaysInRange >= 730) {
-            $periodToUse = 'month'; // rather than fetching > 730 day periods we prefer fetching 24+ months and shows trends better
-        } elseif ($lowestNumDaysInRange >= 180) {
-            $periodToUse = 'week'; // rather than fetching > 180 day periods we prefer fetching 25+ weeks making it faster and shows trends better
-        }
-        return $periodToUse;
-    }
-
-    private function setSparklineDatePeriodIfNeeded($params, Period $originalPeriod, $comparisonPeriods)
-    {
-        $isComparingDates = !empty($comparisonPeriods);
-        $highestPeriodInCommon = $this->getHighestPeriodInCommon($originalPeriod, $comparisonPeriods);
-        if ($isComparingDates) {
-            // we don't want to show last X for each of the peridos
-            // when comparing, we have to fallback to a range because different periods might be selected.
-            // when not comparing and a longer range is selected, then we select a higher period for improved
-            // performance and also to see trends better
-            // whenever possible we try to use a higher period for faster performance and to see trends better
-            $params['period'] = $highestPeriodInCommon;
-            $params['date'] = $originalPeriod->getRangeString();
-
-            $params['compareDates'] = [];
-            $params['comparePeriods'] = [];
-
-            foreach ($comparisonPeriods as $period) {
-                $params['compareDates'][] = $period->getRangeString();
-                $params['comparePeriods'][] = $params['period']; // need to ensure to use same period for both the base and the comparison period
-            }
-        } else {
-            // by default we select the last 30 days/weeks/months/years.
-            // For period range it will select the selected range with a day metric
-            $params = $this->config->getGraphParamsModified($params);
-            if ($originalPeriod->getLabel() === 'range') {
-                // when a longer range is selected, then we select a higher period for improved performance and also to see trends better
-                // eg when selecting a range of 2 years then we rather show 24 months instead of 730 day points.
-                $params['period'] = $highestPeriodInCommon;
-                $params['date'] = $originalPeriod->getRangeString();
-            }
-        }
-
-        return $params;
-    }
-
-
-    private function getNumDaysDifference(Date $date1, Date $date2)
-    {
-        $days = (abs($date1->getTimestamp() - $date2->getTimestamp())) / 60 / 60 / 24;
-        return (int) abs(round($days));
     }
 
     private function applyFilters(DataTable\DataTableInterface $table)

--- a/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
@@ -286,22 +286,7 @@ class Config extends \Piwik\ViewDataTable\Config
             $groupedMetrics[$metricGroup][] = $metricInfo;
         }
 
-        $tooltip = '';
-        if (!empty($requestParamsForSparkline['period'])) {
-            $periodTranslated = Piwik::translate('Intl_Period' . ucfirst($requestParamsForSparkline['period']));
-            $tooltip = Piwik::translate('General_SparklineTooltipUsedPeriod', $periodTranslated);
-            if (!empty($requestParamsForSparkline['date'])) {
-                $period = Period\Factory::build('day', $requestParamsForSparkline['date']);
-                $tooltip .= ' ' . Piwik::translate('General_Period') . ': ' . $period->getPrettyString() . '.';
-
-                if (!empty($requestParamsForSparkline['compareDates'])) {
-                    foreach ($requestParamsForSparkline['compareDates'] as $index => $comparisonDate) {
-                        $comparePeriod = Period\Factory::build('day', $comparisonDate);
-                        $tooltip .= ' ' . Piwik::translate('General_Period') . ' '.($index+2).': ' . $comparePeriod->getPrettyString() . '.';
-                    }
-                }
-            }
-        }
+        $tooltip = $this->generateSparklineTooltip($requestParamsForSparkline);
 
         $sparkline = array(
             'url' => $this->getUrlSparkline($requestParamsForSparkline),
@@ -336,6 +321,27 @@ class Config extends \Piwik\ViewDataTable\Config
         }
 
         $this->sparklines[] = $sparkline;
+    }
+
+    public function generateSparklineTooltip($params)
+    {
+        $tooltip = '';
+        if (!empty($params['period'])) {
+            $periodTranslated = Piwik::translate('Intl_Period' . ucfirst($params['period']));
+            $tooltip = Piwik::translate('General_SparklineTooltipUsedPeriod', $periodTranslated);
+            if (!empty($params['date'])) {
+                $period = Period\Factory::build('day', $params['date']);
+                $tooltip .= ' ' . Piwik::translate('General_Period') . ': ' . $period->getPrettyString() . '.';
+
+                if (!empty($params['compareDates'])) {
+                    foreach ($params['compareDates'] as $index => $comparisonDate) {
+                        $comparePeriod = Period\Factory::build('day', $comparisonDate);
+                        $tooltip .= ' ' . Piwik::translate('General_Period') . ' '.($index+2).': ' . $comparePeriod->getPrettyString() . '.';
+                    }
+                }
+            }
+        }
+        return $tooltip;
     }
 
     /**

--- a/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
@@ -295,7 +295,7 @@ class Config extends \Piwik\ViewDataTable\Config
         }(
 
         $tooltip = Piwik::translate('Each data point in the sparkline represents a %1$s.',
-            Piwik::translate('Intl_Period' . ucfirst($this->translations[$usedPeriod]))));
+            Piwik::translate('Intl_Period' . ucfirst($usedPeriod))));
 
         $sparkline = array(
             'url' => $this->getUrlSparkline($requestParamsForSparkline),

--- a/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
@@ -331,12 +331,12 @@ class Config extends \Piwik\ViewDataTable\Config
             $tooltip = Piwik::translate('General_SparklineTooltipUsedPeriod', $periodTranslated);
             if (!empty($params['date'])) {
                 $period = Period\Factory::build('day', $params['date']);
-                $tooltip .= ' ' . Piwik::translate('General_Period') . ': ' . $period->getPrettyString() . '.';
+                $tooltip .= ' ' . Piwik::translate('General_Period') . ': ' . $period->getLocalizedShortString() . '.';
 
                 if (!empty($params['compareDates'])) {
                     foreach ($params['compareDates'] as $index => $comparisonDate) {
                         $comparePeriod = Period\Factory::build('day', $comparisonDate);
-                        $tooltip .= ' ' . Piwik::translate('General_Period') . ' '.($index+2).': ' . $comparePeriod->getPrettyString() . '.';
+                        $tooltip .= ' ' . Piwik::translate('General_Period') . ' '.($index+2).': ' . $comparePeriod->getLocalizedShortString() . '.';
                     }
                 }
             }

--- a/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
@@ -12,7 +12,9 @@ use Piwik\Common;
 use Piwik\DataTable\Filter\CalculateEvolutionFilter;
 use Piwik\Metrics;
 use Piwik\NoAccessException;
+use Piwik\Period;
 use Piwik\Period\Range;
+use Piwik\Piwik;
 use Piwik\Site;
 use Piwik\Url;
 
@@ -284,8 +286,20 @@ class Config extends \Piwik\ViewDataTable\Config
             $groupedMetrics[$metricGroup][] = $metricInfo;
         }
 
+        $usedPeriod = 'day';
+        if (!empty($requestParamsForSparkline['period'])) {
+            $usedPeriod = !empty($requestParamsForSparkline['period']);
+            if ($usedPeriod === 'range') {
+                $usedPeriod = 'day'; // unless specified Matomo will apply this period
+            }
+        }(
+
+        $tooltip = Piwik::translate('Each data point in the sparkline represents a %1$s.',
+            Piwik::translate('Intl_Period' . ucfirst($this->translations[$usedPeriod]))));
+
         $sparkline = array(
             'url' => $this->getUrlSparkline($requestParamsForSparkline),
+            'tooltip' => $tooltip,
             'metrics' => $groupedMetrics,
             'order' => $this->getSparklineOrder($order),
             'title' => $title,

--- a/plugins/CoreVisualizations/Visualizations/Sparklines/SparklinePeriodSelector.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines/SparklinePeriodSelector.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines;
+use Piwik\Date;
+use Piwik\Period;
+use Piwik\Period\Factory;
+
+/**
+ * DataTable Visualization that derives from Sparklines.
+ */
+class SparklinePeriodSelector
+{
+    /**
+     * @var Config
+     */
+    private $config;
+
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    public function getNumDaysDifference(Date $date1, Date $date2): int
+    {
+        $days = abs($date1->getTimestamp() - $date2->getTimestamp()) / 60 / 60 / 24;
+        return (int) round($days);
+    }
+
+    public function setSparklineDatePeriods($params, Period $originalPeriod, $comparisonPeriods): array
+    {
+        $isComparingDates = !empty($comparisonPeriods);
+        $highestPeriodInCommon = $this->getHighestPeriodInCommon($originalPeriod, $comparisonPeriods);
+
+        if ($isComparingDates) {
+            // when not comparing we usually show the last30 data points from the end date. However, when comparing dates,
+            // then we don't want to do this and rather only draw the evolution of the selected range. This way you can
+            // better compare the two specific date ranges and how they change over time.
+            // Otherwise, if you were to compare for example today vs yesterday, then you would see the trends for today
+            // over last 30 days vs yesterday over the last 30 days which isn't very helpful to compare.
+            // that means when you compare month of Dec 2022 with Dec 2021, then the shown sparkline should be comparing
+            // Dec 1st 2022,Dec 31st 2022 with Dec 1st 2021,Dec31st 2021. And not show eg the last 30 months.
+
+            // we want to use the higest possible period we can for best performance and for best detecting trends
+            $params['period'] = $highestPeriodInCommon;
+            $params['date'] = $originalPeriod->getRangeString();
+
+            $params['compareDates'] = [];
+            $params['comparePeriods'] = [];
+
+            foreach ($comparisonPeriods as $period) {
+                $params['compareDates'][] = $period->getRangeString();
+                $params['comparePeriods'][] = $params['period']; // need to ensure to use same period for both the base and the comparison period
+            }
+        } else {
+            // when not comparing we select the last 30 days/weeks/months/years.
+            // For period range it will select the selected range with a day metric
+            $params = $this->config->getGraphParamsModified($params);
+            if ($originalPeriod->getLabel() === 'range') {
+                // when a longer range is selected, then we select a higher period for improved performance and also to see trends better
+                // eg when selecting a range of 2 years then we rather show 24 months instead of 730 day points.
+                $params['period'] = $highestPeriodInCommon;
+                $params['date'] = $originalPeriod->getRangeString();
+            }
+        }
+
+        return $params;
+    }
+
+    public function getComparisonPeriodObjects($comparePeriods, $compareDates): array
+    {
+        $periods = [];
+        if (!empty($comparePeriods)) {
+            foreach ($comparePeriods as $periodIndex => $period) {
+                if ($periodIndex === 0) {
+                    continue; // this is the original period and we need to skip it
+                }
+                $date = $compareDates[$periodIndex];
+                $periods[] = Factory::build($period, $date);
+            }
+        }
+        return $periods;
+    }
+
+    /**
+     * Given all the periods, determine what is the lowest period we can use. For example if someone compares
+     * a range of 2 years with a range of 2 days, then we still need to use "day" periods in the sparkline as otherwise
+     * you would not be able to compare the 2 different sparklines when they use different periods.
+     *
+     * For best performance and for better detecting trends we try to select the highest period if all the periods given
+     * allow it.
+     *
+     * @param Period $originalPeriod
+     * @param $comparisonPeriods
+     * @return string
+     */
+    public function getHighestPeriodInCommon(Period $originalPeriod, $comparisonPeriods): string
+    {
+        $lowestNumDaysInRange = $this->getNumDaysDifference($originalPeriod->getDateStart(), $originalPeriod->getDateEnd());
+
+        if (!empty($comparisonPeriods)) {
+            foreach ($comparisonPeriods as $period) {
+                $numDaysInRange = $this->getNumDaysDifference($period->getDateStart(), $period->getDateEnd());
+                if ($numDaysInRange < $lowestNumDaysInRange) {
+                    $lowestNumDaysInRange = $numDaysInRange;
+                }
+            }
+        }
+
+        $periodToUse = 'day';
+        if ($lowestNumDaysInRange >= 730) {
+            $periodToUse = 'month'; // rather than fetching > 730 day periods we prefer fetching 24+ months and shows trends better
+        } elseif ($lowestNumDaysInRange >= 180) {
+            $periodToUse = 'week'; // rather than fetching > 180 day periods we prefer fetching 25+ weeks making it faster and shows trends better
+        }
+
+        return $periodToUse;
+    }
+
+}

--- a/plugins/CoreVisualizations/Visualizations/Sparklines/SparklinePeriodSelector.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines/SparklinePeriodSelector.php
@@ -12,9 +12,6 @@ use Piwik\Date;
 use Piwik\Period;
 use Piwik\Period\Factory;
 
-/**
- * DataTable Visualization that derives from Sparklines.
- */
 class SparklinePeriodSelector
 {
     /**

--- a/plugins/CoreVisualizations/templates/macros.twig
+++ b/plugins/CoreVisualizations/templates/macros.twig
@@ -25,7 +25,9 @@
          {% if sparkline.seriesIndices|default is not empty %}data-series-indices="{{ sparkline.seriesIndices|json_encode|e('html_attr') }}"{% endif %}
          {% if sparkline.graphParams|default is not empty %}data-graph-params="{{ sparkline.graphParams|json_encode|e('html_attr') }}"{% endif %}
     >
-        <div>
+        <div
+            {% if sparkline.tooltip|default %}title="{{ sparkline.tooltip|e('html_attr') }}"{% endif %}
+        >
             {% if sparkline.title|default is not empty %}<h6 class="sparkline-title" title="{{ sparkline.title|rawSafeDecoded|e('html_attr') }}">{{ sparkline.title }}</h6>{% endif %}
             {% if sparkline.url %}{{ sparkline(sparkline.url)|raw }}{% endif %}
         </div>

--- a/plugins/CoreVisualizations/tests/Integration/Sparklines/SparklinePeriodSelectorTest.php
+++ b/plugins/CoreVisualizations/tests/Integration/Sparklines/SparklinePeriodSelectorTest.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreVisualizations\tests\Integration\Sparklines;
+
+use Piwik\Date;
+use Piwik\Period;
+use Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines\Config;
+use Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines\SparklinePeriodSelector;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group CoreVisualizations
+ * @group SparklinePeriodSelectorTest
+ * @group Plugins
+ */
+class SparklinePeriodSelectorTest extends IntegrationTestCase
+{
+    /**
+     * @var SparklinePeriodSelector
+     */
+    private $selector;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        FakeAccess::$superUser = true;
+
+        if (!Fixture::siteCreated(1)) {
+            Fixture::createWebsite('2014-01-01 00:00:00');
+        }
+
+        $this->selector = new SparklinePeriodSelector(new Config());
+    }
+
+    public function tearDown(): void
+    {
+        unset($_GET['period']);
+        unset($_GET['idSite']);
+        unset($_GET['date']);
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider getNumDaysDifferenceProvider
+     */
+    public function test_getNumDaysDifference($expected, $date1, $date2)
+    {
+        $this->assertSame($expected, $this->selector->getNumDaysDifference(Date::factory($date1), Date::factory($date2)));
+    }
+
+    public function getNumDaysDifferenceProvider()
+    {
+        return [
+            [0, '2022-02-20','2022-02-20'],
+            [0, '2022-02-20 01:02:03','2022-02-20 01:02:05'],
+            [1, '2022-02-20 01:02:03','2022-02-20 16:02:05'],
+            [1, '2022-02-20','2022-02-21'],
+            [2, '2022-02-22','2022-02-20'], // first date is later
+            [2, '2022-02-20','2022-02-22'],
+            [792, '2020-02-20','2022-04-22'],
+        ];
+    }
+
+    public function test_getComparisonPeriodObjects_whenNoPeriodsGiven()
+    {
+        $this->assertEquals([], $this->selector->getComparisonPeriodObjects(false, false));
+        $this->assertEquals([], $this->selector->getComparisonPeriodObjects([], []));
+    }
+
+    public function test_getComparisonPeriodObjects_whenOnlyOriginalPeriodGiven()
+    {
+        $this->assertEquals([], $this->selector->getComparisonPeriodObjects(['day'], ['today']));
+    }
+
+    public function test_getComparisonPeriodObjects_whenActuallyComparisonPeriodsGiven()
+    {
+        /** @var Period[] $periods */
+        $periods = $this->selector->getComparisonPeriodObjects(['day', 'week', 'month'], ['today', '2022-01-02', '2020-05-09']);
+
+        $this->assertSame('week', $periods[0]->getLabel());
+        $this->assertSame('2021-12-27,2022-01-02', $periods[0]->getRangeString());
+
+        $this->assertSame('month', $periods[1]->getLabel());
+        $this->assertSame('2020-05-01,2020-05-31', $periods[1]->getRangeString());
+    }
+
+    public function test_getHighestPeriodInCommon_noComparision()
+    {
+        $day = Period\Factory::build('day', 'today');
+        $week = Period\Factory::build('week', 'today');
+        $month = Period\Factory::build('month', 'today');
+        $year = Period\Factory::build('year', 'today');
+        $shortRange = Period\Factory::build('range', '2022-01-02,2022-02-03');
+        $mediumRange = Period\Factory::build('range', '2022-01-02,2022-10-03');
+        $largeRange = Period\Factory::build('range', '2020-10-02,2022-10-03');
+
+        $this->assertHighestPeriodInCommon('day', $day, []);
+        $this->assertHighestPeriodInCommon('day', $week, []);
+        $this->assertHighestPeriodInCommon('day', $month, []);
+        $this->assertHighestPeriodInCommon('week', $year, []);
+        $this->assertHighestPeriodInCommon('day', $shortRange, []);
+        $this->assertHighestPeriodInCommon('week', $mediumRange, []);
+        $this->assertHighestPeriodInCommon('month', $largeRange, []);
+    }
+
+    public function test_getHighestPeriodInCommon_withComparision()
+    {
+        $day = Period\Factory::build('day', 'today');
+        $week = Period\Factory::build('week', 'today');
+        $month = Period\Factory::build('month', 'today');
+        $year = Period\Factory::build('year', 'today');
+        $shortRange = Period\Factory::build('range', '2022-01-02,2022-02-03');
+        $mediumRange = Period\Factory::build('range', '2022-01-02,2022-10-03');
+        $largeRange = Period\Factory::build('range', '2020-10-02,2022-10-03');
+
+        $this->assertHighestPeriodInCommon('day', $day, [$largeRange]);
+        $this->assertHighestPeriodInCommon('day', $month, [$largeRange]);
+        $this->assertHighestPeriodInCommon('week', $year, [$largeRange]);
+        $this->assertHighestPeriodInCommon('week', $year, [$mediumRange, $year]);
+        $this->assertHighestPeriodInCommon('week', $year, [$mediumRange]);
+        $this->assertHighestPeriodInCommon('month', $largeRange, [$largeRange]);
+        $this->assertHighestPeriodInCommon('day', $largeRange, [$largeRange, $shortRange]);
+        $this->assertHighestPeriodInCommon('day', $largeRange, [$largeRange, $week]);
+    }
+
+    public function test_setSparklineDatePeriods_whenNotComparing()
+    {
+        $day = Period\Factory::build('day', '2022-05-02');
+        $week = Period\Factory::build('week', '2022-05-02');
+        $month = Period\Factory::build('month', '2022-05-02');
+        $year = Period\Factory::build('year', '2022-05-02');
+        $shortRange = Period\Factory::build('range', '2022-01-02,2022-02-03');
+        $mediumRange = Period\Factory::build('range', '2022-01-02,2022-10-03');
+        $largeRange = Period\Factory::build('range', '2020-10-02,2022-10-03');
+
+        $this->assertSetSparklineDatePeriods(['period' => 'day','date' => '2022-04-03,2022-05-02'], $day, []);
+        $this->assertSetSparklineDatePeriods(['period' => 'week','date' => '2021-10-11,2022-05-08'], $week, []);
+        $this->assertSetSparklineDatePeriods(['period' => 'month','date' => '2019-12-01,2022-05-31'], $month, []);
+        $this->assertSetSparklineDatePeriods(['period' => 'year','date' => '2013-01-01,2022-12-31'], $year, []);
+        $this->assertSetSparklineDatePeriods(['period' => 'day','date' => '2022-01-02,2022-02-03'], $shortRange, []);
+        $this->assertSetSparklineDatePeriods(['period' => 'week','date' => '2022-01-02,2022-10-03'], $mediumRange, []);
+        $this->assertSetSparklineDatePeriods(['period' => 'month','date' => '2020-10-02,2022-10-03'], $largeRange, []);
+    }
+
+    public function test_setSparklineDatePeriods_whenComparing()
+    {
+        $day = Period\Factory::build('day', '2022-05-02');
+        $dayPrevious = Period\Factory::build('day', '2022-05-01');
+        $week = Period\Factory::build('week', '2022-05-02');
+        $weekPrevious = Period\Factory::build('week', '2022-04-25');
+        $month = Period\Factory::build('month', '2022-05-02');
+        $monthPrevious = Period\Factory::build('month', '2022-04-02');
+        $year = Period\Factory::build('year', '2022-05-02');
+        $yearPrevious = Period\Factory::build('year', '2021-05-02');
+
+        $shortRange = Period\Factory::build('range', '2022-01-02,2022-02-03');
+        $shortRangePrevious = Period\Factory::build('range', '2021-12-20,2022-01-02');
+
+        $mediumRange = Period\Factory::build('range', '2022-01-02,2022-10-03');
+        $mediumRangePrevious = Period\Factory::build('range', '2021-04-02,2022-01-01');
+
+        $largeRange = Period\Factory::build('range', '2020-10-02,2022-10-03');
+        $largeRangePrevious = Period\Factory::build('range', '2018-09-02,2020-09-29');
+
+        // compare with previous
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'day','date' => '2022-05-02,2022-05-02',
+            'comparePeriods' => ['day'], 'compareDates' => ['2022-05-01,2022-05-01']
+        ], $day, [$dayPrevious]);
+
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'day','date' => $week->getRangeString(),
+            'comparePeriods' => ['day'], 'compareDates' => [$weekPrevious->getRangeString()]
+        ], $week, [$weekPrevious]);
+
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'day','date' => $month->getRangeString(),
+            'comparePeriods' => ['day'], 'compareDates' => [$monthPrevious->getRangeString()]
+        ], $month, [$monthPrevious]);
+
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'week','date' => $year->getRangeString(),
+            'comparePeriods' => ['week'], 'compareDates' => [$yearPrevious->getRangeString()]
+        ], $year, [$yearPrevious]);
+
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'day','date' => $shortRange->getRangeString(),
+            'comparePeriods' => ['day'], 'compareDates' => [$shortRangePrevious->getRangeString()]
+        ], $shortRange, [$shortRangePrevious]);
+
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'week','date' => $mediumRange->getRangeString(),
+            'comparePeriods' => ['week'], 'compareDates' => [$mediumRangePrevious->getRangeString()]
+        ], $mediumRange, [$mediumRangePrevious]);
+
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'month','date' => $largeRange->getRangeString(),
+            'comparePeriods' => ['month'], 'compareDates' => [$largeRangePrevious->getRangeString()]
+        ], $largeRange, [$largeRangePrevious]);
+
+        // MIXED LENGTH PERIODS GIVEN SHOULD USE LOWEST PERIOD IN COMMON
+
+        // largeRange would usually use period months but because there is a year it should use lower period week
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'week','date' => $year->getRangeString(),
+            'comparePeriods' => ['week'], 'compareDates' => [$largeRangePrevious->getRangeString()]
+        ], $year, [$largeRangePrevious]);
+
+        // largeRange would usually use period months but because there is a year it should use lower period week
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'week','date' => $largeRangePrevious->getRangeString(),
+            'comparePeriods' => ['week'], 'compareDates' => [$year->getRangeString()]
+        ], $largeRangePrevious, [$year]);
+
+        // largeRange would usually use period months but because there is a day it should use lower period day
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'day','date' => $day->getRangeString(),
+            'comparePeriods' => ['day'], 'compareDates' => [$largeRange->getRangeString()]
+        ], $day, [$largeRange]);
+
+        // largeRange would usually use period months but because there is a day it should use lower period day
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'day','date' => $largeRange->getRangeString(),
+            'comparePeriods' => ['day'], 'compareDates' => [$day->getRangeString()]
+        ], $largeRange, [$day]);
+
+        // USING MULTIPLE COMPARISON PERIODS
+
+        // largeRange would usually use period months but because the lowest comparison period is a day it should use lower period day
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'day','date' => $year->getRangeString(),
+            'comparePeriods' => ['day', 'day'], 'compareDates' => [$largeRangePrevious->getRangeString(), $weekPrevious->getRangeString()]
+        ], $year, [$largeRangePrevious, $weekPrevious]);
+
+        $this->assertSetSparklineDatePeriods([
+            'period' => 'week','date' => $year->getRangeString(),
+            'comparePeriods' => ['week', 'week'], 'compareDates' => [$largeRangePrevious->getRangeString(), $mediumRangePrevious->getRangeString()]
+        ], $year, [$largeRangePrevious, $mediumRangePrevious]);
+
+    }
+
+    private function assertHighestPeriodInCommon($expected, $originalPeriod, $comparePeriods)
+    {
+        $period = $this->selector->getHighestPeriodInCommon($originalPeriod, $comparePeriods);
+        $this->assertSame($expected, $period);
+    }
+
+    private function assertSetSparklineDatePeriods($expected, Period $originalPeriod, $comparisonPeriods)
+    {
+        $_GET['period'] = $originalPeriod->getLabel();
+        if ($originalPeriod->getLabel() === 'range') {
+            $_GET['date'] = $originalPeriod->getRangeString();
+        } else {
+            $_GET['date'] = $originalPeriod->getDateEnd()->toString();
+        }
+        $_GET['idSite'] = 1;
+        $period = $this->selector->setSparklineDatePeriods([], $originalPeriod, $comparisonPeriods);
+        $this->assertEquals($expected, $period);
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
+    }
+}

--- a/plugins/CoreVisualizations/tests/Integration/SparklinesConfigTest.php
+++ b/plugins/CoreVisualizations/tests/Integration/SparklinesConfigTest.php
@@ -58,7 +58,7 @@ class SparklinesConfigTest extends IntegrationTestCase
 
     public function test_generateSparklineTooltip_periodAndDate()
     {
-        $this->assertSame('Each data point in the sparkline represents a week. Period: From 2022-02-02 to 2022-05-05.', $this->config->generateSparklineTooltip(['period' => 'week', 'date' => '2022-02-02,2022-05-05']));
+        $this->assertSame('Each data point in the sparkline represents a week. Period: Feb 2 – May 5, 2022.', $this->config->generateSparklineTooltip(['period' => 'week', 'date' => '2022-02-02,2022-05-05']));
     }
 
     public function test_generateSparklineTooltip_periodAndDateAndComparison()
@@ -68,7 +68,7 @@ class SparklinesConfigTest extends IntegrationTestCase
             'comparePeriods' => ['week', 'week'], 'compareDates' => ['2021-02-02,2021-05-05', '2020-02-02,2020-05-05']
         ]);
 
-        $expected = 'Each data point in the sparkline represents a week. Period: From 2022-02-02 to 2022-05-05. Period 2: From 2021-02-02 to 2021-05-05. Period 3: From 2020-02-02 to 2020-05-05.';
+        $expected = 'Each data point in the sparkline represents a week. Period: Feb 2 – May 5, 2022. Period 2: Feb 2 – May 5, 2021. Period 3: Feb 2 – May 5, 2020.';
         $this->assertSame($expected, $tooltip);
     }
 

--- a/plugins/CoreVisualizations/tests/Integration/SparklinesConfigTest.php
+++ b/plugins/CoreVisualizations/tests/Integration/SparklinesConfigTest.php
@@ -46,6 +46,32 @@ class SparklinesConfigTest extends IntegrationTestCase
         parent::tearDown();
     }
 
+    public function test_generateSparklineTooltip_noParams()
+    {
+        $this->assertSame('', $this->config->generateSparklineTooltip([]));
+    }
+
+    public function test_generateSparklineTooltip_onlyPeriod()
+    {
+        $this->assertSame('Each data point in the sparkline represents a week.', $this->config->generateSparklineTooltip(['period' => 'week']));
+    }
+
+    public function test_generateSparklineTooltip_periodAndDate()
+    {
+        $this->assertSame('Each data point in the sparkline represents a week. Period: From 2022-02-02 to 2022-05-05.', $this->config->generateSparklineTooltip(['period' => 'week', 'date' => '2022-02-02,2022-05-05']));
+    }
+
+    public function test_generateSparklineTooltip_periodAndDateAndComparison()
+    {
+        $tooltip = $this->config->generateSparklineTooltip([
+            'period' => 'week', 'date' => '2022-02-02,2022-05-05',
+            'comparePeriods' => ['week', 'week'], 'compareDates' => ['2021-02-02,2021-05-05', '2020-02-02,2020-05-05']
+        ]);
+
+        $expected = 'Each data point in the sparkline represents a week. Period: From 2022-02-02 to 2022-05-05. Period 2: From 2021-02-02 to 2021-05-05. Period 3: From 2020-02-02 to 2020-05-05.';
+        $this->assertSame($expected, $tooltip);
+    }
+
     public function test_areSparklinesLinkable_byDefaultSparklinesAreLinkable()
     {
         $this->assertTrue($this->config->areSparklinesLinkable());

--- a/plugins/CoreVisualizations/tests/Integration/SparklinesConfigTest.php
+++ b/plugins/CoreVisualizations/tests/Integration/SparklinesConfigTest.php
@@ -89,6 +89,7 @@ class SparklinesConfigTest extends IntegrationTestCase
 
         $expectedSparkline = array(
             'url' => '?period=day&date=2012-03-06,2012-04-04&idSite=1&module=CoreHome&action=renderMe&viewDataTable=sparkline',
+            'tooltip' => 'Each data point in the sparkline represents a day. Period: Wed, Apr 4.',
             'metrics' => array (
                 '' => [
                     array ('value' => 10, 'description' => 'Visits', 'column' => ''),
@@ -185,7 +186,7 @@ class SparklinesConfigTest extends IntegrationTestCase
 
         $sparklines = $this->config->getSortedSparklines();
 
-        $this->assertSame('?columns=nb_visits&viewDataTable=sparkline&date=2012-03-06,2012-04-04', $sparklines[''][0]['url']);
+        $this->assertSame('?columns=nb_visits&viewDataTable=sparkline&date=2012-03-06,2012-04-04&period=day', $sparklines[''][0]['url']);
     }
 
     public function test_addSparkline_shouldAddSparklinesWithGroups()
@@ -200,6 +201,7 @@ class SparklinesConfigTest extends IntegrationTestCase
             'one' => [
                 [
                     'url' => '?period=day&date=2012-03-06,2012-04-04&idSite=1&module=CoreHome&action=renderMe&viewDataTable=sparkline',
+                    'tooltip' => 'Each data point in the sparkline represents a day. Period: Wed, Apr 4.',
                     'metrics' => [
                         '' => [
                             0 => [
@@ -217,6 +219,7 @@ class SparklinesConfigTest extends IntegrationTestCase
                 ],
                 [
                     'url' => '?period=day&date=2012-03-06,2012-04-04&idSite=1&module=CoreHome&action=renderMe&viewDataTable=sparkline',
+                    'tooltip' => 'Each data point in the sparkline represents a day. Period: Wed, Apr 4.',
                     'metrics' => [
                         '' => [
                             0 => [
@@ -236,6 +239,7 @@ class SparklinesConfigTest extends IntegrationTestCase
             'two' => [
                 [
                     'url' => '?period=day&date=2012-03-06,2012-04-04&idSite=1&module=CoreHome&action=renderMe&viewDataTable=sparkline',
+                    'tooltip' => 'Each data point in the sparkline represents a day. Period: Wed, Apr 4.',
                     'metrics' => [
                         '' => [
                             0 => [
@@ -253,6 +257,7 @@ class SparklinesConfigTest extends IntegrationTestCase
                 ],
                 [
                     'url' => '?period=day&date=2012-03-06,2012-04-04&idSite=1&module=CoreHome&action=renderMe&viewDataTable=sparkline',
+                    'tooltip' => 'Each data point in the sparkline represents a day. Period: Wed, Apr 4.',
                     'metrics' => [
                         '' => [
                             0 => [
@@ -305,6 +310,7 @@ class SparklinesConfigTest extends IntegrationTestCase
             '' => [
                 [
                     'url' => '?period=day&date=2012-03-06,2012-04-04&idSite=1&module=CoreHome&action=renderMe&viewDataTable=sparkline',
+                    'tooltip' => 'Each data point in the sparkline represents a day. Period: Wed, Apr 4.',
                     'metrics' => [
                         'g1' => [
                             0 => [


### PR DESCRIPTION
### Description:

* fix #20066 when selecting currently eg a date range of 2 years it can take 2 minutes to load. Instead, we select 24 months which takes 2 seconds and allows the detection of trends much better. 
  * When now selecting a range of 6+ months Matomo will plot weeks in the sparklines
  * When now selecting a range of 24+ months Matomo will plot months in the sparklines
* Fix sparklines when comparing dates. Eg when you compared year vs previous year, then Matomo would load the previous 9 years in days (3000+days) and compared it to 1 year entry. It's completely broken visually and also performance wise it takes forever to load. Now no matter what period is selected, it will behave consistently and compare the selected dates. Eg when a year is compared to previous year, then we're showing the weeks of the first year and also plot the years of the second year so you can compare both years in detail. When comparing, selecting eg the previous 30 periods and comparing them is not as useful (although it can be). 
  * --> Right now without this change comparing any date of a week, month or year is basically broken as the sparklines never load.
  * --> It now also makes the sparklines behavior consistent with the evolution graph.
* We're now showing tooltips when possible to describe what date range and period the sparkline is showing. Before this was never clear eg when a year is selected, it's not obvious if Matomo is showing the months in that period or the previous years.
* Changed the logic to have things tested and clearly defined and so the behaviour can be changed easily.
* This PR does not change anything in the evolution graph.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
