### PR TITLE
Fix tag cloud visualization failing on formatted values

### DIFF
--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -905,4 +905,19 @@ class Visualization extends ViewDataTable
 
         return $request;
     }
+
+    /**
+     * Apply the metrics formatting filter to the dataset
+     *
+     * This is a workaround to allow visualizations to access unformatted data via format_metrics=0 and then
+     * subsequently apply formatting without needed to reload the dataset or reapply other filters. This method may
+     * be removed in the future.
+     *
+     * @internal
+     */
+    protected function applyMetricsFormatting()
+    {
+        $postProcessor = $this->makeDataTablePostProcessor(); // must be created after requestConfig is final
+        $this->dataTable = $postProcessor->applyMetricsFormatting($this->dataTable);
+    }
 }

--- a/plugins/CoreVisualizations/Visualizations/Cloud.php
+++ b/plugins/CoreVisualizations/Visualizations/Cloud.php
@@ -47,10 +47,11 @@ class Cloud extends Visualization
 
     public function beforeLoadDataTable()
     {
+        $this->requestConfig->request_parameters_to_modify['format_metrics'] = 0;
         $this->checkRequestIsNotForMultiplePeriods();
     }
 
-    public function beforeGenericFiltersAreAppliedToLoadedDataTable()
+    public function afterAllFiltersAreApplied()
     {
         if ($this->dataTable->getRowsCount() == 0) {
             return;

--- a/plugins/CoreVisualizations/Visualizations/Cloud.php
+++ b/plugins/CoreVisualizations/Visualizations/Cloud.php
@@ -50,7 +50,7 @@ class Cloud extends Visualization
         $this->checkRequestIsNotForMultiplePeriods();
     }
 
-    public function afterAllFiltersAreApplied()
+    public function beforeGenericFiltersAreAppliedToLoadedDataTable()
     {
         if ($this->dataTable->getRowsCount() == 0) {
             return;


### PR DESCRIPTION
### Description:

When using the tag cloud data visualization on currency values an error is shown.

`"message":"Unsupported operand types: string \/ string","file":"\/var\/www\/html\/plugins\/CoreVisualizations\/Visualizations\/Cloud.php","line":197,`

This is because the tag cloud is generated after the datatable filters are applied, so when the data includes currency values the visualization fails to compute tag sizes because it cannot parse formatted currency values.

This PR changes the point where the tag cloud data is generated to happen before the metric formatting filters are applied.

Ref PG-2896

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
