### PR TITLE
use local build script for tests

### DIFF
--- a/.github/scripts/build-package.sh
+++ b/.github/scripts/build-package.sh
@@ -5,6 +5,8 @@
 # $ git tag 1.11-b3
 # $ git push origin tags/1.11-b3
 
+shopt -s extglob
+
 URL_REPO=https://github.com/matomo-org/matomo.git
 
 LOCAL_REPO="matomo_last_version_git"
@@ -15,14 +17,6 @@ SUBMODULES_PACKAGED_WITH_CORE='log-analytics|plugins/Morpheus/icons|plugins/TagM
 
 # Setting umask so it works for most users, see https://github.com/matomo-org/matomo/issues/3869
 umask 0022
-
-# this is our current folder
-CURRENT_DIR="$(pwd)"
-
-# this is where our build script is.
-WORK_DIR="$CURRENT_DIR/archives/"
-
-echo "Working directory is '$WORK_DIR'..."
 
 function Usage() {
     echo -e "ERROR: This command is missing one or more option. See help below."
@@ -92,7 +86,7 @@ function organizePackage() {
         rm composer-setup.php
     fi
     # --ignore-platform-reqs in case the building machine does not have one of the packages required ie. GD required by cpchart
-    php composer.phar install --no-dev -o --ignore-platform-reqs || die "Error installing composer packages"
+    php composer.phar install --no-dev -o -q --ignore-platform-reqs || die "Error installing composer packages"
 
     # delete most submodules
     for P in $(git submodule status | egrep -v $SUBMODULES_PACKAGED_WITH_CORE | awk '{print $2}')
@@ -160,9 +154,16 @@ fi
 # check for local requirements
 checkEnv
 
+# this is our current folder
+CURRENT_DIR="$(pwd)"
+
+ARCH_DIR="$CURRENT_DIR/$LOCAL_ARCH"
+
+echo "Working directory is '$WORK_DIR'..."
+
 echo -e "Going to build Matomo $VERSION (Major version: $MAJOR_VERSION)"
 
-if ! echo "$VERSION" | grep -E 'rc|b|a|alpha|beta|dev' -i
+if ! echo "$VERSION" | grep -E 'rc|b|a|alpha|beta|dev|build' -i
 then
     if curl --output /dev/null --silent --head --fail "https://builds.matomo.org/$F-$VERSION.zip"
     then
@@ -175,26 +176,28 @@ sleep 2
 
 echo "Starting '$FLAVOUR' build...."
 
-mkdir -p "$WORK_DIR"
-cd "$WORK_DIR" || exit
+if [ "$VERSION" == "build" ]; then
+  mkdir $LOCAL_REPO
+  cp -pdr !($LOCAL_REPO) $LOCAL_REPO
+else
+  if [ -d "$LOCAL_REPO" ] ; then
+      rm -rf $LOCAL_REPO
+  fi
 
-[ -d "$LOCAL_ARCH" ] || mkdir "$LOCAL_ARCH"
+  echo "cloning repository for tag $VERSION..."
+
+  # for this to work 'git-lfs' has to be installed on the local machine
+  git clone --config filter.lfs.smudge="git-lfs smudge --skip" --single-branch --branch "$VERSION" "$URL_REPO" "$LOCAL_REPO"
+
+  if [ "$?" -ne "0" ] || [ ! -d "$LOCAL_REPO" ]; then
+      die "Error: Failed to clone git repository $URL_REPO, maybe tag $VERSION does not exist"
+  fi
+fi
+
+mkdir -p "$ARCH_DIR"
+cd "$ARCH_DIR" || exit
 
 cd "$CURRENT_DIR" || exit
-cd "$WORK_DIR" || exit
-
-if [ -d "$LOCAL_REPO" ] ; then
-    rm -rf $LOCAL_REPO
-fi
-
-echo "cloning repository for tag $VERSION..."
-
-# for this to work 'git-lfs' has to be installed on the local machine
-git clone --config filter.lfs.smudge="git-lfs smudge --skip" --single-branch --branch "$VERSION" "$URL_REPO" "$LOCAL_REPO"
-
-if [ "$?" -ne "0" ] || [ ! -d "$LOCAL_REPO" ]; then
-    die "Error: Failed to clone git repository $URL_REPO, maybe tag $VERSION does not exist"
-fi
 
 echo -e "Working in $LOCAL_REPO"
 cd "$LOCAL_REPO" || exit
@@ -208,10 +211,12 @@ done
 
 echo "Preparing release $VERSION"
 echo "Git tag: $(git describe --exact-match --tags HEAD)"
-echo "Git path: $WORK_DIR/$LOCAL_REPO"
+echo "Git path: $CURRENT_DIR/$LOCAL_REPO"
 echo "Matomo version in core/Version.php: $(grep "'$VERSION'" core/Version.php)"
 
-[ "$(grep "'$VERSION'" core/Version.php | wc -l)" = "1" ] || die "version $VERSION does not match core/Version.php";
+if [ "$VERSION" != "build" ]; then
+  [ "$(grep "'$VERSION'" core/Version.php | wc -l)" = "1" ] || die "version $VERSION does not match core/Version.php";
+fi
 
 echo "Organizing files and generating manifest file..."
 organizePackage
@@ -220,36 +225,43 @@ for F in $FLAVOUR; do
     echo "Creating '$F' release package"
 
     # leave $LOCAL_REPO folder
-    cd "$WORK_DIR" || exit
+    cd "$ARCH_DIR" || exit
 
     echo "copying files to a new directory..."
     [ -d "$F" ] && rm -rf "$F"
-    cp -pdr "$LOCAL_REPO" "$F"
+    cp -pdr "$CURRENT_DIR/$LOCAL_REPO" "$F"
+    cp "$CURRENT_DIR/How to install Matomo.html" "$ARCH_DIR"
     cd "$F" || exit
 
     # leave $F folder
     cd ..
 
     echo "packaging release..."
-    rm "../$LOCAL_ARCH/$F-$VERSION.zip" 2> /dev/null
-    zip -9 -r "../$LOCAL_ARCH/$F-$VERSION.zip" "$F" How\ to\ install\ Matomo.html > /dev/null
+    rm "$ARCH_DIR/$F-$VERSION.zip" 2> /dev/null
+    zip -9 -r "$ARCH_DIR/$F-$VERSION.zip" "$F" How\ to\ install\ Matomo.html > /dev/null
 
-    gpg --armor --detach-sign "../$LOCAL_ARCH/$F-$VERSION.zip" || die "Failed to sign $F-$VERSION.zip"
+    if [ "$VERSION" != "build" ]; then
+      gpg --armor --detach-sign "$ARCH_DIR/$F-$VERSION.zip" || die "Failed to sign $F-$VERSION.zip"
+    fi
 
-    rm "../$LOCAL_ARCH/$F-$VERSION.tar.gz"  2> /dev/null
-    tar -czf "../$LOCAL_ARCH/$F-$VERSION.tar.gz" "$F" How\ to\ install\ Matomo.html
+    rm "$ARCH_DIR/$F-$VERSION.tar.gz"  2> /dev/null
+    tar -czf "$ARCH_DIR/$F-$VERSION.tar.gz" "$F" How\ to\ install\ Matomo.html
 
-    gpg --armor --detach-sign "../$LOCAL_ARCH/$F-$VERSION.tar.gz" || die "Failed to sign $F-$VERSION.tar.gz"
+    if [ "$VERSION" != "build" ]; then
+      gpg --armor --detach-sign "$ARCH_DIR/$F-$VERSION.tar.gz" || die "Failed to sign $F-$VERSION.tar.gz"
+    fi
 
 done
 
-# Check File signatures are correct
-for ext in zip tar.gz
-do
-    for F in $FLAVOUR; do
-        gpg --verify ../$LOCAL_ARCH/$F-$VERSION.$ext.asc
-        if [ "$?" -ne "0" ]; then
-            die "Failed to verify signature for ../$LOCAL_ARCH/$F-$VERSION.$ext"
-        fi
-    done
-done
+if [ "$VERSION" != "build" ]; then
+  # Check File signatures are correct
+  for ext in zip tar.gz
+  do
+      for F in $FLAVOUR; do
+          gpg --verify $ARCH_DIR/$F-$VERSION.$ext.asc
+          if [ "$?" -ne "0" ]; then
+              die "Failed to verify signature for $ARCH_DIR/$F-$VERSION.$ext"
+          fi
+      done
+  done
+fi

--- a/.github/scripts/build-package.sh
+++ b/.github/scripts/build-package.sh
@@ -164,8 +164,6 @@ ARCH_DIR="$CURRENT_DIR/$LOCAL_ARCH"
 
 echo "Working directory is '$CURRENT_DIR'..."
 
-ls "$CURRENT_DIR/plugins"
-
 echo -e "Going to build Matomo $VERSION (Major version: $MAJOR_VERSION)"
 
 if ! echo "$VERSION" | grep -E 'rc|b|a|alpha|beta|dev|build' -i
@@ -257,8 +255,6 @@ for F in $FLAVOUR; do
     fi
 
 done
-
-ls "$CURRENT_DIR/plugins"
 
 if [ "$VERSION" != "build" ]; then
   # Check File signatures are correct

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
           
           echo "version=$version" >> $GITHUB_OUTPUT
           echo 'body<<EOF' >> $GITHUB_OUTPUT
-          echo $body >> $GITHUB_OUTPUT
+          echo "$body" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
           cd $GITHUB_WORKSPACE

--- a/plugins/CoreUpdater/ReleaseChannel/LatestStable.php
+++ b/plugins/CoreUpdater/ReleaseChannel/LatestStable.php
@@ -30,7 +30,7 @@ class LatestStable extends ReleaseChannel
 
     public function getDownloadUrlWithoutScheme($version)
     {
-        return '://builds.matomo.org/piwik.zip';
+        return '://builds.matomo.org/matomo.zip';
     }
 
     public function getOrder()

--- a/tests/PHPUnit/Fixtures/LatestStableInstall.php
+++ b/tests/PHPUnit/Fixtures/LatestStableInstall.php
@@ -43,6 +43,11 @@ class LatestStableInstall extends Fixture
         $this->verifyInstall($tokenAuth);
     }
 
+    public function tearDown(): void
+    {
+        $this->removeLatestStableInstall();
+    }
+
     private function removeLatestStableInstall()
     {
         $installSubdirectory = $this->getInstallSubdirectoryPath();
@@ -78,7 +83,7 @@ class LatestStableInstall extends Fixture
             throw new \Exception("Failed to extract matomo build ZIP archive.");
         }
 
-        shell_exec('mv "' . $installSubdirectory . '"/piwik/* "' . $installSubdirectory . '"');
+        shell_exec('mv "' . $installSubdirectory . '"/matomo/* "' . $installSubdirectory . '"');
     }
 
     private function installSubdirectoryInstall()

--- a/tests/PHPUnit/Fixtures/LatestStableInstall.php
+++ b/tests/PHPUnit/Fixtures/LatestStableInstall.php
@@ -132,41 +132,22 @@ class LatestStableInstall extends Fixture
 
     private function generateMatomoPackageFromGit()
     {
-        $this->cloneMatomoPackageRepo();
-        $this->runMatomoPackage();
-    }
-
-    private function cloneMatomoPackageRepo()
-    {
-        $pathToMatomoPackage = PIWIK_INCLUDE_PATH . '/../matomo-package';
-        if (file_exists($pathToMatomoPackage)) {
-            Filesystem::unlinkRecursive($pathToMatomoPackage, true);
-        }
-
-        $command = 'git clone https://github.com/matomo-org/matomo-package.git --depth=1 "' . $pathToMatomoPackage . '"';
-        exec($command, $output, $returnCode);
-
-        if ($returnCode != 0) {
-            throw new \Exception("Could not clone matomo-package repo: " . implode("\n", $output));
-        }
-    }
-
-    private function runMatomoPackage()
-    {
         $matomoBuildPath = PIWIK_INCLUDE_PATH . '/matomo-build.zip';
         if (file_exists($matomoBuildPath)) {
             unlink($matomoBuildPath);
         }
 
-        $command = 'cd "' . PIWIK_INCLUDE_PATH . '/../matomo-package" && ';
-        $command .= './scripts/build-package.sh "' . PIWIK_INCLUDE_PATH . '" piwik true';
+        $command = 'cd ' . PIWIK_INCLUDE_PATH . ' && ';
+        $command .= 'chmod 755 ./.github/scripts/*.sh && ';
+        $command .= './.github/scripts/build-package.sh build matomo';
 
         exec($command, $output, $returnCode);
+        echo implode("\n", $output);
         if ($returnCode != 0) {
             throw new \Exception("matomo-package failed: " . implode("\n", $output));
         }
 
-        $path = PIWIK_INCLUDE_PATH . '/../matomo-package/piwik-build.zip';
+        $path = PIWIK_INCLUDE_PATH . '/archives/matomo-build.zip';
         rename($path, $matomoBuildPath);
     }
 }


### PR DESCRIPTION
### Description:

We have a UI test case, that builds a matomo package out of the current branch and tries to perform an update from the latest stable version to this package.

Currently this test is still using our old script to build an archive. We moved that process to a git action a while ago.
This PR aims to update the test to use the local build script used in the github action.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
