### PR TITLE
[PHP 8.3 compatibility] Fix deprecated call to setValue with single property

### DIFF
--- a/tests/PHPUnit/Integration/RetryScheduledTaskTest.php
+++ b/tests/PHPUnit/Integration/RetryScheduledTaskTest.php
@@ -7,6 +7,7 @@
  */
 
 namespace Piwik\Tests\Integration;
+use Piwik\Option;
 use Piwik\Scheduler\RetryableException;
 use Piwik\Scheduler\Timetable;
 use Piwik\Scheduler\Scheduler;
@@ -14,7 +15,6 @@ use Piwik\Scheduler\Task;
 use Piwik\Tests\Framework\Mock\PiwikOption;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Psr\Log\NullLogger;
-use ReflectionProperty;
 
 /**
  * @group Scheduler
@@ -25,7 +25,6 @@ class RetryScheduledTaskTest extends IntegrationTestCase
 
     public function testRetryCount()
     {
-
         $timetable = new Timetable();
 
         $task1 = 'task1';
@@ -54,14 +53,13 @@ class RetryScheduledTaskTest extends IntegrationTestCase
 
     }
 
-    public function testTaskIsRetriedIfRetryableExcetionIsThrown()
+    public function testTaskIsRetriedIfRetryableExceptionIsThrown()
     {
-
         // Mock timetable
         $now = time() - 60;
         $taskName = 'Piwik\Tests\Integration\RetryScheduledTaskTest.exceptionalTask';
         $timetableData = serialize([$taskName => $now]);
-        self::getReflectedPiwikOptionInstance()->setValue(new PiwikOption($timetableData));
+        self::stubPiwikOption($timetableData);
 
         // Create task
         $dailySchedule = $this->createPartialMock('Piwik\Scheduler\Schedule\Daily', array('getTime'));
@@ -85,8 +83,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         // Should be rescheduled one hour from now
         $this->assertEquals($now+3660, $nextRun);
 
-        self::getReflectedPiwikOptionInstance()->setValue(null);
-
+        self::resetPiwikOption();
     }
 
     public function testTaskIsNotRetriedIfNormalExcetionIsThrown()
@@ -95,7 +92,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         $now = time() - 60;
         $taskName = 'Piwik\Tests\Integration\RetryScheduledTaskTest.normalExceptionTask';
         $timetableData = serialize([$taskName => $now]);
-        self::getReflectedPiwikOptionInstance()->setValue(new PiwikOption($timetableData));
+        self::stubPiwikOption($timetableData);
 
         // Create task
         $specificSchedule = $this->createPartialMock('Piwik\Scheduler\Schedule\SpecificTime', array('getTime'));
@@ -120,14 +117,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         // Should not have scheduled for retry
         $this->assertEquals($now+50000, $nextRun);
 
-        self::getReflectedPiwikOptionInstance()->setValue(null);
-    }
-
-    private static function getReflectedPiwikOptionInstance()
-    {
-        $piwikOptionInstance = new ReflectionProperty('Piwik\Option', 'instance');
-        $piwikOptionInstance->setAccessible(true);
-        return $piwikOptionInstance;
+        self::resetPiwikOption();
     }
 
     public function exceptionalTask()
@@ -140,4 +130,13 @@ class RetryScheduledTaskTest extends IntegrationTestCase
         throw new \Exception('This task fails and should not be retried');
     }
 
+    private static function stubPiwikOption($timetable)
+    {
+        Option::setSingletonInstance(new PiwikOption($timetable));
+    }
+
+    private static function resetPiwikOption()
+    {
+        Option::setSingletonInstance(null);
+    }
 }

--- a/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
@@ -9,13 +9,13 @@
 namespace Piwik\Tests\Unit\Scheduler;
 
 use Piwik\Date;
+use Piwik\Option;
 use Piwik\Plugin;
 use Piwik\Scheduler\Scheduler;
 use Piwik\Scheduler\Task;
 use Piwik\Scheduler\Timetable;
 use Piwik\Tests\Framework\Mock\PiwikOption;
 use Psr\Log\NullLogger;
-use ReflectionProperty;
 
 /**
  * @group Scheduler
@@ -232,18 +232,11 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
 
     private static function stubPiwikOption($timetable)
     {
-        self::getReflectedPiwikOptionInstance()->setValue(new PiwikOption($timetable));
+        Option::setSingletonInstance(new PiwikOption($timetable));
     }
 
     private static function resetPiwikOption()
     {
-        self::getReflectedPiwikOptionInstance()->setValue(null);
-    }
-
-    private static function getReflectedPiwikOptionInstance()
-    {
-        $piwikOptionInstance = new ReflectionProperty('Piwik\Option', 'instance');
-        $piwikOptionInstance->setAccessible(true);
-        return $piwikOptionInstance;
+        Option::setSingletonInstance(null);
     }
 }

--- a/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
@@ -9,10 +9,10 @@
 namespace Piwik\Tests\Unit\Scheduler;
 
 use Piwik\Date;
+use Piwik\Option;
 use Piwik\Scheduler\Task;
 use Piwik\Scheduler\Timetable;
 use Piwik\Tests\Framework\Mock\PiwikOption;
-use ReflectionProperty;
 
 /**
  * @group Scheduler
@@ -170,18 +170,11 @@ class TimetableTest extends \PHPUnit\Framework\TestCase
 
     private static function stubPiwikOption($timetable)
     {
-        self::getReflectedPiwikOptionInstance()->setValue(new PiwikOption($timetable));
+        Option::setSingletonInstance(new PiwikOption($timetable));
     }
 
     private static function resetPiwikOption()
     {
-        self::getReflectedPiwikOptionInstance()->setValue(null);
-    }
-
-    private static function getReflectedPiwikOptionInstance()
-    {
-        $piwikOptionInstance = new ReflectionProperty('Piwik\Option', 'instance');
-        $piwikOptionInstance->setAccessible(true);
-        return $piwikOptionInstance;
+        Option::setSingletonInstance(null);
     }
 }


### PR DESCRIPTION
### Description:

4.x version of : https://github.com/matomo-org/matomo/pull/21475

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
