### PR TITLE
check dataTableActions CSS class when building label param for row evolution

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable_rowactions.js
+++ b/plugins/CoreHome/javascripts/dataTable_rowactions.js
@@ -178,7 +178,10 @@ DataTable_RowAction.prototype.trigger = function (tr, e, subTableLabel, original
     }
 
     // ascend in action reports
-    if (subtable.closest('div.dataTable').data('table-type') === 'ActionsDataTable') {
+    var $dataTable = subtable.closest('div.dataTable');
+    if ($dataTable.hasClass('dataTableActions')
+      || $dataTable.data('table-type') === 'ActionsDataTable'
+    ) {
         var allClasses = tr.attr('class');
         var matches = allClasses.match(/level[0-9]+/);
         var level = parseInt(matches[0].substring(5, matches[0].length), 10);
@@ -369,8 +372,8 @@ DataTable_RowActions_RowEvolution.prototype.performAction = function (label, tr,
 };
 
 DataTable_RowActions_RowEvolution.prototype.getPrettyLabel = function getPrettyLabel(tr) {
-  if (tr.closest('.dataTableActions').length) {
-    return null; // actions tables don't need to override the pretty label, since they should not have a custom row identifier
+  if (!this.dataTable.props.row_identifier || this.dataTable.props.row_identifier === 'label') {
+    return null; // only necessary if a custom row identifier is provided for the report
   }
 
   var prettyLabel = [];


### PR DESCRIPTION
### Description:

Since some premium features use the dataTableActions CSS class but a non-ActionsDataTabe JS type.

Refs https://github.com/matomo-org/matomo/pull/21122

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
