### PR TITLE
fix issue in javascript test runner when JS tests finish before test runner setup code

### DIFF
--- a/tests/javascript/testrunnerNode.js
+++ b/tests/javascript/testrunnerNode.js
@@ -30,41 +30,41 @@ async function main() {
       url += `?module=${encodeURIComponent(plugin)}`;
     }
 
-    await page.goto(url);
-    await page.waitForFunction(() => window.QUnit);
-
-    await page.evaluate(() => {
+    page.on('domcontentloaded', async () => {
+      await page.evaluate(() => {
         window.testsDone = false;
         window.testsSuccessfull = false;
 
         QUnit.done(function (obj) {
-            console.info("Tests passed: " + obj.passed);
-            console.info("Tests failed: " + obj.failed);
-            console.info("Total tests:  " + obj.total);
-            console.info("Runtime (ms): " + obj.runtime);
-            window.testsDone = true;
-            window.testsSuccessfull = (obj.failed == 0);
+          console.info("Tests passed: " + obj.passed);
+          console.info("Tests failed: " + obj.failed);
+          console.info("Total tests:  " + obj.total);
+          console.info("Runtime (ms): " + obj.runtime);
+          window.testsDone = true;
+          window.testsSuccessfull = (obj.failed == 0);
         });
 
         QUnit.log(function (obj) {
-            if (!obj.result) {
-                var errorMessage = "Test failed in module " + obj.module + ": '" + obj.name + "' \nError: " + obj.message;
+          if (!obj.result) {
+            var errorMessage = "Test failed in module " + obj.module + ": '" + obj.name + "' \nError: " + obj.message;
 
-                if (obj.actual) {
-                    errorMessage += " \nActual: " + obj.actual;
-                }
-
-                if (obj.expected) {
-                    errorMessage += " \nExpected: " + obj.expected;
-                }
-
-                errorMessage += " \nSource: " + obj.source + "\n\n";
-
-                console.info(errorMessage);
+            if (obj.actual) {
+              errorMessage += " \nActual: " + obj.actual;
             }
+
+            if (obj.expected) {
+              errorMessage += " \nExpected: " + obj.expected;
+            }
+
+            errorMessage += " \nSource: " + obj.source + "\n\n";
+
+            console.info(errorMessage);
+          }
         });
+      });
     });
 
+    await page.goto(url);
     await page.waitForFunction(() => !!window.testsDone, {timeout: 600000});
 
     var success = await page.evaluate(function() {


### PR DESCRIPTION
### Description:

When a single plugin w/ very few tests is run, it's possible the tests will run before the evaluate function that calls QUnit.done() is called. This results in the test runner waiting forever. Fixed by using a puppeteer page event before loading the URL.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
