### PR TITLE
Fix error message when UI asset can't be written

### DIFF
--- a/core/AssetManager/UIAsset/OnDiskUIAsset.php
+++ b/core/AssetManager/UIAsset/OnDiskUIAsset.php
@@ -6,6 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  *
  */
+
 namespace Piwik\AssetManager\UIAsset;
 
 use Exception;
@@ -92,14 +93,16 @@ class OnDiskUIAsset extends UIAsset
      * @param string $content
      * @throws \Exception
      */
-    public function writeContent($content)
+    public function writeContent($content): void
     {
         $this->delete();
 
-        $newFile = @fopen($this->getAbsoluteLocation(), "w");
+        $location = $this->getAbsoluteLocation();
+
+        $newFile = @fopen($location, 'w');
 
         if (!$newFile) {
-            throw new Exception("The file : " . $newFile . " can not be opened in write mode.");
+            throw new Exception('The file : ' . $location . ' can not be opened in write mode.');
         }
 
         fwrite($newFile, $content);


### PR DESCRIPTION
### Description:

Guess the error message was supposed to contain the file name, but it actually didn't, so it doesn't help much.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
