### PR TITLE
Support ranges with two dates for invalidateArchivedReports API call

### DIFF
--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -177,7 +177,7 @@ class API extends \Piwik\Plugin\API
                 implode("', '", $invalidDates) . "'. Matomo simply ignored those and proceeded with the others.";
         }
 
-        return $invalidationResult->makeOutputLogs();
+        return $output;
     }
 
     /**
@@ -337,9 +337,8 @@ class API extends \Piwik\Plugin\API
                     $invalidDates[] = $theDate;
                     continue;
                 }
-
-                if ($period->getRangeString() == $theDate) {
-                    $toInvalidate[] = $theDate;
+                if (count($period->getSubperiods())) {
+                    $toInvalidate[] = $period->getRangeString();
                 } else {
                     $invalidDates[] = $theDate;
                 }

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -575,14 +575,6 @@ abstract class SystemTestCase extends TestCase
         self::assertTrue(stripos($response, 'exception') === false, "exception in $response");
     }
 
-    public static function assertApiResponseHasError($response)
-    {
-        if(!is_string($response)) {
-            $response = json_encode($response);
-        }
-        self::assertTrue(stripos($response, 'error') || stripos($response, 'exception'), "error or exception not found in $response");
-    }
-
     protected static function getProcessedAndExpectedDirs()
     {
         $path = static::getPathToTestDirectory();

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -575,6 +575,14 @@ abstract class SystemTestCase extends TestCase
         self::assertTrue(stripos($response, 'exception') === false, "exception in $response");
     }
 
+    public static function assertApiResponseHasError($response)
+    {
+        if(!is_string($response)) {
+            $response = json_encode($response);
+        }
+        self::assertTrue(stripos($response, 'error') || stripos($response, 'exception'), "error or exception not found in $response");
+    }
+
     protected static function getProcessedAndExpectedDirs()
     {
         $path = static::getPathToTestDirectory();

--- a/tests/PHPUnit/System/ArchiveInvalidationTest.php
+++ b/tests/PHPUnit/System/ArchiveInvalidationTest.php
@@ -291,14 +291,12 @@ class ArchiveInvalidationTest extends SystemTestCase
         $method->setAccessible(true);
 
         $parameters = [$dateString, $period];
-        try {
-            $result = $method->invokeArgs($api, $parameters);
-            self::assertEquals($expected, $result);
-        } catch (\Exception $e) {
-            if (!$expectAPIError) {
-                throw $e;
-            }
+        if ($expectAPIError) {
+            self::expectException(\Exception::class);
         }
+
+        $result = $method->invokeArgs($api, $parameters);
+        self::assertEquals($expected, $result);
     }
 
     /**

--- a/tests/PHPUnit/System/ArchiveInvalidationTest.php
+++ b/tests/PHPUnit/System/ArchiveInvalidationTest.php
@@ -214,7 +214,7 @@ class ArchiveInvalidationTest extends SystemTestCase
             ['dateString' => '2020-01-01',            'period' => 'day',   'expected' => [['2020-01-01'],[]]],
             ['dateString' => '2020-04-01',            'period' => 'month', 'expected' => [['2020-04-01'],[]]],
             ['dateString' => '2020-05-01,2020-05-02', 'period' => 'day',   'expected' => [[Date::factory('2020-05-01'), Date::factory('2020-05-02')],[]]],
-            ['dateString' => 'today,yesterday',       'period' => 'month', 'expected' => [[Date::factory('today'), Date::factory('yesterday')],[]]],
+            ['dateString' => 'today,yesterday',       'period' => 'day',   'expected' => [[Date::factory('today'), Date::factory('yesterday')],[]]],
         ];
 
         // Test API

--- a/tests/PHPUnit/System/ArchiveInvalidationTest.php
+++ b/tests/PHPUnit/System/ArchiveInvalidationTest.php
@@ -5,6 +5,7 @@
  * @link    https://matomo.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
+
 namespace Piwik\Tests\System;
 
 use Piwik\API\Request;
@@ -65,48 +66,48 @@ class ArchiveInvalidationTest extends SystemTestCase
     public function getApiForTesting()
     {
         // We test a typical Numeric and a Recursive blob reports
-        $apiToCall = array('VisitsSummary.get', 'Actions.getPageUrls');
+        $apiToCall = ['VisitsSummary.get', 'Actions.getPageUrls'];
 
         // Build tests for the 2 websites
-        return array(
+        return [
 
-          array(
-            $apiToCall,
-            array(
-              'idSite'                 => self::$fixture->idSite2,
-              'testSuffix'             => 'Website' . self::$fixture->idSite2 . $this->suffix,
-              'date'                   => self::$fixture->dateTimeFirstDateWebsite2,
-              'periods'                => 'day',
-              'segment'                => self::TEST_SEGMENT,
-              'setDateLastN'           => 4, // 4months ahead
-              'otherRequestParameters' => array('expanded' => 1)
-            )
-          ),
-          array(
-            $apiToCall,
-            array(
-              'idSite'                 => self::$fixture->idSite1,
-              'testSuffix'             => 'Website' . self::$fixture->idSite1 . $this->suffix,
-              'date'                   => self::$fixture->dateTimeFirstDateWebsite1,
-              'periods'                => 'month',
-              'setDateLastN'           => 4, // 4months ahead
-              'otherRequestParameters' => array('expanded' => 1)
-            )
-          ),
+            [
+                $apiToCall,
+                [
+                    'idSite'                 => self::$fixture->idSite2,
+                    'testSuffix'             => 'Website' . self::$fixture->idSite2 . $this->suffix,
+                    'date'                   => self::$fixture->dateTimeFirstDateWebsite2,
+                    'periods'                => 'day',
+                    'segment'                => self::TEST_SEGMENT,
+                    'setDateLastN'           => 4, // 4months ahead
+                    'otherRequestParameters' => ['expanded' => 1],
+                ],
+            ],
+            [
+                $apiToCall,
+                [
+                    'idSite'                 => self::$fixture->idSite1,
+                    'testSuffix'             => 'Website' . self::$fixture->idSite1 . $this->suffix,
+                    'date'                   => self::$fixture->dateTimeFirstDateWebsite1,
+                    'periods'                => 'month',
+                    'setDateLastN'           => 4, // 4months ahead
+                    'otherRequestParameters' => ['expanded' => 1],
+                ],
+            ],
 
-          array(
-            $apiToCall,
-            array(
-              'idSite'                 => self::$fixture->idSite2,
-              'testSuffix'             => 'Website' . self::$fixture->idSite2 . $this->suffix,
-              'date'                   => self::$fixture->dateTimeFirstDateWebsite2,
-              'periods'                => 'month',
-              'segment'                => self::TEST_SEGMENT,
-              'setDateLastN'           => 4, // 4months ahead
-              'otherRequestParameters' => array('expanded' => 1)
-            )
-          )
-        );
+            [
+                $apiToCall,
+                [
+                    'idSite'                 => self::$fixture->idSite2,
+                    'testSuffix'             => 'Website' . self::$fixture->idSite2 . $this->suffix,
+                    'date'                   => self::$fixture->dateTimeFirstDateWebsite2,
+                    'periods'                => 'month',
+                    'segment'                => self::TEST_SEGMENT,
+                    'setDateLastN'           => 4, // 4months ahead
+                    'otherRequestParameters' => ['expanded' => 1],
+                ],
+            ],
+        ];
     }
 
     /**
@@ -134,14 +135,14 @@ class ArchiveInvalidationTest extends SystemTestCase
 
         Rules::setBrowserTriggerArchiving(true);
 
-        foreach ($this->getAnotherApiForTesting() as list($api, $params)) {
+        foreach ($this->getAnotherApiForTesting() as [$api, $params]) {
             $this->runApiTests($api, $params);
         }
     }
 
     public function testDisablePluginArchive()
     {
-        $config = Config::getInstance();
+        $config                                                   = Config::getInstance();
         $config->General['disable_archiving_segment_for_plugins'] = 'testPlugin';
         $this->assertTrue(Rules::isSegmentPluginArchivingDisabled('testPlugin'));
 
@@ -153,12 +154,11 @@ class ArchiveInvalidationTest extends SystemTestCase
 
         $config->General['disable_archiving_segment_for_plugins'] = '';
         $this->assertFalse(Rules::isSegmentPluginArchivingDisabled('testPlugin'));
-
     }
 
     public function testDisablePluginArchiveCaseInsensitive()
     {
-        $config = Config::getInstance();
+        $config                                                   = Config::getInstance();
         $config->General['disable_archiving_segment_for_plugins'] = 'testplugin,testplugin2';
         $this->assertTrue(Rules::isSegmentPluginArchivingDisabled('testPlugin'));
     }
@@ -166,7 +166,7 @@ class ArchiveInvalidationTest extends SystemTestCase
     public function testDisablePluginArchiveSpecialCharacters()
     {
         //special characters will not work
-        $config = Config::getInstance();
+        $config                                                   = Config::getInstance();
         $config->General['disable_archiving_segment_for_plugins'] = '!@##$%^^&&**(()_+';
         $this->assertFalse(Rules::isSegmentPluginArchivingDisabled('!@##$%^^&&**(()_+'));
     }
@@ -175,43 +175,52 @@ class ArchiveInvalidationTest extends SystemTestCase
     {
         //test siteId 1 by string
         Config::setSetting('General_1', 'disable_archiving_segment_for_plugins', 'testPlugin');
-        $this->assertTrue(Rules::isSegmentPluginArchivingDisabled('testPlugin',1));
+        $this->assertTrue(Rules::isSegmentPluginArchivingDisabled('testPlugin', 1));
 
         //test siteId 1 by array
-        Config::setSetting('General_1', 'disable_archiving_segment_for_plugins',['testPlugin', 'testPlugin2'] );
-        $this->assertTrue(Rules::isSegmentPluginArchivingDisabled('testPlugin',1));
+        Config::setSetting('General_1', 'disable_archiving_segment_for_plugins', ['testPlugin', 'testPlugin2']);
+        $this->assertTrue(Rules::isSegmentPluginArchivingDisabled('testPlugin', 1));
 
         //test siteId 1 by string with comma
-        Config::setSetting('General_1', 'disable_archiving_segment_for_plugins','testPlugin,testPlugin2' );
-        $this->assertTrue(Rules::isSegmentPluginArchivingDisabled('testPlugin',1));
+        Config::setSetting('General_1', 'disable_archiving_segment_for_plugins', 'testPlugin,testPlugin2');
+        $this->assertTrue(Rules::isSegmentPluginArchivingDisabled('testPlugin', 1));
 
         //test empty
-        Config::setSetting('General_1', 'disable_archiving_segment_for_plugins','' );
-        $this->assertFalse(Rules::isSegmentPluginArchivingDisabled('testPlugin',1));
+        Config::setSetting('General_1', 'disable_archiving_segment_for_plugins', '');
+        $this->assertFalse(Rules::isSegmentPluginArchivingDisabled('testPlugin', 1));
 
         //test siteId 2 not affect siteId1
-        Config::setSetting('General_2', 'disable_archiving_segment_for_plugins','testPlugin' );
-        $this->assertFalse(Rules::isSegmentPluginArchivingDisabled('testPlugin',1));
+        Config::setSetting('General_2', 'disable_archiving_segment_for_plugins', 'testPlugin');
+        $this->assertFalse(Rules::isSegmentPluginArchivingDisabled('testPlugin', 1));
 
 
         //test general setting not affect siteId1
-        Config::setSetting('General', 'disable_archiving_segment_for_plugins','myPlugin' );
-        Config::setSetting('General_1', 'disable_archiving_segment_for_plugins','testPlugin' );
-        $this->assertFalse(Rules::isSegmentPluginArchivingDisabled('myPlugin',1));
+        Config::setSetting('General', 'disable_archiving_segment_for_plugins', 'myPlugin');
+        Config::setSetting('General_1', 'disable_archiving_segment_for_plugins', 'testPlugin');
+        $this->assertFalse(Rules::isSegmentPluginArchivingDisabled('myPlugin', 1));
 
         Config::setSetting('General_1', 'disable_archiving_segment_for_plugins', 'testPlugin2');
         $this->assertFalse(Rules::isSegmentPluginArchivingDisabled('testPlugin', 1));
     }
 
-    /**
-     * Check that dates are correctly parsed without any exceptions
-     */
     public function getDatesToParse(): iterable
     {
-        yield 'normal range' => [
-            '2020-01-01,2020-03-31',
+        yield 'normal range as array' => [
+            ['2020-01-01,2020-03-31'],
             'range',
             [['2020-01-01,2020-03-31'], []],
+        ];
+
+        yield 'range not provided as array' => [
+            '2020-01-31,2020-03-31',
+            'range',
+            [['2020-01-31,2020-03-31'], []],
+        ];
+
+        yield 'multiple ranges' => [
+            ['2020-01-01,2020-03-31', '2020-07-01,2020-08-30'],
+            'range',
+            [['2020-01-01,2020-03-31', '2020-07-01,2020-08-30'], []],
         ];
 
         yield 'range using lastX keyword' => [
@@ -244,6 +253,24 @@ class ArchiveInvalidationTest extends SystemTestCase
             [[Date::factory('today'), Date::factory('yesterday')], []],
         ];
 
+        yield 'valid and invalid days' => [
+            '2022-12-12,2022-31-15',
+            'period' => 'day',
+            [['2022-12-12'], ['2022-31-15']],
+        ];
+
+        yield 'valid and invalid months' => [
+            '2022-12-12,2022-31-15',
+            'period' => 'month',
+            [['2022-12-12'], ['2022-31-15']],
+        ];
+
+        yield 'valid and invalid ranges' => [
+            ['2022-12-12,2022-12-15', '2020-12-12,2019-01-01'],
+            'period' => 'range',
+            [['2022-12-12,2022-12-15'], ['2020-12-12,2019-01-01']],
+        ];
+
         yield 'invalid text' => [
             'abcdef',
             'period' => 'day',
@@ -263,37 +290,44 @@ class ArchiveInvalidationTest extends SystemTestCase
         ];
 
         yield 'invalid range' => [
-            '2020-08-15, 2020-08-01',
+            ['2020-08-15, 2020-08-01'],
             'period' => 'range',
-            [[], ['2020-02-31']],
-            true
+            [[], ['2020-08-15, 2020-08-01']],
+        ];
+
+        yield 'another invalid range' => [
+            ['2020-08-15,2020-08-01,2020-09-01'],
+            'period' => 'range',
+            [[], ['2020-08-15,2020-08-01,2020-09-01']],
         ];
     }
 
     /**
      * @dataProvider getDatesToParse
      */
-    public function testDatesCorrectlyParsed($dateString, $period, $expected, bool $expectAPIError = false)
+    public function testDatesCorrectlyParsed($dates, $period, $expected)
     {
         // Test API
-        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=".self::$fixture->idSite1."&period=" .
-            $period . "&dates=" . $dateString);
-        if ($expectAPIError) {
-            $this->assertApiResponseHasError($r->process());
-        } else {
-            $this->assertApiResponseHasNoError($r->process());
-        }
+        $r = new Request(
+            [
+                'module'  => 'API',
+                'method'  => 'CoreAdminHome.invalidateArchivedReports',
+                'idSites' => self::$fixture->idSite1,
+                'period'  => $period,
+                'dates'   => $dates,
+            ],
+            []
+        );
+
+        $this->assertApiResponseHasNoError($r->process());
 
         // Test date parsing method
-        $api = CoreAdminHomeApi::getInstance();
+        $api        = CoreAdminHomeApi::getInstance();
         $reflection = new \ReflectionClass(CoreAdminHomeApi::class);
-        $method = $reflection->getMethod('getDatesToInvalidateFromString');
+        $method     = $reflection->getMethod('getDatesToInvalidateFromString');
         $method->setAccessible(true);
 
-        $parameters = [$dateString, $period];
-        if ($expectAPIError) {
-            self::expectException(\Exception::class);
-        }
+        $parameters = [$dates, $period];
 
         $result = $method->invokeArgs($api, $parameters);
         self::assertEquals($expected, $result);
@@ -318,7 +352,11 @@ class ArchiveInvalidationTest extends SystemTestCase
     {
         $dateToInvalidate1 = new \DateTime(self::$fixture->dateTimeFirstDateWebsite1);
 
-        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=" . self::$fixture->idSite1 . "&dates=" . $dateToInvalidate1->format('Y-m-d'));
+        $r = new Request(
+            "module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=" . self::$fixture->idSite1 . "&dates=" . $dateToInvalidate1->format(
+                'Y-m-d'
+            )
+        );
         $this->assertApiResponseHasNoError($r->process());
 
         // week reports only are invalidated. we test our daily report will show new data, even though weekly reports only are invalidated,
@@ -330,12 +368,11 @@ class ArchiveInvalidationTest extends SystemTestCase
     {
         $dates = new \DateTime($dateTime);
         $dates = $dates->format('Y-m-d');
-        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&period=$period&idSites=$idSite&dates=$dates&cascadeDown=" . (int)$cascadeDown);
+        $r     = new Request(
+            "module=API&method=CoreAdminHome.invalidateArchivedReports&period=$period&idSites=$idSite&dates=$dates&cascadeDown=" . (int)$cascadeDown
+        );
         $this->assertApiResponseHasNoError($r->process());
     }
-
-
-
 }
 
 ArchiveInvalidationTest::$fixture = new VisitsTwoWebsitesWithAdditionalVisits();

--- a/tests/PHPUnit/System/ArchiveInvalidationTest.php
+++ b/tests/PHPUnit/System/ArchiveInvalidationTest.php
@@ -201,7 +201,18 @@ class ArchiveInvalidationTest extends SystemTestCase
         $this->assertFalse(Rules::isSegmentPluginArchivingDisabled('testPlugin', 1));
     }
 
+    /**
+     * Check that both date range types are correctly parsed without any exceptions
+     */
+    public function testDateRangesCorrectlyParsed()
+    {
+        $testRanges = ['2020-01-01,2020-03-31', 'last30'];
 
+        foreach ($testRanges as $dateRange) {
+            $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=".self::$fixture->idSite1."&period=range&dates=".$dateRange);
+            $this->assertApiResponseHasNoError($r->process());
+        }
+    }
 
     /**
      * This is called after getApiToTest()
@@ -237,6 +248,9 @@ class ArchiveInvalidationTest extends SystemTestCase
         $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&period=$period&idSites=$idSite&dates=$dates&cascadeDown=" . (int)$cascadeDown);
         $this->assertApiResponseHasNoError($r->process());
     }
+
+
+
 }
 
 ArchiveInvalidationTest::$fixture = new VisitsTwoWebsitesWithAdditionalVisits();


### PR DESCRIPTION
### Description:

Fixes #20400

`invalidateArchivedReports` API calls with specific date ranges were failing with an invalid date error due to the was the date string was being processed:

`/index.php?module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=1&period=range&dates=2023-01-01,2023-03-03&token_auth=xxx`

This PR adds explicit handling for specific date ranges.


* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
