### PR TITLE
in AutoSuggestAPITest make sure static var overrides are undone after the test finishes

### DIFF
--- a/plugins/API/tests/System/AutoSuggestAPITest.php
+++ b/plugins/API/tests/System/AutoSuggestAPITest.php
@@ -47,12 +47,23 @@ class AutoSuggestAPITest extends SystemTestCase
 {
     public static $fixture = null; // initialized below class definition
 
+    private static $originalAutoSuggestLookBack = null;
+
     protected static $processed = 0;
     protected static $skipped = array();
     private static $hasArchivedData = false;
 
     public static function setUpBeforeClass(): void
     {
+        $date = mktime(0, 0, 0, 1, 1, 2018);
+
+        $lookBack = ceil((time() - $date) / 86400);
+
+        self::$originalAutoSuggestLookBack = API::$_autoSuggestLookBack;
+
+        API::$_autoSuggestLookBack = $lookBack;
+        self::$fixture->dateTime = Date::factory($date)->getDatetime();
+
         parent::setUpBeforeClass();
 
         API::setSingletonInstance(CachedAPI::getInstance());
@@ -60,6 +71,8 @@ class AutoSuggestAPITest extends SystemTestCase
 
     public static function tearDownAfterClass(): void
     {
+        API::$_autoSuggestLookBack = self::$originalAutoSuggestLookBack;
+
         parent::tearDownAfterClass();
 
         CachedAPI::$cache = [];
@@ -293,11 +306,4 @@ class AutoSuggestAPITest extends SystemTestCase
     }
 }
 
-$date = mktime(0, 0, 0, 1, 1, 2018);
-
-$lookBack = ceil((time() - $date) / 86400);
-
-API::$_autoSuggestLookBack = $lookBack;
-
 \Piwik\Plugins\API\tests\System\AutoSuggestAPITest::$fixture = new ManyVisitsWithGeoIPAndEcommerce();
-\Piwik\Plugins\API\tests\System\AutoSuggestAPITest::$fixture->dateTime = Date::factory($date)->getDatetime();


### PR DESCRIPTION
### Description:

Currently this is done outside the test class, in the global scope, which means it will be run if the file is included and not undone. This is a problem if you write your own tests for the autosuggest API in a plugin, and expect the value to be it's default (because phpunit will include the file when running the plugin test suite).

This cost me about ~6 hrs of debugging time to find so I thought I'd prevent it from happening again.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
