### PR TITLE
4.x Check if report exists prior to getting its row identifier

### DIFF
--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -250,7 +250,7 @@ class Visualization extends ViewDataTable
         $view->isWidget    = Common::getRequestVar('widget', 0, 'int');
         $view->notifications = [];
         $view->isComparing = $this->isComparing();
-        $view->rowIdentifier = $this->report->getRowIdentifier() ?? 'label';
+        $view->rowIdentifier = $this->report ? ($this->report->getRowIdentifier() ?: 'label') : 'label';
 
         if (!$this->supportsComparison()
             && DataComparisonFilter::isCompareParamsPresent()

--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -250,7 +250,7 @@ class Visualization extends ViewDataTable
         $view->isWidget    = Common::getRequestVar('widget', 0, 'int');
         $view->notifications = [];
         $view->isComparing = $this->isComparing();
-        $view->rowIdentifier = $this->report->getRowIdentifier() ?: 'label';
+        $view->rowIdentifier = $this->report->getRowIdentifier() ?? 'label';
 
         if (!$this->supportsComparison()
             && DataComparisonFilter::isCompareParamsPresent()


### PR DESCRIPTION
### Description:

Prevent calling `getRowIdentifier` function on null.

![Screenshot 2023-06-12 at 10 42 51 AM](https://github.com/matomo-org/matomo/assets/233342/b21f3d81-89b0-4baf-a435-715705522bc8)

This will remove the error but we should probably do a follow up test to see if the functionality still works as report should be set here, so perhaps there's an issue somewhere else that this might just cover.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
