### PR TITLE
Load clientside translation strings during installation

### DIFF
--- a/plugins/Installation/templates/layout.twig
+++ b/plugins/Installation/templates/layout.twig
@@ -9,7 +9,7 @@
     <script>window.piwik = {installation: true};</script>
     <link rel="stylesheet" type="text/css" href="index.php?module=Installation&action=getInstallationCss"/>
     <script type="text/javascript" src="index.php?module=Installation&action=getInstallationJs"></script>
-
+    <script type="text/javascript">{{ getJavascriptTranslations()|raw }}</script>
     <link rel="shortcut icon" href="plugins/CoreHome/images/favicon.png"/>
 </head>
 <body ng-app="app" id="installation">


### PR DESCRIPTION
### Description:

The copy to clipboard button uses the vue translate function to translate UI strings, this depends on the translation strings being loaded via javascript which does not happen by default in the installation plugin.

This resulted in no translated text being shown for the copy to clipboard button:

![image](https://github.com/matomo-org/matomo/assets/88810029/713f3597-e07c-4f64-b4dd-d74b15026288)

This PR simply adds a call to the existing `getJavascriptTranslations()` twig method to the main installation template to make sure the translation string are always loaded.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
