### PR TITLE
Ensure response codes are not set for nested API calls

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -228,6 +228,11 @@ class Request
 
             // create the response
             $response = new ResponseBuilder($outputFormat, $this->request);
+            // do not send any header when processing a nested API request,
+            // as the headers might remain for to the original response
+            if (!self::isCurrentApiRequestTheRootApiRequest()) {
+                $response->disableSendHeader();
+            }
             if ($disablePostProcessing) {
                 $response->disableDataTablePostProcessor();
             }
@@ -249,8 +254,8 @@ class Request
             // read parameters
             $moduleMethod = Common::getRequestVar('method', null, 'string', $this->request);
 
-            list($module, $method) = $this->extractModuleAndMethod($moduleMethod);
-            list($module, $method) = self::getRenamedModuleAndAction($module, $method);
+            [$module, $method] = $this->extractModuleAndMethod($moduleMethod);
+            [$module, $method] = self::getRenamedModuleAndAction($module, $method);
 
             PluginManager::getInstance()->checkIsPluginActivated($module);
 
@@ -680,7 +685,7 @@ class Request
         if (empty($this->request['apiAction'])) {
             $this->request['apiAction'] = null;
         }
-        list($this->request['apiModule'], $this->request['apiAction']) = $this->getRenamedModuleAndAction($this->request['apiModule'], $this->request['apiAction']);
+        [$this->request['apiModule'], $this->request['apiAction']] = $this->getRenamedModuleAndAction($this->request['apiModule'], $this->request['apiAction']);
     }
 
     /**

--- a/tests/PHPUnit/System/ResponseCodeTest.php
+++ b/tests/PHPUnit/System/ResponseCodeTest.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\System;
+
+use Piwik\API\Request;
+use Piwik\Date;
+use Piwik\Plugins\UsersManager\Model;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
+
+/**
+ * @group Core
+ */
+class ResponseCodeTest extends SystemTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $model = new Model();
+        $model->addUser(
+            Fixture::VIEW_USER_LOGIN,
+            Fixture::VIEW_USER_PASSWORD,
+            'hello2@example.org',
+            Date::now()->getDatetime()
+        );
+        $model->addUserAccess(Fixture::VIEW_USER_LOGIN, 'view', [1]);
+        $model->addTokenAuth(
+            Fixture::VIEW_USER_LOGIN,
+            Fixture::VIEW_USER_TOKEN,
+            'View user token',
+            Date::now()->getDatetime()
+        );
+    }
+
+    public function testApiCallWithoutPermissionShouldHaveCorrectHttpStatus()
+    {
+        [$response, $info] = $this->curl(
+            Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php?module=API&method=API.getPhpVersion',
+            ['token_auth' => Fixture::VIEW_USER_TOKEN]
+        );
+
+        // The user doesn't have superuser access, so status code should be 401
+        $this->assertEquals(401, $info['http_code']);
+    }
+
+    public function testApiShouldHaveCorrectHttpStatus()
+    {
+        [$response, $info] = $this->curl(
+            Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php?module=API&method=API.getPhpVersion',
+            ['token_auth' => Fixture::ADMIN_USER_TOKEN]
+        );
+
+        // User has access so status code should be 200
+        $this->assertEquals(200, $info['http_code']);
+    }
+
+    public function testProcessedApiCallWithExceptionShouldHaveCorrectHttpStatus()
+    {
+        [$response, $info] = $this->curl(
+            Fixture::getRootUrl(
+            ) . 'tests/PHPUnit/proxy/index.php?module=API&method=SitesManager.getSiteUrlsFromId&idSite=1&reThrow=1',
+            ['token_auth' => Fixture::VIEW_USER_TOKEN]
+        );
+
+        // The message and status code from a nested API call should be used if they are not catched.
+        $this->assertEquals("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<result>\n	<error message=\"You can't access this resource as it requires a 'superuser' access.\" />\n</result>", $response);
+        $this->assertEquals(401, $info['http_code']);
+    }
+
+    public function testProcessedApiCallWithCaughtExceptionShouldHaveCorrectHttpStatus()
+    {
+        [$response, $info] = $this->curl(
+            Fixture::getRootUrl(
+            ) . 'tests/PHPUnit/proxy/index.php?module=API&method=SitesManager.getSiteUrlsFromId&idSite=1',
+            ['token_auth' => Fixture::VIEW_USER_TOKEN]
+        );
+
+        // Even though the user doesn't have superuser access, the response code should be 200 as the exception in the nested API call is caught
+        $this->assertEquals("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<result>error caught</result>", $response);
+        $this->assertEquals(200, $info['http_code']);
+    }
+
+    public function testProcessedApiShouldHaveCorrectHttpStatus()
+    {
+        [$response, $info] = $this->curl(
+            Fixture::getRootUrl(
+            ) . 'tests/PHPUnit/proxy/index.php?module=API&method=SitesManager.getSiteUrlsFromId&idSite=1',
+            ['token_auth' => Fixture::ADMIN_USER_TOKEN]
+        );
+
+        // The user has access to nested API method, so it's response should be returned
+        $this->assertEquals("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<result>no error</result>", $response);
+        $this->assertEquals(200, $info['http_code']);
+    }
+
+    private function curl($url, $postParams = [])
+    {
+        if (!function_exists('curl_init')) {
+            $this->markTestSkipped('Curl is not installed');
+        }
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HEADER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $postParams);
+
+        $response = curl_exec($ch);
+        $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+        $response = substr($response, $headerSize);
+
+        $responseInfo = curl_getinfo($ch);
+
+        curl_close($ch);
+
+        return [$response, $responseInfo];
+    }
+
+    public function provideContainerConfig()
+    {
+        return [
+            'observers.global' => \DI\add(
+                [
+                    [
+                        'API.Request.intercept',
+                        \DI\value(
+                            function (&$returnedValue, $finalParameters, $pluginName, $methodName, $parametersRequest) {
+                                if ($pluginName !== 'SitesManager' || $methodName !== 'getSiteUrlsFromId') {
+                                    return;
+                                }
+
+                                try {
+                                    // This call requires SuperUser access
+                                    Request::processRequest('API.getPhpVersion', [], $parametersRequest);
+                                    $returnedValue = 'no error';
+                                } catch (\Exception $e) {
+                                    $returnedValue = 'error caught';
+                                    if (!empty($parametersRequest['reThrow'])) {
+                                        throw $e;
+                                    }
+                                }
+                            }
+                        ),
+                    ],
+                ]
+            ),
+        ];
+    }
+}
+
+ResponseCodeTest::$fixture = new Fixture();


### PR DESCRIPTION
### Description:

with https://github.com/matomo-org/matomo/pull/19813 we introduced http status code 401 for unauthenticated API calls.

This caused some sort of regression when using nested API calls using `Request::process`.

If e.g. the processed API call throws an Exception with a http status code, this will be directly send using `http_response_code`. Even if this Exception would then be caught, and handled properly, the http status code remains, and the possibly valid response would be send with an incorrect status code.

This PR changes the behavior, so that the status code will only be set if the currently processed API call is the root request.
That way nested calls won't set the status code. But if their exceptions aren't caught the root request would set the correct status based on this (uncaught) exception.

refs #21254, DEV-17199, DEV-17183

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
