### PR TITLE
Fix non-countable fatal error in the datatable class

### DIFF
--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -229,7 +229,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      *
      * @var Row[]
      */
-    protected $rows = array();
+    protected $rows = [];
 
     /**
      * Id assigned to the DataTable, used to lookup the table using the DataTable_Manager
@@ -393,7 +393,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
     public function setRows($rows)
     {
         unset($this->rows);
-        $this->rows = $rows;
+        $this->rows = (is_array($rows) ? $rows : []);
         $this->indexNotUpToDate = true;
     }
 
@@ -917,7 +917,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     public function getRowsCountWithoutSummaryRow()
     {
-        return (is_array($this->rows) ? count($this->rows) : 0);
+        return count($this->rows);
     }
 
     /**
@@ -1033,7 +1033,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
     public function getRowsCount()
     {
         if (is_null($this->summaryRow)) {
-            return (is_array($this->rows) ? count($this->rows) : 0);
+            return count($this->rows);
         } else {
             return count($this->rows) + 1;
         }
@@ -1046,7 +1046,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     public function getFirstRow()
     {
-        if (!is_array($this->rows) || count($this->rows) == 0) {
+        if (count($this->rows) == 0) {
             if (!is_null($this->summaryRow)) {
                 return $this->summaryRow;
             }
@@ -1067,7 +1067,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
             return $this->summaryRow;
         }
 
-        if (!is_array($this->rows) || count($this->rows) == 0) {
+        if (count($this->rows) == 0) {
             return false;
         }
 
@@ -1533,7 +1533,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     public function addRowsFromSimpleArray($array)
     {
-        if (!is_array($array) || count($array) === 0) {
+        if (count($array) === 0) {
             return;
         }
 

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -917,7 +917,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     public function getRowsCountWithoutSummaryRow()
     {
-        return count($this->rows);
+        return (is_array($this->rows) ? count($this->rows) : 0);
     }
 
     /**
@@ -1033,7 +1033,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
     public function getRowsCount()
     {
         if (is_null($this->summaryRow)) {
-            return count($this->rows);
+            return (is_array($this->rows) ? count($this->rows) : 0);
         } else {
             return count($this->rows) + 1;
         }
@@ -1046,7 +1046,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     public function getFirstRow()
     {
-        if (count($this->rows) == 0) {
+        if (!is_array($this->rows) || count($this->rows) == 0) {
             if (!is_null($this->summaryRow)) {
                 return $this->summaryRow;
             }
@@ -1067,7 +1067,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
             return $this->summaryRow;
         }
 
-        if (count($this->rows) == 0) {
+        if (!is_array($this->rows) || count($this->rows) == 0) {
             return false;
         }
 
@@ -1533,7 +1533,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     public function addRowsFromSimpleArray($array)
     {
-        if (count($array) === 0) {
+        if (!is_array($array) || count($array) === 0) {
             return;
         }
 
@@ -1791,7 +1791,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     public function walkPath($path, $missingRowColumns = false, $maxSubtableRows = 0)
     {
-        $pathLength = count($path);
+        $pathLength = (is_array($path) ? count($path) : 0);
 
         $table = $this;
         $next = false;


### PR DESCRIPTION
### Description:

Fixes #20333 

Added checks for all occurrences in the Datatable class where the `rows` property is counted to first make sure it is actually an array.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
