### PR TITLE
Github action to check that the font cachebuster was updated

### DIFF
--- a/.github/workflows/update-font.yml
+++ b/.github/workflows/update-font.yml
@@ -34,5 +34,5 @@ jobs:
            echo "::error Font cachebuster parameter not updated see https://developer.matomo.org/guides/matomo-font"
            exit 1
          else
-          exit 0
+           exit 0
          fi

--- a/.github/workflows/update-font.yml
+++ b/.github/workflows/update-font.yml
@@ -6,7 +6,6 @@ name: Font update check
 
 on:
   pull_request_target:
-    types: [opened, reopened]
     paths:
       - 'plugins/Morpheus/fonts/matomo.woff2'
 
@@ -29,7 +28,7 @@ jobs:
      - uses: actions/checkout@v3
      - name: Compare stylesheet to base branch
        run: |
-         if [[ $(wget -O - -o /dev/null https://raw.githubusercontent.com/matomo-org/matomo/$GITHUB_BASE_REF/plugins/Morpheus/stylesheets/base/icons.css | sed '4q;d') == $(sed '4q;d' plugins/Morpheus/stylesheets/base/icons.css) ]]
+         if [[ $(wget -O - -o /dev/null https://raw.githubusercontent.com/matomo-org/matomo/$GITHUB_BASE_REF/plugins/Morpheus/stylesheets/base/icons.css | grep -m1  -- 'plugins/Morpheus/fonts/matomo.woff2?') == $(grep -m1  -- 'plugins/Morpheus/fonts/matomo.woff2?' plugins/Morpheus/stylesheets/base/icons.css) ]]
          then
            echo "::error Font cachebuster parameter not updated see https://developer.matomo.org/guides/matomo-font"
            exit 1

--- a/.github/workflows/update-font.yml
+++ b/.github/workflows/update-font.yml
@@ -27,11 +27,12 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
      - uses: actions/checkout@v3
-         run: |
-           if [[ $(wget -O - -o /dev/null https://raw.githubusercontent.com/matomo-org/matomo/$GITHUB_BASE_REF/plugins/Morpheus/stylesheets/base/icons.css | sed '4q;d') == $(sed>
-           then
-             echo "::error Font cachebuster paramater not updated see https://developer.matomo.org/guides/matomo-font"
-             exit 1
-           else
-            exit 0
-           fi
+     - name: Compare stylesheet to base branch
+       run: |
+         if [[ $(wget -O - -o /dev/null https://raw.githubusercontent.com/matomo-org/matomo/$GITHUB_BASE_REF/plugins/Morpheus/stylesheets/base/icons.css | sed '4q;d') == $(sed>
+         then
+           echo "::error Font cachebuster paramater not updated see https://developer.matomo.org/guides/matomo-font"
+           exit 1
+         else
+          exit 0
+         fi

--- a/.github/workflows/update-font.yml
+++ b/.github/workflows/update-font.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
      - uses: actions/checkout@v3
-         bash:
+         run: |
            if [[ $(wget -O - -o /dev/null https://raw.githubusercontent.com/matomo-org/matomo/$GITHUB_BASE_REF/plugins/Morpheus/stylesheets/base/icons.css | sed '4q;d') == $(sed>
            then
              echo "::error Font cachebuster paramater not updated see https://developer.matomo.org/guides/matomo-font"

--- a/.github/workflows/update-font.yml
+++ b/.github/workflows/update-font.yml
@@ -5,9 +5,10 @@ name: Font update check
 # **Who does it impact**: Any PR which changes the font file
 
 on:
-  pull_request_target:
+  pull_request:
+    types: [synchronize, opened]
     paths:
-      - 'plugins/Morpheus/fonts/matomo.woff2'
+      - 'plugins/Morpheus/fonts/matomo.*'
 
 permissions:
   actions: read
@@ -30,7 +31,8 @@ jobs:
        run: |
          if [[ $(wget -O - -o /dev/null https://raw.githubusercontent.com/matomo-org/matomo/$GITHUB_BASE_REF/plugins/Morpheus/stylesheets/base/icons.css | grep -m1  -- "format('woff2')") == $(grep -m1  -- "format('woff2')" plugins/Morpheus/stylesheets/base/icons.css) ]]
          then
-           echo "::error Font cachebuster parameter not updated see https://developer.matomo.org/guides/matomo-font"
+           line=$(grep -n "format('woff2')" plugins/Morpheus/stylesheets/base/icons.css | cut -f1 -d:)
+           echo "::error file=plugins/Morpheus/stylesheets/base/icons.css,line=$line::Font cachebuster parameter not updated. See https://developer.matomo.org/guides/matomo-font"
            exit 1
          else
            exit 0

--- a/.github/workflows/update-font.yml
+++ b/.github/workflows/update-font.yml
@@ -29,9 +29,9 @@ jobs:
      - uses: actions/checkout@v3
      - name: Compare stylesheet to base branch
        run: |
-         if [[ $(wget -O - -o /dev/null https://raw.githubusercontent.com/matomo-org/matomo/$GITHUB_BASE_REF/plugins/Morpheus/stylesheets/base/icons.css | sed '4q;d') == $(sed>
+         if [[ $(wget -O - -o /dev/null https://raw.githubusercontent.com/matomo-org/matomo/$GITHUB_BASE_REF/plugins/Morpheus/stylesheets/base/icons.css | sed '4q;d') == $(sed '4q;d' plugins/Morpheus/stylesheets/base/icons.css) ]]
          then
-           echo "::error Font cachebuster paramater not updated see https://developer.matomo.org/guides/matomo-font"
+           echo "::error Font cachebuster parameter not updated see https://developer.matomo.org/guides/matomo-font"
            exit 1
          else
           exit 0

--- a/.github/workflows/update-font.yml
+++ b/.github/workflows/update-font.yml
@@ -28,7 +28,7 @@ jobs:
      - uses: actions/checkout@v3
      - name: Compare stylesheet to base branch
        run: |
-         if [[ $(wget -O - -o /dev/null https://raw.githubusercontent.com/matomo-org/matomo/$GITHUB_BASE_REF/plugins/Morpheus/stylesheets/base/icons.css | grep -m1  -- 'plugins/Morpheus/fonts/matomo.woff2?') == $(grep -m1  -- 'plugins/Morpheus/fonts/matomo.woff2?' plugins/Morpheus/stylesheets/base/icons.css) ]]
+         if [[ $(wget -O - -o /dev/null https://raw.githubusercontent.com/matomo-org/matomo/$GITHUB_BASE_REF/plugins/Morpheus/stylesheets/base/icons.css | grep -m1  -- "format('woff2')") == $(grep -m1  -- "format('woff2')" plugins/Morpheus/stylesheets/base/icons.css) ]]
          then
            echo "::error Font cachebuster parameter not updated see https://developer.matomo.org/guides/matomo-font"
            exit 1

--- a/.github/workflows/update-font.yml
+++ b/.github/workflows/update-font.yml
@@ -1,0 +1,37 @@
+name: Font update check
+
+# **What it does**: Checks that the font cachebuster parameter has been updated if the font file has changed
+# **Why we have it**: To make sure that browser font caching is invalidated and the updated font is used
+# **Who does it impact**: Any PR which changes the font file
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    paths:
+      - 'plugins/Morpheus/fonts/matomo.woff2'
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  deployments: none
+  issues: read
+  packages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: read
+
+jobs:
+  check:
+    runs-on: "ubuntu-latest"
+    steps:
+     - uses: actions/checkout@v3
+         bash:
+           if [[ $(wget -O - -o /dev/null https://raw.githubusercontent.com/matomo-org/matomo/$GITHUB_BASE_REF/plugins/Morpheus/stylesheets/base/icons.css | sed '4q;d') == $(sed>
+           then
+             echo "::error Font cachebuster paramater not updated see https://developer.matomo.org/guides/matomo-font"
+             exit 1
+           else
+            exit 0
+           fi


### PR DESCRIPTION
### Description:

Fixes #20991

This is a simple github action to check that the font cachebuster parameter was updated whenever the Matomo font file has changed. It's pretty basic implementation using sed and wget.

If the font has been updated then it will compare the Matomo font URL line from the icons stylesheet in the PR branch against the base branch, if they are the same (ie. not updated) then the check will fail.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
