### PR TITLE
Fixing PHP 8.3 deprecation error

### DIFF
--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -160,7 +160,7 @@ class Plugin
 
     private function hasDefinedPluginInformationInPluginClass()
     {
-        $myClassName = get_class();
+        $myClassName = self::class;
         $pluginClassName = get_class($this);
 
         if ($pluginClassName == $myClassName) {


### PR DESCRIPTION
### Description:

Fixing PHP 8.3 deprecation error

Example error:
```
Deprecated: Calling get_class() without arguments is deprecated in /home/runner/work/plugin-CustomAlerts/plugin-CustomAlerts/matomo/core/Plugin.php on line 163
```

Example builds:
https://github.com/matomo-org/plugin-CustomAlerts/actions/runs/6845303068/job/18610510335?pr=152
https://github.com/matomo-org/plugin-CustomVariables/actions/runs/6845326418/job/18610518738?pr=79
https://github.com/matomo-org/plugin-DeviceDetectorCache/actions/runs/6845471216/job/18610718297?pr=65
https://github.com/matomo-org/plugin-GoogleAnalyticsImporter/actions/runs/6845477086/job/18610734326?pr=473

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
