### PR TITLE
Remove unintended blank target from link

### DIFF
--- a/plugins/SitesManager/templates/siteWithoutData.twig
+++ b/plugins/SitesManager/templates/siteWithoutData.twig
@@ -33,7 +33,7 @@
                 {{ 'SitesManager_SiteWithoutDataStartTrackingDataHeader'|translate }}
             </h1>
             <p>{{ siteWithoutDataStartTrackingTranslationKey|translate('<a rel="noreferrer noopener" target="_blank" class="emailTrackingCode" href="mailto:?subject=' ~ 'SitesManager_EmailInstructionsSubject'|translate|url_encode|e('html_attr') ~ '&body=' ~ emailBody|url_encode|e('html_attr') ~ '">', '</a>', '<a rel="noreferrer noopener" target="_blank" href="' ~ inviteUserLink ~'">', '</a>')|raw }}</p>
-            <p>{{ 'SitesManager_SiteWithoutDataStartTrackingDataDescriptionLine2'|translate('<a rel="noreferrer noopener" target="_blank" class="ignoreSitesWithoutData" href="' ~ linkTo({module: 'SitesManager', action: 'ignoreNoDataMessage'}) ~'">', '</a>')|raw }}</p>
+            <p>{{ 'SitesManager_SiteWithoutDataStartTrackingDataDescriptionLine2'|translate('<a rel="noreferrer noopener" class="ignoreSitesWithoutData" href="' ~ linkTo({module: 'SitesManager', action: 'ignoreNoDataMessage'}) ~'">', '</a>')|raw }}</p>
             <p>&nbsp;</p>
 
             <div piwik-widget-loader='{"module":"SitesManager","action":"siteWithoutDataTabs"}' loading-message="{{ 'SitesManager_DetectingYourSite'|translate|e('html_attr') }}..."></div>


### PR DESCRIPTION
### Description:

@AltamashShaikh was it on purpose that the link has a `target=blank`? To me it looks unintended that clicking the ignore link would oben the dashboard in a new tab.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
