### PR TITLE
Fix for card formatting on what's new popup

### DIFF
--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -483,6 +483,7 @@ nav {
   max-height: 500px;
   margin-bottom: 10px;
   padding-right: 5px;
+  padding-left: 5px;
 }
 
 .whatisnew-btn {

--- a/plugins/CoreHome/tests/UI/expected-screenshots/WhatIsNew_what_is_new.png
+++ b/plugins/CoreHome/tests/UI/expected-screenshots/WhatIsNew_what_is_new.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:64b2b6f0a9e83c317b7fabf17f280739f272168fd0892a5d3e219eb4f5495feb
-size 51183
+oid sha256:ee07319ea5a1556587b6eebf625fb4f5f018f90a6255a96641bfde64d1439e76
+size 51455


### PR DESCRIPTION
### Description:

Fixes #21442

Tweaks the left margin of the what's new popup items so that the card border is not cut off.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
