### PR TITLE
support record names that end in ints (ie entity IDs) when aggregating one blob at a time

### DIFF
--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -390,7 +390,7 @@ class ArchiveProcessor
 
         foreach ($dataTableBlobs as $archiveDataRow) {
             $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
-            $tableId = $this->getSubtableIdFromBlobName($archiveDataRow['name']);
+            $tableId = $archiveDataRow['name'] == $name ? null : $this->getSubtableIdFromBlobName($archiveDataRow['name']);
 
             $blobTable = DataTable::fromSerializedArray($archiveDataRow['value']);
 

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveSelectorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveSelectorTest.php
@@ -709,6 +709,27 @@ class ArchiveSelectorTest extends IntegrationTestCase
                     ['idsubtable' => 52, 'name' => 'Actions_actions_url_chunk_52_100'],
                 ],
             ],
+
+            // entity root table w/ chunked subtables and normal subtables
+            [
+                [
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 1, 'date1' => '2019-10-05', 'date2' => '2019-10-05', 'name' => 'MyPlugin_myReport_1_chunk_52_100', 'value' => 'nop', 'ts_archived' => '2020-06-13 09:04:56', 'is_blob_data' => true],
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 1, 'date1' => '2019-10-05', 'date2' => '2019-10-05', 'name' => 'MyPlugin_myReport_1_chunk_03_50', 'value' => 'nop', 'ts_archived' => '2020-06-13 09:04:56', 'is_blob_data' => true],
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 1, 'date1' => '2019-10-05', 'date2' => '2019-10-05', 'name' => 'MyPlugin_myReport_1_2', 'value' => 'nop', 'ts_archived' => '2020-06-13 09:04:56', 'is_blob_data' => true],
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 1, 'date1' => '2019-10-05', 'date2' => '2019-10-05', 'name' => 'MyPlugin_myReport_1_51', 'value' => 'nop', 'ts_archived' => '2020-06-13 09:04:56', 'is_blob_data' => true],
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 1, 'date1' => '2019-10-05', 'date2' => '2019-10-05', 'name' => 'MyPlugin_myReport_1_chunk_0_1', 'value' => 'nop', 'ts_archived' => '2020-06-13 09:04:56', 'is_blob_data' => true],
+                    ['idarchive' => 1, 'idsite' => 1, 'period' => 1, 'date1' => '2019-10-05', 'date2' => '2019-10-05', 'name' => 'MyPlugin_myReport_1', 'value' => 'nop', 'ts_archived' => '2020-06-13 09:04:56', 'is_blob_data' => true],
+                ],
+                'MyPlugin_myReport_1',
+                [
+                    ['idsubtable' => -1, 'name' => 'MyPlugin_myReport_1'],
+                    ['idsubtable' => 0, 'name' => 'MyPlugin_myReport_1_chunk_0_1'],
+                    ['idsubtable' => 2, 'name' => 'MyPlugin_myReport_1_2'],
+                    ['idsubtable' => 3, 'name' => 'MyPlugin_myReport_1_chunk_03_50'],
+                    ['idsubtable' => 51, 'name' => 'MyPlugin_myReport_1_51'],
+                    ['idsubtable' => 52, 'name' => 'MyPlugin_myReport_1_chunk_52_100'],
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
applies #20595 to 5.x-dev

* to support record names that end in integers (such as entity IDs), check whether a table is the root table against the original name of the record instead of checking if the end of the blob name is an integer

* add test to ensure querySingleBlob sql orders blobs correctly when record name has an entity id in it
