### PR TITLE
Fix scheduled reports array access

### DIFF
--- a/plugins/ScheduledReports/Controller.php
+++ b/plugins/ScheduledReports/Controller.php
@@ -138,17 +138,17 @@ class Controller extends \Piwik\Plugin\Controller
         $subscriptionModel = new SubscriptionModel();
         $subscription      = $subscriptionModel->getSubscription($token);
 
-        $report = Access::doAsSuperUser(function() use ($subscription) {
-            $reports = Request::processRequest('ScheduledReports.getReports', array(
-                'idReport'    => $subscription['idreport'],
-            ));
-            return reset($reports);
-        });
-
         if (empty($subscription)) {
             $view->error = Piwik::translate('ScheduledReports_NoSubscriptionFound');
             return $view->render();
         }
+
+        $report = Access::doAsSuperUser(function() use ($subscription) {
+            $reports = Request::processRequest('ScheduledReports.getReports', [
+                'idReport'    => $subscription['idreport'],
+            ]);
+            return reset($reports);
+        });
 
         $confirm = Common::getRequestVar('confirm', '', 'string');
 


### PR DESCRIPTION
### Description:

Backport of e79804a183 to fix an "array access on false": https://github.com/matomo-org/matomo/actions/runs/6902167504/job/18778336901#step:3:2658

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
