### PR TITLE
Fix undefined index if forced archiving is configured

### DIFF
--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -359,6 +359,7 @@ class Loader
                 'archiveExists' => false,
                 'tsArchived' => false,
                 'doneFlagValue' => false,
+                'existingRecords' => null,
             ];
         }
 

--- a/tests/PHPUnit/Integration/ArchiveProcessor/LoaderLockTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/LoaderLockTest.php
@@ -13,6 +13,10 @@ use Piwik\ArchiveProcessor\LoaderLock;
 use Piwik\Common;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
+/**
+ * @group ArchiveProcessor
+ * @group ArchiveProcessorLoaderLock
+ */
 class LoaderLockTest extends IntegrationTestCase
 {
 

--- a/tests/PHPUnit/Integration/ArchiveProcessor/LoaderTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/LoaderTest.php
@@ -32,6 +32,10 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Plugins\SegmentEditor\API as SegmentApi;
 use Piwik\ArchiveProcessor\Rules;
 
+/**
+ * @group ArchiveProcessor
+ * @group ArchiveProcessorLoader
+ */
 class LoaderTest extends IntegrationTestCase
 {
     protected static function beforeTableDataCached()
@@ -1131,6 +1135,7 @@ class LoaderTest extends IntegrationTestCase
             'archiveExists' => false,
             'doneFlagValue' => false,
             'tsArchived' => false,
+            'existingRecords' => null,
         ], $archiveInfo);
     }
 

--- a/tests/PHPUnit/Integration/ArchiveProcessor/ParametersTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/ParametersTest.php
@@ -17,6 +17,10 @@ use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Period;
 
+/**
+ * @group ArchiveProcessor
+ * @group ArchiveProcessorParameters
+ */
 class ParametersTest extends IntegrationTestCase
 {
     public function setUp(): void


### PR DESCRIPTION
### Description:

Running the archiver when forced archiving is configured (`always_data_archive_*`) produces a bunch of unnecessary log entries:

```
/srv/matomo/core/ArchiveProcessor/Loader.php(227): Notice - Undefined index: existingRecords
#0/core/ArchiveProcessor/Loader.php(227)
#1/core/ArchiveProcessor/Loader.php(133)
#2/core/ArchiveProcessor/Loader.php(104)
#3/core/Context.php(75)
#4/core/ArchiveProcessor/Loader.php(108)
#5/plugins/CoreAdminHome/API.php(297)
#6/core/Archive.php(923)
#7/core/Archive.php(699)
#8/core/Archive.php(638)
#9/core/Archive.php(564)
```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
