### PR TITLE
Exclude wbraid and gbraid URL parameters by default

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -951,7 +951,7 @@ default_time_one_page_visit = 0
 
 ; Comma separated list of URL query string variable names that will be removed from your tracked URLs
 ; By default, Matomo will remove the most common parameters which are known to change often (eg. session ID parameters)
-url_query_parameter_to_exclude_from_url = "gclid,fbclid,msclkid,twclid,yclid,fb_xd_fragment,fb_comment_id,phpsessid,jsessionid,sessionid,aspsessionid,doing_wp_cron,sid,pk_vid"
+url_query_parameter_to_exclude_from_url = "gclid,fbclid,msclkid,twclid,wbraid,gbraid,yclid,fb_xd_fragment,fb_comment_id,phpsessid,jsessionid,sessionid,aspsessionid,doing_wp_cron,sid,pk_vid"
 
 ; If set to 1, Matomo will use the default provider if no other provider is configured.
 ; In addition the default provider will be used as a fallback when the configure provider does not return any results.

--- a/tests/PHPUnit/Integration/Tracker/ActionTest.php
+++ b/tests/PHPUnit/Integration/Tracker/ActionTest.php
@@ -182,6 +182,8 @@ class ActionTest extends IntegrationTestCase
             ['https://www.example.com/path3?msclkid=1234', 'https://www.example.com/path3'],
             ['https://www.example.com/path4?yclid=1234', 'https://www.example.com/path4'],
             ['https://www.example.com/path5?twclid=1234', 'https://www.example.com/path5'],
+            ['https://www.example.com/path6?wbraid=1234', 'https://www.example.com/path6'],
+            ['https://www.example.com/path7?gbraid=1234', 'https://www.example.com/path7'],
             ['https://www.example.com?random=1234', 'https://www.example.com?random=1234'],
             ['https://www.example.com?random=1234&yclid=qwerty', 'https://www.example.com?random=1234'],
         ];


### PR DESCRIPTION
### Description:

Similar to https://github.com/matomo-org/matomo/pull/21452

We have been already excluding gclid. In compliance with Apple’s ATT policy changes, Google is no longer sending GCLID parameters on iOS traffic coming from various Google apps. Google has introduced new URL parameters termed WBRAID and GBRAID to be compliant with Apple’s ATT framework. 

We should exclude these by default as well to keep `log_action` table fast, reports useful, and record less personal data when it's not needed.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
