### PR TITLE
Fix last-n date lookup query for calculate-conversion-pages command

### DIFF
--- a/plugins/Goals/Commands/CalculateConversionPages.php
+++ b/plugins/Goals/Commands/CalculateConversionPages.php
@@ -245,8 +245,10 @@ class CalculateConversionPages extends ConsoleCommand
 
             // Since MySQL doesn't support multi-table updates with a LIMIT clause we will find the exact date time of
             // the lastN record and use that as a date range start with the current date time as the date range end
+            /** @noinspection SqlResolve SqlUnused */
             $sql = "
-                    SELECT MIN(c.server_time) 
+                    SELECT MIN(s.t) FROM (
+                    SELECT c.server_time AS t
                     FROM " . Common::prefixTable('log_conversion') . " c                                 
                     ";
 
@@ -269,7 +271,7 @@ class CalculateConversionPages extends ConsoleCommand
                 $sql .= ' WHERE '.ltrim($where, 'AND ');
             }
 
-            $sql .= " ORDER BY c.server_time DESC LIMIT " . $lastN;
+            $sql .= " ORDER BY c.server_time DESC LIMIT " . $lastN . ") AS s";
 
             $result = Db::fetchOne($sql, $bind);
 


### PR DESCRIPTION
### Description:

Fixes #21340

The `./console core:calculate-conversion-pages --last-n=x` command used to populate the conversion page before field looks up the date of the conversion x records ago and uses that date for the start of the calculation range. The query that looks up the date is malformed and will always return the date of the oldest conversion in the table regardless of the `--last-n` parameter supplied.

The impact of this is that when running the command on a large dataset with `--last-n=5000` the parameter will effectively be ignored and an attempt will be made to update the entire conversion table which is likely to exceed the lock timeout and fail.

This PR changes the data lookup query from :

```
SELECT MIN(c.server_time)
FROM log_conversion c
WHERE c.pageviews_before IS NULL
AND c.idgoal = 1
AND c.idsite = 1
ORDER BY c.server_time DESC LIMIT 5000;
```

to:

```
SELECT MIN(s.t) FROM (
  SELECT c.server_time AS t
  FROM log_conversion c
  WHERE c.pageviews_before IS NULL
  AND c.idgoal = 1
  AND c.idsite = 1
  ORDER BY c.server_time DESC LIMIT 5000;
) AS s
```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
