### PR TITLE
Allow to optionally defer JS from custom layout templates

### DIFF
--- a/core/AssetManager.php
+++ b/core/AssetManager.php
@@ -141,7 +141,7 @@ class AssetManager extends Singleton
      * @param bool $deferJS
      * @return string
      */
-    public function getJsInclusionDirective(bool $deferJS = false)
+    public function getJsInclusionDirective(bool $deferJS = false): string
     {
         $result = "<script type=\"text/javascript\">\n" . StaticContainer::get('Piwik\Translation\Translator')->getJavascriptTranslations() . "\n</script>";
 
@@ -149,7 +149,7 @@ class AssetManager extends Singleton
             $this->getMergedCoreJSAsset()->delete();
             $this->getMergedNonCoreJSAsset()->delete();
 
-            $result .= $this->getIndividualCoreAndNonCoreJsIncludes($deferJS);
+            $result .= $this->getIndividualCoreAndNonCoreJsIncludes();
         } else {
             $result .= sprintf($deferJS ? self::JS_DEFER_IMPORT_DIRECTIVE : self::JS_IMPORT_DIRECTIVE, self::GET_CORE_JS_MODULE_ACTION);
             $result .= sprintf($deferJS ? self::JS_DEFER_IMPORT_DIRECTIVE : self::JS_IMPORT_DIRECTIVE, self::GET_NON_CORE_JS_MODULE_ACTION);
@@ -375,23 +375,21 @@ class AssetManager extends Singleton
     /**
      * Return individual JS file inclusion directive(s) using the markup <script>
      *
-     * @param bool $deferJS
      * @return string
      */
-    protected function getIndividualCoreAndNonCoreJsIncludes(bool $deferJS = false)
+    protected function getIndividualCoreAndNonCoreJsIncludes(): string
     {
         return
-            $this->getIndividualJsIncludesFromAssetFetcher($this->getCoreJScriptFetcher(), $deferJS) .
-            $this->getIndividualJsIncludesFromAssetFetcher($this->getNonCoreJScriptFetcher(), $deferJS) .
-            $this->getIndividualJsIncludesFromAssetFetcher($this->getPluginUmdJScriptFetcher(), $deferJS);
+            $this->getIndividualJsIncludesFromAssetFetcher($this->getCoreJScriptFetcher()) .
+            $this->getIndividualJsIncludesFromAssetFetcher($this->getNonCoreJScriptFetcher()) .
+            $this->getIndividualJsIncludesFromAssetFetcher($this->getPluginUmdJScriptFetcher());
     }
 
     /**
      * @param UIAssetFetcher $assetFetcher
-     * @param bool $deferJS
      * @return string
      */
-    protected function getIndividualJsIncludesFromAssetFetcher($assetFetcher, bool $deferJS = false)
+    protected function getIndividualJsIncludesFromAssetFetcher($assetFetcher): string
     {
         $jsIncludeString = '';
 
@@ -399,7 +397,7 @@ class AssetManager extends Singleton
 
         foreach ($assets as $jsFile) {
             $jsFile->validateFile();
-            $jsIncludeString = $jsIncludeString . sprintf($deferJS ? self::JS_DEFER_IMPORT_DIRECTIVE : self::JS_IMPORT_DIRECTIVE, $jsFile->getRelativeLocation());
+            $jsIncludeString = $jsIncludeString . sprintf(self::JS_IMPORT_DIRECTIVE, $jsFile->getRelativeLocation());
         }
 
         return $jsIncludeString;

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -217,11 +217,12 @@ class Twig
             }
 
             $assetType = strtolower($params['type']);
+            $deferJs = boolval($params['defer'] ?? false);
             switch ($assetType) {
                 case 'css':
                     return AssetManager::getInstance()->getCssInclusionDirective();
                 case 'js':
-                    return AssetManager::getInstance()->getJsInclusionDirective();
+                    return AssetManager::getInstance()->getJsInclusionDirective($deferJs);
                 default:
                     throw new Exception("The twig function includeAssets 'type' parameter needs to be either 'css' or 'js'.");
             }

--- a/core/View.php
+++ b/core/View.php
@@ -365,8 +365,8 @@ class View implements ViewInterface
         $pattern = array(
             '~<script type=[\'"]text/javascript[\'"] src=[\'"]([^\'"]+)[\'"]>~',
             '~<script src=[\'"]([^\'"]+)[\'"] type=[\'"]text/javascript[\'"]>~',
-            '~<script type=[\'"]text/javascript[\'"] src=[\'"]([^\'"]+?chunk=[^\'"]+)[\'"] defer>~',
-            '~<script type=[\'"]text/javascript[\'"] src=[\'"]([^\'"]+)[\'"] defer>~',
+            '~<script type=[\'"]text/javascript[\'"] src=[\'"]([^\'"?]*\?[^\'"]+)[\'"] defer>~',
+            '~<script type=[\'"]text/javascript[\'"] src=[\'"]([^\'"?]+)[\'"] defer>~',
             '~<link rel=[\'"]stylesheet[\'"] type=[\'"]text/css[\'"] href=[\'"]([^\'"]+)[\'"] ?/?>~',
             // removes the double ?cb= tag
             '~(src|href)=\"index.php\?module=([A-Za-z0-9_]+)&action=([A-Za-z0-9_]+)\?cb=~',

--- a/core/View.php
+++ b/core/View.php
@@ -364,6 +364,7 @@ class View implements ViewInterface
 
         $pattern = array(
             '~<script type=[\'"]text/javascript[\'"] src=[\'"]([^\'"]+)[\'"]>~',
+            '~<script type=[\'"]text/javascript[\'"] src=[\'"]([^\'"]+)[\'"] defer>~',
             '~<script src=[\'"]([^\'"]+)[\'"] type=[\'"]text/javascript[\'"]>~',
             '~<script type=[\'"]text/javascript[\'"] src=[\'"]([^\'"]+?chunk=[^\'"]+)[\'"] defer>~',
             '~<link rel=[\'"]stylesheet[\'"] type=[\'"]text/css[\'"] href=[\'"]([^\'"]+)[\'"] ?/?>~',
@@ -373,6 +374,7 @@ class View implements ViewInterface
 
         $replace = array(
             '<script type="text/javascript" src="$1?' . $tagJs . '">',
+            '<script type="text/javascript" src="$1?' . $tagJs . '" defer>',
             '<script type="text/javascript" src="$1?' . $tagJs . '">',
             '<script type="text/javascript" src="$1&' . $tagJs . '" defer>',
             '<link rel="stylesheet" type="text/css" href="$1?' . $tagCss . '" />',

--- a/core/View.php
+++ b/core/View.php
@@ -364,9 +364,9 @@ class View implements ViewInterface
 
         $pattern = array(
             '~<script type=[\'"]text/javascript[\'"] src=[\'"]([^\'"]+)[\'"]>~',
-            '~<script type=[\'"]text/javascript[\'"] src=[\'"]([^\'"]+)[\'"] defer>~',
             '~<script src=[\'"]([^\'"]+)[\'"] type=[\'"]text/javascript[\'"]>~',
             '~<script type=[\'"]text/javascript[\'"] src=[\'"]([^\'"]+?chunk=[^\'"]+)[\'"] defer>~',
+            '~<script type=[\'"]text/javascript[\'"] src=[\'"]([^\'"]+)[\'"] defer>~',
             '~<link rel=[\'"]stylesheet[\'"] type=[\'"]text/css[\'"] href=[\'"]([^\'"]+)[\'"] ?/?>~',
             // removes the double ?cb= tag
             '~(src|href)=\"index.php\?module=([A-Za-z0-9_]+)&action=([A-Za-z0-9_]+)\?cb=~',
@@ -374,9 +374,9 @@ class View implements ViewInterface
 
         $replace = array(
             '<script type="text/javascript" src="$1?' . $tagJs . '">',
-            '<script type="text/javascript" src="$1?' . $tagJs . '" defer>',
             '<script type="text/javascript" src="$1?' . $tagJs . '">',
             '<script type="text/javascript" src="$1&' . $tagJs . '" defer>',
+            '<script type="text/javascript" src="$1?' . $tagJs . '" defer>',
             '<link rel="stylesheet" type="text/css" href="$1?' . $tagCss . '" />',
             '$1="index.php?module=$2&amp;action=$3&amp;cb=',
         );

--- a/plugins/CoreHome/templates/_uiControl.twig
+++ b/plugins/CoreHome/templates/_uiControl.twig
@@ -6,4 +6,9 @@
     data-params="{{ clientSideParameters|json_encode }}">
 {% render implView with implOverride %}
 </div>
-<script>$(document).ready(function () { require('{{ jsNamespace }}').{{ jsClass }}.initElements(); });</script>
+<script>
+    document.addEventListener('DOMContentLoaded', function load() {
+        if (!window.jQuery) return setTimeout(load, 50);
+        $(document).ready(function () { require('{{ jsNamespace }}').{{ jsClass }}.initElements(); });
+    }, false);
+</script>

--- a/plugins/CoreHome/templates/_uiControl.twig
+++ b/plugins/CoreHome/templates/_uiControl.twig
@@ -7,8 +7,7 @@
 {% render implView with implOverride %}
 </div>
 <script>
-    document.addEventListener('DOMContentLoaded', function load() {
-        if (!window.jQuery) return setTimeout(load, 50);
+    document.addEventListener('DOMContentLoaded', function () {
         $(document).ready(function () { require('{{ jsNamespace }}').{{ jsClass }}.initElements(); });
     }, false);
 </script>

--- a/plugins/Login/templates/loginLayout.twig
+++ b/plugins/Login/templates/loginLayout.twig
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block head %}
+    {% set deferjs = true %}
     {{ parent() }}
 {% endblock %}
 

--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -774,8 +774,12 @@ try {
 } catch (e) {}
 }(jQuery));
 
-(function ($) {
+window.addEventListener('DOMContentLoaded', function () {
   $(function () {
     piwikHelper.compileVueEntryComponents('body');
+
+    window.Vue.nextTick(function () {
+      window.CoreHome.Matomo.postEvent('Matomo.afterInitialVueEntryProcess');
+    });
   });
-}(jQuery))
+});

--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -777,9 +777,5 @@ try {
 window.addEventListener('DOMContentLoaded', function () {
   $(function () {
     piwikHelper.compileVueEntryComponents('body');
-
-    window.Vue.nextTick(function () {
-      window.CoreHome.Matomo.postEvent('Matomo.afterInitialVueEntryProcess');
-    });
   });
 });

--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -776,8 +776,7 @@ document.addEventListener('DOMContentLoaded', function load() {
 
     } catch (e) {}
 
-    $(function () {
-      piwikHelper.compileVueEntryComponents('body');
-    });
+    piwikHelper.compileVueEntryComponents('body');
+
   }(jQuery));
 });

--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -743,9 +743,7 @@ function isEscapeKey(e)
 }
 
 // workarounds
-document.addEventListener('DOMContentLoaded', function load() {
-  if (!window.jQuery) return setTimeout(load, 50);
-
+document.addEventListener('DOMContentLoaded', function () {
   (function($){
     try {
       // this code is not vital, so we make sure any errors are ignored
@@ -779,4 +777,4 @@ document.addEventListener('DOMContentLoaded', function load() {
     piwikHelper.compileVueEntryComponents('body');
 
   }(jQuery));
-});
+}, false);

--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -743,39 +743,41 @@ function isEscapeKey(e)
 }
 
 // workarounds
-(function($){
-try {
-    // this code is not vital, so we make sure any errors are ignored
+document.addEventListener('DOMContentLoaded', function load() {
+  if (!window.jQuery) return setTimeout(load, 50);
 
-    //--------------------------------------
-    //
-    // monkey patch that works around bug in arc function of some browsers where
-    // nothing gets drawn if angles are 2 * PI apart and in counter-clockwise direction.
-    // affects some versions of chrome & IE 8
-    //
-    //--------------------------------------
-    var oldArc = CanvasRenderingContext2D.prototype.arc;
-    CanvasRenderingContext2D.prototype.arc = function(x, y, r, sAngle, eAngle, clockwise) {
+  (function($){
+    try {
+      // this code is not vital, so we make sure any errors are ignored
+
+      //--------------------------------------
+      //
+      // monkey patch that works around bug in arc function of some browsers where
+      // nothing gets drawn if angles are 2 * PI apart and in counter-clockwise direction.
+      // affects some versions of chrome & IE 8
+      //
+      //--------------------------------------
+      var oldArc = CanvasRenderingContext2D.prototype.arc;
+      CanvasRenderingContext2D.prototype.arc = function(x, y, r, sAngle, eAngle, clockwise) {
         if (Math.abs(eAngle - sAngle - Math.PI * 2) < 0.000001 && !clockwise)
-            eAngle -= 0.000001;
+          eAngle -= 0.000001;
         oldArc.call(this, x, y, r, sAngle, eAngle, clockwise);
-    };
+      };
 
-    // Fix jQuery UI dialogs scrolling when click on links with tooltips
-    jQuery.ui.dialog.prototype._focusTabbable = $.noop;
+      // Fix jQuery UI dialogs scrolling when click on links with tooltips
+      jQuery.ui.dialog.prototype._focusTabbable = $.noop;
 
-    // Fix jQuery UI tooltip displaying when dialog is closed by Esc key
-    jQuery(document).keyup(function(e) {
-      if (e.keyCode == 27) {
+      // Fix jQuery UI tooltip displaying when dialog is closed by Esc key
+      jQuery(document).keyup(function(e) {
+        if (e.keyCode == 27) {
           $('.ui-tooltip').hide();
-      }
+        }
+      });
+
+    } catch (e) {}
+
+    $(function () {
+      piwikHelper.compileVueEntryComponents('body');
     });
-
-} catch (e) {}
-}(jQuery));
-
-window.addEventListener('DOMContentLoaded', function () {
-  $(function () {
-    piwikHelper.compileVueEntryComponents('body');
-  });
+  }(jQuery));
 });

--- a/plugins/Morpheus/templates/_iframeBuster.twig
+++ b/plugins/Morpheus/templates/_iframeBuster.twig
@@ -1,7 +1,6 @@
 {% if (enableFrames is defined and enableFrames == false) %}
     <script type="text/javascript">
-        document.addEventListener('DOMContentLoaded', function load() {
-            if (!window.jQuery) return setTimeout(load, 50);
+        document.addEventListener('DOMContentLoaded', function () {
             $(document).ready(function () {
                 $('body').css("display", "none");
                 if (self == top) {

--- a/plugins/Morpheus/templates/_iframeBuster.twig
+++ b/plugins/Morpheus/templates/_iframeBuster.twig
@@ -1,7 +1,7 @@
 {% if (enableFrames is defined and enableFrames == false) %}
     <script type="text/javascript">
         if (self !== top) {
-            const theBody = document.getElementsByTagName('body')[0];
+            var theBody = document.getElementsByTagName('body')[0];
             theBody.style.display = 'none';
 
             top.location = self.location;

--- a/plugins/Morpheus/templates/_iframeBuster.twig
+++ b/plugins/Morpheus/templates/_iframeBuster.twig
@@ -1,15 +1,14 @@
 {% if (enableFrames is defined and enableFrames == false) %}
     <script type="text/javascript">
-        window.addEventListener('DOMContentLoaded', function () {
-            $(function () {
+        document.addEventListener('DOMContentLoaded', function load() {
+            if (!window.jQuery) return setTimeout(load, 50);
+            $(document).ready(function () {
                 $('body').css("display", "none");
                 if (self == top) {
                     var theBody = document.getElementsByTagName('body')[0];
                     theBody.style.display = 'block';
-                } else {
-                    top.location = self.location;
-                }
+                } else { top.location = self.location; }
             });
-        });
+        }, false);
     </script>
 {% endif %}

--- a/plugins/Morpheus/templates/_iframeBuster.twig
+++ b/plugins/Morpheus/templates/_iframeBuster.twig
@@ -1,13 +1,10 @@
 {% if (enableFrames is defined and enableFrames == false) %}
     <script type="text/javascript">
-        document.addEventListener('DOMContentLoaded', function () {
-            $(document).ready(function () {
-                $('body').css("display", "none");
-                if (self == top) {
-                    var theBody = document.getElementsByTagName('body')[0];
-                    theBody.style.display = 'block';
-                } else { top.location = self.location; }
-            });
-        }, false);
+        if (self !== top) {
+            const theBody = document.getElementsByTagName('body')[0];
+            theBody.style.display = 'none';
+
+            top.location = self.location;
+        }
     </script>
 {% endif %}

--- a/plugins/Morpheus/templates/_iframeBuster.twig
+++ b/plugins/Morpheus/templates/_iframeBuster.twig
@@ -1,11 +1,15 @@
 {% if (enableFrames is defined and enableFrames == false) %}
     <script type="text/javascript">
-        $(function () {
-        $('body').css("display", "none");
-        if (self == top) {
-            var theBody = document.getElementsByTagName('body')[0];
-            theBody.style.display = 'block';
-        } else { top.location = self.location; }
-    });
+        window.addEventListener('DOMContentLoaded', function () {
+            $(function () {
+                $('body').css("display", "none");
+                if (self == top) {
+                    var theBody = document.getElementsByTagName('body')[0];
+                    theBody.style.display = 'block';
+                } else {
+                    top.location = self.location;
+                }
+            });
+        });
     </script>
 {% endif %}

--- a/plugins/Morpheus/templates/_jsCssIncludes.twig
+++ b/plugins/Morpheus/templates/_jsCssIncludes.twig
@@ -1,4 +1,4 @@
 {% autoescape false %}
     {{ includeAssets({"type": "css"}) }}
-    {{ includeAssets({"type":"js"}) }}
+    {{ includeAssets({"type": "js", "defer": deferjs|default(false) }) }}
 {% endautoescape %}


### PR DESCRIPTION
### Description:

Since login page doesn't use nearly any of the bundled JS, we can defer its loading and the form will still be visible quite early. Then with the JS already loaded continuing to the dashboard should use the cached files already.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
