### PR TITLE
convert scalar result of getNumeric() to array if only one goal metric is requested

### DIFF
--- a/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
+++ b/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
@@ -108,6 +108,10 @@ class CalculateConversionPageRate extends BaseFilter
         }
 
         $sum = $archive->getNumeric($names);
+        if (!is_array($sum) && count($names) == 1) {
+            $sum = [reset($names) => $sum];
+        }
+
         foreach ($names as $idGoal => $name) {
             if (is_numeric($sum[$name])) {
                 $goalTotals[$idGoal] = $sum[$name];


### PR DESCRIPTION
### Description:

Noticed this when debugging a failing test. If the `$names` is just an array with one element (because there's only one goal), `getNumeric()` will return a float. It will then try to access that float like an array, causing an error.

This fix should probably be replicated on 4.x-dev.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
