### PR TITLE
Show email on invite acceptation screen instead of login

### DIFF
--- a/plugins/Login/templates/invitation.twig
+++ b/plugins/Login/templates/invitation.twig
@@ -20,9 +20,9 @@
                         <input type="hidden" name="token" value="{{ token }}"/>
                         <div class="row">
                             <div class="col s12 input-field">
-                                <input type="text" name="login" value="{{ user.login }}" size="20" readonly="readonly"
+                                <input type="text" name="email" value="{{ user.email }}" size="20" readonly="readonly"
                                        tabindex="0"/>
-                                <label><i class="icon-user icon"></i> {{ 'Login_LoginOrEmail'|translate }}</label>
+                                <label><i class="icon-user icon"></i> {{ 'UsersManager_Email'|translate }}</label>
                             </div>
                             <div class="col s12 input-field">
                                 <input type="password" placeholder="" name="password" id="password" class="input" value="" size="20"

--- a/plugins/Login/tests/UI/expected-screenshots/Invite_set_password.png
+++ b/plugins/Login/tests/UI/expected-screenshots/Invite_set_password.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b73e20ada4be79b4a10d9dd33fb6dc42f4df7f0280f8b46da3db477b2b57cbb4
-size 33359
+oid sha256:c2200c278508a28df205bd61d266428fd224490d143c566968e62e38bda91ae3
+size 34614

--- a/plugins/Login/tests/UI/expected-screenshots/Invite_wrong_password.png
+++ b/plugins/Login/tests/UI/expected-screenshots/Invite_wrong_password.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d555360d6a1be5adfcff321b70faf9a4bfb890600614a789d64fb98eca3184ae
-size 39385
+oid sha256:b93f7d38f12c636de141826eb622a964ba89f89eb92031229515d1c207f5538b
+size 40607


### PR DESCRIPTION
### Description:

fixes #20306 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
