### PR TITLE
Fix for PHP 8.2 deprecation warnings in datatable filters

### DIFF
--- a/core/Archive/DataCollection.php
+++ b/core/Archive/DataCollection.php
@@ -96,6 +96,8 @@ class DataCollection
      */
     private $periods;
 
+    private $segment;
+
     /**
      * Constructor.
      *
@@ -143,11 +145,11 @@ class DataCollection
      * Set data for a specific site & period. If there is no data for the given site ID & period,
      * it is set to the default row.
      *
-     * @param int $idSite
-     * @param string $period eg, '2012-01-01,2012-01-31'
-     * @param string $name eg 'nb_visits'
-     * @param string $value eg 5
-     * @param array  $meta Optional metadata to add to the row
+     * @param int           $idSite
+     * @param string        $period eg, '2012-01-01,2012-01-31'
+     * @param string        $name   eg 'nb_visits'
+     * @param string        $value  eg 5
+     * @param array|null    $meta   Optional metadata to add to the row
      */
     public function set($idSite, $period, $name, $value, array $meta = null)
     {

--- a/core/DataTable/Filter/AddColumnsProcessedMetricsGoal.php
+++ b/core/DataTable/Filter/AddColumnsProcessedMetricsGoal.php
@@ -102,6 +102,21 @@ class AddColumnsProcessedMetricsGoal extends AddColumnsProcessedMetrics
     const GOALS_FULL_TABLE = 0;
 
     /**
+     * @var string
+     */
+    private $processOnlyIdGoal;
+
+    /**
+     * @var bool
+     */
+    private $isEcommerce;
+
+    /**
+     * @var mixed|null
+     */
+    private $goalsToProcess;
+
+    /**
      * Constructor.
      *
      * @param DataTable $table The table that will eventually filtered.

--- a/core/DataTable/Filter/AddSegmentByRangeLabel.php
+++ b/core/DataTable/Filter/AddSegmentByRangeLabel.php
@@ -25,6 +25,7 @@ class AddSegmentByRangeLabel extends BaseFilter
 {
     private $segments;
     private $delimiter;
+    private $segment;
 
     /**
      * Generates a segment filter based on the label column and the given segment name

--- a/core/DataTable/Filter/AddSummaryRow.php
+++ b/core/DataTable/Filter/AddSummaryRow.php
@@ -26,6 +26,12 @@ use Piwik\DataTable\Row\DataTableSummaryRow;
  */
 class AddSummaryRow extends BaseFilter
 {
+
+    /**
+     * @var int
+     */
+    private $labelSummaryRow;
+
     /**
      * Constructor.
      *

--- a/core/DataTable/Filter/ColumnCallbackDeleteRow.php
+++ b/core/DataTable/Filter/ColumnCallbackDeleteRow.php
@@ -27,6 +27,7 @@ class ColumnCallbackDeleteRow extends BaseFilter
 {
     private $function;
     private $functionParams;
+    private $columnsToFilter;
 
     /**
      * Constructor.
@@ -39,7 +40,7 @@ class ColumnCallbackDeleteRow extends BaseFilter
      * @param array $functionParams deprecated - use an [anonymous function](http://php.net/manual/en/functions.anonymous.php)
      *                              instead.
      */
-    public function __construct($table, $columnsToFilter, $function, $functionParams = array())
+    public function __construct($table, $columnsToFilter, $function, $functionParams = [])
     {
         parent::__construct($table);
 

--- a/core/DataTable/Filter/ExcludeLowPopulation.php
+++ b/core/DataTable/Filter/ExcludeLowPopulation.php
@@ -44,6 +44,8 @@ class ExcludeLowPopulation extends BaseFilter
      */
     private $minimumValue;
 
+    private $columnToFilter;
+
     /**
      * Constructor.
      *

--- a/core/DataTable/Filter/Limit.php
+++ b/core/DataTable/Filter/Limit.php
@@ -23,6 +23,22 @@ use Piwik\DataTable\BaseFilter;
  */
 class Limit extends BaseFilter
 {
+
+    /**
+     * @var int
+     */
+    public $offset;
+
+    /**
+     * @var int
+     */
+    public $limit;
+
+    /**
+     * @var bool
+     */
+    public $keepSummaryRow;
+
     /**
      * Constructor.
      *

--- a/core/DataTable/Filter/PivotByDimension.php
+++ b/core/DataTable/Filter/PivotByDimension.php
@@ -405,7 +405,7 @@ class PivotByDimension extends BaseFilter
     }
 
     /**
-     * @param $columnRow
+     * @param Row $columnRow
      * @param $pivotColumn
      * @return false|mixed
      */

--- a/core/DataTable/Filter/RangeCheck.php
+++ b/core/DataTable/Filter/RangeCheck.php
@@ -21,6 +21,11 @@ class RangeCheck extends BaseFilter
     public static $maximumValue = 100.0;
 
     /**
+     * @var string
+     */
+    private $columnToFilter;
+
+    /**
      * @param DataTable $table
      * @param string $columnToFilter name of the column to filter
      * @param float $minimumValue minimum value for range

--- a/core/DataTable/Filter/ReplaceSummaryRowLabel.php
+++ b/core/DataTable/Filter/ReplaceSummaryRowLabel.php
@@ -29,6 +29,12 @@ use Piwik\Piwik;
  */
 class ReplaceSummaryRowLabel extends BaseFilter
 {
+
+    /**
+     * @var string|null
+     */
+    private $newLabel;
+
     /**
      * Constructor.
      *

--- a/core/DataTable/Filter/SafeDecodeLabel.php
+++ b/core/DataTable/Filter/SafeDecodeLabel.php
@@ -34,7 +34,7 @@ class SafeDecodeLabel extends BaseFilter
      * Decodes the given value
      *
      * @param string $value
-     * @return mixed|string
+     * @return string
      */
     public static function decodeLabelSafe($value)
     {

--- a/core/DataTable/Filter/Truncate.php
+++ b/core/DataTable/Filter/Truncate.php
@@ -33,6 +33,28 @@ use Piwik\Piwik;
  */
 class Truncate extends BaseFilter
 {
+
+    /**
+     * @var int
+     */
+    private $truncateAfter;
+
+    /**
+     * @var string|null
+     */
+    private $labelSummaryRow;
+
+    /**
+     * @var string|null
+     */
+    private $columnToSortByBeforeTruncating;
+
+    /**
+     * @var bool
+     */
+    private $filterRecursive;
+
+
     /**
      * Constructor.
      *


### PR DESCRIPTION
### Description:

Fixes #20182 

Added declarations for all dynamically accessed properties on filter classes.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
