### PR TITLE
Fix warning Trying to add two strings in DataTable\Row::sumRowArray

### DIFF
--- a/plugins/CoreHome/Columns/Metrics/EvolutionMetric.php
+++ b/plugins/CoreHome/Columns/Metrics/EvolutionMetric.php
@@ -142,7 +142,7 @@ class EvolutionMetric extends ProcessedMetric
         $ratio = self::getRatio($this->currentData, $this->pastData, $row);
         $period = $this->pastData->getMetadata(DataTableFactory::TABLE_METADATA_PERIOD_INDEX);
         $row->setMetadata('ratio', $ratio);
-        $row->setMetadata('currencySymbol', $row['label'] !== DataTable::ID_SUMMARY_ROW ? Site::getCurrencySymbolFor($row['label']) : API::getInstance()->getDefaultCurrency());
+        $row->setMetadata('currencySymbol', $row['label'] !== DataTable::ID_SUMMARY_ROW && $row['label'] !== DataTable::LABEL_TOTALS_ROW ? Site::getCurrencySymbolFor($row['label']) : API::getInstance()->getDefaultCurrency());
         $row->setMetadata('previous_'.$columnName, $pastValue);
         $row->setMetadata('periodName', $period->getLabel());
         $row->setMetadata('previousRange', $period->getLocalizedShortString());

--- a/plugins/CoreHome/tests/Integration/Columns/Metrics/EvolutionMetricTest.php
+++ b/plugins/CoreHome/tests/Integration/Columns/Metrics/EvolutionMetricTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreHome\tests\Integration\Columns\Metrics;
+
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+use Piwik\Date;
+use Piwik\Plugins\CoreHome\Columns\Metrics\EvolutionMetric;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group CoreHome
+ * @group EvolutionMetricTest
+ * @group Plugins
+ * @group Columns
+ */
+class EvolutionMetricTest extends IntegrationTestCase
+{
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        Fixture::createWebsite('2022-01-01 00:00:00');
+    }
+
+    public function test_shouldNotBreakIfSummaryRowGiven()
+    {
+        $this->assertNoFailureOnComputeForLabel(DataTable::ID_SUMMARY_ROW);
+    }
+
+    public function test_shouldNotBreakIfTotalsRowGiven()
+    {
+        $this->assertNoFailureOnComputeForLabel(DataTable::LABEL_TOTALS_ROW);
+    }
+
+    private function assertNoFailureOnComputeForLabel($label): void
+    {
+        $pastData = new DataTable();
+        $cPeriod = new \Piwik\Period\Week(Date::factory('2021-10-10'));
+        $pastData->setMetadata('period', $cPeriod);
+
+        $evolution = new EvolutionMetric('nb_visits', $pastData);
+
+        $row = new Row([Row::COLUMNS => ['nb_visits' => 5, 'label' => $label]]);
+        $evolution->compute($row);
+
+        $currency = $row->getMetadata('currencySymbol');
+        $this->assertNotEmpty($currency);
+    }
+}

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Conversions_MultiSites.getAll_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Conversions_MultiSites.getAll_firstSite_lastN__API.getProcessedReport_day.xml
@@ -342,5 +342,16 @@
 		</result>
 	</reportMetadata>
 	<reportTotal>
+		<nb_visits>9</nb_visits>
+		<nb_actions>31</nb_actions>
+		<nb_pageviews>31</nb_pageviews>
+		<revenue>35</revenue>
+		<_metadata>
+			<ts_archived>today-date-removed-in-tests</ts_archived>
+		</_metadata>
+		<visits_evolution_trend>7</visits_evolution_trend>
+		<actions_evolution_trend>7</actions_evolution_trend>
+		<pageviews_evolution_trend>7</pageviews_evolution_trend>
+		<revenue_evolution_trend>6</revenue_evolution_trend>
 	</reportTotal>
 </result>


### PR DESCRIPTION
### Description:

fixes DEV-17267  https://github.com/matomo-org/matomo/issues/21373

In the stack trace you can see this happens with label "-2". The evolution metric fails with an exception because the site -2 does not exist when trying to determine the currency symbol.

I reproduced it multiple times with this patch and without. With this patch the scheduled report works but not without.

<img width="1450" alt="image" src="https://github.com/matomo-org/matomo/assets/273120/ad5e0cb4-4b20-4346-9c9c-d22bfe9e78ee">


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
