### PR TITLE
Fix failure when session times out

### DIFF
--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik\Plugins\CoreHome;
 
+use Piwik\Access;
 use Piwik\Archive\ArchiveInvalidator;
 use Piwik\Columns\ComputedMetricFactory;
 use Piwik\Columns\MetricsList;
@@ -388,16 +389,19 @@ class CoreHome extends \Piwik\Plugin
         // add admin menu translations
         if (SettingsPiwik::isMatomoInstalled()
             && Common::getRequestVar('module', '') != 'CoreUpdater'
+            && Piwik::isUserHasSomeViewAccess()
         ) {
-            $menu = MenuAdmin::getInstance()->getMenu();
-            foreach ($menu as $level1 => $level2) {
-                $translationKeys[] = $level1;
-                foreach ($level2 as $name => $params) {
-                    if (strpos($name, '_') !== false) {
-                        $translationKeys[] = $name;
+            Access::doAsSuperUser(function() use (&$translationKeys) {
+                $menu = MenuAdmin::getInstance()->getMenu();
+                foreach ($menu as $level1 => $level2) {
+                    $translationKeys[] = $level1;
+                    foreach ($level2 as $name => $params) {
+                        if (strpos($name, '_') !== false) {
+                            $translationKeys[] = $name;
+                        }
                     }
                 }
-            }
+            });
         }
     }
 }


### PR DESCRIPTION
### Description:

When the authentication expires this currently always results in an error screen `An exception has been thrown during the rendering of a template ("You must be logged in to access this functionality.").`

This is due to the fact, that we try to include the admin menu translations in the javascript translations that are rendered into a template. This throws a auth exception when trying to fetch certain report details like custom dimensions or goals.
As the menu should only be needed when having at least view access, I've added an additional check.
In addition fetching the menu entries is now performed as super user, to ensure it can't fail at some point.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
