### PR TITLE
Ensure parameters expected to be provided as json are handled correctly

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -529,7 +529,9 @@ class Common
         // we deal w/ json differently
         if ($varType === 'json') {
             $value = $requestArrayToUse[$varName];
-            $value = json_decode($value, $assoc = true);
+            if (is_string($value)) {
+                $value = json_decode($value, $assoc = true);
+            }
             return self::sanitizeInputValues($value, true);
         }
 


### PR DESCRIPTION
### Description:

`Common::getRequestVar` allows the type to be expected as json. In this case we currently always try to perform an json_decode. This might end in a fatal error on newer php versions in case the parameter was actually provided as array.

refs https://github.com/matomo-org/plugin-QueuedTracking/issues/194
fixes #20361

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
