### PR TITLE
Added code to include schedule command for plugins while generating github action

### DIFF
--- a/plugins/TestRunner/Commands/GenerateGitHubTestActionFile.php
+++ b/plugins/TestRunner/Commands/GenerateGitHubTestActionFile.php
@@ -36,6 +36,7 @@ class GenerateGitHubTestActionFile extends ConsoleCommand
     protected $enableRedis = true;
     protected $setupScript = null;
     protected $hasSubmodules = null;
+    protected $scheduleCron = null;
 
     protected function configure()
     {
@@ -51,7 +52,8 @@ class GenerateGitHubTestActionFile extends ConsoleCommand
              ->addOption('protect-artifacts', null, InputOption::VALUE_NONE, "Indicates if artifacts should be stored protected on artifact server.")
              ->addOption('setup-script', null, InputOption::VALUE_OPTIONAL, "Shell script to run (after setup, before tests), relative to plugins directory. .i.e .github/scripts/setup.sh")
              ->addOption('has-submodules', null, InputOption::VALUE_NONE, "Defines if the repo has submodules that need to be checked out.")
-             ->addOption('enable-redis', null, InputOption::VALUE_NONE, "Defines if a redis service should be set up for PHP and UI testing.");
+             ->addOption('enable-redis', null, InputOption::VALUE_NONE, "Defines if a redis service should be set up for PHP and UI testing.")
+             ->addOption('schedule-cron', null, InputOption::VALUE_OPTIONAL, "Value to schedule cron.");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -69,6 +71,7 @@ class GenerateGitHubTestActionFile extends ConsoleCommand
         $this->protectArtifacts = !!$input->getOption('protect-artifacts');
         $this->setupScript = $input->getOption('setup-script');
         $this->hasSubmodules = $input->getOption('setup-script');
+        $this->scheduleCron = $input->getOption('schedule-cron');
 
         if (!empty($this->plugin)) {
             if (!file_exists($this->getRepoRootDir())) {
@@ -121,6 +124,7 @@ class GenerateGitHubTestActionFile extends ConsoleCommand
         $template->assign('hasClientTests', $this->isTargetPluginContainsClientTests());
         $template->assign('hasUITests', $this->isTargetPluginContainsUITests());
         $template->assign('hasPluginTests', $this->isTargetPluginContainsPluginTests());
+        $template->assign('scheduleCron', $this->scheduleCron);
 
         $basePath = empty($this->plugin) ? $this->getPiwikRootDir() : $this->getRepoRootDir();
         $filePath = $basePath . '/.github/workflows/matomo-tests.yml';

--- a/plugins/TestRunner/Commands/GenerateGitHubTestActionFile.php
+++ b/plugins/TestRunner/Commands/GenerateGitHubTestActionFile.php
@@ -53,7 +53,7 @@ class GenerateGitHubTestActionFile extends ConsoleCommand
              ->addOption('setup-script', null, InputOption::VALUE_OPTIONAL, "Shell script to run (after setup, before tests), relative to plugins directory. .i.e .github/scripts/setup.sh")
              ->addOption('has-submodules', null, InputOption::VALUE_NONE, "Defines if the repo has submodules that need to be checked out.")
              ->addOption('enable-redis', null, InputOption::VALUE_NONE, "Defines if a redis service should be set up for PHP and UI testing.")
-             ->addOption('schedule-cron', null, InputOption::VALUE_OPTIONAL, "Value to schedule cron.");
+             ->addOption('schedule-cron', null, InputOption::VALUE_OPTIONAL, "Value to schedule cron. eg \"0 2 * * 6\" will run the job at 02:00 on Saturday.");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/plugins/TestRunner/Commands/GenerateGitHubTestActionFile.php
+++ b/plugins/TestRunner/Commands/GenerateGitHubTestActionFile.php
@@ -53,7 +53,7 @@ class GenerateGitHubTestActionFile extends ConsoleCommand
              ->addOption('setup-script', null, InputOption::VALUE_OPTIONAL, "Shell script to run (after setup, before tests), relative to plugins directory. .i.e .github/scripts/setup.sh")
              ->addOption('has-submodules', null, InputOption::VALUE_NONE, "Defines if the repo has submodules that need to be checked out.")
              ->addOption('enable-redis', null, InputOption::VALUE_NONE, "Defines if a redis service should be set up for PHP and UI testing.")
-             ->addOption('schedule-cron', null, InputOption::VALUE_OPTIONAL, "Value to schedule cron. eg \"0 2 * * 6\" will run the job at 02:00 on Saturday.");
+             ->addOption('schedule-cron', null, InputOption::VALUE_OPTIONAL, "Value to schedule a cron. eg \"0 2 * * 6\" will run the job at 02:00 on Saturday.");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/plugins/TestRunner/templates/matomo-tests.yml.twig
+++ b/plugins/TestRunner/templates/matomo-tests.yml.twig
@@ -24,6 +24,10 @@ on:
       - 'next_release'
 {% endif %}
   workflow_dispatch:
+{% if plugin %}
+  schedule:
+  - cron: "0 2 * * 6"
+{% endif %}
 
 permissions:
   actions: read

--- a/plugins/TestRunner/templates/matomo-tests.yml.twig
+++ b/plugins/TestRunner/templates/matomo-tests.yml.twig
@@ -10,6 +10,7 @@
         {%- if protectArtifacts %} --protect-artifacts{% endif %}
         {%- if setupScript %} --setup-script="{{ setupScript }}"{% endif %}
         {%- if hasSubmodules %} --has-submodules{% endif %}
+        {%- if scheduleCron %} --schedule-cron="{{ scheduleCron }}"{% endif %}
 
 
 name: {% if plugin %}Plugin {{ plugin }}{% else %}Matomo{% endif %} Tests
@@ -24,9 +25,9 @@ on:
       - 'next_release'
 {% endif %}
   workflow_dispatch:
-{% if plugin %}
+{% if scheduleCron %}
   schedule:
-  - cron: "0 2 * * 6"
+  - cron: "{{ scheduleCron }}"
 {% endif %}
 
 permissions:


### PR DESCRIPTION
### Description:

Added code to include schedule command for plugins while generating github action.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
