### PR TITLE
Fix deprecated call to setValue with single property

### DIFF
--- a/tests/PHPUnit/Integration/RetryScheduledTaskTest.php
+++ b/tests/PHPUnit/Integration/RetryScheduledTaskTest.php
@@ -61,7 +61,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         $now = time() - 60;
         $taskName = 'Piwik\Tests\Integration\RetryScheduledTaskTest.exceptionalTask';
         $timetableData = serialize([$taskName => $now]);
-        self::getReflectedPiwikOptionInstance()->setValue(new PiwikOption($timetableData));
+        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue(new PiwikOption($timetableData));
 
         // Create task
         $dailySchedule = $this->createPartialMock('Piwik\Scheduler\Schedule\Daily', array('getTime'));
@@ -95,7 +95,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         $now = time() - 60;
         $taskName = 'Piwik\Tests\Integration\RetryScheduledTaskTest.normalExceptionTask';
         $timetableData = serialize([$taskName => $now]);
-        self::getReflectedPiwikOptionInstance()->setValue(new PiwikOption($timetableData));
+        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue(new PiwikOption($timetableData));
 
         // Create task
         $specificSchedule = $this->createPartialMock('Piwik\Scheduler\Schedule\SpecificTime', array('getTime'));

--- a/tests/PHPUnit/Integration/RetryScheduledTaskTest.php
+++ b/tests/PHPUnit/Integration/RetryScheduledTaskTest.php
@@ -7,6 +7,7 @@
  */
 
 namespace Piwik\Tests\Integration;
+use Piwik\Option;
 use Piwik\Scheduler\RetryableException;
 use Piwik\Scheduler\Timetable;
 use Piwik\Scheduler\Scheduler;
@@ -14,7 +15,7 @@ use Piwik\Scheduler\Task;
 use Piwik\Tests\Framework\Mock\PiwikOption;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Log\NullLogger;
-use ReflectionProperty;
+use ReflectionClass;
 
 /**
  * @group Scheduler
@@ -61,7 +62,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         $now = time() - 60;
         $taskName = 'Piwik\Tests\Integration\RetryScheduledTaskTest.exceptionalTask';
         $timetableData = serialize([$taskName => $now]);
-        self::getReflectedPiwikOptionInstance()->setValue(null, new PiwikOption($timetableData));
+        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue('instance', new PiwikOption($timetableData));
 
         // Create task
         $dailySchedule = $this->createPartialMock('Piwik\Scheduler\Schedule\Daily', array('getTime'));
@@ -85,7 +86,8 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         // Should be rescheduled one hour from now
         $this->assertEquals($now+3660, $nextRun);
 
-        self::getReflectedPiwikOptionInstance()->setValue(null, null);
+
+        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue('instance', null);
 
     }
 
@@ -95,7 +97,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         $now = time() - 60;
         $taskName = 'Piwik\Tests\Integration\RetryScheduledTaskTest.normalExceptionTask';
         $timetableData = serialize([$taskName => $now]);
-        self::getReflectedPiwikOptionInstance()->setValue(null, new PiwikOption($timetableData));
+        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue('instance', new PiwikOption($timetableData));
 
         // Create task
         $specificSchedule = $this->createPartialMock('Piwik\Scheduler\Schedule\SpecificTime', array('getTime'));
@@ -120,14 +122,12 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         // Should not have scheduled for retry
         $this->assertEquals($now+50000, $nextRun);
 
-        self::getReflectedPiwikOptionInstance()->setValue(null, null);
+        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue('instance', null);
     }
 
-    private static function getReflectedPiwikOptionInstance()
+    private static function getReflectedPiwikOptionInstance(): ReflectionClass
     {
-        $piwikOptionInstance = new ReflectionProperty('Piwik\Option', 'instance');
-        $piwikOptionInstance->setAccessible(true);
-        return $piwikOptionInstance;
+        return new ReflectionClass(Option::class);
     }
 
     public function exceptionalTask()

--- a/tests/PHPUnit/Integration/RetryScheduledTaskTest.php
+++ b/tests/PHPUnit/Integration/RetryScheduledTaskTest.php
@@ -61,7 +61,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         $now = time() - 60;
         $taskName = 'Piwik\Tests\Integration\RetryScheduledTaskTest.exceptionalTask';
         $timetableData = serialize([$taskName => $now]);
-        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue(new PiwikOption($timetableData));
+        self::getReflectedPiwikOptionInstance()->setValue(null, new PiwikOption($timetableData));
 
         // Create task
         $dailySchedule = $this->createPartialMock('Piwik\Scheduler\Schedule\Daily', array('getTime'));
@@ -85,7 +85,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         // Should be rescheduled one hour from now
         $this->assertEquals($now+3660, $nextRun);
 
-        self::getReflectedPiwikOptionInstance()->setValue(null);
+        self::getReflectedPiwikOptionInstance()->setValue(null, null);
 
     }
 
@@ -95,7 +95,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         $now = time() - 60;
         $taskName = 'Piwik\Tests\Integration\RetryScheduledTaskTest.normalExceptionTask';
         $timetableData = serialize([$taskName => $now]);
-        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue(new PiwikOption($timetableData));
+        self::getReflectedPiwikOptionInstance()->setValue(null, new PiwikOption($timetableData));
 
         // Create task
         $specificSchedule = $this->createPartialMock('Piwik\Scheduler\Schedule\SpecificTime', array('getTime'));
@@ -120,7 +120,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         // Should not have scheduled for retry
         $this->assertEquals($now+50000, $nextRun);
 
-        self::getReflectedPiwikOptionInstance()->setValue(null);
+        self::getReflectedPiwikOptionInstance()->setValue(null, null);
     }
 
     private static function getReflectedPiwikOptionInstance()

--- a/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
@@ -232,7 +232,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
 
     private static function stubPiwikOption($timetable)
     {
-        self::getReflectedPiwikOptionInstance()->setValue(new PiwikOption($timetable));
+        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue(new PiwikOption($timetable));
     }
 
     private static function resetPiwikOption()

--- a/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
@@ -9,13 +9,14 @@
 namespace Piwik\Tests\Unit\Scheduler;
 
 use Piwik\Date;
+use Piwik\Option;
 use Piwik\Plugin;
 use Piwik\Scheduler\Scheduler;
 use Piwik\Scheduler\Task;
 use Piwik\Scheduler\Timetable;
 use Piwik\Tests\Framework\Mock\PiwikOption;
 use Piwik\Log\NullLogger;
-use ReflectionProperty;
+use ReflectionClass;
 
 /**
  * @group Scheduler
@@ -232,18 +233,16 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
 
     private static function stubPiwikOption($timetable)
     {
-        self::getReflectedPiwikOptionInstance()->setValue(null, new PiwikOption($timetable));
+        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue('instance', new PiwikOption($timetable));
     }
 
     private static function resetPiwikOption()
     {
-        self::getReflectedPiwikOptionInstance()->setValue(null, null);
+        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue('instance', null);
     }
 
-    private static function getReflectedPiwikOptionInstance()
+    private static function getReflectedPiwikOptionInstance(): ReflectionClass
     {
-        $piwikOptionInstance = new ReflectionProperty('Piwik\Option', 'instance');
-        $piwikOptionInstance->setAccessible(true);
-        return $piwikOptionInstance;
+        return new ReflectionClass(Option::class);
     }
 }

--- a/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
@@ -16,7 +16,6 @@ use Piwik\Scheduler\Task;
 use Piwik\Scheduler\Timetable;
 use Piwik\Tests\Framework\Mock\PiwikOption;
 use Piwik\Log\NullLogger;
-use ReflectionClass;
 
 /**
  * @group Scheduler
@@ -233,16 +232,11 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
 
     private static function stubPiwikOption($timetable)
     {
-        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue('instance', new PiwikOption($timetable));
+        Option::setSingletonInstance(new PiwikOption($timetable));
     }
 
     private static function resetPiwikOption()
     {
-        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue('instance', null);
-    }
-
-    private static function getReflectedPiwikOptionInstance(): ReflectionClass
-    {
-        return new ReflectionClass(Option::class);
+        Option::setSingletonInstance(null);
     }
 }

--- a/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
@@ -232,12 +232,12 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
 
     private static function stubPiwikOption($timetable)
     {
-        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue(new PiwikOption($timetable));
+        self::getReflectedPiwikOptionInstance()->setValue(null, new PiwikOption($timetable));
     }
 
     private static function resetPiwikOption()
     {
-        self::getReflectedPiwikOptionInstance()->setValue(null);
+        self::getReflectedPiwikOptionInstance()->setValue(null, null);
     }
 
     private static function getReflectedPiwikOptionInstance()

--- a/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
@@ -12,7 +12,8 @@ use Piwik\Date;
 use Piwik\Scheduler\Task;
 use Piwik\Scheduler\Timetable;
 use Piwik\Tests\Framework\Mock\PiwikOption;
-use ReflectionProperty;
+use ReflectionClass;
+use Piwik\Option;
 
 /**
  * @group Scheduler
@@ -170,18 +171,16 @@ class TimetableTest extends \PHPUnit\Framework\TestCase
 
     private static function stubPiwikOption($timetable)
     {
-        self::getReflectedPiwikOptionInstance()->setValue(null, new PiwikOption($timetable));
+        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue('instance', new PiwikOption($timetable));
     }
 
     private static function resetPiwikOption()
     {
-        self::getReflectedPiwikOptionInstance()->setValue(null, null);
+        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue('instance', null);
     }
 
-    private static function getReflectedPiwikOptionInstance()
+    private static function getReflectedPiwikOptionInstance(): ReflectionClass
     {
-        $piwikOptionInstance = new ReflectionProperty('Piwik\Option', 'instance');
-        $piwikOptionInstance->setAccessible(true);
-        return $piwikOptionInstance;
+        return new ReflectionClass(Option::class);
     }
 }

--- a/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
@@ -170,12 +170,12 @@ class TimetableTest extends \PHPUnit\Framework\TestCase
 
     private static function stubPiwikOption($timetable)
     {
-        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue(new PiwikOption($timetable));
+        self::getReflectedPiwikOptionInstance()->setValue(null, new PiwikOption($timetable));
     }
 
     private static function resetPiwikOption()
     {
-        self::getReflectedPiwikOptionInstance()->setValue(null);
+        self::getReflectedPiwikOptionInstance()->setValue(null, null);
     }
 
     private static function getReflectedPiwikOptionInstance()

--- a/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
@@ -170,7 +170,7 @@ class TimetableTest extends \PHPUnit\Framework\TestCase
 
     private static function stubPiwikOption($timetable)
     {
-        self::getReflectedPiwikOptionInstance()->setValue(new PiwikOption($timetable));
+        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue(new PiwikOption($timetable));
     }
 
     private static function resetPiwikOption()

--- a/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
@@ -12,7 +12,6 @@ use Piwik\Date;
 use Piwik\Scheduler\Task;
 use Piwik\Scheduler\Timetable;
 use Piwik\Tests\Framework\Mock\PiwikOption;
-use ReflectionClass;
 use Piwik\Option;
 
 /**
@@ -171,16 +170,11 @@ class TimetableTest extends \PHPUnit\Framework\TestCase
 
     private static function stubPiwikOption($timetable)
     {
-        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue('instance', new PiwikOption($timetable));
+        Option::setSingletonInstance(new PiwikOption($timetable));
     }
 
     private static function resetPiwikOption()
     {
-        self::getReflectedPiwikOptionInstance()->setStaticPropertyValue('instance', null);
-    }
-
-    private static function getReflectedPiwikOptionInstance(): ReflectionClass
-    {
-        return new ReflectionClass(Option::class);
+        Option::setSingletonInstance(null);
     }
 }


### PR DESCRIPTION
### Description:

[Using ReflectionProperty::SetValue()
](https://www.php.net/manual/en/reflectionproperty.setvalue.php#:~:text=Sets%20(changes)%20the%20property%27s%20value,ReflectionClass%3A%3AsetStaticPropertyValue()%20instead.)
with a single parameter is deprecated in PHP 8.3.

Fixes : https://github.com/matomo-org/matomo/issues/21481

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
