### PR TITLE
Discard campaign values if they are provided as arrays

### DIFF
--- a/plugins/Referrers/Columns/Base.php
+++ b/plugins/Referrers/Columns/Base.php
@@ -376,7 +376,11 @@ abstract class Base extends VisitDimension
     protected function detectCampaignFromString($string)
     {
         foreach ($this->campaignNames as $campaignNameParameter) {
-            $campaignName = trim(urldecode(UrlHelper::getParameterFromQueryString($string, $campaignNameParameter) ?? ''));
+            $campaignName = UrlHelper::getParameterFromQueryString($string, $campaignNameParameter);
+            if (!is_string($campaignName)) {
+                continue; // discard value if it was not provided or as an array
+            }
+            $campaignName = trim(urldecode($campaignName));
             if (!empty($campaignName)) {
                 break;
             }
@@ -390,8 +394,12 @@ abstract class Base extends VisitDimension
 
         foreach ($this->campaignKeywords as $campaignKeywordParameter) {
             $campaignKeyword = UrlHelper::getParameterFromQueryString($string, $campaignKeywordParameter);
+            if (!is_string($campaignKeyword)) {
+                continue; // discard value if it was not provided or as an array
+            }
+            $campaignKeyword = trim(urldecode($campaignKeyword));
             if (!empty($campaignKeyword)) {
-                $this->keywordReferrerAnalyzed = trim(urldecode($campaignKeyword));
+                $this->keywordReferrerAnalyzed = $campaignKeyword;
                 break;
             }
         }

--- a/plugins/Referrers/tests/Integration/Columns/ReferrerTypeTest.php
+++ b/plugins/Referrers/tests/Integration/Columns/ReferrerTypeTest.php
@@ -113,6 +113,9 @@ class ReferrerTypeTest extends IntegrationTestCase
             [Common::REFERRER_TYPE_CAMPAIGN,     $this->idSite2, $url . '?pk_campaign=test', $referrer],
             [Common::REFERRER_TYPE_CAMPAIGN,     $this->idSite3, $url . '?pk_campaign=test', $referrer],
 
+            // campaign parameters provided as array should simply be ignored (and not produce an error)
+            [Common::REFERRER_TYPE_DIRECT_ENTRY,     $this->idSite1, $url . '?pk_campaign[]=test', $referrer],
+
             [Common::REFERRER_TYPE_SEARCH_ENGINE, $this->idSite3, $url, 'http://google.com/search?q=piwik'],
 
             [Common::REFERRER_TYPE_SOCIAL_NETWORK, $this->idSite3, $url, 'https://twitter.com/matomo_org'],


### PR DESCRIPTION
### Description:

If campaign parameters are provided as arrays in the URL, that might currently let the tracking fail.
As arrays should be unexpected in that case, I guess simply ignoring such values should be a suitable solution.

fixes #20189

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
