### PR TITLE
Fix possible action data loss in segmentation due to signed int32 overflow

### DIFF
--- a/core/DataAccess/RawLogDao.php
+++ b/core/DataAccess/RawLogDao.php
@@ -331,7 +331,7 @@ class RawLogDao
     private function createTempTableForStoringUsedActions()
     {
         $sql = "CREATE TEMPORARY TABLE " . Common::prefixTable(self::DELETE_UNUSED_ACTIONS_TEMP_TABLE_NAME) . " (
-					idaction INT(11),
+					idaction INTEGER(10) UNSIGNED NOT NULL,
 					PRIMARY KEY (idaction)
 				)";
         Db::query($sql);


### PR DESCRIPTION
When idaction exceeds signed int32 max (2147483647) - the temp table in "createTempTableForStoringUsedActions()" cannot store the idactions anymore and thus still used log_action rows will get deleted.