### PR TITLE
Implement custom console formatter to allow logging request id

### DIFF
--- a/plugins/Monolog/Formatter/ConsoleFormatter.php
+++ b/plugins/Monolog/Formatter/ConsoleFormatter.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Monolog\Formatter;
+
+use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter AS SymfonyConsoleFormatter;
+
+class ConsoleFormatter extends SymfonyConsoleFormatter
+{
+    public function format(array $record)
+    {
+        $formatted = parent::format($record);
+
+        foreach ($record['extra'] as $var => $val) {
+            if (false !== strpos($formatted, '%extra.' . $var . '%')) {
+                $formatted = str_replace('%extra.' . $var . '%', $val, $formatted);
+                unset($record['extra'][$var]);
+            }
+        }
+
+        return $formatted;
+    }
+}

--- a/plugins/Monolog/config/cli.php
+++ b/plugins/Monolog/config/cli.php
@@ -3,7 +3,6 @@
 use Psr\Container\ContainerInterface;
 use Monolog\Logger;
 use Piwik\Plugins\Monolog\Handler\FailureLogMessageDetector;
-use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter;
 use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -32,7 +31,7 @@ return array(
             OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG,
         );
         $handler = new ConsoleHandler(null, true, $verbosityMap);
-        $handler->setFormatter(new ConsoleFormatter([
+        $handler->setFormatter(new \Piwik\Plugins\Monolog\Formatter\ConsoleFormatter([
             'format' => $c->get('log.console.format'),
             'multiline' => true
         ]));


### PR DESCRIPTION
### Description:

Due to updating the symfony dependencies logging the request id within console message does no longer work.
Internally the symfony logging was changed and the console formatter does not longer allow to use single extra values in the format.
I've added a custom console formatter to allow this again.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
