### PR TITLE
Prevent duplicate dates for the purge old archive data command

### DIFF
--- a/plugins/CoreAdminHome/Commands/PurgeOldArchiveData.php
+++ b/plugins/CoreAdminHome/Commands/PurgeOldArchiveData.php
@@ -147,7 +147,10 @@ class PurgeOldArchiveData extends ConsoleCommand
 
                 try {
                     $date    = Date::factory($year . '-' . $month . '-' . '01');
-                    $dates[] = $date;
+                    // Make sure the date is not duplicated
+                    if (!in_array($date, $dates)) {
+                        $dates[] = $date;
+                    }
                 } catch (\Exception $e) {
                     // this might occur if archive tables like piwik_archive_numeric_1875_09 exist
                 }

--- a/plugins/CoreAdminHome/Commands/PurgeOldArchiveData.php
+++ b/plugins/CoreAdminHome/Commands/PurgeOldArchiveData.php
@@ -140,17 +140,14 @@ class PurgeOldArchiveData extends ConsoleCommand
         if (count($dateSpecifier) === 1
             && reset($dateSpecifier) == self::ALL_DATES_STRING
         ) {
-            foreach (ArchiveTableCreator::getTablesArchivesInstalled() as $table) {
+            foreach (ArchiveTableCreator::getTablesArchivesInstalled(ArchiveTableCreator::NUMERIC_TABLE) as $table) {
                 $tableDate = ArchiveTableCreator::getDateFromTableName($table);
 
                 list($year, $month) = explode('_', $tableDate);
 
                 try {
                     $date    = Date::factory($year . '-' . $month . '-' . '01');
-                    // Make sure the date is not duplicated
-                    if (!in_array($date, $dates)) {
-                        $dates[] = $date;
-                    }
+                    $dates[] = $date;
                 } catch (\Exception $e) {
                     // this might occur if archive tables like piwik_archive_numeric_1875_09 exist
                 }
@@ -176,7 +173,7 @@ class PurgeOldArchiveData extends ConsoleCommand
             $dates = array_values($dates);
         }
 
-        return $dates;
+        return array_unique($dates);
     }
 
     private function performTimedPurging($startMessage, $callback)


### PR DESCRIPTION
### Description:

When using the `./console core:purge-old-archive-data all` command the list of archive dates to purge is generated by iterating through the existing archive tables, however since there can be both blob and numeric archive tables this results in each date being added twice to the list. Then every archive purge and table optimization is unnecessarily performed twice.

This PR simply checks the dates array as it is being generated and prevents duplicates date being added.

Although the `getTablesArchivesInstalled()` method used to retrieve the list of table could be called with a single table type (e.g. just return blob tables) this wouldn't cover scenarios where archive tables only existed of one type for a date.

Fixes #20692

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
