### PR TITLE
Updating multiple plugins in UI doesn't work

### DIFF
--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -222,8 +222,8 @@ class Controller extends Plugin\ControllerAdmin
         $view->isMarketplaceEnabled = Marketplace::isMarketplaceEnabled();
         $view->isPluginsAdminEnabled = CorePluginsAdmin::isPluginsAdminEnabled();
 
-        $view->pluginsHavingUpdate    = array();
-        $view->marketplacePluginNames = array();
+        $view->pluginsHavingUpdate    = [];
+        $view->marketplacePluginNames = [];
 
         if (Marketplace::isMarketplaceEnabled() && $this->marketplacePlugins) {
             try {

--- a/plugins/Marketplace/Api/Client.php
+++ b/plugins/Marketplace/Api/Client.php
@@ -191,13 +191,13 @@ class Client
 
     /**
      * @param \Piwik\Plugin[] $plugins
-     * @return array
+     * @return array (pluginName => pluginDetails)
      */
-    public function getInfoOfPluginsHavingUpdate($plugins)
+    public function getInfoOfPluginsHavingUpdate($plugins): array
     {
         $hasUpdates = $this->checkUpdates($plugins);
 
-        $pluginDetails = array();
+        $pluginDetails = [];
 
         foreach ($hasUpdates as $pluginHavingUpdate) {
             if (empty($pluginHavingUpdate)) {
@@ -213,7 +213,7 @@ class Client
 
             if (!empty($plugin)) {
                 $plugin['repositoryChangelogUrl'] = $pluginHavingUpdate['repositoryChangelogUrl'];
-                $pluginDetails[] = $plugin;
+                $pluginDetails[$pluginHavingUpdate['name']] = $plugin;
             }
         }
 

--- a/plugins/Marketplace/Api/Client.php
+++ b/plugins/Marketplace/Api/Client.php
@@ -73,14 +73,19 @@ class Client
         return $this->environment;
     }
 
+    /**
+     * @param string $name
+     * @return array|null
+     * @throws Exception
+     */
     public function getPluginInfo($name)
     {
         $action = sprintf('plugins/%s/info', $name);
 
         $plugin = $this->fetch($action, array());
 
-        if (!empty($plugin) && $this->shouldIgnorePlugin($plugin)) {
-            return;
+        if (empty($plugin['name']) || $this->shouldIgnorePlugin($plugin)) {
+            return null;
         }
 
         return $plugin;

--- a/plugins/Marketplace/Plugins.php
+++ b/plugins/Marketplace/Plugins.php
@@ -172,10 +172,9 @@ class Plugins
     }
 
     /**
-     * @param bool $themesOnly
-     * @return array
+     * @return array (pluginName => pluginDetails)
      */
-    public function getPluginsHavingUpdate()
+    public function getPluginsHavingUpdate(): array
     {
         $this->pluginManager->loadAllPluginsAndGetTheirInfo();
         $loadedPlugins = $this->pluginManager->getLoadedPlugins();
@@ -186,23 +185,23 @@ class Plugins
             $pluginsHavingUpdate = array();
         }
 
-        foreach ($pluginsHavingUpdate as $key => $updatePlugin) {
+        foreach ($pluginsHavingUpdate as $pluginName => $updatePlugin) {
             foreach ($loadedPlugins as $loadedPlugin) {
                 if (!empty($updatePlugin['name'])
                     && $loadedPlugin->getPluginName() == $updatePlugin['name']
                 ) {
                     $updatePlugin['currentVersion'] = $loadedPlugin->getVersion();
                     $updatePlugin['isActivated'] = $this->pluginManager->isPluginActivated($updatePlugin['name']);
-                    $pluginsHavingUpdate[$key] = $this->addMissingRequirements($updatePlugin);
+                    $pluginsHavingUpdate[$pluginName] = $this->addMissingRequirements($updatePlugin);
                     break;
                 }
             }
         }
 
         // remove plugins that have updates but for some reason are not loaded
-        foreach ($pluginsHavingUpdate as $key => $updatePlugin) {
+        foreach ($pluginsHavingUpdate as $pluginName => $updatePlugin) {
             if (empty($updatePlugin['currentVersion'])) {
-                unset($pluginsHavingUpdate[$key]);
+                unset($pluginsHavingUpdate[$pluginName]);
             }
         }
 


### PR DESCRIPTION
### Description:

When using the checkboxes in plugin management to update multiple plugins at once, clicking the button currently leads to an URL that complains that plugin '0' couldn't be found.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
