### PR TITLE
if no subwidgets are defined for a category, do not display the category

### DIFF
--- a/plugins/Dashboard/javascripts/widgetMenu.js
+++ b/plugins/Dashboard/javascripts/widgetMenu.js
@@ -47,6 +47,9 @@ widgetsHelper.getAvailableWidgets = function (callback) {
 
         $.each(categorized, function (category, widgets) {
             $.each(widgets, function (subcategory, subwidgets) {
+                if (!subwidgets.length) {
+                  return;
+                }
 
                 var categoryToUse = category;
                 if (subwidgets.length >= 3 && subcategory !== '-') {


### PR DESCRIPTION
### Description:

If a plugin has no category with less than 4 reports, the widget menu code will end up creating a Category with no reports in the widget selector:

![image](https://user-images.githubusercontent.com/125140/236002111-e38052e8-1a8f-4ef0-a0ce-f24ea40af5b3.png)

vs.

![image](https://user-images.githubusercontent.com/125140/236002154-f3035a54-2f9e-4c88-a56b-8ae64ff96cb1.png)

This PR avoids creating empty categories.

Should probably be replicated on 4.x-dev after merging.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
