### PR TITLE
Ignore "code style" commits in the blame view

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -23,3 +23,5 @@ d3de8d64f477d14bf10d5cd1d17521f0c19950ed
 593437a3fd35381c13fe5cf7fabae5767dc3a519
 # [PHPCS] Enable PSR1 coding standard (#20724)
 aa2674a8241d5e4e55a2f7fbb74292e06eab8780
+[PHPCS] disallow using tabs for intending
+d40e11f6decbe84834ed5f33406189055e6989b8

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -23,5 +23,5 @@ d3de8d64f477d14bf10d5cd1d17521f0c19950ed
 593437a3fd35381c13fe5cf7fabae5767dc3a519
 # [PHPCS] Enable PSR1 coding standard (#20724)
 aa2674a8241d5e4e55a2f7fbb74292e06eab8780
-[PHPCS] disallow using tabs for intending
+# [PHPCS] disallow using tabs for intending
 d40e11f6decbe84834ed5f33406189055e6989b8

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,25 @@
+# .git-blame-ignore-revs
+# converted some links to use @link
+b40e4d1da3296b05e5aa1abe64ee12548023da77
+#  Remove all occurences of @Package / @subpackage / @category from core/ files.
+f9d52ca9433e33783e59b209554dfba58f30cec4
+# Piwik is a free/libre analytics platform. Refs #4455 GNU Package requirement to use free/libre instead of open source
+a8fbaf86abc13de414f1e2ceb855a49bb28de593
+# removed lots of trailing whitespace
+d9adcfe6169c6c10059a670f2ed984908eb4e105
+# coding style fixes, some PHPStorm inspection fixes, improved readability of code, few refactorings, all as part of our code cleanup strategy
+a00487b0b841c4b15463b591c7f62176c4b84d15
+# fix core folder with php-cs-fixer for psr-2
+a2a63d34ebb460174e1a3e8d8022fe3e3ab4b469
+# Update the link tag for all php files (#14635)
+b16a791aa3650d85af829156129c2bd44c7cb075
+# many typo fixes in the code thanks to codespell (#15730)
+2c5c72e2da4c015efa78069c9c1b407fc55a6483
+# Update doc blocks with new name (#15857)
+115527353a9e75e01aa4d263408956ae45403bea
+# Typofixes (#19805)
+d3de8d64f477d14bf10d5cd1d17521f0c19950ed
+# [PHPCS] force new line at end of php file (#20715)
+593437a3fd35381c13fe5cf7fabae5767dc3a519
+# [PHPCS] Enable PSR1 coding standard (#20724)
+aa2674a8241d5e4e55a2f7fbb74292e06eab8780

--- a/.gitattributes
+++ b/.gitattributes
@@ -53,6 +53,7 @@ tests/ export-ignore
 .gitignore export-ignore
 .gitattributes export-ignore
 .gitmodules export-ignore
+.git-blame-ignore-revs export-ignore
 .phpstorm.meta.php export-ignore
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore

--- a/.github/scripts/clean-build.sh
+++ b/.github/scripts/clean-build.sh
@@ -217,7 +217,7 @@ for x in .git .github ; do
 done
 
 # delete unwanted common files, recursively
-for x in .gitignore .gitmodules .gitattributes .bowerrc .bower.json bower.json \
+for x in .gitignore .gitmodules .gitattributes .git-blame-ignore-revs .bowerrc .bower.json bower.json \
     .coveralls.yml .editorconfig .gitkeep .jshintrc .php_cs .php_cs.dist \
     phpunit.xml.dist phpunit.xml .phpcs.xml.dist phpcs.xml Gruntfile.js gruntfile.js \
     *.map .travis.yml installed.json package.json package-lock.json yarn.lock\

--- a/config/global.php
+++ b/config/global.php
@@ -170,6 +170,7 @@ return [
         '*.gitkeep',
         '*.gitmodules',
         '*.gitattributes',
+        '*.git-blame-ignore-revs',
         '*.bower.json',
         '*.travis.yml',
     ]),

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -984,6 +984,7 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
             '*.gitignore',
             '*.gitmodules',
             '*.gitattributes',
+            '*.git-blame-ignore-revs',
             '*.bowerrc',
             '*.bower.json',
             '*bower.json',


### PR DESCRIPTION
### Description:

Introduce `.git-blame-ignore-revs` to ignore commits doing only code style or other automatic changes.

This declutters the git blame view and by that eases  the retrace of code changes.

Activate via:
+ GitHub: automatically
+ local: `git config --local blame.ignoreRevsFile .git-blame-ignore-revs`

See:
+ https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
+ https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
