### PR TITLE
Don't force using day period for sparkline when comparing to ensure it compares correct periods and is fast

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/Sparkline.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparkline.php
@@ -37,9 +37,7 @@ class Sparkline extends ViewDataTable
         $period = Common::getRequestVar('period');
         $date = Common::getRequestVar('date');
 
-        if ($period == 'range'
-            || $this->isComparing()
-        ) {
+        if ($period == 'range') {
             $periodObj = Period\Factory::build($period, $date);
             $_GET['period'] = 'day';
             $_GET['date'] = $periodObj->getRangeString();


### PR DESCRIPTION
Since we merged https://github.com/matomo-org/matomo/pull/20090 when comparing dates we no longer need to force day periods when comparing dates since we're ensuring the correct period is being used in the Sparklines visualisation.

Deployed that PR on production and noticed the [URL](https://demo.matomo.cloud/index.php?date=2022-01-01,2022-12-31&module=API&format=html&forceView=1&viewDataTable=sparkline&action=get&idSite=1&period=week&comparePeriods[]=week&compareDates[]=2021-01-01%2C2021-12-31&segment=&widget=&showtitle=1&random=9426&columns=nb_visits&compareSegments=&colors=%7B%22backgroundColor%22%3A%22%23ffffff%22%2C%22lineColor%22%3A%5B%22%230277bd%22%2C%22%23ff8f00%22%5D%2C%22minPointColor%22%3A%22%23ff7f7f%22%2C%22maxPointColor%22%3A%22%2375bf7c%22%2C%22lastPointColor%22%3A%22%2355aaff%22%2C%22fillColor%22%3A%22%23ffffff%22%7D) looks like:

<img width="331" alt="image" src="https://user-images.githubusercontent.com/273120/206992543-c7a92874-30fc-4720-9ca6-e32228c97125.png">

Even though both periods given are week it falsely chose day for the initial period. Which not only made it compare wrong data but also got very slow (since it had to load 365 days which is slower than 52 weeks).

This PR fixes it and now looks like
<img width="243" alt="image" src="https://user-images.githubusercontent.com/273120/206993232-49dab0f2-dcd0-4e29-8cbb-982c4a5232f9.png">



### Description:

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
