### PR TITLE
allow some tests that use exception backtraces to pass if line number changes

### DIFF
--- a/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
@@ -70,13 +70,15 @@ class ExceptionToTextProcessorTest extends \PHPUnit\Framework\TestCase
         $result = $processor($record);
 
         $expected = array(
-            'message' => __FILE__ . "(63): [message and stack trace] [Query: , CLI mode: 1]",
+            'message' => __FILE__ . "(%d): [message and stack trace] [Query: , CLI mode: 1]",
             'context' => array(
                 'exception' => $exception,
             ),
         );
 
-        $this->assertEquals($expected, $result);
+        $this->assertStringMatchesFormat($expected['message'], $result['message']);
+        $this->assertEquals($expected['context'], $result['context']);
+        $this->assertEquals(['context', 'message'], array_keys($result));
     }
 
     /**

--- a/tests/PHPUnit/System/ConsoleTest.php
+++ b/tests/PHPUnit/System/ConsoleTest.php
@@ -172,10 +172,10 @@ Matomo encountered an error: Allowed memory size of X bytes exhausted (tried to 
   'type' => 1,
   'message' => 'Allowed memory size of X bytes exhausted (tried to allocate X bytes)',
   'file' => '/tests/PHPUnit/System/ConsoleTest.php',
-  'line' => 84,
-  'backtrace' => ' on /tests/PHPUnit/System/ConsoleTest.php(84)
-#0 /tests/PHPUnit/System/ConsoleTest.php(69): Piwik\\\\Tests\\\\System\\\\TestCommandWithFatalError->executeImpl()
-#1 /core/Plugin/ConsoleCommand.php(110): Piwik\\\\Tests\\\\System\\\\TestCommandWithFatalError->doExecute()
+  'line' => %d,
+  'backtrace' => ' on /tests/PHPUnit/System/ConsoleTest.php(%d)
+#0 /tests/PHPUnit/System/ConsoleTest.php(%d): Piwik\\\\Tests\\\\System\\\\TestCommandWithFatalError->executeImpl()
+#1 /core/Plugin/ConsoleCommand.php(%d): Piwik\\\\Tests\\\\System\\\\TestCommandWithFatalError->doExecute()
 ',
 ))
 END;
@@ -184,7 +184,7 @@ END;
             $expected = "#!/usr/bin/env php\n" . $expected;
         }
 
-        $this->assertEquals($expected, $output);
+        $this->assertStringMatchesFormat($expected, $output);
     }
 
     public function test_Console_handlesExceptionsCorrectly()
@@ -199,7 +199,7 @@ END;
         $expected = <<<END
 *** IN SAFEMODE ***
 
-In ConsoleTest.php line 103:
+In ConsoleTest.php line %d:
               \n  test error  \n              \n
 test-command-with-exception
 
@@ -210,7 +210,7 @@ END;
             $expected = "#!/usr/bin/env php\n" . $expected;
         }
 
-        $this->assertEquals($expected, $output);
+        $this->assertStringMatchesFormat($expected, $output);
     }
 
     public static function provideContainerConfigBeforeClass()


### PR DESCRIPTION
### Description:

This change makes it possible for these tests to pass after related files have been prefixed.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
