### PR TITLE
Different escape strategy for login when accepting invite

### DIFF
--- a/plugins/Login/templates/invitation.twig
+++ b/plugins/Login/templates/invitation.twig
@@ -17,10 +17,10 @@
                 {% endif %}
                 {% block content %}
                     <form method="post" action="{{ linkTo({'module': loginPlugin, 'action': 'acceptInvitation', 'token': null}) }}">
-                        <input type="hidden" name="token" value="{{ token }}"/>
+                        <input type="hidden" name="token" value="{{ token|e('html_attr') }}"/>
                         <div class="row">
                             <div class="col s12 input-field">
-                                <input type="text" name="login" value="{{ user.login }}" size="20" readonly
+                                <input type="text" name="login" value="{{ user.login|e('html_attr') }}" size="20" readonly
                                        tabindex="0"/>
                                 <label><i class="icon-user icon"></i> {{ 'Login_LoginOrEmail'|translate }}</label>
                             </div>


### PR DESCRIPTION
### Description:

By default, this shouldn't be a problem. However, `disable_checks_usernames_attributes` can be enabled and then all kind of characters are allowed that could maybe cause issue when not using the correct strategy maybe.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
