### PR TITLE
Fix password handling when uploading plugins

### DIFF
--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -116,7 +116,7 @@ class Controller extends Plugin\ControllerAdmin
 
         if (!$this->passwordVerify->isPasswordCorrect(
             Piwik::getCurrentUserLogin(),
-            Common::getRequestVar('confirmPassword', null, 'string')
+            \Piwik\Request::fromRequest()->getStringParameter('confirmPassword')
         )) {
             throw new \Exception($this->translator->translate('Login_LoginPasswordNotCorrect'));
         }


### PR DESCRIPTION
### Description:

Due to using `Common::getRequestVar` for checking the password, this failed before if the password contains certain special chars like `<`.

fixes #21274 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
