### PR TITLE
Also unset link token when accepting an invite

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -604,6 +604,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                     [
                         'password'          => $password,
                         'invite_token'      => null,
+                        'invite_link_token' => null,
                         'invite_accept_at'  => Date::now()->getDatetime(),
                         'invite_expired_at' => null,
                     ]


### PR DESCRIPTION
### Description:

Figured this could maybe cause some potential bugs in the future as we almost used something like `$isPendingUser = invite_token is not null or invite_link_token is not null` to check if a user is pending invite. One could assume that if the link token is still set, that the invite is still pending when in reality it isn't and might be better to simply unset it? If not, feel free to close this PR. No problem.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
