### PR TITLE
Fix array access issue for a single goal ID only

### DIFF
--- a/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
+++ b/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
@@ -109,8 +109,10 @@ class CalculateConversionPageRate extends BaseFilter
 
         $sum = $archive->getNumeric($names);
         foreach ($names as $idGoal => $name) {
-            if (is_numeric($sum[$name])) {
+            if (is_array($sum) && array_key_exists($name, $sum) && is_numeric($sum[$name])) {
                 $goalTotals[$idGoal] = $sum[$name];
+            } elseif (is_numeric($sum)) {
+                $goalTotals[$idGoal] = $sum;
             }
         }
 


### PR DESCRIPTION
### Description:

Fix for an array access issue introduced in https://github.com/matomo-org/matomo/pull/20438 where a single goal produces a numeric value straight away, not an array.

fixes #20636

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
