### PR TITLE
Use correct login plugin when resetting password link

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -487,9 +487,10 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
         $nonce = Nonce::getNonce(self::NONCE_CONFIRMRESETPASSWORD);
 
-        return $this->renderTemplateAs('confirmResetPassword', [
+        return $this->renderTemplateAs('@Login/confirmResetPassword', [
           'nonce'        => $nonce,
-          'errorMessage' => $errorMessage
+          'errorMessage' => $errorMessage,
+          'loginPlugin' => Piwik::getLoginPluginName(),
         ], 'basic');
     }
 

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -121,6 +121,7 @@ class PasswordResetter
         }
         $this->usersManagerApi = $usersManagerApi;
 
+        $this->confirmPasswordModule = Piwik::getLoginPluginName();
         if (!empty($confirmPasswordModule)) {
             $this->confirmPasswordModule = $confirmPasswordModule;
         }

--- a/plugins/Login/templates/confirmResetPassword.twig
+++ b/plugins/Login/templates/confirmResetPassword.twig
@@ -19,7 +19,7 @@
             </div>
             <br>
 
-            <form action="{{ linkTo({'module': 'Login', 'action': 'confirmResetPassword'}) }}" ng-non-bindable method="post">
+            <form action="{{ linkTo({'module': loginPlugin, 'action': 'confirmResetPassword'}) }}" ng-non-bindable method="post">
                 <div class="row">
                     <div class="col s12 input-field">
                         <input type="hidden" name="nonce" value="{{ nonce }}"/>


### PR DESCRIPTION
### Description:

Use correct login plugin when resetting password link
Fixes: https://github.com/matomo-org/plugin-LoginLdap/issues/340

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
