### PR TITLE
[PHP 8.x compatibility] Remove unused prop causing Deprecated - Creation of dynamic property

### DIFF
--- a/plugins/UserId/Reports/GetUsers.php
+++ b/plugins/UserId/Reports/GetUsers.php
@@ -55,7 +55,6 @@ class GetUsers extends Base
          */
         $view->config->columns_to_display = $this->metrics;
         $view->config->show_all_views_icons = false;
-        $view->config->show_active_view_icon = false;
         $view->config->show_related_reports = false;
         $view->config->show_insights = false;
         $view->config->show_pivot_by_subtable = false;


### PR DESCRIPTION
### Description:

Fixes this error in PHP 8.2

The property isn't even used, so just removed it.

![image](https://github.com/matomo-org/matomo/assets/1169490/4d8164c2-a9d3-4cd6-ae84-11aa0e57b33a)


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
