### PR TITLE
Custom Dimensions: Allow non-capturing groups in extraction regex

### DIFF
--- a/plugins/CustomDimensions/Dimension/Extraction.php
+++ b/plugins/CustomDimensions/Dimension/Extraction.php
@@ -42,7 +42,7 @@ class Extraction
         }
         
         //Count the number of non-capturing groups in order to omit them from being counted as capturing groups
-        $ncgCount = substr_count($pattern, '(?');
+        $ncgCount = substr_count($this->pattern, '(?');
         if (!empty($this->pattern) && $this->dimension !== 'urlparam') {
             // make sure there is exactly one ( followed by one )
             if (1 !== substr_count($this->pattern, '(') - $ncgCount ||

--- a/plugins/CustomDimensions/Dimension/Extraction.php
+++ b/plugins/CustomDimensions/Dimension/Extraction.php
@@ -40,12 +40,14 @@ class Extraction
             $dimensions = implode(', ', array_keys($dimensions));
             throw new Exception("Invald dimension '$this->dimension' used in an extraction. Available dimensions are: " . $dimensions);
         }
-
+        
+        //Count the number of non-capturing groups in order to omit them from being counted as capturing groups
+        $ncgCount = substr_count($pattern, '(?');
         if (!empty($this->pattern) && $this->dimension !== 'urlparam') {
             // make sure there is exactly one ( followed by one )
-            if (1 !== substr_count($this->pattern, '(') ||
-                1 !== substr_count($this->pattern, ')') ||
-                1 !== substr_count($this->pattern, ')', strpos($this->pattern, '('))) {
+            if (1 !== substr_count($this->pattern, '(') - $ncgCount ||
+                1 !== substr_count($this->pattern, ')') - $ncgCount ||
+                1 !== substr_count($this->pattern, ')', strpos($this->pattern, '(')) - $ncgCount) {
                 throw new Exception("You need to group exactly one part of the regular expression inside round brackets, eg 'index_(.+).html'");
             }
         }

--- a/plugins/CustomDimensions/tests/Integration/Dimension/ExtractionTest.php
+++ b/plugins/CustomDimensions/tests/Integration/Dimension/ExtractionTest.php
@@ -34,6 +34,36 @@ class ExtractionTest extends IntegrationTestCase
         }
     }
 
+    public function test_non_capturing_group()
+    {
+        $extraction = $this->buildExtraction('url', '.com/(?:test)/.*camelCase=(.*)');
+
+        $request = $this->buildRequest();
+        $value   = $extraction->extract($request);
+
+        $this->assertSame('fooBarBaz', $value);
+    }
+
+    public function test_non_capturing_group_within_capture_group()
+    {
+        $extraction = $this->buildExtraction('url', '.com/.*(?:camel=|camelCase=(.*))');
+
+        $request = $this->buildRequest();
+        $value   = $extraction->extract($request);
+
+        $this->assertSame('fooBarBaz', $value);
+    }
+
+    public function test_multiple_non_capturing_groups()
+    {
+        $extraction = $this->buildExtraction('url', '.com/(?:test)/.*(?:camel=|camelCase=(.*))');
+
+        $request = $this->buildRequest();
+        $value   = $extraction->extract($request);
+
+        $this->assertSame('fooBarBaz', $value);
+    }
+    
     public function test_toArray()
     {
         $extraction = $this->buildExtraction('url', '.com/(.+)/index');
@@ -223,6 +253,8 @@ class ExtractionTest extends IntegrationTestCase
             array('index.)html'),
             array('index.)(html'),
             array('index.)(.+)html'),
+            array('(?:index.(html)'),
+            array('(?:index).html)'),
         );
     }
 


### PR DESCRIPTION
### Description:

Fix the issue with Matomo counting non-capturing groups like this (?...) as capturing groups.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
