### PR TITLE
do not send pretty label to row evolution request for actions tables

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable_rowactions.js
+++ b/plugins/CoreHome/javascripts/dataTable_rowactions.js
@@ -325,7 +325,7 @@ DataTable_RowActions_RowEvolution.prototype.performAction = function (label, tr,
         }
     } else {
       var labelPretty = this.getPrettyLabel(originalRow || tr);
-      if (labelPretty != label) {
+      if (labelPretty && labelPretty != label) {
         extraParams['labelPretty'] = labelPretty;
       }
     }
@@ -369,6 +369,10 @@ DataTable_RowActions_RowEvolution.prototype.performAction = function (label, tr,
 };
 
 DataTable_RowActions_RowEvolution.prototype.getPrettyLabel = function getPrettyLabel(tr) {
+  if (tr.closest('.dataTableActions').length) {
+    return null; // actions tables don't need to override the pretty label, since they should not have a custom row identifier
+  }
+
   var prettyLabel = [];
 
   var row = $(tr);
@@ -402,7 +406,7 @@ DataTable_RowActions_RowEvolution.prototype.addMultiEvolutionRow = function (lab
 
         if (!found) {
             this.multiEvolutionRows.push(label);
-            this.multiEvolutionRowsPretty.push(this.getPrettyLabel(tr))
+            this.multiEvolutionRowsPretty.push(this.getPrettyLabel(tr));
             this.multiEvolutionRowsSeries.push(seriesIndex);
         }
     } else if ($.inArray(label, this.multiEvolutionRows) === -1) {


### PR DESCRIPTION
### Description:

Fixes an issue caused by https://github.com/matomo-org/matomo/pull/20009. For ActionsDataTables there are no nested `<table>` elements so `getPrettyLabel()` fails to take into account parent tables. ActionsDataTables, unlike other reports, shouldn't have a unique row identifier property on them, so we don't need to send a custom pretty label from the client JS.

Note: the bug can be seen in the UI tests for MediaAnalytics.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
