### PR TITLE
FIX Ensure visitor profile country name doesn't overflow

### DIFF
--- a/plugins/Live/stylesheets/visitor_profile.less
+++ b/plugins/Live/stylesheets/visitor_profile.less
@@ -290,6 +290,8 @@
         white-space: nowrap;
         position: absolute;
         left: 26px;
+        right: 0px;
+        text-overflow: ellipsis;
       }
     }
 

--- a/plugins/Live/stylesheets/visitor_profile.less
+++ b/plugins/Live/stylesheets/visitor_profile.less
@@ -290,8 +290,7 @@
         white-space: nowrap;
         position: absolute;
         left: 26px;
-        right: 0px;
-        text-overflow: ellipsis;
+        right: 0;
       }
     }
 


### PR DESCRIPTION
### Description:

:after element width was not set so it was overflowing. fixed this by adding the right property so it will remain inside parent container, set text-overflow to ellipsis in case country name goes out of the box. 

fixes https://github.com/matomo-org/matomo/issues/20963

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [x] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [x] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [x] Existing documentation updated if needed
