### PR TITLE
Making millisecond dimension grouping less error prone

### DIFF
--- a/core/Columns/Dimension.php
+++ b/core/Columns/Dimension.php
@@ -424,7 +424,7 @@ abstract class Dimension
                     $message = Piwik::translate('General_ValidatorErrorNotANumber') . ' ' . $value;
                     StaticContainer::get(LoggerInterface::class)->warning($message, ['value' => $value, 'idSite' => $idSite]);
                 }
-                return floatval(number_format(floatval($value) / 1000, 2, '.', '')) * 1000; // because we divide we need to group them and cannot do this in formatting step
+                return number_format(floatval($value) / 1000, 2, '.', '') * 1000; // because we divide we need to group them and cannot do this in formatting step
         }
         return $value;
     }

--- a/core/Columns/Dimension.php
+++ b/core/Columns/Dimension.php
@@ -8,7 +8,6 @@
  */
 namespace Piwik\Columns;
 use Piwik\Common;
-use Piwik\Container\StaticContainer;
 use Piwik\Db;
 use Piwik\Piwik;
 use Piwik\Plugin;
@@ -20,7 +19,6 @@ use Piwik\Cache as PiwikCache;
 use Piwik\Plugin\Manager as PluginManager;
 use Piwik\Metrics\Formatter;
 use Piwik\Segment\SegmentsList;
-use Psr\Log\LoggerInterface;
 
 /**
  * @api

--- a/core/Columns/Dimension.php
+++ b/core/Columns/Dimension.php
@@ -424,7 +424,7 @@ abstract class Dimension
                     $message = Piwik::translate('General_ValidatorErrorNotANumber') . ' ' . $value;
                     StaticContainer::get(LoggerInterface::class)->warning($message, ['value' => $value, 'idSite' => $idSite]);
                 }
-                return floatval(number_format(floatval($value) / 1000, 2)) * 1000; // because we divide we need to group them and cannot do this in formatting step
+                return floatval(number_format(floatval($value) / 1000, 2, '.', '')) * 1000; // because we divide we need to group them and cannot do this in formatting step
         }
         return $value;
     }

--- a/core/Columns/Dimension.php
+++ b/core/Columns/Dimension.php
@@ -419,12 +419,7 @@ abstract class Dimension
             case Dimension::TYPE_BOOL:
                 return !empty($value) ? '1' : '0';
             case Dimension::TYPE_DURATION_MS:
-                // Log a warning if the value isn't actually numeric
-                if (!is_numeric($value)) {
-                    $message = Piwik::translate('General_ValidatorErrorNotANumber') . ' ' . $value;
-                    StaticContainer::get(LoggerInterface::class)->warning($message, ['value' => $value, 'idSite' => $idSite]);
-                }
-                return number_format(floatval($value) / 1000, 2, '.', '') * 1000; // because we divide we need to group them and cannot do this in formatting step
+                return round($value / 1000, 2) * 1000; // because we divide we need to group them and cannot do this in formatting step
         }
         return $value;
     }

--- a/core/Columns/Dimension.php
+++ b/core/Columns/Dimension.php
@@ -424,7 +424,7 @@ abstract class Dimension
                     $message = Piwik::translate('General_ValidatorErrorNotANumber') . ' ' . $value;
                     StaticContainer::get(LoggerInterface::class)->warning($message, ['value' => $value, 'idSite' => $idSite]);
                 }
-                return number_format(floatval($value) / 1000, 2) * 1000; // because we divide we need to group them and cannot do this in formatting step
+                return floatval(number_format(floatval($value) / 1000, 2)) * 1000; // because we divide we need to group them and cannot do this in formatting step
         }
         return $value;
     }

--- a/tests/PHPUnit/Integration/Columns/DimensionTest.php
+++ b/tests/PHPUnit/Integration/Columns/DimensionTest.php
@@ -447,4 +447,40 @@ class ColumnDimensionTest extends IntegrationTestCase
             $this->assertFalse(class_exists($removedDimension), "Dimension marked as removed but still exist: $removedDimension");
         }
     }
+
+    public function test_groupValue()
+    {
+        $this->dimension->setType(Dimension::TYPE_DURATION_MS);
+        $this->assertSame(800.0, $this->dimension->groupValue(800, 1));
+    }
+
+    public function test_groupValue_stringValue()
+    {
+        $this->dimension->setType(Dimension::TYPE_DURATION_MS);
+        $this->assertSame(800.0, $this->dimension->groupValue('800', 1));
+    }
+
+    public function test_groupValue_largerValue()
+    {
+        $this->dimension->setType(Dimension::TYPE_DURATION_MS);
+        $this->assertSame(80000000.0, $this->dimension->groupValue(80000000, 1));
+    }
+
+    public function test_groupValue_largerStringValue()
+    {
+        $this->dimension->setType(Dimension::TYPE_DURATION_MS);
+        $this->assertSame(80000000.0, $this->dimension->groupValue('80000000', 1));
+    }
+
+    public function test_groupValue_largerValueWithDecimal()
+    {
+        $this->dimension->setType(Dimension::TYPE_DURATION_MS);
+        $this->assertSame(80000000.0, $this->dimension->groupValue(80000000.123, 1));
+    }
+
+    public function test_groupValue_largerStringValueWithDecimal()
+    {
+        $this->dimension->setType(Dimension::TYPE_DURATION_MS);
+        $this->assertSame(80000000.0, $this->dimension->groupValue('80000000.123', 1));
+    }
 }

--- a/tests/PHPUnit/Integration/Columns/DimensionTest.php
+++ b/tests/PHPUnit/Integration/Columns/DimensionTest.php
@@ -12,7 +12,6 @@ namespace Piwik\Tests\Integration\Columns;
 
 use Piwik\Columns\Dimension;
 use Piwik\Columns\DimensionSegmentFactory;
-use Piwik\Container\StaticContainer;
 use Piwik\Plugin\Segment;
 use Piwik\Metrics\Formatter;
 use Piwik\Plugin\Dimension\ActionDimension;
@@ -21,9 +20,7 @@ use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugin\Manager;
 use Piwik\Segment\SegmentsList;
 use Piwik\Tests\Framework\Fixture;
-use Piwik\Tests\Framework\Mock\FakeLogger;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
-use Psr\Log\LoggerInterface;
 
 class CustomDimensionTest extends Dimension
 {
@@ -96,9 +93,6 @@ class ColumnDimensionTest extends IntegrationTestCase
         Manager::getInstance()->doNotLoadAlwaysActivatedPlugins();
 
         $this->dimension = new CustomDimensionTest();
-
-        // Set a fake logger on the container so that we can check when something is logged.
-        StaticContainer::getContainer()->set(LoggerInterface::class, new FakeLogger());
     }
 
     public function tearDown(): void
@@ -458,53 +452,35 @@ class ColumnDimensionTest extends IntegrationTestCase
     {
         $this->dimension->setType(Dimension::TYPE_DURATION_MS);
         $this->assertSame(800.0, $this->dimension->groupValue(800, 1));
-        $fakeLogger = StaticContainer::get(LoggerInterface::class);
-        $this->assertInstanceOf(FakeLogger::class, $fakeLogger);
-        $this->assertEmpty($fakeLogger->output);
     }
 
     public function test_groupValue_stringValue()
     {
         $this->dimension->setType(Dimension::TYPE_DURATION_MS);
         $this->assertSame(800.0, $this->dimension->groupValue('800', 1));
-        $fakeLogger = StaticContainer::get(LoggerInterface::class);
-        $this->assertInstanceOf(FakeLogger::class, $fakeLogger);
-        $this->assertEmpty($fakeLogger->output);
     }
 
     public function test_groupValue_largerValue()
     {
         $this->dimension->setType(Dimension::TYPE_DURATION_MS);
         $this->assertSame(80000000.0, $this->dimension->groupValue(80000000, 1));
-        $fakeLogger = StaticContainer::get(LoggerInterface::class);
-        $this->assertInstanceOf(FakeLogger::class, $fakeLogger);
-        $this->assertEmpty($fakeLogger->output);
     }
 
     public function test_groupValue_largerStringValue()
     {
         $this->dimension->setType(Dimension::TYPE_DURATION_MS);
         $this->assertSame(80000000.0, $this->dimension->groupValue('80000000', 1));
-        $fakeLogger = StaticContainer::get(LoggerInterface::class);
-        $this->assertInstanceOf(FakeLogger::class, $fakeLogger);
-        $this->assertEmpty($fakeLogger->output);
     }
 
     public function test_groupValue_largerValueWithDecimal()
     {
         $this->dimension->setType(Dimension::TYPE_DURATION_MS);
         $this->assertSame(80000000.0, $this->dimension->groupValue(80000000.123, 1));
-        $fakeLogger = StaticContainer::get(LoggerInterface::class);
-        $this->assertInstanceOf(FakeLogger::class, $fakeLogger);
-        $this->assertEmpty($fakeLogger->output);
     }
 
     public function test_groupValue_largerStringValueWithDecimal()
     {
         $this->dimension->setType(Dimension::TYPE_DURATION_MS);
         $this->assertSame(80000000.0, $this->dimension->groupValue('80000000.123', 1));
-        $fakeLogger = StaticContainer::get(LoggerInterface::class);
-        $this->assertInstanceOf(FakeLogger::class, $fakeLogger);
-        $this->assertEmpty($fakeLogger->output);
     }
 }

--- a/tests/PHPUnit/Integration/Columns/DimensionTest.php
+++ b/tests/PHPUnit/Integration/Columns/DimensionTest.php
@@ -507,24 +507,4 @@ class ColumnDimensionTest extends IntegrationTestCase
         $this->assertInstanceOf(FakeLogger::class, $fakeLogger);
         $this->assertEmpty($fakeLogger->output);
     }
-
-    public function test_groupValue_nonNumeric()
-    {
-        $this->dimension->setType(Dimension::TYPE_DURATION_MS);
-        $this->assertSame(0.0, $this->dimension->groupValue('abc123', 1));
-        $fakeLogger = StaticContainer::get(LoggerInterface::class);
-        $this->assertInstanceOf(FakeLogger::class, $fakeLogger);
-        $this->assertNotEmpty($fakeLogger->output);
-        $this->assertStringContainsString('abc123', $fakeLogger->output);
-    }
-
-    public function test_groupValue_partialNumeric()
-    {
-        $this->dimension->setType(Dimension::TYPE_DURATION_MS);
-        $this->assertSame(120.0, $this->dimension->groupValue('123abc', 1));
-        $fakeLogger = StaticContainer::get(LoggerInterface::class);
-        $this->assertInstanceOf(FakeLogger::class, $fakeLogger);
-        $this->assertNotEmpty($fakeLogger->output);
-        $this->assertStringContainsString('123abc', $fakeLogger->output);
-    }
 }


### PR DESCRIPTION
### Description:

Some customers were occasionally seeing errors from millisecond dimensions being grouped. This checks if the value is numeric and casts it as a float. If the value isn't numeric, a warning is logged.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
