### PR TITLE
OptOut: Remove extra twig markings

### DIFF
--- a/plugins/CoreAdminHome/templates/optOut.twig
+++ b/plugins/CoreAdminHome/templates/optOut.twig
@@ -56,13 +56,13 @@
         </p>
         {%  endif %}
 
-        <p id="textError_cookies" style="display:none; color: red; font-weight: bold;" %}>
+        <p id="textError_cookies" style="display:none; color: red; font-weight: bold;">
             {{ 'CoreAdminHome_OptOutErrorNoCookies'|translate }}
         </p>
-        <p id="textError_https" style="display:none; color: red; font-weight: bold;" %}>
+        <p id="textError_https" style="display:none; color: red; font-weight: bold;">
             {{ 'CoreAdminHome_OptOutErrorNotHttps'|translate }}
         </p>
-        <p id="textError_popupBlocker" style="display:none; color: red; font-weight: bold;" %}>
+        <p id="textError_popupBlocker" style="display:none; color: red; font-weight: bold;">
             {{ 'CoreAdminHome_OptOutErrorWindowOpen'|translate }}
         </p>
 


### PR DESCRIPTION
### Description:

There are extra `%}` which are not matched by a opening bracket and which are rendered like a html attribute.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
