### PR TITLE
Ensure to unsanitize goal pattern correctly

### DIFF
--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -116,6 +116,7 @@ class API extends \Piwik\Plugin\API
         $goal['name'] = Common::unsanitizeInputValue($goal['name']);
         $goal['description'] = Common::unsanitizeInputValue($goal['description']);
         $goal['pattern_type'] = Common::unsanitizeInputValue($goal['pattern_type']);
+        $goal['pattern'] = Common::unsanitizeInputValue($goal['pattern']);
 
         if ($goal['match_attribute'] == 'manually') {
             unset($goal['pattern']);


### PR DESCRIPTION
### Description:

This seems to be a regression from #19490 where pattern_type is being unsanitized instead of of pattern

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
