### PR TITLE
Ensure error message screen is shown instead of safemode when a regular error happens while rendering a view

### DIFF
--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -181,8 +181,14 @@ class FrontController extends Singleton
              */
             Piwik::postEvent('User.isNotAuthorized', array($exception), $pending = true);
         } catch (\Twig\Error\RuntimeError $e) {
-            echo $this->generateSafeModeOutputFromException($e);
-            exit;
+            if ($e->getPrevious() && !$e->getPrevious() instanceof \Twig\Error\RuntimeError) {
+                // a regular exception unrelated to twig was triggered while rendering an a view, for example as part of a triggered event
+                // we want to ensure to show the regular error message response instead of the safemode as it's likely wrong user input
+                throw $e;
+            } else {
+                echo $this->generateSafeModeOutputFromException($e);
+                exit;
+            }
         } catch(StylesheetLessCompileException $e) {
             echo $this->generateSafeModeOutputFromException($e);
             exit;

--- a/tests/UI/expected-screenshots/UIIntegrationTest_view_render_error_user_input.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_view_render_error_user_input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85bcb31c09f82578a1c101c79e53e224e55b4b2b4409f3d406922c6b10f88bcd
+size 174072

--- a/tests/UI/expected-screenshots/UIIntegrationTest_view_render_error_user_input.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_view_render_error_user_input.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85bcb31c09f82578a1c101c79e53e224e55b4b2b4409f3d406922c6b10f88bcd
-size 174072
+oid sha256:2ddffa4f256dd55e38ed5febdd63c25255d7dcddd836c5f6cdee6aa23e9aaa7c
+size 48911

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -201,6 +201,12 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             expect(await page.screenshot({ fullPage: true })).to.matchImage('fatal_error_safemode');
         });
 
+        it('should the error page instead of safemode when error while rendering view is not a twig error', async function() {
+
+            await page.goto("?" + generalParams + "&module=Widgetize&action=iframe&moduleToWidgetize=Dashboard&actionToWidgetize=index&segment=userid%3D%3D35745");
+            expect(await page.screenshot({ fullPage: true })).to.matchImage('view_render_error_user_input');
+        });
+
         // not logged in
         it('should show login form for non super user if invalid idsite given', async function() {
             testEnvironment.testUseMockAuth = 0;


### PR DESCRIPTION
This can be reproduced via a URL like `/index.php?&module=Widgetize&action=iframe&moduleToWidgetize=Dashboard&actionToWidgetize=index&idSite=2&period=week&date=yesterday&updated=2`

Currently, on Cloud would see a screen like below while on On-Premise they would see a similar ["safemode" screenshot](https://github.com/matomo-org/matomo/blob/4.x-dev/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png)
<img width="689" alt="image" src="https://user-images.githubusercontent.com/273120/212392232-6b7f2131-328a-4da3-97a8-531d4c7a8da7.png">

As in above case it is a user input error, and not a twig error, we should still show the regular exception error like below: 
<img width="967" alt="image" src="https://user-images.githubusercontent.com/273120/212392550-397bf8f4-900c-4217-b91f-9f6b1800bb62.png">

This way, the Cloud team also won't be emailed every time there is a wrong user input and the user will know what needs changing.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
