### PR TITLE
E_ALL implied E_NOTICE, hence remove the latter

### DIFF
--- a/core/bootstrap.php
+++ b/core/bootstrap.php
@@ -14,7 +14,7 @@ if (!defined('PIWIK_USER_PATH')) {
     define('PIWIK_USER_PATH', PIWIK_DOCUMENT_ROOT);
 }
 
-error_reporting(E_ALL | E_NOTICE);
+error_reporting(E_ALL);
 @ini_set('display_errors', defined('PIWIK_DISPLAY_ERRORS') ? PIWIK_DISPLAY_ERRORS : @ini_get('display_errors'));
 @ini_set('xdebug.show_exception_trace', 0);
 


### PR DESCRIPTION
### Description:

Matomo enforces the error level, setting `E_ALL` and `E_NOTICE`. Since the first implies the second, the second is redundant. For reference: For reference: https://www.php.net/manual/en/errorfunc.configuration.php#ini.error-reporting

I can imagine that it was wanted to NOT show `E_NOTICE` logs, but for this the syntax is wrong and should then be:
```php
error_reporting(E_ALL & ~E_NOTICE);
```
For reference: https://www.php.net/manual/en/function.error-reporting.php#refsect1-function.error-reporting-examples

Also, I do not understand the real reason for this. It took me an hour to find out why I see deprecation warnings (testing PHP 8.2) even that I disabled them in `php.ini`. Is there any specific reason why Matomo enforces full error logging?

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
