### PR TITLE
Retry establishing DB connection if it fails with MySQL Server Has Gone Away

### DIFF
--- a/core/Updater/Migration/Db.php
+++ b/core/Updater/Migration/Db.php
@@ -87,4 +87,9 @@ abstract class Db extends Migration
      */
     const ERROR_CODE_MAX_EXECUTION_TIME_EXCEEDED_SORT_ABORTED = 1028;
 
+    /**
+     * MySQL server has gone away
+     */
+    const ERROR_CODE_MYSQL_SERVER_HAS_GONE_AWAY = 2006;
+
 }


### PR DESCRIPTION
### Description:

On production, around 1 in say 10 million requests we have an issue that the MySQL DB connection fails with "MySQL Server has gone away" error. 

We've spend many days trying to find root cause and what's happening going down to network layers etc but there doesn't really seem any solution. All MySQL settings etc are in a good place.

Generally, the solution is to retry the connection when it fails. Below patch we've been running on production for some time and it solves the problem that when on establishing the connection we get such an error, that we retry establishing the connection once.

We still have such [MySQL gone away](https://matomo.org/faq/troubleshooting/faq_183/) errors in other places but this is a start to fix the ones visible in the UI and we'll later may provide few other patches.

The error we're getting was for example:

> SQLSTATE[HY000]: General error: 2006 MySQL server has gone away : #0 core/Db/Adapter/Pdo/Mysql.php(109): PDO->exec('SET sql_mode = ...')

See CLOUD-1094 for more details.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
