### PR TITLE
Delete log table data in chunks to prevent possible performance issues

### DIFF
--- a/core/Db.php
+++ b/core/Db.php
@@ -154,7 +154,7 @@ class Db
     {
         $dbConfig = self::getDatabaseConfig($dbConfig);
 
-        $db = @Adapter::factory('MYSQLI', $dbConfig);
+        $db = @Adapter::factory($dbConfig['adapter'], $dbConfig);
 
         self::$connection = $db;
     }
@@ -404,7 +404,6 @@ class Db
         $totalRowsDeleted = 0;
 
         do {
-            echo $sql . "\n";
             $rowsDeleted = self::query($sql, $parameters)->rowCount();
 
             $totalRowsDeleted += $rowsDeleted;

--- a/core/Db.php
+++ b/core/Db.php
@@ -154,7 +154,7 @@ class Db
     {
         $dbConfig = self::getDatabaseConfig($dbConfig);
 
-        $db = @Adapter::factory($dbConfig['adapter'], $dbConfig);
+        $db = @Adapter::factory('MYSQLI', $dbConfig);
 
         self::$connection = $db;
     }
@@ -404,6 +404,7 @@ class Db
         $totalRowsDeleted = 0;
 
         do {
+            echo $sql . "\n";
             $rowsDeleted = self::query($sql, $parameters)->rowCount();
 
             $totalRowsDeleted += $rowsDeleted;

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -208,7 +208,7 @@ class DataSubjects
             $tblFrom = $this->makeFromStatement($from);
 
             if (count($from) === 1) {
-                $result = Db::deleteAllRows($tblFrom, ' WHERE ' . $where, '', 100000, $bind);
+                $result = Db::deleteAllRows($tblFrom, ' WHERE ' . $where, '', 25000, $bind);
             } else {
                 // You cannot use ORDER BY or LIMIT in a multiple-table DELETE. We have to delete it all at once
                 $sql = "DELETE $logTableName FROM $tblFrom WHERE $where";

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -206,9 +206,13 @@ class DataSubjects
 
             [$where, $bind] = $generateWhere($tableToSelect);
 
-            $sql = "DELETE $logTableName FROM " . $this->makeFromStatement($from) . " WHERE $where";
-
-            $result = Db::query($sql, $bind)->rowCount();
+            if (count($from) === 1) {
+                $result = Db::deleteAllRows($logTableName, $where, '', 100000, $bind);
+            } else {
+                // You cannot use ORDER BY or LIMIT in a multiple-table DELETE. We have to delete it all at once
+                $sql = "DELETE $logTableName FROM " . $this->makeFromStatement($from) . " WHERE $where";
+                $result = Db::query($sql, $bind)->rowCount();
+            }
 
             $results[$logTableName] = $result;
         }

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -205,11 +205,13 @@ class DataSubjects
             }
 
             [$where, $bind] = $generateWhere($tableToSelect);
-            $tblFrom = $this->makeFromStatement($from);
 
             if (count($from) === 1) {
+                $tblFrom = Common::prefixTable($logTableName) . ' AS '. $logTableName;
                 $result = Db::deleteAllRows($tblFrom, ' WHERE ' . $where, '', 25000, $bind);
             } else {
+                $tblFrom = $this->makeFromStatement($from);
+
                 // You cannot use ORDER BY or LIMIT in a multiple-table DELETE. We have to delete it all at once
                 $sql = "DELETE $logTableName FROM $tblFrom WHERE $where";
                 $result = Db::query($sql, $bind)->rowCount();

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -207,7 +207,8 @@ class DataSubjects
             [$where, $bind] = $generateWhere($tableToSelect);
 
             if (count($from) === 1) {
-                $tblFrom = Common::prefixTable($logTableName) . ' AS '. $logTableName;
+                $tblFrom = Common::prefixTable($logTableName);
+                $where = str_replace($logTableName . '.', $tblFrom . '.', $where);
                 $result = Db::deleteAllRows($tblFrom, ' WHERE ' . $where, '', 25000, $bind);
             } else {
                 $tblFrom = $this->makeFromStatement($from);

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -211,7 +211,7 @@ class DataSubjects
                 $result = Db::deleteAllRows($tblFrom, ' WHERE ' . $where, '', 100000, $bind);
             } else {
                 // You cannot use ORDER BY or LIMIT in a multiple-table DELETE. We have to delete it all at once
-                $sql = "DELETE $logTableName FROM " . $tblFrom . " WHERE $where";
+                $sql = "DELETE $logTableName FROM $tblFrom WHERE $where";
                 $result = Db::query($sql, $bind)->rowCount();
             }
 

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -205,12 +205,13 @@ class DataSubjects
             }
 
             [$where, $bind] = $generateWhere($tableToSelect);
+            $tblFrom = $this->makeFromStatement($from);
 
             if (count($from) === 1) {
-                $result = Db::deleteAllRows($logTableName, $where, '', 100000, $bind);
+                $result = Db::deleteAllRows($tblFrom, ' WHERE ' . $where, '', 100000, $bind);
             } else {
                 // You cannot use ORDER BY or LIMIT in a multiple-table DELETE. We have to delete it all at once
-                $sql = "DELETE $logTableName FROM " . $this->makeFromStatement($from) . " WHERE $where";
+                $sql = "DELETE $logTableName FROM " . $tblFrom . " WHERE $where";
                 $result = Db::query($sql, $bind)->rowCount();
             }
 


### PR DESCRIPTION
### Description:

refs https://github.com/matomo-org/matomo/issues/20221

This won't fully solve the issue but it will fix it for the tables that cause the biggest issues.

After this is merged, we could maybe deprioritise #20221 as it potentially can't even be fixed maybe and it'll be less of a problem then.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
