### PR TITLE
Update the font cache buster parameter

### DIFF
--- a/plugins/Morpheus/stylesheets/base/icons.css
+++ b/plugins/Morpheus/stylesheets/base/icons.css
@@ -1,10 +1,10 @@
 @font-face {
   font-family: 'matomo';
   src:
-          url('plugins/Morpheus/fonts/matomo.woff2?rjeutj') format('woff2'),
-          url('plugins/Morpheus/fonts/matomo.woff?rjeutj') format('woff'),
-          url('plugins/Morpheus/fonts/matomo.ttf?rjeutj') format('truetype'),
-          url('plugins/Morpheus/fonts/matomo.svg?rjeutj#matomo') format('svg');
+          url('plugins/Morpheus/fonts/matomo.woff2?rzeu9j') format('woff2'),
+          url('plugins/Morpheus/fonts/matomo.woff?rzeu9j') format('woff'),
+          url('plugins/Morpheus/fonts/matomo.ttf?rzeu9j') format('truetype'),
+          url('plugins/Morpheus/fonts/matomo.svg?rzeu9j#matomo') format('svg');
   font-weight: normal;
   font-style: normal;
   font-display: block;


### PR DESCRIPTION
### Description:

Recent changes have added new glyphs to the Matomo icon font, this PR updates the cache buster parameter in the icons stylesheet to invalidate any browser font caching and make sure the updated font is used.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
