### PR TITLE
Ensure UI test always has same result

### DIFF
--- a/tests/UI/expected-screenshots/UIIntegrationTest_dashboard3.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_dashboard3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2becc2b27b6608a861c68e517832e309b73ffef2f8262f1f4e4f1f68449d4d79
-size 708130
+oid sha256:f1e41a8925a26bdb67f4cd66304de8f22adf399eb6482f4dedf43ec4f87acc34
+size 708953

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -28,8 +28,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             visitorId: testEnvironment.forcedIdVisitor,
             realtimeWindow: 'false'
         };
-        testEnvironment.save();
-
+        testEnvironment.completeNoChallenge = true;
         testEnvironment.pluginsToLoad = ['CustomDirPlugin'];
         testEnvironment.save();
 
@@ -52,6 +51,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
 
     after(function () {
         delete testEnvironment.queryParamOverride;
+        delete testEnvironment.completeNoChallenge;
         testEnvironment.testUseMockAuth = 1;
         testEnvironment.save();
     });


### PR DESCRIPTION
### Description:

When working on another PR I had to remove some UI test suites. This caused the dashboard3 test to start failing. This seems to be caused by the new order the tests are running in there.
To ensure the Tour widget in that test always shows the same result, the tests now predefine a state where no challenges are completed.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
