### PR TITLE
Escape underscore in archive name when used in like query

### DIFF
--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -623,7 +623,7 @@ class ArchiveSelector
                                     AND SUBSTRING(name, $nameEndAppendix, 1) <= '9')";
 
             $whereNameIs = "(name = ? OR (name LIKE ? AND ( $checkForChunkBlob OR $checkForSubtableId ) ))";
-            $bind = array($name, $name . '%');
+            $bind = array($name, str_replace("_", "\_", $name) . '%');
 
             if ($orderBySubtableId && count($recordNames) == 1) {
                 $idSubtableAsInt = self::getExtractIdSubtableFromBlobNameSql($chunk, $name);

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -623,7 +623,7 @@ class ArchiveSelector
                                     AND SUBSTRING(name, $nameEndAppendix, 1) <= '9')";
 
             $whereNameIs = "(name = ? OR (name LIKE ? AND ( $checkForChunkBlob OR $checkForSubtableId ) ))";
-            $bind = array($name, str_replace("_", "\_", $name) . '%');
+            $bind = array($name, addcslashes($name, '%_') . '%');
 
             if ($orderBySubtableId && count($recordNames) == 1) {
                 $idSubtableAsInt = self::getExtractIdSubtableFromBlobNameSql($chunk, $name);


### PR DESCRIPTION
### Description:

The ArchiveSelector is responsible for selecting related archives based on the record name. It should select the archive itself, but also all chunks and subtables.

The generated where statement might currently look like this:

```sql
WHERE (
  name = 'CustomReports_customreport_1_0' OR 
  (
       name LIKE 'CustomReports_customreport_1_0%' AND
       ( 
	     SUBSTRING(name, 31, 7) = '_chunk_' OR
             ( SUBSTRING(name, 32, 1) >= '0' AND SUBSTRING(name, 32, 1) <= '9') 
        ) 
    )
)
```

Problem with this query currently is, that the record name in the like query contains (unescaped) underscores (`_`). MySQL interprets them as a single char wildcard and the records such might also match e.g. `CustomReports_customreport_100_0`

This one maybe should be backported to 4.x-dev

fixes L3-590

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
