### PR TITLE
Add missing annotation delete translation

### DIFF
--- a/plugins/Annotations/templates/_annotation.twig
+++ b/plugins/Annotations/templates/_annotation.twig
@@ -51,7 +51,7 @@
     <span class="icon-edit"></span>
   </span>
 
-  <a class="delete-annotation" title="Delete">
+  <a class="delete-annotation" title="{{ 'Annotations_ClickToDelete'|translate }}">
       <span class="icon-delete"></span>
   </a>
 


### PR DESCRIPTION
### Description:

Fixes the delete annotation tooltip not using it's translation and always showing in English. 

Fixes #20484

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
