### PR TITLE
Ignore summary row when aggregating goal metrics for custom dimensions

### DIFF
--- a/plugins/CustomDimensions/RecordBuilders/CustomDimension.php
+++ b/plugins/CustomDimensions/RecordBuilders/CustomDimension.php
@@ -137,6 +137,11 @@ class CustomDimension extends RecordBuilder
             $value = $this->cleanCustomDimensionValue($row[$valueField]);
             unset($row[$valueField]);
 
+            if ($value === RankingQuery::LABEL_SUMMARY_ROW) {
+                // skip summary row
+                continue;
+            }
+
             $idGoal = (int) $row['idgoal'];
             $columns = [
                 Metrics::INDEX_GOALS => [


### PR DESCRIPTION
### Description:

_This is only some sort of "quick fix". As the grouping into summary rows for goal metrics actually might make the data inaccurate. See #21345 for more details on the problem._

Metrics for custom dimensions might be queried using a ranking query. If there are more records found than the ranking query allows, all additional data would be combined in a summary row.
Goal metrics are fetched here:
https://github.com/matomo-org/matomo/blob/5e96e8dec9fef438dffc7c3fdbda1196708d4bac/plugins/CustomDimensions/RecordBuilders/CustomDimension.php#L124-L154

This might result in a record where the value as well as the goal id is set to `__mtm_ranking_query_others__`.
Without the casting to int for the goal id, this would end up as a goal record for the summary row of the custom dimension record.
The newly added cast to int, actually only causes this summarized row to be added to goal id `0`, which represents abandoned carts. So it makes the values incorrect.

Reproducing this can be done by setting the config values:
```
datatable_archiving_maximum_rows_custom_dimensions = 5
archiving_ranking_query_row_limit = 5
```

In addition a couple of goals need to be created and a lot visits needs to be generated for a single day, so there are a enough conversions with different dimension values to hit the limit. (Note: it's multiplied by 10, so at least over 50 conversion records are required)

For testing the dimension with id2 can be used, as the visitor generator should fill it with random numbers. 

Note: This is a very specific issue that only happens in custom dimensions as far as I could see. Other archivers currently don't use a ranking query and therefor no summary rows are created in mysql.

refs https://github.com/matomo-org/matomo/issues/21345

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
