### PR TITLE
Disable API.getPagesComparisonsDisabledFor check in glossary widget

### DIFF
--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -848,6 +848,7 @@ class Plugin extends \Piwik\Plugin
             $out .= "piwik.isPagesComparisonApiDisabled = true;\n";
         }
     }
+    
     public function getClientSideTranslationKeys(&$translations)
     {
         $translations[] = 'API_Glossary';

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -823,6 +823,7 @@ class Plugin extends \Piwik\Plugin
         return array(
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
             'AssetManager.getStylesheetFiles' => 'getStylesheetFiles',
+            'Template.jsGlobalVariables' => 'getJsGlobalVariables',
             'Platform.initialized' => 'detectIsApiRequest'
         );
     }
@@ -838,6 +839,15 @@ class Plugin extends \Piwik\Plugin
         $stylesheets[] = "plugins/API/stylesheets/glossary.less";
     }
 
+    public function getJsGlobalVariables(&$out)
+    {
+        // Do not perform page comparison check for glossary widget
+        // This is performed here and not in Comparison.store.ts, as the widget might be used like on glossary.matomo.org
+        // where url parameters are hidden in the request and javascript can't access the current module and action
+        if (Piwik::getModule() === 'API' && Piwik::getAction() === 'glossary' && \Piwik\Request::fromRequest()->getBoolParameter('widget')) {
+            $out .= "piwik.isPagesComparisonApiDisabled = true;\n";
+        }
+    }
     public function getClientSideTranslationKeys(&$translations)
     {
         $translations[] = 'API_Glossary';


### PR DESCRIPTION
### Description:

There is no use in checking for comparison stuff when the glossary is shown as a widget.

refs DEV-16871

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
