### PR TITLE
Prevent MySQL error has gone away error during tracking

### DIFF
--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -124,7 +124,12 @@ class Mysql extends Db
         }
     }
 
-    private function isMysqlServerHasGoneAwayError(Exception $e)
+    /**
+     * @internal  tests only
+     * @param Exception $e
+     * @return bool
+     */
+    public function isMysqlServerHasGoneAwayError(Exception $e)
     {
         return $this->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_MYSQL_SERVER_HAS_GONE_AWAY)
                 || stripos($e->getMessage(), 'MySQL server has gone away') !== false;
@@ -217,9 +222,8 @@ class Mysql extends Db
         try {
             return $this->executeQuery($query, $parameters);
         } catch (Exception $e) {
-            $queryLowerCase = mb_strtolower(trim($query));
-            $isSelectQuery = str_starts_with($queryLowerCase, 'select ');
-            $isUpdateQuery = str_starts_with($queryLowerCase, 'update ');
+            $isSelectQuery = stripos(trim($query), 'select ') === 0;
+            $isUpdateQuery = stripos(trim($query), 'update ') === 0;
 
             if (($isSelectQuery || $isUpdateQuery)
                 && !$this->activeTransaction
@@ -238,7 +242,12 @@ class Mysql extends Db
         }
     }
 
-    private function reconnect(Exception $e)
+    /**
+     * @internal for tests only
+     * @param Exception $e
+     * @throws Exception
+     */
+    public function reconnect(Exception $e)
     {
         $this->disconnect();
         usleep(100 * 1000); // wait for 100ms

--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -26,8 +26,8 @@ class Mysql extends Db
      */
     protected $connection = null;
     protected $dsn;
-    protected $username;
-    protected $password;
+    private $username;
+    private $password;
     protected $charset;
 
     protected $mysqlOptions = array();
@@ -110,13 +110,11 @@ class Mysql extends Db
         try {
             $this->establishConnection();
         } catch (Exception $e) {
-            if ($this->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_MYSQL_SERVER_HAS_GONE_AWAY)) {
+            if ($this->isMysqlServerHasGoneAwayError($e)) {
                 // mysql may return a MySQL server has gone away error when trying to establish the connection.
                 // in that case we want to retry establishing the connection once after a short sleep
-                usleep(400 * 1000);
-                $this->establishConnection();
+                $this->reconnect($e);
             } else {
-                $this->resetPassword();
                 throw $e;
             }
         }
@@ -124,6 +122,12 @@ class Mysql extends Db
         if (self::$profiling && isset($timer)) {
             $this->recordQueryProfile('connect', $timer);
         }
+    }
+
+    private function isMysqlServerHasGoneAwayError(Exception $e)
+    {
+        return $this->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_MYSQL_SERVER_HAS_GONE_AWAY)
+                || stripos($e->getMessage(), 'MySQL server has gone away') !== false;
     }
 
     /**
@@ -210,6 +214,53 @@ class Mysql extends Db
      */
     public function query($query, $parameters = array())
     {
+        try {
+            return $this->executeQuery($query, $parameters);
+        } catch (Exception $e) {
+            $queryLowerCase = mb_strtolower(trim($query));
+            $isSelectQuery = str_starts_with($queryLowerCase, 'select ');
+            $isUpdateQuery = str_starts_with($queryLowerCase, 'update ');
+
+            if (($isSelectQuery || $isUpdateQuery)
+                && !$this->activeTransaction
+                && $this->isMysqlServerHasGoneAwayError($e)) {
+                // mysql may return a MySQL server has gone away error when trying to execute the query
+                // in that case we want to retry establishing the connection once after a short sleep
+                // we're only retrying SELECT and UPDATE queries to prevent inserting records twice for some reason
+                // when transactions are used, then we just want it to fail as we'd be only writing partial data
+                $this->reconnect($e);
+                return $this->executeQuery($query, $parameters);
+            } else {
+                $message = $e->getMessage() . " In query: $query Parameters: " . var_export($parameters, true);
+                throw new DbException("Error query: " . $message, (int) $e->getCode());
+            }
+
+        }
+    }
+
+    private function reconnect(Exception $e)
+    {
+        $this->disconnect();
+        usleep(100 * 1000); // wait for 100ms
+        try {
+            $this->establishConnection();
+        } catch (Exception $exceptionReconnect) {
+            // forward the original exception so we get a better stack trace of where this error happens
+            // and what happened originally
+            throw $e;
+        }
+    }
+
+    /**
+     * Executes a query, using optional bound parameters.
+     *
+     * @param string $query Query
+     * @param array|string $parameters Parameters to bind array('idsite'=> 1)
+     * @return PDOStatement|bool  PDOStatement or false if failed
+     * @throws DbException if an exception occurred
+     */
+    private function executeQuery($query, $parameters = array())
+    {
         if (is_null($this->connection)) {
             return false;
         }
@@ -279,7 +330,20 @@ class Mysql extends Db
             return;
         }
 
-        if ($this->connection->beginTransaction()) {
+        try {
+            $success = $this->connection->beginTransaction();
+        } catch (Exception $e) {
+            if ($this->isMysqlServerHasGoneAwayError($e)) {
+                // mysql may return a MySQL server has gone away error when trying begin transaction, in that case we
+                // want to retry this once
+                $this->reconnect($e);
+                $success = $this->connection->beginTransaction();
+            } else {
+                throw $e;
+            }
+        }
+
+        if ($success) {
             $this->activeTransaction = uniqid();
             return $this->activeTransaction;
         }
@@ -339,14 +403,7 @@ class Mysql extends Db
             $sql = "SET NAMES '".$this->charset."'";
             $this->connection->exec($sql);
         }
-
-        $this->resetPassword();
     }
 
-    private function resetPassword()
-    {
 
-        // we delete the password from this object "just in case" it could be printed
-        $this->password = '';
-    }
 }

--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -223,14 +223,13 @@ class Mysql extends Db
             return $this->executeQuery($query, $parameters);
         } catch (Exception $e) {
             $isSelectQuery = stripos(trim($query), 'select ') === 0;
-            $isUpdateQuery = stripos(trim($query), 'update ') === 0;
 
-            if (($isSelectQuery || $isUpdateQuery)
+            if ($isSelectQuery
                 && !$this->activeTransaction
                 && $this->isMysqlServerHasGoneAwayError($e)) {
                 // mysql may return a MySQL server has gone away error when trying to execute the query
                 // in that case we want to retry establishing the connection once after a short sleep
-                // we're only retrying SELECT and UPDATE queries to prevent inserting records twice for some reason
+                // we're only retrying SELECT queries to prevent updating or inserting records twice for some reason
                 // when transactions are used, then we just want it to fail as we'd be only writing partial data
                 $this->reconnect($e);
                 return $this->executeQuery($query, $parameters);

--- a/tests/PHPUnit/Integration/Tracker/Db/Pdo/MySqlTest.php
+++ b/tests/PHPUnit/Integration/Tracker/Db/Pdo/MySqlTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Tracker\Db\Pdo;
+
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Tracker\Db\Pdo\Mysql;
+use Piwik\Config;
+use Exception;
+
+class MySqlTest extends IntegrationTestCase
+{
+    /**
+     * @var Mysql
+     */
+    private $mysql;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $configDb = Config::getInstance()->database;
+        $this->mysql = new Mysql($configDb);
+    }
+
+
+    public function test_isMysqlServerHasGoneAwayError()
+    {
+        $this->assertFalse($this->mysql->isMysqlServerHasGoneAwayError(new Exception('fff')));
+        $this->assertFalse($this->mysql->isMysqlServerHasGoneAwayError(new Exception('[1234] Duplicate Entry')));
+        $this->assertTrue($this->mysql->isMysqlServerHasGoneAwayError(new Exception('[2006] foo')));
+        $this->assertTrue($this->mysql->isMysqlServerHasGoneAwayError(new Exception('SQLSTATE[HY000]: General error: 2006 MySQL server has gone away')));
+    }
+
+    public function test_reconnect_wontFail()
+    {
+        $e = new Exception('fff');
+        $this->assertNull($this->mysql->reconnect($e));
+    }
+}


### PR DESCRIPTION
### Description:

This fixed Cloud-1178 and follows up from https://github.com/matomo-org/matomo/pull/20110

After deploying https://github.com/matomo-org/matomo/pull/20110 we noticed we're already getting less MySQL gone away errors during tracking but were still getting 50-100 per day. This change here reduced it down to around 5 per day and is now basically only still happening for inserts.

Inserts we didn't want to retry to prevent the double execution of a query. Thought to rather not insert than double insert.

This change will now also re-establish the DB connection when:
* there is any kind of select query
* there is any kind of update query
* we try to begin a transaction

It reduces the MySQL Server has gone away errors by 95%.

We don't want these changes in the regular PDO adapter as there would be issues during archiving segments etc.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
