### PR TITLE
Adjust day to fetch new geo location databases when done monthly

### DIFF
--- a/plugins/GeoIp2/GeoIP2AutoUpdater.php
+++ b/plugins/GeoIp2/GeoIP2AutoUpdater.php
@@ -81,7 +81,7 @@ class GeoIP2AutoUpdater extends Task
             case self::SCHEDULE_PERIOD_MONTHLY:
             default:
                 $schedulePeriod = new Monthly();
-                $schedulePeriod->setDayOfWeek(3, 0);
+                $schedulePeriod->setDay(3);
                 break;
         }
 


### PR DESCRIPTION
### Description:

When geolocation database updates are configured to be done monthly, they were scheduled on the 3rd day of _the week_, so Wednesday. For months that start on a Wednesday, that means that we tried to fetch a file that might not exist yet.

We now schedule on the 3rd day of _the month_, as I believe was the original intent of dc98a97182 that introduced the behavior a long time ago. So this gives 3 days to db-ip.com to update their files in all cases.

Fixes #18427

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
