### PR TITLE
Wait for element to be visible in overlay UI tests

### DIFF
--- a/plugins/Overlay/tests/UI/Overlay_spec.js
+++ b/plugins/Overlay/tests/UI/Overlay_spec.js
@@ -58,6 +58,8 @@ describe("Overlay", function () {
 
             it("should load correctly" + descAppendix, async function () {
                 await page.goto(getUrl(useTokenAuth));
+                // wait for sidebar to be finished loading
+                await page.waitForSelector('#overlaySidebar', {visible: true});
 
                 await removeOptOutIframe(page);
                 expect(await page.screenshot({fullPage: true})).to.matchImage('loaded');
@@ -82,6 +84,8 @@ describe("Overlay", function () {
 
             it("should show stats for new links when dropdown opened" + descAppendix, async function () {
                 await page.reload();
+                // wait for sidebar to be finished loading
+                await page.waitForSelector('#overlaySidebar', {visible: true});
                 const frame = page.frames().find(f => f.name() === 'overlayIframe');
                 await (await frame.$('.dropdown-toggle')).click();
 
@@ -159,7 +163,8 @@ describe("Overlay", function () {
 
             it("should load an overlay with segment" + descAppendix, async function () {
                 await page.goto(getUrl(useTokenAuth, true));
-                await page.waitForNetworkIdle();
+                // wait for sidebar to be finished loading
+                await page.waitForSelector('#overlaySidebar', {visible: true});
 
                 await page.waitForTimeout(2000);
 

--- a/tests/UI/specs/EmptySite_CloudflareOverGTM_spec.js
+++ b/tests/UI/specs/EmptySite_CloudflareOverGTM_spec.js
@@ -16,6 +16,7 @@ describe("EmptySite_CloudflareOverGTM", function () {
     it('should select the tab provided by hash param', async function () {
         const urlToTest = "?" + generalParams + "&module=CoreHome&action=index#?" + generalParams + "&activeTab=cloudflare";
         await page.goto(urlToTest);
+        await page.waitForTimeout(200); // svg takes some time to render
 
         const pageElement = await page.$('.page');
         expect(await pageElement.screenshot()).to.matchImage('emptySiteDashboard');

--- a/tests/UI/specs/EmptySite_Cloudflare_spec.js
+++ b/tests/UI/specs/EmptySite_Cloudflare_spec.js
@@ -16,6 +16,7 @@ describe("EmptySite_Cloudflare", function () {
     it('should show the tracking code if the website has no recorded data and Cloudflare guide', async function () {
         const urlToTest = "?" + generalParams + "&module=CoreHome&action=index";
         await page.goto(urlToTest);
+        await page.waitForTimeout(200); // svg takes some time to render
 
         const pageElement = await page.$('.page');
         expect(await pageElement.screenshot()).to.matchImage('emptySiteDashboard');

--- a/tests/UI/specs/EmptySite_Vue_spec.js
+++ b/tests/UI/specs/EmptySite_Vue_spec.js
@@ -16,6 +16,7 @@ describe("EmptySite_Vue", function () {
   it('should show the tracking code if the website has no recorded data and Vue guide', async function () {
     const urlToTest = "?" + generalParams + "&module=CoreHome&action=index";
     await page.goto(urlToTest);
+    await page.waitForTimeout(200); // svg takes some time to render
 
     const pageElement = await page.$('.page');
     expect(await pageElement.screenshot()).to.matchImage('emptySiteDashboard');


### PR DESCRIPTION
### Description:

Some of the overlay UI tests were randomly failing as the sidebar was not yet fully loaded.
Waiting for the element might fix it. Will rerun to tests on this PR a couple of times to check if it still occurs.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
