### PR TITLE
Disable userId segment if visitor profile is disabled

### DIFF
--- a/plugins/CoreHome/Columns/UserId.php
+++ b/plugins/CoreHome/Columns/UserId.php
@@ -9,11 +9,14 @@
 namespace Piwik\Plugins\CoreHome\Columns;
 
 use Piwik\Cache;
+use Piwik\Columns\DimensionSegmentFactory;
 use Piwik\DataTable;
 use Piwik\DataTable\Map;
 use Piwik\Metrics;
 use Piwik\Plugin;
 use Piwik\Plugin\Dimension\VisitDimension;
+use Piwik\Plugins\Live\Live;
+use Piwik\Segment\SegmentsList;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\Visitor;
 use Piwik\Tracker\Action;
@@ -42,6 +45,14 @@ class UserId extends VisitDimension
 
         if (Plugin\Manager::getInstance()->isPluginActivated('UserId')) {
             $this->suggestedValuesApi = 'UserId.getUsers';
+        }
+    }
+
+    public function configureSegments(SegmentsList $segmentsList, DimensionSegmentFactory $dimensionSegmentFactory)
+    {
+        // Configure userId segment only if visitor profile is available
+        if (Live::isVisitorProfileEnabled()) {
+            parent::configureSegments($segmentsList, $dimensionSegmentFactory);
         }
     }
 

--- a/plugins/Live/tests/System/ApiTest.php
+++ b/plugins/Live/tests/System/ApiTest.php
@@ -276,6 +276,15 @@ class ApiTest extends SystemTestCase
             ],
             'testSuffix' => 'disabledProfile2'
         ]);
+
+        // user id segment should be disabled if visitor profile isn't available
+        $this->runApiTests('VisitsSummary.get', [
+            'idSite'     => 1,
+            'date'       => self::$fixture->dateTime,
+            'periods'    => ['day'],
+            'segment'    => 'userId==' . urlencode('new-email@example.com'),
+            'testSuffix' => 'disabledProfile',
+        ]);
     }
 
     public static function getOutputPrefix()

--- a/plugins/Live/tests/System/expected/test_disabledProfile__VisitsSummary.get_day.xml
+++ b/plugins/Live/tests/System/expected/test_disabledProfile__VisitsSummary.get_day.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<error message="Segment 'userId' is not a supported segment.
+ 
+ --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
+</result>


### PR DESCRIPTION
### Description:

fixes #21137 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
