### PR TITLE
Added "keywords" to the default search keyword parameters

### DIFF
--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -56,7 +56,7 @@ use Piwik\UrlHelper;
  */
 class API extends \Piwik\Plugin\API
 {
-    const DEFAULT_SEARCH_KEYWORD_PARAMETERS = 'q,query,s,search,searchword,k,keyword';
+    const DEFAULT_SEARCH_KEYWORD_PARAMETERS = 'q,query,s,search,searchword,k,keyword,keywords';
     const OPTION_EXCLUDED_IPS_GLOBAL = 'SitesManager_ExcludedIpsGlobal';
     const OPTION_DEFAULT_TIMEZONE = 'SitesManager_DefaultTimezone';
     const OPTION_DEFAULT_CURRENCY = 'SitesManager_DefaultCurrency';

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getSiteSettings.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getSiteSettings.xml
@@ -173,7 +173,7 @@ https://www.example.org/</placeholder>
 				<uiControlAttributes>
 				</uiControlAttributes>
 				<availableValues />
-				<description>Query parameter (Default): q,query,s,search,searchword,k,keyword &amp; Category parameter: </description>
+				<description>Query parameter (Default): q,query,s,search,searchword,k,keyword,keywords &amp; Category parameter: </description>
 				<inlineHelp />
 				<introduction />
 				<condition>1 &amp;&amp; sitesearch</condition>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getAvailableMeasurableTypes.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getAvailableMeasurableTypes.xml
@@ -178,7 +178,7 @@ https://www.example.org/</placeholder>
 						<uiControlAttributes>
 						</uiControlAttributes>
 						<availableValues />
-						<description>Query parameter (Default): q,query,s,search,searchword,k,keyword &amp; Category parameter: </description>
+						<description>Query parameter (Default): q,query,s,search,searchword,k,keyword,keywords &amp; Category parameter: </description>
 						<inlineHelp />
 						<introduction />
 						<condition>1 &amp;&amp; sitesearch</condition>
@@ -483,7 +483,7 @@ https://www.example.org/</placeholder>
 						<uiControlAttributes>
 						</uiControlAttributes>
 						<availableValues />
-						<description>Query parameter (Default): q,query,s,search,searchword,k,keyword &amp; Category parameter: </description>
+						<description>Query parameter (Default): q,query,s,search,searchword,k,keyword,keywords &amp; Category parameter: </description>
 						<inlineHelp />
 						<introduction />
 						<condition>1 &amp;&amp; sitesearch</condition>


### PR DESCRIPTION
### Description:

First time contributor and this is just a little addition, so I didn't read into the entire Matomo docs of how to contribute just yet 😅 
[Contao](https://www.contao.org)'s search engine uses `keywords` instead of `keyword` as a search query parameter so every time we use Matomo, we have to add `keywords` to the list of search query parameters. I don't see why `keyword` is valid but `keywords` would not be 😊 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
