### PR TITLE
Avoid possible problems with invalid segments

### DIFF
--- a/core/Segment.php
+++ b/core/Segment.php
@@ -404,6 +404,11 @@ class Segment
         }
 
         $segmentObject = $segmentsList->getSegment($name);
+
+        if (empty($segmentObject)) {
+            throw new Exception("Segment '$name' is not a supported segment.");
+        }
+
         $sqlName = $segmentObject->getSqlSegment();
 
         $joinTable = null;

--- a/plugins/API/Filter/DataComparisonFilter.php
+++ b/plugins/API/Filter/DataComparisonFilter.php
@@ -131,7 +131,7 @@ class DataComparisonFilter
 
     public function __construct($request, Report $report = null)
     {
-        $this->request = $request;
+        $this->request = new \Piwik\Request($request);
 
         $generalConfig = Config::getInstance()->General;
         $this->segmentCompareLimit = (int) $generalConfig['data_comparison_segment_limit'];
@@ -173,7 +173,7 @@ class DataComparisonFilter
             $this->comparePeriodIndices[$period][$date] = $index;
         }
 
-        $this->invertCompareChangeCompute = Common::getRequestVar('invert_compare_change_compute', $default = 0, $type = 'int', $request) == 1;
+        $this->invertCompareChangeCompute = $this->request->getIntegerParameter('invert_compare_change_compute', 0) === 1;
         if ($this->invertCompareChangeCompute && count($this->comparePeriods) != 2) {
             throw new \Exception("invert_compare_change_compute=1 can only be used when comparing two periods.");
         }
@@ -200,8 +200,8 @@ class DataComparisonFilter
             return;
         }
 
-        $method = Common::getRequestVar('method', $default = null, $type = 'string', $this->request);
-        if ($method == 'Live') {
+        $method = $this->request->getStringParameter('method');
+        if ($method === 'Live') {
             throw new \Exception("Data comparison is not enabled for the Live API.");
         }
 
@@ -295,31 +295,31 @@ class DataComparisonFilter
                 'disable_queued_filters' => 1,
                 'format_metrics' => 0,
                 'label' => '',
-                'flat' => Common::getRequestVar('flat', 0, 'int', $this->request),
-                'filter_add_columns_when_show_all_columns' => Common::getRequestVar('filter_add_columns_when_show_all_columns', '', 'string', $this->request),
-                'filter_update_columns_when_show_all_goals' => Common::getRequestVar('filter_update_columns_when_show_all_goals', '', 'string', $this->request),
-                'filter_show_goal_columns_process_goals' => Common::getRequestVar('filter_show_goal_columns_process_goals', '', 'string', $this->request),
-                'idGoal' => Common::getRequestVar('idGoal', '', 'string', $this->request),
+                'flat' => $this->request->getIntegerParameter('flat', 0),
+                'filter_add_columns_when_show_all_columns' => $this->request->getStringParameter('filter_add_columns_when_show_all_columns', ''),
+                'filter_update_columns_when_show_all_goals' => $this->request->getStringParameter('filter_update_columns_when_show_all_goals', ''),
+                'filter_show_goal_columns_process_goals' => $this->request->getStringParameter('filter_show_goal_columns_process_goals', ''),
+                'idGoal' => $this->request->getStringParameter('idGoal', ''),
             ],
             $paramsToModify
         );
 
-        $params['keep_totals_row'] = Common::getRequestVar('keep_totals_row', 0, 'int', $this->request);
-        $params['keep_totals_row_label'] = Common::getRequestVar('keep_totals_row_label', '', 'string', $this->request);
+        $params['keep_totals_row'] = $this->request->getIntegerParameter('keep_totals_row', 0);
+        $params['keep_totals_row_label'] = $this->request->getStringParameter('keep_totals_row_label', '');
 
         if (!isset($params['idSite'])) {
-            $params['idSite'] = Common::getRequestVar('idSite', null, 'string', $this->request);
+            $params['idSite'] = $this->request->getStringParameter('idSite');
         }
         if (!isset($params['period'])) {
-            $params['period'] = Common::getRequestVar('period', null, 'string', $this->request);
+            $params['period'] = $this->request->getStringParameter('period');
         }
         if (!isset($params['date'])) {
-            $params['date'] = Common::getRequestVar('date', null, 'string', $this->request);
+            $params['date'] = $this->request->getStringParameter('date');
         }
 
-        $idSubtable = Common::getRequestVar('idSubtable', 0, 'int', $this->request);
+        $idSubtable = $this->request->getIntegerParameter('idSubtable', 0);
         if ($idSubtable > 0) {
-            $comparisonIdSubtables = Common::getRequestVar('comparisonIdSubtables', $default = false, 'json', $this->request);
+            $comparisonIdSubtables = $this->request->getJsonParameter('comparisonIdSubtables', false);
             if (empty($comparisonIdSubtables)) {
                 throw new \Exception("Comparing segments/periods with subtables only works when the comparison idSubtables are supplied as well.");
             }
@@ -389,7 +389,7 @@ class DataComparisonFilter
 
         $metadata['compareSegment'] = $segment;
 
-        $idSite = $modifiedParams['idSite'] ??  Common::getRequestVar('idSite', null, 'string', $this->request);
+        $idSite = $modifiedParams['idSite'] ?? $this->request->getStringParameter('idSite');
 
         $segmentObj = new Segment($segment, [$idSite]);
         $metadata['compareSegmentPretty'] = $segmentObj->getStoredSegmentName($idSite);
@@ -459,8 +459,8 @@ class DataComparisonFilter
     private function isRequestMultiplePeriod()
     {
         if ($this->isRequestMultiplePeriod === null) {
-            $period = Common::getRequestVar('period', $default = null, 'string', $this->request);
-            $date = Common::getRequestVar('date', $default = null, 'string', $this->request);
+            $period = $this->request->getStringParameter('period');
+            $date = $this->request->getStringParameter('date');
 
             $this->isRequestMultiplePeriod = Period::isMultiplePeriod($date, $period);
         }
@@ -601,7 +601,7 @@ class DataComparisonFilter
      */
     private function shouldIncludeTrendValues(): bool
     {
-        return (bool) Common::getRequestVar('include_trends', 0, 'int', $this->request);
+        return $this->request->getBoolParameter('include_trends', false);
     }
 
     /**

--- a/plugins/API/Filter/DataComparisonFilter.php
+++ b/plugins/API/Filter/DataComparisonFilter.php
@@ -389,8 +389,10 @@ class DataComparisonFilter
 
         $metadata['compareSegment'] = $segment;
 
-        $segmentObj = new Segment($segment, []);
-        $metadata['compareSegmentPretty'] = $segmentObj->getStoredSegmentName(false);
+        $idSite = $modifiedParams['idSite'] ??  Common::getRequestVar('idSite', null, 'string', $this->request);
+
+        $segmentObj = new Segment($segment, [$idSite]);
+        $metadata['compareSegmentPretty'] = $segmentObj->getStoredSegmentName($idSite);
 
         $metadata['comparePeriod'] = $period;
         $metadata['compareDate'] = $date;

--- a/plugins/API/Filter/DataComparisonFilter.php
+++ b/plugins/API/Filter/DataComparisonFilter.php
@@ -617,8 +617,9 @@ class DataComparisonFilter
 
         [$periodIndex, $segmentIndex] = self::getIndividualComparisonRowIndices(null, $labelSeriesIndex, count($compareSegments));
 
-        $segmentObj = new Segment($compareSegments[$segmentIndex], []);
-        $prettySegment = $segmentObj->getStoredSegmentName(false);
+        $idSite = \Piwik\Request::fromRequest()->getStringParameter('idSite');
+        $segmentObj = new Segment($compareSegments[$segmentIndex], [$idSite]);
+        $prettySegment = $segmentObj->getStoredSegmentName($idSite);
 
         $prettyPeriod = Factory::build($comparePeriods[$periodIndex], $compareDates[$periodIndex])->getLocalizedLongString();
         $prettyPeriod = ucfirst($prettyPeriod);

--- a/tests/PHPUnit/System/DataComparisonTest.php
+++ b/tests/PHPUnit/System/DataComparisonTest.php
@@ -34,7 +34,7 @@ class DataComparisonTest extends SystemTestCase
         // the specific site and will be invalid in global context
         // Added to avoid further regressions like: https://github.com/matomo-org/matomo/issues/21573
         $idDimension = \Piwik\Plugins\CustomDimensions\API::getInstance()->configureNewCustomDimension(
-            self::$fixture->idSite, 'test', CustomDimensions::SCOPE_VISIT,  true
+            self::$fixture->idSite, 'test', CustomDimensions::SCOPE_VISIT, true
         );
         Fixture::clearInMemoryCaches(false);
         \Piwik\Plugins\SegmentEditor\API::getInstance()->add('custom dimension', "dimension$idDimension==test", self::$fixture->idSite);


### PR DESCRIPTION
### Description:

Steps to reproduce the original issue:

* Create a custom dimension (if there isn't any yet)
* Create a segment for that custom dimension (for current site only)
* Open the segment selector and choose any segment for comparison
* Reports will fail to load with the error "Call to a member function getSqlSegment() on null in /srv/matomo/core/Segment.php:407"

fixes #21573 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
