### PR TITLE
allow running JS tests for a single plugin in tests:run-js

### DIFF
--- a/plugins/TestRunner/Commands/TestsRunJS.php
+++ b/plugins/TestRunner/Commands/TestsRunJS.php
@@ -16,6 +16,7 @@ class TestsRunJS extends ConsoleCommand
         $this->setName('tests:run-js');
         $this->setDescription('Run javascript tests');
         $this->addRequiredValueOption('matomo-url', null, 'Custom matomo url. Defaults to http://localhost');
+        $this->addOptionalValueOption('plugin', null, 'The plugin to run tests for. If not supplied, all tests are run.');
     }
 
     protected function doExecute(): int
@@ -23,11 +24,15 @@ class TestsRunJS extends ConsoleCommand
         $input = $this->getInput();
         $output = $this->getOutput();
         $matomoUrl = $input->getOption('matomo-url') ?? 'http://localhost';
+        $plugin = $input->getOption('plugin');
 
         $screenshotTestingDir = PIWIK_INCLUDE_PATH . "/tests/lib/screenshot-testing";
         $javascriptTestingDir = PIWIK_INCLUDE_PATH . "/tests/javascript";
 
         $cmdNode = "cd '$javascriptTestingDir' && NODE_PATH='$screenshotTestingDir/node_modules' node testrunnerNode.js '$matomoUrl/tests/javascript/'";
+        if (!empty($plugin)) {
+            $cmdNode .= ' --plugin=' . escapeshellarg($plugin);
+        }
 
         $output->writeln('Executing command: <info>' . $cmdNode . '</info>');
         $output->writeln('');
@@ -35,6 +40,9 @@ class TestsRunJS extends ConsoleCommand
         passthru($cmdNode, $returnCodeNode);
 
         $cmdPhantom = "phantomjs $javascriptTestingDir/testrunnerPhantom.js '$matomoUrl/tests/javascript/'";
+        if (!empty($plugin)) {
+            $cmdPhantom .= ' --plugin=' . escapeshellarg($plugin);
+        }
 
         $output->writeln('');
         $output->writeln('');

--- a/tests/javascript/testrunnerNode.js
+++ b/tests/javascript/testrunnerNode.js
@@ -9,7 +9,10 @@
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0; // ignore ssl errors
 
 const puppeteer = require('puppeteer');
-const url = process.argv[2] || 'http://localhost/tests/javascript/';
+const baseUrl = process.argv[2] || 'http://localhost/tests/javascript/';
+
+const pluginArg = process.argv.find((arg) => /--plugin=(.*?)/.test(arg));
+const plugin = pluginArg ?pluginArg.split('=', 2)[1] : null;
 
 main();
 
@@ -21,6 +24,11 @@ async function main() {
     page.on('console', async (consoleMessage) => {
         console.log("[" + consoleMessage.type()  + "] " + consoleMessage.text());
     });
+
+    let url = baseUrl;
+    if (plugin) {
+      url += `?module=${encodeURIComponent(plugin)}`;
+    }
 
     await page.goto(url);
     await page.waitForFunction(() => window.QUnit);

--- a/tests/javascript/testrunnerPhantom.js
+++ b/tests/javascript/testrunnerPhantom.js
@@ -23,7 +23,23 @@
 
 var fs  = require("fs");
 var system = require("system");
-var url = system.args[1] || 'http://localhost/tests/javascript/';
+var baseUrl = system.args[1] || 'http://localhost/tests/javascript/';
+
+function getPluginArg() {
+  for (var i = 0; i < system.args.length; ++i) {
+    if (/--plugin=(.*?)/.test(system.args[i])) {
+      return system.args[i].split('=', 2)[1];
+    }
+  }
+  return null;
+}
+
+var plugin = getPluginArg();
+
+var url = baseUrl;
+if (plugin) {
+  url += '?module=' + encodeURIComponent(plugin);
+}
 
 function printError(message) {
    console.error(message + "\n");


### PR DESCRIPTION
### Description:

Adds a `--plugin=$pluginName` option to tests:run-js. This is to fix the JS tests in a premium plugin.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
