### PR TITLE
Use variadics/splat instead of call_user_func_array()/func_get_args()

### DIFF
--- a/DIObject.php
+++ b/DIObject.php
@@ -10,18 +10,18 @@ namespace DI;
 
 if (!function_exists("\DI\object")) {
 
-    function object()
+    function object(...$params)
     {
-        return call_user_func_array("\Piwik\DI::autowire", func_get_args());
+        return \Piwik\DI::autowire(...$params);
     }
 
 }
 
 if (!function_exists("\DI\link")) {
 
-    function link()
+    function link(...$params)
     {
-        return call_user_func_array("\Piwik\DI::get", func_get_args());
+        return \Piwik\DI::get(...$params);
     }
 
 }

--- a/core/Common.php
+++ b/core/Common.php
@@ -70,13 +70,13 @@ class Common
     /**
      * Returns an array containing the prefixed table names of every passed argument.
      *
-     * @param string ... The table names to prefix, ie "log_visit"
+     * @param string ...$tables The table names to prefix, ie "log_visit"
      * @return array The prefixed names in an array.
      */
-    public static function prefixTables()
+    public static function prefixTables(...$tables)
     {
         $result = array();
-        foreach (func_get_args() as $table) {
+        foreach ($tables as $table) {
             $result[] = self::prefixTable($table);
         }
         return $result;

--- a/core/DataAccess/ArchivingDbAdapter.php
+++ b/core/DataAccess/ArchivingDbAdapter.php
@@ -44,52 +44,52 @@ class ArchivingDbAdapter
         return call_user_func_array([$this->wrapped, $name], $arguments);
     }
 
-    public function exec($sql)
+    public function exec($sql, ...$params)
     {
         $sql = DbHelper::addMaxExecutionTimeHintToQuery($sql, $this->maxExecutionTime);
         $this->logSql($sql);
 
-        return call_user_func_array([$this, "callFunction"], array_merge([__FUNCTION__], func_get_args()));
+        return $this->callFunction(__FUNCTION__, $sql, ...$params);
     }
 
-    public function query($sql)
+    public function query($sql, ...$params)
     {
         $sql = DbHelper::addMaxExecutionTimeHintToQuery($sql, $this->maxExecutionTime);
         $this->logSql($sql);
 
-        return call_user_func_array([$this, "callFunction"], array_merge([__FUNCTION__], func_get_args()));
+        return $this->callFunction(__FUNCTION__, $sql, ...$params);
     }
 
-    public function fetchAll($sql)
+    public function fetchAll($sql, ...$params)
     {
         $sql = DbHelper::addMaxExecutionTimeHintToQuery($sql, $this->maxExecutionTime);
         $this->logSql($sql);
 
-        return call_user_func_array([$this, "callFunction"], array_merge([__FUNCTION__], func_get_args()));
+        return $this->callFunction(__FUNCTION__, $sql, ...$params);
     }
 
-    public function fetchRow($sql)
+    public function fetchRow($sql, ...$params)
     {
         $sql = DbHelper::addMaxExecutionTimeHintToQuery($sql, $this->maxExecutionTime);
         $this->logSql($sql);
 
-        return call_user_func_array([$this, "callFunction"], array_merge([__FUNCTION__], func_get_args()));
+        return $this->callFunction(__FUNCTION__, $sql, ...$params);
     }
 
-    public function fetchOne($sql)
+    public function fetchOne($sql, ...$params)
     {
         $sql = DbHelper::addMaxExecutionTimeHintToQuery($sql, $this->maxExecutionTime);
         $this->logSql($sql);
 
-        return call_user_func_array([$this, "callFunction"], array_merge([__FUNCTION__], func_get_args()));
+        return $this->callFunction(__FUNCTION__, $sql, ...$params);
     }
 
-    public function fetchAssoc($sql)
+    public function fetchAssoc($sql, ...$params)
     {
         $sql = DbHelper::addMaxExecutionTimeHintToQuery($sql, $this->maxExecutionTime);
         $this->logSql($sql);
 
-        return call_user_func_array([$this, "callFunction"], array_merge([__FUNCTION__], func_get_args()));
+        return $this->callFunction(__FUNCTION__, $sql, ...$params);
     }
 
     /**
@@ -112,10 +112,7 @@ class ArchivingDbAdapter
         }
     }
 
-    private function callFunction($function) {
-
-        $args = func_get_args();
-        unset($args[0]);
+    private function callFunction($function, ...$args) {
 
         try {
             return call_user_func_array([$this->wrapped, $function], $args);

--- a/core/Log.php
+++ b/core/Log.php
@@ -120,75 +120,75 @@ class Log extends Singleton
      * Logs a message using the ERROR log level.
      *
      * @param string $message The log message. This can be a sprintf format string.
-     * @param ... mixed Optional sprintf params.
+     * @param mixed ...$printFparams Optional sprintf params.
      * @api
      *
      * @deprecated Inject and call Piwik\Log\LoggerInterface::error() instead.
      * @see \Piwik\Log\LoggerInterface::error()
      */
-    public static function error($message /* ... */)
+    public static function error($message, ...$printFparams)
     {
-        self::logMessage(Logger::ERROR, $message, array_slice(func_get_args(), 1));
+        self::logMessage(Logger::ERROR, $message, $printFparams);
     }
 
     /**
      * Logs a message using the WARNING log level.
      *
      * @param string $message The log message. This can be a sprintf format string.
-     * @param ... mixed Optional sprintf params.
+     * @param mixed ...$printFparams Optional sprintf params.
      * @api
      *
      * @deprecated Inject and call Piwik\Log\LoggerInterface::warning() instead.
      * @see \Piwik\Log\LoggerInterface::warning()
      */
-    public static function warning($message /* ... */)
+    public static function warning($message, ...$printFparams)
     {
-        self::logMessage(Logger::WARNING, $message, array_slice(func_get_args(), 1));
+        self::logMessage(Logger::WARNING, $message, $printFparams);
     }
 
     /**
      * Logs a message using the INFO log level.
      *
      * @param string $message The log message. This can be a sprintf format string.
-     * @param ... mixed Optional sprintf params.
+     * @param mixed ...$printFparams Optional sprintf params.
      * @api
      *
      * @deprecated Inject and call Piwik\Log\LoggerInterface::info() instead.
      * @see \Piwik\Log\LoggerInterface::info()
      */
-    public static function info($message /* ... */)
+    public static function info($message, ...$printFparams)
     {
-        self::logMessage(Logger::INFO, $message, array_slice(func_get_args(), 1));
+        self::logMessage(Logger::INFO, $message, $printFparams);
     }
 
     /**
      * Logs a message using the DEBUG log level.
      *
      * @param string $message The log message. This can be a sprintf format string.
-     * @param ... mixed Optional sprintf params.
+     * @param mixed ...$printFparams Optional sprintf params.
      * @api
      *
      * @deprecated Inject and call Piwik\Log\LoggerInterface::debug() instead.
      * @see \Piwik\Log\LoggerInterface::debug()
      */
-    public static function debug($message /* ... */)
+    public static function debug($message, ...$printFparams)
     {
-        self::logMessage(Logger::DEBUG, $message, array_slice(func_get_args(), 1));
+        self::logMessage(Logger::DEBUG, $message, $printFparams);
     }
 
     /**
      * Logs a message using the VERBOSE log level.
      *
      * @param string $message The log message. This can be a sprintf format string.
-     * @param ... mixed Optional sprintf params.
+     * @param mixed ...$printFparams Optional sprintf params.
      * @api
      *
      * @deprecated Inject and call Piwik\Log\LoggerInterface::debug() instead (the verbose level doesn't exist in the PSR standard).
      * @see \Piwik\Log\LoggerInterface::debug()
      */
-    public static function verbose($message /* ... */)
+    public static function verbose($message, ...$printFparams)
     {
-        self::logMessage(Logger::DEBUG, $message, array_slice(func_get_args(), 1));
+        self::logMessage(Logger::DEBUG, $message, $printFparams);
     }
 
     private function doLog($level, $message, $parameters = array())
@@ -209,7 +209,7 @@ class Log extends Singleton
         $this->logger->log($level, $message, $parameters);
     }
 
-    private static function logMessage($level, $message, $parameters)
+    private static function logMessage($level, $message, array $parameters)
     {
         self::getInstance()->doLog($level, $message, $parameters);
     }

--- a/core/Visualization/Sparkline.php
+++ b/core/Visualization/Sparkline.php
@@ -43,11 +43,11 @@ class Sparkline implements ViewInterface
 
     /**
      * Array with format: array( x, y, z, ... )
-     * @param array $data,...
+     * @param array ...$data
      */
-    public function setValues()
+    public function setValues(...$data)
     {
-        $this->serieses = func_get_args();
+        $this->serieses = $data;
     }
 
     public function addSeries(array $values)

--- a/plugins/SitesManager/tests/Integration/SiteUrlsTest.php
+++ b/plugins/SitesManager/tests/Integration/SiteUrlsTest.php
@@ -312,9 +312,9 @@ class SiteUrlsTest extends IntegrationTestCase
         $this->assertEquals($expectedUrls, $urls);
     }
 
-    private function addSite($urls)
+    private function addSite(...$urls)
     {
-        $this->api->addSite('siteName', func_get_args());
+        $this->api->addSite('siteName', $urls);
     }
 
     private function assertValueInCache($value)


### PR DESCRIPTION
### Description:

the more explicit form is easier to read and static analysis tooling friendly

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
