### PR TITLE
Enhance console command plugin:list with version information

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -1716,9 +1716,19 @@ class Manager
         }
     }
 
-    public function getVersion($pluginName)
+    public function getVersion(string $pluginName): ?string
     {
-        return $this->getLoadedPlugin($pluginName)->getVersion();
+        if ($this->isPluginLoaded($pluginName)) {
+            return (string) $this->getLoadedPlugin($pluginName)->getVersion();
+        } elseif (!$this->isPluginInFilesystem($pluginName)) {
+            return null;
+        } else {
+            try {
+                $plugin = new Plugin($pluginName);
+                return (string) $plugin->getVersion();
+            } catch (\Exception $e) {
+                return null;
+            }
+        }
     }
-
 }

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -1716,4 +1716,9 @@ class Manager
         }
     }
 
+    public function getVersion($pluginName)
+    {
+        return $this->getLoadedPlugin($pluginName)->getVersion();
+    }
+
 }

--- a/plugins/CorePluginsAdmin/Commands/ListPlugins.php
+++ b/plugins/CorePluginsAdmin/Commands/ListPlugins.php
@@ -37,12 +37,18 @@ class ListPlugins extends ConsoleCommand
             });
         }
 
-        $plugins = array_map(function ($plugin) use ($pluginManager) {
-            return array(
+        $verbose = $this->getOutput()->isVerbose();
+
+        $plugins = array_map(function ($plugin) use ($pluginManager, $verbose) {
+            $pluginInformation = array(
                 '<info>' . $plugin . '</info>',
                 $pluginManager->isPluginBundledWithCore($plugin) ? 'Core' : 'Optional',
                 $pluginManager->isPluginActivated($plugin) ? 'Activated' : '<comment>Not activated</comment>',
             );
+            if ($verbose) {
+                $pluginInformation[] =  $pluginManager->getVersion($plugin);
+            }
+            return $pluginInformation;
         }, $plugins);
 
         // Sort Core plugins first
@@ -50,7 +56,11 @@ class ListPlugins extends ConsoleCommand
             return strcmp($a[1], $b[1]);
         });
 
-        $this->renderTable(['Plugin', 'Core or optional?', 'Status'], $plugins);
+        if (!$verbose){
+            $this->renderTable(['Plugin', 'Core or optional?', 'Status'], $plugins);
+        } else {
+            $this->renderTable(['Plugin', 'Core or optional?', 'Status', 'Version'], $plugins);
+        }
 
         return self::SUCCESS;
     }

--- a/plugins/CorePluginsAdmin/Commands/ListPlugins.php
+++ b/plugins/CorePluginsAdmin/Commands/ListPlugins.php
@@ -43,10 +43,10 @@ class ListPlugins extends ConsoleCommand
             $pluginInformation = array(
                 '<info>' . $plugin . '</info>',
                 $pluginManager->isPluginBundledWithCore($plugin) ? 'Core' : 'Optional',
-                $pluginManager->isPluginActivated($plugin) ? 'Activated' : '<comment>Not activated</comment>',
+                !$pluginManager->isPluginInFilesystem($plugin) ? '<error>Not found</error>' : ($pluginManager->isPluginActivated($plugin) ? 'Activated' : '<comment>Not activated</comment>'),
             );
             if ($verbose) {
-                $pluginInformation[] =  $pluginManager->getVersion($plugin);
+                $pluginInformation[] =  $pluginManager->getVersion($plugin) ?? 'Unknown';
             }
             return $pluginInformation;
         }, $plugins);


### PR DESCRIPTION
### Description:

Add a column to the plugin information table with the plugin version when the verbosity level of the console command `plugin:list` is increased (-v).


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
