### PR TITLE
Fix failing UI tests caused by update message partially shown

### DIFF
--- a/plugins/CoreHome/tests/UI/VersionInfoHeaderMessage_spec.js
+++ b/plugins/CoreHome/tests/UI/VersionInfoHeaderMessage_spec.js
@@ -9,6 +9,7 @@
 
 describe('VersionInfoHeaderMessage', function() {
   const parentSuite = this;
+  this.fixture = "Piwik\\Tests\\Fixtures\\OneVisit";
 
   const selectorComponent = 'div[vue-entry="CoreHome.VersionInfoHeaderMessage"]';
   const selectorMessage = '#header_message';


### PR DESCRIPTION
### Description:

The new tests for testing the updater message are (re)using the UITestFixture. That's fine in general, but the overridden options remain in the database causing tests running later to work with that data.

This causes a couple of tests to fail currently as parts of the updater message are visible (see e.g. https://builds-artifacts.matomo.org/matomo-org/matomo/5.x-dev/6379907012/DashboardManager_expanded.png).
We actually would need a way to clean up such options correctly in the end.
Note: Setting  `optionsOverride` in `after()` might not work correctly, as it wouldn't be updated in the database unless we send another request.

Using another test fixture that doesn't contain much data seems to be the easiest solution for now, as it shouldn't affect other tests that way.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
