### PR TITLE
Increase security of X-Forwarded-For header usage by using last ip by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * When an invalid token is provided in an API request, a 401 response code is now returned instead of 200 response code.
 * By default, the `file://` protocol is not tracked. To enable tracking of the `file://` protocol add `enableTrackFile` to the tracker settings. 
 * We have migrated our automated tests from Travis CI to GitHub actions. If your plugin used Travis CI for running tests ensure to migrate that to a GitHub action as support for running tests on Travis has been dropped.
+* By default, the last ip address in the proxy list will now be used rather than the first ip address. To force the first ip address to be used set the config option `proxy_ip_read_last_in_list = 0`.
 
 ### New APIs
 

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -690,7 +690,7 @@ proxy_uri_header = 0
 ; If set to 1 we use the last IP in the list of proxy IPs when determining the client IP. Using the last IP can be more
 ; secure when using proxy headers in combination with a load balancer. By default the first IP is read according to RFC7239
 ; which is required when the client sends the IP through a proxy header as well as the load balancer.
-proxy_ip_read_last_in_list = 0
+proxy_ip_read_last_in_list = 1
 
 ; Whether to enable trusted host checking. This can be disabled if you're running Matomo
 ; on several URLs and do not wish to constantly edit the trusted host list.

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b470defbafd923ee00e636a012357ea5c4ba29793f5a45b55387823a68cc9f8
-size 5327943
+oid sha256:f6b7cf43d1cec00c10dc10779a22aed986aec6987aa5ec3c3b68e47e523acf55
+size 5327917


### PR DESCRIPTION
### Description:

[PR #17765](https://github.com/matomo-org/matomo/pull/17765) already added support to use the last ip in the X-Forwarded header list by adding the `proxy_ip_read_last_in_list` config option, but by default it is false.

This PR changes the default `global.ini.php` value to `proxy_ip_read_last_in_list = 1`

As this is a potentially breaking change, the following tasks are also need to be completed:

:heavy_check_mark: Developer change log updated
:heavy_check_mark: Update the guide in https://matomo.org/faq/how-to-install/faq_98/ to mention people may need to disable this feature if the first IP should be used.

Fixes #17202

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
