### PR TITLE
Allow goals processed metrics to appear in API.getProcessedReport output

### DIFF
--- a/core/API/DataTablePostProcessor.php
+++ b/core/API/DataTablePostProcessor.php
@@ -284,8 +284,20 @@ class DataTablePostProcessor
         }
 
         if ($addGoalProcessedMetrics !== null) {
-            $idGoal = Common::getRequestVar(
-                'idGoal', DataTable\Filter\AddColumnsProcessedMetricsGoal::GOALS_OVERVIEW, 'string', $this->request);
+            // if no idGoal is present, but filter_show_goal_columns_process_goals is set to one goal,
+            // default idGoal to that value. this allows us to use filter_update_columns_when_show_all_goals
+            // w/ API.getProcessedReport w/o setting idGoal, which affects the search for report metadata.
+            if (!empty($goalsToProcess)
+                && count($goalsToProcess) == 1
+                && $goalsToProcess[0] !== '0'
+                && $goalsToProcess[0] !== 0
+            ) {
+                $defaultIdGoal = $goalsToProcess[0];
+            } else {
+                $defaultIdGoal = DataTable\Filter\AddColumnsProcessedMetricsGoal::GOALS_OVERVIEW;
+            }
+
+            $idGoal = Common::getRequestVar('idGoal', $defaultIdGoal, 'string', $this->request);
 
             $dataTable->filter('AddColumnsProcessedMetricsGoal', array($ignore = true, $idGoal, $goalsToProcess));
         }

--- a/core/API/DocumentationGenerator.php
+++ b/core/API/DocumentationGenerator.php
@@ -296,6 +296,7 @@ class DocumentationGenerator
         $aParameters['compareSegments'] = false;
         $aParameters['comparisonIdSubtables'] = false;
         $aParameters['invert_compare_change_compute'] = false;
+        $aParameters['filter_update_columns_when_show_all_goals'] = false;
 
         $entityNames = StaticContainer::get('entities.idNames');
         foreach ($entityNames as $entityName) {

--- a/core/API/DocumentationGenerator.php
+++ b/core/API/DocumentationGenerator.php
@@ -297,6 +297,7 @@ class DocumentationGenerator
         $aParameters['comparisonIdSubtables'] = false;
         $aParameters['invert_compare_change_compute'] = false;
         $aParameters['filter_update_columns_when_show_all_goals'] = false;
+        $aParameters['filter_show_goal_columns_process_goals'] = false;
 
         $entityNames = StaticContainer::get('entities.idNames');
         foreach ($entityNames as $entityName) {

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -267,8 +267,13 @@ class ProcessedReport
                 }
             }
             // when there are per goal metrics, don't display conversion_rate since it can differ from per goal sum
+            // (but only if filter_update_columns_when_show_all_goals is not in the request, if it is then we assume
+            // the caller wants this information)
             // TODO we should remove this once we remove the getReportMetadata event, leaving it here for backwards compatibility
-            if (isset($availableReport['metricsGoal'])) {
+            $requestingGoalMetrics = Common::getRequestVar('filter_update_columns_when_show_all_goals', false);
+            if (isset($availableReport['metricsGoal'])
+                && !$requestingGoalMetrics
+            ) {
                 unset($availableReport['processedMetrics']['conversion_rate']);
                 unset($availableReport['metricsGoal']['conversion_rate']);
             }

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -649,7 +649,9 @@ class ProcessedReport
 
             foreach ($rowMetrics as $columnName => $columnValue) {
                 // filter metrics according to metadata definition
-                if (isset($metadataColumns[$columnName])) {
+                if (isset($metadataColumns[$columnName])
+                    || preg_match('/^goal_[0-9]+_/', $columnName)
+                ) {
                     // generate 'human readable' metric values
 
                     // if we handle MultiSites.getAll we do not always have the same idSite but different ones for

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_VisitTime.getVisitInformationPerServerTime__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_VisitTime.getVisitInformationPerServerTime__API.getProcessedReport_day.xml
@@ -49,6 +49,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=VisitTime&amp;apiAction=getVisitInformationPerServerTime&amp;period=day&amp;date=2011-04-05</imageGraphUrl>
 		<uniqueId>VisitTime_getVisitInformationPerServerTime</uniqueId>
 	</metadata>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems__API.getProcessedReport_day.xml
@@ -45,6 +45,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=day&amp;date=2011-04-05</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=day&amp;date=2011-03-07,2011-04-05</imageGraphEvolutionUrl>
 		<uniqueId>UserCountry_getCountry</uniqueId>

--- a/plugins/Goals/Goals.php
+++ b/plugins/Goals/Goals.php
@@ -274,6 +274,13 @@ class Goals extends \Piwik\Plugin
             'revenue'         => Piwik::translate('General_ColumnRevenue')
         );
 
+        $goalMetricTypes = [
+            'revenue_per_visit' => Dimension::TYPE_MONEY,
+            'nb_conversions' => Dimension::TYPE_NUMBER,
+            'conversion_rate' => Dimension::TYPE_PERCENT,
+            'revenue' => Dimension::TYPE_MONEY,
+        ];
+
         $reportsWithGoals = self::getAllReportsWithGoalMetrics();
 
         foreach ($reportsWithGoals as $reportWithGoals) {
@@ -291,6 +298,7 @@ class Goals extends \Piwik\Plugin
                 ) {
                     $apiReportToUpdate['metricsGoal'] = $goalMetrics;
                     $apiReportToUpdate['processedMetricsGoal'] = $goalProcessedMetrics;
+                    $apiReportToUpdate['metricTypesGoal'] = $goalMetricTypes;
                     break;
                 }
             }

--- a/plugins/Goals/Goals.php
+++ b/plugins/Goals/Goals.php
@@ -287,7 +287,8 @@ class Goals extends \Piwik\Plugin
 
                 if ($apiReportToUpdate['module'] == $reportWithGoals['module']
                     && $apiReportToUpdate['action'] == $reportWithGoals['action']
-                    && empty($apiReportToUpdate['parameters'])) {
+                    && empty($apiReportToUpdate['parameters'])
+                ) {
                     $apiReportToUpdate['metricsGoal'] = $goalMetrics;
                     $apiReportToUpdate['processedMetricsGoal'] = $goalProcessedMetrics;
                     break;

--- a/plugins/Goals/tests/System/TrackGoalsOneConversionPerVisitTest.php
+++ b/plugins/Goals/tests/System/TrackGoalsOneConversionPerVisitTest.php
@@ -68,6 +68,30 @@ class TrackGoalsOneConversionPerVisitTest extends SystemTestCase
                 'segment' => 'visitCount>=1;pageUrl=@/',
                 'testSuffix' => '_withLogLinkVisitActionAndLogVisitSegment'
             )),
+
+            ['API.getProcessedReport', [
+                'idSite' => self::$fixture->idSite,
+                'date' => self::$fixture->dateTime,
+                'period' => 'day',
+                'testSuffix' => 'showGoalsMetricsSingleGoal',
+                'otherRequestParameters' => [
+                    'filter_update_columns_when_show_all_goals' => '1',
+                    'filter_show_goal_columns_process_goals' => '1',
+                    'apiModule' => 'DevicesDetection',
+                    'apiAction' => 'getBrowsers',
+                ],
+            ]],
+            ['API.getProcessedReport', [
+                'idSite' => self::$fixture->idSite,
+                'date' => self::$fixture->dateTime,
+                'period' => 'day',
+                'testSuffix' => 'showGoalsMetricsAllGoals',
+                'otherRequestParameters' => [
+                    'filter_update_columns_when_show_all_goals' => '1',
+                    'apiModule' => 'DevicesDetection',
+                    'apiAction' => 'getBrowsers',
+                ],
+            ]],
         );
     }
 

--- a/plugins/Goals/tests/System/TrackGoalsPagesTest.php
+++ b/plugins/Goals/tests/System/TrackGoalsPagesTest.php
@@ -44,7 +44,30 @@ class TrackGoalsPagesTest extends SystemTestCase
                                                               ['filter_update_columns_when_show_all_goals' => 1]]],
             ['Actions.getEntryPageTitles', ['idSite' => self::$fixture->idSite, 'date' => self::$fixture->dateTime,
                                             'idGoal' => 1, 'period' => 'day', 'otherRequestParameters' =>
-                                                              ['filter_update_columns_when_show_all_goals' => 1]]]
+                                                              ['filter_update_columns_when_show_all_goals' => 1]]],
+
+            ['API.getProcessedReport', [
+                'idSite' => self::$fixture->idSite,
+                'date' => self::$fixture->dateTime,
+                'period' => 'day',
+                'testSuffix' => 'showGoalsMetricsSingleGoal',
+                'otherRequestParameters' => [
+                    'filter_update_columns_when_show_all_goals' => 1,
+                    'apiModule' => 'Actions',
+                    'apiAction' => 'getEntryPageUrls',
+                ],
+            ]],
+            ['API.getProcessedReport', [
+                'idSite' => self::$fixture->idSite,
+                'date' => self::$fixture->dateTime,
+                'period' => 'day',
+                'testSuffix' => 'showGoalsMetricsAllGoals',
+                'otherRequestParameters' => [
+                    // 'filter_update_columns_when_show_all_goals' => '0',
+                    'apiModule' => 'Actions',
+                    'apiAction' => 'getEntryPageUrls',
+                ],
+            ]],
         ];
     }
 

--- a/plugins/Goals/tests/System/TrackGoalsPagesTest.php
+++ b/plugins/Goals/tests/System/TrackGoalsPagesTest.php
@@ -52,9 +52,10 @@ class TrackGoalsPagesTest extends SystemTestCase
                 'period' => 'day',
                 'testSuffix' => 'showGoalsMetricsSingleGoal',
                 'otherRequestParameters' => [
-                    'filter_update_columns_when_show_all_goals' => 1,
+                    'filter_update_columns_when_show_all_goals' => '1',
+                    'filter_show_goal_columns_process_goals' => '1',
                     'apiModule' => 'Actions',
-                    'apiAction' => 'getEntryPageUrls',
+                    'apiAction' => 'getEntryPageTitles',
                 ],
             ]],
             ['API.getProcessedReport', [
@@ -63,9 +64,9 @@ class TrackGoalsPagesTest extends SystemTestCase
                 'period' => 'day',
                 'testSuffix' => 'showGoalsMetricsAllGoals',
                 'otherRequestParameters' => [
-                    // 'filter_update_columns_when_show_all_goals' => '0',
+                    'filter_update_columns_when_show_all_goals' => '1',
                     'apiModule' => 'Actions',
-                    'apiAction' => 'getEntryPageUrls',
+                    'apiAction' => 'getEntryPageTitles',
                 ],
             ]],
         ];

--- a/plugins/Goals/tests/System/expected/test_trackGoals_oneConversionPerVisitshowGoalsMetricsAllGoals__API.getProcessedReport_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_oneConversionPerVisitshowGoalsMetricsAllGoals__API.getProcessedReport_day.xml
@@ -55,6 +55,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getBrowsers&amp;period=day&amp;date=2010-01-03</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getBrowsers&amp;period=day&amp;date=2009-12-05,2010-01-03</imageGraphEvolutionUrl>
 		<uniqueId>DevicesDetection_getBrowsers</uniqueId>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_oneConversionPerVisitshowGoalsMetricsAllGoals__API.getProcessedReport_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_oneConversionPerVisitshowGoalsMetricsAllGoals__API.getProcessedReport_day.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<website>Piwik test</website>
+	<prettyDate>Sunday, January 3, 2010</prettyDate>
+	<metadata>
+		<category>Visitors</category>
+		<subcategory>Software</subcategory>
+		<name>Browsers</name>
+		<module>DevicesDetection</module>
+		<action>getBrowsers</action>
+		<dimension>Browser</dimension>
+		<documentation>This report contains information about what kind of browser your visitors were using.</documentation>
+		<metrics>
+			<nb_visits>Visits</nb_visits>
+			<nb_uniq_visitors>Unique visitors</nb_uniq_visitors>
+			<nb_actions>Actions</nb_actions>
+			<nb_users>Users</nb_users>
+		</metrics>
+		<metricsDocumentation>
+			<nb_visits>If a visitor comes to your website for the first time or if they visit a page more than 30 minutes after their last page view, this will be recorded as a new visit.</nb_visits>
+			<nb_uniq_visitors>The number of unduplicated visitors coming to your website. Every user is only counted once, even if they visit the website multiple times a day.</nb_uniq_visitors>
+			<nb_actions>The number of actions performed by your visitors. Actions can be page views, internal site searches, downloads or outlinks.</nb_actions>
+			<nb_users>The number of users logged in your website. It is the number of unique active users that have a User ID set (via the Tracking code function 'setUserId').</nb_users>
+			<nb_actions_per_visit>The average number of actions (page views, site searches, downloads or outlinks) that were performed during the visits.</nb_actions_per_visit>
+			<avg_time_on_site>The average duration of a visit.</avg_time_on_site>
+			<bounce_rate>The percentage of visits that only had a single pageview. This means, that the visitor left the website directly from the entrance page.</bounce_rate>
+			<conversion_rate>The percentage of visits that triggered a goal conversion.</conversion_rate>
+		</metricsDocumentation>
+		<processedMetrics>
+			<nb_actions_per_visit>Actions per Visit</nb_actions_per_visit>
+			<avg_time_on_site>Avg. Time on Website</avg_time_on_site>
+			<bounce_rate>Bounce Rate</bounce_rate>
+		</processedMetrics>
+		<metricTypes>
+			<nb_visits>number</nb_visits>
+			<nb_uniq_visitors>number</nb_uniq_visitors>
+			<nb_actions>number</nb_actions>
+			<nb_users>number</nb_users>
+			<nb_actions_per_visit>number</nb_actions_per_visit>
+			<avg_time_on_site>duration_s</avg_time_on_site>
+			<bounce_rate>percent</bounce_rate>
+			<conversion_rate>percent</conversion_rate>
+		</metricTypes>
+		<relatedReports>
+			<row>
+				<name>Browser version</name>
+				<module>DevicesDetection</module>
+				<action>getBrowserVersions</action>
+			</row>
+		</relatedReports>
+		<metricsGoal>
+			<nb_conversions>Conversions</nb_conversions>
+			<revenue>Revenue</revenue>
+		</metricsGoal>
+		<processedMetricsGoal>
+			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
+		</processedMetricsGoal>
+		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getBrowsers&amp;period=day&amp;date=2010-01-03</imageGraphUrl>
+		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getBrowsers&amp;period=day&amp;date=2009-12-05,2010-01-03</imageGraphEvolutionUrl>
+		<uniqueId>DevicesDetection_getBrowsers</uniqueId>
+	</metadata>
+	<columns>
+		<label>Browser</label>
+		<nb_visits>Visits</nb_visits>
+		<nb_uniq_visitors>Unique visitors</nb_uniq_visitors>
+		<nb_actions>Actions</nb_actions>
+		<nb_users>Users</nb_users>
+		<nb_actions_per_visit>Actions per Visit</nb_actions_per_visit>
+		<avg_time_on_site>Avg. Time on Website</avg_time_on_site>
+		<bounce_rate>Bounce Rate</bounce_rate>
+		<revenue>Revenue</revenue>
+	</columns>
+	<reportData>
+		<row>
+			<label>Firefox</label>
+			<nb_uniq_visitors>2</nb_uniq_visitors>
+			<nb_visits>3</nb_visits>
+			<nb_actions>5</nb_actions>
+			<nb_users>0</nb_users>
+			<revenue>$1,000</revenue>
+			<nb_actions_per_visit>1.7</nb_actions_per_visit>
+			<avg_time_on_site>00:04:02</avg_time_on_site>
+			<bounce_rate>67%</bounce_rate>
+			<goal_1_conversion_rate>66.67%</goal_1_conversion_rate>
+			<goal_2_conversion_rate>33.33%</goal_2_conversion_rate>
+		</row>
+	</reportData>
+	<reportMetadata>
+		<row>
+			<logo>plugins/Morpheus/icons/dist/browsers/FF.png</logo>
+			<segment>browserCode==FF</segment>
+		</row>
+	</reportMetadata>
+	<reportTotal>
+		<nb_uniq_visitors>2</nb_uniq_visitors>
+		<nb_visits>3</nb_visits>
+		<nb_actions>5</nb_actions>
+		<nb_users>0</nb_users>
+		<max_actions>3</max_actions>
+		<sum_visit_length>725</sum_visit_length>
+		<bounce_count>2</bounce_count>
+		<nb_visits_converted>2</nb_visits_converted>
+		<goals>
+			<row idgoal="1">
+				<nb_conversions>2</nb_conversions>
+				<nb_visits_converted>2</nb_visits_converted>
+				<revenue>1000</revenue>
+			</row>
+			<row idgoal="2">
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>0</revenue>
+			</row>
+		</goals>
+		<nb_conversions>3</nb_conversions>
+		<revenue>1000</revenue>
+		<nb_actions_per_visit>1.7</nb_actions_per_visit>
+	</reportTotal>
+</result>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_oneConversionPerVisitshowGoalsMetricsAllGoals__API.getProcessedReport_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_oneConversionPerVisitshowGoalsMetricsAllGoals__API.getProcessedReport_day.xml
@@ -30,6 +30,7 @@
 			<nb_actions_per_visit>Actions per Visit</nb_actions_per_visit>
 			<avg_time_on_site>Avg. Time on Website</avg_time_on_site>
 			<bounce_rate>Bounce Rate</bounce_rate>
+			<conversion_rate>Conversion Rate</conversion_rate>
 		</processedMetrics>
 		<metricTypes>
 			<nb_visits>number</nb_visits>
@@ -50,6 +51,7 @@
 		</relatedReports>
 		<metricsGoal>
 			<nb_conversions>Conversions</nb_conversions>
+			<conversion_rate>Conversion Rate</conversion_rate>
 			<revenue>Revenue</revenue>
 		</metricsGoal>
 		<processedMetricsGoal>
@@ -74,6 +76,7 @@
 		<nb_actions_per_visit>Actions per Visit</nb_actions_per_visit>
 		<avg_time_on_site>Avg. Time on Website</avg_time_on_site>
 		<bounce_rate>Bounce Rate</bounce_rate>
+		<conversion_rate>Conversion Rate</conversion_rate>
 		<revenue>Revenue</revenue>
 	</columns>
 	<reportData>
@@ -84,6 +87,7 @@
 			<nb_actions>5</nb_actions>
 			<nb_users>0</nb_users>
 			<revenue>$1,000</revenue>
+			<conversion_rate>66.67%</conversion_rate>
 			<nb_actions_per_visit>1.7</nb_actions_per_visit>
 			<avg_time_on_site>00:04:02</avg_time_on_site>
 			<bounce_rate>67%</bounce_rate>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_oneConversionPerVisitshowGoalsMetricsSingleGoal__API.getProcessedReport_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_oneConversionPerVisitshowGoalsMetricsSingleGoal__API.getProcessedReport_day.xml
@@ -55,6 +55,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getBrowsers&amp;period=day&amp;date=2010-01-03</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getBrowsers&amp;period=day&amp;date=2009-12-05,2010-01-03</imageGraphEvolutionUrl>
 		<uniqueId>DevicesDetection_getBrowsers</uniqueId>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_oneConversionPerVisitshowGoalsMetricsSingleGoal__API.getProcessedReport_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_oneConversionPerVisitshowGoalsMetricsSingleGoal__API.getProcessedReport_day.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<website>Piwik test</website>
+	<prettyDate>Sunday, January 3, 2010</prettyDate>
+	<metadata>
+		<category>Visitors</category>
+		<subcategory>Software</subcategory>
+		<name>Browsers</name>
+		<module>DevicesDetection</module>
+		<action>getBrowsers</action>
+		<dimension>Browser</dimension>
+		<documentation>This report contains information about what kind of browser your visitors were using.</documentation>
+		<metrics>
+			<nb_visits>Visits</nb_visits>
+			<nb_uniq_visitors>Unique visitors</nb_uniq_visitors>
+			<nb_actions>Actions</nb_actions>
+			<nb_users>Users</nb_users>
+		</metrics>
+		<metricsDocumentation>
+			<nb_visits>If a visitor comes to your website for the first time or if they visit a page more than 30 minutes after their last page view, this will be recorded as a new visit.</nb_visits>
+			<nb_uniq_visitors>The number of unduplicated visitors coming to your website. Every user is only counted once, even if they visit the website multiple times a day.</nb_uniq_visitors>
+			<nb_actions>The number of actions performed by your visitors. Actions can be page views, internal site searches, downloads or outlinks.</nb_actions>
+			<nb_users>The number of users logged in your website. It is the number of unique active users that have a User ID set (via the Tracking code function 'setUserId').</nb_users>
+			<nb_actions_per_visit>The average number of actions (page views, site searches, downloads or outlinks) that were performed during the visits.</nb_actions_per_visit>
+			<avg_time_on_site>The average duration of a visit.</avg_time_on_site>
+			<bounce_rate>The percentage of visits that only had a single pageview. This means, that the visitor left the website directly from the entrance page.</bounce_rate>
+			<conversion_rate>The percentage of visits that triggered a goal conversion.</conversion_rate>
+		</metricsDocumentation>
+		<processedMetrics>
+			<nb_actions_per_visit>Actions per Visit</nb_actions_per_visit>
+			<avg_time_on_site>Avg. Time on Website</avg_time_on_site>
+			<bounce_rate>Bounce Rate</bounce_rate>
+		</processedMetrics>
+		<metricTypes>
+			<nb_visits>number</nb_visits>
+			<nb_uniq_visitors>number</nb_uniq_visitors>
+			<nb_actions>number</nb_actions>
+			<nb_users>number</nb_users>
+			<nb_actions_per_visit>number</nb_actions_per_visit>
+			<avg_time_on_site>duration_s</avg_time_on_site>
+			<bounce_rate>percent</bounce_rate>
+			<conversion_rate>percent</conversion_rate>
+		</metricTypes>
+		<relatedReports>
+			<row>
+				<name>Browser version</name>
+				<module>DevicesDetection</module>
+				<action>getBrowserVersions</action>
+			</row>
+		</relatedReports>
+		<metricsGoal>
+			<nb_conversions>Conversions</nb_conversions>
+			<revenue>Revenue</revenue>
+		</metricsGoal>
+		<processedMetricsGoal>
+			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
+		</processedMetricsGoal>
+		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getBrowsers&amp;period=day&amp;date=2010-01-03</imageGraphUrl>
+		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getBrowsers&amp;period=day&amp;date=2009-12-05,2010-01-03</imageGraphEvolutionUrl>
+		<uniqueId>DevicesDetection_getBrowsers</uniqueId>
+	</metadata>
+	<columns>
+		<label>Browser</label>
+		<nb_visits>Visits</nb_visits>
+		<nb_uniq_visitors>Unique visitors</nb_uniq_visitors>
+		<nb_actions>Actions</nb_actions>
+		<nb_users>Users</nb_users>
+		<nb_actions_per_visit>Actions per Visit</nb_actions_per_visit>
+		<avg_time_on_site>Avg. Time on Website</avg_time_on_site>
+		<bounce_rate>Bounce Rate</bounce_rate>
+		<revenue>Revenue</revenue>
+	</columns>
+	<reportData>
+		<row>
+			<label>Firefox</label>
+			<nb_uniq_visitors>2</nb_uniq_visitors>
+			<nb_visits>3</nb_visits>
+			<nb_actions>5</nb_actions>
+			<nb_users>0</nb_users>
+			<revenue>$1,000</revenue>
+			<nb_actions_per_visit>1.7</nb_actions_per_visit>
+			<avg_time_on_site>00:04:02</avg_time_on_site>
+			<bounce_rate>67%</bounce_rate>
+			<goal_1_conversion_rate>66.67%</goal_1_conversion_rate>
+			<goal_1_nb_conversions>2</goal_1_nb_conversions>
+			<goal_1_revenue_per_visit>$333.33</goal_1_revenue_per_visit>
+			<goal_1_revenue>$1,000</goal_1_revenue>
+		</row>
+	</reportData>
+	<reportMetadata>
+		<row>
+			<logo>plugins/Morpheus/icons/dist/browsers/FF.png</logo>
+			<segment>browserCode==FF</segment>
+		</row>
+	</reportMetadata>
+	<reportTotal>
+		<nb_uniq_visitors>2</nb_uniq_visitors>
+		<nb_visits>3</nb_visits>
+		<nb_actions>5</nb_actions>
+		<nb_users>0</nb_users>
+		<max_actions>3</max_actions>
+		<sum_visit_length>725</sum_visit_length>
+		<bounce_count>2</bounce_count>
+		<nb_visits_converted>2</nb_visits_converted>
+		<goals>
+			<row idgoal="1">
+				<nb_conversions>2</nb_conversions>
+				<nb_visits_converted>2</nb_visits_converted>
+				<revenue>1000</revenue>
+			</row>
+			<row idgoal="2">
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>0</revenue>
+			</row>
+		</goals>
+		<nb_conversions>3</nb_conversions>
+		<revenue>1000</revenue>
+		<nb_actions_per_visit>1.7</nb_actions_per_visit>
+	</reportTotal>
+</result>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_oneConversionPerVisitshowGoalsMetricsSingleGoal__API.getProcessedReport_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_oneConversionPerVisitshowGoalsMetricsSingleGoal__API.getProcessedReport_day.xml
@@ -30,6 +30,7 @@
 			<nb_actions_per_visit>Actions per Visit</nb_actions_per_visit>
 			<avg_time_on_site>Avg. Time on Website</avg_time_on_site>
 			<bounce_rate>Bounce Rate</bounce_rate>
+			<conversion_rate>Conversion Rate</conversion_rate>
 		</processedMetrics>
 		<metricTypes>
 			<nb_visits>number</nb_visits>
@@ -50,6 +51,7 @@
 		</relatedReports>
 		<metricsGoal>
 			<nb_conversions>Conversions</nb_conversions>
+			<conversion_rate>Conversion Rate</conversion_rate>
 			<revenue>Revenue</revenue>
 		</metricsGoal>
 		<processedMetricsGoal>
@@ -74,6 +76,7 @@
 		<nb_actions_per_visit>Actions per Visit</nb_actions_per_visit>
 		<avg_time_on_site>Avg. Time on Website</avg_time_on_site>
 		<bounce_rate>Bounce Rate</bounce_rate>
+		<conversion_rate>Conversion Rate</conversion_rate>
 		<revenue>Revenue</revenue>
 	</columns>
 	<reportData>
@@ -84,6 +87,7 @@
 			<nb_actions>5</nb_actions>
 			<nb_users>0</nb_users>
 			<revenue>$1,000</revenue>
+			<conversion_rate>66.67%</conversion_rate>
 			<nb_actions_per_visit>1.7</nb_actions_per_visit>
 			<avg_time_on_site>00:04:02</avg_time_on_site>
 			<bounce_rate>67%</bounce_rate>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pages__Actions.getEntryPageTitles_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pages__Actions.getEntryPageTitles_day.xml
@@ -45,8 +45,16 @@
 		</goals>
 		<avg_bandwidth>0</avg_bandwidth>
 		<avg_page_load_time>0</avg_page_load_time>
-		<avg_time_on_page>360</avg_time_on_page>
+		<conversion_rate>0%</conversion_rate>
+		<nb_actions_per_visit>0</nb_actions_per_visit>
+		<avg_time_on_site>0</avg_time_on_site>
 		<bounce_rate>0%</bounce_rate>
+		<revenue_per_visit>12.5</revenue_per_visit>
+		<goal_1_conversion_rate>75%</goal_1_conversion_rate>
+		<goal_1_nb_conversions>3</goal_1_nb_conversions>
+		<goal_1_revenue_per_visit>7.5</goal_1_revenue_per_visit>
+		<goal_1_revenue>30</goal_1_revenue>
+		<avg_time_on_page>360</avg_time_on_page>
 		<exit_rate>0%</exit_rate>
 		<segment>entryPageTitle==Page%2BA%2B-%2Bindex.html</segment>
 	</row>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pages__Actions.getEntryPageUrls_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pages__Actions.getEntryPageUrls_day.xml
@@ -43,8 +43,16 @@
 		</goals>
 		<avg_bandwidth>0</avg_bandwidth>
 		<avg_page_load_time>0</avg_page_load_time>
-		<avg_time_on_page>360</avg_time_on_page>
+		<conversion_rate>0%</conversion_rate>
+		<nb_actions_per_visit>0</nb_actions_per_visit>
+		<avg_time_on_site>0</avg_time_on_site>
 		<bounce_rate>0%</bounce_rate>
+		<revenue_per_visit>11.67</revenue_per_visit>
+		<goal_1_conversion_rate>83.33%</goal_1_conversion_rate>
+		<goal_1_nb_conversions>5</goal_1_nb_conversions>
+		<goal_1_revenue_per_visit>8.33</goal_1_revenue_per_visit>
+		<goal_1_revenue>50</goal_1_revenue>
+		<avg_time_on_page>360</avg_time_on_page>
 		<exit_rate>0%</exit_rate>
 		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fpage_A</segment>
 		<subtable>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pages_segment__Actions.getEntryPageTitles_week.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pages_segment__Actions.getEntryPageTitles_week.xml
@@ -34,8 +34,16 @@
 		<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
 		<avg_bandwidth>0</avg_bandwidth>
 		<avg_page_load_time>0</avg_page_load_time>
-		<avg_time_on_page>0</avg_time_on_page>
+		<conversion_rate>0%</conversion_rate>
+		<nb_actions_per_visit>0</nb_actions_per_visit>
+		<avg_time_on_site>0</avg_time_on_site>
 		<bounce_rate>0%</bounce_rate>
+		<revenue_per_visit>10</revenue_per_visit>
+		<goal_1_conversion_rate>100%</goal_1_conversion_rate>
+		<goal_1_nb_conversions>1</goal_1_nb_conversions>
+		<goal_1_revenue_per_visit>10</goal_1_revenue_per_visit>
+		<goal_1_revenue>10</goal_1_revenue>
+		<avg_time_on_page>0</avg_time_on_page>
 		<exit_rate>100%</exit_rate>
 		<segment>entryPageTitle==Page%2BA%2B-%2Bindex.html</segment>
 	</row>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pages_segment__Actions.getEntryPageUrls_week.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pages_segment__Actions.getEntryPageUrls_week.xml
@@ -31,8 +31,16 @@
 		</goals>
 		<avg_bandwidth>0</avg_bandwidth>
 		<avg_page_load_time>0</avg_page_load_time>
-		<avg_time_on_page>0</avg_time_on_page>
+		<conversion_rate>0%</conversion_rate>
+		<nb_actions_per_visit>0</nb_actions_per_visit>
+		<avg_time_on_site>0</avg_time_on_site>
 		<bounce_rate>0%</bounce_rate>
+		<revenue_per_visit>10</revenue_per_visit>
+		<goal_1_conversion_rate>100%</goal_1_conversion_rate>
+		<goal_1_nb_conversions>1</goal_1_nb_conversions>
+		<goal_1_revenue_per_visit>10</goal_1_revenue_per_visit>
+		<goal_1_revenue>10</goal_1_revenue>
+		<avg_time_on_page>0</avg_time_on_page>
 		<exit_rate>100%</exit_rate>
 		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fpage_A</segment>
 		<subtable>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pagesshowGoalsMetricsAllGoals__API.getProcessedReport_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pagesshowGoalsMetricsAllGoals__API.getProcessedReport_day.xml
@@ -5,11 +5,11 @@
 	<metadata>
 		<category>Actions</category>
 		<subcategory>Entry pages</subcategory>
-		<name>Entry pages</name>
+		<name>Entry page titles</name>
 		<module>Actions</module>
-		<action>getEntryPageUrls</action>
-		<dimension>Entry Page URL</dimension>
-		<documentation>This report contains information about the entry pages that were used during the specified period. An entry page is the first page that a user views during their visit. &lt;br /&gt; The entry URLs are displayed as a folder structure.&lt;br /&gt;Use the plus and minus icons on the left to navigate.</documentation>
+		<action>getEntryPageTitles</action>
+		<dimension>Entry Page title</dimension>
+		<documentation>This report contains information about the titles of entry pages that were used during the specified period. Use the plus and minus icons on the left to navigate.</documentation>
 		<metrics>
 			<entry_nb_visits>Entrances</entry_nb_visits>
 			<entry_bounce_count>Bounces</entry_bounce_count>
@@ -17,7 +17,7 @@
 		<metricsDocumentation>
 			<entry_nb_visits>Number of visits that started on this page.</entry_nb_visits>
 			<entry_bounce_count>Number of visits that started and ended on this page. This means that the visitor left the website after viewing only this page.</entry_bounce_count>
-			<avg_time_on_page>The average amount of time visitors spent on this page (only the page, not the entire website).</avg_time_on_page>
+			<bounce_rate>The percentage of visits that started on this page and left the website straight away.</bounce_rate>
 		</metricsDocumentation>
 		<processedMetrics>
 			<bounce_rate>Bounce Rate</bounce_rate>
@@ -31,57 +31,64 @@
 			<exit_rate>percent</exit_rate>
 			<avg_time_generation>duration_s</avg_time_generation>
 		</metricTypes>
-		<actionToLoadSubTables>getEntryPageUrls</actionToLoadSubTables>
+		<actionToLoadSubTables>getEntryPageTitles</actionToLoadSubTables>
 		<relatedReports>
 			<row>
-				<name>Entry page titles</name>
+				<name>Page titles</name>
 				<module>Actions</module>
-				<action>getEntryPageTitles</action>
+				<action>getPageTitles</action>
+			</row>
+			<row>
+				<name>Entry pages</name>
+				<module>Actions</module>
+				<action>getEntryPageUrls</action>
 			</row>
 		</relatedReports>
-		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getEntryPageUrls&amp;period=day&amp;date=2009-01-05</imageGraphUrl>
-		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getEntryPageUrls&amp;period=day&amp;date=2008-12-07,2009-01-05</imageGraphEvolutionUrl>
-		<uniqueId>Actions_getEntryPageUrls</uniqueId>
+		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getEntryPageTitles&amp;period=day&amp;date=2009-01-05</imageGraphUrl>
+		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getEntryPageTitles&amp;period=day&amp;date=2008-12-07,2009-01-05</imageGraphEvolutionUrl>
+		<uniqueId>Actions_getEntryPageTitles</uniqueId>
 	</metadata>
 	<columns>
-		<label>Entry Page URL</label>
+		<label>Entry Page title</label>
 		<entry_nb_visits>Entrances</entry_nb_visits>
 		<entry_bounce_count>Bounces</entry_bounce_count>
 		<bounce_rate>Bounce Rate</bounce_rate>
 	</columns>
 	<reportData>
 		<row>
-			<label>page_A</label>
+			<label> Page A - index.html</label>
 			<entry_nb_visits>4</entry_nb_visits>
 			<entry_bounce_count>0</entry_bounce_count>
 			<bounce_rate>0%</bounce_rate>
+			<goal_1_conversion_rate>75%</goal_1_conversion_rate>
+			<goal_2_conversion_rate>50%</goal_2_conversion_rate>
 		</row>
 	</reportData>
 	<reportMetadata>
 		<row>
-			
-			<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fpage_A</segment>
-			<idsubdatatable>2</idsubdatatable>
+			<segment>entryPageTitle==Page%2BA%2B-%2Bindex.html</segment>
 		</row>
 	</reportMetadata>
 	<reportTotal>
-		<nb_visits>6</nb_visits>
-		<nb_hits>7</nb_hits>
-		<sum_time_spent>2520</sum_time_spent>
+		<nb_visits>4</nb_visits>
+		<nb_uniq_visitors>4</nb_uniq_visitors>
+		<nb_hits>5</nb_hits>
+		<sum_time_spent>1800</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<entry_nb_uniq_visitors>4</entry_nb_uniq_visitors>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>18</entry_nb_actions>
 		<entry_sum_visit_length>5047</entry_sum_visit_length>
 		<entry_bounce_count>0</entry_bounce_count>
 		<goals>
 			<row idgoal="1">
-				<nb_conversions>5</nb_conversions>
-				<revenue>50</revenue>
-				<nb_conv_pages_before>11</nb_conv_pages_before>
-				<nb_conversions_attrib>1.6666</nb_conversions_attrib>
-				<nb_conversions_page_uniq>5</nb_conversions_page_uniq>
-				<revenue_attrib>16.66</revenue_attrib>
+				<nb_conversions>3</nb_conversions>
+				<revenue>30</revenue>
+				<nb_conv_pages_before>4</nb_conv_pages_before>
+				<nb_conversions_attrib>1.0833</nb_conversions_attrib>
+				<nb_conversions_page_uniq>3</nb_conversions_page_uniq>
+				<revenue_attrib>10.83</revenue_attrib>
 				<revenue_entry>30</revenue_entry>
 				<revenue_per_entry>7.5</revenue_per_entry>
 				<nb_conversions_entry>3</nb_conversions_entry>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pagesshowGoalsMetricsAllGoals__API.getProcessedReport_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pagesshowGoalsMetricsAllGoals__API.getProcessedReport_day.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<website>Piwik test</website>
+	<prettyDate>Monday, January 5, 2009</prettyDate>
+	<metadata>
+		<category>Actions</category>
+		<subcategory>Entry pages</subcategory>
+		<name>Entry pages</name>
+		<module>Actions</module>
+		<action>getEntryPageUrls</action>
+		<dimension>Entry Page URL</dimension>
+		<documentation>This report contains information about the entry pages that were used during the specified period. An entry page is the first page that a user views during their visit. &lt;br /&gt; The entry URLs are displayed as a folder structure.&lt;br /&gt;Use the plus and minus icons on the left to navigate.</documentation>
+		<metrics>
+			<entry_nb_visits>Entrances</entry_nb_visits>
+			<entry_bounce_count>Bounces</entry_bounce_count>
+		</metrics>
+		<metricsDocumentation>
+			<entry_nb_visits>Number of visits that started on this page.</entry_nb_visits>
+			<entry_bounce_count>Number of visits that started and ended on this page. This means that the visitor left the website after viewing only this page.</entry_bounce_count>
+			<avg_time_on_page>The average amount of time visitors spent on this page (only the page, not the entire website).</avg_time_on_page>
+		</metricsDocumentation>
+		<processedMetrics>
+			<bounce_rate>Bounce Rate</bounce_rate>
+			<avg_time_generation>Avg. generation time</avg_time_generation>
+		</processedMetrics>
+		<metricTypes>
+			<entry_nb_visits>number</entry_nb_visits>
+			<entry_bounce_count>number</entry_bounce_count>
+			<avg_time_on_page>duration_s</avg_time_on_page>
+			<bounce_rate>percent</bounce_rate>
+			<exit_rate>percent</exit_rate>
+			<avg_time_generation>duration_s</avg_time_generation>
+		</metricTypes>
+		<actionToLoadSubTables>getEntryPageUrls</actionToLoadSubTables>
+		<relatedReports>
+			<row>
+				<name>Entry page titles</name>
+				<module>Actions</module>
+				<action>getEntryPageTitles</action>
+			</row>
+		</relatedReports>
+		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getEntryPageUrls&amp;period=day&amp;date=2009-01-05</imageGraphUrl>
+		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getEntryPageUrls&amp;period=day&amp;date=2008-12-07,2009-01-05</imageGraphEvolutionUrl>
+		<uniqueId>Actions_getEntryPageUrls</uniqueId>
+	</metadata>
+	<columns>
+		<label>Entry Page URL</label>
+		<entry_nb_visits>Entrances</entry_nb_visits>
+		<entry_bounce_count>Bounces</entry_bounce_count>
+		<bounce_rate>Bounce Rate</bounce_rate>
+	</columns>
+	<reportData>
+		<row>
+			<label>page_A</label>
+			<entry_nb_visits>4</entry_nb_visits>
+			<entry_bounce_count>0</entry_bounce_count>
+			<bounce_rate>0%</bounce_rate>
+		</row>
+	</reportData>
+	<reportMetadata>
+		<row>
+			
+			<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fpage_A</segment>
+			<idsubdatatable>2</idsubdatatable>
+		</row>
+	</reportMetadata>
+	<reportTotal>
+		<nb_visits>6</nb_visits>
+		<nb_hits>7</nb_hits>
+		<sum_time_spent>2520</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<entry_nb_visits>4</entry_nb_visits>
+		<entry_nb_actions>18</entry_nb_actions>
+		<entry_sum_visit_length>5047</entry_sum_visit_length>
+		<entry_bounce_count>0</entry_bounce_count>
+		<goals>
+			<row idgoal="1">
+				<nb_conversions>5</nb_conversions>
+				<revenue>50</revenue>
+				<nb_conv_pages_before>11</nb_conv_pages_before>
+				<nb_conversions_attrib>1.6666</nb_conversions_attrib>
+				<nb_conversions_page_uniq>5</nb_conversions_page_uniq>
+				<revenue_attrib>16.66</revenue_attrib>
+				<revenue_entry>30</revenue_entry>
+				<revenue_per_entry>7.5</revenue_per_entry>
+				<nb_conversions_entry>3</nb_conversions_entry>
+				<nb_conversions_page_rate>1</nb_conversions_page_rate>
+				<nb_conversions_entry_rate>0.75</nb_conversions_entry_rate>
+			</row>
+			<row idgoal="2">
+				<nb_conversions>2</nb_conversions>
+				<revenue>20</revenue>
+				<nb_conv_pages_before>5</nb_conv_pages_before>
+				<nb_conversions_attrib>0.4</nb_conversions_attrib>
+				<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
+				<revenue_attrib>4</revenue_attrib>
+				<revenue_entry>10</revenue_entry>
+				<revenue_per_entry>2.5</revenue_per_entry>
+				<nb_conversions_entry>1</nb_conversions_entry>
+				<nb_conversions_page_rate>1</nb_conversions_page_rate>
+				<nb_conversions_entry_rate>0.25</nb_conversions_entry_rate>
+			</row>
+		</goals>
+	</reportTotal>
+</result>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pagesshowGoalsMetricsSingleGoal__API.getProcessedReport_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pagesshowGoalsMetricsSingleGoal__API.getProcessedReport_day.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<website>Piwik test</website>
+	<prettyDate>Monday, January 5, 2009</prettyDate>
+	<metadata>
+		<category>Actions</category>
+		<subcategory>Entry pages</subcategory>
+		<name>Entry pages</name>
+		<module>Actions</module>
+		<action>getEntryPageUrls</action>
+		<dimension>Entry Page URL</dimension>
+		<documentation>This report contains information about the entry pages that were used during the specified period. An entry page is the first page that a user views during their visit. &lt;br /&gt; The entry URLs are displayed as a folder structure.&lt;br /&gt;Use the plus and minus icons on the left to navigate.</documentation>
+		<metrics>
+			<entry_nb_visits>Entrances</entry_nb_visits>
+			<entry_bounce_count>Bounces</entry_bounce_count>
+		</metrics>
+		<metricsDocumentation>
+			<entry_nb_visits>Number of visits that started on this page.</entry_nb_visits>
+			<entry_bounce_count>Number of visits that started and ended on this page. This means that the visitor left the website after viewing only this page.</entry_bounce_count>
+			<avg_time_on_page>The average amount of time visitors spent on this page (only the page, not the entire website).</avg_time_on_page>
+		</metricsDocumentation>
+		<processedMetrics>
+			<bounce_rate>Bounce Rate</bounce_rate>
+			<avg_time_generation>Avg. generation time</avg_time_generation>
+		</processedMetrics>
+		<metricTypes>
+			<entry_nb_visits>number</entry_nb_visits>
+			<entry_bounce_count>number</entry_bounce_count>
+			<avg_time_on_page>duration_s</avg_time_on_page>
+			<bounce_rate>percent</bounce_rate>
+			<exit_rate>percent</exit_rate>
+			<avg_time_generation>duration_s</avg_time_generation>
+		</metricTypes>
+		<actionToLoadSubTables>getEntryPageUrls</actionToLoadSubTables>
+		<relatedReports>
+			<row>
+				<name>Entry page titles</name>
+				<module>Actions</module>
+				<action>getEntryPageTitles</action>
+			</row>
+		</relatedReports>
+		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getEntryPageUrls&amp;period=day&amp;date=2009-01-05</imageGraphUrl>
+		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getEntryPageUrls&amp;period=day&amp;date=2008-12-07,2009-01-05</imageGraphEvolutionUrl>
+		<uniqueId>Actions_getEntryPageUrls</uniqueId>
+	</metadata>
+	<columns>
+		<label>Entry Page URL</label>
+		<entry_nb_visits>Entrances</entry_nb_visits>
+		<entry_bounce_count>Bounces</entry_bounce_count>
+		<bounce_rate>Bounce Rate</bounce_rate>
+	</columns>
+	<reportData>
+		<row>
+			<label>page_A</label>
+			<entry_nb_visits>4</entry_nb_visits>
+			<entry_bounce_count>0</entry_bounce_count>
+			<bounce_rate>0%</bounce_rate>
+			<goal_1_conversion_rate>83.33%</goal_1_conversion_rate>
+			<goal_2_conversion_rate>33.33%</goal_2_conversion_rate>
+		</row>
+	</reportData>
+	<reportMetadata>
+		<row>
+			
+			<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fpage_A</segment>
+			<idsubdatatable>2</idsubdatatable>
+		</row>
+	</reportMetadata>
+	<reportTotal>
+		<nb_visits>6</nb_visits>
+		<nb_hits>7</nb_hits>
+		<sum_time_spent>2520</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<entry_nb_visits>4</entry_nb_visits>
+		<entry_nb_actions>18</entry_nb_actions>
+		<entry_sum_visit_length>5047</entry_sum_visit_length>
+		<entry_bounce_count>0</entry_bounce_count>
+		<goals>
+			<row idgoal="1">
+				<nb_conversions>5</nb_conversions>
+				<revenue>50</revenue>
+				<nb_conv_pages_before>11</nb_conv_pages_before>
+				<nb_conversions_attrib>1.6666</nb_conversions_attrib>
+				<nb_conversions_page_uniq>5</nb_conversions_page_uniq>
+				<revenue_attrib>16.66</revenue_attrib>
+				<revenue_entry>30</revenue_entry>
+				<revenue_per_entry>7.5</revenue_per_entry>
+				<nb_conversions_entry>3</nb_conversions_entry>
+				<nb_conversions_page_rate>1</nb_conversions_page_rate>
+				<nb_conversions_entry_rate>0.75</nb_conversions_entry_rate>
+			</row>
+			<row idgoal="2">
+				<nb_conversions>2</nb_conversions>
+				<revenue>20</revenue>
+				<nb_conv_pages_before>5</nb_conv_pages_before>
+				<nb_conversions_attrib>0.4</nb_conversions_attrib>
+				<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
+				<revenue_attrib>4</revenue_attrib>
+				<revenue_entry>10</revenue_entry>
+				<revenue_per_entry>2.5</revenue_per_entry>
+				<nb_conversions_entry>1</nb_conversions_entry>
+				<nb_conversions_page_rate>1</nb_conversions_page_rate>
+				<nb_conversions_entry_rate>0.25</nb_conversions_entry_rate>
+			</row>
+		</goals>
+	</reportTotal>
+</result>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pagesshowGoalsMetricsSingleGoal__API.getProcessedReport_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pagesshowGoalsMetricsSingleGoal__API.getProcessedReport_day.xml
@@ -5,11 +5,11 @@
 	<metadata>
 		<category>Actions</category>
 		<subcategory>Entry pages</subcategory>
-		<name>Entry pages</name>
+		<name>Entry page titles</name>
 		<module>Actions</module>
-		<action>getEntryPageUrls</action>
-		<dimension>Entry Page URL</dimension>
-		<documentation>This report contains information about the entry pages that were used during the specified period. An entry page is the first page that a user views during their visit. &lt;br /&gt; The entry URLs are displayed as a folder structure.&lt;br /&gt;Use the plus and minus icons on the left to navigate.</documentation>
+		<action>getEntryPageTitles</action>
+		<dimension>Entry Page title</dimension>
+		<documentation>This report contains information about the titles of entry pages that were used during the specified period. Use the plus and minus icons on the left to navigate.</documentation>
 		<metrics>
 			<entry_nb_visits>Entrances</entry_nb_visits>
 			<entry_bounce_count>Bounces</entry_bounce_count>
@@ -17,7 +17,7 @@
 		<metricsDocumentation>
 			<entry_nb_visits>Number of visits that started on this page.</entry_nb_visits>
 			<entry_bounce_count>Number of visits that started and ended on this page. This means that the visitor left the website after viewing only this page.</entry_bounce_count>
-			<avg_time_on_page>The average amount of time visitors spent on this page (only the page, not the entire website).</avg_time_on_page>
+			<bounce_rate>The percentage of visits that started on this page and left the website straight away.</bounce_rate>
 		</metricsDocumentation>
 		<processedMetrics>
 			<bounce_rate>Bounce Rate</bounce_rate>
@@ -31,59 +31,66 @@
 			<exit_rate>percent</exit_rate>
 			<avg_time_generation>duration_s</avg_time_generation>
 		</metricTypes>
-		<actionToLoadSubTables>getEntryPageUrls</actionToLoadSubTables>
+		<actionToLoadSubTables>getEntryPageTitles</actionToLoadSubTables>
 		<relatedReports>
 			<row>
-				<name>Entry page titles</name>
+				<name>Page titles</name>
 				<module>Actions</module>
-				<action>getEntryPageTitles</action>
+				<action>getPageTitles</action>
+			</row>
+			<row>
+				<name>Entry pages</name>
+				<module>Actions</module>
+				<action>getEntryPageUrls</action>
 			</row>
 		</relatedReports>
-		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getEntryPageUrls&amp;period=day&amp;date=2009-01-05</imageGraphUrl>
-		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getEntryPageUrls&amp;period=day&amp;date=2008-12-07,2009-01-05</imageGraphEvolutionUrl>
-		<uniqueId>Actions_getEntryPageUrls</uniqueId>
+		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getEntryPageTitles&amp;period=day&amp;date=2009-01-05</imageGraphUrl>
+		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getEntryPageTitles&amp;period=day&amp;date=2008-12-07,2009-01-05</imageGraphEvolutionUrl>
+		<uniqueId>Actions_getEntryPageTitles</uniqueId>
 	</metadata>
 	<columns>
-		<label>Entry Page URL</label>
+		<label>Entry Page title</label>
 		<entry_nb_visits>Entrances</entry_nb_visits>
 		<entry_bounce_count>Bounces</entry_bounce_count>
 		<bounce_rate>Bounce Rate</bounce_rate>
 	</columns>
 	<reportData>
 		<row>
-			<label>page_A</label>
+			<label> Page A - index.html</label>
 			<entry_nb_visits>4</entry_nb_visits>
 			<entry_bounce_count>0</entry_bounce_count>
 			<bounce_rate>0%</bounce_rate>
-			<goal_1_conversion_rate>83.33%</goal_1_conversion_rate>
-			<goal_2_conversion_rate>33.33%</goal_2_conversion_rate>
+			<goal_1_conversion_rate>75%</goal_1_conversion_rate>
+			<goal_1_nb_conversions>3</goal_1_nb_conversions>
+			<goal_1_revenue_per_visit>$7.50</goal_1_revenue_per_visit>
+			<goal_1_revenue>$30</goal_1_revenue>
 		</row>
 	</reportData>
 	<reportMetadata>
 		<row>
-			
-			<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fpage_A</segment>
-			<idsubdatatable>2</idsubdatatable>
+			<segment>entryPageTitle==Page%2BA%2B-%2Bindex.html</segment>
 		</row>
 	</reportMetadata>
 	<reportTotal>
-		<nb_visits>6</nb_visits>
-		<nb_hits>7</nb_hits>
-		<sum_time_spent>2520</sum_time_spent>
+		<nb_visits>4</nb_visits>
+		<nb_uniq_visitors>4</nb_uniq_visitors>
+		<nb_hits>5</nb_hits>
+		<sum_time_spent>1800</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<entry_nb_uniq_visitors>4</entry_nb_uniq_visitors>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>18</entry_nb_actions>
 		<entry_sum_visit_length>5047</entry_sum_visit_length>
 		<entry_bounce_count>0</entry_bounce_count>
 		<goals>
 			<row idgoal="1">
-				<nb_conversions>5</nb_conversions>
-				<revenue>50</revenue>
-				<nb_conv_pages_before>11</nb_conv_pages_before>
-				<nb_conversions_attrib>1.6666</nb_conversions_attrib>
-				<nb_conversions_page_uniq>5</nb_conversions_page_uniq>
-				<revenue_attrib>16.66</revenue_attrib>
+				<nb_conversions>3</nb_conversions>
+				<revenue>30</revenue>
+				<nb_conv_pages_before>4</nb_conv_pages_before>
+				<nb_conversions_attrib>1.0833</nb_conversions_attrib>
+				<nb_conversions_page_uniq>3</nb_conversions_page_uniq>
+				<revenue_attrib>10.83</revenue_attrib>
 				<revenue_entry>30</revenue_entry>
 				<revenue_per_entry>7.5</revenue_per_entry>
 				<nb_conversions_entry>3</nb_conversions_entry>

--- a/plugins/Referrers/tests/System/expected/test_Referrers_getReferrerType__API.getProcessedReport_day.xml
+++ b/plugins/Referrers/tests/System/expected/test_Referrers_getReferrerType__API.getProcessedReport_day.xml
@@ -49,6 +49,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getReferrerType&amp;period=range&amp;date=2010-01-01,2010-03-10</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getReferrerType&amp;period=day&amp;date=2010-01-01,2010-03-10</imageGraphEvolutionUrl>
 		<uniqueId>Referrers_getReferrerType</uniqueId>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_processedReportSingle__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_processedReportSingle__API.getProcessedReport_day.xml
@@ -45,6 +45,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getContinent&amp;period=day&amp;date=2012-08-10</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getContinent&amp;period=day&amp;date=2012-07-12,2012-08-10</imageGraphEvolutionUrl>
 		<uniqueId>UserCountry_getContinent</uniqueId>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric_constantRowsCountShouldKeepEmptyRows__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric_constantRowsCountShouldKeepEmptyRows__API.getProcessedReport_day.xml
@@ -49,6 +49,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=VisitTime&amp;apiAction=getVisitInformationPerServerTime&amp;period=day&amp;date=2010-01-03</imageGraphUrl>
 		<uniqueId>VisitTime_getVisitInformationPerServerTime</uniqueId>
 	</metadata>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_showColumnsWithProcessedMetrics___API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_showColumnsWithProcessedMetrics___API.getProcessedReport_day.xml
@@ -27,6 +27,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=VisitTime&amp;apiAction=getVisitInformationPerServerTime&amp;period=day&amp;date=2010-03-06</imageGraphUrl>
 		<uniqueId>VisitTime_getVisitInformationPerServerTime</uniqueId>
 	</metadata>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Conversions_Goals.getDaysToConversion_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Conversions_Goals.getDaysToConversion_firstSite_lastN__API.getProcessedReport_day.xml
@@ -24,6 +24,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Goals&amp;apiAction=getDaysToConversion&amp;period=range&amp;date=2010-01-03,2010-01-09</imageGraphUrl>
 		<uniqueId>Goals_getDaysToConversion</uniqueId>
 	</metadata>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Referrers.getWebsites_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Referrers.getWebsites_firstSite_lastN__API.getProcessedReport_day.xml
@@ -53,6 +53,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getWebsites&amp;period=range&amp;date=2010-01-03,2010-01-09</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getWebsites&amp;period=day&amp;date=2010-01-03,2010-01-09</imageGraphEvolutionUrl>
 		<uniqueId>Referrers_getWebsites</uniqueId>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getMetadata_day.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getMetadata_day.xml
@@ -43,6 +43,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>UserCountry_getCountry</uniqueId>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getProcessedReport_day.xml
@@ -45,6 +45,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>UserCountry_getCountry</uniqueId>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getReportMetadata_day.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getReportMetadata_day.xml
@@ -185,6 +185,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>UserCountry_getCountry</uniqueId>
@@ -232,6 +238,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getContinent&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getContinent&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>UserCountry_getContinent</uniqueId>
@@ -279,6 +291,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getRegion&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getRegion&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>UserCountry_getRegion</uniqueId>
@@ -377,6 +395,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCity&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCity&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>UserCountry_getCity</uniqueId>
@@ -478,6 +502,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getType&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getType&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>DevicesDetection_getType</uniqueId>
@@ -528,6 +558,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getModel&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getModel&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>DevicesDetection_getModel</uniqueId>
@@ -578,6 +614,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getBrand&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getBrand&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>DevicesDetection_getBrand</uniqueId>
@@ -737,6 +779,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getBrowsers&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=DevicesDetection&amp;apiAction=getBrowsers&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>DevicesDetection_getBrowsers</uniqueId>
@@ -1061,6 +1109,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=VisitTime&amp;apiAction=getVisitInformationPerServerTime&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<uniqueId>VisitTime_getVisitInformationPerServerTime</uniqueId>
 	</row>
@@ -1209,6 +1263,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=CustomVariables&amp;apiAction=getCustomVariables&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=CustomVariables&amp;apiAction=getCustomVariables&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>CustomVariables_getCustomVariables</uniqueId>
@@ -2246,6 +2306,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getReferrerType&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getReferrerType&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>Referrers_getReferrerType</uniqueId>
@@ -2344,6 +2410,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getKeywords&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getKeywords&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>Referrers_getKeywords</uniqueId>
@@ -2399,6 +2471,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getSearchEngines&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getSearchEngines&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>Referrers_getSearchEngines</uniqueId>
@@ -2454,6 +2532,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getWebsites&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getWebsites&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>Referrers_getWebsites</uniqueId>
@@ -2559,6 +2643,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getCampaigns&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Referrers&amp;apiAction=getCampaigns&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>Referrers_getCampaigns</uniqueId>
@@ -2862,6 +2952,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Goals&amp;apiAction=getVisitsUntilConversion&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<uniqueId>Goals_getVisitsUntilConversion</uniqueId>
 	</row>
@@ -2887,6 +2983,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Goals&amp;apiAction=getDaysToConversion&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<uniqueId>Goals_getDaysToConversion</uniqueId>
 	</row>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata_showRawMetrics__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata_showRawMetrics__API.getProcessedReport_day.xml
@@ -45,6 +45,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=day&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=day&amp;date=2008-12-06,2009-01-04</imageGraphEvolutionUrl>
 		<uniqueId>UserCountry_getCountry</uniqueId>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__API.getProcessedReport_year.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__API.getProcessedReport_year.xml
@@ -44,6 +44,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenu par visite</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=year&amp;date=2009-01-04</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=year&amp;date=2000-01-01,2009-12-31</imageGraphEvolutionUrl>
 		<uniqueId>UserCountry_getCountry</uniqueId>

--- a/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI__API.getProcessedReport_range.xml
+++ b/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI__API.getProcessedReport_range.xml
@@ -44,6 +44,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=range&amp;date=</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=day&amp;date=</imageGraphEvolutionUrl>
 		<uniqueId>UserCountry_getCountry</uniqueId>

--- a/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI_pagesegment__API.getProcessedReport_range.xml
+++ b/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI_pagesegment__API.getProcessedReport_range.xml
@@ -44,6 +44,12 @@
 		<processedMetricsGoal>
 			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
 		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+		</metricTypesGoal>
 		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=range&amp;date=</imageGraphUrl>
 		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=UserCountry&amp;apiAction=getCountry&amp;period=day&amp;date=</imageGraphEvolutionUrl>
 		<uniqueId>UserCountry_getCountry</uniqueId>


### PR DESCRIPTION
### Description:

Changes:
* In DataTablePostProcessor.php, if `filter_update_columns_when_show_all_goals` is supplied, and only one goal is supplied in `filter_show_goal_columns_process_goals`, use that goal as the default value for `idGoal`. This allows us to use `filter_update_columns_when_show_all_goals` w/o `idGoal`. Which is necessary for processed reports since if `idGoal` is supplied, the code that searches for report metadata will try to match the report metadata `$parameters` w/ `['idGoal' => ...]`, which won't work for non-Goals reports.
* In Goals, add a new metadata output property `<metricTypesGoal>` so metric types can be specified for `<metricsGoal>` and `<processedMetricsGoal>`.
* In DocumentationGenerator.php, add `filter_update_columns_when_show_all_goals` and `filter_show_goal_columns_process_goals` as parameters so they will be forwarded to API methods in tests.
* Fix existing tests that were not accurate due to the above change.
* Do not remove `conversion_rate` from API report metadata if filter_update_columns_when_show_all_goals is present in report metadata actions.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
