### PR TITLE
Fixing Order metric so that the plural name is used correctly

### DIFF
--- a/plugins/Ecommerce/Columns/Order.php
+++ b/plugins/Ecommerce/Columns/Order.php
@@ -28,7 +28,6 @@ class Order extends BaseConversion
     public function configureMetrics(MetricsList $metricsList, DimensionMetricFactory $dimensionMetricFactory)
     {
         $metric = $dimensionMetricFactory->createMetric(ArchivedMetric::AGGREGATION_UNIQUE);
-        $metric->setTranslatedName(Piwik::translate('Ecommerce_OrderId'));
         $metricsList->addMetric($metric);
     }
 

--- a/plugins/Ecommerce/Columns/Order.php
+++ b/plugins/Ecommerce/Columns/Order.php
@@ -11,7 +11,6 @@ namespace Piwik\Plugins\Ecommerce\Columns;
 use Piwik\Columns\DimensionMetricFactory;
 use Piwik\Columns\Discriminator;
 use Piwik\Columns\MetricsList;
-use Piwik\Piwik;
 use Piwik\Plugin\ArchivedMetric;
 use Piwik\Tracker\GoalManager;
 


### PR DESCRIPTION
### Description:

The Order metric was using `Order ID` as the plural name instead of `Orders`. This PR removes the explicit setting of the translated name so that the plural name is used as expected. This came up because it was confusing customers, especially when selecting metrics in the CustomReports plugin.
Jira Issue: PG-2801

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
