### PR TITLE
[PHP 8.x compatibility] Fix possible deprecation warning in ProxyHttp class

### DIFF
--- a/core/ProxyHttp.php
+++ b/core/ProxyHttp.php
@@ -68,7 +68,7 @@ class ProxyHttp
                                             $byteEnd = false, $filename = false)
     {
         // if the file cannot be found return HTTP status code '404'
-        if (!file_exists($file)) {
+        if (empty($file) || !file_exists($file)) {
             Common::sendResponseCode(404);
             return;
         }


### PR DESCRIPTION
### Description:

Currently our tests are logging this error:

```
PHP Deprecated:  file_exists(): Passing null to parameter #1 ($filename) of type string is deprecated in /home/runner/work/matomo/matomo/matomo/core/ProxyHttp.php on line 71
```

This is caused by a test explicitly passing `null` to `serverStaticFile`.
Had a look through the code where the method `serverStaticFile` is being used and it seems like in rare conditions it could happen that `false` or `null` could be passed through, which the additional check should cover.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
