### PR TITLE
Improve API error UI test by checking for content instead of screenshot

### DIFF
--- a/tests/UI/expected-screenshots/UIIntegrationTest_api_error.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_api_error.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07eae07d4d64145903c7c8560b851fce4218411a903b711bfdcaea593485df37
-size 159811

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -910,8 +910,10 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await page.goto(adminUrl);
             await page.waitForSelector('#notificationContainer');
 
-            const pageWrap = await page.$('.pageWrap, #notificationContainer');
-            expect(await pageWrap.screenshot()).to.matchImage('api_error');
+            const notificationContent = await page.evaluate(() => $('#notificationContainer').text().trim());
+
+            // ensure no notification is being displayed
+            expect(notificationContent).to.be.empty;
         });
     });
 


### PR DESCRIPTION
### Description:

The test is meant to check that no notification is shown in administration in case of an API error.
Taking a screenshot is quite useless there, as it only shows the admin overview. A notification might appear in case of a regression. Simply checking for the text content should therefor be a better choice.

Note: This test also regressed in #21605 due to the menu changes 🙈 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
