### PR TITLE
Fix failing ArchiveCron test

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -778,7 +778,7 @@ class ArchiveInvalidator
     private function getSegmentArchiving()
     {
         if (empty($this->segmentArchiving)) {
-            $this->segmentArchiving = new SegmentArchiving(StaticContainer::get('ini.General.process_new_segments_from'));
+            $this->segmentArchiving = new SegmentArchiving();
         }
         return $this->segmentArchiving;
     }

--- a/plugins/CoreConsole/tests/System/ArchiveCronTest.php
+++ b/plugins/CoreConsole/tests/System/ArchiveCronTest.php
@@ -466,7 +466,8 @@ class ArchiveCronTest extends SystemTestCase
             'Tests.log.allowAllHandlers' => true,
 
             CronArchive\SegmentArchiving::class => \DI\object()
-                ->constructorParameter('beginningOfTimeLastNInYears', 10)
+                // Oldest reports are for 2012, so ensure segments are processed for that year
+                ->constructorParameter('beginningOfTimeLastNInYears', date('Y')-2012)
         );
     }
 

--- a/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
+++ b/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
@@ -63,7 +63,7 @@ class QueueConsumerTest extends IntegrationTestCase
             3,
             24,
             new Model(),
-            new SegmentArchiving('beginning_of_time'),
+            new SegmentArchiving(),
             $cronArchive,
             new RequestParser(true),
             $archiveFilter
@@ -167,7 +167,7 @@ class QueueConsumerTest extends IntegrationTestCase
             3,
             24,
             new Model(),
-            new SegmentArchiving('beginning_of_time'),
+            new SegmentArchiving(),
             $cronArchive,
             new RequestParser(true),
             $archiveFilter
@@ -525,7 +525,7 @@ class QueueConsumerTest extends IntegrationTestCase
             3,
             24,
             new Model(),
-            new SegmentArchiving('beginning_of_time'),
+            new SegmentArchiving(),
             $cronArchive,
             new RequestParser(true),
             $archiveFilter
@@ -606,7 +606,7 @@ class QueueConsumerTest extends IntegrationTestCase
             3,
             24,
             new Model(),
-            new SegmentArchiving('beginning_of_time'),
+            new SegmentArchiving(),
             $cronArchive,
             new RequestParser(true),
             $archiveFilter
@@ -738,7 +738,7 @@ class QueueConsumerTest extends IntegrationTestCase
             3,
             24,
             new Model(),
-            new SegmentArchiving('beginning_of_time'),
+            new SegmentArchiving(),
             $cronArchive,
             new RequestParser(true),
             $archiveFilter
@@ -875,7 +875,7 @@ class QueueConsumerTest extends IntegrationTestCase
             3,
             24,
             new Model(),
-            new SegmentArchiving('beginning_of_time'),
+            new SegmentArchiving(),
             $cronArchive,
             new RequestParser(true),
             $archiveFilter
@@ -914,7 +914,7 @@ class QueueConsumerTest extends IntegrationTestCase
             3,
             24,
             new Model(),
-            new SegmentArchiving('beginning_of_time'),
+            new SegmentArchiving(),
             $cronArchive,
             new RequestParser(true),
             $archiveFilter
@@ -953,7 +953,7 @@ class QueueConsumerTest extends IntegrationTestCase
             3,
             24,
             new Model(),
-            new SegmentArchiving('beginning_of_time'),
+            new SegmentArchiving(),
             $cronArchive,
             new RequestParser(true),
             $archiveFilter
@@ -999,7 +999,7 @@ class QueueConsumerTest extends IntegrationTestCase
             3,
             24,
             new Model(),
-            new SegmentArchiving('beginning_of_time'),
+            new SegmentArchiving(),
             $cronArchive,
             new RequestParser(true),
             $archiveFilter
@@ -1228,7 +1228,7 @@ class QueueConsumerTest extends IntegrationTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        return new QueueConsumer(new NullLogger(), null, null, null, new Model(), new SegmentArchiving(null), $mockCronArchive, $cliRequestProcessor);
+        return new QueueConsumer(new NullLogger(), null, null, null, new Model(), new SegmentArchiving(), $mockCronArchive, $cliRequestProcessor);
     }
 
     protected static function configureFixture($fixture)


### PR DESCRIPTION
### Description:

Starting 2023 one of the tests started to fail. The problem is, that the segments were not archived anymore for the year the tests are using. Adjusting the archiving parameter fixed that.

While looking for the reason of the failure, I also found a few places where an incorrect constructor parameter was provided for `SegmentArchiving`. It expects as first parameter the number of years it should process new segments for when processing them from beginning of time.
Seem that used to be the value of the configuration for from when to processes segments. 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
