### PR TITLE
Remove datatable maxiumum width

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -417,49 +417,6 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             return parseInt(totalWidth, 10);
         }
 
-        function setMaxTableWidthIfNeeded (domElem, maxTableWidth)
-        {
-            var $domElem = $(domElem);
-            var dataTableInCard = $domElem.parents('.card').first();
-            var parentDataTable = $domElem.parent('.dataTable');
-
-            if ($domElem.is('.dataTableVizEvolution,.dataTableVizStackedBarEvolution')) {
-                return; // don't resize evolution charts
-            }
-
-            dataTableInCard.width('');
-            $domElem.width('');
-            parentDataTable.width('');
-
-            var tableWidth = getTableWidth(domElem);
-
-            if (tableWidth <= maxTableWidth && tableWidth > 0) {
-                return;
-            }
-
-            if (self.isWidgetized() || self.isDashboard()) {
-                return;
-            }
-
-            if (dataTableInCard && dataTableInCard.length) {
-                // makes sure card has the same width
-                dataTableInCard.css('max-width', maxTableWidth);
-            } else {
-                $domElem.css('max-width', maxTableWidth);
-            }
-
-            if (parentDataTable && parentDataTable.length) {
-                // makes sure dataTableWrapper and DataTable has same size => makes sure maxLabelWidth does not get
-                // applied in getLabelWidth() since they will have the same size.
-
-                if (dataTableInCard.length) {
-                    dataTableInCard.css('max-width', maxTableWidth);
-                } else {
-                    parentDataTable.css('max-width', maxTableWidth);
-                }
-            }
-        }
-
         function getLabelWidth(domElem, tableWidth, minLabelWidth, maxLabelWidth)
         {
             var labelWidth = minLabelWidth;
@@ -559,8 +516,6 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
             return labelWidth - paddingLeft - paddingRight;
         }
-
-        setMaxTableWidthIfNeeded(domElem, 1600);
 
         var isTableVisualization = this.param.viewDataTable
             && typeof this.param.viewDataTable === 'string'


### PR DESCRIPTION
### Description:

Fixes #21009

After further discussion of the restrictions on table width, this PR removes the maximum width limit for datatables allowing them to expand to the full available window width, whatever that may be.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
