### PR TITLE
Remove outdated misleading comment

### DIFF
--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -587,11 +587,6 @@ class Model
         $db->query(sprintf('UPDATE `%s` SET %s WHERE `login` = ?', $this->userTable, implode(', ', $set)), $bind);
     }
 
-    /**
-     * Note that this returns the token_auth which is as private as the password!
-     *
-     * @return array[] containing login, email and token_auth
-     */
     public function getUsersHavingSuperUserAccess()
     {
         $db = $this->getDb();


### PR DESCRIPTION
### Description:

The getUsersHavingSuperUserAccess() method was updated in  #15410 and token_auth was removed  from the return array, but its annotation was not altered.

Since no sensitive information is returned any more I believe it's enough to remove the note instead of updating it.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed

None of the above points apply.