### PR TITLE
Provide json output of console command `plugin:list`

### DIFF
--- a/core/Plugin/ConsoleCommand.php
+++ b/core/Plugin/ConsoleCommand.php
@@ -57,7 +57,7 @@ class ConsoleCommand extends SymfonyCommand
         $this->getOutput()->writeln('');
 
         foreach ($messages as $message) {
-            $this->getOutput()->writeln('<info>' . $message . '</info>');
+            $this->getOutput()->writeln(self::wrapInTag('info', $message ));
         }
 
         $this->getOutput()->writeln('');
@@ -74,7 +74,7 @@ class ConsoleCommand extends SymfonyCommand
         $this->getOutput()->writeln('');
 
         foreach ($messages as $message) {
-            $this->getOutput()->writeln('<comment>' . $message . '</comment>');
+            $this->getOutput()->writeln(self::wrapInTag('comment' , $message ));
         }
 
         $this->getOutput()->writeln('');
@@ -487,5 +487,18 @@ class ConsoleCommand extends SymfonyCommand
         $inputObject = new ArrayInput($arguments);
         $inputObject->setInteractive($this->getInput()->isInteractive());
         return $command->run($inputObject, $hideOutput ? new NullOutput() : $this->getOutput());
+    }
+
+    /**
+     * Wrap the input string in an open and closing HTML/XML tag.
+     * E.g. wrap_in_tag('info', 'my string') returns '<info>my string</info>'
+     *
+     * @param string $tagname Tag name to wrap the string in.
+     * @param string $str String to wrap with the tag.
+     * @return string The wrapped string.
+     */
+    public static function wrapInTag(string $tagname, string $str): string
+    {
+        return "<$tagname>$str</$tagname>";
     }
 }

--- a/plugins/CoreAdminHome/Commands/ConfigDelete.php
+++ b/plugins/CoreAdminHome/Commands/ConfigDelete.php
@@ -266,17 +266,4 @@ NOTES:
 
         return $settingWrappedNew;
     }
-
-    /**
-     * Wrap the input string in an open and closing HTML/XML tag.
-     * E.g. wrap_in_tag('info', 'my string') returns '<info>my string</info>'
-     *
-     * @param string $tagname Tag name to wrap the string in.
-     * @param string $str String to wrap with the tag.
-     * @return string The wrapped string.
-     */
-    public static function wrapInTag(string $tagname, string $str): string
-    {
-        return "<$tagname>$str</$tagname>";
-    }
 }

--- a/plugins/CoreAdminHome/Commands/ConfigGet.php
+++ b/plugins/CoreAdminHome/Commands/ConfigGet.php
@@ -200,19 +200,6 @@ NOTES:
     }
 
     /**
-     * Wrap the input string in an open and closing HTML/XML tag.
-     * E.g. wrap_in_tag('info', 'my string') returns '<info>my string</info>'
-     *
-     * @param string $tagname Tag name to wrap the string in.
-     * @param string $str String to wrap with the tag.
-     * @return string The wrapped string.
-     */
-    public static function wrapInTag(string $tagname, string $str): string
-    {
-        return "<$tagname>$str</$tagname>";
-    }
-
-    /**
      * Format the config setting to the specified output format.
      *
      * @param SystemConfigSetting $setting The found SystemConfigSetting.

--- a/plugins/CorePluginsAdmin/Commands/ListPlugins.php
+++ b/plugins/CorePluginsAdmin/Commands/ListPlugins.php
@@ -21,6 +21,7 @@ class ListPlugins extends ConsoleCommand
         $this->setName('plugin:list');
         $this->setDescription('List installed plugins.');
         $this->addOptionalValueOption('filter-plugin', null, 'If given, prints only plugins that contain this term.');
+        $this->addNoValueOption('json', null,'If given, outputs JSON formatted data.');
     }
 
     protected function doExecute(): int
@@ -41,27 +42,53 @@ class ListPlugins extends ConsoleCommand
 
         $plugins = array_map(function ($plugin) use ($pluginManager, $verbose) {
             $pluginInformation = array(
-                '<info>' . $plugin . '</info>',
-                $pluginManager->isPluginBundledWithCore($plugin) ? 'Core' : 'Optional',
-                !$pluginManager->isPluginInFilesystem($plugin) ? '<error>Not found</error>' : ($pluginManager->isPluginActivated($plugin) ? 'Activated' : '<comment>Not activated</comment>'),
+                "plugin" => $plugin,
+                "core" =>  $pluginManager->isPluginBundledWithCore($plugin),
+                "activated" => !$pluginManager->isPluginInFilesystem($plugin) ? null : $pluginManager->isPluginActivated($plugin),
             );
             if ($verbose) {
-                $pluginInformation[] =  $pluginManager->getVersion($plugin) ?? 'Unknown';
+                $pluginInformation["version"] = $pluginManager->getVersion($plugin);
             }
             return $pluginInformation;
         }, $plugins);
 
-        // Sort Core plugins first
-        usort($plugins, function ($a, $b) {
-            return strcmp($a[1], $b[1]);
-        });
+        if($this->getInput()->getOption('json')) {
+            $plugins = array_map(function ($plugin) {
+                $plugin["comment"] = !isset($plugin["activated"]) ? 'Plugin not found in filesystem.' : '';
+                if (isset($plugin["version"]) && !isset($plugin["activated"])) {
+                    $plugin["version"] = '';
+                }
+                $plugin["activated"] = isset($plugin["activated"]);
+                return $plugin;
+            }, $plugins);
 
-        if (!$verbose){
-            $this->renderTable(['Plugin', 'Core or optional?', 'Status'], $plugins);
+            // write JSON output
+            $this->getOutput()->write(json_encode($plugins));
         } else {
-            $this->renderTable(['Plugin', 'Core or optional?', 'Status', 'Version'], $plugins);
+            // Decorate the plugin information
+            $plugins = array_map(function ($plugin) {
+                $plugin["plugin"] = '<info>' . $plugin["plugin"] . '</info>';
+                $plugin["core"] = $plugin["core"] ? 'Core' : 'Optional';
+                if (isset($plugin["version"]) && !isset($plugin["activated"])) {
+                    $plugin["version"] = '';
+                }
+                $plugin["activated"] = !isset($plugin["activated"]) ? '<error>Not found</error>' : ($plugin["activated"] ? 'Activated' : '<comment>Not activated</comment>');
+                return $plugin;
+            }, $plugins);
+
+            // Sort Core plugins first
+            uasort($plugins, function ($a, $b) {
+                return strcmp($a["core"], $b["core"]);
+            });
+            if (!$verbose){
+                $this->renderTable(['Plugin', 'Core or optional?', 'Status'], $plugins);
+            } else {
+                $this->renderTable(['Plugin', 'Core or optional?', 'Status', 'Version'], $plugins);
+            }
         }
+
 
         return self::SUCCESS;
     }
+
 }

--- a/plugins/CorePluginsAdmin/Commands/ListPlugins.php
+++ b/plugins/CorePluginsAdmin/Commands/ListPlugins.php
@@ -67,12 +67,12 @@ class ListPlugins extends ConsoleCommand
         } else {
             // Decorate the plugin information
             $plugins = array_map(function ($plugin) {
-                $plugin["plugin"] = '<info>' . $plugin["plugin"] . '</info>';
+                $plugin["plugin"] = self::wrapInTag('info', $plugin["plugin"] );
                 $plugin["core"] = $plugin["core"] ? 'Core' : 'Optional';
                 if (isset($plugin["version"]) && !isset($plugin["activated"])) {
                     $plugin["version"] = '';
                 }
-                $plugin["activated"] = !isset($plugin["activated"]) ? '<error>Not found</error>' : ($plugin["activated"] ? 'Activated' : '<comment>Not activated</comment>');
+                $plugin["activated"] = !isset($plugin["activated"]) ? self::wrapInTag('error','Not found') : ($plugin["activated"] ? 'Activated' : self::wrapInTag('comment','Not activated'));
                 return $plugin;
             }, $plugins);
 

--- a/plugins/CorePluginsAdmin/Commands/ListPlugins.php
+++ b/plugins/CorePluginsAdmin/Commands/ListPlugins.php
@@ -21,7 +21,7 @@ class ListPlugins extends ConsoleCommand
         $this->setName('plugin:list');
         $this->setDescription('List installed plugins.');
         $this->addOptionalValueOption('filter-plugin', null, 'If given, prints only plugins that contain this term.');
-        $this->addNoValueOption('json', null,'If given, outputs JSON formatted data.');
+        $this->addNoValueOption('json', null, 'If given, outputs JSON formatted data.');
     }
 
     protected function doExecute(): int
@@ -43,7 +43,7 @@ class ListPlugins extends ConsoleCommand
         $plugins = array_map(function ($plugin) use ($pluginManager, $verbose) {
             $pluginInformation = array(
                 "plugin" => $plugin,
-                "core" =>  $pluginManager->isPluginBundledWithCore($plugin),
+                "core" => $pluginManager->isPluginBundledWithCore($plugin),
                 "activated" => !$pluginManager->isPluginInFilesystem($plugin) ? null : $pluginManager->isPluginActivated($plugin),
             );
             if ($verbose) {
@@ -52,7 +52,7 @@ class ListPlugins extends ConsoleCommand
             return $pluginInformation;
         }, $plugins);
 
-        if($this->getInput()->getOption('json')) {
+        if ($this->getInput()->getOption('json')) {
             $plugins = array_map(function ($plugin) {
                 $plugin["comment"] = !isset($plugin["activated"]) ? 'Plugin not found in filesystem.' : '';
                 if (isset($plugin["version"]) && !isset($plugin["activated"])) {
@@ -67,12 +67,12 @@ class ListPlugins extends ConsoleCommand
         } else {
             // Decorate the plugin information
             $plugins = array_map(function ($plugin) {
-                $plugin["plugin"] = self::wrapInTag('info', $plugin["plugin"] );
+                $plugin["plugin"] = self::wrapInTag('info', $plugin["plugin"]);
                 $plugin["core"] = $plugin["core"] ? 'Core' : 'Optional';
                 if (isset($plugin["version"]) && !isset($plugin["activated"])) {
                     $plugin["version"] = '';
                 }
-                $plugin["activated"] = !isset($plugin["activated"]) ? self::wrapInTag('error','Not found') : ($plugin["activated"] ? 'Activated' : self::wrapInTag('comment','Not activated'));
+                $plugin["activated"] = !isset($plugin["activated"]) ? self::wrapInTag('error', 'Not found') : ($plugin["activated"] ? 'Activated' : self::wrapInTag('comment', 'Not activated'));
                 return $plugin;
             }, $plugins);
 
@@ -80,7 +80,7 @@ class ListPlugins extends ConsoleCommand
             uasort($plugins, function ($a, $b) {
                 return strcmp($a["core"], $b["core"]);
             });
-            if (!$verbose){
+            if (!$verbose) {
                 $this->renderTable(['Plugin', 'Core or optional?', 'Status'], $plugins);
             } else {
                 $this->renderTable(['Plugin', 'Core or optional?', 'Status', 'Version'], $plugins);


### PR DESCRIPTION
### Description:

Add a new option `--json` to the console command plugin:list and output the information as json instead of a rendered table. This helps with automation when managing Matomo installs.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
