### PR TITLE
Reverting isToday method changes

### DIFF
--- a/core/Date.php
+++ b/core/Date.php
@@ -563,10 +563,7 @@ class Date
      */
     public function isToday()
     {
-        $timeZone = Date::getDateTimeZone($this->timezone);
-        $today = (new \DateTime('today', $timeZone))->format('Y-m-d');
-        $time = (new \DateTime(gmdate(self::DATE_TIME_FORMAT, $this->timestamp), $timeZone))->format('Y-m-d');
-        return $time === $today;
+        return $this->toString('Y-m-d') === Date::factory('today', $this->timezone)->toString('Y-m-d');
     }
 
     /**
@@ -1155,33 +1152,5 @@ class Date
     public static function getNowTimestamp()
     {
         return isset(self::$now) ? self::$now : time();
-    }
-
-    /**
-     * Generate a DateTimeZone object using a timezone string. It should be a valid PHP timezone or a UTF offset string.
-     *
-     * @param string $tzString String to use while instantiating the DateTimeZone object.
-     * @param bool $defaultBadTzToUtc If an error occurs while instantiating, should we default to a UTC object or null.
-     * The default is true so that we return a UTC DateTimeZone object.
-     * @return \DateTimeZone|null This should always be a DateTimeZone object unless the tzString is invalid and
-     * defaultBadTzToUtc is set to false.
-     */
-    public static function getDateTimeZone(string $tzString = 'UTC', bool $defaultBadTzToUtc = true):?\DateTimeZone
-    {
-        $timeZone = null;
-        try {
-            $timeZone = new \DateTimeZone($tzString);
-        } catch (\Throwable $th) {
-            // Check if this is one of the UTF-5, UTF-3, ... timezones that we allow. If so, try using the GMT offset
-            if (preg_match('/^UTC\b(\+|\-)\d+$/i', $tzString)) {
-                $timeZone =  self::getDateTimeZone('Etc/GMT' . substr($tzString, 3), false);
-            }
-        }
-
-        if ($timeZone === null && $defaultBadTzToUtc) {
-            $timeZone = new \DateTimeZone('UTC');
-        }
-
-        return $timeZone;
     }
 }

--- a/tests/PHPUnit/Unit/DateTest.php
+++ b/tests/PHPUnit/Unit/DateTest.php
@@ -444,76 +444,70 @@ class DateTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider getTestDataForIsTodayTest
      */
-    public function test_isToday($tzString, $dateString, $isToday)
-    {
-        $date = new \DateTime($dateString, Date::getDateTimeZone($tzString));
-        $period = Factory::build('day', $date->format('Y-m-d'));
-        $periodDate = $period->getDateEnd()->setTimezone($tzString);
-        $this->assertSame($isToday, $periodDate->isToday());
-        $this->assertSame($isToday, $periodDate->getStartOfDay()->isToday());
-        $this->assertSame($isToday, $periodDate->getEndOfDay()->isToday());
-    }
+    // Commenting this out for now otherwise there would always be failing tests due to inaccuracies in the isToday method
+//    public function test_isToday($tzString, $dateString, $isToday)
+//    {
+//        $date = new \DateTime($dateString, (new \DateTimeZone($tzString)));
+//        $period = Factory::build('day', $date->format('Y-m-d'));
+//        $periodDate = $period->getDateEnd()->setTimezone($tzString);
+//        $isTodayString = $isToday ? 'true' : 'false';
+//        $this->assertSame($isToday, $periodDate->isToday(), "For {$dateString} {$tzString}, isToday should be {$isTodayString}.");
+//        $this->assertSame($isToday, $periodDate->getStartOfDay()->isToday(), "The start of day {$dateString} {$tzString}, isToday should be {$isTodayString}.");
+//        $this->assertSame($isToday, $periodDate->getEndOfDay()->isToday(), "The end of day {$dateString} {$tzString}, isToday should be {$isTodayString}.");
+//    }
 
-    public function getTestDataForIsTodayTest()
-    {
-        $timeZones = [
-            'Pacific/Midway',
-            'Pacific/Honolulu',
-            'America/Anchorage',
-            'America/Los_Angeles',
-            'America/Denver',
-            'America/Chicago',
-            'America/New_York',
-            'America/Toronto',
-            'America/Puerto_Rico',
-            'America/Sao_Paulo',
-            'America/Noronha',
-            'Atlantic/Azores',
-            'Europe/London',
-            'UTC',
-            'Europe/Berlin',
-            'Europe/Kiev',
-            'Europe/Moscow',
-            'Asia/Dubai',
-            'Asia/Karachi',
-            'Asia/Dhaka',
-            'Asia/Bangkok',
-            'Asia/Shanghai',
-            'Asia/Tokyo',
-            'Australia/Sydney',
-            'Pacific/Efate',
-            'Pacific/Auckland',
-            'Pacific/Apia',
-            'Pacific/Kiritimati',
-            'UTC-1',
-            'UTC-5',
-            'UTC-8',
-            'UTC-12',
-            'UTC+1',
-            'UTC+5',
-            'UTC+8',
-            'UTC+12',
-        ];
-        $dates = [
-            ['today', true],
-            ['now', true],
-            ['yesterday', false],
-            ['tomorrow', false],
-            ['-5 Days', false],
-            ['+5 Days', false],
-            ['-1 Months', false],
-            ['+1 Months', false],
-            ['-1 Years', false],
-            ['+1 Years', false],
-        ];
-        $data = [];
-        foreach ($timeZones as $tz) {
-            foreach ($dates as $date) {
-                $data[] = array_merge([$tz], $date);
-            }
-        }
-        return $data;
-    }
+//    public function getTestDataForIsTodayTest()
+//    {
+//        $timeZones = [
+//            'Pacific/Midway',
+//            'Pacific/Honolulu',
+//            'America/Anchorage',
+//            'America/Los_Angeles',
+//            'America/Denver',
+//            'America/Chicago',
+//            'America/New_York',
+//            'America/Toronto',
+//            'America/Puerto_Rico',
+//            'America/Sao_Paulo',
+//            'America/Noronha',
+//            'Atlantic/Azores',
+//            'Europe/London',
+//            'UTC',
+//            'Europe/Berlin',
+//            'Europe/Kiev',
+//            'Europe/Moscow',
+//            'Asia/Dubai',
+//            'Asia/Karachi',
+//            'Asia/Dhaka',
+//            'Asia/Bangkok',
+//            'Asia/Shanghai',
+//            'Asia/Tokyo',
+//            'Australia/Sydney',
+//            'Pacific/Efate',
+//            'Pacific/Auckland',
+//            'Pacific/Apia',
+//            'Pacific/Kiritimati',
+//        ];
+//        $dates = [
+//            ['today', true],
+//            ['now', true],
+//            ['yesterday', false],
+//            ['tomorrow', false],
+//            ['-5 Days', false],
+//            ['+5 Days', false],
+//            ['-1 Months', false],
+//            ['+1 Months', false],
+//            ['-1 Years', false],
+//            ['+1 Years', false],
+//        ];
+//        $data = [];
+//        foreach ($timeZones as $tz) {
+//            foreach ($dates as $date) {
+//                $data[] = array_merge([$tz], $date);
+//            }
+//        }
+//        return $data;
+//    }
 
     public function getTestDataForFactoryInTimezone()
     {
@@ -594,77 +588,5 @@ class DateTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Date::factoryInTimezone() should not be used with');
 
         Date::factoryInTimezone(time(), 'America/Toronto');
-    }
-
-    public function test_getDateTimeZone_default()
-    {
-        $timeZone = Date::getDateTimeZone();
-        $this->assertIsObject($timeZone);
-        $this->assertSame('UTC', $timeZone->getName());
-    }
-
-    public function test_getDateTimeZone_badString()
-    {
-        $timeZone = Date::getDateTimeZone('Meh');
-        $this->assertIsObject($timeZone);
-        $this->assertSame('UTC', $timeZone->getName());
-    }
-
-    public function test_getDateTimeZone_badStringNoDefault()
-    {
-        $timeZone = Date::getDateTimeZone('Meh', false);
-        $this->assertNull($timeZone);
-    }
-
-    /**
-     * @dataProvider getTestDataForGetDateTimeZoneTest
-     */
-    public function test_getDateTimeZone($tzString, $alternate = '')
-    {
-        $timeZone = Date::getDateTimeZone($tzString);
-        $this->assertIsObject($timeZone);
-        $this->assertSame($alternate ?: $tzString, $timeZone->getName());
-    }
-
-    public function getTestDataForGetDateTimeZoneTest()
-    {
-        return [
-            ['Pacific/Midway'],
-            ['Pacific/Honolulu'],
-            ['America/Anchorage'],
-            ['America/Los_Angeles'],
-            ['America/Denver'],
-            ['America/Chicago'],
-            ['America/New_York'],
-            ['America/Toronto'],
-            ['America/Puerto_Rico'],
-            ['America/Sao_Paulo'],
-            ['America/Noronha'],
-            ['Atlantic/Azores'],
-            ['Europe/London'],
-            ['UTC'],
-            ['Europe/Berlin'],
-            ['Europe/Kiev'],
-            ['Europe/Moscow'],
-            ['Asia/Dubai'],
-            ['Asia/Karachi'],
-            ['Asia/Dhaka'],
-            ['Asia/Bangkok'],
-            ['Asia/Shanghai'],
-            ['Asia/Tokyo'],
-            ['Australia/Sydney'],
-            ['Pacific/Efate'],
-            ['Pacific/Auckland'],
-            ['Pacific/Apia'],
-            ['Pacific/Kiritimati'],
-            ['UTC-1', 'Etc/GMT-1'],
-            ['UTC-5', 'Etc/GMT-5'],
-            ['UTC-8', 'Etc/GMT-8'],
-            ['UTC-12', 'Etc/GMT-12'],
-            ['UTC+1', 'Etc/GMT+1'],
-            ['UTC+5', 'Etc/GMT+5'],
-            ['UTC+8', 'Etc/GMT+8'],
-            ['UTC+12', 'Etc/GMT+12'],
-        ];
     }
 }

--- a/tests/PHPUnit/Unit/DateTest.php
+++ b/tests/PHPUnit/Unit/DateTest.php
@@ -11,7 +11,6 @@ namespace Piwik\Tests\Unit;
 use Exception;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
-use Piwik\Period\Factory;
 use Piwik\SettingsServer;
 use Piwik\Tests\Framework\Fixture;
 

--- a/tests/PHPUnit/Unit/DateTest.php
+++ b/tests/PHPUnit/Unit/DateTest.php
@@ -11,6 +11,7 @@ namespace Piwik\Tests\Unit;
 use Exception;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
+use Piwik\Period\Factory;
 use Piwik\SettingsServer;
 use Piwik\Tests\Framework\Fixture;
 
@@ -439,74 +440,6 @@ class DateTest extends \PHPUnit\Framework\TestCase
         $date = Date::factoryInTimezone($dateString, $timezone);
         $this->assertEquals($expectedDatetime, $date->getDatetime());
     }
-
-    /**
-     * @dataProvider getTestDataForIsTodayTest
-     */
-    // Commenting this out for now otherwise there would always be failing tests due to inaccuracies in the isToday method
-//    public function test_isToday($tzString, $dateString, $isToday)
-//    {
-//        $date = new \DateTime($dateString, (new \DateTimeZone($tzString)));
-//        $period = Factory::build('day', $date->format('Y-m-d'));
-//        $periodDate = $period->getDateEnd()->setTimezone($tzString);
-//        $isTodayString = $isToday ? 'true' : 'false';
-//        $this->assertSame($isToday, $periodDate->isToday(), "For {$dateString} {$tzString}, isToday should be {$isTodayString}.");
-//        $this->assertSame($isToday, $periodDate->getStartOfDay()->isToday(), "The start of day {$dateString} {$tzString}, isToday should be {$isTodayString}.");
-//        $this->assertSame($isToday, $periodDate->getEndOfDay()->isToday(), "The end of day {$dateString} {$tzString}, isToday should be {$isTodayString}.");
-//    }
-
-//    public function getTestDataForIsTodayTest()
-//    {
-//        $timeZones = [
-//            'Pacific/Midway',
-//            'Pacific/Honolulu',
-//            'America/Anchorage',
-//            'America/Los_Angeles',
-//            'America/Denver',
-//            'America/Chicago',
-//            'America/New_York',
-//            'America/Toronto',
-//            'America/Puerto_Rico',
-//            'America/Sao_Paulo',
-//            'America/Noronha',
-//            'Atlantic/Azores',
-//            'Europe/London',
-//            'UTC',
-//            'Europe/Berlin',
-//            'Europe/Kiev',
-//            'Europe/Moscow',
-//            'Asia/Dubai',
-//            'Asia/Karachi',
-//            'Asia/Dhaka',
-//            'Asia/Bangkok',
-//            'Asia/Shanghai',
-//            'Asia/Tokyo',
-//            'Australia/Sydney',
-//            'Pacific/Efate',
-//            'Pacific/Auckland',
-//            'Pacific/Apia',
-//            'Pacific/Kiritimati',
-//        ];
-//        $dates = [
-//            ['today', true],
-//            ['now', true],
-//            ['yesterday', false],
-//            ['tomorrow', false],
-//            ['-5 Days', false],
-//            ['+5 Days', false],
-//            ['-1 Months', false],
-//            ['+1 Months', false],
-//            ['-1 Years', false],
-//            ['+1 Years', false],
-//        ];
-//        $data = [];
-//        foreach ($timeZones as $tz) {
-//            foreach ($dates as $date) {
-//                $data[] = array_merge([$tz], $date);
-//            }
-//        }
-//        return $data;
-//    }
 
     public function getTestDataForFactoryInTimezone()
     {


### PR DESCRIPTION
### Description:

Due to the need to continue to support UTC +/- # timezones, we are reverting the accuracy improvement to the isToday method for the time being.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
