### PR TITLE
Add missing action reference to prevent data loss

### DIFF
--- a/core/Plugin/Dimension/DimensionMetadataProvider.php
+++ b/core/Plugin/Dimension/DimensionMetadataProvider.php
@@ -42,6 +42,7 @@ class DimensionMetadataProvider
     {
         $result = array(
             'log_link_visit_action' => array('idaction_url',
+                'idaction_name'
                 'idaction_url_ref',
                 'idaction_name_ref'
             ),

--- a/core/Plugin/Dimension/DimensionMetadataProvider.php
+++ b/core/Plugin/Dimension/DimensionMetadataProvider.php
@@ -42,7 +42,7 @@ class DimensionMetadataProvider
     {
         $result = array(
             'log_link_visit_action' => array('idaction_url',
-                'idaction_name'
+                'idaction_name',
                 'idaction_url_ref',
                 'idaction_name_ref'
             ),

--- a/tests/PHPUnit/Integration/Plugin/Dimension/DimensionMetadataProviderTest.php
+++ b/tests/PHPUnit/Integration/Plugin/Dimension/DimensionMetadataProviderTest.php
@@ -33,11 +33,11 @@ class DimensionMetadataProviderTest extends IntegrationTestCase
         $expectedColumns = array(
             'log_link_visit_action' => array(
                 'idaction_url',
+                'idaction_name',
                 'idaction_url_ref',
                 'idaction_name_ref',
                 'idaction_event_action',
                 'idaction_event_category',
-                'idaction_name',
                 'idaction_content_interaction',
                 'idaction_content_name',
                 'idaction_content_piece',
@@ -70,6 +70,7 @@ class DimensionMetadataProviderTest extends IntegrationTestCase
     {
         $dimensionMetadataProvider = new DimensionMetadataProvider(array(
             'log_link_visit_action' => array('idaction_url',
+                'idaction_name',
                 'idaction_event_category'
             ),
 
@@ -85,11 +86,11 @@ class DimensionMetadataProviderTest extends IntegrationTestCase
         $expectedColumns = array(
             'log_link_visit_action' => array(
                 'idaction_url',
+                'idaction_name',
                 'idaction_url_ref',
                 'idaction_name_ref',
                 'idaction_event_action',
                 'idaction_event_category',
-                'idaction_name',
                 'idaction_content_interaction',
                 'idaction_content_name',
                 'idaction_content_piece',


### PR DESCRIPTION
It looks like idaction_name was missing in the action reference. When then raw log data deletion is configured with log_action cleanup, we would delete related `idaction_name` entries.

Didn't check if any other references were missing.

Could we also apply this to 4.x-dev as it's quite important to have?

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
