### PR TITLE
Improve Diagnostics UI test

### DIFF
--- a/plugins/Diagnostics/tests/UI/Diagnostics_spec.js
+++ b/plugins/Diagnostics/tests/UI/Diagnostics_spec.js
@@ -24,6 +24,14 @@ describe("Diagnostics", function () {
                 html = html.replaceAll(directory.replaceAll('/', '\\/'), '\\/path\\/matomo');
                 $(this).html(html);
             });
+            // replace varying invalidation counts with 0
+            $('#systemCheckInformational td:contains(nvalidation) + td').each(function () {
+                let text = $(this).text();
+                if (text.match(/^[0-9]+$/)) {
+                  $(this).html($(this).html().replace(/[0-9]+/, '0'));
+                }
+            });
+
         }, PIWIK_INCLUDE_PATH);
         expect(await content.screenshot()).to.matchImage('page');
     });

--- a/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
+++ b/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e09e8fad9655f8b6f7cde5139cb15851819a04b162334189ba0a81b8a31d31a
-size 446607
+oid sha256:e05957a062cdcac94a50f4ab5c46db9c35f3c207de710a11a25a8d371d909a78
+size 446168


### PR DESCRIPTION
### Description:

The Diagnostics UI tests keeps randomly failing as soon as the order of tests changes. This is caused by the fact, that other test suites might cause invalidations to be triggered for the persisted fixture.

To ensure the test doesn't fail anymore in this case, the numbers will be replaced before taking the screenshot.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
