### PR TITLE
Avoid unneeded screenshots in SupportedBrowser UI tests

### DIFF
--- a/tests/UI/expected-screenshots/SupportedBrowser_page_loads_when_browser_supported.png
+++ b/tests/UI/expected-screenshots/SupportedBrowser_page_loads_when_browser_supported.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9f9b429582e4351b494c4ef50d2c813cadd1a6445ac645b9380ce9d714af191
-size 223644

--- a/tests/UI/expected-screenshots/SupportedBrowser_widget_loads_when_browser_supported.png
+++ b/tests/UI/expected-screenshots/SupportedBrowser_widget_loads_when_browser_supported.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32c8e91fab8902de77b8537044a75fc5dfafad7f2b864b6c573ac551d9e9d46e
-size 78884

--- a/tests/UI/specs/SupportedBrowser_spec.js
+++ b/tests/UI/specs/SupportedBrowser_spec.js
@@ -10,7 +10,7 @@
 describe("SupportedBrowser", function () {
     const widgetUrl = "?module=Widgetize&action=iframe&containerId=VisitOverviewWithGraph&disableLink=0&widget=1&moduleToWidgetize=CoreHome&actionToWidgetize=renderWidgetContainer&idSite=1&period=range&date=2012-01-12,2012-01-17&disableLink=1&widget=1";
     const generalParams = 'idSite=1&period=year&date=2009-01-04';
-    const pageUrl = '?module=CoreHome&action=index&' + generalParams;
+    const pageUrl = '?module=CoreHome&action=index&'+generalParams+'#?'+generalParams+'&category=General_Visitors&subcategory=General_Overview';
     const ie10UserAgent = "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)";
     const firefoxUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.2; rv:85.0) Gecko/20100101 Firefox/85.0";
 
@@ -27,15 +27,21 @@ describe("SupportedBrowser", function () {
     it("should load widget when browser supported", async function () {
         page.setUserAgent(firefoxUserAgent);
         await page.goto(widgetUrl);
-        expect(await page.screenshot({ fullPage: true })).to.matchImage('widget_loads_when_browser_supported');
+
+        // only check that widgetized report is loaded, no need to take a screenshot
+        const widget = await page.waitForSelector('.widget-container');
+        await page.waitForNetworkIdle();
+        expect(widget).to.be.ok;
     });
 
     it("should load page when browser supported", async function () {
         page.setUserAgent(firefoxUserAgent);
         await page.goto(pageUrl);
-        await page.waitForSelector('.widget', { visible: true });
+
+        // only check that reporting page is loaded, no need to take a screenshot
+        const reportingPage = await page.waitForSelector('.reporting-page');
         await page.waitForNetworkIdle();
-        expect(await page.screenshot({ fullPage: true })).to.matchImage('page_loads_when_browser_supported');
+        expect(reportingPage).to.be.ok;
     });
 
     it("should fail load widget when browser not supported", async function () {


### PR DESCRIPTION
### Description:

refs #21458

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
