### PR TITLE
process general goal metrics if no conversions, but site is ecommerce enabled

### DIFF
--- a/plugins/Ecommerce/tests/Fixtures/AbandonedCartWithoutConversions.php
+++ b/plugins/Ecommerce/tests/Fixtures/AbandonedCartWithoutConversions.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Ecommerce\tests\Fixtures;
+
+use Piwik\Date;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Plugins\Goals\API as GoalsAPI;
+
+class AbandonedCartWithoutConversions extends Fixture
+{
+    public $idSite = 1;
+    public $idGoalStandard = 1;
+    public $dateTime = '2011-04-05 00:11:42';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpWebsitesAndGoals();
+        $this->trackVisits();
+    }
+
+    private function setUpWebsitesAndGoals()
+    {
+        if (!self::siteCreated($this->idSite)) {
+            $this->idSite = self::createWebsite($this->dateTime, $ecommerce = 1, 'test site');
+        }
+
+        if (!self::goalExists($this->idSite, $this->idGoalStandard)) {
+            GoalsAPI::getInstance()->addGoal(
+                $this->idSite, 'title match, triggered NEVER', 'title', 'saldkfjaslkdfjsalkdjf', 'contains',
+                $caseSensitive = false, $revenue = 10, $allowMultipleConversions = true
+            );
+        }
+    }
+
+    private function trackVisits()
+    {
+        // visit without ecommerce
+        $t = self::getTracker($this->idSite, $this->dateTime, $defaultInit = true);
+        $t->setUrl('http://piwik.net/here/we/go');
+        $t->setForceVisitDateTime(Date::factory($this->dateTime)->getDatetime());
+        self::checkResponse($t->doTrackPageView('one page visit'));
+
+        // visit with abandoned cart
+        $t = self::getTracker($this->idSite, $this->dateTime, $defaultInit = true);
+        $t->setUrl('http://piwik.net/here/we/go');
+        $t->setForceVisitDateTime(Date::factory($this->dateTime)->addHour(1)->getDatetime());
+        self::checkResponse($t->doTrackPageView('one page visit'));
+
+        $t->setForceVisitDateTime(Date::factory($this->dateTime)->addHour(1.1)->getDatetime());
+        $t->addEcommerceItem($sku = 'SKU IN ABANDONED CART ONE', $name = 'PRODUCT ONE LEFT in cart', $category = '', $price = 500.11111112, $quantity = 2);
+        self::checkResponse($t->doTrackEcommerceCartUpdate($grandTotal = 1000));
+    }
+}

--- a/plugins/Ecommerce/tests/System/AbandonedCartWithoutConversionsTest.php
+++ b/plugins/Ecommerce/tests/System/AbandonedCartWithoutConversionsTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Ecommerce\tests\System;
+
+use Piwik\Piwik;
+use Piwik\Plugins\Ecommerce\tests\Fixtures\AbandonedCartWithoutConversions;
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
+
+class AbandonedCartWithoutConversionsTest extends SystemTestCase
+{
+    /**
+     * @var AbandonedCartWithoutConversions
+     */
+    public static $fixture;
+
+    /**
+     * @dataProvider getApiForTesting
+     */
+    public function testApi($api, $params)
+    {
+        $this->runApiTests($api, $params);
+    }
+
+    public function getApiForTesting()
+    {
+        $idSite   = self::$fixture->idSite;
+        $dateTime = self::$fixture->dateTime;
+
+        $api = ['Goals'];
+        $goalItemApi = ['Goals.getItemsSku', 'Goals.getItemsName', 'Goals.getItemsCategory'];
+
+        return [
+            [
+                $api, [
+                    'idSite' => $idSite,
+                    'date' => $dateTime,
+                    'periods' => ['day', 'week'],
+                    'idGoal' => Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_CART,
+                ],
+            ],
+            [
+                $goalItemApi, [
+                    'idSite'                 => $idSite,
+                    'date'                   => $dateTime,
+                    'periods'                => ['day', 'week'],
+                    'testSuffix'             => '_AbandonedCarts',
+                    'otherRequestParameters' => [
+                        'abandonedCarts' => 1,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public static function getOutputPrefix()
+    {
+        return 'abandonedCartWithoutConversions';
+    }
+
+    public static function getPathToTestDirectory()
+    {
+        return dirname(__FILE__);
+    }
+}
+
+AbandonedCartWithoutConversionsTest::$fixture = new AbandonedCartWithoutConversions();

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions_AbandonedCarts__Goals.getItemsCategory_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions_AbandonedCarts__Goals.getItemsCategory_day.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>Product Category not defined</label>
+		<revenue>1000.22</revenue>
+		<quantity>2</quantity>
+		<abandoned_carts>1</abandoned_carts>
+		<avg_price>500.11</avg_price>
+		<avg_quantity>2</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions_AbandonedCarts__Goals.getItemsCategory_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions_AbandonedCarts__Goals.getItemsCategory_week.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>Product Category not defined</label>
+		<revenue>1000.22</revenue>
+		<quantity>2</quantity>
+		<abandoned_carts>1</abandoned_carts>
+		<avg_price>500.11</avg_price>
+		<avg_quantity>2</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions_AbandonedCarts__Goals.getItemsName_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions_AbandonedCarts__Goals.getItemsName_day.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>PRODUCT ONE LEFT in cart</label>
+		<revenue>1000.22</revenue>
+		<quantity>2</quantity>
+		<abandoned_carts>1</abandoned_carts>
+		<avg_price>500.11</avg_price>
+		<avg_quantity>2</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions_AbandonedCarts__Goals.getItemsName_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions_AbandonedCarts__Goals.getItemsName_week.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>PRODUCT ONE LEFT in cart</label>
+		<revenue>1000.22</revenue>
+		<quantity>2</quantity>
+		<abandoned_carts>1</abandoned_carts>
+		<avg_price>500.11</avg_price>
+		<avg_quantity>2</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions_AbandonedCarts__Goals.getItemsSku_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions_AbandonedCarts__Goals.getItemsSku_day.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>SKU IN ABANDONED CART ONE</label>
+		<revenue>1000.22</revenue>
+		<quantity>2</quantity>
+		<abandoned_carts>1</abandoned_carts>
+		<avg_price>500.11</avg_price>
+		<avg_quantity>2</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions_AbandonedCarts__Goals.getItemsSku_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions_AbandonedCarts__Goals.getItemsSku_week.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>SKU IN ABANDONED CART ONE</label>
+		<revenue>1000.22</revenue>
+		<quantity>2</quantity>
+		<abandoned_carts>1</abandoned_carts>
+		<avg_price>500.11</avg_price>
+		<avg_quantity>2</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getDaysToConversion_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getDaysToConversion_day.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>0 days</label>
+		<nb_conversions>1</nb_conversions>
+	</row>
+	<row>
+		<label>1 day</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>2 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>3 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>4 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>5 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>6 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>7 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>8-14 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>15-30 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>31-60 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>61-120 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>121-364 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>365+ days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getDaysToConversion_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getDaysToConversion_week.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>0 days</label>
+		<nb_conversions>1</nb_conversions>
+	</row>
+	<row>
+		<label>1 day</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>2 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>3 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>4 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>5 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>6 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>7 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>8-14 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>15-30 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>31-60 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>61-120 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>121-364 days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>365+ days</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getGoal.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getGoal.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<success message="ok" />
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getGoals.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getGoals.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row key="1">
+		<idsite>1</idsite>
+		<idgoal>1</idgoal>
+		<name>title match, triggered NEVER</name>
+		<description />
+		<match_attribute>title</match_attribute>
+		<pattern>saldkfjaslkdfjsalkdjf</pattern>
+		<pattern_type>contains</pattern_type>
+		<case_sensitive>0</case_sensitive>
+		<allow_multiple>1</allow_multiple>
+		<revenue>10</revenue>
+		<deleted>0</deleted>
+		<event_value_as_revenue>0</event_value_as_revenue>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getItemsCategory_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getItemsCategory_day.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result />

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getItemsCategory_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getItemsCategory_week.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result />

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getItemsName_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getItemsName_day.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result />

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getItemsName_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getItemsName_week.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result />

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getItemsSku_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getItemsSku_day.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result />

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getItemsSku_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getItemsSku_week.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result />

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getMetrics_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getMetrics_day.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_conversions>1</nb_conversions>
+	<nb_visits_converted>1</nb_visits_converted>
+	<revenue>1000</revenue>
+	<items>2</items>
+	<avg_order_revenue>1000</avg_order_revenue>
+	<conversion_rate>50%</conversion_rate>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getMetrics_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getMetrics_week.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_conversions>1</nb_conversions>
+	<nb_visits_converted>1</nb_visits_converted>
+	<revenue>1000</revenue>
+	<items>2</items>
+	<avg_order_revenue>1000</avg_order_revenue>
+	<conversion_rate>50%</conversion_rate>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getVisitsUntilConversion_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getVisitsUntilConversion_day.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>1 visit</label>
+		<nb_conversions>1</nb_conversions>
+	</row>
+	<row>
+		<label>2 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>3 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>4 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>5 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>6 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>7 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>8 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>9-14 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>15-25 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>26-50 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>51-100 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>101+ visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getVisitsUntilConversion_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getVisitsUntilConversion_week.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>1 visit</label>
+		<nb_conversions>1</nb_conversions>
+	</row>
+	<row>
+		<label>2 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>3 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>4 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>5 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>6 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>7 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>8 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>9-14 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>15-25 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>26-50 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>51-100 visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+	<row>
+		<label>101+ visits</label>
+		<nb_conversions>0</nb_conversions>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.get_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.get_day.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_conversions>1</nb_conversions>
+	<nb_visits_converted>1</nb_visits_converted>
+	<revenue>1000</revenue>
+	<items>2</items>
+	<avg_order_revenue>1000</avg_order_revenue>
+	<conversion_rate>50%</conversion_rate>
+	<nb_conversions_new_visit>1</nb_conversions_new_visit>
+	<nb_visits_converted_new_visit>1</nb_visits_converted_new_visit>
+	<revenue_new_visit>1000</revenue_new_visit>
+	<items_new_visit>2</items_new_visit>
+	<avg_order_revenue_new_visit>1000</avg_order_revenue_new_visit>
+	<conversion_rate_new_visit>50%</conversion_rate_new_visit>
+	<nb_conversions_returning_visit>0</nb_conversions_returning_visit>
+	<nb_visits_converted_returning_visit>0</nb_visits_converted_returning_visit>
+	<revenue_returning_visit>0</revenue_returning_visit>
+	<items_returning_visit>0</items_returning_visit>
+	<avg_order_revenue_returning_visit>0</avg_order_revenue_returning_visit>
+	<conversion_rate_returning_visit>0%</conversion_rate_returning_visit>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.get_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.get_week.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_conversions>1</nb_conversions>
+	<nb_visits_converted>1</nb_visits_converted>
+	<revenue>1000</revenue>
+	<items>2</items>
+	<avg_order_revenue>1000</avg_order_revenue>
+	<conversion_rate>50%</conversion_rate>
+	<nb_conversions_new_visit>1</nb_conversions_new_visit>
+	<nb_visits_converted_new_visit>1</nb_visits_converted_new_visit>
+	<revenue_new_visit>1000</revenue_new_visit>
+	<items_new_visit>2</items_new_visit>
+	<avg_order_revenue_new_visit>1000</avg_order_revenue_new_visit>
+	<conversion_rate_new_visit>50%</conversion_rate_new_visit>
+	<nb_conversions_returning_visit>0</nb_conversions_returning_visit>
+	<nb_visits_converted_returning_visit>0</nb_visits_converted_returning_visit>
+	<revenue_returning_visit>0</revenue_returning_visit>
+	<items_returning_visit>0</items_returning_visit>
+	<avg_order_revenue_returning_visit>0</avg_order_revenue_returning_visit>
+	<conversion_rate_returning_visit>0%</conversion_rate_returning_visit>
+</result>

--- a/plugins/Goals/Archiver.php
+++ b/plugins/Goals/Archiver.php
@@ -116,7 +116,7 @@ class Archiver extends \Piwik\Plugin\Archiver
     public function aggregateDayReport()
     {
         $hasConversions = $this->getProcessor()->getNumberOfVisitsConverted() > 0;
-        if ($hasConversions) {
+        if ($hasConversions || $this->usesEcommerce($this->getSiteId())) {
             $this->aggregateGeneralGoalMetrics();
         }
 
@@ -531,7 +531,7 @@ class Archiver extends \Piwik\Plugin\Archiver
         }
 
         // overall numeric metrics
-        if ($hasConversions) {
+        if ($hasConversions || $this->usesEcommerce($this->getSiteId())) {
             $fieldsToSum = array();
             foreach ($goalIdsToSum as $goalId) {
                 $metricsToSum = Goals::getGoalColumns($goalId);


### PR DESCRIPTION
### Description:

Apply https://github.com/matomo-org/matomo/pull/21265 to 4.x-dev

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
