### PR TITLE
Make API method VisitFrequency.get working with multiple sites

### DIFF
--- a/plugins/VisitFrequency/API.php
+++ b/plugins/VisitFrequency/API.php
@@ -15,6 +15,7 @@ use Piwik\Piwik;
 use Piwik\Plugins\API\DataTable\MergeDataTables;
 use Piwik\Segment;
 use Piwik\Segment\SegmentExpression;
+use Piwik\Site;
 
 /**
  * VisitFrequency API lets you access a list of metrics related to Returning Visitors.
@@ -49,7 +50,7 @@ class API extends \Piwik\Plugin\API
         $columns = Piwik::getArrayFromApiParameter($columns);
 
         /** @var \Piwik\DataTable\DataTableInterface $resultSet */
-        if ($idSite === 'all') {
+        if ($idSite === 'all' || count(Site::getIdSitesFromIdSitesString($idSite)) > 1) {
             $resultSet = new DataTable\Map();
             $resultSet->setKeyName('idSite');
         } else if (Period::isMultiplePeriod($date, $period)) {

--- a/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysTest.php
+++ b/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysTest.php
@@ -55,10 +55,11 @@ class TwoVisitorsTwoWebsitesDifferentDaysTest extends SystemTestCase
     public function getApiForTesting()
     {
         $idSite1  = self::$fixture->idSite1;
+        $idSite2  = self::$fixture->idSite2;
         $dateTime = self::$fixture->dateTime;
 
         $apiToCall       = $this->getApiToCall();
-        $singlePeriodApi = ['VisitsSummary.get', 'Goals.get'];
+        $singlePeriodApi = ['VisitFrequency.get', 'VisitsSummary.get', 'Goals.get'];
 
         $periods = ['day', 'week', 'month', 'year'];
 
@@ -115,6 +116,16 @@ class TwoVisitorsTwoWebsitesDifferentDaysTest extends SystemTestCase
                 'periods'      => ['day', 'month'],
                 'setDateLastN' => false,
                 'testSuffix'   => '_NotLastNPeriods',
+            ],
+        ];
+        $result[] = [
+            $singlePeriodApi,
+            [
+                'idSite'       => "$idSite1,$idSite2",
+                'date'         => $dateTime,
+                'periods'      => 'month',
+                'setDateLastN' => false,
+                'testSuffix'   => '_idsites',
             ],
         ];
 

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_NotLastNPeriods__VisitFrequency.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_NotLastNPeriods__VisitFrequency.get_day.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result idSite="1">
+		<nb_uniq_visitors_new>2</nb_uniq_visitors_new>
+		<nb_users_new>0</nb_users_new>
+		<nb_visits_new>2</nb_visits_new>
+		<nb_actions_new>2</nb_actions_new>
+		<nb_visits_converted_new>0</nb_visits_converted_new>
+		<bounce_count_new>2</bounce_count_new>
+		<sum_visit_length_new>0</sum_visit_length_new>
+		<max_actions_new>1</max_actions_new>
+		<bounce_rate_new>100%</bounce_rate_new>
+		<nb_actions_per_visit_new>1</nb_actions_per_visit_new>
+		<avg_time_on_site_new>0</avg_time_on_site_new>
+	</result>
+	<result idSite="2" />
+</results>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_NotLastNPeriods__VisitFrequency.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_NotLastNPeriods__VisitFrequency.get_month.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result idSite="1">
+		<nb_uniq_visitors_new>2</nb_uniq_visitors_new>
+		<nb_users_new>0</nb_users_new>
+		<nb_visits_new>2</nb_visits_new>
+		<nb_actions_new>2</nb_actions_new>
+		<nb_visits_converted_new>0</nb_visits_converted_new>
+		<bounce_count_new>2</bounce_count_new>
+		<sum_visit_length_new>0</sum_visit_length_new>
+		<max_actions_new>1</max_actions_new>
+		<bounce_rate_new>100%</bounce_rate_new>
+		<nb_actions_per_visit_new>1</nb_actions_per_visit_new>
+		<avg_time_on_site_new>0</avg_time_on_site_new>
+		<nb_uniq_visitors_returning>2</nb_uniq_visitors_returning>
+		<nb_users_returning>0</nb_users_returning>
+		<nb_visits_returning>9</nb_visits_returning>
+		<nb_actions_returning>41</nb_actions_returning>
+		<nb_visits_converted_returning>0</nb_visits_converted_returning>
+		<bounce_count_returning>1</bounce_count_returning>
+		<sum_visit_length_returning>7208</sum_visit_length_returning>
+		<max_actions_returning>5</max_actions_returning>
+		<bounce_rate_returning>11%</bounce_rate_returning>
+		<nb_actions_per_visit_returning>4.6</nb_actions_per_visit_returning>
+		<avg_time_on_site_returning>801</avg_time_on_site_returning>
+	</result>
+	<result idSite="2">
+		<nb_uniq_visitors_new>1</nb_uniq_visitors_new>
+		<nb_users_new>0</nb_users_new>
+		<nb_visits_new>1</nb_visits_new>
+		<nb_actions_new>3</nb_actions_new>
+		<nb_visits_converted_new>0</nb_visits_converted_new>
+		<bounce_count_new>0</bounce_count_new>
+		<sum_visit_length_new>1</sum_visit_length_new>
+		<max_actions_new>3</max_actions_new>
+		<bounce_rate_new>0%</bounce_rate_new>
+		<nb_actions_per_visit_new>3</nb_actions_per_visit_new>
+		<avg_time_on_site_new>1</avg_time_on_site_new>
+	</result>
+</results>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idsites__Goals.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idsites__Goals.get_month.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result idSite="1">
+		<nb_conversions>0</nb_conversions>
+		<nb_visits_converted>0</nb_visits_converted>
+		<revenue>0</revenue>
+		<conversion_rate>0%</conversion_rate>
+		<nb_conversions_new_visit>0</nb_conversions_new_visit>
+		<nb_visits_converted_new_visit>0</nb_visits_converted_new_visit>
+		<revenue_new_visit>0</revenue_new_visit>
+		<conversion_rate_new_visit>0%</conversion_rate_new_visit>
+		<nb_conversions_returning_visit>0</nb_conversions_returning_visit>
+		<nb_visits_converted_returning_visit>0</nb_visits_converted_returning_visit>
+		<revenue_returning_visit>0</revenue_returning_visit>
+		<conversion_rate_returning_visit>0%</conversion_rate_returning_visit>
+	</result>
+	<result idSite="2">
+		<nb_conversions>0</nb_conversions>
+		<nb_visits_converted>0</nb_visits_converted>
+		<revenue>0</revenue>
+		<conversion_rate>0%</conversion_rate>
+		<nb_conversions_new_visit>0</nb_conversions_new_visit>
+		<nb_visits_converted_new_visit>0</nb_visits_converted_new_visit>
+		<revenue_new_visit>0</revenue_new_visit>
+		<conversion_rate_new_visit>0%</conversion_rate_new_visit>
+	</result>
+</results>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idsites__VisitFrequency.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idsites__VisitFrequency.get_month.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result idSite="1">
+		<nb_uniq_visitors_new>2</nb_uniq_visitors_new>
+		<nb_users_new>0</nb_users_new>
+		<nb_visits_new>2</nb_visits_new>
+		<nb_actions_new>2</nb_actions_new>
+		<nb_visits_converted_new>0</nb_visits_converted_new>
+		<bounce_count_new>2</bounce_count_new>
+		<sum_visit_length_new>0</sum_visit_length_new>
+		<max_actions_new>1</max_actions_new>
+		<bounce_rate_new>100%</bounce_rate_new>
+		<nb_actions_per_visit_new>1</nb_actions_per_visit_new>
+		<avg_time_on_site_new>0</avg_time_on_site_new>
+		<nb_uniq_visitors_returning>2</nb_uniq_visitors_returning>
+		<nb_users_returning>0</nb_users_returning>
+		<nb_visits_returning>9</nb_visits_returning>
+		<nb_actions_returning>41</nb_actions_returning>
+		<nb_visits_converted_returning>0</nb_visits_converted_returning>
+		<bounce_count_returning>1</bounce_count_returning>
+		<sum_visit_length_returning>7208</sum_visit_length_returning>
+		<max_actions_returning>5</max_actions_returning>
+		<bounce_rate_returning>11%</bounce_rate_returning>
+		<nb_actions_per_visit_returning>4.6</nb_actions_per_visit_returning>
+		<avg_time_on_site_returning>801</avg_time_on_site_returning>
+	</result>
+	<result idSite="2">
+		<nb_uniq_visitors_new>1</nb_uniq_visitors_new>
+		<nb_users_new>0</nb_users_new>
+		<nb_visits_new>1</nb_visits_new>
+		<nb_actions_new>3</nb_actions_new>
+		<nb_visits_converted_new>0</nb_visits_converted_new>
+		<bounce_count_new>0</bounce_count_new>
+		<sum_visit_length_new>1</sum_visit_length_new>
+		<max_actions_new>3</max_actions_new>
+		<bounce_rate_new>0%</bounce_rate_new>
+		<nb_actions_per_visit_new>3</nb_actions_per_visit_new>
+		<avg_time_on_site_new>1</avg_time_on_site_new>
+	</result>
+</results>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idsites__VisitsSummary.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idsites__VisitsSummary.get_month.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result idSite="1">
+		<nb_uniq_visitors>2</nb_uniq_visitors>
+		<nb_users>0</nb_users>
+		<nb_visits>11</nb_visits>
+		<nb_actions>43</nb_actions>
+		<nb_visits_converted>0</nb_visits_converted>
+		<bounce_count>3</bounce_count>
+		<sum_visit_length>7208</sum_visit_length>
+		<max_actions>5</max_actions>
+		<bounce_rate>27%</bounce_rate>
+		<nb_actions_per_visit>3.9</nb_actions_per_visit>
+		<avg_time_on_site>655</avg_time_on_site>
+	</result>
+	<result idSite="2">
+		<nb_uniq_visitors>1</nb_uniq_visitors>
+		<nb_users>0</nb_users>
+		<nb_visits>1</nb_visits>
+		<nb_actions>3</nb_actions>
+		<nb_visits_converted>0</nb_visits_converted>
+		<bounce_count>0</bounce_count>
+		<sum_visit_length>1</sum_visit_length>
+		<max_actions>3</max_actions>
+		<bounce_rate>0%</bounce_rate>
+		<nb_actions_per_visit>3</nb_actions_per_visit>
+		<avg_time_on_site>1</avg_time_on_site>
+	</result>
+</results>


### PR DESCRIPTION
### Description:

The API method `VisitFrequency.get` didn't work correctly, when providing an idSites string like `1,2`

fixes #20768

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
