### PR TITLE
align allowed characters for option `--value` on console command `config:delete` to `config:set`

### DIFF
--- a/plugins/CoreAdminHome/Commands/ConfigDelete.php
+++ b/plugins/CoreAdminHome/Commands/ConfigDelete.php
@@ -237,7 +237,7 @@ NOTES:
     {
 
         $matches = [];
-        if (!preg_match('/^([a-zA-Z0-9_]+)(?:\.([a-zA-Z0-9_]+))?(?:\[\])?(?:\.([a-zA-Z0-9_]+))?/', $settingStr, $matches) || empty($matches[1])) {
+        if (!preg_match('/^([a-zA-Z0-9_]+)(?:\.([a-zA-Z0-9_]+))?(?:\[\])?(?:\.(.+))?/', $settingStr, $matches) || empty($matches[1])) {
             throw new \InvalidArgumentException("Invalid input string='{$settingStr}': expected section.name or section.name[]");
         }
 

--- a/plugins/CoreAdminHome/tests/Integration/Commands/ConfigDeleteTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/ConfigDeleteTest.php
@@ -35,17 +35,75 @@ class ConfigDeleteTest extends ConsoleCommandTestCase
     private const TEST_CONFIG_PATH = '/tmp/test.config.ini.php';
     // Section 1.
     private const TEST_SECTION_1_NAME = self::CLASS_NAME_SHORT . '_test_section_1';
+    // Setting 1.1
     private const TEST_SETTING_1_1_NAME = self::CLASS_NAME_SHORT . '_test_setting_1';
     private const TEST_SETTING_1_1_VALUE = self::CLASS_NAME_SHORT . '_test_value_1';
+    // Setting 1.2
     private const TEST_SETTING_1_2_NAME = self::CLASS_NAME_SHORT . '_test_setting_2';
     private const TEST_SETTING_1_2_VALUE = self::CLASS_NAME_SHORT . '_test_value_2';
+    // Setting 1.3 - IPv4 address with port
+    private const TEST_SETTING_1_3_NAME = self::CLASS_NAME_SHORT . '_test_setting_3_ipv4_address';
+    private const TEST_SETTING_1_3_VALUE = self::CLASS_NAME_SHORT . '123.123.123.123:8080';
+    // Setting 1.4 - IPv6 address with port
+    private const TEST_SETTING_1_4_NAME = self::CLASS_NAME_SHORT . '_test_setting_4_ipv6_address';
+    private const TEST_SETTING_1_4_VALUE = self::CLASS_NAME_SHORT . '[2001:858:a6::186]:80';
+    // Setting 1.5 - IPv4 subnet
+    private const TEST_SETTING_1_5_NAME = self::CLASS_NAME_SHORT . '_test_setting_5_ipv6_subnet';
+    private const TEST_SETTING_1_5_VALUE = self::CLASS_NAME_SHORT . '192.168.x.x/24';
+    // Setting 1.6 - IPv6 subnet
+    private const TEST_SETTING_1_6_NAME = self::CLASS_NAME_SHORT . '_test_setting_6_ipv6_subnet';
+    private const TEST_SETTING_1_6_VALUE = self::CLASS_NAME_SHORT . '2001:db8::/32';
+    // Setting 1.7 - mail address with extension
+    private const TEST_SETTING_1_7_NAME = self::CLASS_NAME_SHORT . '_test_setting_7_mail_address';
+    private const TEST_SETTING_1_7_VALUE = self::CLASS_NAME_SHORT . 'no-reply+with-extension@test.at';
+    // Setting 1.8 - comma separated list
+    private const TEST_SETTING_1_8_NAME = self::CLASS_NAME_SHORT . '_test_setting_8_comma_separated_list';
+    private const TEST_SETTING_1_8_VALUE = self::CLASS_NAME_SHORT . '50,100,250,500,1000,2000,5000';
+
     // Section 2.
     private const TEST_SECTION_2_NAME = self::CLASS_NAME_SHORT . '_test_section_2';
-    private const TEST_SETTING_2_1_NAME = self::CLASS_NAME_SHORT . '_array_setting';
+    // Setting 2.1
+    private const TEST_SETTING_2_1_NAME = self::CLASS_NAME_SHORT . '_array_setting_1';
     private const TEST_SETTING_2_1_VALUE_0 = self::CLASS_NAME_SHORT . '_arr_val_1';
     private const TEST_SETTING_2_1_VALUE_1 = self::CLASS_NAME_SHORT . '_arr_val_2';
     private const TEST_SETTING_2_1_VALUE_2 = self::CLASS_NAME_SHORT . '_arr_val_3';
     private const TEST_SETTING_2_1_VALUES = [self::TEST_SETTING_2_1_VALUE_0, self::TEST_SETTING_2_1_VALUE_1, self::TEST_SETTING_2_1_VALUE_2];
+    // Setting 2.2 - IPv4 address with port
+    private const TEST_SETTING_2_2_NAME = self::CLASS_NAME_SHORT . '_array_setting_2_ipv4_address';
+    private const TEST_SETTING_2_2_VALUE_0 = self::CLASS_NAME_SHORT . '123.123.123.123:8080';
+    private const TEST_SETTING_2_2_VALUE_1 = self::CLASS_NAME_SHORT . '234.234.234.234:8080';
+    private const TEST_SETTING_2_2_VALUE_2 = self::CLASS_NAME_SHORT . '16.16.16.16:5423';
+    private const TEST_SETTING_2_2_VALUES = [self::TEST_SETTING_2_2_VALUE_0, self::TEST_SETTING_2_2_VALUE_1, self::TEST_SETTING_2_2_VALUE_2];
+    // Setting 2.3 - IPv6 address with port
+    private const TEST_SETTING_2_3_NAME = self::CLASS_NAME_SHORT . '_array_setting_3_ipv6_address';
+    private const TEST_SETTING_2_3_VALUE_0 = self::CLASS_NAME_SHORT . '[2001:858:dead::186]:80';
+    private const TEST_SETTING_2_3_VALUE_1 = self::CLASS_NAME_SHORT . '[2001:858:beef::186]:180';
+    private const TEST_SETTING_2_3_VALUE_2 = self::CLASS_NAME_SHORT . '[2001:858:cafe::186]:9080';
+    private const TEST_SETTING_2_3_VALUES = [self::TEST_SETTING_2_3_VALUE_0, self::TEST_SETTING_2_3_VALUE_1, self::TEST_SETTING_2_3_VALUE_2];
+    // Setting 2.4 - IPv4 subnet
+    private const TEST_SETTING_2_4_NAME = self::CLASS_NAME_SHORT . '_array_setting_4_ipv4_subnet';
+    private const TEST_SETTING_2_4_VALUE_0 = self::CLASS_NAME_SHORT . '192.168.x.x/24';
+    private const TEST_SETTING_2_4_VALUE_1 = self::CLASS_NAME_SHORT . '172.16.x.x/30';
+    private const TEST_SETTING_2_4_VALUE_2 = self::CLASS_NAME_SHORT . '10.0.0.0/16';
+    private const TEST_SETTING_2_4_VALUES = [self::TEST_SETTING_2_4_VALUE_0, self::TEST_SETTING_2_4_VALUE_1, self::TEST_SETTING_2_4_VALUE_2];
+    // Setting 2.5 - IPv6 subnet
+    private const TEST_SETTING_2_5_NAME = self::CLASS_NAME_SHORT . '_array_setting_5_ipv6_subnet';
+    private const TEST_SETTING_2_5_VALUE_0 = self::CLASS_NAME_SHORT . '2001:db8:dead:/32';
+    private const TEST_SETTING_2_5_VALUE_1 = self::CLASS_NAME_SHORT . '2001:db8:beef:/32';
+    private const TEST_SETTING_2_5_VALUE_2 = self::CLASS_NAME_SHORT . '2001:858:cafe:/64';
+    private const TEST_SETTING_2_5_VALUES = [self::TEST_SETTING_2_5_VALUE_0, self::TEST_SETTING_2_5_VALUE_1, self::TEST_SETTING_2_5_VALUE_2];
+    // Setting 2.6 - mail address with extension
+    private const TEST_SETTING_2_6_NAME = self::CLASS_NAME_SHORT . '_array_setting_6_mail_address';
+    private const TEST_SETTING_2_6_VALUE_0 = self::CLASS_NAME_SHORT . 'no-reply+with_extension@test.at';
+    private const TEST_SETTING_2_6_VALUE_1 = self::CLASS_NAME_SHORT . 'your-mail_address@example.com';
+    private const TEST_SETTING_2_6_VALUE_2 = self::CLASS_NAME_SHORT . 'noreply@example.com';
+    private const TEST_SETTING_2_6_VALUES = [self::TEST_SETTING_2_6_VALUE_0, self::TEST_SETTING_2_6_VALUE_1, self::TEST_SETTING_2_6_VALUE_2];
+    // Setting 2.7 - comma separated list
+    private const TEST_SETTING_2_7_NAME = self::CLASS_NAME_SHORT . '_array_setting_7_commaseparated_list';
+    private const TEST_SETTING_2_7_VALUE_0 = self::CLASS_NAME_SHORT . '50,100,250,500,1000,2000,5000';
+    private const TEST_SETTING_2_7_VALUE_1 = self::CLASS_NAME_SHORT . '1,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597';
+    private const TEST_SETTING_2_7_VALUE_2 = self::CLASS_NAME_SHORT . 'm,a,t,o,m,o,r,p,h,o,s,i,s';
+    private const TEST_SETTING_2_7_VALUES = [self::TEST_SETTING_2_7_VALUE_0, self::TEST_SETTING_2_7_VALUE_1, self::TEST_SETTING_2_7_VALUE_2];
 
     public static function setUpBeforeClass(): void
     {
@@ -92,6 +150,12 @@ class ConfigDeleteTest extends ConsoleCommandTestCase
         $sectionName = self::TEST_SECTION_1_NAME;
         $config->$sectionName[self::TEST_SETTING_1_1_NAME] = self::TEST_SETTING_1_1_VALUE;
         $config->$sectionName[self::TEST_SETTING_1_2_NAME] = self::TEST_SETTING_1_2_VALUE;
+        $config->$sectionName[self::TEST_SETTING_1_3_NAME] = self::TEST_SETTING_1_3_VALUE;
+        $config->$sectionName[self::TEST_SETTING_1_4_NAME] = self::TEST_SETTING_1_4_VALUE;
+        $config->$sectionName[self::TEST_SETTING_1_5_NAME] = self::TEST_SETTING_1_5_VALUE;
+        $config->$sectionName[self::TEST_SETTING_1_6_NAME] = self::TEST_SETTING_1_6_VALUE;
+        $config->$sectionName[self::TEST_SETTING_1_7_NAME] = self::TEST_SETTING_1_7_VALUE;
+        $config->$sectionName[self::TEST_SETTING_1_8_NAME] = self::TEST_SETTING_1_8_VALUE;
 
         // Add a second section so we are testing that we do not accidentally return it.
         $sectionName = self::TEST_SECTION_1_NAME . '_second_section';
@@ -100,10 +164,18 @@ class ConfigDeleteTest extends ConsoleCommandTestCase
         // Add another setting to the same section with some bogus content.
         $config->$sectionName[self::TEST_SETTING_1_2_NAME . '_another'] = '127.0.0.1';
 
+
+        // Add the second section.
         // Add an array value like section=PluginsInstalled; setting=PluginsInstalled[].
         $sectionName = self::TEST_SECTION_2_NAME;
         // Add some values to the setting array.
         $config->$sectionName[self::TEST_SETTING_2_1_NAME] = self::TEST_SETTING_2_1_VALUES;
+        $config->$sectionName[self::TEST_SETTING_2_2_NAME] = self::TEST_SETTING_2_2_VALUES;
+        $config->$sectionName[self::TEST_SETTING_2_3_NAME] = self::TEST_SETTING_2_3_VALUES;
+        $config->$sectionName[self::TEST_SETTING_2_4_NAME] = self::TEST_SETTING_2_4_VALUES;
+        $config->$sectionName[self::TEST_SETTING_2_5_NAME] = self::TEST_SETTING_2_5_VALUES;
+        $config->$sectionName[self::TEST_SETTING_2_6_NAME] = self::TEST_SETTING_2_6_VALUES;
+        $config->$sectionName[self::TEST_SETTING_2_7_NAME] = self::TEST_SETTING_2_7_VALUES;
 
         $config->forceSave();
         return $config;
@@ -380,10 +452,13 @@ class ConfigDeleteTest extends ConsoleCommandTestCase
     //*************************************************************************
     //
 
-    public function testUsingOptsDeleteSingleSetting()
+    /**
+     * @dataProvider getSingleSettingDataProvider1
+     */
+    public function testUsingOptsDeleteSingleSetting($sectionName, $settingName, $settingValue)
     {
 
-        $resultObj = $this->runCommandWithOptions(self::TEST_SECTION_1_NAME, self::TEST_SETTING_1_1_NAME);
+        $resultObj = $this->runCommandWithOptions($sectionName, $settingName);
 
         // The CLI error code should be 0 indicating success.
         $this->assertEquals(0, $resultObj->exitCode, $this->getCommandDisplayOutputErrorMessage());
@@ -392,14 +467,17 @@ class ConfigDeleteTest extends ConsoleCommandTestCase
 
         $config = $this->makeNewConfig();
         $configDump = $config->dumpConfig();
-        $needle = self::TEST_SETTING_1_1_NAME . ' = ' . self::TEST_SETTING_1_1_VALUE;
+        $needle = $settingName . ' = ' . $settingValue;
         $this->assertStringNotContainsString($needle, $configDump);
     }
 
-    public function testUsingArgsDeleteSingleSetting()
+    /**
+     * @dataProvider getSingleSettingDataProvider2
+     */
+    public function testUsingArgsDeleteSingleSetting($sectionName, $settingName, $settingValue)
     {
 
-        $resultObj = $this->runCommandWithArguments(self::TEST_SECTION_1_NAME, self::TEST_SETTING_1_2_NAME);
+        $resultObj = $this->runCommandWithArguments($sectionName, $settingName);
 
         // The CLI error code should be 0 indicating success.
         $this->assertEquals(0, $resultObj->exitCode, $this->getCommandDisplayOutputErrorMessage());
@@ -408,14 +486,17 @@ class ConfigDeleteTest extends ConsoleCommandTestCase
 
         $config = $this->makeNewConfig();
         $configDump = $config->dumpConfig();
-        $needle = self::TEST_SETTING_1_1_NAME . ' = ' . self::TEST_SETTING_1_1_VALUE;
+        $needle = $settingName . ' = ' . $settingValue;
         $this->assertStringNotContainsString($needle, $configDump);
     }
 
-    public function testUsingOptsDeleteArraySetting()
+    /**
+     * @dataProvider getArraySettingDataProvider1
+     */
+    public function testUsingOptsDeleteArraySetting($sectionName, $settingName, $settingValue)
     {
 
-        $resultObj = $this->runCommandWithOptions(self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_1_NAME, self::TEST_SETTING_2_1_VALUE_0);
+        $resultObj = $this->runCommandWithOptions($sectionName, $settingName, $settingValue);
 
         // The CLI error code should be 0 indicating success.
         $this->assertEquals(0, $resultObj->exitCode, $this->getCommandDisplayOutputErrorMessage());
@@ -424,14 +505,17 @@ class ConfigDeleteTest extends ConsoleCommandTestCase
 
         $config = $this->makeNewConfig();
         $configDump = $config->dumpConfig();
-        $needle = self::TEST_SETTING_1_1_NAME . ' = ' . self::TEST_SETTING_1_1_VALUE;
+        $needle = $settingName . ' = ' . $settingValue;
         $this->assertStringNotContainsString($needle, $configDump);
     }
 
-    public function testUsingArgsDeleteArraySetting()
+    /**
+     * @dataProvider getArraySettingDataProvider2
+     */
+    public function testUsingArgsDeleteArraySetting($sectionName, $settingName, $settingValue)
     {
 
-        $resultObj = $this->runCommandWithArguments(self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_1_NAME, self::TEST_SETTING_2_1_VALUE_2);
+        $resultObj = $this->runCommandWithArguments($sectionName, $settingName, $settingValue);
 
         // The CLI error code should be 0 indicating success.
         $this->assertEquals(0, $resultObj->exitCode, $this->getCommandDisplayOutputErrorMessage());
@@ -440,7 +524,45 @@ class ConfigDeleteTest extends ConsoleCommandTestCase
 
         $config = $this->makeNewConfig();
         $configDump = $config->dumpConfig();
-        $needle = self::TEST_SETTING_1_1_NAME . ' = ' . self::TEST_SETTING_1_1_VALUE;
+        $needle = $settingName . ' = ' . $settingValue;
         $this->assertStringNotContainsString($needle, $configDump);
+    }
+
+    public function getSingleSettingDataProvider1()
+    {
+        yield 'Section 1, Setting 1.1'                                  => [self::TEST_SECTION_1_NAME, self::TEST_SETTING_1_1_NAME, self::TEST_SETTING_1_1_VALUE];
+        yield 'Section 1, Setting 1.2'                                  => [self::TEST_SECTION_1_NAME, self::TEST_SETTING_1_2_NAME, self::TEST_SETTING_1_2_VALUE];
+        yield 'Section 1, Setting 1.3 - IPv4 address with port'         => [self::TEST_SECTION_1_NAME, self::TEST_SETTING_1_3_NAME, self::TEST_SETTING_1_3_VALUE];
+        yield 'Section 1, Setting 1.4 - IPv6 address with port'         => [self::TEST_SECTION_1_NAME, self::TEST_SETTING_1_4_NAME, self::TEST_SETTING_1_4_VALUE];
+    }
+
+    public function getSingleSettingDataProvider2()
+    {
+        yield 'Section 1, Setting 1.5 - IPv4 subnet'                    => [self::TEST_SECTION_1_NAME, self::TEST_SETTING_1_5_NAME, self::TEST_SETTING_1_5_VALUE];
+        yield 'Section 1, Setting 1.6 - IPv6 subnet'                    => [self::TEST_SECTION_1_NAME, self::TEST_SETTING_1_6_NAME, self::TEST_SETTING_1_6_VALUE];
+        yield 'Section 1, Setting 1.7 - mail address with extension'    => [self::TEST_SECTION_1_NAME, self::TEST_SETTING_1_7_NAME, self::TEST_SETTING_1_7_VALUE];
+        yield 'Section 1, Setting 1.8 - comma separated list'           => [self::TEST_SECTION_1_NAME, self::TEST_SETTING_1_8_NAME, self::TEST_SETTING_1_8_VALUE];
+    }
+
+    public function getArraySettingDataProvider1()
+    {
+        yield 'Section 2, Setting 2.1'                                  => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_1_NAME, self::TEST_SETTING_2_1_VALUE_0];
+        yield 'Section 2, Setting 2.2 - IPv4 address with port'         => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_2_NAME, self::TEST_SETTING_2_2_VALUE_0];
+        yield 'Section 2, Setting 2.3 - IPv6 address with port'         => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_3_NAME, self::TEST_SETTING_2_3_VALUE_0];
+        yield 'Section 2, Setting 2.4 - IPv4 subnet'                    => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_4_NAME, self::TEST_SETTING_2_4_VALUE_0];
+        yield 'Section 2, Setting 2.5 - IPv6 subnet'                    => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_5_NAME, self::TEST_SETTING_2_5_VALUE_0];
+        yield 'Section 2, Setting 2.6 - mail address with extension'    => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_6_NAME, self::TEST_SETTING_2_6_VALUE_0];
+        yield 'Section 2, Setting 2.7 - comma separated list'           => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_7_NAME, self::TEST_SETTING_2_7_VALUE_0];
+    }
+    
+    public function getArraySettingDataProvider2()
+    {
+        yield 'Section 2, Setting 2.1'                                  => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_1_NAME, self::TEST_SETTING_2_1_VALUE_1];
+        yield 'Section 2, Setting 2.2 - IPv4 address with port'         => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_2_NAME, self::TEST_SETTING_2_2_VALUE_1];
+        yield 'Section 2, Setting 2.3 - IPv6 address with port'         => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_3_NAME, self::TEST_SETTING_2_3_VALUE_1];
+        yield 'Section 2, Setting 2.4 - IPv4 subnet'                    => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_4_NAME, self::TEST_SETTING_2_4_VALUE_1];
+        yield 'Section 2, Setting 2.5 - IPv6 subnet'                    => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_5_NAME, self::TEST_SETTING_2_5_VALUE_1];
+        yield 'Section 2, Setting 2.6 - mail address with extension'    => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_6_NAME, self::TEST_SETTING_2_6_VALUE_1];
+        yield 'Section 2, Setting 2.7 - comma separated list'           => [self::TEST_SECTION_2_NAME, self::TEST_SETTING_2_7_NAME, self::TEST_SETTING_2_7_VALUE_1];
     }
 }


### PR DESCRIPTION
### Description:
The console command `config:set` allows any character for the `--value` option (see: `\Piwik\Plugins\CoreAdminHome\Commands\SetConfig\ConfigSettingManipulation::make`).

The regex used for `config:set` is: `/^([a-zA-Z0-9_]+)\.([a-zA-Z0-9_]+)(\[\])?=(.*)/`

The console command `config:delete` only allows characters a to z (upper and lower case), numbers and the underscore. This prevents one from deleting configs values like IPv4 or IPV6 addresses, mail addresses, networks or IP ranges and lists of values. The currently used regex is: `/^([a-zA-Z0-9_]+)(?:\.([a-zA-Z0-9_]+))?(?:\[\])?(?:\.([a-zA-Z0-9_]+))?/`

The following is a list of possible settings found in the wild. Those can be set with `console config:set` but cannot be deleted.

```
[General]
login_allowlist_ip[] = "123.123.123.123"
trusted_hosts = "[2001:858:6::186]:80"
contact_email_address = "no-reply+with-extension@test.at"
proxy_ips[] = "192.168.x.x/24"

[HeatmapSessionRecording]
session_recording_sample_limits = 50,100,250,500,1000,2000,5000
```

This commit aligns the allowed characters for the option `--value` on the console command `config:delete` to the ones for `config:set` and changes the regex to
`/^([a-zA-Z0-9_]+)(?:\.([a-zA-Z0-9_]+))?(?:\[\])?(?:\.(.+))?/`.

Fixes: #19966

If we do not want to accept all special characters we could also go with the following regex:
`/^([a-zA-Z0-9_]+)(?:\.([a-zA-Z0-9_]+))?(?:\[\])?(?:\.([a-zA-Z0-9\x28-\x2F\[\]_:@]+))?`

Besides the well-known character classes (`a-zA-Z0-9`) this allows the following characters:

- \x28-\x2F: `(`, `)`, `*`, `+`, `,`, `-`, `.`, `/`
- `[`, `]`, `_`, `:`, `@`

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
