### PR TITLE
Fix for row labels sometimes disappearing when double clicked in table report

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -496,8 +496,11 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             if (allColumns > 2 * firstTableColumn) {
                 amount = 2 * firstTableColumn;
             }
-
-            return parseInt(labelWidth / amount, 10);
+            var newWidth = parseInt(labelWidth / amount, 10)
+            if (newWidth == 0) {
+                newWidth = minLabelWidth; // fallback to the minimum width if zero
+            }
+            return newWidth;
         }
 
         function getLabelColumnMinWidth(domElem)

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -498,7 +498,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             }
             var newWidth = parseInt(labelWidth / amount, 10)
             if (newWidth == 0) {
-                newWidth = minLabelWidth; // fallback to the minimum width if zero
+                newWidth = maxLabelWidth; // fallback to the maximum width if zero
             }
             return newWidth;
         }


### PR DESCRIPTION
### Description:

Fixes #20894 

This can take a bit of time to recreate, I used the event report and clicked repeatedly on the first label to expand and collapse it:
![image](https://github.com/matomo-org/matomo/assets/88810029/d0ab8e5a-aafc-4e66-9bd1-ec0f70a4ba58)

Eventually the label disappears:
![image](https://github.com/matomo-org/matomo/assets/88810029/39d7c117-058e-480e-a03f-f8f99cd0b2c4)

The label is disappearing because the column width is being set to zero by the `resizeDataTable()` event, a minimum label size is passed to `getLabelWidth()` but this method sometimes incorrectly calculates a zero width value from existing DOM elements. I suspect that this could be race condition between the row collapse and resize table events.

This PR adds a check to the `getLabelWidth()` method to prevent zero values being returned and instead falls back to the passed `minLabelWidth` value. After this change I was no longer able to recreate the issue, despite much clicking.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
