### PR TITLE
Correctly escape report name in CSV exports

### DIFF
--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -227,7 +227,7 @@ class Csv extends Renderer
      * @param mixed $value
      * @return string
      */
-    protected function formatValue($value)
+    public function formatValue($value)
     {
         if (is_string($value)
             && !is_numeric($value)

--- a/core/ReportRenderer/Csv.php
+++ b/core/ReportRenderer/Csv.php
@@ -116,11 +116,10 @@ class Csv extends ReportRenderer
 
         $reportData = $csvRenderer->render($processedReport);
         if (empty($reportData)) {
-            $reportData = Piwik::translate('CoreHome_ThereIsNoDataForThisReport');
+            $reportData = $csvRenderer->formatValue(Piwik::translate('CoreHome_ThereIsNoDataForThisReport'));
         }
 
-        $replaceBySpace = array( $csvRenderer->separator, ";");
-        $reportName = str_replace($replaceBySpace, " ", $processedReport['metadata']['name']);
+        $reportName = $csvRenderer->formatValue($processedReport['metadata']['name']);
         $this->rendered .= implode(
             '',
             array(


### PR DESCRIPTION
### Description:

The report name in a CSV report is not correctly escaped. This might e.g. cause the name to be split into multiple columns if it contains a comma.

refs AS-270

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
