### PR TITLE
Use explicit timeout when rendering evolution graphs

### DIFF
--- a/plugins/CoreHome/templates/_dataTableJS.twig
+++ b/plugins/CoreHome/templates/_dataTableJS.twig
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     $(document).ready(function () {
-        window.Vue.nextTick(function () {
+        setTimeout(function () {
             require('piwik/UI/DataTable').initNewDataTables({{ reportId|json_encode|raw }});
-        });
+        }, 250);
     });
 </script>


### PR DESCRIPTION
### Description:

Refs DEV-17230.

This should be seen as a temporary workaround before a proper fix is implemented. Local testing showed that 100ms may not be enough and the graph still doesn't render, 250ms worked reliably in cases where the markup for the card was returned instantly (via temporary hardcoding in index.php).

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
