### PR TITLE
Cast column label to string to stop magic casting issues.

### DIFF
--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -830,7 +830,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
         ) {
             $label = $row->getColumn('label');
             if ($label !== false) {
-                $this->rowsIndexByLabel[$label] = count($this->rows) - 1;
+                $this->rowsIndexByLabel[(string) $label] = count($this->rows) - 1;
             }
         }
         return $row;

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -751,7 +751,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
         foreach ($this->rows as $id => $row) {
             $label = $row->getColumn('label');
             if ($label !== false) {
-                $this->rowsIndexByLabel[$label] = $id;
+                $this->rowsIndexByLabel[(string) $label] = $id;
             }
         }
 


### PR DESCRIPTION
### Description:

Labels can be anything, and PHP likes trying to cast itself. ( see https://3v4l.org/X6v6E#v8.1.24 )

This causes errors, and we can safely assume the key for the array should always be a string.

I didn't modify `Row.getColumn`'s response type or cast within there as there is a lot of code that depends on that and the change would be riskier.

Fixes: https://github.com/matomo-org/matomo/issues/21357

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
