### PR TITLE
use "tooltip-enabled" data to mark datatable as having tooltip enabled

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1456,11 +1456,11 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
         var $domElement = $(domElement);
 
-        if ($domElement.data('tooltip') == 'enabled') {
+        if ($domElement.data('tooltip-enabled') == '1') {
             return;
         }
 
-        $domElement.data('tooltip', 'enabled');
+        $domElement.data('tooltip-enabled', '1');
 
         if (!isTextEllipsized($domElement)) {
             return;


### PR DESCRIPTION
### Description:

...instead of setting "tooltip" data which jquery-ui tooltip appears to use. Currently if a label is too long, it will be ellipsized and hovering over it will display the text: `"enabled"` rather than the label text. Changing the attribute name used in dataTable.js seems to fix this.

Note: I put this into the 4.14 milestone, because it seemed like the right place to go.

refs PG-2627

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
