### PR TITLE
Prevent leaking backend user IP address to plugins.matomo.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
       * For progress bars use the methods `initProgressBar`, `startProgressBar`, `advanceProgressBar` and `finishProgressBar`
       * Tables can be rendered using the new method `renderTable`
     * For executing another command within your command use the new method `runCommand`
+* Requests sent by Matomo to plugins.matomo.org will no longer include an `HTTP_X_FORWARDED_FOR` header containing the current user's IP address. If you use an outbound proxy rule that used this header to allow access for Matomo then it should be replaced with rule allowing access by IP and/or URL.    
 
 ### New APIs
 

--- a/core/Http.php
+++ b/core/Http.php
@@ -250,11 +250,6 @@ class Http
             $requestBodyQuery = $requestBody;
         }
 
-        // Piwik services behave like a proxy, so we should act like one.
-        $xff = 'X-Forwarded-For: '
-            . (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && !empty($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] . ',' : '')
-            . IP::getIpFromHeader();
-
         if (empty($userAgent)) {
             $userAgent = self::getUserAgent();
         }
@@ -291,9 +286,9 @@ class Http
             'body' => $requestBody,
             'userAgent' => $userAgent,
             'timeout' => $timeout,
-            'headers' => array_map('trim', array_filter(array_merge(array(
-                $rangeHeader, $via, $xff, $httpAuth, $acceptLanguage
-            ), $additionalHeaders))),
+            'headers' => array_map('trim', array_filter(array_merge([
+                $rangeHeader, $via, $httpAuth, $acceptLanguage
+            ], $additionalHeaders))),
             'verifySsl' => !$acceptInvalidSslCertificate,
             'destinationPath' => $destinationPath
         );

--- a/core/Http.php
+++ b/core/Http.php
@@ -398,7 +398,6 @@ class Http
                 . ($proxyAuth ? $proxyAuth : '')
                 . 'User-Agent: ' . $userAgent . "\r\n"
                 . ($acceptLanguage ? $acceptLanguage . "\r\n" : '')
-                . $xff . "\r\n"
                 . $via . "\r\n"
                 . $rangeHeader
                 . (!empty($additionalHeaders) ? implode("\r\n", $additionalHeaders) . "\r\n" : '')
@@ -560,7 +559,6 @@ class Http
                         'header'        => 'User-Agent: ' . $userAgent . "\r\n"
                             . ($httpAuth ? $httpAuth : '')
                             . ($acceptLanguage ? $acceptLanguage . "\r\n" : '')
-                            . $xff . "\r\n"
                             . $via . "\r\n"
                             . (!empty($additionalHeaders) ? implode("\r\n", $additionalHeaders) . "\r\n" : '')
                             . $rangeHeader,
@@ -645,7 +643,6 @@ class Http
                 CURLOPT_URL            => $aUrl,
                 CURLOPT_USERAGENT      => $userAgent,
                 CURLOPT_HTTPHEADER     => array_merge(array(
-                    $xff,
                     $via,
                     $acceptLanguage
                 ), $additionalHeaders),

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -399,7 +399,6 @@ class HttpTest extends \PHPUnit\Framework\TestCase
             'headers' => array(
                 'Range: bytes=10-20',
                 'Via: ' . Version::VERSION . '  (Matomo/' . Version::VERSION . ')',
-                'X-Forwarded-For: 127.0.0.1',
             ),
             'verifySsl' => true,
             'destinationPath' => $destinationPath
@@ -415,7 +414,6 @@ class HttpTest extends \PHPUnit\Framework\TestCase
             'headers' => array(
                 'Range: bytes=10-20',
                 'Via: ' . Version::VERSION . '  (Matomo/' . Version::VERSION . ')',
-                'X-Forwarded-For: 127.0.0.1',
             ),
             'verifySsl' => true,
             'destinationPath' => $destinationPath


### PR DESCRIPTION
### Description:

Fixes #20713 

This PR simply removes the code which modifies the `X-FORWARDED-FOR` header with the current user IP address in the `HTTP` class which prevents the unintentional leaking of the user IP to `plugins.matomo.org`, After analyzing the reason this code was originally added it was determined that it was incorrect to consider Matomo a proxy in this case and that any issues with outbound proxies should be solved at network and not application level.

A breaking change note is included in `changelog.md` to warn anyone using this header for outbound proxies that they may need to update their rules.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
