### PR TITLE
Fix for language selection error when updating

### DIFF
--- a/plugins/LanguagesManager/Controller.php
+++ b/plugins/LanguagesManager/Controller.php
@@ -10,11 +10,9 @@
 namespace Piwik\Plugins\LanguagesManager;
 
 use Piwik\Common;
-use Piwik\DbHelper;
 use Piwik\Nonce;
 use Piwik\Piwik;
 use Piwik\Url;
-use Piwik\Updater as PiwikCoreUpdater;
 
 /**
  */
@@ -28,16 +26,6 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
     {
         $language = Common::getRequestVar('language');
         $nonce = Common::getRequestVar('nonce', '');
-
-        // Check if is an update in progress
-        $updater = new PiwikCoreUpdater();
-        $updating = ($updater->getComponentUpdates() !== null);
-
-        // Prevent CSRF if Matomo is not installed yet or is updating
-        // (During install/update user can change language)
-        if (DbHelper::isInstalled() && !$updating) {
-            $this->checkTokenInUrl();
-        }
 
         Nonce::checkNonce(LanguagesManager::LANGUAGE_SELECTION_NONCE, $nonce);
 

--- a/plugins/LanguagesManager/Controller.php
+++ b/plugins/LanguagesManager/Controller.php
@@ -14,6 +14,7 @@ use Piwik\DbHelper;
 use Piwik\Nonce;
 use Piwik\Piwik;
 use Piwik\Url;
+use Piwik\Updater as PiwikCoreUpdater;
 
 /**
  */
@@ -28,8 +29,13 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $language = Common::getRequestVar('language');
         $nonce = Common::getRequestVar('nonce', '');
 
-        // Prevent CSRF only when piwik is not installed yet (During install user can change language)
-        if (DbHelper::isInstalled()) {
+        // Check if is an update in progress
+        $updater = new PiwikCoreUpdater();
+        $updating = ($updater->getComponentUpdates() !== null);
+
+        // Prevent CSRF if Matomo is not installed yet or is updating
+        // (During install/update user can change language)
+        if (DbHelper::isInstalled() && !$updating) {
             $this->checkTokenInUrl();
         }
 


### PR DESCRIPTION
### Description:

Fixes #20960 

This PR disables the CSRF check for the languages manager `saveLanguage` controller method if it is detected that an update is in progress, this allows the language to be changed on the update screen. A similar exclusion already exists for installation.

I tried adding the `language=xxx` URL parameter to the updater URL and reloading the page instead of calling `saveLanguage`, but this only works for the initial updater page and since the language is not saved in the session then subsequent updater pages are not shown in the chosen language.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
