### PR TITLE
Use bound sql and backticks for table name

### DIFF
--- a/core/Updates/5.0.0-rc2.php
+++ b/core/Updates/5.0.0-rc2.php
@@ -43,12 +43,9 @@ class Updates_5_0_0_rc2 extends PiwikUpdates
         $viewDataTableSettings = Option::getLike('viewDataTableParameters_%_Referrers.getEvolutionGraph');
 
         foreach ($viewDataTableSettings as $name => $value) {
-            $migrations[] = $this->migration->db->sql(
-                sprintf(
-                    'DELETE FROM %s WHERE option_name = "%s"',
-                    Common::prefixTable('option'),
-                    $name
-                )
+            $migrations[] = $this->migration->db->boundSql(
+                sprintf('DELETE FROM `%s` WHERE option_name = ?', Common::prefixTable('option')),
+                [$name]
             );
         }
 


### PR DESCRIPTION
### Description:

Tweak migration script to be more secure using bound sql and backticks around table name.

Fixes #21337

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
