### PR TITLE
Automatically set translation for label column based on dimension

### DIFF
--- a/core/Plugin/ViewDataTable.php
+++ b/core/Plugin/ViewDataTable.php
@@ -234,6 +234,11 @@ abstract class ViewDataTable implements ViewInterface
                 $this->config->addTranslations($processedMetrics);
             }
 
+            $dimension = $report->getDimension();
+            if (!empty($dimension)) {
+                $this->config->addTranslations(['label' => $dimension->getName()]);
+            }
+
             $this->config->title = $report->getName();
 
             $report->configureView($this);

--- a/plugins/Actions/Reports/GetDownloads.php
+++ b/plugins/Actions/Reports/GetDownloads.php
@@ -47,8 +47,6 @@ class GetDownloads extends Base
 
     public function configureView(ViewDataTable $view)
     {
-        $view->config->addTranslations(array('label' => $this->dimension->getName()));
-
         $view->config->columns_to_display = array('label', 'nb_visits', 'nb_hits');
         $view->config->show_exclude_low_population = false;
 

--- a/plugins/Actions/Reports/GetEntryPageTitles.php
+++ b/plugins/Actions/Reports/GetEntryPageTitles.php
@@ -75,8 +75,6 @@ class GetEntryPageTitles extends Base
 
     public function configureView(ViewDataTable $view)
     {
-        $view->config->addTranslations(array('label' => $this->dimension->getName()));
-
         $view->config->columns_to_display = array('label', 'entry_nb_visits', 'entry_bounce_count', 'bounce_rate');
         $view->config->title = $this->name;
 

--- a/plugins/Actions/Reports/GetEntryPageUrls.php
+++ b/plugins/Actions/Reports/GetEntryPageUrls.php
@@ -69,8 +69,6 @@ class GetEntryPageUrls extends Base
 
     public function configureView(ViewDataTable $view)
     {
-        $view->config->addTranslations(array('label' => $this->dimension->getName()));
-
         $view->config->title = $this->name;
         $view->config->columns_to_display = array('label', 'entry_nb_visits', 'entry_bounce_count', 'bounce_rate');
         $view->requestConfig->filter_sort_column = 'entry_nb_visits';

--- a/plugins/Actions/Reports/GetExitPageTitles.php
+++ b/plugins/Actions/Reports/GetExitPageTitles.php
@@ -83,8 +83,6 @@ class GetExitPageTitles extends Base
 
     public function configureView(ViewDataTable $view)
     {
-        $view->config->addTranslations(array('label' => $this->dimension->getName()));
-
         $view->config->title = $this->name;
         $view->config->columns_to_display = array('label', 'exit_nb_visits', 'nb_visits', 'exit_rate');
 

--- a/plugins/Actions/Reports/GetExitPageUrls.php
+++ b/plugins/Actions/Reports/GetExitPageUrls.php
@@ -81,8 +81,6 @@ class GetExitPageUrls extends Base
             'action' => 'getExitPageUrls',
         ));
 
-        $view->config->addTranslations(array('label' => $this->dimension->getName()));
-
         $view->config->title = $this->name;
 
         $view->config->columns_to_display        = array('label', 'exit_nb_visits', 'nb_visits', 'exit_rate');

--- a/plugins/Actions/Reports/GetOutlinks.php
+++ b/plugins/Actions/Reports/GetOutlinks.php
@@ -50,8 +50,6 @@ class GetOutlinks extends Base
 
     public function configureView(ViewDataTable $view)
     {
-        $view->config->addTranslations(array('label' => $this->dimension->getName()));
-
         $view->config->columns_to_display          = array('label', 'nb_visits', 'nb_hits');
         $view->config->show_exclude_low_population = false;
 

--- a/plugins/Actions/Reports/GetPageTitles.php
+++ b/plugins/Actions/Reports/GetPageTitles.php
@@ -74,7 +74,6 @@ class GetPageTitles extends Base
 
         $view->config->title = $this->name;
 
-        $view->config->addTranslation('label', $this->dimension->getName());
         $view->config->columns_to_display = array('label', 'nb_hits', 'nb_visits', 'bounce_rate',
                                                   'avg_time_on_page', 'exit_rate');
 

--- a/plugins/Actions/Reports/GetPageTitlesFollowingSiteSearch.php
+++ b/plugins/Actions/Reports/GetPageTitlesFollowingSiteSearch.php
@@ -67,8 +67,6 @@ class GetPageTitlesFollowingSiteSearch extends SiteSearchBase
 
     protected function configureViewForUrlAndTitle(ViewDataTable $view, $title)
     {
-        $view->config->addTranslations(array('label' => $this->dimension->getName()));
-
         $view->config->title = $title;
         $view->config->columns_to_display          = array('label', 'nb_hits_following_search', 'nb_hits');
         $view->config->show_exclude_low_population = false;

--- a/plugins/Actions/Reports/GetPageUrls.php
+++ b/plugins/Actions/Reports/GetPageUrls.php
@@ -71,7 +71,6 @@ class GetPageUrls extends Base
 
     public function configureView(ViewDataTable $view)
     {
-        $view->config->addTranslation('label', $this->dimension->getName());
         $view->config->columns_to_display = array('label', 'nb_hits', 'nb_visits', 'bounce_rate',
                                                   'avg_time_on_page', 'exit_rate');
 

--- a/plugins/Actions/Reports/GetSiteSearchCategories.php
+++ b/plugins/Actions/Reports/GetSiteSearchCategories.php
@@ -52,8 +52,6 @@ class GetSiteSearchCategories extends SiteSearchBase
 
     public function configureView(ViewDataTable $view)
     {
-        $view->config->addTranslations(array('label' => $this->dimension->getName()));
-
         $view->config->columns_to_display     = array('label', 'nb_visits', 'nb_pages_per_search');
         $view->config->show_table_all_columns = false;
         $view->config->show_bar_chart         = false;

--- a/plugins/Actions/Reports/GetSiteSearchKeywords.php
+++ b/plugins/Actions/Reports/GetSiteSearchKeywords.php
@@ -61,7 +61,6 @@ class GetSiteSearchKeywords extends SiteSearchBase
 
     public function configureView(ViewDataTable $view)
     {
-        $view->config->addTranslation('label', $this->dimension->getName());
         $view->config->columns_to_display = array('label', 'nb_visits', 'nb_pages_per_search', 'exit_rate');
 
         $this->addSiteSearchDisplayProperties($view);

--- a/plugins/Actions/Reports/GetSiteSearchNoResultKeywords.php
+++ b/plugins/Actions/Reports/GetSiteSearchNoResultKeywords.php
@@ -60,7 +60,6 @@ class GetSiteSearchNoResultKeywords extends SiteSearchBase
 
     public function configureView(ViewDataTable $view)
     {
-        $view->config->addTranslation('label', $this->dimension->getName());
         $view->config->columns_to_display = array('label', 'nb_visits', 'exit_rate');
 
         $this->addSiteSearchDisplayProperties($view);

--- a/plugins/Contents/Reports/Base.php
+++ b/plugins/Contents/Reports/Base.php
@@ -44,10 +44,6 @@ abstract class Base extends Report
         $view->config->datatable_css_class = 'ContentsDataTable';
         $view->config->show_table_all_columns = false;
 
-        if (!empty($this->dimension)) {
-            $view->config->addTranslations(array('label' => $this->dimension->getName()));
-        }
-
         $view->config->columns_to_display = array_merge(
             array('label'),
             array_keys($this->getMetrics()),

--- a/plugins/CustomDimensions/GetCustomDimension.php
+++ b/plugins/CustomDimensions/GetCustomDimension.php
@@ -89,8 +89,6 @@ class GetCustomDimension extends Report
 
         if ($view->requestConfig->idSubtable) {
             $view->config->addTranslation('label', Piwik::translate('Actions_ColumnActionURL'));
-        } elseif (!empty($this->dimension)) {
-            $view->config->addTranslation('label', $this->dimension->getName());
         }
 
         $view->requestConfig->request_parameters_to_modify['idDimension'] = $idDimension;

--- a/plugins/DevicePlugins/Reports/GetPlugin.php
+++ b/plugins/DevicePlugins/Reports/GetPlugin.php
@@ -34,7 +34,6 @@ class GetPlugin extends Base
         $this->getBasicDevicePluginsDisplayProperties($view);
 
         $view->config->addTranslations(array(
-            'label'                => $this->dimension->getName(),
             'nb_visits_percentage' =>
             str_replace(' ', '&nbsp;', Piwik::translate('General_ColumnPercentageVisits'))
         ));

--- a/plugins/DevicesDetection/Reports/GetBrowserEngines.php
+++ b/plugins/DevicesDetection/Reports/GetBrowserEngines.php
@@ -35,6 +35,5 @@ class GetBrowserEngines extends Base
     {
         $view->config->show_search = false;
         $view->config->show_exclude_low_population = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
     }
 }

--- a/plugins/DevicesDetection/Reports/GetBrowserVersions.php
+++ b/plugins/DevicesDetection/Reports/GetBrowserVersions.php
@@ -29,7 +29,6 @@ class GetBrowserVersions extends Base
     {
         $view->config->show_search = true;
         $view->config->show_exclude_low_population = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
     }
 
     public function getRelatedReports()

--- a/plugins/DevicesDetection/Reports/GetBrowsers.php
+++ b/plugins/DevicesDetection/Reports/GetBrowsers.php
@@ -31,7 +31,6 @@ class GetBrowsers extends Base
         $view->config->title = $this->name;
         $view->config->show_search = true;
         $view->config->show_exclude_low_population = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
     }
 
     public function getRelatedReports()

--- a/plugins/DevicesDetection/Reports/GetOsFamilies.php
+++ b/plugins/DevicesDetection/Reports/GetOsFamilies.php
@@ -31,7 +31,6 @@ class GetOsFamilies extends Base
         $view->config->title = $this->name;
         $view->config->show_search = false;
         $view->config->show_exclude_low_population = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
     }
 
     public function getRelatedReports()

--- a/plugins/ExampleReport/Reports/GetExampleReport.php
+++ b/plugins/ExampleReport/Reports/GetExampleReport.php
@@ -59,10 +59,6 @@ class GetExampleReport extends Base
      */
     public function configureView(ViewDataTable $view)
     {
-        if (!empty($this->dimension)) {
-            $view->config->addTranslations(array('label' => $this->dimension->getName()));
-        }
-
         // $view->config->show_search = false;
         // $view->requestConfig->filter_sort_column = 'nb_visits';
         // $view->requestConfig->filter_limit = 10';

--- a/plugins/Goals/Reports/GetDaysToConversion.php
+++ b/plugins/Goals/Reports/GetDaysToConversion.php
@@ -46,8 +46,6 @@ class GetDaysToConversion extends Base
         $view->requestConfig->filter_sort_column = 'label';
         $view->requestConfig->filter_sort_order  = 'asc';
         $view->requestConfig->filter_limit       = count(Archiver::$daysToConvRanges);
-
-        $view->config->addTranslations(array('label' => $this->dimension->getName()));
     }
 
     public function configureReportMetadata(&$availableReports, $infos)

--- a/plugins/Goals/Reports/GetVisitsUntilConversion.php
+++ b/plugins/Goals/Reports/GetVisitsUntilConversion.php
@@ -45,8 +45,6 @@ class GetVisitsUntilConversion extends Base
         $view->requestConfig->filter_sort_column = 'label';
         $view->requestConfig->filter_sort_order  = 'asc';
         $view->requestConfig->filter_limit       = count(Archiver::$visitCountRanges);
-
-        $view->config->addTranslations(array('label' => $this->dimension->getName()));
     }
 
     public function configureReportMetadata(&$availableReports, $infos)

--- a/plugins/Referrers/Reports/GetAll.php
+++ b/plugins/Referrers/Reports/GetAll.php
@@ -48,7 +48,6 @@ class GetAll extends Base
 
         $view->config->show_exclude_low_population = false;
         $view->config->show_goals = true;
-        $view->config->addTranslation('label', $this->dimension->getName());
 
         $view->requestConfig->filter_limit = 20;
 

--- a/plugins/Referrers/Reports/GetCampaigns.php
+++ b/plugins/Referrers/Reports/GetCampaigns.php
@@ -32,7 +32,6 @@ class GetCampaigns extends Base
     public function configureView(ViewDataTable $view)
     {
         $view->config->show_exclude_low_population = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
 
         $view->requestConfig->filter_limit = 25;
 

--- a/plugins/Referrers/Reports/GetKeywordsFromCampaignId.php
+++ b/plugins/Referrers/Reports/GetKeywordsFromCampaignId.php
@@ -29,7 +29,6 @@ class GetKeywordsFromCampaignId extends Base
     {
         $view->config->show_search = false;
         $view->config->show_exclude_low_population = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
     }
 
 }

--- a/plugins/Referrers/Reports/GetKeywordsFromSearchEngineId.php
+++ b/plugins/Referrers/Reports/GetKeywordsFromSearchEngineId.php
@@ -28,7 +28,6 @@ class GetKeywordsFromSearchEngineId extends Base
     {
         $view->config->show_search = false;
         $view->config->show_exclude_low_population = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
     }
 
 }

--- a/plugins/Referrers/Reports/GetSearchEngines.php
+++ b/plugins/Referrers/Reports/GetSearchEngines.php
@@ -33,7 +33,6 @@ class GetSearchEngines extends Base
     {
         $view->config->show_exclude_low_population = false;
         $view->config->show_search = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
 
         $view->requestConfig->filter_limit = 25;
 

--- a/plugins/Referrers/Reports/GetSearchEnginesFromKeywordId.php
+++ b/plugins/Referrers/Reports/GetSearchEnginesFromKeywordId.php
@@ -28,7 +28,6 @@ class GetSearchEnginesFromKeywordId extends Base
     {
         $view->config->show_search = false;
         $view->config->show_exclude_low_population = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
     }
 
 }

--- a/plugins/Referrers/Reports/GetSocials.php
+++ b/plugins/Referrers/Reports/GetSocials.php
@@ -46,7 +46,6 @@ class GetSocials extends Base
         $view->config->show_pivot_by_subtable = false;
         $view->config->show_exclude_low_population = false;
         $view->config->show_goals = true;
-        $view->config->addTranslation('label', $this->dimension->getName());
 
         $view->requestConfig->filter_limit = 10;
 

--- a/plugins/Referrers/Reports/GetUrlsForSocial.php
+++ b/plugins/Referrers/Reports/GetUrlsForSocial.php
@@ -28,7 +28,6 @@ class GetUrlsForSocial extends Base
     {
         $view->config->show_goals = true;
         $view->config->show_exclude_low_population = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
 
         $view->requestConfig->filter_limit = 10;
     }

--- a/plugins/Referrers/Reports/GetUrlsFromWebsiteId.php
+++ b/plugins/Referrers/Reports/GetUrlsFromWebsiteId.php
@@ -29,7 +29,6 @@ class GetUrlsFromWebsiteId extends Base
         $view->config->show_search = false;
         $view->config->show_exclude_low_population = false;
         $view->config->tooltip_metadata_name       = 'url';
-        $view->config->addTranslation('label', $this->dimension->getName());
     }
 
 }

--- a/plugins/Referrers/Reports/GetWebsites.php
+++ b/plugins/Referrers/Reports/GetWebsites.php
@@ -41,7 +41,6 @@ class GetWebsites extends Base
     public function configureView(ViewDataTable $view)
     {
         $view->config->show_exclude_low_population = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
 
         $view->requestConfig->filter_limit = 25;
 

--- a/plugins/Resolution/Reports/GetConfiguration.php
+++ b/plugins/Resolution/Reports/GetConfiguration.php
@@ -30,8 +30,6 @@ class GetConfiguration extends Base
     {
         $this->getBasicResolutionDisplayProperties($view);
 
-        $view->config->addTranslation('label', $this->dimension->getName());
-
         $view->requestConfig->filter_limit = 3;
         $view->config->show_search = true;
     }

--- a/plugins/Resolution/Reports/GetResolution.php
+++ b/plugins/Resolution/Reports/GetResolution.php
@@ -29,8 +29,6 @@ class GetResolution extends Base
     public function configureView(ViewDataTable $view)
     {
         $this->getBasicResolutionDisplayProperties($view);
-
-        $view->config->addTranslation('label', $this->dimension->getName());
     }
 
     public function getRelatedReports()

--- a/plugins/UserCountry/Reports/GetCity.php
+++ b/plugins/UserCountry/Reports/GetCity.php
@@ -30,7 +30,6 @@ class GetCity extends Base
     {
         $view->config->show_exclude_low_population = false;
         $view->config->documentation = $this->documentation;
-        $view->config->addTranslation('label', $this->dimension->getName());
 
         $view->requestConfig->filter_limit = 5;
 

--- a/plugins/UserCountry/Reports/GetContinent.php
+++ b/plugins/UserCountry/Reports/GetContinent.php
@@ -47,7 +47,6 @@ class GetContinent extends Base
         $view->config->show_pagination_control = false;
         $view->config->show_limit_control = false;
         $view->config->documentation = $this->documentation;
-        $view->config->addTranslation('label', $this->dimension->getName());
     }
 
 }

--- a/plugins/UserCountry/Reports/GetCountry.php
+++ b/plugins/UserCountry/Reports/GetCountry.php
@@ -30,7 +30,6 @@ class GetCountry extends Base
     public function configureView(ViewDataTable $view)
     {
         $view->config->show_exclude_low_population = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
         $view->config->documentation = $this->documentation;
 
         $view->requestConfig->filter_limit = 5;

--- a/plugins/UserCountry/Reports/GetRegion.php
+++ b/plugins/UserCountry/Reports/GetRegion.php
@@ -31,7 +31,6 @@ class GetRegion extends Base
     {
         $view->config->show_exclude_low_population = false;
         $view->config->documentation = $this->documentation;
-        $view->config->addTranslation('label', $this->dimension->getName());
 
         $view->requestConfig->filter_limit = 5;
 

--- a/plugins/UserLanguage/Reports/GetLanguage.php
+++ b/plugins/UserLanguage/Reports/GetLanguage.php
@@ -29,7 +29,6 @@ class GetLanguage extends Base
         $view->config->show_search = false;
         $view->config->columns_to_display = array('label', 'nb_visits');
         $view->config->show_exclude_low_population = false;
-        $view->config->addTranslation('label', $this->dimension->getName());
 
         $view->requestConfig->filter_sort_column = 'nb_visits';
         $view->requestConfig->filter_sort_order  = 'desc';

--- a/plugins/VisitTime/Reports/GetByDayOfWeek.php
+++ b/plugins/VisitTime/Reports/GetByDayOfWeek.php
@@ -40,7 +40,6 @@ class GetByDayOfWeek extends Base
 
         $view->config->enable_sort = false;
         $view->config->show_footer_message = Piwik::translate('General_ReportGeneratedFrom', $this->getDateRangeForFooterMessage());
-        $view->config->addTranslation('label', $this->dimension->getName());
 
         if (property_exists($view->config, 'disable_row_evolution')) {
             $view->config->disable_row_evolution = true;

--- a/plugins/VisitorInterest/Reports/GetNumberOfVisitsPerVisitDuration.php
+++ b/plugins/VisitorInterest/Reports/GetNumberOfVisitsPerVisitDuration.php
@@ -50,7 +50,6 @@ class GetNumberOfVisitsPerVisitDuration extends Base
         $view->requestConfig->filter_sort_column = 'label';
         $view->requestConfig->filter_sort_order  = 'asc';
 
-        $view->config->addTranslation('label', $this->dimension->getName());
         $view->config->enable_sort = false;
         $view->config->show_exclude_low_population = false;
         $view->config->show_offset_information = false;


### PR DESCRIPTION
### Description:

While working on another issue I came across the fact, that we are manually setting the translation for the label column for most reports based on the dimension name.

Logically it should be the default that the name of the dimension is used as title for the label column.
Some reports still have custom overwrites, which is fine and should still work, as they are set in `configureView`, which is called after the new "default" translation for the label column is set.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
