### PR TITLE
Cache request responses in UI tests to avoid some external requests

### DIFF
--- a/plugins/TestRunner/Commands/TestsRunUI.php
+++ b/plugins/TestRunner/Commands/TestsRunUI.php
@@ -9,6 +9,7 @@ namespace Piwik\Plugins\TestRunner\Commands;
 
 use Piwik\AssetManager;
 use Piwik\Config;
+use Piwik\Filesystem;
 use Piwik\Plugin\ConsoleCommand;
 use Piwik\Tests\Framework\Fixture;
 
@@ -31,6 +32,7 @@ class TestsRunUI extends ConsoleCommand
         $this->addRequiredValueOption('plugin', null, "Execute all tests for a plugin.");
         $this->addNoValueOption('core', null, "Execute only tests for Piwik core & core plugins.");
         $this->addNoValueOption('skip-delete-assets', null, "Skip deleting of merged assets (will speed up a test run, but not by a lot).");
+        $this->addNoValueOption('skip-delete-request-cache', null, "Skip deleting of cached requests. Can be used to speed up tests accross multiple runs.");
         $this->addNoValueOption('screenshot-repo', null, "For tests");
         $this->addNoValueOption('store-in-ui-tests-repo', null, "For tests");
         $this->addNoValueOption('debug', null, "Enables node inspector");
@@ -51,6 +53,7 @@ class TestsRunUI extends ConsoleCommand
         $assumeArtifacts = $input->getOption('assume-artifacts');
         $plugin = $input->getOption('plugin');
         $skipDeleteAssets = $input->getOption('skip-delete-assets');
+        $skipDeleteRequestCache = $input->getOption('skip-delete-request-cache');
         $core = $input->getOption('core');
         $extraOptions = $input->getOption('extra-options');
         $storeInUiTestsRepo = $input->getOption('store-in-ui-tests-repo');
@@ -137,6 +140,11 @@ class TestsRunUI extends ConsoleCommand
         $output->writeln('');
 
         passthru($cmd, $returnCode);
+
+        if (!$skipDeleteRequestCache) {
+            // remove cached request files. @see config/environment/ui-test.php
+            Filesystem::unlinkRecursive(PIWIK_INCLUDE_PATH . '/tmp/request-cache/', false);
+        }
 
         return $returnCode;
     }


### PR DESCRIPTION
### Description:

Many of our UI tests might currently request the Marketplace or the Matomo API to look for updates and similar. Depending on the response time this can slow down the tests. 

This PR implements a simple caching for requests sent to any Matomo domain during a UI test run. After the run, the cache will be cleared.

Across our 4 UI test suites this currently saves around 200 - 300 requests. Haven't counted that in detail though.
Hard to say how much time that saves. Comparing the run times of this PR and 5.x-dev it seems to be around 1-5 minutes for each suite.

Note: This is not meant to be a final solution and only to improve the current situation a bit. A proper solution would imho be to implement proper response mocks, where we manually place the (expected) responses instead, so the tests don't perform any requests to marketplace/api anymore.

@matomo-org/core-reviewers happy to your opinions on this (temporary) approach.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
