### PR TITLE
Fix language detection for UI

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -844,7 +844,7 @@ class Common
         );
 
         if (is_null($browserLang)) {
-            $browserLang = self::sanitizeInputValues(@$_SERVER['HTTP_ACCEPT_LANGUAGE']);
+            $browserLang = self::sanitizeInputValues($_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '');
             if (empty($browserLang) && self::isPhpCliMode()) {
                 $browserLang = @getenv('LANG');
             }

--- a/core/Common.php
+++ b/core/Common.php
@@ -966,7 +966,7 @@ class Common
     {
         $validLanguages = self::checkValidLanguagesIsSet($validLanguages);
 
-        if (!preg_match_all('/(?:^|,)([a-z]{2,3})([-][a-z]{2})?/', $browserLanguage, $matches, PREG_SET_ORDER)) {
+        if (!preg_match_all('/(?:^|,)([a-z]{2,3})(?:[-][a-z]{4})?([-][a-z]{2})?/', $browserLanguage, $matches, PREG_SET_ORDER)) {
             return self::LANGUAGE_CODE_INVALID;
         }
         foreach ($matches as $parts) {

--- a/core/Common.php
+++ b/core/Common.php
@@ -930,7 +930,7 @@ class Common
     }
 
     /**
-     * Returns the language and region string, based only on the Browser 'accepted language' information.
+     * Returns the language string, based only on the Browser 'accepted language' information.
      * * The language tag is defined by ISO 639-1
      *
      * @param string $browserLanguage Browser's accepted language header
@@ -939,8 +939,8 @@ class Common
      */
     public static function extractLanguageCodeFromBrowserLanguage($browserLanguage, $validLanguages = array())
     {
-        $validLanguages = self::checkValidLanguagesIsSet($validLanguages);
         $languageRegionCode = self::extractLanguageAndRegionCodeFromBrowserLanguage($browserLanguage, $validLanguages);
+        $validLanguages = self::checkValidLanguagesIsSet($validLanguages);
 
         if (strlen($languageRegionCode) === 2) {
             $languageCode = $languageRegionCode;
@@ -959,11 +959,12 @@ class Common
      * * The region tag is defined by ISO 3166-1
      *
      * @param string $browserLanguage Browser's accepted language header
-     * @param array $validLanguages array of valid language codes. Note that if the array includes "fr" then it will consider all regional variants of this language valid, such as "fr-ca" etc.
-     * @return string 2 letter ISO 639 code 'es' (Spanish) or if found, includes the region as well: 'es-ar'
+     * @param array $validLanguages array of valid language/region codes.
+     * @return string 2-letter ISO 639 code 'es' (Spanish) or if found, includes the region as well: 'es-ar'
      */
     public static function extractLanguageAndRegionCodeFromBrowserLanguage($browserLanguage, $validLanguages = array())
     {
+        $forceRegionValidation = !empty($validLanguages);
         $validLanguages = self::checkValidLanguagesIsSet($validLanguages);
 
         if (!preg_match_all('/(?:^|,)([a-z]{2,3})(?:[-][a-z]{4})?([-][a-z]{2})?/', $browserLanguage, $matches, PREG_SET_ORDER)) {
@@ -983,7 +984,8 @@ class Common
                     return $langIso639 . $regionIso3166;
                 }
 
-                if (in_array($langIso639, $validLanguages)) {
+                // if a set of valid codes was provided, we do not append the region if it was not included
+                if (in_array($langIso639, $validLanguages) && !$forceRegionValidation) {
                     return $langIso639 . $regionIso3166;
                 }
             }

--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -284,7 +284,7 @@ HTML;
 
         // If the language parameter is 'auto' then use the browser language
         if ($language === 'auto') {
-            $language = Common::extractLanguageCodeFromBrowserLanguage(Common::getBrowserLanguage(),
+            $language = Common::extractLanguageAndRegionCodeFromBrowserLanguage(Common::getBrowserLanguage(),
                                        APILanguagesManager::getInstance()->getAvailableLanguages());
         }
 

--- a/plugins/LanguagesManager/LanguagesManager.php
+++ b/plugins/LanguagesManager/LanguagesManager.php
@@ -159,7 +159,7 @@ class LanguagesManager extends \Piwik\Plugin
     {
         $languageCode = self::getLanguageFromPreferences();
         if (!API::getInstance()->isLanguageAvailable($languageCode)) {
-            $languageCode = Common::extractLanguageCodeFromBrowserLanguage(Common::getBrowserLanguage(), API::getInstance()->getAvailableLanguages());
+            $languageCode = Common::extractLanguageAndRegionCodeFromBrowserLanguage(Common::getBrowserLanguage(), API::getInstance()->getAvailableLanguages());
         }
         if (!API::getInstance()->isLanguageAvailable($languageCode)) {
             $languageCode = StaticContainer::get('Piwik\Translation\Translator')->getDefaultLanguage();

--- a/plugins/UserLanguage/tests/System/GetLanguageSystemTest.php
+++ b/plugins/UserLanguage/tests/System/GetLanguageSystemTest.php
@@ -6,20 +6,18 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  *
  */
-namespace Piwik\Plugins\UserLanguage\tests\System;
 
+namespace Piwik\Plugins\UserLanguage\tests\System;
 
 use Piwik\Plugins\UserLanguage\tests\Fixtures\LanguageFixture;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
 /**
- * Class GetLanguageSystemTest
  * @group GetLanguageSystemTest
  * @group Plugins
  * @group UserLanguage
  */
 class GetLanguageSystemTest extends SystemTestCase {
-
     public static $fixture = null;
 
     public static function getOutputPrefix()
@@ -43,21 +41,21 @@ class GetLanguageSystemTest extends SystemTestCase {
      */
     public function getApiForTesting()
     {
-        $apiToCall = array(
+        $apiToCall = [
             "UserLanguage.getLanguage",
             "UserLanguage.getLanguageCode"
-        );
+        ];
 
-        $apiToTest = array();
+        $apiToTest = [];
 
-        $apiToTest[] = array(
+        $apiToTest[] = [
                             $apiToCall,
-                            array(
+                            [
                                 'idSite'  => self::$fixture->idSite,
                                 'date'    => self::$fixture->dateTime,
-                                'periods' => array('day')
-                            )
-                       );
+                                'periods' => ['day']
+                            ]
+                       ];
 
         return $apiToTest;
     }
@@ -67,7 +65,6 @@ class GetLanguageSystemTest extends SystemTestCase {
     {
         return dirname(__FILE__);
     }
-
 }
 
 GetLanguageSystemTest::$fixture = new LanguageFixture();

--- a/tests/PHPUnit/Unit/CommonTest.php
+++ b/tests/PHPUnit/Unit/CommonTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Tests\Unit;
 
+use __PHP_Incomplete_Class;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Piwik\Application\Environment;
@@ -51,34 +52,34 @@ class CommonTest extends TestCase
         return [ // input, output
                  // sanitize an array OK
                  [
-                     ['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52],
-                     ['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52],
+                     ['test1' => 't1', 't45', 'teatae', 4568, ['test'], 1.52],
+                     ['test1' => 't1', 't45', 'teatae', 4568, ['test'], 1.52],
                  ],
                  [
                      [
                          'test1' => 't1',
                          't45',
-                         "teatae",
+                         'teatae',
                          4568,
                          ['test'],
                          1.52,
-                         ['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52],
-                         ['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52],
+                         ['test1' => 't1', 't45', 'teatae', 4568, ['test'], 1.52],
+                         ['test1' => 't1', 't45', 'teatae', 4568, ['test'], 1.52],
                          [
-                             [[['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52]]],
+                             [[['test1' => 't1', 't45', 'teatae', 4568, ['test'], 1.52]]],
                          ],
                      ],
                      [
                          'test1' => 't1',
                          't45',
-                         "teatae",
+                         'teatae',
                          4568,
                          ['test'],
                          1.52,
-                         ['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52],
-                         ['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52],
+                         ['test1' => 't1', 't45', 'teatae', 4568, ['test'], 1.52],
+                         ['test1' => 't1', 't45', 'teatae', 4568, ['test'], 1.52],
                          [
-                             [[['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52]]],
+                             [[['test1' => 't1', 't45', 'teatae', 4568, ['test'], 1.52]]],
                          ],
                      ],
                  ],
@@ -94,8 +95,8 @@ class CommonTest extends TestCase
                  ],
                  // sanitize a string unicode => no change
                  [
-                     " Поиск в Интернете  Поgqegиск страниц на рgeqg8978усском",
-                     " Поиск в Интернете  Поgqegиск страниц на рgeqg8978усском",
+                     ' Поиск в Интернете  Поgqegиск страниц на рgeqg8978усском',
+                     ' Поиск в Интернете  Поgqegиск страниц на рgeqg8978усском',
                  ],
                  // sanitize a bad string
                  [
@@ -120,18 +121,18 @@ class CommonTest extends TestCase
                  // sanitize HTML
                  [
                      "<test toto='mama' piwik=\"cool\">Piwik!!!!!</test>",
-                     "&lt;test toto=&#039;mama&#039; piwik=&quot;cool&quot;&gt;Piwik!!!!!&lt;/test&gt;",
+                     '&lt;test toto=&#039;mama&#039; piwik=&quot;cool&quot;&gt;Piwik!!!!!&lt;/test&gt;',
                  ],
                  // sanitize a SQL query
                  [
                      "SELECT piwik FROM piwik_tests where test= 'super\"value' AND cool=toto #comment here",
-                     "SELECT piwik FROM piwik_tests where test= &#039;super&quot;value&#039; AND cool=toto #comment here",
+                     'SELECT piwik FROM piwik_tests where test= &#039;super&quot;value&#039; AND cool=toto #comment here',
                  ],
                  // sanitize php variables
                  [true, true],
                  [false, false],
                  [null, null],
-                 ["", ""],
+                 ['', ''],
         ];
     }
 
@@ -236,17 +237,17 @@ class CommonTest extends TestCase
                      'string',
                      'http://url?arg1=val1&amp;arg2=val2',
                  ],
-                 [["test", 1345524, ["gaga"]], [], 'array', ["test", 1345524, ["gaga"]]],
+                 [['test', 1345524, ['gaga']], [], 'array', ['test', 1345524, ['gaga']]],
                  // array as a default value / types
-                 [["test", 1345524, ["gaga"]], 45, 'string', "45"],
-                 [["test", 1345524, ["gaga"]], [1], 'array', ["test", 1345524, ["gaga"]]],
+                 [['test', 1345524, ['gaga']], 45, 'string', '45'],
+                 [['test', 1345524, ['gaga']], [1], 'array', ['test', 1345524, ['gaga']]],
                  [
-                     ["test", 1345524, "Start of hello\nworld\n\t", ["gaga"]],
+                     ['test', 1345524, "Start of hello\nworld\n\t", ['gaga']],
                      [1],
                      'array',
-                     ["test", 1345524, "Start of hello\nworld\n\t", ["gaga"]],
+                     ['test', 1345524, "Start of hello\nworld\n\t", ['gaga']],
                  ],
-                 [["test", 1345524, ["gaga"]], 4, 'int', 4],
+                 [['test', 1345524, ['gaga']], 4, 'int', 4],
                  ['', [1], 'array', [1]],
                  ['', [], 'array', []],
                  // we give a number in a string and request for a number => it should give the string casted as a number
@@ -287,30 +288,30 @@ class CommonTest extends TestCase
     public function testIsValidFilenameValidValues()
     {
         $valid = [
-            "test",
-            "test.txt",
-            "test.......",
-            "en-ZHsimplified",
+            'test',
+            'test.txt',
+            'test.......',
+            'en-ZHsimplified',
             '0',
         ];
         foreach ($valid as $toTest) {
-            $this->assertTrue(Filesystem::isValidFilename($toTest), $toTest . " not valid!");
+            $this->assertTrue(Filesystem::isValidFilename($toTest), $toTest . ' not valid!');
         }
     }
 
     public function testIsValidFilenameNotValidValues()
     {
         $notvalid = [
-            "../test",
-            "/etc/htpasswd",
+            '../test',
+            '/etc/htpasswd',
             '$var',
             ';test',
             '[bizarre]',
             '',
             false,
-            ".htaccess",
-            "very long long eogaioge ageja geau ghaeihieg heiagie aiughaeui hfilename",
-            "WHITE SPACE",
+            '.htaccess',
+            'very long long eogaioge ageja geau ghaeihieg heiagie aiughaeui hfilename',
+            'WHITE SPACE',
         ];
         foreach ($notvalid as $toTest) {
             self::assertFalse(Filesystem::isValidFilename($toTest), $toTest . " valid but shouldn't!");
@@ -323,7 +324,7 @@ class CommonTest extends TestCase
         $this->assertTrue(Common::safe_unserialize('O:12:"Piwik\Common":0:{}', ['Piwik\Common']) instanceof Common);
 
         // not allowed classed should result in an incomplete class
-        $this->assertTrue(Common::safe_unserialize('O:12:"Piwik\Common":0:{}') instanceof \__PHP_Incomplete_Class);
+        $this->assertTrue(Common::safe_unserialize('O:12:"Piwik\Common":0:{}') instanceof __PHP_Incomplete_Class);
 
         // strings not unserializable should return false and trigger a debug log
         $logger = $this->createFakeLogger();
@@ -357,33 +358,33 @@ class CommonTest extends TestCase
     public function getBrowserLanguageData()
     {
         return [ // user agent, browser language
-                 ["en-gb", "en-gb"],
+                 ['en-gb', 'en-gb'],
 
                  // filter quality attribute
-                 ["en-us,en;q=0.5", "en-us,en"],
+                 ['en-us,en;q=0.5', 'en-us,en'],
 
                  // bad user agents
-                 ["en-us,chrome://global/locale/intl.properties", "en-us"],
+                 ['en-us,chrome://global/locale/intl.properties', 'en-us'],
 
                  // unregistered language tag
-                 ["en,en-securid", "en"],
-                 ["en-securid,en", "en"],
-                 ["en-us,en-securid,en", "en-us,en"],
+                 ['en,en-securid', 'en'],
+                 ['en-securid,en', 'en'],
+                 ['en-us,en-securid,en', 'en-us,en'],
 
                  // accept private sub tags
-                 ["en-us,x-en-securid", "en-us,x-en-securid"],
-                 ["en-us,en-x-securid", "en-us,en-x-securid"],
+                 ['en-us,x-en-securid', 'en-us,x-en-securid'],
+                 ['en-us,en-x-securid', 'en-us,en-x-securid'],
 
                  // filter arbitrary white space
-                 ["en-us, en", "en-us,en"],
-                 ["en-ca, en-us ,en", "en-ca,en-us,en"],
+                 ['en-us, en', 'en-us,en'],
+                 ['en-ca, en-us ,en', 'en-ca,en-us,en'],
 
                  // handle comments
-                 [" ( comment ) en-us (another comment) ", "en-us"],
+                 [' ( comment ) en-us (another comment) ', 'en-us'],
 
                  // handle quoted pairs (embedded in comments)
-                 [" ( \( start ) en-us ( \) end ) ", "en-us"],
-                 [" ( \) en-ca, \( ) en-us ( \) ,en ) ", "en-us"],
+                 [' ( \( start ) en-us ( \) end ) ', 'en-us'],
+                 [' ( \) en-ca, \( ) en-us ( \) ,en ) ', 'en-us'],
         ];
     }
 
@@ -406,18 +407,18 @@ class CommonTest extends TestCase
         $regionDataProvider = StaticContainer::get('Piwik\Intl\Data\Provider\RegionDataProvider');
 
         return [ // browser language, valid countries, expected result
-                 ["", [], "xx"],
-                 ["", ["us" => 'amn'], "xx"],
-                 ["en", ["us" => 'amn'], "xx"],
-                 ["en-us", ["us" => 'amn'], "us"],
-                 ["en-ca", ["us" => 'amn'], "xx"],
-                 ["en-ca", ["us" => 'amn', "ca" => 'amn'], "ca"],
-                 ["fr-fr,fr-ca", ["us" => 'amn', "ca" => 'amn'], "ca"],
-                 ["fr-fr;q=1.0,fr-ca;q=0.9", ["us" => 'amn', "ca" => 'amn'], "ca"],
-                 ["fr-ca,fr;q=0.1", ["us" => 'amn', "ca" => 'amn'], "ca"],
-                 ["en-us,en;q=0.5", $regionDataProvider->getCountryList(), "us"],
-                 ["fr-ca,fr;q=0.1", ["fr" => 'eur', "us" => 'amn', "ca" => 'amn'], "ca"],
-                 ["fr-fr,fr-ca", ["fr" => 'eur', "us" => 'amn', "ca" => 'amn'], "fr"],
+                 ['', [], 'xx'],
+                 ['', ['us' => 'amn'], 'xx'],
+                 ['en', ['us' => 'amn'], 'xx'],
+                 ['en-us', ['us' => 'amn'], 'us'],
+                 ['en-ca', ['us' => 'amn'], 'xx'],
+                 ['en-ca', ['us' => 'amn', 'ca' => 'amn'], 'ca'],
+                 ['fr-fr,fr-ca', ['us' => 'amn', 'ca' => 'amn'], 'ca'],
+                 ['fr-fr;q=1.0,fr-ca;q=0.9', ['us' => 'amn', 'ca' => 'amn'], 'ca'],
+                 ['fr-ca,fr;q=0.1', ['us' => 'amn', 'ca' => 'amn'], 'ca'],
+                 ['en-us,en;q=0.5', $regionDataProvider->getCountryList(), 'us'],
+                 ['fr-ca,fr;q=0.1', ['fr' => 'eur', 'us' => 'amn', 'ca' => 'amn'], 'ca'],
+                 ['fr-fr,fr-ca', ['fr' => 'eur', 'us' => 'amn', 'ca' => 'amn'], 'fr'],
         ];
     }
 
@@ -443,10 +444,10 @@ class CommonTest extends TestCase
     public function getCountryCodeTestDataInfer()
     {
         return [ // browser language, valid countries, expected result (non-guess vs guess)
-                 ["fr,en-us", ["us" => 'amn', "ca" => 'amn'], "us", "fr"],
-                 ["fr,en-us", ["fr" => 'eur', "us" => 'amn', "ca" => 'amn'], "us", "fr"],
-                 ["fr,fr-fr,en-us", ["fr" => 'eur', "us" => 'amn', "ca" => 'amn'], "fr", "fr"],
-                 ["fr-fr,fr,en-us", ["fr" => 'eur', "us" => 'amn', "ca" => 'amn'], "fr", "fr"],
+                 ['fr,en-us', ['us' => 'amn', 'ca' => 'amn'], 'us', 'fr'],
+                 ['fr,en-us', ['fr' => 'eur', 'us' => 'amn', 'ca' => 'amn'], 'us', 'fr'],
+                 ['fr,fr-fr,en-us', ['fr' => 'eur', 'us' => 'amn', 'ca' => 'amn'], 'fr', 'fr'],
+                 ['fr-fr,fr,en-us', ['fr' => 'eur', 'us' => 'amn', 'ca' => 'amn'], 'fr', 'fr'],
         ];
     }
 
@@ -488,26 +489,30 @@ class CommonTest extends TestCase
     {
         return [
             // browser language, valid languages (with optional region), expected result
-            ["fr-ca", ["fr"], "fr-ca"],
-            ["fr-ca", ["ca"], "xx"],
-            ["", [], "xx"],
-            ["", ["en"], "xx"],
-            ["fr", ["en"], "xx"],
-            ["en", ["en"], "en"],
-            ["en", ["en-ca"], "xx"],
-            ["en-ca", ["en-ca"], "en-ca"],
-            ["en-ca", ["en"], "en-ca"],
-            ["fr,en-us", ["fr", "en"], "fr"],
-            ["fr,en-us", ["en", "fr"], "fr"],
-            ["fr-fr,fr-ca", ["fr"], "fr-fr"],
-            ["fr-fr,fr-ca", ["fr-ca"], "fr-ca"],
-            ["-ca", ["fr", "ca"], "xx"],
-            ["fr-fr;q=1.0,fr-ca;q=0.9", ["fr-ca"], "fr-ca"],
-            ["es,en,fr;q=0.7,de;q=0.3", ["fr", "es", "de", "en"], "es"],
-            ["zh-sg,de;q=0.3", ["zh", "es", "de"], "zh-sg"],
-            ["fr-ca,fr;q=0.1", ["fr-ca"], "fr-ca"],
-            ["r5,fr;q=1,de", ["fr", "de"], "fr"],
-            ["Zen§gq1", ["en"], "xx"],
+            ['fr-ca', ['fr'], 'fr-ca'],
+            ['fr-ca', ['ca'], 'xx'],
+            ['', [], 'xx'],
+            ['', ['en'], 'xx'],
+            ['fr', ['en'], 'xx'],
+            ['en', ['en'], 'en'],
+            ['en', ['en-ca'], 'xx'],
+            ['en-ca', ['en-ca'], 'en-ca'],
+            ['en-ca', ['en'], 'en-ca'],
+            ['fr,en-us', ['fr', 'en'], 'fr'],
+            ['fr,en-us', ['en', 'fr'], 'fr'],
+            ['fr-fr,fr-ca', ['fr'], 'fr-fr'],
+            ['fr-fr,fr-ca', ['fr-ca'], 'fr-ca'],
+            ['-ca', ['fr', 'ca'], 'xx'],
+            ['fr-fr;q=1.0,fr-ca;q=0.9', ['fr-ca'], 'fr-ca'],
+            ['es,en,fr;q=0.7,de;q=0.3', ['fr', 'es', 'de', 'en'], 'es'],
+            ['zh-sg,de;q=0.3', ['zh', 'es', 'de'], 'zh-sg'],
+            ['fr-ca,fr;q=0.1', ['fr-ca'], 'fr-ca'],
+            ['r5,fr;q=1,de', ['fr', 'de'], 'fr'],
+            ['Zen§gq1', ['en'], 'xx'],
+            ['zh-hans-cn', ['zh-cn'], 'zh-cn'],
+            ['zh-hant-tw', ['zh-tw'], 'zh-tw'],
+            ['az-cyrl-az', ['az'], 'az-az'],
+            ['shi-tfng-ma', ['shi', 'shi-ma'], 'shi-ma'],
         ];
     }
 
@@ -531,21 +536,21 @@ class CommonTest extends TestCase
     {
         return [
             // browser language, valid languages, expected result
-            ["fr-ca", ["fr"], "fr"],
-            ["fr-ca", ["ca"], "xx"],
-            ["", ["en"], "xx"],
-            ["fr", ["en"], "xx"],
-            ["en", ["en"], "en"],
-            ["en", ["en-ca"], "xx"],
-            ["en-ca", ["en"], "en"],
-            ["fr,en-us", ["fr", "en"], "fr"],
-            ["fr,en-us", ["en", "fr"], "fr"],
-            ["fr-fr,fr-ca", ["fr"], "fr"],
-            ["-ca", ["fr", "ca"], "xx"],
-            ["es,en,fr;q=0.7,de;q=0.3", ["fr", "es", "de", "en"], "es"],
-            ["zh-sg,de;q=0.3", ["zh", "es", "de"], "zh"],
-            ["r5,fr;q=1,de", ["fr", "de"], "fr"],
-            ["Zen§gq1", ["en"], "xx"],
+            ['fr-ca', ['fr'], 'fr'],
+            ['fr-ca', ['ca'], 'xx'],
+            ['', ['en'], 'xx'],
+            ['fr', ['en'], 'xx'],
+            ['en', ['en'], 'en'],
+            ['en', ['en-ca'], 'xx'],
+            ['en-ca', ['en'], 'en'],
+            ['fr,en-us', ['fr', 'en'], 'fr'],
+            ['fr,en-us', ['en', 'fr'], 'fr'],
+            ['fr-fr,fr-ca', ['fr'], 'fr'],
+            ['-ca', ['fr', 'ca'], 'xx'],
+            ['es,en,fr;q=0.7,de;q=0.3', ['fr', 'es', 'de', 'en'], 'es'],
+            ['zh-sg,de;q=0.3', ['zh', 'es', 'de'], 'zh'],
+            ['r5,fr;q=1,de', ['fr', 'de'], 'fr'],
+            ['Zen§gq1', ['en'], 'xx'],
         ];
     }
 

--- a/tests/PHPUnit/Unit/CommonTest.php
+++ b/tests/PHPUnit/Unit/CommonTest.php
@@ -17,6 +17,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\Filesystem;
 use Piwik\Intl\Data\Provider\RegionDataProvider;
 use Piwik\Log;
+use Piwik\Plugins\LanguagesManager\API as APILanguagesManager;
 use Piwik\Tests\Framework\Mock\FakeLogger;
 
 /**
@@ -489,7 +490,7 @@ class CommonTest extends TestCase
     {
         return [
             // browser language, valid languages (with optional region), expected result
-            ['fr-ca', ['fr'], 'fr-ca'],
+            ['fr-ca', ['fr'], 'fr'],
             ['fr-ca', ['ca'], 'xx'],
             ['', [], 'xx'],
             ['', ['en'], 'xx'],
@@ -497,21 +498,21 @@ class CommonTest extends TestCase
             ['en', ['en'], 'en'],
             ['en', ['en-ca'], 'xx'],
             ['en-ca', ['en-ca'], 'en-ca'],
-            ['en-ca', ['en'], 'en-ca'],
+            ['en-ca', ['en'], 'en'],
             ['fr,en-us', ['fr', 'en'], 'fr'],
             ['fr,en-us', ['en', 'fr'], 'fr'],
-            ['fr-fr,fr-ca', ['fr'], 'fr-fr'],
+            ['fr-fr,fr-ca', [], 'fr-fr'],
             ['fr-fr,fr-ca', ['fr-ca'], 'fr-ca'],
             ['-ca', ['fr', 'ca'], 'xx'],
             ['fr-fr;q=1.0,fr-ca;q=0.9', ['fr-ca'], 'fr-ca'],
             ['es,en,fr;q=0.7,de;q=0.3', ['fr', 'es', 'de', 'en'], 'es'],
-            ['zh-sg,de;q=0.3', ['zh', 'es', 'de'], 'zh-sg'],
+            ['zh-sg,de;q=0.3', ['zh', 'es', 'de'], 'zh'],
             ['fr-ca,fr;q=0.1', ['fr-ca'], 'fr-ca'],
             ['r5,fr;q=1,de', ['fr', 'de'], 'fr'],
             ['Zen§gq1', ['en'], 'xx'],
             ['zh-hans-cn', ['zh-cn'], 'zh-cn'],
             ['zh-hant-tw', ['zh-tw'], 'zh-tw'],
-            ['az-cyrl-az', ['az'], 'az-az'],
+            ['az-cyrl-az', ['az'], 'az'],
             ['shi-tfng-ma', ['shi', 'shi-ma'], 'shi-ma'],
         ];
     }
@@ -565,4 +566,40 @@ class CommonTest extends TestCase
             "test with {$browserLanguage} failed, expected {$expected}"
         );
     }
+
+    /**
+     * @dataProvider getLanguageChainTestData
+     */
+    public function testGetLanguageChain($expected, $browserLanguage)
+    {
+        self::assertEquals(
+            $expected,
+            Common::extractLanguageAndRegionCodeFromBrowserLanguage(
+                Common::getBrowserLanguage($browserLanguage),
+                APILanguagesManager::getInstance()->getAvailableLanguages()
+            )
+        );
+    }
+
+    public function getLanguageChainTestData(): array
+    {
+        return [
+            ['en', 'en-US,en;q=0.8,de-DE;q=0.6,de;q=0.4'],
+            ['de', 'de-DE;q=0.6,de;q=0.4'],
+            ['zh-cn', 'zh-CN,zh;q=0.9'],
+            ['fr', 'fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3'],
+            ['fr', 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7'],
+            ['de', 'de,en-US;q=0.7,en;q=0.3'],
+            ['pt-br', 'pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7,ru;q=0.6'],
+            ['hi', 'hi;en-US,en;q=0.8,q=0.6'],
+            ['ta', 'ta-IN,ta'],
+            ['hi', 'hi-in,hi,en-us,en'],
+            ['th', 'th-TH,th;q=0.9,en;q=0.8'],
+            ['zh-tw', 'zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7'],
+            ['fa', 'fa,en-US;q=0.9,en;q=0.8,fa-IR;q=0.7'],
+            ['nl', 'nl-NL,nl;q=0.9,en-US;q=0.8,en;q=0.7'],
+            ['it', 'it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7'],
+        ];
+    }
+
 }

--- a/tests/PHPUnit/Unit/CommonTest.php
+++ b/tests/PHPUnit/Unit/CommonTest.php
@@ -2,7 +2,7 @@
 /**
  * Matomo - free/libre analytics platform
  *
- * @link https://matomo.org
+ * @link    https://matomo.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
@@ -20,11 +20,10 @@ use Piwik\Tests\Framework\Mock\FakeLogger;
 
 /**
  * @backupGlobals enabled
- * @group Common
+ * @group         Common
  */
 class CommonTest extends TestCase
 {
-
     public function test_getProcessId()
     {
         $this->assertEquals(getmypid(), Common::getProcessId());
@@ -49,75 +48,91 @@ class CommonTest extends TestCase
      */
     public function getInputValues()
     {
-        return array( // input, output
-            // sanitize an array OK
-            array(
-                array('test1' => 't1', 't45', "teatae", 4568, array('test'), 1.52),
-                array('test1' => 't1', 't45', "teatae", 4568, array('test'), 1.52)
-            ),
-            array(
-                array('test1' => 't1', 't45', "teatae", 4568, array('test'), 1.52,
-                      array('test1' => 't1', 't45', "teatae", 4568, array('test'), 1.52),
-                      array('test1' => 't1', 't45', "teatae", 4568, array('test'), 1.52),
-                      array(array(array(array('test1' => 't1', 't45', "teatae", 4568, array('test'), 1.52)))
-                      )),
-                array('test1' => 't1', 't45', "teatae", 4568, array('test'), 1.52,
-                      array('test1' => 't1', 't45', "teatae", 4568, array('test'), 1.52),
-                      array('test1' => 't1', 't45', "teatae", 4568, array('test'), 1.52),
-                      array(array(array(array('test1' => 't1', 't45', "teatae", 4568, array('test'), 1.52)))
-                      ))
-            ),
-            // sanitize an array with bad value level1
-            array(
-                array('test1' => 't1', 't45', 'tea1"ta"e', 568, 1 => array('t<e"st'), 1.52),
-                array('test1' => 't1', 't45', 'tea1&quot;ta&quot;e', 568, 1 => array('t&lt;e&quot;st'), 1.52)
-            ),
-            // sanitize an array with bad value level2
-            array(
-                array('tea1"ta"e' => array('t<e"st' => array('tgeag454554"t')), 1.52),
-                array('tea1&quot;ta&quot;e' => array('t&lt;e&quot;st' => array('tgeag454554&quot;t')), 1.52)
-            ),
-            // sanitize a string unicode => no change
-            array(
-                " Поиск в Интернете  Поgqegиск страниц на рgeqg8978усском",
-                " Поиск в Интернете  Поgqegиск страниц на рgeqg8978усском"
-            ),
-            // sanitize a bad string
-            array(
-                '& " < > 123abc\'',
-                '&amp; &quot; &lt; &gt; 123abc&#039;'
-            ),
-            // test filter - expect new line and null byte to be filtered out
-            array(
-                "Null\0Byte",
-                'NullByte'
-            ),
-            // double encoded - no change (document as user error)
-            array(
-                '%48%45%4C%00%4C%4F+%57%4F%52%4C%44',
-                '%48%45%4C%00%4C%4F+%57%4F%52%4C%44'
-            ),
-            // sanitize an integer
-            array('121564564', '121564564'),
-            array('121564564.0121', '121564564.0121'),
-            array(121564564.0121, 121564564.0121),
-            array(12121, 12121),
-            // sanitize HTML
-            array(
-                "<test toto='mama' piwik=\"cool\">Piwik!!!!!</test>",
-                "&lt;test toto=&#039;mama&#039; piwik=&quot;cool&quot;&gt;Piwik!!!!!&lt;/test&gt;"
-            ),
-            // sanitize a SQL query
-            array(
-                "SELECT piwik FROM piwik_tests where test= 'super\"value' AND cool=toto #comment here",
-                "SELECT piwik FROM piwik_tests where test= &#039;super&quot;value&#039; AND cool=toto #comment here"
-            ),
-            // sanitize php variables
-            array(true, true),
-            array(false, false),
-            array(null, null),
-            array("", ""),
-        );
+        return [ // input, output
+                 // sanitize an array OK
+                 [
+                     ['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52],
+                     ['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52],
+                 ],
+                 [
+                     [
+                         'test1' => 't1',
+                         't45',
+                         "teatae",
+                         4568,
+                         ['test'],
+                         1.52,
+                         ['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52],
+                         ['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52],
+                         [
+                             [[['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52]]],
+                         ],
+                     ],
+                     [
+                         'test1' => 't1',
+                         't45',
+                         "teatae",
+                         4568,
+                         ['test'],
+                         1.52,
+                         ['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52],
+                         ['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52],
+                         [
+                             [[['test1' => 't1', 't45', "teatae", 4568, ['test'], 1.52]]],
+                         ],
+                     ],
+                 ],
+                 // sanitize an array with bad value level1
+                 [
+                     ['test1' => 't1', 't45', 'tea1"ta"e', 568, 1 => ['t<e"st'], 1.52],
+                     ['test1' => 't1', 't45', 'tea1&quot;ta&quot;e', 568, 1 => ['t&lt;e&quot;st'], 1.52],
+                 ],
+                 // sanitize an array with bad value level2
+                 [
+                     ['tea1"ta"e' => ['t<e"st' => ['tgeag454554"t']], 1.52],
+                     ['tea1&quot;ta&quot;e' => ['t&lt;e&quot;st' => ['tgeag454554&quot;t']], 1.52],
+                 ],
+                 // sanitize a string unicode => no change
+                 [
+                     " Поиск в Интернете  Поgqegиск страниц на рgeqg8978усском",
+                     " Поиск в Интернете  Поgqegиск страниц на рgeqg8978усском",
+                 ],
+                 // sanitize a bad string
+                 [
+                     '& " < > 123abc\'',
+                     '&amp; &quot; &lt; &gt; 123abc&#039;',
+                 ],
+                 // test filter - expect new line and null byte to be filtered out
+                 [
+                     "Null\0Byte",
+                     'NullByte',
+                 ],
+                 // double encoded - no change (document as user error)
+                 [
+                     '%48%45%4C%00%4C%4F+%57%4F%52%4C%44',
+                     '%48%45%4C%00%4C%4F+%57%4F%52%4C%44',
+                 ],
+                 // sanitize an integer
+                 ['121564564', '121564564'],
+                 ['121564564.0121', '121564564.0121'],
+                 [121564564.0121, 121564564.0121],
+                 [12121, 12121],
+                 // sanitize HTML
+                 [
+                     "<test toto='mama' piwik=\"cool\">Piwik!!!!!</test>",
+                     "&lt;test toto=&#039;mama&#039; piwik=&quot;cool&quot;&gt;Piwik!!!!!&lt;/test&gt;",
+                 ],
+                 // sanitize a SQL query
+                 [
+                     "SELECT piwik FROM piwik_tests where test= 'super\"value' AND cool=toto #comment here",
+                     "SELECT piwik FROM piwik_tests where test= &#039;super&quot;value&#039; AND cool=toto #comment here",
+                 ],
+                 // sanitize php variables
+                 [true, true],
+                 [false, false],
+                 [null, null],
+                 ["", ""],
+        ];
     }
 
     /**
@@ -154,20 +169,19 @@ class CommonTest extends TestCase
     {
         $_GET['test'] = 1413.431413;
         $this->assertEquals($_GET['test'], Common::getRequestVar('test'));
-
     }
 
     public function testGetRequestVar_GetStringFloatGiven()
     {
         $_GET['test'] = 1413.431413;
-        $value = Common::getRequestVar('test', null, 'string');
+        $value        = Common::getRequestVar('test', null, 'string');
         $this->assertEquals('1413.431413', $value);
     }
 
     public function testGetRequestVar_GetStringIntegerGiven()
     {
         $_GET['test'] = 1413;
-        $value = Common::getRequestVar('test', null, 'string');
+        $value        = Common::getRequestVar('test', null, 'string');
         $this->assertEquals('1413', $value);
     }
 
@@ -196,47 +210,61 @@ class CommonTest extends TestCase
      */
     public function getRequestVarValues()
     {
-        return array( // value of request var, default value, var type, expected
-            array(1413.431413, 2, 'int', 2), // withdefault Withtype WithValue => value casted as type
-            array(null, 'default', null, 'default'), // withdefault Notype NoValue => default value
-            array(null, 'default', 'string', 'default'), // withdefault Withtype NoValue =>default value casted as type
-            // integer as a default value / types
-            array('', 45, 'int', 45),
-            array(1413.431413, 45, 'int', 45),
-            array('', 45, 'integer', 45),
-            array('', 45.0, 'float', 45.0),
-            array('', 45.25, 'float', 45.25),
-            // string as a default value / types
-            array('1413.431413', 45, 'int', 45),
-            array('1413.431413', 45, 'string', '1413.431413'),
-            array('', 45, 'string', '45'),
-            array('', 'geaga', 'string', 'geaga'),
-            array('', '&#039;}{}}{}{}&#039;', 'string', '&#039;}{}}{}{}&#039;'),
-            array('', 'http://url?arg1=val1&arg2=val2', 'string', 'http://url?arg1=val1&amp;arg2=val2'),
-            array('http://url?arg1=val1&arg2=val2', 'http://url?arg1=val1&arg2=val4', 'string', 'http://url?arg1=val1&amp;arg2=val2'),
-            array(array("test", 1345524, array("gaga")), array(), 'array', array("test", 1345524, array("gaga"))), // array as a default value / types
-            array(array("test", 1345524, array("gaga")), 45, 'string', "45"),
-            array(array("test", 1345524, array("gaga")), array(1), 'array', array("test", 1345524, array("gaga"))),
-            array(array("test", 1345524, "Start of hello\nworld\n\t", array("gaga")), array(1), 'array', array("test", 1345524, "Start of hello\nworld\n\t", array("gaga"))),
-            array(array("test", 1345524, array("gaga")), 4, 'int', 4),
-            array('', array(1), 'array', array(1)),
-            array('', array(), 'array', array()),
-            // we give a number in a string and request for a number => it should give the string casted as a number
-            array('45645646', 1, 'int', 45645646),
-            array('45645646', 45, 'integer', 45645646),
-            array('45645646', '45454', 'string', '45645646'),
-            array('45645646', array(), 'array', array()),
-        );
+        return [ // value of request var, default value, var type, expected
+                 [1413.431413, 2, 'int', 2],
+                 // withdefault Withtype WithValue => value casted as type
+                 [null, 'default', null, 'default'],
+                 // withdefault Notype NoValue => default value
+                 [null, 'default', 'string', 'default'],
+                 // withdefault Withtype NoValue =>default value casted as type
+                 // integer as a default value / types
+                 ['', 45, 'int', 45],
+                 [1413.431413, 45, 'int', 45],
+                 ['', 45, 'integer', 45],
+                 ['', 45.0, 'float', 45.0],
+                 ['', 45.25, 'float', 45.25],
+                 // string as a default value / types
+                 ['1413.431413', 45, 'int', 45],
+                 ['1413.431413', 45, 'string', '1413.431413'],
+                 ['', 45, 'string', '45'],
+                 ['', 'geaga', 'string', 'geaga'],
+                 ['', '&#039;}{}}{}{}&#039;', 'string', '&#039;}{}}{}{}&#039;'],
+                 ['', 'http://url?arg1=val1&arg2=val2', 'string', 'http://url?arg1=val1&amp;arg2=val2'],
+                 [
+                     'http://url?arg1=val1&arg2=val2',
+                     'http://url?arg1=val1&arg2=val4',
+                     'string',
+                     'http://url?arg1=val1&amp;arg2=val2',
+                 ],
+                 [["test", 1345524, ["gaga"]], [], 'array', ["test", 1345524, ["gaga"]]],
+                 // array as a default value / types
+                 [["test", 1345524, ["gaga"]], 45, 'string', "45"],
+                 [["test", 1345524, ["gaga"]], [1], 'array', ["test", 1345524, ["gaga"]]],
+                 [
+                     ["test", 1345524, "Start of hello\nworld\n\t", ["gaga"]],
+                     [1],
+                     'array',
+                     ["test", 1345524, "Start of hello\nworld\n\t", ["gaga"]],
+                 ],
+                 [["test", 1345524, ["gaga"]], 4, 'int', 4],
+                 ['', [1], 'array', [1]],
+                 ['', [], 'array', []],
+                 // we give a number in a string and request for a number => it should give the string casted as a number
+                 ['45645646', 1, 'int', 45645646],
+                 ['45645646', 45, 'integer', 45645646],
+                 ['45645646', '45454', 'string', '45645646'],
+                 ['45645646', [], 'array', []],
+        ];
     }
 
     /**
      * @dataProvider getRequestVarValues
-     * @group Core
+     * @group        Core
      */
     public function testGetRequestVar($varValue, $default, $type, $expected)
     {
         $_GET['test'] = $varValue;
-        $return = Common::getRequestVar('test', $default, $type);
+        $return       = Common::getRequestVar('test', $default, $type);
         $this->assertEquals($expected, $return);
         // validate correct type
         switch ($type) {
@@ -258,13 +286,13 @@ class CommonTest extends TestCase
 
     public function testIsValidFilenameValidValues()
     {
-        $valid = array(
+        $valid = [
             "test",
             "test.txt",
             "test.......",
             "en-ZHsimplified",
             '0',
-        );
+        ];
         foreach ($valid as $toTest) {
             $this->assertTrue(Filesystem::isValidFilename($toTest), $toTest . " not valid!");
         }
@@ -272,7 +300,7 @@ class CommonTest extends TestCase
 
     public function testIsValidFilenameNotValidValues()
     {
-        $notvalid = array(
+        $notvalid = [
             "../test",
             "/etc/htpasswd",
             '$var',
@@ -283,7 +311,7 @@ class CommonTest extends TestCase
             ".htaccess",
             "very long long eogaioge ageja geau ghaeihieg heiagie aiughaeui hfilename",
             "WHITE SPACE",
-        );
+        ];
         foreach ($notvalid as $toTest) {
             self::assertFalse(Filesystem::isValidFilename($toTest), $toTest . " valid but shouldn't!");
         }
@@ -300,21 +328,24 @@ class CommonTest extends TestCase
         // strings not unserializable should return false and trigger a debug log
         $logger = $this->createFakeLogger();
         self::assertFalse(Common::safe_unserialize('{1:somebroken}'));
-        self::assertStringContainsString('Unable to unserialize a string: unserialize(): Error at offset 0 of 14 bytes', $logger->output);
+        self::assertStringContainsString(
+            'Unable to unserialize a string: unserialize(): Error at offset 0 of 14 bytes',
+            $logger->output
+        );
     }
 
     private function createFakeLogger()
     {
         $logger = new FakeLogger();
 
-        $newEnv = new Environment('test', array(
+        $newEnv = new Environment('test', [
             'Psr\Log\LoggerInterface' => $logger,
             'Tests.log.allowAllHandlers' => true,
-        ));
+        ]);
         $newEnv->init();
 
         $newMonologLogger = $newEnv->getContainer()->make('Psr\Log\LoggerInterface');
-        $oldLogger = new Log($newMonologLogger);
+        $oldLogger        = new Log($newMonologLogger);
         Log::setSingletonInstance($oldLogger);
 
         return $logger;
@@ -325,40 +356,40 @@ class CommonTest extends TestCase
      */
     public function getBrowserLanguageData()
     {
-        return array( // user agent, browser language
-            array("en-gb", "en-gb"),
+        return [ // user agent, browser language
+                 ["en-gb", "en-gb"],
 
-            // filter quality attribute
-            array("en-us,en;q=0.5", "en-us,en"),
+                 // filter quality attribute
+                 ["en-us,en;q=0.5", "en-us,en"],
 
-            // bad user agents
-            array("en-us,chrome://global/locale/intl.properties", "en-us"),
+                 // bad user agents
+                 ["en-us,chrome://global/locale/intl.properties", "en-us"],
 
-            // unregistered language tag
-            array("en,en-securid", "en"),
-            array("en-securid,en", "en"),
-            array("en-us,en-securid,en", "en-us,en"),
+                 // unregistered language tag
+                 ["en,en-securid", "en"],
+                 ["en-securid,en", "en"],
+                 ["en-us,en-securid,en", "en-us,en"],
 
-            // accept private sub tags
-            array("en-us,x-en-securid", "en-us,x-en-securid"),
-            array("en-us,en-x-securid", "en-us,en-x-securid"),
+                 // accept private sub tags
+                 ["en-us,x-en-securid", "en-us,x-en-securid"],
+                 ["en-us,en-x-securid", "en-us,en-x-securid"],
 
-            // filter arbitrary white space
-            array("en-us, en", "en-us,en"),
-            array("en-ca, en-us ,en", "en-ca,en-us,en"),
+                 // filter arbitrary white space
+                 ["en-us, en", "en-us,en"],
+                 ["en-ca, en-us ,en", "en-ca,en-us,en"],
 
-            // handle comments
-            array(" ( comment ) en-us (another comment) ", "en-us"),
+                 // handle comments
+                 [" ( comment ) en-us (another comment) ", "en-us"],
 
-            // handle quoted pairs (embedded in comments)
-            array(" ( \( start ) en-us ( \) end ) ", "en-us"),
-            array(" ( \) en-ca, \( ) en-us ( \) ,en ) ", "en-us"),
-        );
+                 // handle quoted pairs (embedded in comments)
+                 [" ( \( start ) en-us ( \) end ) ", "en-us"],
+                 [" ( \) en-ca, \( ) en-us ( \) ,en ) ", "en-us"],
+        ];
     }
 
     /**
      * @dataProvider getBrowserLanguageData
-     * @group Core
+     * @group        Core
      */
     public function testGetBrowserLanguage($useragent, $browserLanguage)
     {
@@ -374,30 +405,36 @@ class CommonTest extends TestCase
         /** @var RegionDataProvider $regionDataProvider */
         $regionDataProvider = StaticContainer::get('Piwik\Intl\Data\Provider\RegionDataProvider');
 
-        return array( // browser language, valid countries, expected result
-            array("", array(), "xx"),
-            array("", array("us" => 'amn'), "xx"),
-            array("en", array("us" => 'amn'), "xx"),
-            array("en-us", array("us" => 'amn'), "us"),
-            array("en-ca", array("us" => 'amn'), "xx"),
-            array("en-ca", array("us" => 'amn', "ca" => 'amn'), "ca"),
-            array("fr-fr,fr-ca", array("us" => 'amn', "ca" => 'amn'), "ca"),
-            array("fr-fr;q=1.0,fr-ca;q=0.9", array("us" => 'amn', "ca" => 'amn'), "ca"),
-            array("fr-ca,fr;q=0.1", array("us" => 'amn', "ca" => 'amn'), "ca"),
-            array("en-us,en;q=0.5", $regionDataProvider->getCountryList(), "us"),
-            array("fr-ca,fr;q=0.1", array("fr" => 'eur', "us" => 'amn', "ca" => 'amn'), "ca"),
-            array("fr-fr,fr-ca", array("fr" => 'eur', "us" => 'amn', "ca" => 'amn'), "fr")
-        );
+        return [ // browser language, valid countries, expected result
+                 ["", [], "xx"],
+                 ["", ["us" => 'amn'], "xx"],
+                 ["en", ["us" => 'amn'], "xx"],
+                 ["en-us", ["us" => 'amn'], "us"],
+                 ["en-ca", ["us" => 'amn'], "xx"],
+                 ["en-ca", ["us" => 'amn', "ca" => 'amn'], "ca"],
+                 ["fr-fr,fr-ca", ["us" => 'amn', "ca" => 'amn'], "ca"],
+                 ["fr-fr;q=1.0,fr-ca;q=0.9", ["us" => 'amn', "ca" => 'amn'], "ca"],
+                 ["fr-ca,fr;q=0.1", ["us" => 'amn', "ca" => 'amn'], "ca"],
+                 ["en-us,en;q=0.5", $regionDataProvider->getCountryList(), "us"],
+                 ["fr-ca,fr;q=0.1", ["fr" => 'eur', "us" => 'amn', "ca" => 'amn'], "ca"],
+                 ["fr-fr,fr-ca", ["fr" => 'eur', "us" => 'amn', "ca" => 'amn'], "fr"],
+        ];
     }
 
     /**
      * @dataProvider getCountryCodeTestData
-     * @group Core
+     * @group        Core
      */
     public function testExtractCountryCodeFromBrowserLanguage($browserLanguage, $validCountries, $expected)
     {
-        $this->assertEquals($expected, Common::extractCountryCodeFromBrowserLanguage($browserLanguage, $validCountries, true));
-        $this->assertEquals($expected, Common::extractCountryCodeFromBrowserLanguage($browserLanguage, $validCountries, false));
+        $this->assertEquals(
+            $expected,
+            Common::extractCountryCodeFromBrowserLanguage($browserLanguage, $validCountries, true)
+        );
+        $this->assertEquals(
+            $expected,
+            Common::extractCountryCodeFromBrowserLanguage($browserLanguage, $validCountries, false)
+        );
     }
 
     /**
@@ -405,26 +442,43 @@ class CommonTest extends TestCase
      */
     public function getCountryCodeTestDataInfer()
     {
-
-        return array( // browser language, valid countries, expected result (non-guess vs guess)
-            array("fr,en-us", array("us" => 'amn', "ca" => 'amn'), "us", "fr"),
-            array("fr,en-us", array("fr" => 'eur', "us" => 'amn', "ca" => 'amn'), "us", "fr"),
-            array("fr,fr-fr,en-us", array("fr" => 'eur', "us" => 'amn', "ca" => 'amn'), "fr", "fr"),
-            array("fr-fr,fr,en-us", array("fr" => 'eur', "us" => 'amn', "ca" => 'amn'), "fr", "fr")
-        );
+        return [ // browser language, valid countries, expected result (non-guess vs guess)
+                 ["fr,en-us", ["us" => 'amn', "ca" => 'amn'], "us", "fr"],
+                 ["fr,en-us", ["fr" => 'eur', "us" => 'amn', "ca" => 'amn'], "us", "fr"],
+                 ["fr,fr-fr,en-us", ["fr" => 'eur', "us" => 'amn', "ca" => 'amn'], "fr", "fr"],
+                 ["fr-fr,fr,en-us", ["fr" => 'eur', "us" => 'amn', "ca" => 'amn'], "fr", "fr"],
+        ];
     }
 
     /**
      * @dataProvider getCountryCodeTestDataInfer
-     * @group Core
+     * @group        Core
      */
-    public function testExtractCountryCodeFromBrowserLanguageInfer($browserLanguage, $validCountries, $expected, $expectedInfer)
-    {
+    public function testExtractCountryCodeFromBrowserLanguageInfer(
+        $browserLanguage,
+        $validCountries,
+        $expected,
+        $expectedInfer
+    ) {
         // do not infer country from language
-        $this->assertEquals($expected, Common::extractCountryCodeFromBrowserLanguage($browserLanguage, $validCountries, $enableLanguageToCountryGuess = false));
+        $this->assertEquals(
+            $expected,
+            Common::extractCountryCodeFromBrowserLanguage(
+                $browserLanguage,
+                $validCountries,
+                $enableLanguageToCountryGuess = false
+            )
+        );
 
         // infer country from language
-        $this->assertEquals($expectedInfer, Common::extractCountryCodeFromBrowserLanguage($browserLanguage, $validCountries, $enableLanguageToCountryGuess = true));
+        $this->assertEquals(
+            $expectedInfer,
+            Common::extractCountryCodeFromBrowserLanguage(
+                $browserLanguage,
+                $validCountries,
+                $enableLanguageToCountryGuess = true
+            )
+        );
     }
 
     /**
@@ -432,29 +486,29 @@ class CommonTest extends TestCase
      */
     public function getLanguageDataToExtractLanguageRegionCode()
     {
-        return array(
+        return [
             // browser language, valid languages (with optional region), expected result
-            array("fr-ca", array("fr"), "fr-ca"),
-            array("fr-ca", array("ca"), "xx"),
-            array("", array(), "xx"),
-            array("", array("en"), "xx"),
-            array("fr", array("en"), "xx"),
-            array("en", array("en"), "en"),
-            array("en", array("en-ca"), "xx"),
-            array("en-ca", array("en-ca"), "en-ca"),
-            array("en-ca", array("en"), "en-ca"),
-            array("fr,en-us", array("fr", "en"), "fr"),
-            array("fr,en-us", array("en", "fr"), "fr"),
-            array("fr-fr,fr-ca", array("fr"), "fr-fr"),
-            array("fr-fr,fr-ca", array("fr-ca"), "fr-ca"),
-            array("-ca", array("fr","ca"), "xx"),
-            array("fr-fr;q=1.0,fr-ca;q=0.9", array("fr-ca"), "fr-ca"),
-            array("es,en,fr;q=0.7,de;q=0.3", array("fr", "es", "de", "en"), "es"),
-            array("zh-sg,de;q=0.3", array("zh", "es", "de"), "zh-sg"),
-            array("fr-ca,fr;q=0.1", array("fr-ca"), "fr-ca"),
-            array("r5,fr;q=1,de", array("fr", "de"), "fr"),
-            array("Zen§gq1", array("en"), "xx"),
-        );
+            ["fr-ca", ["fr"], "fr-ca"],
+            ["fr-ca", ["ca"], "xx"],
+            ["", [], "xx"],
+            ["", ["en"], "xx"],
+            ["fr", ["en"], "xx"],
+            ["en", ["en"], "en"],
+            ["en", ["en-ca"], "xx"],
+            ["en-ca", ["en-ca"], "en-ca"],
+            ["en-ca", ["en"], "en-ca"],
+            ["fr,en-us", ["fr", "en"], "fr"],
+            ["fr,en-us", ["en", "fr"], "fr"],
+            ["fr-fr,fr-ca", ["fr"], "fr-fr"],
+            ["fr-fr,fr-ca", ["fr-ca"], "fr-ca"],
+            ["-ca", ["fr", "ca"], "xx"],
+            ["fr-fr;q=1.0,fr-ca;q=0.9", ["fr-ca"], "fr-ca"],
+            ["es,en,fr;q=0.7,de;q=0.3", ["fr", "es", "de", "en"], "es"],
+            ["zh-sg,de;q=0.3", ["zh", "es", "de"], "zh-sg"],
+            ["fr-ca,fr;q=0.1", ["fr-ca"], "fr-ca"],
+            ["r5,fr;q=1,de", ["fr", "de"], "fr"],
+            ["Zen§gq1", ["en"], "xx"],
+        ];
     }
 
     /**
@@ -462,7 +516,11 @@ class CommonTest extends TestCase
      */
     public function testExtractLanguageAndRegionCodeFromBrowserLanguage($browserLanguage, $validLanguages, $expected)
     {
-        $this->assertEquals($expected, Common::extractLanguageAndRegionCodeFromBrowserLanguage($browserLanguage, $validLanguages), "test with {$browserLanguage} failed, expected {$expected}");
+        $this->assertEquals(
+            $expected,
+            Common::extractLanguageAndRegionCodeFromBrowserLanguage($browserLanguage, $validLanguages),
+            "test with {$browserLanguage} failed, expected {$expected}"
+        );
     }
 
 
@@ -471,24 +529,24 @@ class CommonTest extends TestCase
      */
     public function getLanguageDataToExtractLanguageCode()
     {
-        return array(
+        return [
             // browser language, valid languages, expected result
-            array("fr-ca", array("fr"), "fr"),
-            array("fr-ca", array("ca"), "xx"),
-            array("", array("en"), "xx"),
-            array("fr", array("en"), "xx"),
-            array("en", array("en"), "en"),
-            array("en", array("en-ca"), "xx"),
-            array("en-ca", array("en"), "en"),
-            array("fr,en-us", array("fr", "en"), "fr"),
-            array("fr,en-us", array("en", "fr"), "fr"),
-            array("fr-fr,fr-ca", array("fr"), "fr"),
-            array("-ca", array("fr","ca"), "xx"),
-            array("es,en,fr;q=0.7,de;q=0.3", array("fr", "es", "de", "en"), "es"),
-            array("zh-sg,de;q=0.3", array("zh", "es", "de"), "zh"),
-            array("r5,fr;q=1,de", array("fr", "de"), "fr"),
-            array("Zen§gq1", array("en"), "xx"),
-        );
+            ["fr-ca", ["fr"], "fr"],
+            ["fr-ca", ["ca"], "xx"],
+            ["", ["en"], "xx"],
+            ["fr", ["en"], "xx"],
+            ["en", ["en"], "en"],
+            ["en", ["en-ca"], "xx"],
+            ["en-ca", ["en"], "en"],
+            ["fr,en-us", ["fr", "en"], "fr"],
+            ["fr,en-us", ["en", "fr"], "fr"],
+            ["fr-fr,fr-ca", ["fr"], "fr"],
+            ["-ca", ["fr", "ca"], "xx"],
+            ["es,en,fr;q=0.7,de;q=0.3", ["fr", "es", "de", "en"], "es"],
+            ["zh-sg,de;q=0.3", ["zh", "es", "de"], "zh"],
+            ["r5,fr;q=1,de", ["fr", "de"], "fr"],
+            ["Zen§gq1", ["en"], "xx"],
+        ];
     }
 
     /**
@@ -496,6 +554,10 @@ class CommonTest extends TestCase
      */
     public function testExtractLanguageCodeFromBrowserLanguage($browserLanguage, $validLanguages, $expected)
     {
-        $this->assertEquals($expected, Common::extractLanguageCodeFromBrowserLanguage($browserLanguage, $validLanguages), "test with {$browserLanguage} failed, expected {$expected}");
+        $this->assertEquals(
+            $expected,
+            Common::extractLanguageCodeFromBrowserLanguage($browserLanguage, $validLanguages),
+            "test with {$browserLanguage} failed, expected {$expected}"
+        );
     }
 }


### PR DESCRIPTION
### Description:

We had been using `Common::extractLanguageCodeFromBrowserLanguage` in some places for detecting the language. As this never includes the region, this kind of disabled detection for languages like `zh-cn`, `pt-br`,...
Using `Common::extractLanguageAndRegionCodeFromBrowserLanguage` solves that problem.

In addition I've also improved the extracting of language & region from language codes. Before we were not handling codes including the script at all. So if someone only provided the language code `zh_Hans_CN`, it would have falled back to `en`, as `zh` only is not available. The script will now be ignored/removed when detecting languages, so `zh_Hans_CN` results in `zh-cn`

fixes #20374 
fixes #20388

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
