### PR TITLE
Ensure getmypid is only used when available otherwise disable SharedSiteIds

### DIFF
--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -359,7 +359,7 @@ class CliMulti
         $this->processes[] = new Process($cmdId);
 
         $url = $this->appendTestmodeParamToUrlIfNeeded($url);
-        $query = UrlHelper::getQueryFromUrl($url, array('pid' => $cmdId, 'runid' => getmypid()));
+        $query = UrlHelper::getQueryFromUrl($url, ['pid' => $cmdId, 'runid' => Common::getProcessId()]);
         $hostname = Url::getHost($checkIfTrusted = false);
         $command = $this->buildCommand($hostname, $query, $output->getPathToFile());
 

--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -122,7 +122,7 @@ class Process
 
     public function startProcess()
     {
-        $this->writePidFileContent(getmypid());
+        $this->writePidFileContent(Common::getProcessId());
     }
 
     public function isRunning()
@@ -235,7 +235,7 @@ class Process
         if (!self::psExistsAndRunsCorrectly()) {
             $reasons[] = 'shell_exec(' . self::PS_COMMAND . '" 2> /dev/null") did not return a success code';
         } else if (!$getMyPidDisabled) {
-            $pid = @getmypid();
+            $pid = @\getmypid();
             if (empty($pid) || !in_array($pid, self::getRunningProcesses())) {
                 $reasons[] = 'could not find our pid (from getmypid()) in the output of `' . self::PS_COMMAND . '`';
             }

--- a/core/Common.php
+++ b/core/Common.php
@@ -211,7 +211,7 @@ class Common
             if (Process::isMethodDisabled('getmypid')) {
                 $pid = Common::getRandomInt(12);
             } else {
-                $pid = getmypid();
+                $pid = \getmypid();
             }
         }
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1457,7 +1457,7 @@ class CronArchive
             return new FixedSiteIds($websitesIds);
         }
 
-        if (!empty($this->shouldArchiveSpecifiedSites)) {
+        if (!empty($this->shouldArchiveSpecifiedSites) && !SharedSiteIds::isSupported()) {
             $this->logger->info("- Will process specified sites: " . implode(', ', $websitesIds));
             return new FixedSiteIds($websitesIds);
         }

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1457,7 +1457,7 @@ class CronArchive
             return new FixedSiteIds($websitesIds);
         }
 
-        if (!empty($this->shouldArchiveSpecifiedSites) && !SharedSiteIds::isSupported()) {
+        if (!empty($this->shouldArchiveSpecifiedSites) || !SharedSiteIds::isSupported()) {
             $this->logger->info("- Will process specified sites: " . implode(', ', $websitesIds));
             return new FixedSiteIds($websitesIds);
         }

--- a/plugins/Monolog/Processor/RequestIdProcessor.php
+++ b/plugins/Monolog/Processor/RequestIdProcessor.php
@@ -22,7 +22,7 @@ class RequestIdProcessor
     {
         if (empty($this->currentRequestKey)) {
             if (Common::isPhpCliMode()) {
-                $this->currentRequestKey = getmypid();
+                $this->currentRequestKey = Common::getProcessId();
             } else {
                 $this->currentRequestKey = FrontController::getUniqueRequestId();
             }


### PR DESCRIPTION
### Description:

Fixes #20537 

Based on @sgiehl's changes in https://github.com/matomo-org/matomo/pull/20540 and also incorporating the feedback from @tsteur: 

> Another way would be something like below code to check if `SharedSiteIds` is supported and only then use it. Otherwise use the `FixedSiteIds`. This can make it worse though in cases where there are many sites and `getmypid()` is disabled. In this case Matomo would always start archiving with idsite 1 etc and never make it to the higher idsites. Meaning the created PR could work better overall even though it means the logic may not always run concurrently.

Disabling `SharedSiteIds` seems like the safer option if using random process ids. Since the current state is that archiving doesn't run at all and fails with an error on hosts without `getmypid()` I'd suggest a fix that may degrade performance on some edge cases (only if `getmyid()` is disabled) is preferable to no fix at all. We could perhaps document somewhere that hosting providers who disable `getmypid()` are not recommended for installations with many sites or high traffic.

I've tested this by disabling `getmypid()` locally, recreating the original issue and then successfully running archiving with the fix applied.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
