### PR TITLE
Cache and restore system LC_CTYPE option after all other locales are set

### DIFF
--- a/core/Intl/Locale.php
+++ b/core/Intl/Locale.php
@@ -28,9 +28,10 @@ class Locale
                 $newLocale[] = $localeVariant;
             }
         }
-        
+
+        $systemLC_CTYPE = setlocale(LC_CTYPE, 0);
         setlocale(LC_ALL, $newLocale);
-        setlocale(LC_CTYPE, '');
+        setlocale(LC_CTYPE, $systemLC_CTYPE);
         // Always use english for numbers. otherwise the decimal separator might get localized when casting a float to string
         setlocale(LC_NUMERIC, array('en_US.UTF-8', 'en-US', 'C.UTF-8', 'C'));
     }


### PR DESCRIPTION
### Description:

Tweak for #21126 that should be functionally equivalent.
Even repeated calls to changing the locale should persist the value for LC_CTYPE from the very first call.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
