### PR TITLE
cannot move Archiver consts/static vars to GeneralGoalsRecords/ProductRecord

### DIFF
--- a/plugins/Goals/Archiver.php
+++ b/plugins/Goals/Archiver.php
@@ -32,6 +32,45 @@ class Archiver extends \Piwik\Plugin\Archiver
 
     public static $ARCHIVE_DEPENDENT = true;
 
+    /**
+     * This array stores the ranges to use when displaying the 'visits to conversion' report
+     */
+    public static $visitCountRanges = [
+        [1, 1],
+        [2, 2],
+        [3, 3],
+        [4, 4],
+        [5, 5],
+        [6, 6],
+        [7, 7],
+        [8, 8],
+        [9, 14],
+        [15, 25],
+        [26, 50],
+        [51, 100],
+        [100],
+    ];
+
+    /**
+     * This array stores the ranges to use when displaying the 'days to conversion' report
+     */
+    public static $daysToConvRanges = [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+        [3, 3],
+        [4, 4],
+        [5, 5],
+        [6, 6],
+        [7, 7],
+        [8, 14],
+        [15, 30],
+        [31, 60],
+        [61, 120],
+        [121, 364],
+        [364],
+    ];
+
     protected $dimensionRecord = [
         self::SKU_FIELD      => self::ITEMS_SKU_RECORD_NAME,
         self::NAME_FIELD     => self::ITEMS_NAME_RECORD_NAME,

--- a/plugins/Goals/RecordBuilders/GeneralGoalsRecords.php
+++ b/plugins/Goals/RecordBuilders/GeneralGoalsRecords.php
@@ -23,50 +23,9 @@ use Piwik\Tracker\GoalManager;
 
 class GeneralGoalsRecords extends Base
 {
-    const VISITS_UNTIL_RECORD_NAME = 'visits_until_conv';
-    const DAYS_UNTIL_CONV_RECORD_NAME = 'days_until_conv';
     const VISITS_COUNT_FIELD = 'visitor_count_visits';
     const LOG_CONVERSION_TABLE = 'log_conversion';
     const SECONDS_SINCE_FIRST_VISIT_FIELD = 'visitor_seconds_since_first';
-
-    /**
-     * This array stores the ranges to use when displaying the 'visits to conversion' report
-     */
-    public static $visitCountRanges = [
-        [1, 1],
-        [2, 2],
-        [3, 3],
-        [4, 4],
-        [5, 5],
-        [6, 6],
-        [7, 7],
-        [8, 8],
-        [9, 14],
-        [15, 25],
-        [26, 50],
-        [51, 100],
-        [100],
-    ];
-
-    /**
-     * This array stores the ranges to use when displaying the 'days to conversion' report
-     */
-    public static $daysToConvRanges = [
-        [0, 0],
-        [1, 1],
-        [2, 2],
-        [3, 3],
-        [4, 4],
-        [5, 5],
-        [6, 6],
-        [7, 7],
-        [8, 14],
-        [15, 30],
-        [31, 60],
-        [61, 120],
-        [121, 364],
-        [364],
-    ];
 
     protected function aggregate(ArchiveProcessor $archiveProcessor): array
     {
@@ -76,8 +35,8 @@ class GeneralGoalsRecords extends Base
         }
 
         $prefixes = [
-            self::VISITS_UNTIL_RECORD_NAME    => 'vcv',
-            self::DAYS_UNTIL_CONV_RECORD_NAME => 'vdsf',
+            Archiver::VISITS_UNTIL_RECORD_NAME    => 'vcv',
+            Archiver::DAYS_UNTIL_CONV_RECORD_NAME => 'vdsf',
         ];
 
         $totalConversions = 0;
@@ -111,10 +70,10 @@ class GeneralGoalsRecords extends Base
         if ($siteHasEcommerceOrGoals) {
             $selects = [];
             $selects = array_merge($selects, LogAggregator::getSelectsFromRangedColumn(
-                self::VISITS_COUNT_FIELD, self::$visitCountRanges, self::LOG_CONVERSION_TABLE, $prefixes[self::VISITS_UNTIL_RECORD_NAME]
+                self::VISITS_COUNT_FIELD, Archiver::$visitCountRanges, self::LOG_CONVERSION_TABLE, $prefixes[Archiver::VISITS_UNTIL_RECORD_NAME]
             ));
             $selects = array_merge($selects, LogAggregator::getSelectsFromRangedColumn(
-                'FLOOR(log_conversion.' . self::SECONDS_SINCE_FIRST_VISIT_FIELD . ' / 86400)', self::$daysToConvRanges, self::LOG_CONVERSION_TABLE, $prefixes[self::DAYS_UNTIL_CONV_RECORD_NAME]
+                'FLOOR(log_conversion.' . self::SECONDS_SINCE_FIRST_VISIT_FIELD . ' / 86400)', Archiver::$daysToConvRanges, self::LOG_CONVERSION_TABLE, $prefixes[Archiver::DAYS_UNTIL_CONV_RECORD_NAME]
             ));
 
             $query = $logAggregator->queryConversionsByDimension([], false, $selects);
@@ -137,13 +96,13 @@ class GeneralGoalsRecords extends Base
                 if (empty($visitsToConversions[$idGoal])) {
                     $visitsToConversions[$idGoal] = new DataTable();
                 }
-                $array = LogAggregator::makeArrayOneColumn($row, Metrics::INDEX_NB_CONVERSIONS, $prefixes[self::VISITS_UNTIL_RECORD_NAME]);
+                $array = LogAggregator::makeArrayOneColumn($row, Metrics::INDEX_NB_CONVERSIONS, $prefixes[Archiver::VISITS_UNTIL_RECORD_NAME]);
                 $visitsToConversions[$idGoal]->addDataTable(DataTable::makeFromIndexedArray($array));
 
                 if (empty($daysToConversions[$idGoal])) {
                     $daysToConversions[$idGoal] = new DataTable();
                 }
-                $array = LogAggregator::makeArrayOneColumn($row, Metrics::INDEX_NB_CONVERSIONS, $prefixes[self::DAYS_UNTIL_CONV_RECORD_NAME]);
+                $array = LogAggregator::makeArrayOneColumn($row, Metrics::INDEX_NB_CONVERSIONS, $prefixes[Archiver::DAYS_UNTIL_CONV_RECORD_NAME]);
                 $daysToConversions[$idGoal]->addDataTable(DataTable::makeFromIndexedArray($array));
 
                 // We don't want to sum Abandoned cart metrics in the overall revenue/conversions/converted visits
@@ -168,16 +127,16 @@ class GeneralGoalsRecords extends Base
         ], $numericRecords);
 
         foreach ($visitsToConversions as $idGoal => $table) {
-            $recordName = Archiver::getRecordName(self::VISITS_UNTIL_RECORD_NAME, $idGoal);
+            $recordName = Archiver::getRecordName(Archiver::VISITS_UNTIL_RECORD_NAME, $idGoal);
             $result[$recordName] = $table;
         }
-        $result[Archiver::getRecordName(self::VISITS_UNTIL_RECORD_NAME)] = $this->getOverviewFromGoalTables($visitsToConversions);
+        $result[Archiver::getRecordName(Archiver::VISITS_UNTIL_RECORD_NAME)] = $this->getOverviewFromGoalTables($visitsToConversions);
 
         foreach ($daysToConversions as $idGoal => $table) {
-            $recordName = Archiver::getRecordName(self::DAYS_UNTIL_CONV_RECORD_NAME, $idGoal);
+            $recordName = Archiver::getRecordName(Archiver::DAYS_UNTIL_CONV_RECORD_NAME, $idGoal);
             $result[$recordName] = $table;
         }
-        $result[Archiver::getRecordName(self::DAYS_UNTIL_CONV_RECORD_NAME)] = $this->getOverviewFromGoalTables($daysToConversions);
+        $result[Archiver::getRecordName(Archiver::DAYS_UNTIL_CONV_RECORD_NAME)] = $this->getOverviewFromGoalTables($daysToConversions);
 
         return $result;
     }
@@ -217,8 +176,8 @@ class GeneralGoalsRecords extends Base
                 $records[] = Record::make(Record::TYPE_NUMERIC, Archiver::getRecordName($metricName, $idGoal));
             }
 
-            $records[] = Record::make(Record::TYPE_BLOB, Archiver::getRecordName(self::VISITS_UNTIL_RECORD_NAME, $idGoal));
-            $records[] = Record::make(Record::TYPE_BLOB, Archiver::getRecordName(self::DAYS_UNTIL_CONV_RECORD_NAME, $idGoal));
+            $records[] = Record::make(Record::TYPE_BLOB, Archiver::getRecordName(Archiver::VISITS_UNTIL_RECORD_NAME, $idGoal));
+            $records[] = Record::make(Record::TYPE_BLOB, Archiver::getRecordName(Archiver::DAYS_UNTIL_CONV_RECORD_NAME, $idGoal));
         }
         return $records;
     }

--- a/plugins/Goals/Reports/GetVisitsUntilConversion.php
+++ b/plugins/Goals/Reports/GetVisitsUntilConversion.php
@@ -10,8 +10,8 @@ namespace Piwik\Plugins\Goals\Reports;
 
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
+use Piwik\Plugins\Goals\Archiver;
 use Piwik\Plugins\Goals\Columns\VisitsUntilConversion;
-use Piwik\Plugins\Goals\RecordBuilders\GeneralGoalsRecords;
 
 class GetVisitsUntilConversion extends Base
 {
@@ -44,7 +44,7 @@ class GetVisitsUntilConversion extends Base
 
         $view->requestConfig->filter_sort_column = 'label';
         $view->requestConfig->filter_sort_order  = 'asc';
-        $view->requestConfig->filter_limit       = count(GeneralGoalsRecords::$visitCountRanges);
+        $view->requestConfig->filter_limit       = count(Archiver::$visitCountRanges);
 
         $view->config->addTranslations(array('label' => $this->dimension->getName()));
     }


### PR DESCRIPTION
### Description:

... since they are in use by the GoogleAnalyticsImporter plugin.

Noticed this while fixing up tests for other PRs.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
