### PR TITLE
Fix problem with incorrectly placed modals

### DIFF
--- a/plugins/CoreHome/javascripts/popover.js
+++ b/plugins/CoreHome/javascripts/popover.js
@@ -107,6 +107,10 @@ var Piwik_Popover = (function () {
         if (container !== false) {
             $('.ui-dialog').css({margin: '0 0'});
             container.dialog("option", "position", {my: 'center', at: 'center', of: '.ui-widget-overlay', collision: 'fit'});
+            // in some cases jQuery UI fails to place the dialog correctly and set the top values to something negative
+            if ($('.ui-dialog').position().top < 0) {
+                $('.ui-dialog').css('top', '0');
+            }
             $('.ui-dialog').css({margin: '15px 0'});
         }
     };


### PR DESCRIPTION
### Description:

In some weird cases modals might currently be placed incorrect, causing them to get partially hidden when being placed with a negative top position.

The positioning is handled by jQuery UI. It seems like for some reason the collision detection of jquery doesn't work properly resulting in a negative top value.

I tried debugging that for a while, but decided not to waste more time. The simple fix in this PR should fix the problem by simply unsetting negative top values to ensure the element is correctly visible.

fixes DEV-17273

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
