### PR TITLE
make sure processDynamicHtml() is still called now that angularjs has been removed entirely

### DIFF
--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -260,6 +260,10 @@ window.piwikHelper = {
 
       // process vue-directive attributes (only uses .mounted/.unmounted hooks)
       piwikHelper.compileVueDirectives(selector);
+
+      Vue.nextTick(function () {
+        piwikHelper.processDynamicHtml($(selector).parent());
+      });
     },
 
     compileVueDirectives: function (selector) {

--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -261,9 +261,11 @@ window.piwikHelper = {
       // process vue-directive attributes (only uses .mounted/.unmounted hooks)
       piwikHelper.compileVueDirectives(selector);
 
-      Vue.nextTick(function () {
-        piwikHelper.processDynamicHtml($(selector).parent());
-      });
+      if (window.Vue) {
+        window.Vue.nextTick(function () {
+          piwikHelper.processDynamicHtml($(selector).parent());
+        });
+      }
     },
 
     compileVueDirectives: function (selector) {


### PR DESCRIPTION
### Description:

This method was previously called by `compileAngularDirectives()`, which has since been removed.

Note: the reason we pass in the parent is that the event handlers for the method expect to be able to use `$(element).find()`, which will not include the current element if it matches the selector.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
