### PR TITLE
Fix visits log might show incorrect action for groups

### DIFF
--- a/plugins/Live/Visualizations/VisitorLog.php
+++ b/plugins/Live/Visualizations/VisitorLog.php
@@ -198,7 +198,7 @@ class VisitorLog extends Visualization
                         $actionGroups[$idPageView]['refreshActions'][] = $actionGroups[$idPageView]['pageviewAction'];
                         $actionGroups[$idPageView]['pageviewAction'] = $action;
                     } else {
-                        $actionGroups[$idPageView]['refreshActions'][] = $actionGroups[$idPageView]['pageviewAction'];
+                        $actionGroups[$idPageView]['refreshActions'][] = $action;
                     }
                 } else {
                     $actionGroups[$idPageView]['actionsOnPage'][] = $action;

--- a/plugins/Live/tests/Fixtures/VisitsWithAllActionsAndDevices.php
+++ b/plugins/Live/tests/Fixtures/VisitsWithAllActionsAndDevices.php
@@ -194,6 +194,17 @@ class VisitsWithAllActionsAndDevices extends Fixture
         self::checkResponse($t->doTrackPageView('home'));
 
         $t->doTrackContentImpression('product slider', 'product_16.jpg', 'http://example.org/product16');
+
+        // track multiple page view within the same pageview id
+        $t->setForceVisitDateTime(Date::factory($dateTime)->addHour(0.6)->getDatetime());
+        $t->setUrl('http://example.org/nice-page.html');
+        $t->setPerformanceTimings(33, 66, 144, 221, 255, 255);
+        $t->setDebugStringAppend('pv_id=abcdef'); // appending this should overwrite the generated pageview id
+        self::checkResponse($t->doTrackPageView('first view'));
+        $t->setForceVisitDateTime(Date::factory($dateTime)->addHour(0.61)->getDatetime());
+        self::checkResponse($t->doTrackPageView('second view'));
+        $t->setForceVisitDateTime(Date::factory($dateTime)->addHour(0.62)->getDatetime());
+        self::checkResponse($t->doTrackPageView('third view'));
     }
 
     private function trackVisitMediaPlayer(\MatomoTracker $t, $dateTime)

--- a/plugins/Live/tests/UI/Live_spec.js
+++ b/plugins/Live/tests/UI/Live_spec.js
@@ -28,7 +28,7 @@ describe("Live", function () {
     });
 
     it('should expand grouped actions', async function() {
-        await page.click('.dataTableVizVisitorLog .repeat.icon-refresh');
+        await page.evaluate(() => $('.dataTableVizVisitorLog .repeat.icon-refresh').click());
         await page.mouse.move(-10, -10);
 
         var report = await page.$('.dataTableVizVisitorLog .card.row:first-child');

--- a/plugins/Live/tests/UI/expected-screenshots/Live_visitor_log.png
+++ b/plugins/Live/tests/UI/expected-screenshots/Live_visitor_log.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6991075edc92e97224ab80e64c3ef2d1c8d5062be2a0305fee4adba53ba9f34d
-size 390942
+oid sha256:75e89196ee6a68294f7f61ffe79dfa7b9950e0142586e0d02ecd7994198e08ee
+size 396186

--- a/plugins/Live/tests/UI/expected-screenshots/Live_visitor_log_expand_actions.png
+++ b/plugins/Live/tests/UI/expected-screenshots/Live_visitor_log_expand_actions.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e0024a43b3a5538a774e017d32d51a1c388e4f868b164fb8a9e13acd44eeaac
-size 54144
+oid sha256:e81dd4cf3a9f37bb02fd5dc7451c4222923387f31590f0b7fe54c7881d4e6f52
+size 67779

--- a/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile.png
+++ b/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96b8bfbebfa750348ce4a00c98379bf1d534fbdd8dca95819dddb8aa69acba2f
-size 427301
+oid sha256:95347271c7e0e7d379b296346228da1a16733813cadf86486a4456ee06d5dccc
+size 433530

--- a/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_action_details.png
+++ b/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_action_details.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d427db219440ccdf3e2b812b108fe02f7058c93de2902750feba716088bf54f
-size 300989
+oid sha256:202d29fb1278776bbcfea5719382ea03a2cb29e6503a30885c18fdf0a1a0b8ed
+size 306314

--- a/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_actions_hidden.png
+++ b/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_actions_hidden.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:033bb82fd319ffdcc489baf4bf95e532460ee7f9a13cdb146ee9b8d08379883e
-size 263575
+oid sha256:28b0f0e3c2d59e1ab5de0c9a4f567524077ee0ebddc1078bc74b224bd0b9e5ba
+size 263499

--- a/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_limited.png
+++ b/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_limited.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07a27a292b9988e327862b19fa7bddd349a9e9d22e98f597bf35772a6ab5a813
-size 315727
+oid sha256:4340c552dbe888b96bff73a3ef43aa4209176cf1483b7b491eba5c10585f492d
+size 321969

--- a/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_more_visits.png
+++ b/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_more_visits.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a4d73c737ee72766a6425460123e51fc50a2298b09b385feab8fd0bcab1629c
-size 454248
+oid sha256:4f7deb2180055ea8f9f4cfea34cfa1489b520b6c3487cf4fdc82c6dd753dfdd1
+size 460567

--- a/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_visit_details.png
+++ b/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_visit_details.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c41d0a900bd8d3ba5b60b70d96f203f4fd37c7307de5dc7c82746c1e927943fe
-size 274749
+oid sha256:50e0e9b8842ee5f83760c63768f4bffea897fb2689c681eb5b2b8f8caa51ee0a
+size 274663


### PR DESCRIPTION
### Description:

The incorrect behavior is reproducible if multiple pageviews are tracked with the same pageview id. e.g.

```javascript
_paq.push(['setPageViewId', 'abcdef']);
_paq.push(['setDocumentTitle', 'view 1']);
_paq.push(['trackPageView']);
_paq.push(['setDocumentTitle', 'view 2']);
_paq.push(['trackPageView']);
_paq.push(['setDocumentTitle', 'view 3']);
_paq.push(['trackPageView']);
```

fixes #20391

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
