### PR TITLE
Fix for "What's new" content visible when it shouldn't be

### DIFF
--- a/core/Changes/Model.php
+++ b/core/Changes/Model.php
@@ -55,7 +55,11 @@ class Model
     {
         $pluginManager = PluginManager::getInstance();
 
-        if ($pluginManager && $pluginManager->isValidPluginName($pluginName) && $pluginManager->isPluginInFilesystem($pluginName)) {
+        if ($pluginManager &&
+            $pluginManager->isValidPluginName($pluginName) &&
+            $pluginManager->isPluginInFilesystem($pluginName) &&
+            $pluginManager->isPluginActivated($pluginName))
+        {
 
             $plugin = $pluginManager->loadPlugin($pluginName);
             if (!$plugin) {

--- a/plugins/CoreAdminHome/templates/whatIsNew.twig
+++ b/plugins/CoreAdminHome/templates/whatIsNew.twig
@@ -10,7 +10,7 @@
         <div class="card">
             <div class="card-content">
                 <span style="float: left; font-size:32px; color:#3450A3; margin-right:10px" class="icon-new_releases"></span>
-                {% if change.plugin_name == "CoreHome" %}
+                {% if change.plugin_name == "CoreHome" or change.plugin_name == "ProfessionalServices"%}
                     <h2 class="card-title">{{ change.title }}</h2>
                 {% else %}
                     <h2 class="card-title">{{ change.plugin_name }} - {{ change.title }}</h2>

--- a/plugins/CorePluginsAdmin/CorePluginsAdmin.php
+++ b/plugins/CorePluginsAdmin/CorePluginsAdmin.php
@@ -28,17 +28,16 @@ class CorePluginsAdmin extends Plugin
             'AssetManager.getStylesheetFiles'        => 'getStylesheetFiles',
             'System.addSystemSummaryItems'           => 'addSystemSummaryItems',
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
-            'PluginManager.pluginActivated'          => 'onPluginActivated',
-            'PluginManager.pluginInstalled'          => 'addPluginChanges',
             'Updater.componentUpdated'               => 'addPluginChanges',
-            'PluginManager.pluginUninstalled'        => 'removePluginChanges'
+            'PluginManager.pluginActivated'          => 'onPluginActivated',
+            'PluginManager.pluginDeactivated'        => 'removePluginChanges'
         );
     }
 
     /**
-     * Add any changes from newly installed or updated plugins to the changes table
+     * Add any changes from newly activated or updated plugins to the changes table
      *
-     * @param string $pluginName The name of the plugin that was updated or installed
+     * @param string $pluginName The name of the plugin that was updated or activated
      */
     public function addPluginChanges(string $pluginName)
     {
@@ -72,6 +71,8 @@ class CorePluginsAdmin extends Plugin
             $tagManagerTeaser = new TagManagerTeaser(Piwik::getCurrentUserLogin());
             $tagManagerTeaser->disableGlobally();
         }
+
+        $this->addPluginChanges($pluginName);
     }
 
     public function addSystemSummaryItems(&$systemSummary)


### PR DESCRIPTION
### Description:

The "What's new" feature loaded change items from each plugin's `changes.json` file into the database, however this is happening even for plugins that are deactivated.

This PR changes this behaviour to:
-  Load the changes into the database only when a plugin is activated/updated
-  Remove the changes from the database when a plugin is deactivated
-  Remove the automatic plugin name prefix when displaying the changes for the professional services plugin

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
