### PR TITLE
Fix operator handling in subquery segment values

### DIFF
--- a/core/Segment.php
+++ b/core/Segment.php
@@ -712,7 +712,7 @@ class Segment
     private function escapeSegmentValue(string $value): string
     {
         $delimiterPattern = SegmentExpression::AND_DELIMITER . SegmentExpression::OR_DELIMITER;
-        $pattern = '/((?<!\\\)[' . $delimiterPattern . '])/';
+        $pattern = '/((?<!\\\)[' . preg_quote($delimiterPattern) . '])/';
 
         return preg_replace($pattern, '\\\$1', $value);
     }

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -433,7 +433,7 @@ class Segment
         // This is required to ensure segments like actionUrl!@value really do not include any visit having an action containing `value`
         if ($this->doesSegmentNeedSubquery($matchType, $name)) {
             $operator = $this->getInvertedOperatorForSubQuery($matchType);
-            $stringSegment = $name . $operator . preg_replace('/((?<!\\\)[,;])/', '\\\$1', $value);
+            $stringSegment = $name . $operator . $this->escapeSegmentValue($value);
             $segmentObj = new Segment($stringSegment, $this->idSites, $this->startDate, $this->endDate);
 
             $select = 'log_visit.idvisit';
@@ -704,5 +704,16 @@ class Segment
     public function getOriginalString()
     {
         return $this->originalString;
+    }
+
+    /**
+     * Escapes segment expression delimiters in a segment value with a backslash if not already done.
+     */
+    private function escapeSegmentValue(string $value): string
+    {
+        $delimiterPattern = SegmentExpression::AND_DELIMITER . SegmentExpression::OR_DELIMITER;
+        $pattern = '/((?<!\\\)[' . $delimiterPattern . '])/';
+
+        return preg_replace($pattern, '\\\$1', $value);
     }
 }

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -433,7 +433,7 @@ class Segment
         // This is required to ensure segments like actionUrl!@value really do not include any visit having an action containing `value`
         if ($this->doesSegmentNeedSubquery($matchType, $name)) {
             $operator = $this->getInvertedOperatorForSubQuery($matchType);
-            $stringSegment = $name . $operator . $value;
+            $stringSegment = $name . $operator . preg_replace('/((?<!\\\)[,;])/', '\\\$1', $value);
             $segmentObj = new Segment($stringSegment, $this->idSites, $this->startDate, $this->endDate);
 
             $select = 'log_visit.idvisit';

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -169,6 +169,143 @@ class SegmentTest extends IntegrationTestCase
         $this->assertEquals(32, strlen($segment->getHash()));
     }
 
+    /**
+     * @return iterable<string, array{string, string, array{where: string, bind: string}}>
+     */
+    public function getCommonSubqueryTestData(): iterable
+    {
+        $encodedValueOr = urlencode(urlencode('a,b'));
+        $encodedValueAnd = urlencode(urlencode('a;b'));
+        $escapedValueOr = urlencode(urlencode('a\,b'));
+        $escapedValueAnd = urlencode(urlencode('a\;b'));
+
+        $segmentFrom = '2020-02-02 02:00:00';
+
+        $whereSingle = '(log_visit.idvisit NOT IN(SELECT log_visit.idvisit FROM log_visit AS log_visit LEFT JOIN log_link_visit_action AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit WHERE(log_visit.visit_last_action_time >= ?)AND(log_link_visit_action.idaction_name = ?)))';
+        $whereMultiAnd = '(log_visit.idvisit NOT IN(SELECT log_visit.idvisit FROM log_visit AS log_visit LEFT JOIN log_link_visit_action AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit WHERE(log_visit.visit_last_action_time >= ?)AND(log_link_visit_action.idaction_name = ?)))AND(log_visit.idvisit NOT IN(SELECT log_visit.idvisit FROM log_visit AS log_visit LEFT JOIN log_link_visit_action AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit WHERE(log_visit.visit_last_action_time >= ?)AND(log_link_visit_action.idaction_name = ?)))';
+        $whereMultiOr = '((log_visit.idvisit NOT IN(SELECT log_visit.idvisit FROM log_visit AS log_visit LEFT JOIN log_link_visit_action AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit WHERE(log_visit.visit_last_action_time >= ?)AND(log_link_visit_action.idaction_name = ?)))OR(log_visit.idvisit NOT IN(SELECT log_visit.idvisit FROM log_visit AS log_visit LEFT JOIN log_link_visit_action AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit WHERE(log_visit.visit_last_action_time >= ?)AND(log_link_visit_action.idaction_name = ?))))';
+
+        yield 'normal segment' => [
+            'pageTitle!=a',
+            $segmentFrom,
+            [
+                'where' => $whereSingle,
+                'bind' => [$segmentFrom, '1'],
+            ],
+        ];
+
+        yield 'segment with AND in value' => [
+            'pageTitle!=' . $encodedValueAnd,
+            $segmentFrom,
+            [
+                'where' => $whereSingle,
+                'bind' => [$segmentFrom, '3'],
+            ],
+        ];
+
+        yield 'segment with AND in value, already escaped' => [
+            'pageTitle!=' . $escapedValueAnd,
+            $segmentFrom,
+            [
+                'where' => $whereSingle,
+                'bind' => [$segmentFrom, '3'],
+            ],
+        ];
+
+        yield 'segment with OR in value' => [
+            'pageTitle!=' . $encodedValueOr,
+            $segmentFrom,
+            [
+                'where' => $whereSingle,
+                'bind' => [$segmentFrom, '4'],
+            ],
+        ];
+
+        yield 'segment with OR in value, already escaped' => [
+            'pageTitle!=' . $escapedValueOr,
+            $segmentFrom,
+            [
+                'where' => $whereSingle,
+                'bind' => [$segmentFrom, '4'],
+            ],
+        ];
+
+        yield 'segment with two values, AND operator' => [
+            'pageTitle!=a;pageTitle!=b',
+            $segmentFrom,
+            [
+                'where' => $whereMultiAnd,
+                'bind' => [$segmentFrom, '1', $segmentFrom, '2'],
+            ],
+        ];
+
+        yield 'segment with two values, OR operator' => [
+            'pageTitle!=a,pageTitle!=b',
+            $segmentFrom,
+            [
+                'where' => $whereMultiOr,
+                'bind' => [$segmentFrom, '1', $segmentFrom, '2'],
+            ],
+        ];
+
+        yield 'mixed operator in value and two segments' => [
+            'pageTitle!=' . $encodedValueAnd . ';pageTitle!=' . $encodedValueOr,
+            $segmentFrom,
+            [
+                'where' => $whereMultiAnd,
+                'bind' => [$segmentFrom, '3', $segmentFrom, '4'],
+            ],
+        ];
+
+        yield 'mixed operator in value and two segments, already escaped' => [
+            'pageTitle!=' . $escapedValueAnd . ',pageTitle!=' . $escapedValueOr,
+            $segmentFrom,
+            [
+                'where' => $whereMultiOr,
+                'bind' => [$segmentFrom, '3', $segmentFrom, '4'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getCommonSubqueryTestData
+     *
+     * @param array{where: string, bind: string} $expected
+     */
+    public function testCommonSubquery(string $segment, string $segmentFrom, array $expected): void
+    {
+        $this->insertPageUrlAsAction('a', 'idaction_name', Action::TYPE_PAGE_TITLE);
+        $this->insertPageUrlAsAction('b', 'idaction_name', Action::TYPE_PAGE_TITLE);
+        $this->insertPageUrlAsAction('a;b', 'idaction_name', Action::TYPE_PAGE_TITLE);
+        $this->insertPageUrlAsAction('a,b', 'idaction_name', Action::TYPE_PAGE_TITLE);
+
+        $select = 'log_visit.idvisit';
+        $from = 'log_visit';
+
+        $expected = array(
+            'sql'  => '
+                SELECT
+                    log_visit.idvisit
+                FROM
+                    ' . Common::prefixTable('log_visit') . ' AS log_visit
+                WHERE
+                    ' . $expected['where'],
+            'bind' => $expected['bind']
+        );
+
+        $segment = new Segment($segment, $idSites = array(), Date::factory($segmentFrom));
+        $sql = $segment->getSelectQuery($select, $from, false);
+        $this->assertQueryDoesNotFail($sql);
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($sql));
+
+        // calling twice should give same results
+        $sql = $segment->getSelectQuery($select, array($from));
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($sql));
+
+        $this->assertEquals(32, strlen($segment->getHash()));
+    }
+
     public function test_getSelectQuery_whenNoJoin()
     {
         $select = '*';


### PR DESCRIPTION
### Description:

Having a segment definition with one of the operators (`,` and `;`) in the value can break if the segment requires a subquery expression. This is, for example, the case for `PageTitle NotIn "a,b"`.

Should probably be backported to 4.x.

Refs L3-581
Refs #16172
Refs #19617 (should be fixed by backporting)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
