### PR TITLE
Fix problems with displayed encoded entities in javascript translations

### DIFF
--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -199,13 +199,39 @@ class Translator
         $clientSideTranslations = array();
         foreach ($this->getClientSideTranslationKeys() as $id) {
             [$plugin, $key] = explode('_', $id, 2);
-            $clientSideTranslations[$id] = $this->getTranslation($id, $this->currentLanguage, $plugin, $key);
+            $clientSideTranslations[$id] = $this->decodeEntitiesSafeForHTML($this->getTranslation($id, $this->currentLanguage, $plugin, $key));
         }
 
         $js = 'var translations = ' . json_encode($clientSideTranslations) . ';';
         $js .= "\n" . 'if (typeof(piwik_translations) == \'undefined\') { var piwik_translations = new Object; }' .
             'for(var i in translations) { piwik_translations[i] = translations[i];} ';
         return $js;
+    }
+
+    /**
+     * Decodes all entities in the given string except of &gt; and &lt;
+     *
+     * @param string $text
+     * @return string
+     */
+    private function decodeEntitiesSafeForHTML(string $text): string
+    {
+        // replace encoded html tag entities, as they need to remain encoded
+        $text = str_replace(
+            ['&gt;', '&lt;'],
+            ['###gt###', '###lt###'],
+            $text
+        );
+
+        // decode all remaining entities
+        $text = html_entity_decode($text);
+
+        // recover encoded html tag entities
+        return str_replace(
+            ['###gt###', '###lt###'],
+            ['&gt;', '&lt;'],
+            $text
+        );
     }
 
     /**

--- a/plugins/CoreAdminHome/tests/UI/expected-screenshots/MobileMenu_mobileMenuPartial.png
+++ b/plugins/CoreAdminHome/tests/UI/expected-screenshots/MobileMenu_mobileMenuPartial.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9186a28e4ef2c2187fbbd6e4642206e6c8bad833f2f6e8384992eb4f88cd29a0
-size 58948
+oid sha256:dfdf9b95b915012ef623f73c90503f4bf5792bbbbb25957a127e760275cdf4e2
+size 58315


### PR DESCRIPTION
### Description:

In various places Matomo currently might display encoded entities to the user. This happens as some translations include encoded entities. When they are used in javascript/vue, they would currently be used as provided. That means that already encoded entities would encoded again for safety reasons (unless used in `v-html`). 

This PR tries to remove encoded entities provided for javascript. For safety reasons `&gt;` and `&lt;` will be kept, as decoding them could cause problems if they break html.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
