### PR TITLE
support record names that end in ints (ie entity IDs) when aggregating one blob at a time

### DIFF
--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -390,7 +390,7 @@ class ArchiveProcessor
 
         foreach ($dataTableBlobs as $archiveDataRow) {
             $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
-            $tableId = $this->getSubtableIdFromBlobName($archiveDataRow['name']);
+            $tableId = $archiveDataRow['name'] == $name ? null : $this->getSubtableIdFromBlobName($archiveDataRow['name']);
 
             $blobTable = DataTable::fromSerializedArray($archiveDataRow['value']);
 

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveSelectorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveSelectorTest.php
@@ -709,6 +709,27 @@ class ArchiveSelectorTest extends IntegrationTestCase
                     ['idsubtable' => 52, 'name' => 'Actions_actions_url_chunk_52_100'],
                 ],
             ],
+
+            // entity root table w/ chunked subtables and normal subtables
+            [
+                [
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 1, 'date1' => '2019-10-05', 'date2' => '2019-10-05', 'name' => 'MyPlugin_myReport_1_chunk_52_100', 'value' => 'nop', 'ts_archived' => '2020-06-13 09:04:56', 'is_blob_data' => true],
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 1, 'date1' => '2019-10-05', 'date2' => '2019-10-05', 'name' => 'MyPlugin_myReport_1_chunk_03_50', 'value' => 'nop', 'ts_archived' => '2020-06-13 09:04:56', 'is_blob_data' => true],
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 1, 'date1' => '2019-10-05', 'date2' => '2019-10-05', 'name' => 'MyPlugin_myReport_1_2', 'value' => 'nop', 'ts_archived' => '2020-06-13 09:04:56', 'is_blob_data' => true],
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 1, 'date1' => '2019-10-05', 'date2' => '2019-10-05', 'name' => 'MyPlugin_myReport_1_51', 'value' => 'nop', 'ts_archived' => '2020-06-13 09:04:56', 'is_blob_data' => true],
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 1, 'date1' => '2019-10-05', 'date2' => '2019-10-05', 'name' => 'MyPlugin_myReport_1_chunk_0_1', 'value' => 'nop', 'ts_archived' => '2020-06-13 09:04:56', 'is_blob_data' => true],
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 1, 'date1' => '2019-10-05', 'date2' => '2019-10-05', 'name' => 'MyPlugin_myReport_1', 'value' => 'nop', 'ts_archived' => '2020-06-13 09:04:56', 'is_blob_data' => true],
+                ],
+                'MyPlugin_myReport_1',
+                [
+                    ['idsubtable' => -1, 'name' => 'MyPlugin_myReport_1'],
+                    ['idsubtable' => 0, 'name' => 'MyPlugin_myReport_1_chunk_0_1'],
+                    ['idsubtable' => 2, 'name' => 'MyPlugin_myReport_1_2'],
+                    ['idsubtable' => 3, 'name' => 'MyPlugin_myReport_1_chunk_03_50'],
+                    ['idsubtable' => 51, 'name' => 'MyPlugin_myReport_1_51'],
+                    ['idsubtable' => 52, 'name' => 'MyPlugin_myReport_1_chunk_52_100'],
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
### Description:

As title.

Changes:
* Instead of checking if a blob is the root blob by checking if it ends in `_\d+`, just compare it against the queried for record name.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
