### PR TITLE
Ensure always the same challenges are completed when running Dashboard UI tests

### DIFF
--- a/plugins/Dashboard/tests/UI/Dashboard_spec.js
+++ b/plugins/Dashboard/tests/UI/Dashboard_spec.js
@@ -35,6 +35,8 @@ describe("Dashboard", function () {
     var setup = async function() {
         // make sure live widget doesn't refresh constantly for UI tests
         testEnvironment.overrideConfig('General', 'live_widget_refresh_after_seconds', 1000000);
+        // ensure tour widget always shows the same state
+        testEnvironment.completeAllChallenges = 1;
         testEnvironment.testUseMockAuth = 1;
         testEnvironment.save();
 

--- a/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_reset.png
+++ b/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_reset.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ab8b0b8938510bb880e8a26038d0fd2de3396f796d128e733cdf4c0efcc9f05
-size 380439
+oid sha256:dc48bdf5191b29d430c93fc150eb17615f6c32cbf743874d289d9ce7775a39dd
+size 361970


### PR DESCRIPTION
### Description:

The tests currently randomly fail depending on which tests ran before, as the fixture data is reused.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
