### PR TITLE
Fix SEO plugin test

### DIFF
--- a/plugins/SEO/tests/Integration/SEOTest.php
+++ b/plugins/SEO/tests/Integration/SEOTest.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\SEO\tests\Integration;
 use Piwik\DataTable\Renderer;
 use Piwik\Piwik;
 use Piwik\Plugins\SEO\API;
+use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -26,14 +27,19 @@ class SEOTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        // setup the access layer
+        // Setup the access layer
         FakeAccess::setIdSitesView([1, 2]);
         FakeAccess::setIdSitesAdmin([3, 4]);
 
-        //finally we set the user as a Super User by default
+        // Finally we set the user as a Super User by default
         FakeAccess::$superUser = true;
 
-        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (X11; Fedora; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36';
+        // Needed to load the Intl_NumberFormatNumber translation string used when formatting the ranking numbers
+        Fixture::loadAllTranslations();
+
+        // Google and Bing may not show the indexed pages count for some user agents, some UA strings will work for
+        // Google, but not Bing and visa-versa. This user agent string works for both as of 2023-06-26:
+        $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36';
     }
 
     /**


### PR DESCRIPTION
### Description:

Fixes #20929

The SEO test was failing for two reasons:
 - The user agent string used by the test was causing Google to not shown the indexed pages count
 - Translations for international number formats were not being loaded for the test resulting in incorrect number formatting.
 
This PR updates the user agent and adds in the translations.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
