### PR TITLE
Prevent possible DI errors during update

### DIFF
--- a/core/AssetManager/UIAssetFetcher/PluginUmdAssetFetcher.php
+++ b/core/AssetManager/UIAssetFetcher/PluginUmdAssetFetcher.php
@@ -360,12 +360,22 @@ class PluginUmdAssetFetcher extends UIAssetFetcher
 
     private function shouldLoadUmdOnDemand(string $pluginName)
     {
-        $pluginsToNotLoadOnDemand = StaticContainer::get('plugins.shouldNotLoadOnDemand');
+        try {
+            $pluginsToNotLoadOnDemand = StaticContainer::get('plugins.shouldNotLoadOnDemand');
+        } catch (\Exception $e) {
+            // ignore errors, as this might be loaded during the update, before it is defined
+            $pluginsToNotLoadOnDemand = [];
+        }
         if (in_array($pluginName, $pluginsToNotLoadOnDemand)) {
             return false;
         }
 
-        $pluginsToLoadOnDemand = StaticContainer::get('plugins.shouldLoadOnDemand');
+        try {
+            $pluginsToLoadOnDemand = StaticContainer::get('plugins.shouldLoadOnDemand');
+        } catch (\Exception $e) {
+            // ignore errors, as this might be loaded during the update, before it is defined
+            $pluginsToLoadOnDemand = [];
+        }
         if (in_array($pluginName, $pluginsToLoadOnDemand)) {
             return true;
         }


### PR DESCRIPTION
### Description:

Updating demo resulted in the error message `No entry or class found for &#039;plugins.shouldNotLoadOnDemand&#039;`

I assume that happens if the DI values are used before the new `global.php` was loaded, which would define them.
I've added some try/catch around using such DI values to prevent possible failures.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
