### PR TITLE
Remove translation / badge count from admin plugins

### DIFF
--- a/plugins/CoreAdminHome/CoreAdminHome.php
+++ b/plugins/CoreAdminHome/CoreAdminHome.php
@@ -151,6 +151,7 @@ class CoreAdminHome extends \Piwik\Plugin
         $translationKeys[] = 'General_OnlyUsedIfUserPwdIsSet';
         $translationKeys[] = 'General_SmtpUsername';
         $translationKeys[] = 'General_OnlyEnterIfRequired';
+        $translationKeys[] = 'General_Plugins';
         $translationKeys[] = 'General_SmtpPassword';
         $translationKeys[] = 'General_SmtpFromAddress';
         $translationKeys[] = 'General_SmtpFromEmailHelp';

--- a/plugins/CoreAdminHome/tests/UI/MobileMenu_spec.js
+++ b/plugins/CoreAdminHome/tests/UI/MobileMenu_spec.js
@@ -24,7 +24,7 @@ describe("MobileMenu", function () {
         await page.click('[data-target="mobile-left-menu"]');
         await page.waitForTimeout(150);
         await page.click('ul#mobile-left-menu > li:nth-child(2) a');
-        await page.waitForTimeout(200);
+        await page.waitForTimeout(250);
 
         expect(await page.screenshotSelector(contentSelector)).to.matchImage(screenshotName);
     });

--- a/plugins/CoreAdminHome/tests/UI/MobileMenu_spec.js
+++ b/plugins/CoreAdminHome/tests/UI/MobileMenu_spec.js
@@ -23,7 +23,12 @@ describe("MobileMenu", function () {
         await page.waitForNetworkIdle();
         await page.click('[data-target="mobile-left-menu"]');
         await page.waitForTimeout(150);
+        await page.click('ul#mobile-left-menu > li:nth-child(1) a');
         await page.click('ul#mobile-left-menu > li:nth-child(2) a');
+        await page.click('ul#mobile-left-menu > li:nth-child(3) a');
+        await page.click('ul#mobile-left-menu > li:nth-child(4) a');
+        await page.click('ul#mobile-left-menu > li:nth-child(5) a');
+        await page.click('ul#mobile-left-menu > li:nth-child(6) a');
         await page.waitForTimeout(250);
 
         expect(await page.screenshotSelector(contentSelector)).to.matchImage(screenshotName);

--- a/plugins/CoreAdminHome/tests/UI/MobileMenu_spec.js
+++ b/plugins/CoreAdminHome/tests/UI/MobileMenu_spec.js
@@ -1,0 +1,31 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * Screenshot integration tests.
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+describe("MobileMenu", function () {
+    this.timeout(0);
+    before(function () {
+      testEnvironment.pluginsToLoad = ['CorePluginsAdmin'];
+      testEnvironment.save();
+
+    });
+    it('menu should load and be able to expand to see sub menus on mobile', async function() {
+        const screenshotName  = 'mobileMenuPartial';
+        const contentSelector = '#mobile-left-menu';
+
+        await page.webpage.setViewport({ width: 815, height: 512 });
+        await page.goto('?module=CoreAdminHome&action=home');
+        await page.waitForNetworkIdle();
+        await page.click('[data-target="mobile-left-menu"]');
+        await page.waitForTimeout(150);
+        await page.click('ul#mobile-left-menu > li:nth-child(2) a');
+        await page.waitForTimeout(150);
+
+        expect(await page.screenshotSelector(contentSelector)).to.matchImage(screenshotName);
+    });
+});

--- a/plugins/CoreAdminHome/tests/UI/MobileMenu_spec.js
+++ b/plugins/CoreAdminHome/tests/UI/MobileMenu_spec.js
@@ -18,7 +18,7 @@ describe("MobileMenu", function () {
         const screenshotName  = 'mobileMenuPartial';
         const contentSelector = '#mobile-left-menu';
 
-        await page.webpage.setViewport({ width: 815, height: 512 });
+        await page.webpage.setViewport({ width: 815, height: 1500 });
         await page.goto('?module=CoreAdminHome&action=home');
         await page.waitForNetworkIdle();
         await page.click('[data-target="mobile-left-menu"]');

--- a/plugins/CoreAdminHome/tests/UI/MobileMenu_spec.js
+++ b/plugins/CoreAdminHome/tests/UI/MobileMenu_spec.js
@@ -24,7 +24,7 @@ describe("MobileMenu", function () {
         await page.click('[data-target="mobile-left-menu"]');
         await page.waitForTimeout(150);
         await page.click('ul#mobile-left-menu > li:nth-child(2) a');
-        await page.waitForTimeout(150);
+        await page.waitForTimeout(200);
 
         expect(await page.screenshotSelector(contentSelector)).to.matchImage(screenshotName);
     });

--- a/plugins/CoreAdminHome/tests/UI/expected-screenshots/MobileMenu_mobileMenuPartial.png
+++ b/plugins/CoreAdminHome/tests/UI/expected-screenshots/MobileMenu_mobileMenuPartial.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:af7606bbbe83146ae2ea762bc5f2c63805d88146a46b6fcd63907edc3c2273de
-size 21689
+oid sha256:9186a28e4ef2c2187fbbd6e4642206e6c8bad833f2f6e8384992eb4f88cd29a0
+size 58948

--- a/plugins/CoreAdminHome/tests/UI/expected-screenshots/MobileMenu_mobileMenuPartial.png
+++ b/plugins/CoreAdminHome/tests/UI/expected-screenshots/MobileMenu_mobileMenuPartial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30b0d35d76775e96fc40d56d92a5d2da4f9838ea4f15eb9a0169eb5e065dc2be
+size 21184

--- a/plugins/CoreAdminHome/tests/UI/expected-screenshots/MobileMenu_mobileMenuPartial.png
+++ b/plugins/CoreAdminHome/tests/UI/expected-screenshots/MobileMenu_mobileMenuPartial.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30b0d35d76775e96fc40d56d92a5d2da4f9838ea4f15eb9a0169eb5e065dc2be
-size 21184
+oid sha256:61833cda64992710842c1e6f735d7efaf83f8fcfdb56a497673b0ef104002704
+size 21789

--- a/plugins/CoreAdminHome/tests/UI/expected-screenshots/MobileMenu_mobileMenuPartial.png
+++ b/plugins/CoreAdminHome/tests/UI/expected-screenshots/MobileMenu_mobileMenuPartial.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61833cda64992710842c1e6f735d7efaf83f8fcfdb56a497673b0ef104002704
-size 21789
+oid sha256:af7606bbbe83146ae2ea762bc5f2c63805d88146a46b6fcd63907edc3c2273de
+size 21689

--- a/plugins/CorePluginsAdmin/Menu.php
+++ b/plugins/CorePluginsAdmin/Menu.php
@@ -64,7 +64,7 @@ class Menu extends \Piwik\Plugin\Menu
         }
 
         if ($hasSuperUserAcess) {
-            $menu->addSystemItem(Piwik::translate('General_Plugins') . $pluginsUpdateMessage,
+            $menu->addSystemItem('General_Plugins',
                 $this->urlForAction('plugins', array('activated' => '')),
                 $order = 20);
         }


### PR DESCRIPTION
### Description:

Currently on mobile the Plugins menu item is broken and unreadable, this removes the feature of adding the amount of plugin updates there are making the translation work.

In the future we can make the UI consistent and use a badge count for this menu.

https://github.com/matomo-org/matomo/issues/21204

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
