### PR TITLE
Fixing some more PHP 8.1 deprecation warnings in Device Detector

### DIFF
--- a/plugins/DevicesDetection/functions.php
+++ b/plugins/DevicesDetection/functions.php
@@ -63,6 +63,11 @@ function getBrowserNameWithVersion($label)
 
 function getBrowserName($label)
 {
+    // Return early if the label is empty so that we don't try to manipulate an empty value
+    if (empty($label)) {
+        return Piwik::translate('General_Unknown');
+    }
+
     $short    = substr($label, 0, 2);
     $browsers = BrowserParser::getAvailableBrowsers();
 
@@ -91,7 +96,7 @@ function getBrowserLogo($short)
     $path = 'plugins/Morpheus/icons/dist/browsers/%s.png';
 
     // If name is given instead of short code, try to find matching shortcode
-    if (strlen($short) > 2) {
+    if (!empty($short) && strlen($short) > 2) {
         if (in_array($short, BrowserParser::getAvailableBrowsers())) {
             $flippedBrowsers = array_flip(BrowserParser::getAvailableBrowsers());
             $short           = $flippedBrowsers[$short];
@@ -280,6 +285,11 @@ function getOsFamilyLogo($label)
 
 function getOsFullName($label)
 {
+    // Return early if the label is empty so that we don't try to manipulate an empty value
+    if (empty($label)) {
+        return Piwik::translate('General_Unknown');
+    }
+
     if (substr($label, 0, 3) == Settings::OS_BOT) {
         return 'Bot';
     }


### PR DESCRIPTION
### Description:

The HeatmapSessionRecording plugin is surfacing a few more deprecation warnings in DeviceDetector. I figured that I would try to prevent the warnings from the plugin, but also try to address the root of the problem in core.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
