### PR TITLE
Improve image graph axis display in email reports

### DIFF
--- a/plugins/ImageGraph/API.php
+++ b/plugins/ImageGraph/API.php
@@ -139,7 +139,7 @@ class API extends \Piwik\Plugin\API
         }
 
         $useUnicodeFont = array(
-            'am', 'ar', 'el', 'fa', 'fi', 'fr', 'he', 'ja', 'ka', 'ko', 'te', 'th', 'zh-cn', 'zh-tw',
+            'am', 'ar', 'el', 'fa', 'fi', 'he', 'ja', 'ka', 'ko', 'te', 'th', 'zh-cn', 'zh-tw',
         );
         $languageLoaded = StaticContainer::get('Piwik\Translation\Translator')->getCurrentLanguage();
         $font = self::getFontPath(self::DEFAULT_FONT);

--- a/plugins/ImageGraph/API.php
+++ b/plugins/ImageGraph/API.php
@@ -139,7 +139,7 @@ class API extends \Piwik\Plugin\API
         }
 
         $useUnicodeFont = array(
-            'am', 'ar', 'el', 'fa', 'fi', 'he', 'ja', 'ka', 'ko', 'te', 'th', 'zh-cn', 'zh-tw',
+            'am', 'ar', 'el', 'fa', 'fi', 'fr', 'he', 'ja', 'ka', 'ko', 'te', 'th', 'zh-cn', 'zh-tw',
         );
         $languageLoaded = StaticContainer::get('Piwik\Translation\Translator')->getCurrentLanguage();
         $font = self::getFontPath(self::DEFAULT_FONT);

--- a/plugins/ImageGraph/StaticGraph.php
+++ b/plugins/ImageGraph/StaticGraph.php
@@ -401,5 +401,6 @@ function formatYAxis($value)
  */
 function formatYAxisNonUnifont($value)
 {
-    return str_replace("\xE2\x80\xAF", " ", NumberFormatter::getInstance()->format($value));
+    // Replace any narrow non-breaking spaces with non-breaking spaces as some fonts may not support it
+    return str_replace("\xE2\x80\xAF", "\xC2\xA0", NumberFormatter::getInstance()->format($value));
 }

--- a/plugins/ImageGraph/StaticGraph.php
+++ b/plugins/ImageGraph/StaticGraph.php
@@ -248,7 +248,12 @@ abstract class StaticGraph extends BaseFactory
             }
         }
 
-        $this->pData->setAxisDisplay(0, AXIS_FORMAT_CUSTOM, '\\Piwik\\Plugins\\ImageGraph\\formatYAxis');
+        // Use a different formating method if not using unifont
+        $formatMethodName = 'formatYAxis';
+        if (strpos($this->font, 'unifont') === false) {
+            $formatMethodName = 'formatYAxisNonUnifont';
+        }
+        $this->pData->setAxisDisplay(0, AXIS_FORMAT_CUSTOM, '\\Piwik\\Plugins\\ImageGraph\\' . $formatMethodName);
 
         $this->pData->addPoints($this->abscissaSeries, self::ABSCISSA_SERIE_NAME);
         $this->pData->setAbscissa(self::ABSCISSA_SERIE_NAME);
@@ -376,7 +381,7 @@ abstract class StaticGraph extends BaseFactory
 }
 
 /**
- * Global format method
+ * Global format method - unifont
  *
  * required to format y axis values using CpChart internal format callbacks
  * @param $value
@@ -385,4 +390,16 @@ abstract class StaticGraph extends BaseFactory
 function formatYAxis($value)
 {
     return NumberFormatter::getInstance()->format($value);
+}
+
+/**
+ * Global format method - non-unifont
+ *
+ * required to format y axis values using CpChart internal format callbacks
+ * @param $value
+ * @return mixed
+ */
+function formatYAxisNonUnifont($value)
+{
+    return str_replace("\xE2\x80\xAF", " ", NumberFormatter::getInstance()->format($value));
 }

--- a/plugins/ImageGraph/StaticGraph/GridGraph.php
+++ b/plugins/ImageGraph/StaticGraph/GridGraph.php
@@ -22,10 +22,10 @@ abstract class GridGraph extends StaticGraph
 
     const DEFAULT_TICK_ALPHA = 20;
     const DEFAULT_SERIE_WEIGHT = 0.5;
-    const LEFT_GRID_MARGIN = 4;
+    const LEFT_GRID_MARGIN = 20;
     const BOTTOM_GRID_MARGIN = 10;
-    const TOP_GRID_MARGIN_HORIZONTAL_GRAPH = 1;
-    const RIGHT_GRID_MARGIN_HORIZONTAL_GRAPH = 4;
+    const TOP_GRID_MARGIN_HORIZONTAL_GRAPH = 10;
+    const RIGHT_GRID_MARGIN_HORIZONTAL_GRAPH = 20;
     const OUTER_TICK_WIDTH = 5;
     const INNER_TICK_WIDTH = 0;
     const LABEL_SPACE_VERTICAL_GRAPH = 7;
@@ -33,7 +33,7 @@ abstract class GridGraph extends StaticGraph
     const HORIZONTAL_LEGEND_TOP_MARGIN = 5;
     const HORIZONTAL_LEGEND_LEFT_MARGIN = 10;
     const HORIZONTAL_LEGEND_BOTTOM_MARGIN = 10;
-    const VERTICAL_LEGEND_TOP_MARGIN = 8;
+    const VERTICAL_LEGEND_TOP_MARGIN = 10;
     const VERTICAL_LEGEND_LEFT_MARGIN = 6;
     const VERTICAL_LEGEND_MAX_WIDTH_PCT = 0.70;
     const LEGEND_LINE_BULLET_WIDTH = 14;
@@ -358,7 +358,7 @@ abstract class GridGraph extends StaticGraph
         if ($horizontalGraph) {
             $topMargin = $ordinateMaxHeight + self::TOP_GRID_MARGIN_HORIZONTAL_GRAPH + self::OUTER_TICK_WIDTH;
         } else {
-            $topMargin = $ordinateMaxHeight / 2;
+            $topMargin = $ordinateMaxHeight / 2 + self::TOP_GRID_MARGIN_HORIZONTAL_GRAPH;
         }
 
         if ($this->showLegend && !$verticalLegend) {
@@ -398,7 +398,7 @@ abstract class GridGraph extends StaticGraph
             list($ordinateMaxWidth, $ordinateMaxHeight) = $this->getMaximumTextWidthHeight($this->ordinateSeries);
             return self::RIGHT_GRID_MARGIN_HORIZONTAL_GRAPH + $ordinateMaxWidth;
         } else {
-            return 0;
+            return self::RIGHT_GRID_MARGIN_HORIZONTAL_GRAPH;
         }
     }
 

--- a/plugins/ImageGraph/tests/UI/ImageGraph_spec.js
+++ b/plugins/ImageGraph/tests/UI/ImageGraph_spec.js
@@ -10,6 +10,11 @@
 describe("ImageGraph", function () {
     this.timeout(0);
 
+    before(function () {
+        testEnvironment.multiplicateTableResults = 169856;
+        testEnvironment.save();
+    });
+
     function getImageGraphUrl(apiModule, apiAction, graphType, period, date) {
         return "index.php?module=API&method=ImageGraph.get&idSite=1&width=500&height=250&apiModule=" + apiModule + "&apiAction=" + apiAction
              + "&graphType=" + graphType + "&period=" + period + "&date=" + date;

--- a/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_evolution_graph.png
+++ b/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_evolution_graph.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f81b1118d44f7adecc784b54f4b22060403f9acb83c2a2616214ae01d5120d3b
-size 12980
+oid sha256:89d4d8d484c9c14f802dca4f3f3dc3421d245fd9b982cb41a6b8977d50a96f77
+size 12568

--- a/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_evolution_graph.png
+++ b/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_evolution_graph.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89d4d8d484c9c14f802dca4f3f3dc3421d245fd9b982cb41a6b8977d50a96f77
-size 12568
+oid sha256:106ef366a106fa05c46aaddc5b0c1f2b966b6d2fb3666a26e5fb6cbe6e92b091
+size 13371

--- a/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_horizontal_bar.png
+++ b/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_horizontal_bar.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dfdd3e31d772e3cf624519dde4ac4d7088bd5371d78e5de3ff3bfd6fa2442668
-size 16015
+oid sha256:8901f6690c21dbd009318875613b92e1d503cdf0baaf979b4940b42473894619
+size 17354

--- a/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_horizontal_bar.png
+++ b/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_horizontal_bar.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15e259bc5d40c8c0f5e8fca3cbda446d44b898183b81e292bc23fdd4420ff646
-size 16027
+oid sha256:dfdd3e31d772e3cf624519dde4ac4d7088bd5371d78e5de3ff3bfd6fa2442668
+size 16015

--- a/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_vertical_bar.png
+++ b/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_vertical_bar.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d30798aaacd2e3856b5601525f7ff1cbfdc76f98b583f59e8bb3bac7c9cc287
-size 7554
+oid sha256:ef94dc9390a72543f2f1effa33c1d8a0a10fe8608372915053f7f96e904aac74
+size 7727

--- a/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_vertical_bar.png
+++ b/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_vertical_bar.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca29b9fe3d652b6bce68d4a0393e72b90964a74e99cfc09732c7997b0aebdb21
-size 7474
+oid sha256:6d30798aaacd2e3856b5601525f7ff1cbfdc76f98b583f59e8bb3bac7c9cc287
+size 7554

--- a/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
@@ -13,6 +13,8 @@ use Piwik\Application\EnvironmentManipulator;
 use Piwik\Application\Kernel\GlobalSettingsProvider;
 use Piwik\Application\Kernel\PluginList;
 use Piwik\Config;
+use Piwik\DataTable;
+use Piwik\DataTable\DataTableInterface;
 use Piwik\DbHelper;
 use Piwik\Option;
 use Piwik\Plugin;
@@ -202,6 +204,28 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
                 return $config;
             }),
         );
+
+        if (!empty($this->vars->multiplicateTableResults)) {
+            $diConfigs[] = [
+                'observers.global' => \Piwik\DI::add([
+                    ['API.Request.dispatch.end', \Piwik\DI::value(function($returnedValue) {
+                        if ($returnedValue instanceof DataTableInterface) {
+                            $returnedValue->filter(function(DataTable $dataTable) {
+                                foreach ($dataTable->getRows() as $row) {
+                                    $columns = $row->getColumns();
+                                    foreach($columns as $name => &$value) {
+                                        if ($name !== 'label' && is_numeric($value)) {
+                                            $value *= $this->vars->multiplicateTableResults;
+                                        }
+                                    }
+                                    $row->setColumns($columns);
+                                }
+                            });
+                        }
+                    })
+                ]])
+            ];
+        }
 
         return $diConfigs;
     }


### PR DESCRIPTION
### Description:

Fixes #17747 

When using the :fr: French language locale, numbers with thousand separators are shown with boxes instead of the expected separator. This is because the number formatter is using a [narrow non-breaking space](https://codepoints.net/U+202F) (NNBSP) as the thousand separator which is not supported by all fonts.

![graph-font-before](https://github.com/matomo-org/matomo/assets/88810029/e01407db-5907-402a-b2cc-e9e247be48e5)

This PR makes the following changes to image graphs:
 - If the [unifont](https://matomo.org/faq/how-to-install/faq_142/) is available then it will be used for French and the NNBSP will be shown correctly.
 - If the unifont is not available, then the narrow non-breaking space character will be replaced with a normal space so it displays correctly.
 - Graph margins have been increased to avoid clipping the axis labels when using the unifont.

This is the same report using unifont:
![graph-font-after-unifont](https://github.com/matomo-org/matomo/assets/88810029/a217e6ec-ce47-489b-9184-1e09ce2ddcfe)

And again without unifont:
![graph-font-after-no-unifont](https://github.com/matomo-org/matomo/assets/88810029/005a6c6f-e815-41f2-ad21-85c2f78cb976)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
