### PR TITLE
Fix for unexpected zero value last edit dates in segment archiving

### DIFF
--- a/core/CronArchive/SegmentArchiving.php
+++ b/core/CronArchive/SegmentArchiving.php
@@ -174,7 +174,14 @@ class SegmentArchiving
         }
     }
 
-    private function getCreatedTimeOfSegment($storedSegment)
+    /**
+     * Retrieve the created and last edited time as date objects from the supplied segment array
+     *
+     * @param array|null $storedSegment
+     *
+     * @return array|null
+     */
+    private function getCreatedTimeOfSegment(array $storedSegment): ?array
     {
         // check for an earlier ts_created timestamp
         $createdTime = empty($storedSegment['ts_created']) ? null : Date::factory($storedSegment['ts_created']);
@@ -185,10 +192,10 @@ class SegmentArchiving
         }
 
         // check for a later ts_last_edit timestamp
-        $lastEditTime = empty($storedSegment['ts_last_edit']) || $storedSegment['ts_last_edit'] == '0000-00-00 00:00:00'
+        $lastEditTime = empty($storedSegment['ts_last_edit']) || $storedSegment['ts_last_edit'] === '0000-00-00 00:00:00'
             ? null : Date::factory($storedSegment['ts_last_edit']);
 
-        return array($createdTime, $lastEditTime);
+        return [$createdTime, $lastEditTime];
     }
 
     private function getEarliestVisitTimeFor($idSite)

--- a/core/CronArchive/SegmentArchiving.php
+++ b/core/CronArchive/SegmentArchiving.php
@@ -179,9 +179,9 @@ class SegmentArchiving
      *
      * @param array $storedSegment
      *
-     * @return array|null
+     * @return array
      */
-    private function getCreatedTimeOfSegment(array $storedSegment): ?array
+    private function getCreatedTimeOfSegment(array $storedSegment): array
     {
         // check for an earlier ts_created timestamp
         $createdTime = empty($storedSegment['ts_created']) ? null : Date::factory($storedSegment['ts_created']);

--- a/core/CronArchive/SegmentArchiving.php
+++ b/core/CronArchive/SegmentArchiving.php
@@ -185,7 +185,8 @@ class SegmentArchiving
         }
 
         // check for a later ts_last_edit timestamp
-        $lastEditTime = empty($storedSegment['ts_last_edit']) ? null : Date::factory($storedSegment['ts_last_edit']);
+        $lastEditTime = empty($storedSegment['ts_last_edit']) || $storedSegment['ts_last_edit'] == '0000-00-00 00:00:00'
+            ? null : Date::factory($storedSegment['ts_last_edit']);
 
         return array($createdTime, $lastEditTime);
     }

--- a/core/CronArchive/SegmentArchiving.php
+++ b/core/CronArchive/SegmentArchiving.php
@@ -177,7 +177,7 @@ class SegmentArchiving
     /**
      * Retrieve the created and last edited time as date objects from the supplied segment array
      *
-     * @param array|null $storedSegment
+     * @param array $storedSegment
      *
      * @return array|null
      */

--- a/tests/PHPUnit/Integration/CronArchive/SegmentArchivingTest.php
+++ b/tests/PHPUnit/Integration/CronArchive/SegmentArchivingTest.php
@@ -74,6 +74,20 @@ class SegmentArchivingTest extends IntegrationTestCase
                 '2020-04-13',
             ],
 
+            // creation time, last edit time is 0000-00-00,
+            [
+                SegmentArchiving::CREATION_TIME,
+                ['ts_created' => '2020-04-12 03:34:55', 'ts_last_edit' => '0000-00-00 00:00:00'],
+                '2020-04-12',
+            ],
+
+            // last edit time, last edit time is 0000-00-00
+            [
+                SegmentArchiving::LAST_EDIT_TIME,
+                ['ts_created' => '2020-04-12 03:34:55', 'ts_last_edit' => '0000-00-00 00:00:00'],
+                null,
+            ],
+
             // last edit time, no edit time in segment
             [
                 SegmentArchiving::LAST_EDIT_TIME,


### PR DESCRIPTION
### Description:

If a segment has a last edited date of `0000-00-00` then segment archiving will fail with the exception:  `The date ... is a date before first website was online.`

This is caused by attempting to parse the invalid `0000-00-00` date string. This PR adds a simple check to avoid parsing if the last edited date is null or zero along with some additional tests to check an exception isn't thrown when zero dates are provided.

ref: L3-522

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
