### PR TITLE
Fixed PHP 8.2 deprecation error in CustomDimensions

### DIFF
--- a/plugins/CustomDimensions/Dimension/Name.php
+++ b/plugins/CustomDimensions/Dimension/Name.php
@@ -14,6 +14,8 @@ use Piwik\Piwik;
 
 class Name
 {
+    protected $name;
+
     public function __construct($name)
     {
         $this->name = $name;

--- a/plugins/CustomDimensions/tests/System/ApiTest.php
+++ b/plugins/CustomDimensions/tests/System/ApiTest.php
@@ -91,7 +91,7 @@ class ApiTest extends SystemTestCase
                             'expanded' => '0',
                             'flat' => '0',
                         ),
-                        'testSuffix' => "${period}_site_${idSite}_dimension_${idDimension}",
+                        'testSuffix' => "{$period}_site_{$idSite}_dimension_{$idDimension}",
                         'xmlFieldsToRemove' => $removeColumns
                     )
                 );


### PR DESCRIPTION
### Description:

While switching the plugins to build against PHP 8.2, I noticed a deprecation warning coming from the CustomDimensions ApiTest. This is correcting that deprecation warning.
```
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /home/runner/work/plugin-CustomAlerts/plugin-CustomAlerts/matomo/plugins/CustomDimensions/tests/System/ApiTest.php on line 94
```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
