### PR TITLE
Fix possible error in timezone handling

### DIFF
--- a/core/Date.php
+++ b/core/Date.php
@@ -1172,9 +1172,13 @@ class Date
         try {
             $timeZone = new \DateTimeZone($tzString);
         } catch (\Throwable $th) {
-            // Check if this is one of the UTF-5, UTF-3, ... timezones that we allow. If so, try using the GMT offset
+            // Check if this is one of the UTC-5, UTC-3, ... timezones that we allow. If so, try using the GMT offset
             if (preg_match('/^UTC\b(\+|\-)\d+$/i', $tzString)) {
-                $timeZone =  self::getDateTimeZone('Etc/GMT' . substr($tzString, 3), false);
+                try {
+                    $timeZone = self::getDateTimeZone('Etc/GMT' . substr($tzString, 3), false);
+                } catch (\Throwable $th) {
+                    // Note some Etc/GMT timezones are invalid in newer timezone dbs so we need to ignore possible errors
+                }
             }
         }
 

--- a/tests/PHPUnit/Unit/DateTest.php
+++ b/tests/PHPUnit/Unit/DateTest.php
@@ -621,6 +621,11 @@ class DateTest extends \PHPUnit\Framework\TestCase
      */
     public function test_getDateTimeZone($tzString, $alternate = '')
     {
+        $availableTimezones = \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC);
+        if (!in_array($alternate, $availableTimezones)) {
+            self::markTestSkipped("Alternate timezone $alternate not available in used timezone db.");
+            return;
+        }
         $timeZone = Date::getDateTimeZone($tzString);
         $this->assertIsObject($timeZone);
         $this->assertSame($alternate ?: $tzString, $timeZone->getName());


### PR DESCRIPTION
### Description:

In newer version of PHP some of the `Etc/GMT` timezones are no longer supported (See https://3v4l.org/djVJb). We therefor should also catch possible errors when trying to use those instead.

I've also added a check in the tests to skip tests on PHP versions, that don't support certain fallbacks anymore.

follow up to #20203

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
