### PR TITLE
[Bug] Ensure plugins disabled for segment archiving are skipped

### DIFF
--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -419,6 +419,9 @@ class QueueConsumer
         $segment = new Segment($invalidatedArchive['segment'], [$invalidatedArchive['idsite']]);
 
         $params = new Parameters($site, $period, $segment);
+        if (!empty($invalidatedArchive['plugin'])) {
+            $params->setRequestedPlugin($invalidatedArchive['plugin']);
+        }
 
         $loader = new Loader($params);
         return $loader->canSkipThisArchive(); // if no point in archiving, skip
@@ -612,6 +615,9 @@ class QueueConsumer
         $segment = new Segment($invalidatedArchive['segment'], [$invalidatedArchive['idsite']]);
 
         $params = new Parameters($site, $period, $segment);
+        if (!empty($invalidatedArchive['plugin'])) {
+            $params->setRequestedPlugin($invalidatedArchive['plugin']);
+        }
 
         // if latest archive includes today and is usable (DONE_OK or DONE_INVALIDATED and recent enough), skip
         $today = Date::factoryInTimezone('today', Site::getTimezoneFor($site->getId()));

--- a/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
+++ b/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
@@ -900,17 +900,7 @@ class QueueConsumerTest extends IntegrationTestCase
 
     public function test_canSkipArchiveBecauseNoPoint_returnsFalseIfDateRangeHasVisits_AndPeriodDoesNotIncludeToday()
     {
-        $idSite = Fixture::createWebsite('2015-02-03');
-
-        Date::$now = strtotime('2020-04-05');
-
-        $t = Fixture::getTracker($idSite, '2020-03-05 10:34:00');
-        $t->setUrl('http://whatever.com');
-        Fixture::checkResponse($t->doTrackPageView('test title'));
-
-        $cronArchive = new CronArchive();
-
-        $archiveFilter = $this->makeTestArchiveFilter();
+        $this->setUpSiteAndTrackVisit('2020-03-05 10:34:00');
 
         $queueConsumer = new QueueConsumer(
             StaticContainer::get(LoggerInterface::class),
@@ -919,9 +909,9 @@ class QueueConsumerTest extends IntegrationTestCase
             24,
             new Model(),
             new SegmentArchiving(),
-            $cronArchive,
+            new CronArchive(),
             new RequestParser(true),
-            $archiveFilter
+            $this->makeTestArchiveFilter()
         );
 
         $invalidation = [
@@ -939,17 +929,7 @@ class QueueConsumerTest extends IntegrationTestCase
 
     public function test_usableArchiveExists_returnsTrueIfDateRangeHasVisits_AndPeriodIncludesToday_AndExistingArchiveIsRecent()
     {
-        $idSite = Fixture::createWebsite('2015-02-03');
-
-        Date::$now = strtotime('2020-04-05');
-
-        $t = Fixture::getTracker($idSite, '2020-04-05 10:34:00');
-        $t->setUrl('http://whatever.com');
-        Fixture::checkResponse($t->doTrackPageView('test title'));
-
-        $cronArchive = new CronArchive();
-
-        $archiveFilter = $this->makeTestArchiveFilter();
+        $this->setUpSiteAndTrackVisit();
 
         $queueConsumer = new QueueConsumer(
             StaticContainer::get(LoggerInterface::class),
@@ -958,9 +938,9 @@ class QueueConsumerTest extends IntegrationTestCase
             24,
             new Model(),
             new SegmentArchiving(),
-            $cronArchive,
+            new CronArchive(),
             new RequestParser(true),
-            $archiveFilter
+            $this->makeTestArchiveFilter()
         );
 
         $invalidation = [
@@ -985,17 +965,7 @@ class QueueConsumerTest extends IntegrationTestCase
 
     public function testUsableArchiveExistsReturnsTrueIfDateRangeHasVisitsAndPeriodIncludesTodayAndExistingPluginArchiveIsRecent()
     {
-        $idSite = Fixture::createWebsite('2015-02-03');
-
-        Date::$now = strtotime('2020-04-05');
-
-        $t = Fixture::getTracker($idSite, '2020-04-05 10:34:00');
-        $t->setUrl('http://whatever.com');
-        Fixture::checkResponse($t->doTrackPageView('test title'));
-
-        $cronArchive = new CronArchive();
-
-        $archiveFilter = $this->makeTestArchiveFilter();
+        $this->setUpSiteAndTrackVisit();
 
         $queueConsumer = new QueueConsumer(
             StaticContainer::get(LoggerInterface::class),
@@ -1004,9 +974,9 @@ class QueueConsumerTest extends IntegrationTestCase
             24,
             new Model(),
             new SegmentArchiving(),
-            $cronArchive,
+            new CronArchive(),
             new RequestParser(true),
-            $archiveFilter
+            $this->makeTestArchiveFilter()
         );
 
         $segmentHash = (new Segment('browserCode==IE', [1]))->getHash();
@@ -1034,17 +1004,7 @@ class QueueConsumerTest extends IntegrationTestCase
 
     public function test_canSkipArchiveBecauseNoPoint_returnsFalseIfDateRangeHasVisits_AndPeriodIncludesToday_AndOnlyExistingArchiveIsRecentButPartial()
     {
-        $idSite = Fixture::createWebsite('2015-02-03');
-
-        Date::$now = strtotime('2020-04-05');
-
-        $t = Fixture::getTracker($idSite, '2020-04-05 10:34:00');
-        $t->setUrl('http://whatever.com');
-        Fixture::checkResponse($t->doTrackPageView('test title'));
-
-        $cronArchive = new CronArchive();
-
-        $archiveFilter = $this->makeTestArchiveFilter();
+        $this->setUpSiteAndTrackVisit();
 
         $queueConsumer = new QueueConsumer(
             StaticContainer::get(LoggerInterface::class),
@@ -1053,9 +1013,9 @@ class QueueConsumerTest extends IntegrationTestCase
             24,
             new Model(),
             new SegmentArchiving(),
-            $cronArchive,
+            new CronArchive(),
             new RequestParser(true),
-            $archiveFilter
+            $this->makeTestArchiveFilter()
         );
 
         $invalidation = [
@@ -1080,17 +1040,7 @@ class QueueConsumerTest extends IntegrationTestCase
 
     public function testCanSkipArchiveBecauseNoPointReturnsTrueSegmentArchivingForPluginIsDisabled()
     {
-        $idSite = Fixture::createWebsite('2015-02-03');
-
-        Date::$now = strtotime('2020-04-05');
-
-        $t = Fixture::getTracker($idSite, '2020-04-05 10:34:00');
-        $t->setUrl('http://whatever.com');
-        Fixture::checkResponse($t->doTrackPageView('test title'));
-
-        $cronArchive = new CronArchive();
-
-        $archiveFilter = $this->makeTestArchiveFilter();
+        $this->setUpSiteAndTrackVisit();
 
         $queueConsumer = new QueueConsumer(
             StaticContainer::get(LoggerInterface::class),
@@ -1099,9 +1049,9 @@ class QueueConsumerTest extends IntegrationTestCase
             24,
             new Model(),
             new SegmentArchiving(),
-            $cronArchive,
+            new CronArchive(),
             new RequestParser(true),
-            $archiveFilter
+            $this->makeTestArchiveFilter()
         );
 
         $segmentHash = (new Segment('browserCode==IE', [1]))->getHash();
@@ -1121,6 +1071,17 @@ class QueueConsumerTest extends IntegrationTestCase
         Config::getInstance()->General['disable_archiving_segment_for_plugins'] = 'ExamplePlugin';
 
         $this->assertTrue($queueConsumer->canSkipArchiveBecauseNoPoint($invalidation));
+    }
+
+    private function setUpSiteAndTrackVisit($visitDateTime = '2020-04-05 10:34:00')
+    {
+        $idSite = Fixture::createWebsite('2015-02-03');
+
+        Date::$now = strtotime('2020-04-05');
+
+        $t = Fixture::getTracker($idSite, $visitDateTime);
+        $t->setUrl('http://whatever.com');
+        Fixture::checkResponse($t->doTrackPageView('test title'));
     }
 
     /**


### PR DESCRIPTION
### Description:

We had a couple of reports in the past that plugins disabled for segment archiving were archived nevertheless.
This might have been the case, as the those archives weren't correctly skipped.

Due to not passing through the requested plugin, a segment for a plugin might get archived even if the plugin was disabled for segment archiving.

In addition the detection for a usable archive might currently fail, if there is "only" an existing archive for that specific plugin.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
