### PR TITLE
Trying to improve the accuracy of the isToday method

### DIFF
--- a/core/Date.php
+++ b/core/Date.php
@@ -563,7 +563,10 @@ class Date
      */
     public function isToday()
     {
-        return $this->toString('Y-m-d') === Date::factory('today', $this->timezone)->toString('Y-m-d');
+        $timeZone = new \DateTimeZone($this->timezone);
+        $today = (new \DateTime('today', $timeZone))->format('Y-m-d');
+        $time = (new \DateTime(gmdate(self::DATE_TIME_FORMAT, $this->timestamp), $timeZone))->format('Y-m-d');
+        return $time === $today;
     }
 
     /**

--- a/tests/PHPUnit/Unit/DateTest.php
+++ b/tests/PHPUnit/Unit/DateTest.php
@@ -11,6 +11,7 @@ namespace Piwik\Tests\Unit;
 use Exception;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
+use Piwik\Period\Factory;
 use Piwik\SettingsServer;
 use Piwik\Tests\Framework\Fixture;
 
@@ -438,6 +439,72 @@ class DateTest extends \PHPUnit\Framework\TestCase
 
         $date = Date::factoryInTimezone($dateString, $timezone);
         $this->assertEquals($expectedDatetime, $date->getDatetime());
+    }
+
+    /**
+     * @dataProvider getTestDataForIsTodayTest
+     */
+    public function test_isToday($tzString, $dateString, $isToday)
+    {
+        $date = new \DateTime($dateString, (new \DateTimeZone($tzString)));
+        $period = Factory::build('day', $date->format('Y-m-d'));
+        $periodDate = $period->getDateEnd()->setTimezone($tzString);
+        $this->assertSame($isToday, $periodDate->isToday());
+        $this->assertSame($isToday, $periodDate->getStartOfDay()->isToday());
+        $this->assertSame($isToday, $periodDate->getEndOfDay()->isToday());
+    }
+
+    public function getTestDataForIsTodayTest()
+    {
+        $timeZones = [
+            'Pacific/Midway',
+            'Pacific/Honolulu',
+            'America/Anchorage',
+            'America/Los_Angeles',
+            'America/Denver',
+            'America/Chicago',
+            'America/New_York',
+            'America/Toronto',
+            'America/Puerto_Rico',
+            'America/Sao_Paulo',
+            'America/Noronha',
+            'Atlantic/Azores',
+            'Europe/London',
+            'UTC',
+            'Europe/Berlin',
+            'Europe/Kiev',
+            'Europe/Moscow',
+            'Asia/Dubai',
+            'Asia/Karachi',
+            'Asia/Dhaka',
+            'Asia/Bangkok',
+            'Asia/Shanghai',
+            'Asia/Tokyo',
+            'Australia/Sydney',
+            'Pacific/Efate',
+            'Pacific/Auckland',
+            'Pacific/Apia',
+            'Pacific/Kiritimati',
+        ];
+        $dates = [
+            ['today', true],
+            ['now', true],
+            ['yesterday', false],
+            ['tomorrow', false],
+            ['-5 Days', false],
+            ['+5 Days', false],
+            ['-1 Months', false],
+            ['+1 Months', false],
+            ['-1 Years', false],
+            ['+1 Years', false],
+        ];
+        $data = [];
+        foreach ($timeZones as $tz) {
+            foreach ($dates as $date) {
+                $data[] = array_merge([$tz], $date);
+            }
+        }
+        return $data;
     }
 
     public function getTestDataForFactoryInTimezone()


### PR DESCRIPTION
### Description:

Thomas noticed that the `Date->isToday()` method was producing inconsistent results when dealing with multiple time zones. This is an effort to improve that accuracy.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
