### PR TITLE
Add a what's new entry for premium feature menu items

### DIFF
--- a/plugins/CoreAdminHome/templates/whatIsNew.twig
+++ b/plugins/CoreAdminHome/templates/whatIsNew.twig
@@ -8,7 +8,7 @@
         <div class="card">
             <div class="card-content">
                 <span style="float: left; font-size:32px; color:#3450A3; margin-right:10px" class="icon-new_releases"></span>
-                {% if change.plugin_name == "CoreHome" %}
+                {% if change.plugin_name == "CoreHome" or change.plugin_name == "ProfessionalServices" %}
                     <h2 class="card-title">{{ change.title }}</h2>
                 {% else %}
                     <h2 class="card-title">{{ change.plugin_name }} - {{ change.title }}</h2>

--- a/plugins/CoreHome/tests/Integration/ChangesTest.php
+++ b/plugins/CoreHome/tests/Integration/ChangesTest.php
@@ -27,21 +27,21 @@ class ChangesTest extends IntegrationTestCase
 
     public function test_CoreHomeChanges_ShouldSortChangeListMostRecentFirst()
     {
-        $json = '{"idchange":6,"plugin_name":"CoreHome","version":"4.6.0b5","title":"New feature x added","description":"Now you can do a with b like this","link_name":"For more information go here","link":"https:\/\/www.matomo.org"}';
+        $json = '{"plugin_name":"CoreHome","version":"4.6.0b5","title":"New feature x added","description":"Now you can do a with b like this","link_name":"For more information go here","link":"https:\/\/www.matomo.org"}';
         $changesModel = new ChangesModel();
         $changes = $changesModel->getChangeItems();
         $r = reset($changes);
-        unset($r['created_time']);
+        unset($r['created_time'], $r['idchange']);
         $this->assertEquals($json, json_encode($r, true));
     }
 
     public function test_CoreHomeChanges_ShouldAllowChangeItemAddWithoutLink()
     {
-        $json = '{"idchange":5,"plugin_name":"CoreHome","version":"4.5.0","title":"New feature y added","description":"Now you can do c with d like this","link_name":null,"link":null}';
+        $json = '{"plugin_name":"CoreHome","version":"4.5.0","title":"New feature y added","description":"Now you can do c with d like this","link_name":null,"link":null}';
         $changesModel = new ChangesModel();
         $changes = $changesModel->getChangeItems();
         $r = $changes[1];
-        unset($r['created_time']);
+        unset($r['created_time'], $r['idchange']);
         $this->assertEquals($json, json_encode($r, true));
     }
 

--- a/plugins/CoreHome/tests/UI/expected-screenshots/Changes_show_popover.png
+++ b/plugins/CoreHome/tests/UI/expected-screenshots/Changes_show_popover.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12da66f8aee0f8e5bbcc049c62df7db059cb4bfd09399e78bdcecbceafc06372
-size 99872
+oid sha256:e6393002fa74878d011f64405887093b2f068507bb2361d8ff54927476de93ba
+size 148811

--- a/plugins/ProfessionalServices/changes.json
+++ b/plugins/ProfessionalServices/changes.json
@@ -1,7 +1,7 @@
 [
   {
     "title": "Premium Features Available in the Left-menu Navigation Bar",
-    "description":"The left-menu navigation now highlights some of our amazing premium features. Thousands of customers already find them powerful and the revenue from them helps us maintain and improve Matomo, ensuring that we can continue our commitment to high-quality open-source analytics for everyone. We have made it easy to customise by hiding or disabling them, so you can still navigate fast to the tools you need.",
+    "description":"The left-menu navigation now highlights some of our amazing premium features.<br><br>Thousands of customers already find them powerful and the revenue from them helps us maintain and improve Matomo, ensuring that we can continue our commitment to high-quality open-source analytics for everyone.<br><br>We have made it easy to customise by hiding or disabling them, so you can still navigate fast to the tools you need.",
     "version": "4.16.0-rc2",
     "link_name": "Read more",
     "link": "https://matomo.org/blog/2023/11/discovering-our-premium-on-premise-features?mtm_campaign=in-app-on-prem-premium-features-notification&mtm_kwd=on-prem-features&mtm_source=in-app&mtm_medium=notification&mtm_content=on-prem-features&mtm_group=in-app"

--- a/plugins/ProfessionalServices/changes.json
+++ b/plugins/ProfessionalServices/changes.json
@@ -1,0 +1,9 @@
+[
+  {
+    "title": "Premium Features Available in the Left-menu Navigation Bar",
+    "description":"The left-menu navigation now highlights some of our amazing premium features. Thousands of customers already find them powerful and the revenue from them helps us maintain and improve Matomo, ensuring that we can continue our commitment to high-quality open-source analytics for everyone. We have made it easy to customise by hiding or disabling them, so you can still navigate fast to the tools you need.",
+    "version": "4.16.0-rc2",
+    "link_name": "Read more",
+    "link": "https://matomo.org/blog/2023/11/discovering-our-premium-on-premise-features?mtm_campaign=in-app-on-prem-premium-features-notification&mtm_kwd=on-prem-features&mtm_source=in-app&mtm_medium=notification&mtm_content=on-prem-features&mtm_group=in-app"
+  }
+]


### PR DESCRIPTION
### Description:

This PR adds a new "What's new" entry to explain the premium feature menu items.

Additionally it makes a small tweak to the "What's new" twig template to prevent the plugin name being used as a title prefix for notification added by the professional services plugin.

Suggested review checks:
- Change is properly picked up when updating to 4.16 (after release version commit)
- Campaign parameters in the blog link are correctly set.
- Paragraphs are properly formatted.
- Professional services title prefix isn’t shown.

Refs DEV-17481

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
