### PR TITLE
Avoid additional uncached requests to SegmentEditor.getAll

### DIFF
--- a/core/Segment.php
+++ b/core/Segment.php
@@ -147,11 +147,14 @@ class Segment
         // can usually be parsed successfully. To pick the right one, we try both and pick the one w/ more
         // successfully parsed subexpressions.
         $subexpressionsDecoded = 0;
-        try {
-            $this->initializeSegment(urldecode($segmentCondition), $idSites);
-            $subexpressionsDecoded = $this->segmentExpression->getSubExpressionCount();
-        } catch (Exception $e) {
-            // ignore
+
+        if (urldecode($segmentCondition) !== $segmentCondition) {
+            try {
+                $this->initializeSegment(urldecode($segmentCondition), $idSites);
+                $subexpressionsDecoded = $this->segmentExpression->getSubExpressionCount();
+            } catch (Exception $e) {
+                // ignore
+            }
         }
 
         $subexpressionsRaw = 0;
@@ -163,7 +166,7 @@ class Segment
         }
 
         if ($subexpressionsRaw > $subexpressionsDecoded) {
-            $this->initializeSegment($segmentCondition, $idSites);
+            // segment initialized above
             $this->isSegmentEncoded = false;
         } else {
             $this->initializeSegment(urldecode($segmentCondition), $idSites);

--- a/plugins/CoreVisualizations/JqplotDataGenerator.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator.php
@@ -10,7 +10,6 @@
 namespace Piwik\Plugins\CoreVisualizations;
 
 use Exception;
-use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
@@ -35,8 +34,6 @@ class JqplotDataGenerator
     protected $graphType;
 
     protected $isComparing;
-
-    private $availableSegments;
 
     /**
      * @var JqplotGraph
@@ -78,8 +75,6 @@ class JqplotDataGenerator
         $this->graphType = $graphType;
         $this->isComparing = $graph->isComparing();
         $this->graph = $graph;
-
-        $this->availableSegments = Request::processRequest('SegmentEditor.getAll', $override = [], $default = []);
     }
 
     /**
@@ -115,9 +110,9 @@ class JqplotDataGenerator
 
         $seriesMetadata = null;
         if ($this->isComparing) {
-            list($yLabels, $serieses, $seriesMetadata) = $this->getComparisonTableSerieses($dataTable, $columnsToDisplay);
+            [$yLabels, $serieses, $seriesMetadata] = $this->getComparisonTableSerieses($dataTable, $columnsToDisplay);
         } else {
-            list($yLabels, $serieses) = $this->getMainTableSerieses($dataTable, $columnsToDisplay);
+            [$yLabels, $serieses] = $this->getMainTableSerieses($dataTable, $columnsToDisplay);
         }
 
         $visualization->properties = $this->properties;

--- a/plugins/ScheduledReports/Controller.php
+++ b/plugins/ScheduledReports/Controller.php
@@ -16,6 +16,7 @@ use Piwik\Period\PeriodValidator;
 use Piwik\Piwik;
 use Piwik\Plugins\ImageGraph\ImageGraph;
 use Piwik\Plugins\LanguagesManager\LanguagesManager;
+use Piwik\Plugins\SegmentEditor\SegmentEditor;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\View;
 
@@ -116,8 +117,8 @@ class Controller extends \Piwik\Plugin\Controller
             $savedSegmentsById = array(
                 '' => Piwik::translate('SegmentEditor_DefaultAllVisits')
             );
-            $response = Request::processRequest("SegmentEditor.getAll", ['idSite' => $this->idSite], $defaultRequest = []);
-            foreach ($response as $savedSegment) {
+            $allSegments = SegmentEditor::getAllSegmentsForSite($this->idSite);
+            foreach ($allSegments as $savedSegment) {
                 $savedSegmentsById[$savedSegment['idsegment']] = $savedSegment['name'];
             }
             $view->savedSegmentsById = $savedSegmentsById;

--- a/plugins/SegmentEditor/SegmentEditor.php
+++ b/plugins/SegmentEditor/SegmentEditor.php
@@ -388,9 +388,6 @@ class SegmentEditor extends \Piwik\Plugin
         $segments = $cache->fetch($cacheKey);
         if (!is_array($segments)) {
             $segments = Request::processRequest('SegmentEditor.getAll', ['idSite' => $idSite], $default = []);
-            usort($segments, function ($lhs, $rhs) {
-                return strcmp($lhs['name'], $rhs['name']);
-            });
             $cache->save($cacheKey, $segments);
         }
         return $segments;

--- a/plugins/SegmentEditor/SegmentSelectorControl.php
+++ b/plugins/SegmentEditor/SegmentSelectorControl.php
@@ -68,7 +68,7 @@ class SegmentSelectorControl extends UIControl
         $this->nameOfCurrentSegment = '';
         $this->isSegmentNotAppliedBecauseBrowserArchivingIsDisabled = 0;
 
-        $this->availableSegments = Request::processRequest("SegmentEditor.getAll", ['idSite' => $this->idSite], $defaultRequest = []);
+        $this->availableSegments = SegmentEditor::getAllSegmentsForSite($this->idSite);
         foreach ($this->availableSegments as &$savedSegment) {
             $savedSegment['name'] = Common::sanitizeInputValue($savedSegment['name']);
 


### PR DESCRIPTION
### Description:

With https://github.com/matomo-org/matomo/pull/21521 we introduced a check within the API method `SegmentEditor.getAll` to filter away segments that aren't valid anymore. Depending on the amount of stored segment, this might take some time.

To avoid the filtering multiple times during a request we should avoid calling the API directly, but use `SegmentEditor::getAllSegmentsForSite` instead. This method caches the results for the current request.

This PR changes a couple of direct API usages to use `SegmentEditor::getAllSegmentsForSite` instead.

refs DEV-17463

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
