### PR TITLE
Fix segment SQL fetching for data comparison

### DIFF
--- a/core/Segment.php
+++ b/core/Segment.php
@@ -393,12 +393,17 @@ class Segment
         $matchType = $expression[SegmentExpression::INDEX_OPERAND_OPERATOR];
         $value     = $expression[SegmentExpression::INDEX_OPERAND_VALUE];
 
-        $segmentsList = Context::changeIdSite(implode(',', $this->idSites ?: []), function () {
-            return SegmentsList::get();
-        });
-        $segmentObject = $segmentsList->getSegment($name);
-
         $segment = $this->getSegmentByName($name);
+
+        if (empty($this->idSites)) {
+            $segmentsList = SegmentsList::get();
+        } else {
+            $segmentsList = Context::changeIdSite(implode(',', $this->idSites), function () {
+                return SegmentsList::get();
+            });
+        }
+
+        $segmentObject = $segmentsList->getSegment($name);
         $sqlName = $segmentObject->getSqlSegment();
 
         $joinTable = null;


### PR DESCRIPTION
### Description:

When selecting both a segment on the dashboard and a date for comparison, some widgets may run into a `call to a member function on null` error.

To reproduce:

1. Create (and activate) a visit dimension for a website
2. Create a new segment that uses this dimension, e.g. `dimension1 is test`
3. Add the `Visits over Time` widget to the dashboard
4. Select the previously created segment
5. Activate a date comparison, e.g. `previous period`

The widget should show "Oops… there was a problem during the request. " after the last step.

When creating the segment SQL a call to [`Context::changeIdSite()`](https://github.com/matomo-org/matomo/blob/b9d6dc8225dc577ac0ad83246fe54812077d8dab/core/Segment.php#L396) is issued to fetch the segment list. However, the callsite in the [`DataComparisonFilter`](https://github.com/matomo-org/matomo/blob/b9d6dc8225dc577ac0ad83246fe54812077d8dab/plugins/API/Filter/DataComparisonFilter.php#L392) does not pass the `idSite` parameter from the URL to the Segment for usage.

As the visit dimension is tied to a site, the empty site list will result in the segment not being returned. The nested API call to [`API.getSegmentsMetadata`](https://github.com/matomo-org/matomo/blob/b9d6dc8225dc577ac0ad83246fe54812077d8dab/core/Segment.php#L199) is itself calling `SegmentsList::get()`, but the API call respects the single `idSite` value from the dashboard request resulting in the unaccounted mismatch in the segment list.

Fixes #21348

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
