### PR TITLE
Fix tests failing due to menu changes

### DIFF
--- a/tests/UI/expected-screenshots/Menus_mobile_left.png
+++ b/tests/UI/expected-screenshots/Menus_mobile_left.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1f84e05966f4821892cea97a9d450ecdb4b91018f36caf843274f4be028e0d88
-size 207829
+oid sha256:f3e7ef6320ff5d65ffa53f586a0b4ffbc1e092ea7bd5352f7c72eeb1266681b6
+size 207791

--- a/tests/UI/specs/MeasurableManager_spec.js
+++ b/tests/UI/specs/MeasurableManager_spec.js
@@ -28,7 +28,7 @@ describe("MeasurableManager", function () {
     });
 
     it("should use measurable wording in menu", async function () {
-        const element = await page.jQuery('#secondNavBar li:contains(Manage):first');
+        const element = await page.jQuery('#secondNavBar li:contains(Manage):visible:first');
         expect(await element.screenshot()).to.matchImage('measurable_menu_item');
     });
 

--- a/tests/UI/specs/MeasurableManager_spec.js
+++ b/tests/UI/specs/MeasurableManager_spec.js
@@ -28,7 +28,7 @@ describe("MeasurableManager", function () {
     });
 
     it("should use measurable wording in menu", async function () {
-        const element = await page.jQuery('#secondNavBar li:contains(Manage):visible:first');
+        const element = await page.jQuery('#secondNavBar li:contains(Tracking Code):first');
         expect(await element.screenshot()).to.matchImage('measurable_menu_item');
     });
 

--- a/tests/UI/specs/Menus_spec.js
+++ b/tests/UI/specs/Menus_spec.js
@@ -14,7 +14,7 @@ describe("Menus", function () {
         urlBase = 'module=CoreHome&action=index&' + generalParams;
 
     async function openMenuItem(page, menuItem) {
-        const element = await page.jQuery('#secondNavBar .navbar a:contains(' + menuItem + '):first');
+        const element = await page.jQuery('#secondNavBar .navbar a:contains(' + menuItem + '):visible:first');
         await element.click();
         await page.mouse.move(-10, -10);
         await page.waitForTimeout(250);


### PR DESCRIPTION
### Description:

Some UI tests started to fail due to the changes in #21542
They failed without producing screenshots at all, so they were not visible on the build artifacts server.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
