### PR TITLE
Always warn about unprocessed segments even if no data exists

### DIFF
--- a/plugins/SegmentEditor/SegmentEditor.php
+++ b/plugins/SegmentEditor/SegmentEditor.php
@@ -257,19 +257,6 @@ class SegmentEditor extends \Piwik\Plugin
             return null;
         }
 
-        $idSites = Site::getIdSitesFromIdSitesString($idSite);
-
-        if (strpos($date, ',') !== false) { // if getting multiple periods, check the whole range for visits
-            $periodStr = 'range';
-        }
-
-        // if no visits recorded, data will not appear, so don't show the message
-        $liveModel = new \Piwik\Plugins\Live\Model();
-        $visits = $liveModel->queryLogVisits($idSites, $periodStr, $date, $segment->getString(), $offset = 0, $limit = 1, null, null, 'ASC');
-        if (empty($visits)) {
-            return null;
-        }
-
         // check if requested segment is segment to preprocess
         $isSegmentToPreprocess = Rules::isSegmentPreProcessed([$idSite], $segment);
 

--- a/plugins/SegmentEditor/tests/System/expected/test___VisitsSummary.get_autoArchiveSegmentNoDataPreprocessed.xml
+++ b/plugins/SegmentEditor/tests/System/expected/test___VisitsSummary.get_autoArchiveSegmentNoDataPreprocessed.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_uniq_visitors>0</nb_uniq_visitors>
-	<nb_users>0</nb_users>
-	<nb_visits>0</nb_visits>
-	<nb_actions>0</nb_actions>
-	<nb_visits_converted>0</nb_visits_converted>
-	<bounce_count>0</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>0</max_actions>
-	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>0</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<error message="These reports have no data, because the Segment you requested (testsegment) has not yet been processed by the system. Data for this Segment should become available in a few hours when processing completes. (If it does not, there may be a problem.) Please note that you can test whether your segment will work without having to wait for it to be processed by using the Live.getLastVisitsDetails API. When using this API method, you will see which users and actions were matched by your &amp;segment= parameter. This can help you confirm your Segment matches the users and actions you expect it to." />
 </result>

--- a/plugins/SegmentEditor/tests/System/expected/test___VisitsSummary.get_noLogDataSegmentUnprocessed.xml
+++ b/plugins/SegmentEditor/tests/System/expected/test___VisitsSummary.get_noLogDataSegmentUnprocessed.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_uniq_visitors>0</nb_uniq_visitors>
-	<nb_users>0</nb_users>
-	<nb_visits>0</nb_visits>
-	<nb_actions>0</nb_actions>
-	<nb_visits_converted>0</nb_visits_converted>
-	<bounce_count>0</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>0</max_actions>
-	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>0</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<error message="These reports have no data, because the Segment you requested (testsegment) has not yet been processed by the system. Data for this Segment should become available in a few hours when processing completes. (If it does not, there may be a problem.) Please note that you can test whether your segment will work without having to wait for it to be processed by using the Live.getLastVisitsDetails API. When using this API method, you will see which users and actions were matched by your &amp;segment= parameter. This can help you confirm your Segment matches the users and actions you expect it to." />
 </result>


### PR DESCRIPTION
### Description:

Fixes #20060 

When displaying a newly created segment that has not yet been archived, a check is performed to see if there are any visits that match the segment criteria and selected period, if there are no matching visits then the normal 'no data' report is displayed and the unprocessed segment message is not shown.

This results in inconsistent behavior as the same unprocessed segment may show as unprocessed or not depending on the period selected.

This PR removes the check so that the unprocessed segment message will always be shown when viewing a new segment that has not yet been processed irrespective of whether data exists or not.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
