### PR TITLE
Fix problem with metric formatting in cloud visualization

### DIFF
--- a/core/API/DataTablePostProcessor.php
+++ b/core/API/DataTablePostProcessor.php
@@ -395,18 +395,19 @@ class DataTablePostProcessor
 
     /**
      * @param DataTableInterface $dataTable
+     * @param bool $forceFormatting if set to true, all metrics will be formatted and request parameter will be ignored
      * @return DataTableInterface
      */
-    public function applyMetricsFormatting($dataTable)
+    public function applyMetricsFormatting($dataTable, bool $forceFormatting = false)
     {
         $formatMetrics = Common::getRequestVar('format_metrics', 0, 'string', $this->request);
-        if ($formatMetrics == '0') {
+        if ($formatMetrics == '0' && $forceFormatting === false) {
             return $dataTable;
         }
 
         // in Piwik 2.X & below, metrics are not formatted in API responses except for percents.
         // this code implements this inconsistency
-        $onlyFormatPercents = $formatMetrics === 'bc';
+        $onlyFormatPercents = $forceFormatting === false && $formatMetrics === 'bc';
 
         $metricsToFormat = null;
         if ($onlyFormatPercents) {
@@ -415,9 +416,9 @@ class DataTablePostProcessor
 
         // 'all' is a special value that indicates we should format non-processed metrics that are identified
         // by string, like 'revenue'. this should be removed when all metrics are using the `Metric` class.
-        $formatAll = $formatMetrics === 'all';
+        $formatAll = $forceFormatting === true || $formatMetrics === 'all';
 
-        $dataTable->filter(array($this->formatter, 'formatMetrics'), array($this->report, $metricsToFormat, $formatAll));
+        $dataTable->filter([$this->formatter, 'formatMetrics'], [$this->report, $metricsToFormat, $formatAll]);
         return $dataTable;
     }
 

--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -916,11 +916,13 @@ class Visualization extends ViewDataTable
      * subsequently apply formatting without needed to reload the dataset or reapply other filters. This method may
      * be removed in the future.
      *
+     * @param bool $forceFormatting if set to true, all metrics will be formatted and request parameter will be ignored
+     *
      * @internal
      */
-    protected function applyMetricsFormatting()
+    protected function applyMetricsFormatting(bool $forceFormatting = false)
     {
         $postProcessor = $this->makeDataTablePostProcessor(); // must be created after requestConfig is final
-        $this->dataTable = $postProcessor->applyMetricsFormatting($this->dataTable);
+        $this->dataTable = $postProcessor->applyMetricsFormatting($this->dataTable, $forceFormatting);
     }
 }

--- a/plugins/CoreVisualizations/Visualizations/Cloud.php
+++ b/plugins/CoreVisualizations/Visualizations/Cloud.php
@@ -42,6 +42,7 @@ class Cloud extends Visualization
 
     public function beforeLoadDataTable()
     {
+        // request metrics unformatted, so we can calculate with them, formatting is applied manually before rendering
         $this->requestConfig->request_parameters_to_modify['format_metrics'] = 0;
         $this->checkRequestIsNotForMultiplePeriods();
     }
@@ -68,9 +69,8 @@ class Cloud extends Visualization
         $this->config->show_offset_information     = false;
         $this->config->show_limit_control          = false;
 
-        // Second pass: enable metric formatting, reapply the filters and then generate the tag cloud data
-        $this->requestConfig->request_parameters_to_modify['format_metrics'] = 1;
-        $this->applyMetricsFormatting();
+        // manually apply metric formatting
+        $this->applyMetricsFormatting(true);
         $this->generateCloudData();
     }
 


### PR DESCRIPTION
### Description:

Changing the requestConfig after the datatable was requested shouldn't be done. We therefor even trigger a warning here:

https://github.com/matomo-org/matomo/blob/b8555096dd089e182fba255df941f4fe32e36cfe/core/Plugin/Visualization.php#L837-L870

This is currently done in the cloud visualization to handle problems with formatted/unformatted values.

To reproduce the issue you can simply go the Behaviour > Engagement. Two reports should by default be loaded as Cloud Viz. Rendering them should show the warning message in the logs.

This should also fix random UI test failures like https://builds-artifacts.matomo.org/matomo-org/matomo/5.x-dev/6982498243/UIIntegrationTest_visitors_realtime_visits.png


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
