### PR TITLE
Allow passing campaign parameters directly as tracking parameters

### DIFF
--- a/plugins/Referrers/Columns/Base.php
+++ b/plugins/Referrers/Columns/Base.php
@@ -409,13 +409,13 @@ abstract class Base extends VisitDimension
         return !empty($this->keywordReferrerAnalyzed);
     }
 
-    protected function detectReferrerCampaignFromLandingUrl()
+    protected function detectReferrerCampaignFromLandingUrl(): void
     {
         if (
             !isset($this->currentUrlParse['query'])
             && !isset($this->currentUrlParse['fragment'])
         ) {
-            return false;
+            return;
         }
         $campaignParameters = Common::getCampaignParameters();
         $this->campaignNames = $campaignParameters[0];
@@ -443,9 +443,9 @@ abstract class Base extends VisitDimension
      * This might e.g. be the case when using image tracking
      *
      * @param Request $request
-     * @return bool
+     * @return void
      */
-    protected function detectReferrerCampaignFromTrackerParams(Request $request)
+    protected function detectReferrerCampaignFromTrackerParams(Request $request): void
     {
         $campaignName = null;
         $campaignParameters = Common::getCampaignParameters();
@@ -459,7 +459,7 @@ abstract class Base extends VisitDimension
         }
 
         if (empty($campaignName)) {
-            return false;
+            return;
         }
 
         $this->typeReferrerAnalyzed = Common::REFERRER_TYPE_CAMPAIGN;
@@ -471,8 +471,6 @@ abstract class Base extends VisitDimension
                 break;
             }
         }
-
-        return true;
     }
 
     private function getCachedUrlsByHostAndIdSite()
@@ -529,14 +527,14 @@ abstract class Base extends VisitDimension
         return false;
     }
 
-    protected function detectCampaignKeywordFromReferrerUrl()
+    protected function detectCampaignKeywordFromReferrerUrl(): void
     {
         if (
             !empty($this->nameReferrerAnalyzed)
             && !empty($this->keywordReferrerAnalyzed)
         ) {
             // keyword is already set, we skip
-            return true;
+            return;
         }
 
         // Set the Campaign keyword to the keyword found in the Referrer URL if any

--- a/plugins/Referrers/tests/Integration/Columns/ReferrerTypeTest.php
+++ b/plugins/Referrers/tests/Integration/Columns/ReferrerTypeTest.php
@@ -70,9 +70,9 @@ class ReferrerTypeTest extends IntegrationTestCase
     /**
      * @dataProvider getReferrerUrls
      */
-    public function testOnNewVisitShouldDetectCorrectReferrerType($expectedType, $idSite, $url, $referrerUrl)
+    public function testOnNewVisitShouldDetectCorrectReferrerType($expectedType, $idSite, $url, $referrerUrl, $additionalTrackingParams = [])
     {
-        $request = $this->getRequest(['idsite' => $idSite, 'url' => $url, 'urlref' => $referrerUrl]);
+        $request = $this->getRequest(['idsite' => $idSite, 'url' => $url, 'urlref' => $referrerUrl] + $additionalTrackingParams);
         $type = $this->referrerType->onNewVisit($request, $this->getNewVisitor(), $action = null);
 
         $this->assertSame($expectedType, $type);
@@ -112,6 +112,9 @@ class ReferrerTypeTest extends IntegrationTestCase
             [Common::REFERRER_TYPE_CAMPAIGN,     $this->idSite1, $url . '?pk_campaign=test', $referrer],
             [Common::REFERRER_TYPE_CAMPAIGN,     $this->idSite2, $url . '?pk_campaign=test', $referrer],
             [Common::REFERRER_TYPE_CAMPAIGN,     $this->idSite3, $url . '?pk_campaign=test', $referrer],
+
+            // should detect campaign, when campaign parameter directly provided as tracking parameter
+            [Common::REFERRER_TYPE_CAMPAIGN,     $this->idSite1, $url, $referrer, ['mtm_campaign' => 'test']],
 
             // campaign parameters provided as array should simply be ignored (and not produce an error)
             [Common::REFERRER_TYPE_DIRECT_ENTRY,     $this->idSite1, $url . '?pk_campaign[]=test', $referrer],


### PR DESCRIPTION
### Description:

We used to allow passing `_rcn` or `_rck` as tracking parameters to allow attributing campaigns to visits and conversions. With # we stopped using those parameters for attributing visits. As our FAQs suggested to use those parameters for tracking e.g. email campaigns, we updated the FAQ to use campaign parameters instead. This actually doesn't work, as long as the parameters are not within the tracked url or the tracked referrer (url_ref).

To make it easier to track campaigns when using the image tracker, we should instead allow to directly pass the campaign parameters to our tracker.

fixes #21091 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
