### PR TITLE
Allow to optionally defer JS from custom layout templates

### DIFF
--- a/core/Twig.php
+++ b/core/Twig.php
@@ -215,11 +215,12 @@ class Twig
             }
 
             $assetType = strtolower($params['type']);
+            $deferJs = boolval($params['defer'] ?? false);
             switch ($assetType) {
                 case 'css':
                     return AssetManager::getInstance()->getCssInclusionDirective();
                 case 'js':
-                    return AssetManager::getInstance()->getJsInclusionDirective();
+                    return AssetManager::getInstance()->getJsInclusionDirective($deferJs);
                 default:
                     throw new Exception("The twig function includeAssets 'type' parameter needs to be either 'css' or 'js'.");
             }

--- a/plugins/Login/templates/loginLayout.twig
+++ b/plugins/Login/templates/loginLayout.twig
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block head %}
+    {% set deferjs = true %}
     {{ parent() }}
 {% endblock %}
 

--- a/plugins/Morpheus/templates/_iframeBuster.twig
+++ b/plugins/Morpheus/templates/_iframeBuster.twig
@@ -1,11 +1,15 @@
 {% if (enableFrames is defined and enableFrames == false) %}
     <script type="text/javascript">
-        $(function () {
-        $('body').css("display", "none");
-        if (self == top) {
-            var theBody = document.getElementsByTagName('body')[0];
-            theBody.style.display = 'block';
-        } else { top.location = self.location; }
-    });
+        window.addEventListener('DOMContentLoaded', function () {
+            $(function () {
+                $('body').css("display", "none");
+                if (self == top) {
+                    var theBody = document.getElementsByTagName('body')[0];
+                    theBody.style.display = 'block';
+                } else {
+                    top.location = self.location;
+                }
+            });
+        });
     </script>
 {% endif %}

--- a/plugins/Morpheus/templates/_jsCssIncludes.twig
+++ b/plugins/Morpheus/templates/_jsCssIncludes.twig
@@ -1,4 +1,4 @@
 {% autoescape false %}
     {{ includeAssets({"type": "css"}) }}
-    {{ includeAssets({"type":"js"}) }}
+    {{ includeAssets({"type": "js", "defer": deferjs|default(false) }) }}
 {% endautoescape %}


### PR DESCRIPTION
### Description:

Since login page doesn't use nearly any of the bundled JS, we can defer its loading and the form will still be visible quite early. Then with the JS already loaded continuing to the dashboard should use the cached files already.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
