### PR TITLE
Configure linguist to exclude libs, generated and resource files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -57,3 +57,26 @@ tests/ export-ignore
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore
 PULL_REQUEST_TEMPLATE export-ignore
+
+# Linguist: language statistics
+# + test resources: exclude
+plugins/*/tests/System/expected/** -linguist-detectable
+plugins/*/tests/System/resources/** -linguist-detectable
+plugins/*/tests/UI/expected-screenshots/** -linguist-detectable
+tests/resources/** -linguist-detectable
+tests/PHPUnit/System/expected/** -linguist-detectable
+tests/UI/expected-screenshots/** -linguist-detectable
+# + generated code: exclude and suppress in diffs
+*.min.css linguist-generated
+*.min.js linguist-generated
+matomo.js linguist-generated
+piwik.js linguist-generated
+plugins/*/vue/dist/** linguist-generated
+# + vendor code: exclude
+libs/** linguist-vendored
+plugins/*/libs/** linguist-vendored
+tests/lib/** linguist-vendored
+tests/javascript/assets/** linguist-vendored
+tests/javascript/frameworks/** linguist-vendored
+tests/javascript/jash/** linguist-vendored
+tests/javascript/jslint/** linguist-vendored


### PR DESCRIPTION
### Description:

Configure linguist to exclude libs/vendor, generated and resource files from language statistics.

This surpresses the display of generated files in diffs:
`*.min.css`, `*.min.js`, `/matomo.js`, `/piwik.js`, `plugins/*/vue/dist`

And it makes for a more meaningful language statistic on this repository.
Current state:

![grafik](https://github.com/matomo-org/matomo/assets/29690343/d02f37c8-662b-4b51-a39c-476464dc2faf)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
