### PR TITLE
Fix compatibility of minimum PHP version check with older versions

### DIFF
--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -11,7 +11,7 @@
 /**
  * This file is executed before anything else.
  * It checks the minimum PHP version required to run Matomo.
- * This file must be compatible PHP4.
+ * This file must be compatible with PHP 5.3.
  */
 
 $piwik_errorMessage = '';
@@ -72,8 +72,6 @@ if ($minimumPhpInvalid) {
                     "<a href='https://builds.matomo.org/piwik.zip' rel='noreferrer noopener'>builds.matomo.org</a>.</p>";
     }
 }
-
-define('PAGE_TITLE_WHEN_ERROR', 'Matomo &rsaquo; Error');
 
 if (!function_exists('Piwik_GetErrorMessagePage')) {
     /**
@@ -212,7 +210,7 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
             . ' ' . $optionalLinks;
 
 
-        $message = str_replace(["<br />", "<br>", "<br/>", "</p>"], "\n", $message);
+        $message = str_replace(array("<br />", "<br>", "<br/>", "</p>"), "\n", $message);
         $message = str_replace("\t", "", $message);
         $message = strip_tags($message);
 

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -73,6 +73,8 @@ if ($minimumPhpInvalid) {
     }
 }
 
+define('PAGE_TITLE_WHEN_ERROR', 'Matomo &rsaquo; Error');
+
 if (!function_exists('Piwik_GetErrorMessagePage')) {
     /**
      * Returns true if Piwik should print the backtrace with error messages.

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -125,9 +125,9 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
         $faviconUrl = false,
         $isCli = null,
         $errorLogPrefix = '',
-        bool $writeErrorLog = true,
-        string $redirectUrl = null,
-        int $countdown = null
+        $writeErrorLog = true,
+        $redirectUrl = null,
+        $countdown = null
     ) {
         $hasCountdownRedirect = !empty($redirectUrl) && !empty($countdown);
 


### PR DESCRIPTION
### Description:

Fixes #20350 

The `testMinimumPhpVersion.php` check contains type hints which are not compatible with PHP < 7. When attempting  to run command line tasks with PHP 5.6 this caused the following error to be shown instead of an incompatible version warning:

`PHP Fatal error:  Default value for parameters with a class type hint can only be NULL in /var/www/matomo/core/testMinimumPhpVersion.php on line 128` 

Although the minimum PHP version for Matomo is 7.2+, this specific file needs to be able to run on any PHP version > 4 so it can show the version error.

This PR removes the type hints.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
