### PR TITLE
Prevent stray object references draining database connection pool

### DIFF
--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -64,6 +64,13 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         parent::__construct($config);
     }
 
+    public function closeConnection()
+    {
+        $this->cachePreparedStatement = [];
+
+        parent::closeConnection();
+    }
+
     /**
      * Returns connection handle
      *

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -386,6 +386,7 @@ class Fixture extends \PHPUnit\Framework\Assert
 
         self::clearInMemoryCaches();
 
+        Db::destroyDatabaseObject();
         Log::unsetInstance();
 
         $this->destroyEnvironment();

--- a/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
@@ -114,8 +114,9 @@ abstract class IntegrationTestCase extends SystemTestCase
      */
     protected static function configureFixture($fixture)
     {
-        $fixture->createSuperUser     = false;
-        $fixture->configureComponents = false;
+        $fixture->createSuperUser        = false;
+        $fixture->configureComponents    = false;
+        $fixture->dropDatabaseInTearDown = false;
 
         $fixture->extraTestEnvVars['loadRealTranslations'] = false;
     }

--- a/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
@@ -67,6 +67,8 @@ abstract class IntegrationTestCase extends SystemTestCase
     public static function tearDownAfterClass(): void
     {
         self::$tableData = array();
+
+        parent::tearDownAfterClass();
     }
 
     /**


### PR DESCRIPTION
### Description

As happended in [some test runs](https://github.com/matomo-org/matomo/actions/runs/6312855307/job/17139757396), it is possible for the CI to run out of available MySQL connections for the integration tests.

**tldr;:** Running a suitable amount of teardown in the `IntegrationTestCase` and cleaning the MySQL adapter prepared statement cache made the CI [happy again](https://github.com/matomo-org/matomo/actions/runs/6327099544/job/17182212708).

#### Analysis

MySQL, by default, should allow around 150 simultaneous connections. Exceeding that amount should never be necessary, and only point to fault with no longer used connections not being closed properly.

Verifying connections not being cleaned up can be done by watching the process list and running the tests:

```shell
# keep this open in one shell
watch "mysql -h<mysql_host> -u<mysql_user> -p<mysql_pass> <mysql_db> -e 'SHOW PROCESSLIST'"

# execute tests in another shell
# passing "--testdox" to see once a test was executed
./console tests:run --testsuite integration --options=--testdox
```

Initial process list probably looks like not much happening (yet):

```
+----+--------+-----------------+--------------+---------+------+-----------+---------------------------------------+
| Id | User   | Host            | db           | Command | Time | State     | Info                                  |
+----+--------+-----------------+--------------+---------+------+-----------+---------------------------------------+
| 19 | matomo | localhost:37470 | matomo       | Sleep   |   55 |           | NULL                                  |
| 24 | matomo | localhost:41480 | matomo_tests | Query   |    0 | query end | <-- snip some fixture setup query --> |
| 49 | matomo | localhost:47238 | matomo_tests | Query   |    0 | starting  | SHOW PROCESSLIST                      |
+----+--------+-----------------+--------------+---------+------+-----------+---------------------------------------+
```

After some integration test classes passed (like `Request`, `Access` and `Plugin List`), it probably looks like this:

```
+-----+--------+-----------------+--------------+---------+------+----------+------------------+
| Id  | User   | Host            | db           | Command | Time | State    | Info             |
+-----+--------+-----------------+--------------+---------+------+----------+------------------+
|  19 | matomo | localhost:37470 | matomo       | Sleep   |  455 |          | NULL             |
|  24 | matomo | localhost:41480 | matomo_tests | Sleep   |  342 |          | NULL             |
|  51 | matomo | localhost:56116 | matomo_tests | Sleep   |   18 |          | NULL             |
| 182 | matomo | localhost:45900 | NULL         | Sleep   |   16 |          | NULL             |
| 184 | matomo | localhost:45924 | matomo_tests | Sleep   |    0 |          | NULL             |
| 191 | matomo | localhost:39090 | matomo_tests | Query   |    0 | starting | SHOW PROCESSLIST |
+-----+--------+-----------------+--------------+---------+------+----------+------------------+
```

And then one class later:

```
+-----+--------+-----------------+--------------+---------+------+-----------+---------------------------------------+
| Id  | User   | Host            | db           | Command | Time | State     | Info                                  |
+-----+--------+-----------------+--------------+---------+------+-----------+---------------------------------------+
|  19 | matomo | localhost:37470 | matomo       | Sleep   |  484 |           | NULL                                  |
|  24 | matomo | localhost:41480 | matomo_tests | Sleep   |  371 |           | NULL                                  |
|  51 | matomo | localhost:56116 | matomo_tests | Sleep   |   47 |           | NULL                                  |
| 184 | matomo | localhost:45924 | matomo_tests | Query   |    0 | query end | <-- snip some fixture setup query --> |
| 192 | matomo | localhost:42446 | matomo_tests | Query   |    0 | starting  | SHOW PROCESSLIST                      |
+-----+--------+-----------------+--------------+---------+------+-----------+---------------------------------------+
```

Some connections from some tests (`182` + `184`) where properly cleaned up, but `24` and `51` are sticking around for several minutes after the class finished running.

#### Local setup

Tests were running locally using the minimum supported PHP version (7.2.x), default composer (PHPUnit 8.x) packages, and the `Pdo\Mysql` driver. PHPUnit 8.x does not play nice when using `--testdox` in combination with `--filter` (output buffered instead of each finished test being displayed immediately), so the local environment was stripped down (delete every other file in `/tests/PHPUnit/Integration/`) for a reproducible and small test run:

- `CacheIdTest.php`
- `CacheTest.php`
- `FrontControllerTest.php`

Running this small set had the worst behavior during execution of the `FrontControllerTest`, so it should be a good set:

```
+-----+--------+-----------------+--------------+---------+------+-------------+--------------------+
| Id  | User   | Host            | db           | Command | Time | State       | Info               |
+-----+--------+-----------------+--------------+---------+------+-------------+--------------------+
| 205 | matomo | localhost:35090 | matomo       | Sleep   |   87 |             | NULL               |
| 208 | matomo | localhost:35108 | matomo_tests | Sleep   |   63 |             | NULL               |
| 209 | matomo | localhost:41058 | NULL         | Sleep   |   61 |             | NULL               |
| 210 | matomo | localhost:41060 | matomo_tests | Sleep   |   40 |             | NULL               |
| 217 | matomo | localhost:50680 | NULL         | Sleep   |   38 |             | NULL               |
| 218 | matomo | localhost:52192 | matomo_tests | Sleep   |    7 |             | NULL               |
| 239 | matomo | localhost:56968 | matomo_tests | Sleep   |    6 |             | NULL               |
| 240 | matomo | localhost:56980 | NULL         | Sleep   |    4 |             | NULL               |
| 241 | matomo | localhost:56994 | matomo_tests | Query   |    0 | System lock | TRUNCATE `changes` |
| 243 | matomo | localhost:57018 | matomo_tests | Query   |    0 | starting    | SHOW PROCESSLIST   |
+-----+--------+-----------------+--------------+---------+------+-------------+--------------------+
```

#### Fault finding

There are two sets of database connections not being cleaned up, one with an active DB selection and one without. So not necessarily just one place to find a fault in.

Following the chain `IntegrationTestCase::setUpBeforeClass/0`, `SystemTestCase::setUpBeforeClass/0`, `$fixture->performSetUp/0` there where two connections found, one with a database and one without, both created via `Db::createDatabaseObject/0`. Patching in some bad code to log each connection creation:

```php
// Piwik\Db
public static function createDatabaseObject($dbConfig = null)
{
    // ... snip original code

    static $connections = [];

    $id = spl_object_id(self::$connection->getConnection());

    if (isset($connections[$id])) {
        return;
    }

    $connections[$id] = true;

    echo 'CREATE ' . $id .  PHP_EOL;
    debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 20);
}
```

As expected each test created two new (changed id from `spl_object_id`) database objects:

```
CREATE 13012
#0  Piwik\Db::createDatabaseObject() called at [/srv/matomo/tests/PHPUnit/Framework/Fixture.php:997]
#1  Piwik\Tests\Framework\Fixture::connectWithoutDatabase() called at [/srv/matomo/tests/PHPUnit/Framework/Fixture.php:252]
#2  Piwik\Tests\Framework\Fixture->performSetUp() called at [/srv/matomo/tests/PHPUnit/Framework/TestCase/SystemTestCase.php:121]
#3  Piwik\Tests\Framework\TestCase\SystemTestCase::setUpBeforeClass() called at [/srv/matomo/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php:61]
<-- snip -->
CREATE 13065
#0  Piwik\Db::createDatabaseObject() called at [/srv/matomo/tests/PHPUnit/Framework/Fixture.php:266]
#1  Piwik\Tests\Framework\Fixture->performSetUp() called at [/srv/matomo/tests/PHPUnit/Framework/TestCase/SystemTestCase.php:121]
#2  Piwik\Tests\Framework\TestCase\SystemTestCase::setUpBeforeClass() called at [/srv/matomo/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php:61]
<-- snip -->
```

If those stay around it probably means that somewhere a connection was not cleaned up. Probably a reference to the database object kept around, so the destructor of the connection handle won't run and release it.

#### Fixing

First change in the PR war done to `IntegrationTestCase::tearDownAfterClass/0`. There was no call to `parent::tearDownAfterClass/0` but without any obvious comment why, so adding it. This itself did not improve the situation.

Second change in the PR was done to the now called `Fixture::performTearDown/0`. The setup of the fixture was creating the connections, so it should be responsible to close them. That also did not improve the situation. Having added a teardown call to `Db::destroyDatabaseObject/0` should disconnect the database. And having various `self::$connection = null` in all the nested places of that call the objects should also be cleaned up, resulting in the destructor releasing the connection.

So adding some more bad code to the database disconnection:

```php
// Piwik\Db\Adapter\Pdo\Mysql
public function closeConnection()
{
    echo 'DESTROY ' . spl_object_id($this->_connection) . PHP_EOL;

    parent::closeConnection();
}
```

Now the test output looked like this:

```
CREATE 12988
DESTROY 12988
CREATE 13062
Cache Id (Piwik\Tests\Integration\CacheId)
  ...
DESTROY 13062
CREATE 14108
CREATE 14175
DESTROY 14175
CREATE 14186
Cache (Piwik\Tests\Integration\Cache)
  ...
DESTROY 14186
```

There are some connections that are not getting disconnected, and apparently even those calling `closeConnection/0` are staying open. As during connection closing only the reference to the object is removed (`$this->_connection = null`) there is most likely a reference still being kept around somewhere. And that one prevents the destructor from closing the connection as one would expect.

Patching `closeConnection/0` with an additional `debug_zval_dump($this->_connection)` to get the internal reference count:

```
CREATE 12994
DESTROY 12994
object(PDO)#12994 (0) refcount(5){
}
CREATE 13067
Cache Id (Piwik\Tests\Integration\CacheId)
   ...
DESTROY 13067
object(PDO)#13067 (0) refcount(113){
}
```

The first connection had 5 references to it, the second one a whopping 113, with only one getting released by `closeConnection/0`. And not getting direct information where these references are being held, it went one step up the chain to patching `Db::destroyDatabaseObject/0` with `debug_zval_dump(self::$connection);`, hoping to find more references from one of the known holders:

```
object(Piwik\Db\Adapter\Pdo\Mysql)#727 (14) refcount(5){
  ["supportsUncommitted"]=>
  NULL
  ["cachePreparedStatement":"Piwik\Db\Adapter\Pdo\Mysql":private]=>
  array(2) refcount(1){
    ["SELECT option_value, option_name FROM `matomo_option` WHERE autoload = 1"]=>
    object(Zend_Db_Statement_Pdo)#730 (9) refcount(1){
      ["_fetchMode":protected]=>
      int(2)
      ["_stmt":protected]=>
      object(PDOStatement)#731 (1) refcount(1){
        ["queryString"]=>
        string(72) "SELECT option_value, option_name FROM `matomo_option` WHERE autoload = 1" refcount(1)
      }
      ["_adapter":protected]=>
      object(Piwik\Db\Adapter\Pdo\Mysql)#727 (14) refcount(5){
        ["supportsUncommitted"]=>
        NULL
        ["cachePreparedStatement":"Piwik\Db\Adapter\Pdo\Mysql":private]=>
        array(2) refcount(1){
          ["SELECT option_value, option_name FROM `matomo_option` WHERE autoload = 1"]=>
          object(Zend_Db_Statement_Pdo)#730 (9) refcount(1){
            ["_fetchMode":protected]=>
            int(2)
            ["_stmt":protected]=>
            object(PDOStatement)#731 (1) refcount(1){
              ["queryString"]=>
              string(72) "SELECT option_value, option_name FROM `matomo_option` WHERE autoload = 1" refcount(1)
            }
            ["_adapter":protected]=>
            *RECURSION*
<-- snip -->
```

The `Pdo\Mysql` adapter has the feature of caching prepared statements. Each of those statements keeps a recursive connection to the adapter. But that cache is not getting cleared during `closeConnection/0` and then holds onto these references forever. But as the connection itself is getting closed it should not be usable anymore so as a third change the cache was unset (`$this->cachePreparedStatement = []`) when disconnecting.

And now lots of connections are disappearing during the test run \o/

#### Final thoughts

There are still some connections being kept open. They seem to be eventually cleaned up but can stay around for some time. More investigation should be done to close all connections in the previously pasted outputs having a `CREATE` but no `DESTROY`.

And if you have read all the above: is there a different (perhaps "simpler") approach to finding these problems?

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
