### PR TITLE
Ensure to populate log_action cache when archiving using DB Reader, not using the Writer

### DIFF
--- a/core/Tracker/TableLogAction/Cache.php
+++ b/core/Tracker/TableLogAction/Cache.php
@@ -144,7 +144,7 @@ class Cache
      */
     private function fetchActionIdsFromDb($valueToMatch, $sql)
     {
-        $idActions = \Piwik\Db::fetchAll($sql, $valueToMatch);
+        $idActions = \Piwik\Db::getReader()->fetchAll($sql, $valueToMatch);
 
         $ids = array();
         foreach ($idActions as $idAction) {


### PR DESCRIPTION
For consistency with other archiving queries.

I know this feature is being removed in 5.x-dev but we're currently using for a few customers and it may increase the load on the writer quite a bit when it should use the reader for archiving related queries.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
