### PR TITLE
Use correct HTTP status code when user has no privileges

### DIFF
--- a/core/Exception/NoPrivilegesException.php
+++ b/core/Exception/NoPrivilegesException.php
@@ -8,6 +8,12 @@
  */
 namespace Piwik\Exception;
 
-class NoPrivilegesException extends Exception
+use Piwik\Http\HttpCodeException;
+
+class NoPrivilegesException extends Exception implements HttpCodeException
 {
+    public function __construct($message, $code = 401)
+    {
+        parent::__construct($message, $code);
+    }
 }


### PR DESCRIPTION
### Description:

This specific exception is only used when a logged in user does not have any access to a site. Sending a 401 Unauthorized should be more correct then sending the default 500.

fixes #19774

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
