### PR TITLE
[PHPCS] disallow using tabs for intending

### DIFF
--- a/core/DataTable/Filter/Pattern.php
+++ b/core/DataTable/Filter/Pattern.php
@@ -86,7 +86,7 @@ class Pattern extends BaseFilter
             //instead search must handle
             // - negative search with -piwik
             // - exact match with ""
-            // see (?!pattern) 	A subexpression that performs a negative lookahead search, which matches the search string at any point where a string not matching pattern begins.
+            // see (?!pattern)     A subexpression that performs a negative lookahead search, which matches the search string at any point where a string not matching pattern begins.
             $value = $row->getColumn($this->columnToFilter);
             if ($value === false) {
                 $value = $row->getMetadata($this->columnToFilter);

--- a/core/DataTable/Renderer/Rss.php
+++ b/core/DataTable/Renderer/Rss.php
@@ -140,7 +140,7 @@ class Rss extends Renderer
          * table = array
          * ROW1 = col1 | col2 | col3 | metadata | idSubTable
          * ROW2 = col1 | col2 (no value but appears) | col3 | metadata | idSubTable
-         * 		subtable here
+         *         subtable here
          */
         $allColumns = array();
         foreach ($table->getRows() as $row) {

--- a/core/Http.php
+++ b/core/Http.php
@@ -247,7 +247,7 @@ class Http
         if ( !empty($requestBody ) && is_array($requestBody )) {
             $requestBodyQuery = self::buildQuery($requestBody );
         } else {
-	        $requestBodyQuery = $requestBody;
+            $requestBodyQuery = $requestBody;
         }
 
         // Piwik services behave like a proxy, so we should act like one.
@@ -281,48 +281,48 @@ class Http
 
         $httpAuthIsUsed = !empty($httpUsername) || !empty($httpPassword);
 
-	    $httpAuth = '';
-	    if ($httpAuthIsUsed) {
-		    $httpAuth = 'Authorization: Basic ' . base64_encode($httpUsername.':'.$httpPassword) . "\r\n";
-	    }
+        $httpAuth = '';
+        if ($httpAuthIsUsed) {
+            $httpAuth = 'Authorization: Basic ' . base64_encode($httpUsername.':'.$httpPassword) . "\r\n";
+        }
 
-	    $httpEventParams = array(
-		    'httpMethod' => $httpMethod,
-		    'body' => $requestBody,
-		    'userAgent' => $userAgent,
-		    'timeout' => $timeout,
-		    'headers' => array_map('trim', array_filter(array_merge(array(
-			    $rangeHeader, $via, $xff, $httpAuth, $acceptLanguage
-		    ), $additionalHeaders))),
-		    'verifySsl' => !$acceptInvalidSslCertificate,
-		    'destinationPath' => $destinationPath
-	    );
+        $httpEventParams = array(
+            'httpMethod' => $httpMethod,
+            'body' => $requestBody,
+            'userAgent' => $userAgent,
+            'timeout' => $timeout,
+            'headers' => array_map('trim', array_filter(array_merge(array(
+                $rangeHeader, $via, $xff, $httpAuth, $acceptLanguage
+            ), $additionalHeaders))),
+            'verifySsl' => !$acceptInvalidSslCertificate,
+            'destinationPath' => $destinationPath
+        );
 
-	    /**
-	     * Triggered to send an HTTP request. Allows plugins to resolve the HTTP request themselves or to find out
-	     * when an HTTP request is triggered to log this information for example to a monitoring tool.
-	     *
-	     * @param string $url The URL that needs to be requested
-	     * @param array $params HTTP params like
-	     *                      - 'httpMethod' (eg GET, POST, ...),
-	     *                      - 'body' the request body if the HTTP method needs to be posted
-	     *                      - 'userAgent'
-	     *                      - 'timeout' After how many seconds a request should time out
-	     *                      - 'headers' An array of header strings like array('Accept-Language: en', '...')
-	     *                      - 'verifySsl' A boolean whether SSL certificate should be verified
-	     *                      - 'destinationPath' If set, the response of the HTTP request should be saved to this file
-	     * @param string &$response A plugin listening to this event should assign the HTTP response it received to this variable, for example "{value: true}"
-	     * @param string &$status A plugin listening to this event should assign the HTTP status code it received to this variable, for example "200"
-	     * @param array &$headers A plugin listening to this event should assign the HTTP headers it received to this variable, eg array('Content-Length' => '5')
-	     */
+        /**
+         * Triggered to send an HTTP request. Allows plugins to resolve the HTTP request themselves or to find out
+         * when an HTTP request is triggered to log this information for example to a monitoring tool.
+         *
+         * @param string $url The URL that needs to be requested
+         * @param array $params HTTP params like
+         *                      - 'httpMethod' (eg GET, POST, ...),
+         *                      - 'body' the request body if the HTTP method needs to be posted
+         *                      - 'userAgent'
+         *                      - 'timeout' After how many seconds a request should time out
+         *                      - 'headers' An array of header strings like array('Accept-Language: en', '...')
+         *                      - 'verifySsl' A boolean whether SSL certificate should be verified
+         *                      - 'destinationPath' If set, the response of the HTTP request should be saved to this file
+         * @param string &$response A plugin listening to this event should assign the HTTP response it received to this variable, for example "{value: true}"
+         * @param string &$status A plugin listening to this event should assign the HTTP status code it received to this variable, for example "200"
+         * @param array &$headers A plugin listening to this event should assign the HTTP headers it received to this variable, eg array('Content-Length' => '5')
+         */
         Piwik::postEvent('Http.sendHttpRequest', array($aUrl, $httpEventParams, &$response, &$status, &$headers));
 
-	    if ($response !== null || $status !== null || !empty($headers)) {
-	    	// was handled by event above...
-		    /**
-		     * described below
-		     * @ignore
-		     */
+        if ($response !== null || $status !== null || !empty($headers)) {
+            // was handled by event above...
+            /**
+             * described below
+             * @ignore
+             */
                     Piwik::postEvent('Http.sendHttpRequest.end', array($aUrl, $httpEventParams, &$response, &$status, &$headers));
 
                     if ($destinationPath && file_exists($destinationPath)) {
@@ -334,10 +334,10 @@ class Http
                             'headers' => $headers,
                             'data'    => $response
                         );
-		    } else {
+            } else {
                         return trim($response);
-		    }
-	    }
+            }
+        }
 
         if ($method == 'socket') {
             if (!self::isSocketEnabled()) {
@@ -784,24 +784,24 @@ class Http
             return true;
         }
 
-	    /**
-	     * Triggered when an HTTP request finished. A plugin can for example listen to this and alter the response,
-	     * status code, or finish a timer in case the plugin is measuring how long it took to execute the request
-	     *
-	     * @param string $url The URL that needs to be requested
-	     * @param array $params HTTP params like
-	     *                      - 'httpMethod' (eg GET, POST, ...),
-	     *                      - 'body' the request body if the HTTP method needs to be posted
-	     *                      - 'userAgent'
-	     *                      - 'timeout' After how many seconds a request should time out
-	     *                      - 'headers' An array of header strings like array('Accept-Language: en', '...')
-	     *                      - 'verifySsl' A boolean whether SSL certificate should be verified
-	     *                      - 'destinationPath' If set, the response of the HTTP request should be saved to this file
-	     * @param string &$response The response of the HTTP request, for example "{value: true}"
-	     * @param string &$status The returned HTTP status code, for example "200"
-	     * @param array &$headers The returned headers, eg array('Content-Length' => '5')
-	     */
-	    Piwik::postEvent('Http.sendHttpRequest.end', array($aUrl, $httpEventParams, &$response, &$status, &$headers));
+        /**
+         * Triggered when an HTTP request finished. A plugin can for example listen to this and alter the response,
+         * status code, or finish a timer in case the plugin is measuring how long it took to execute the request
+         *
+         * @param string $url The URL that needs to be requested
+         * @param array $params HTTP params like
+         *                      - 'httpMethod' (eg GET, POST, ...),
+         *                      - 'body' the request body if the HTTP method needs to be posted
+         *                      - 'userAgent'
+         *                      - 'timeout' After how many seconds a request should time out
+         *                      - 'headers' An array of header strings like array('Accept-Language: en', '...')
+         *                      - 'verifySsl' A boolean whether SSL certificate should be verified
+         *                      - 'destinationPath' If set, the response of the HTTP request should be saved to this file
+         * @param string &$response The response of the HTTP request, for example "{value: true}"
+         * @param string &$status The returned HTTP status code, for example "200"
+         * @param array &$headers The returned headers, eg array('Content-Length' => '5')
+         */
+        Piwik::postEvent('Http.sendHttpRequest.end', array($aUrl, $httpEventParams, &$response, &$status, &$headers));
 
         if (!$getExtendedInfo) {
             return trim($response);

--- a/core/Intl/Data/Resources/currencies.php
+++ b/core/Intl/Data/Resources/currencies.php
@@ -69,7 +69,7 @@ return array(
     'EGP' => array('ج.م', 'Egyptian pound'),
     'ERN' => array('Nfk', 'Eritrean nakfa'),
     'ETB' => array('Br', 'Ethiopian birr'),
-//			'EUR' => array('€', 'Euro'),
+//            'EUR' => array('€', 'Euro'),
     'FKP' => array('£', 'Falkland Islands pound'),
     'FJD' => array('$', 'Fijian dollar'),
     'GMD' => array('D', 'Gambian dalasi'),

--- a/core/Theme.php
+++ b/core/Theme.php
@@ -146,7 +146,7 @@ class Theme
         foreach (Manager::getAlternativeWebRootDirectories() as $absDir => $webRootDirectory) {
             $withoutPlugins = str_replace('plugins/', '', $pathAsset);
             if (file_exists($absDir . '/' . $withoutPlugins)) {
-	            return str_replace($pathAsset, $webRootDirectory . $withoutPlugins, $source);
+                return str_replace($pathAsset, $webRootDirectory . $withoutPlugins, $source);
             }
         }
 

--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -486,10 +486,10 @@ class Model
 
         // Two use cases:
         // 1) there is no visitor ID so we try to match only on config_id (heuristics)
-        // 		Possible causes of no visitor ID: no browser cookie support, direct Tracking API request without visitor ID passed,
+        //         Possible causes of no visitor ID: no browser cookie support, direct Tracking API request without visitor ID passed,
         //        importing server access logs with import_logs.py, etc.
-        // 		In this case we use config_id heuristics to try find the visitor in tahhhe past. There is a risk to assign
-        // 		this page view to the wrong visitor, but this is better than creating artificial visits.
+        //         In this case we use config_id heuristics to try find the visitor in tahhhe past. There is a risk to assign
+        //         this page view to the wrong visitor, but this is better than creating artificial visits.
         // 2) there is a visitor ID and we trust it (config setting trust_visitors_cookies, OR it was set using &cid= in tracking API),
         //      and in these cases, we force to look up this visitor id
         $configIdWhere = "visit_last_action_time >= ? AND visit_last_action_time <= ? AND idsite = ?";

--- a/core/UrlHelper.php
+++ b/core/UrlHelper.php
@@ -222,7 +222,7 @@ class UrlHelper
         $separator = '&';
 
         $urlQuery = $separator . $urlQuery;
-        //		$urlQuery = str_replace(array('%20'), ' ', $urlQuery);
+        //        $urlQuery = str_replace(array('%20'), ' ', $urlQuery);
         $referrerQuery = trim($urlQuery);
 
         $values = explode($separator, $referrerQuery);

--- a/core/bootstrap.php
+++ b/core/bootstrap.php
@@ -19,11 +19,11 @@ error_reporting(E_ALL);
 @ini_set('xdebug.show_exception_trace', 0);
 
 if (!defined('PIWIK_VENDOR_PATH')) {
-	if (is_dir(PIWIK_INCLUDE_PATH . '/vendor')) {
-		define('PIWIK_VENDOR_PATH', PIWIK_INCLUDE_PATH . '/vendor'); // Piwik is the main project
-	} else {
-		define('PIWIK_VENDOR_PATH', PIWIK_INCLUDE_PATH . '/../..'); // Piwik is installed as a Composer dependency
-	}
+    if (is_dir(PIWIK_INCLUDE_PATH . '/vendor')) {
+        define('PIWIK_VENDOR_PATH', PIWIK_INCLUDE_PATH . '/vendor'); // Piwik is the main project
+    } else {
+        define('PIWIK_VENDOR_PATH', PIWIK_INCLUDE_PATH . '/../..'); // Piwik is installed as a Composer dependency
+    }
 }
 
 // NOTE: the code above must be PHP 4 compatible

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,7 +16,7 @@
     <exclude-pattern>*/libs/*</exclude-pattern>
 
     <!-- exclude all plugins included as submodule as long as they might not fully follow this CS -->
-    <exclude-pattern>plugins/(AnonymousPiwikUsageMeasurement|Bandwidth|CustomAlerts|CustomVariables|DeviceDetectorCache|LogViewer|LoginLdap|MarketingCampaignsReporting|Provider|QueuedTracking|SecurityInfo|TagManager|TrackingSpamPrevention|TreemapVisualization|VisitorGenerator)/*</exclude-pattern>
+    <exclude-pattern>plugins/(AnonymousPiwikUsageMeasurement|Bandwidth|CustomAlerts|CustomVariables|DeviceDetectorCache|LogViewer|LoginLdap|MarketingCampaignsReporting|Provider|QueuedTracking|SecurityInfo|TagManager|TasksTimetable|TrackingSpamPrevention|TreemapVisualization|VisitorGenerator)/*</exclude-pattern>
 
     <config name="installed_paths" value="../../slevomat/coding-standard"/>
 
@@ -48,6 +48,9 @@
 
 
     <!-- Additional rules that are not covered by PSR above -->
+
+    <!-- Disallow using tabs for indenting -->
+    <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
 
     <!-- Expect a file to end with a new line -->
     <rule ref="PSR2.Files.EndFileNewline"/>

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -864,10 +864,10 @@ class ProcessedReport
         }
 
         // Display time in human readable
-		if (strpos($columnName, 'time_generation') !== false) {
-			return $formatter->getPrettyTimeFromSeconds($value, true);
-		} 
-		if (strpos($columnName, 'time') !== false) {
+        if (strpos($columnName, 'time_generation') !== false) {
+            return $formatter->getPrettyTimeFromSeconds($value, true);
+        } 
+        if (strpos($columnName, 'time') !== false) {
             return $formatter->getPrettyTimeFromSeconds($value);
         }
 

--- a/plugins/ImageGraph/Controller.php
+++ b/plugins/ImageGraph/Controller.php
@@ -60,11 +60,11 @@ class Controller extends \Piwik\Plugin\Controller
         $view->availableReports = $availableReports;
         $view->graphTypes = array(
             '', // default graph type
-//			'evolution',
-//			'verticalBar',
-//			'horizontalBar',
-//			'pie',
-//			'3dPie',
+//            'evolution',
+//            'verticalBar',
+//            'horizontalBar',
+//            'pie',
+//            '3dPie',
         );
         $view->graphSizes = array(
             array(null, null), // default graph size

--- a/plugins/ImageGraph/ImageGraph.php
+++ b/plugins/ImageGraph/ImageGraph.php
@@ -86,21 +86,21 @@ class ImageGraph extends \Piwik\Plugin
             } else if ($info['period'] == 'day' || !Config::getInstance()->General['graphs_show_evolution_within_selected_period']) {
                 // for period=day, always show the last n days
                 // if graphs_show_evolution_within_selected_period=false, show the last n periods
-				$periodForMultiplePeriodGraph = $periodForSinglePeriodGraph;
-				$dateForMultiplePeriodGraph = Range::getRelativeToEndDate(
-					$periodForSinglePeriodGraph,
-					'last' . self::getDefaultGraphEvolutionLastPeriods(),
-					$dateForSinglePeriodGraph,
-					$piwikSite
-				);
-			} else {
+                $periodForMultiplePeriodGraph = $periodForSinglePeriodGraph;
+                $dateForMultiplePeriodGraph = Range::getRelativeToEndDate(
+                    $periodForSinglePeriodGraph,
+                    'last' . self::getDefaultGraphEvolutionLastPeriods(),
+                    $dateForSinglePeriodGraph,
+                    $piwikSite
+                );
+            } else {
                 // if graphs_show_evolution_within_selected_period=true, show the days within the period
                 // (except if the period is day, see above)
-				$periodForMultiplePeriodGraph = 'day';
-				$period = PeriodFactory::build($info['period'], $info['date']);
-				$start = $period->getDateStart()->toString();
-				$end = $period->getDateEnd()->toString();
-				$dateForMultiplePeriodGraph = $start . ',' . $end;
+                $periodForMultiplePeriodGraph = 'day';
+                $period = PeriodFactory::build($info['period'], $info['date']);
+                $start = $period->getDateStart()->toString();
+                $end = $period->getDateEnd()->toString();
+                $dateForMultiplePeriodGraph = $start . ',' . $end;
             }
         }
 

--- a/plugins/ImageGraph/StaticGraph/GridGraph.php
+++ b/plugins/ImageGraph/StaticGraph/GridGraph.php
@@ -424,69 +424,69 @@ abstract class GridGraph extends StaticGraph
     // e.g: it is not possible to remove the box border & the square icon
     // it would require modifying pChart code base which we try to avoid
     // see https://github.com/piwik/piwik/issues/3396
-//	protected function displayMinMaxValues()
-//	{
-//		if ($displayMinMax)
-//		{
-//			// when plotting multiple metrics, display min & max on both series
-//			// to fix: in vertical bars, labels are hidden when multiple metrics are plotted, hence the restriction on count($this->ordinateSeries) == 1
-//			if ($this->multipleMetrics && count($this->ordinateSeries) == 1)
-//			{
-//				$colorIndex = 1;
-//				foreach($this->ordinateSeries as $column => $data)
-//				{
-//					$color = $this->colors[self::GRAPHIC_COLOR_KEY . $colorIndex++];
+//    protected function displayMinMaxValues()
+//    {
+//        if ($displayMinMax)
+//        {
+//            // when plotting multiple metrics, display min & max on both series
+//            // to fix: in vertical bars, labels are hidden when multiple metrics are plotted, hence the restriction on count($this->ordinateSeries) == 1
+//            if ($this->multipleMetrics && count($this->ordinateSeries) == 1)
+//            {
+//                $colorIndex = 1;
+//                foreach($this->ordinateSeries as $column => $data)
+//                {
+//                    $color = $this->colors[self::GRAPHIC_COLOR_KEY . $colorIndex++];
 //
-//					$this->pImage->writeLabel(
-//						$column,
-//						self::locateMinMaxValue($data),
-//						$Format = array(
-//							'NoTitle' => true,
-//							'DrawPoint' => false,
-//							'DrawSerieColor' => true,
-//							'TitleMode' => LABEL_TITLE_NOBACKGROUND,
-//							'GradientStartR' => $color['R'],
-//							'GradientStartG' => $color['G'],
-//							'GradientStartB' => $color['B'],
-//							'GradientEndR' => 255,
-//							'GradientEndG' => 255,
-//							'GradientEndB' => 255,
-//							'BoxWidth' => 0,
-//							'VerticalMargin' => 9,
-//							'HorizontalMargin' => 7,
-//						)
-//					);
-//				}
-//			}
-//			else
-//			{
-//				// display only one min & max label
-//			}
-//		}
-//	}
+//                    $this->pImage->writeLabel(
+//                        $column,
+//                        self::locateMinMaxValue($data),
+//                        $Format = array(
+//                            'NoTitle' => true,
+//                            'DrawPoint' => false,
+//                            'DrawSerieColor' => true,
+//                            'TitleMode' => LABEL_TITLE_NOBACKGROUND,
+//                            'GradientStartR' => $color['R'],
+//                            'GradientStartG' => $color['G'],
+//                            'GradientStartB' => $color['B'],
+//                            'GradientEndR' => 255,
+//                            'GradientEndG' => 255,
+//                            'GradientEndB' => 255,
+//                            'BoxWidth' => 0,
+//                            'VerticalMargin' => 9,
+//                            'HorizontalMargin' => 7,
+//                        )
+//                    );
+//                }
+//            }
+//            else
+//            {
+//                // display only one min & max label
+//            }
+//        }
+//    }
 
-//	protected static function locateMinMaxValue($data)
-//	{
-//		$firstValue = $data[0];
-//		$minValue = $firstValue;
-//		$minValueIndex = 0;
-//		$maxValue = $firstValue;
-//		$maxValueIndex = 0;
-//		foreach($data as $index => $value)
-//		{
-//			if ($value > $maxValue)
-//			{
-//				$maxValue = $value;
-//				$maxValueIndex = $index;
-//			}
+//    protected static function locateMinMaxValue($data)
+//    {
+//        $firstValue = $data[0];
+//        $minValue = $firstValue;
+//        $minValueIndex = 0;
+//        $maxValue = $firstValue;
+//        $maxValueIndex = 0;
+//        foreach($data as $index => $value)
+//        {
+//            if ($value > $maxValue)
+//            {
+//                $maxValue = $value;
+//                $maxValueIndex = $index;
+//            }
 //
-//			if ($value < $minValue)
-//			{
-//				$minValue = $value;
-//				$minValueIndex = $index;
-//			}
-//		}
+//            if ($value < $minValue)
+//            {
+//                $minValue = $value;
+//                $minValueIndex = $index;
+//            }
+//        }
 //
-//		return array($minValueIndex, $maxValueIndex);
-//	}
+//        return array($minValueIndex, $maxValueIndex);
+//    }
 }

--- a/plugins/ImageGraph/StaticGraph/HorizontalBar.php
+++ b/plugins/ImageGraph/StaticGraph/HorizontalBar.php
@@ -151,7 +151,7 @@ class HorizontalBar extends GridGraph
             )
         );
 
-//		// display icons
+//        // display icons
         $graphData = $this->pData->getData();
         $numberOfRows = count($this->abscissaSeries);
         $logoInterleave = $this->getGraphHeight(true, $verticalLegend) / $numberOfRows;

--- a/plugins/Installation/ServerFilesGenerator.php
+++ b/plugins/Installation/ServerFilesGenerator.php
@@ -81,7 +81,7 @@ Header set Cache-Control \"Cache-Control: private, no-cache, no-store\"
             PIWIK_INCLUDE_PATH . '/lang' => $denyAll,
             StaticContainer::get('path.tmp') => $denyAll,
         );
-	    
+
         if (!empty($GLOBALS['CONFIG_INI_PATH_RESOLVER']) && is_callable($GLOBALS['CONFIG_INI_PATH_RESOLVER'])) {
             $file = call_user_func($GLOBALS['CONFIG_INI_PATH_RESOLVER']);
             $directoriesToProtect[dirname($file)] = $denyAll;

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -128,32 +128,32 @@ class Model
             $visits = $readerDb->fetchAll($sql, $bind);
         } catch (Exception $e) {
             $this->handleMaxExecutionTimeError($readerDb, $e, $segment, $dateStart, $dateEnd, $minTimestamp, $limit, ['sql' => $sql, 'bind' => $bind,]);
-	        throw $e;
+            throw $e;
         }
         return $visits;
     }
 
-	/**
-	 * @param \Piwik\Tracker\Db|\Piwik\Db\AdapterInterface|\Piwik\Db $readerDb
-	 * @param Exception $e
-	 * @param $segment
-	 * @param $dateStart
-	 * @param $dateEnd
-	 * @param $minTimestamp
-	 * @param $limit
-	 * @param $parameters
-	 *
-	 * @throws MaxExecutionTimeExceededException
-	 */
+    /**
+     * @param \Piwik\Tracker\Db|\Piwik\Db\AdapterInterface|\Piwik\Db $readerDb
+     * @param Exception $e
+     * @param $segment
+     * @param $dateStart
+     * @param $dateEnd
+     * @param $minTimestamp
+     * @param $limit
+     * @param $parameters
+     *
+     * @throws MaxExecutionTimeExceededException
+     */
     public static function handleMaxExecutionTimeError($readerDb, $e, $segment, $dateStart, $dateEnd, $minTimestamp, $limit, $parameters)
     {
-	    // we also need to check for the 'maximum statement execution time exceeded' text as the query might be
-	    // aborted at different stages and we can't really know all the possible codes at which it may be aborted etc
-	    $isMaxExecutionTimeError = $readerDb->isErrNo($e, DbMigration::ERROR_CODE_MAX_EXECUTION_TIME_EXCEEDED_QUERY_INTERRUPTED)
-	                               || $readerDb->isErrNo($e, DbMigration::ERROR_CODE_MAX_EXECUTION_TIME_EXCEEDED_SORT_ABORTED)
-	                               || strpos($e->getMessage(), 'maximum statement execution time exceeded') !== false;
+        // we also need to check for the 'maximum statement execution time exceeded' text as the query might be
+        // aborted at different stages and we can't really know all the possible codes at which it may be aborted etc
+        $isMaxExecutionTimeError = $readerDb->isErrNo($e, DbMigration::ERROR_CODE_MAX_EXECUTION_TIME_EXCEEDED_QUERY_INTERRUPTED)
+                                   || $readerDb->isErrNo($e, DbMigration::ERROR_CODE_MAX_EXECUTION_TIME_EXCEEDED_SORT_ABORTED)
+                                   || strpos($e->getMessage(), 'maximum statement execution time exceeded') !== false;
 
-	    if (false === $isMaxExecutionTimeError) {
+        if (false === $isMaxExecutionTimeError) {
             return;
         }
 

--- a/plugins/Live/tests/Integration/ModelTest.php
+++ b/plugins/Live/tests/Integration/ModelTest.php
@@ -94,14 +94,14 @@ class ModelTest extends IntegrationTestCase
         $this->expectExceptionMessage('Live_QueryMaxExecutionTimeExceeded  Live_QueryMaxExecutionTimeExceededReasonUnknown');
 
         $db = Db::get();
-    	$e = new \Exception('[3024] Query execution was interrupted, maximum statement execution time exceeded');
-	    $sql = 'SELECT 1';
-	    $bind = array();
-	    $segment = '';
-	    $dateStart = Date::now()->subDay(1);
-	    $dateEnd = Date::now();
-	    $minTimestamp = null;
-	    $limit = 50;
+        $e = new \Exception('[3024] Query execution was interrupted, maximum statement execution time exceeded');
+        $sql = 'SELECT 1';
+        $bind = array();
+        $segment = '';
+        $dateStart = Date::now()->subDay(1);
+        $dateEnd = Date::now();
+        $minTimestamp = null;
+        $limit = 50;
         Model::handleMaxExecutionTimeError($db, $e, $segment, $dateStart, $dateEnd, $minTimestamp, $limit, [$sql, $bind]);
     }
 
@@ -111,12 +111,12 @@ class ModelTest extends IntegrationTestCase
         $this->expectExceptionMessage('Live_QueryMaxExecutionTimeExceeded  Live_QueryMaxExecutionTimeExceededReasonDateRange Live_QueryMaxExecutionTimeExceededReasonSegment Live_QueryMaxExecutionTimeExceededLimit');
 
         $db = Db::get();
-    	$e = new \Exception('Query execution was interrupted, maximum statement execution time exceeded');
-	    $segment = 'userId>=1';
-	    $dateStart = Date::now()->subDay(10);
-	    $dateEnd = Date::now();
-	    $minTimestamp = null;
-	    $limit = 5000;
+        $e = new \Exception('Query execution was interrupted, maximum statement execution time exceeded');
+        $segment = 'userId>=1';
+        $dateStart = Date::now()->subDay(10);
+        $dateEnd = Date::now();
+        $minTimestamp = null;
+        $limit = 5000;
         Model::handleMaxExecutionTimeError($db, $e, $segment, $dateStart, $dateEnd, $minTimestamp, $limit, ['param' => 'value']);
     }
 

--- a/plugins/MobileMessaging/CountryCallingCodes.php
+++ b/plugins/MobileMessaging/CountryCallingCodes.php
@@ -24,7 +24,7 @@ class CountryCallingCodes
         'al' => '355',
         'am' => '374',
         'ao' => '244',
-//		'aq' => 'MISSING CODE', // @wikipedia In Antarctica dialing is dependent on the parent country of each base
+//        'aq' => 'MISSING CODE', // @wikipedia In Antarctica dialing is dependent on the parent country of each base
         'ar' => '54',
         'as' => '1684', // @wikipedia original value: 1 684
         'at' => '43',
@@ -49,7 +49,7 @@ class CountryCallingCodes
         'br' => '55',
         'bs' => '1242', // @wikipedia original value: 1 242
         'bt' => '975',
-//		'bv' => 'MISSING CODE',
+//        'bv' => 'MISSING CODE',
         'bw' => '267',
         'by' => '375',
         'bz' => '501',
@@ -76,7 +76,7 @@ class CountryCallingCodes
         'dj' => '253',
         'dk' => '45',
         'dm' => '1767', // @wikipedia original value: 1 767
-//		'do' => 'MISSING CODE', // @wikipedia original values: 1 809, 1 829, 1 849
+//        'do' => 'MISSING CODE', // @wikipedia original values: 1 809, 1 829, 1 849
         'dz' => '213',
         'ec' => '593',
         'ee' => '372',
@@ -111,7 +111,7 @@ class CountryCallingCodes
         'gw' => '245',
         'gy' => '592',
         'hk' => '852',
-//		'hm' => 'MISSING CODE',
+//        'hm' => 'MISSING CODE',
         'hn' => '504',
         'hr' => '385',
         'ht' => '509',
@@ -140,7 +140,7 @@ class CountryCallingCodes
         'kr' => '82',
         'kw' => '965',
         'ky' => '1345', // @wikipedia original value: 1 345
-//		'kz' => 'MISSING CODE', // @wikipedia original values: 7 6, 7 7
+//        'kz' => 'MISSING CODE', // @wikipedia original values: 7 6, 7 7
         'la' => '856',
         'lb' => '961',
         'lc' => '1758', // @wikipedia original value: 1 758
@@ -197,7 +197,7 @@ class CountryCallingCodes
         'pl' => '48',
         'pm' => '508',
         'pn' => '672',
-//		'pr' => 'MISSING CODE', // @wikipedia original values: 1 787, 1 939
+//        'pr' => 'MISSING CODE', // @wikipedia original values: 1 787, 1 939
         'ps' => '970',
         'pt' => '351',
         'pw' => '680',
@@ -231,7 +231,7 @@ class CountryCallingCodes
         'sz' => '268',
         'tc' => '1649', // @wikipedia original value: 1 649
         'td' => '235',
-//		'tf' => 'MISSING CODE',
+//        'tf' => 'MISSING CODE',
         'tg' => '228',
         'th' => '66',
         'tj' => '992',
@@ -247,11 +247,11 @@ class CountryCallingCodes
         'tz' => '255',
         'ua' => '380',
         'ug' => '256',
-//		'um' => 'MISSING CODE',
+//        'um' => 'MISSING CODE',
         'us' => '1',
         'uy' => '598',
         'uz' => '998',
-//		'va' => 'MISSING CODE', // @wikipedia original values: 39 066, assigned 379
+//        'va' => 'MISSING CODE', // @wikipedia original values: 39 066, assigned 379
         'vc' => '1784', // @wikipedia original value: 1 784
         've' => '58',
         'vg' => '1284', // @wikipedia original value: 1 284

--- a/plugins/SitesManager/GtmSiteTypeGuesser.php
+++ b/plugins/SitesManager/GtmSiteTypeGuesser.php
@@ -160,7 +160,7 @@ class GtmSiteTypeGuesser
             return SitesManager::JS_FRAMEWORK_UNKNOWN;
         }
 
-	    $needles = ['react.min.js' ,'react.development.min.js', 'react-dom.development.min.js' ,'react.development.js',
+        $needles = ['react.min.js' ,'react.development.min.js', 'react-dom.development.min.js' ,'react.development.js',
                     'react-dom.development.js', 'ReactDOM.', 'react.production.min.js', 'react-jsx-dev-runtime.development.js',
                     'react-jsx-dev-runtime.development.min.js', 'react-jsx-dev-runtime.production.min.js',
                     'react-jsx-dev-runtime.profiling.min.js', 'react-jsx-runtime.development.js', 'react-jsx-runtime.development.min.js',

--- a/plugins/VisitsSummary/Reports/Get.php
+++ b/plugins/VisitsSummary/Reports/Get.php
@@ -60,8 +60,8 @@ class Get extends \Piwik\Plugin\Report
 
         $this->subcategoryId = 'General_Overview';
         // Used to process metrics, not displayed/used directly
-//								'sum_visit_length',
-//								'nb_visits_converted',
+//                                'sum_visit_length',
+//                                'nb_visits_converted',
         $this->order = 1;
     }
 

--- a/tests/PHPUnit/Fixtures/OneVisitorTwoVisits.php
+++ b/tests/PHPUnit/Fixtures/OneVisitorTwoVisits.php
@@ -115,7 +115,7 @@ class OneVisitorTwoVisits extends Fixture
         // Record 1st page view
         $urlPage1 = 'http://example.org/index.htm?excluded_Parameter=SHOULD_NOT_DISPLAY&parameter=Should display';
         $t->setUrl($urlPage1);
-		$t->setPerformanceTimings(33, 105, 205, 1325, 390, 222);
+        $t->setPerformanceTimings(33, 105, 205, 1325, 390, 222);
         self::checkResponse($t->doTrackPageView('incredible title!'));
 
         // testing that / and index.htm above record with different URLs

--- a/tests/PHPUnit/Fixtures/SomeVisitsWithNonUnicodePageTitles.php
+++ b/tests/PHPUnit/Fixtures/SomeVisitsWithNonUnicodePageTitles.php
@@ -81,7 +81,7 @@ class SomeVisitsWithNonUnicodePageTitles extends Fixture
         // Test URL with non unicode Site Search keyword
         $visitor->setForceVisitDateTime(Date::factory($dateTime)->addHour(0.5)->getDatetime());
         //TESTS: on jenkins somehow the "<-was here" was cut off so removing this test case and simply append the wrong keyword
-//		$visitor->setUrl('http://example.org/page/index.htm?q=non unicode keyword %EC%E5%F8%EAe%EE%E2%FBf%E5 <-was here');
+//        $visitor->setUrl('http://example.org/page/index.htm?q=non unicode keyword %EC%E5%F8%EAe%EE%E2%FBf%E5 <-was here');
         $visitor->setUrl('http://example.org/page/index.htm?q=non unicode keyword %EC%E5%F8%EA%EE%E2%FB%E5');
         $visitor->setPageCharset('utf-8');
         self::checkResponse($visitor->doTrackPageView('Site Search'));

--- a/tests/PHPUnit/Integration/SessionTest.php
+++ b/tests/PHPUnit/Integration/SessionTest.php
@@ -19,17 +19,17 @@ use Piwik\Tests\Framework\Fixture;
  */
 class SessionTest extends \PHPUnit\Framework\TestCase
 {
-	public function test_session_should_not_be_started_if_it_was_already_started()
-	{
+    public function test_session_should_not_be_started_if_it_was_already_started()
+    {
         $url = Fixture::getRootUrl() . '/tests/resources/sessionStarter.php';
-	    $result = Http::sendHttpRequest($url, 5);
-	    $this->assertSame('ok', trim($result));
-	}
+        $result = Http::sendHttpRequest($url, 5);
+        $this->assertSame('ok', trim($result));
+    }
 
     /**
      * @dataProvider getCookieTests
      */
-	public function testWriteCookie($expected, $name, $value, $expires, $path, $domain, $secure, $httpOnly, $sameSite)
+    public function testWriteCookie($expected, $name, $value, $expires, $path, $domain, $secure, $httpOnly, $sameSite)
     {
         $result = Session::writeCookie($name, $value, $expires, $path, $domain, $secure, $httpOnly, $sameSite);
         $this->assertEquals($expected, $result);

--- a/tests/PHPUnit/System/OneVisitorTwoVisitsTest.php
+++ b/tests/PHPUnit/System/OneVisitorTwoVisitsTest.php
@@ -161,7 +161,7 @@ class OneVisitorTwoVisitsTest extends SystemTestCase
                                                   'otherRequestParameters' => array(
                                                       'hideColumns' => 'nb_visits_converted,xyzaug,entry_nb_visits,' .
                                                           'bounce_rate,nb_hits,nb_visits,avg_time_on_page,' .
-														  'avg_time_generation,nb_hits_with_time_generation'
+                                                          'avg_time_generation,nb_hits_with_time_generation'
                                                   ))),
 
             array('API.getProcessedReport', array('idSite'                 => $idSite, 'date' => $dateTime,

--- a/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
@@ -146,7 +146,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
                 // configured tasks
                 array(
                     $scheduledTaskOne,
-//					$scheduledTaskTwo, Not configured anymore (ie. not returned after TaskScheduler::GET_TASKS_EVENT is issued)
+//                    $scheduledTaskTwo, Not configured anymore (ie. not returned after TaskScheduler::GET_TASKS_EVENT is issued)
                     $scheduledTaskThree,
                 )
             ),


### PR DESCRIPTION
### Description:

Just came across some places where tabs were used and actually thought we would have had added that rule in the past already. So quickly added that and let phpcbf replace all remaining tabs...

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
