### PR TITLE
[WIP] Emit RUN_END event before finishing UI tests

### DIFF
--- a/tests/lib/screenshot-testing/support/app.js
+++ b/tests/lib/screenshot-testing/support/app.js
@@ -319,7 +319,9 @@ Application.prototype.doRunTests = function (mocha) {
 
   
     this.runner.on(EVENT_RUN_END, function() {
-      process.exit(failures);
+      // we are terminating but we are waiting for all other events to finish
+      setTimeout(() => process.exit(failures), 10000);
+      
     })
   
     this.runner.on('suite', function() {

--- a/tests/lib/screenshot-testing/support/app.js
+++ b/tests/lib/screenshot-testing/support/app.js
@@ -296,10 +296,14 @@ Application.prototype.runTests = function (mocha) {
 };
 
 Application.prototype.doRunTests = function (mocha) {
+    const { EVENT_RUN_END } = Mocha.Runner.constants;
+    let failures;
+  
     testEnvironment.reload();
-
+  
     // run tests
-    this.runner = mocha.run(function (failures) {
+    this.runner = mocha.run(function (f) {
+        failures = f;
         // remove symlinks
         if (!options['keep-symlinks']) {
             var symlinks = ['libs', 'plugins', 'tests', 'misc', 'node_modules', 'piwik.js', 'matomo.js'];
@@ -311,10 +315,13 @@ Application.prototype.doRunTests = function (mocha) {
                 }
             });
         }
-
-        process.exit(failures);
     });
 
+  
+    this.runner.on(EVENT_RUN_END, function() {
+      process.exit(failures);
+    })
+  
     this.runner.on('suite', function() {
         page.webpage.mouse.move(-10, -10);
     });


### PR DESCRIPTION
### Description:

This PR is more for discussion and probably should not be merged as it is.

Currently, when tests are reported to Testomat.io they are not marked as "Finished" because mocha process is prematurely terminated with `process.exit()`. In Testomat.io we rely on `EVENT_RUN_END` event to finalize the report. I propose to wait few seconds after the run ends, and then terminating it. Anyway, I don't think the `process.exit` is an elegant way of stopping the process, so this part probably should be improved.

I don't like my solution. If possible, please reconsider using process.exit usage and make sure that `EVENT_RUN_END` is fired before process ends.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
