### PR TITLE
Hide page performance row action on totals row

### DIFF
--- a/plugins/PagePerformance/javascripts/rowaction.js
+++ b/plugins/PagePerformance/javascripts/rowaction.js
@@ -70,7 +70,7 @@
         },
 
         isAvailableOnRow: function (dataTableParams, tr) {
-            return true;
+            return !tr.is('.totalsRow');
         },
 
         createInstance: function (dataTable, param) {


### PR DESCRIPTION
### Description:

The page performance row action is currently shown for all rows. For the totals row this always shows no values, as the current implementation doesn't work for that.

This PR will simply hide the icon on totals rows for now.

We can consider re-adding that later with a proper implementation with #21251

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
