### PR TITLE
Fix jqplot rendering for some currency formats

### DIFF
--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -569,7 +569,7 @@ function rowEvolutionGetMetricNameFromRow(tr)
             if (
               axis.tickOptions
               && axis.tickOptions.formatString
-              && axis.tickOptions.formatString.substring(2, 3) == '%'
+              && axis.tickOptions.formatString.endsWith('%')
               && maxCrossDataSets > 100
             ) {
                 maxCrossDataSets = 100;


### PR DESCRIPTION
### Description:

The improved tick formatting introduced in #19353 can result in some currencies being detected as percentages. For example the formatting string `kr%s` (danish/swedish krona) is detected as a percentage and breaks the Y-Axis tick calculation.

Fixes #21612.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
