### PR TITLE
Apply sanity caps on outlier values in performance reports

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1276,23 +1276,28 @@ PluginsInstalled[] = JsTrackerInstallCheck
 [PagePerformance]
 ; The values used in reports 'sum/total' and 'average' are capped to reduce the impact of single failed performance measurements.
 ;
-; Default caps are at 100-fold an avg/high value. Thereby one wrong value in 10000 values results in a 1% deviation:
+; The recommended caps are at 100-fold an avg/high value. Thereby one wrong value in 10000 values results in a 1% deviation:
 ; (1x 100N + 9999x N) / 10000 ~= 101% N
 ;
-; To disable capping set cap to: 0
-;
+; By default capping is disabled. To enable capping add single lines below as needed to section '[PagePerformance]' in 'config.ini.php'.
+
 ; Network: avg/high 100ms
-time_network_cap_duration_ms = 10000
+;time_network_cap_duration_ms = 10000
+
 ; Server: avg/high 500ms
-time_server_cap_duration_ms = 50000
+;time_server_cap_duration_ms = 50000
+
 ; Transfer: avg/high 250ms
-time_transfer_cap_duration_ms = 25000
+;time_transfer_cap_duration_ms = 25000
+
 ; DOM processing: avg/high 500ms
-time_dom_processing_cap_duration_ms = 50000
+;time_dom_processing_cap_duration_ms = 50000
+
 ; DOM completion: avg/high 1500ms
-time_dom_completion_cap_duration_ms = 150000
+;time_dom_completion_cap_duration_ms = 150000
+
 ; On load: avg/high 2500ms
-time_on_load_cap_duration_ms = 250000
+;time_on_load_cap_duration_ms = 250000
 
 [APISettings]
 ; Any key/value pair can be added in this section, they will be available via the REST call

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1274,30 +1274,31 @@ PluginsInstalled[] = Intl
 PluginsInstalled[] = JsTrackerInstallCheck
 
 [PagePerformance]
-; The values used in reports 'sum/total' and 'average' are capped to reduce the impact of single failed performance measurements.
+; The configuration below provides the possibility to enable capping of values used for generating 'sum/total' and 'average' metrics for page performance reports.
+; This allows to reduce the impact of single failed performance measurements.
 ;
-; The recommended caps are at 100-fold an avg/high value. Thereby one wrong value in 10000 values results in a 1% deviation:
+; The recommended caps are at 100-fold an avg/high value. Thereby one wrong value in 10,000 values results in a 1% deviation:
 ; (1x 100N + 9999x N) / 10000 ~= 101% N
 ;
-; By default capping is disabled. To enable capping add single lines below as needed to section '[PagePerformance]' in 'config.ini.php'.
+; By default capping is disabled. To enable capping overwrite the configs below with a value higher than 0.
 
-; Network: avg/high 100ms
-;time_network_cap_duration_ms = 10000
+; Cap for Network time: avg/high 100ms (recommended value: 10000)
+time_network_cap_duration_ms = 0
 
-; Server: avg/high 500ms
-;time_server_cap_duration_ms = 50000
+; Cap for Server time: avg/high 500ms (recommended value: 50000)
+time_server_cap_duration_ms = 0
 
-; Transfer: avg/high 250ms
-;time_transfer_cap_duration_ms = 25000
+; Cap for Transfer time: avg/high 250ms (recommended value: 25000)
+time_transfer_cap_duration_ms = 0
 
-; DOM processing: avg/high 500ms
-;time_dom_processing_cap_duration_ms = 50000
+; Cap for DOM processing time: avg/high 500ms (recommended value: 50000)
+time_dom_processing_cap_duration_ms = 0
 
-; DOM completion: avg/high 1500ms
-;time_dom_completion_cap_duration_ms = 150000
+; Cap for DOM completion time: avg/high 1500ms (recommended value: 150000)
+time_dom_completion_cap_duration_ms = 0
 
-; On load: avg/high 10ms (time 'DOM complete' to 'Onload-event')
-;time_on_load_cap_duration_ms = 1000
+; Cap for On load time: avg/high 10ms (recommended value: 1000)
+time_on_load_cap_duration_ms = 0
 
 [APISettings]
 ; Any key/value pair can be added in this section, they will be available via the REST call

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1273,7 +1273,7 @@ PluginsInstalled[] = Monolog
 PluginsInstalled[] = Intl
 PluginsInstalled[] = JsTrackerInstallCheck
 
-[PluginPagePerformance]
+[PagePerformance]
 ; The values used in reports 'sum/total' and 'average' are capped to reduce the impact of single failed performance measurements.
 ;
 ; Default caps are at 100-fold an avg/high value. Thereby one wrong value in 10000 values results in a 1% deviation:

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1273,6 +1273,27 @@ PluginsInstalled[] = Monolog
 PluginsInstalled[] = Intl
 PluginsInstalled[] = JsTrackerInstallCheck
 
+[PluginPagePerformance]
+; The values used in reports 'sum/total' and 'average' are capped to reduce the impact of single failed performance measurements.
+;
+; Default caps are at 100-fold an avg/high value. Thereby one wrong value in 10000 values results in a 1% deviation:
+; (1x 100N + 9999x N) / 10000 ~= 101% N
+;
+; To disable capping set cap to: 0
+;
+; Network: avg/high 100ms
+time_network_cap_duration_ms = 10000
+; Server: avg/high 500ms
+time_server_cap_duration_ms = 50000
+; Transfer: avg/high 250ms
+time_transfer_cap_duration_ms = 25000
+; DOM processing: avg/high 500ms
+time_dom_processing_cap_duration_ms = 50000
+; DOM completion: avg/high 1500ms
+time_dom_completion_cap_duration_ms = 150000
+; On load: avg/high 2500ms
+time_on_load_cap_duration_ms = 250000
+
 [APISettings]
 ; Any key/value pair can be added in this section, they will be available via the REST call
 ; index.php?module=API&method=API.getSettings

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1296,8 +1296,8 @@ PluginsInstalled[] = JsTrackerInstallCheck
 ; DOM completion: avg/high 1500ms
 ;time_dom_completion_cap_duration_ms = 150000
 
-; On load: avg/high 2500ms
-;time_on_load_cap_duration_ms = 250000
+; On load: avg/high 10ms (time 'DOM complete' to 'Onload-event')
+;time_on_load_cap_duration_ms = 1000
 
 [APISettings]
 ; Any key/value pair can be added in this section, they will be available via the REST call

--- a/plugins/PagePerformance/Columns/Base.php
+++ b/plugins/PagePerformance/Columns/Base.php
@@ -25,7 +25,7 @@ abstract class Base extends ActionDimension
 
     public function getConfigValueCap()
     {
-        return Config::getInstance()->PluginPagePerformance[$this->columnName . '_cap_' . $this->type];
+        return Config::getInstance()->PagePerformance[$this->columnName . '_cap_' . $this->type];
     }
 
     public function getSqlCappedValue()

--- a/plugins/PagePerformance/Columns/Base.php
+++ b/plugins/PagePerformance/Columns/Base.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik\Plugins\PagePerformance\Columns;
 
+use Exception;
 use Piwik\Config;
 use Piwik\Exception\InvalidRequestParameterException;
 use Piwik\Plugin\Dimension\ActionDimension;
@@ -25,7 +26,13 @@ abstract class Base extends ActionDimension
 
     public function getConfigValueCap()
     {
-        return Config::getInstance()->PagePerformance[$this->columnName . '_cap_' . $this->type];
+        try {
+            $valueCap = Config::getInstance()->PagePerformance[$this->columnName . '_cap_' . $this->type];
+        } catch (Exception $ex) {
+            // 0 disables cap
+            return 0;
+        }
+        return $valueCap;
     }
 
     public function getSqlCappedValue()

--- a/plugins/PagePerformance/Columns/Base.php
+++ b/plugins/PagePerformance/Columns/Base.php
@@ -24,7 +24,7 @@ abstract class Base extends ActionDimension
 
     abstract public function getRequestParam();
 
-    public function getConfigValueCap()
+    private function getConfigValueCap()
     {
         try {
             $valueCap = Config::getInstance()->PagePerformance[$this->columnName . '_cap_' . $this->type];

--- a/plugins/PagePerformance/Columns/Base.php
+++ b/plugins/PagePerformance/Columns/Base.php
@@ -27,7 +27,7 @@ abstract class Base extends ActionDimension
     private function getConfigValueCap()
     {
         try {
-            $valueCap = Config::getInstance()->PagePerformance[$this->columnName . '_cap_' . $this->type];
+            $valueCap = Config::getInstance()->PagePerformance[$this->columnName . '_cap_' . $this->type] ?? 0;
         } catch (Exception $ex) {
             // 0 disables cap
             return 0;

--- a/plugins/PagePerformance/Columns/TimeDomCompletion.php
+++ b/plugins/PagePerformance/Columns/TimeDomCompletion.php
@@ -30,7 +30,7 @@ class TimeDomCompletion extends Base
 
     public function configureMetrics(MetricsList $metricsList, DimensionMetricFactory $dimensionMetricFactory)
     {
-        $metric1 = $dimensionMetricFactory->createMetric(ArchivedMetric::AGGREGATION_SUM);
+        $metric1 = $dimensionMetricFactory->createMetric('sum(' . $this->getSqlCappedValue() . ')');
         $metric1->setName('sum_time_dom_completion');
         $metricsList->addMetric($metric1);
 

--- a/plugins/PagePerformance/Columns/TimeDomProcessing.php
+++ b/plugins/PagePerformance/Columns/TimeDomProcessing.php
@@ -30,7 +30,7 @@ class TimeDomProcessing extends Base
 
     public function configureMetrics(MetricsList $metricsList, DimensionMetricFactory $dimensionMetricFactory)
     {
-        $metric1 = $dimensionMetricFactory->createMetric(ArchivedMetric::AGGREGATION_SUM);
+        $metric1 = $dimensionMetricFactory->createMetric('sum(' . $this->getSqlCappedValue() . ')');
         $metric1->setName('sum_time_dom_processing');
         $metricsList->addMetric($metric1);
 

--- a/plugins/PagePerformance/Columns/TimeNetwork.php
+++ b/plugins/PagePerformance/Columns/TimeNetwork.php
@@ -30,7 +30,7 @@ class TimeNetwork extends Base
 
     public function configureMetrics(MetricsList $metricsList, DimensionMetricFactory $dimensionMetricFactory)
     {
-        $metric1 = $dimensionMetricFactory->createMetric(ArchivedMetric::AGGREGATION_SUM);
+        $metric1 = $dimensionMetricFactory->createMetric('sum(' . $this->getSqlCappedValue() . ')');
         $metric1->setName('sum_time_network');
         $metricsList->addMetric($metric1);
 

--- a/plugins/PagePerformance/Columns/TimeOnLoad.php
+++ b/plugins/PagePerformance/Columns/TimeOnLoad.php
@@ -30,7 +30,7 @@ class TimeOnLoad extends Base
 
     public function configureMetrics(MetricsList $metricsList, DimensionMetricFactory $dimensionMetricFactory)
     {
-        $metric1 = $dimensionMetricFactory->createMetric(ArchivedMetric::AGGREGATION_SUM);
+        $metric1 = $dimensionMetricFactory->createMetric('sum(' . $this->getSqlCappedValue() . ')');
         $metric1->setName('sum_time_on_load');
         $metricsList->addMetric($metric1);
 

--- a/plugins/PagePerformance/Columns/TimeServer.php
+++ b/plugins/PagePerformance/Columns/TimeServer.php
@@ -30,7 +30,7 @@ class TimeServer extends Base
 
     public function configureMetrics(MetricsList $metricsList, DimensionMetricFactory $dimensionMetricFactory)
     {
-        $metric1 = $dimensionMetricFactory->createMetric(ArchivedMetric::AGGREGATION_SUM);
+        $metric1 = $dimensionMetricFactory->createMetric('sum(' . $this->getSqlCappedValue() . ')');
         $metric1->setName('sum_time_server');
         $metricsList->addMetric($metric1);
 

--- a/plugins/PagePerformance/Columns/TimeTransfer.php
+++ b/plugins/PagePerformance/Columns/TimeTransfer.php
@@ -30,7 +30,7 @@ class TimeTransfer extends Base
 
     public function configureMetrics(MetricsList $metricsList, DimensionMetricFactory $dimensionMetricFactory)
     {
-        $metric1 = $dimensionMetricFactory->createMetric(ArchivedMetric::AGGREGATION_SUM);
+        $metric1 = $dimensionMetricFactory->createMetric('sum(' . $this->getSqlCappedValue() . ')');
         $metric1->setName('sum_time_transfer');
         $metricsList->addMetric($metric1);
 

--- a/plugins/PagePerformance/Metrics.php
+++ b/plugins/PagePerformance/Metrics.php
@@ -9,7 +9,7 @@
 namespace Piwik\Plugins\PagePerformance;
 
 use Piwik\Columns\Dimension;
-use Piwik\Plugin\Dimension\ActionDimension;
+use Piwik\Plugins\PagePerformance\Columns\Base;
 use Piwik\Plugins\PagePerformance\Columns\Metrics\AveragePageLoadTime;
 use Piwik\Plugins\PagePerformance\Columns\Metrics\AverageTimeDomCompletion;
 use Piwik\Plugins\PagePerformance\Columns\Metrics\AverageTimeDomProcessing;
@@ -97,7 +97,7 @@ class Metrics
         $table = 'log_link_visit_action';
 
         /**
-         * @var ActionDimension[] $performanceDimensions
+         * @var Base[] $performanceDimensions
          */
         $performanceDimensions = [
             new TimeNetwork(),
@@ -112,12 +112,7 @@ class Metrics
             $column = $table . '.' . $id;
             $metricsConfig['sum_' . $id] = [
                 'aggregation' => 'sum',
-                'query' => "sum(
-                    case when " . $column . " is null
-                        then 0
-                        else " . $column . "
-                    end
-                ) / 1000"
+                'query' => "sum(" . sprintf($dimension->getSqlCappedValue(), $column) . ") / 1000"
             ];
             $metricsConfig['nb_hits_with_' . $id] = [
                 'aggregation' => 'sum',

--- a/plugins/PagePerformance/RecordBuilders/PerformanceTotals.php
+++ b/plugins/PagePerformance/RecordBuilders/PerformanceTotals.php
@@ -13,6 +13,7 @@ use Piwik\ArchiveProcessor;
 use Piwik\ArchiveProcessor\Record;
 use Piwik\ArchiveProcessor\RecordBuilder;
 use Piwik\Plugins\PagePerformance\Archiver;
+use Piwik\Plugins\PagePerformance\Columns\Base;
 use Piwik\Plugins\PagePerformance\Columns\TimeDomCompletion;
 use Piwik\Plugins\PagePerformance\Columns\TimeDomProcessing;
 use Piwik\Plugins\PagePerformance\Columns\TimeNetwork;
@@ -51,6 +52,9 @@ class PerformanceTotals extends RecordBuilder
         $selects = $totalColumns = $allColumns = [];
         $table  = 'log_link_visit_action';
 
+        /**
+         * @var Base[] $performanceDimensions
+         */
         $performanceDimensions = [
             new TimeNetwork(),
             new TimeServer(),
@@ -62,9 +66,9 @@ class PerformanceTotals extends RecordBuilder
 
         foreach($performanceDimensions as $dimension) {
             $column = $dimension->getColumnName();
-            $selects[] = "sum($table.$column) as {$column}_total";
+            $selects[] = "sum(" . sprintf($dimension->getSqlCappedValue(), $table . '.' . $column) . ") as {$column}_total";
             $selects[] = "sum(if($table.$column is null, 0, 1)) as {$column}_hits";
-            $totalColumns[] = "IFNULL($table.$column,0)";
+            $totalColumns[] = sprintf($dimension->getSqlCappedValue(), $table . '.' . $column);
             $allColumns[]  = "$table.$column";
         }
 

--- a/plugins/PagePerformance/tests/Integration/CappedValuesTest.php
+++ b/plugins/PagePerformance/tests/Integration/CappedValuesTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\PagePerformance\tests\Integration;
+
+use Piwik\Config;
+use Piwik\Plugins\PagePerformance\API;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group PagePerformance
+ * @group Plugins
+ */
+class CappedValuesTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createWebsite('2023-01-01 00:00:00');
+        Fixture::createSuperUser();
+        $this->trackVisits();
+    }
+
+    public function testShouldNotCapOutlinerValuesByDefault()
+    {
+        $result = API::getInstance()->get(1, 'day', '2024-01-16');
+        $resultArray = $result->getFirstRow()->getArrayCopy();
+
+        self::assertEquals(
+            [
+                'PagePerformance_network_time' => 0.04,
+                'PagePerformance_network_hits' => 2.0,
+                'PagePerformance_servery_time' => 0.2,
+                'PagePerformance_server_hits' => 2.0,
+                'PagePerformance_transfer_time' => 1.2,
+                'PagePerformance_transfer_hits' => 2.0,
+                'PagePerformance_domprocessing_time' => 4.0,
+                'PagePerformance_domprocessing_hits' => 2.0,
+                'PagePerformance_domcompletion_time' => 1.2,
+                'PagePerformance_domcompletion_hits' => 2.0,
+                'PagePerformance_onload_time' => 0.24,
+                'PagePerformance_onload_hits' => 2.0,
+                'PagePerformance_pageload_time' => 6.88,
+                'PagePerformance_pageload_hits' => 2.0,
+                'avg_time_network' => 0.02,
+                'avg_time_server' => 0.1,
+                'avg_time_transfer' => 0.6,
+                'avg_time_dom_processing' => 2.0,
+                'avg_time_dom_completion' => 0.6,
+                'avg_time_on_load' => 0.12,
+                'avg_page_load_time' => 3.44,
+            ],
+            $resultArray
+        );
+    }
+
+    public function testShouldNotCapOutlinerValuesWhenConfigured()
+    {
+        Config::getInstance()->PagePerformance = [
+            'time_network_cap_duration_ms' => 20,
+            'time_server_cap_duration_ms' => 100,
+            'time_transfer_cap_duration_ms' => 600,
+            'time_dom_processing_cap_duration_ms' => 2000,
+            'time_dom_completion_cap_duration_ms' => 600,
+            'time_on_load_cap_duration_ms' => 120,
+        ];
+
+        $result = API::getInstance()->get(1, 'day', '2024-01-16');
+        $resultArray = $result->getFirstRow()->getArrayCopy();
+
+        self::assertEquals(
+            [
+                'PagePerformance_network_time' => 0.03,
+                'PagePerformance_network_hits' => 2.0,
+                'PagePerformance_servery_time' => 0.15,
+                'PagePerformance_server_hits' => 2.0,
+                'PagePerformance_transfer_time' => 0.9,
+                'PagePerformance_transfer_hits' => 2.0,
+                'PagePerformance_domprocessing_time' => 3.0,
+                'PagePerformance_domprocessing_hits' => 2.0,
+                'PagePerformance_domcompletion_time' => 0.9,
+                'PagePerformance_domcompletion_hits' => 2.0,
+                'PagePerformance_onload_time' => 0.18,
+                'PagePerformance_onload_hits' => 2.0,
+                'PagePerformance_pageload_time' => 5.16,
+                'PagePerformance_pageload_hits' => 2.0,
+                'avg_time_network' => 0.02,
+                'avg_time_server' => 0.08,
+                'avg_time_transfer' => 0.45,
+                'avg_time_dom_processing' => 1.5,
+                'avg_time_dom_completion' => 0.45,
+                'avg_time_on_load' => 0.09,
+                'avg_page_load_time' => 2.58,
+            ],
+            $resultArray
+        );
+    }
+
+    private function trackVisits()
+    {
+        $tracker = Fixture::getTracker(1, '2024-01-16 16:03:04');
+        $tracker->setUrl('http://example.org/test');
+        Fixture::checkResponse($tracker->doTrackPageView('My Page'));
+        $tracker->setPerformanceTimings(10, 50, 300, 1000, 300, 60);
+        Fixture::checkResponse($tracker->doTrackEvent('cat', 'act'));
+
+        $tracker = Fixture::getTracker(1, '2024-01-16 18:03:04');
+        $tracker->setNewVisitorId();
+        $tracker->setUrl('http://example.org/test');
+        $tracker->setPerformanceTimings(30, 150, 900, 3000, 900, 180);
+        Fixture::checkResponse($tracker->doTrackPageView('My Page'));
+    }
+}


### PR DESCRIPTION
### Description:

The values used in performance reports of type 'sum/total' and 'average' are capped to reduce the impact of single failed performance measurements.

This fixes #17847.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
