### PR TITLE
Configure linguist to exclude `node_modules` in statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -74,6 +74,7 @@ tests/UI/expected-screenshots/** -linguist-detectable
 plugins/*/vue/dist/** linguist-generated
 # + vendor code: exclude
 libs/** linguist-vendored
+node_modules/** linguist-vendored
 plugins/*/libs/** linguist-vendored
 tests/lib/** linguist-vendored
 tests/javascript/assets/** linguist-vendored


### PR DESCRIPTION
### Description:

Some directories of `node_modules` are pushed into the git repository. Mark `node_modules` as vendor code for linguist statistics.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
