### PR TITLE
Serialize DeviceDetector and cache it using LazyCache

### DIFF
--- a/core/DeviceDetector/SerializableDeviceDetector.php
+++ b/core/DeviceDetector/SerializableDeviceDetector.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Piwik\DeviceDetector;
+
+use DeviceDetector\ClientHints;
+use DeviceDetector\DeviceDetector;
+
+class SerializableDeviceDetector extends DeviceDetector
+{
+    public function __construct(DeviceDetector $detector, string $userAgent = '', ?ClientHints $clientHints = null)
+    {
+        parent::__construct($userAgent, $clientHints);
+
+        $this->clientHints = $detector->clientHints;
+        $this->bot = $detector->bot;
+        $this->client = $detector->client;
+        $this->device = $detector->device;
+        $this->os = $detector->os;
+        $this->brand = $detector->brand;
+        $this->model = $detector->model;
+    }
+}


### PR DESCRIPTION
The issue is that the constructor DeviceDetector is really really slow, as it is reading and compiling a lot of regular expressions from a yaml file every time a new instance is created. This is done on almost every tracking request. There is already an in-memory cache, but as each tracking requests starts with a new in-memory cache, this isn't really useful. The DeviceDetector itself has a cache, which prevents evaluating the regular expressions against a user agent string, but it looks like a lot of regular expressions still get compiled.

This shaves off 50% of time per tracking request, getting us from 400req/s to 700req/s or from above 150ms to below 100ms. We're using redis as a cache.

Response time for the tracker:
![20230117-171159](https://user-images.githubusercontent.com/6551584/212952139-a60c97c4-07d9-4e27-ae40-b566656c1aab.png)

Number of requests per second for the tracker:
![20230117-171214](https://user-images.githubusercontent.com/6551584/212952174-1fe399a4-3293-4ba3-bd39-2e2b28391559.png)

I guess it is clear that the change was applied at 16:50.


I don't know much php, so this solution is most certainly a dirty hack, but maybe someone can work with this and improve on the solution.

A better solution would probably be:
  * decouple the `DeviceDetector` from the detection result
  * cache only the detection result in redis
 
But that would mean breaking changes in the `DeviceDetector` library which were out of scope of my "hack".

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
