### PR TITLE
Adding helper function for UI tests

### DIFF
--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -56,18 +56,6 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         testEnvironment.save();
     });
 
-    async function screenshotPageWrap() {
-        await page.evaluate(function () {
-          $('#secondNavBar').css('visibility', 'hidden'); // hide navbar so shadow isn't shown on screenshot
-        });
-        const pageWrap = await page.$('.pageWrap');
-        const screenshot = await pageWrap.screenshot();
-        await page.evaluate(function () {
-          $('#secondNavBar').css('visibility', 'visible'); // show navbar again
-        });
-        return screenshot;
-    }
-
     describe("misc", function () {
         this.title = parentSuite.title; // to make sure the screenshot prefix is the same
 
@@ -78,7 +66,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         it("should load the page of a plugin located in a custom directory", async function () {
             await page.goto("?module=CustomDirPlugin&action=index&idSite=1&period=day&date=yesterday");
 
-            expect(await screenshotPageWrap()).to.matchImage('customdirplugin');
+            expect(await page.screenshotPageWrap()).to.matchImage('customdirplugin');
         });
 
         // shortcuts help
@@ -123,7 +111,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         // Notifications
         it('should load the notifications page correctly', async function() {
             await page.goto("?" + generalParams + "&module=ExampleUI&action=notifications&idSite=1&period=day&date=yesterday");
-            expect(await screenshotPageWrap()).to.matchImage('notifications');
+            expect(await page.screenshotPageWrap()).to.matchImage('notifications');
         });
 
         // Fatal error safemode
@@ -195,7 +183,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await page.evaluate(() => { // give table headers constant width so the screenshot stays the same
               $('.dataTableScroller').css('overflow-x', 'scroll');
             });
-            expect(await screenshotPageWrap()).to.matchImage('visitors_overview_columns');
+            expect(await page.screenshotPageWrap()).to.matchImage('visitors_overview_columns');
         });
 
         it('should reload the visitors > overview page when clicking on the visitors overview page element again', async function () {
@@ -203,7 +191,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await page.waitForNetworkIdle();
             await page.waitForSelector('.piwik-graph');
 
-            expect(await screenshotPageWrap()).to.matchImage('visitors_overview');
+            expect(await page.screenshotPageWrap()).to.matchImage('visitors_overview');
         });
 
         it('should be possible to change the limit of evolution chart', async function () {
@@ -215,7 +203,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await page.mouse.move(0, 0);
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('visitors_overview_limit');
+            expect(await page.screenshotPageWrap()).to.matchImage('visitors_overview_limit');
         });
 
         it('should keep the limit when reload the page', async function () {
@@ -224,14 +212,14 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             delete testEnvironment.ignoreClearAllViewDataTableParameters;
             testEnvironment.save();
 
-            expect(await screenshotPageWrap()).to.matchImage('visitors_overview_limit');
+            expect(await page.screenshotPageWrap()).to.matchImage('visitors_overview_limit');
         });
 
         it('should load the visitors > devices page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Visitors&subcategory=DevicesDetection_Devices");
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('visitors_devices');
+            expect(await page.screenshotPageWrap()).to.matchImage('visitors_devices');
         });
 
         it('should load visitors > locations & provider page correctly', async function () {
@@ -239,35 +227,35 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await page.waitForNetworkIdle();
             await page.waitForTimeout(500); // wait for map widget to render
 
-            expect(await screenshotPageWrap()).to.matchImage('visitors_locations_provider');
+            expect(await page.screenshotPageWrap()).to.matchImage('visitors_locations_provider');
         });
 
         it('should load the visitors > software page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Visitors&subcategory=DevicesDetection_Software");
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('visitors_software');
+            expect(await page.screenshotPageWrap()).to.matchImage('visitors_software');
         });
 
         it('should load the visitors > times page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Visitors&subcategory=VisitTime_SubmenuTimes");
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('visitors_times');
+            expect(await page.screenshotPageWrap()).to.matchImage('visitors_times');
         });
 
         it('should load the visitors > engagement page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Actions&subcategory=VisitorInterest_Engagement");
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('visitors_engagement');
+            expect(await page.screenshotPageWrap()).to.matchImage('visitors_engagement');
         });
 
         it('should load the visitors > custom variables page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Visitors&subcategory=CustomVariables_CustomVariables");
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('visitors_custom_vars');
+            expect(await page.screenshotPageWrap()).to.matchImage('visitors_custom_vars');
         });
 
         it('should load the visitors > real-time map page correctly', async function () {
@@ -296,7 +284,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             //await page.click('#pauseImage'); // prevent refreshes breaking the tests
             await page.waitForTimeout(100);
 
-            expect(await screenshotPageWrap()).to.matchImage('visitors_realtime_visits');
+            expect(await page.screenshotPageWrap()).to.matchImage('visitors_realtime_visits');
         });
     });
 
@@ -309,7 +297,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await page.mouse.move(-10, -10);
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('actions_pages');
+            expect(await page.screenshotPageWrap()).to.matchImage('actions_pages');
         });
 
         // actions pages
@@ -325,42 +313,42 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             });
             await page.mouse.move(-10, -10);
 
-            expect(await screenshotPageWrap()).to.matchImage('actions_pages_tooltip_help');
+            expect(await page.screenshotPageWrap()).to.matchImage('actions_pages_tooltip_help');
         });
 
         it('should load the actions > entry pages page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Actions&subcategory=Actions_SubmenuPagesEntry");
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('actions_entry_pages');
+            expect(await page.screenshotPageWrap()).to.matchImage('actions_entry_pages');
         });
 
         it('should load the actions > exit pages page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Actions&subcategory=Actions_SubmenuPagesExit");
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('actions_exit_pages');
+            expect(await page.screenshotPageWrap()).to.matchImage('actions_exit_pages');
         });
 
         it('should load the actions > page titles page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Actions&subcategory=Actions_SubmenuPageTitles");
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('actions_page_titles');
+            expect(await page.screenshotPageWrap()).to.matchImage('actions_page_titles');
         });
 
         it('should load the actions > site search page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Actions&subcategory=Actions_SubmenuSitesearch");
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('actions_site_search');
+            expect(await page.screenshotPageWrap()).to.matchImage('actions_site_search');
         });
 
         it('should load the actions > outlinks page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Actions&subcategory=General_Outlinks");
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('actions_outlinks');
+            expect(await page.screenshotPageWrap()).to.matchImage('actions_outlinks');
         });
 
         it('should load the segmented vlog correctly for outlink containing a &', async function () {
@@ -387,14 +375,14 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await page.waitForTimeout(500);
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('actions_downloads');
+            expect(await page.screenshotPageWrap()).to.matchImage('actions_downloads');
         });
 
         it('should load the actions > contents page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Actions&subcategory=Contents_Contents&period=day&date=2012-01-01");
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('actions_contents');
+            expect(await page.screenshotPageWrap()).to.matchImage('actions_contents');
         });
 
         it("should show all corresponding content pieces when clicking on a content name", async function () {
@@ -407,7 +395,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             });
             await page.mouse.move(-10, -10);
 
-            expect(await screenshotPageWrap()).to.matchImage('actions_content_name_piece');
+            expect(await page.screenshotPageWrap()).to.matchImage('actions_content_name_piece');
         });
 
         it("should show all tracked content pieces when clicking on the table", async function () {
@@ -415,7 +403,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await elem.click();
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('actions_content_piece');
+            expect(await page.screenshotPageWrap()).to.matchImage('actions_content_piece');
         });
 
         it("should show all corresponding content names when clicking on a content piece", async function () {
@@ -428,7 +416,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             });
             await page.mouse.move(-10, -10);
 
-            expect(await screenshotPageWrap()).to.matchImage('actions_content_piece_name');
+            expect(await page.screenshotPageWrap()).to.matchImage('actions_content_piece_name');
         });
     });
 
@@ -452,37 +440,37 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=ExampleUI_UiFramework&subcategory=ExampleUI_GetTemperaturesDataTable");
             await page.mouse.move(-10, -10);
 
-            expect(await screenshotPageWrap()).to.matchImage('exampleui_dataTables');
+            expect(await page.screenshotPageWrap()).to.matchImage('exampleui_dataTables');
         });
 
         it('should load the example ui > barGraph page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=ExampleUI_UiFramework&subcategory=Bar%20graph");
 
-            expect(await screenshotPageWrap()).to.matchImage('exampleui_barGraph');
+            expect(await page.screenshotPageWrap()).to.matchImage('exampleui_barGraph');
         });
 
         it('should load the example ui > pieGraph page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=ExampleUI_UiFramework&subcategory=Pie%20graph");
 
-            expect(await screenshotPageWrap()).to.matchImage('exampleui_pieGraph');
+            expect(await page.screenshotPageWrap()).to.matchImage('exampleui_pieGraph');
         });
 
         it('should load the example ui > tagClouds page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=ExampleUI_UiFramework&subcategory=Tag%20clouds");
 
-            expect(await screenshotPageWrap()).to.matchImage('exampleui_tagClouds');
+            expect(await page.screenshotPageWrap()).to.matchImage('exampleui_tagClouds');
         });
 
         it('should load the example ui > sparklines page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=ExampleUI_UiFramework&subcategory=Sparklines");
 
-            expect(await screenshotPageWrap()).to.matchImage('exampleui_sparklines');
+            expect(await page.screenshotPageWrap()).to.matchImage('exampleui_sparklines');
         });
 
         it('should load the example ui > evolution graph page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=ExampleUI_UiFramework&subcategory=Evolution%20Graph");
 
-            expect(await screenshotPageWrap()).to.matchImage('exampleui_evolutionGraph');
+            expect(await page.screenshotPageWrap()).to.matchImage('exampleui_evolutionGraph');
         });
 
         it('should load the example ui > treemap page correctly', async function () {
@@ -490,7 +478,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await page.waitForNetworkIdle();
             await page.waitForTimeout(500);
 
-            expect(await screenshotPageWrap()).to.matchImage('exampleui_treemap');
+            expect(await page.screenshotPageWrap()).to.matchImage('exampleui_treemap');
         });
 
         it('should load sparklines view correctly even when there is no matching row', async function () {
@@ -559,13 +547,13 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         it('should load the ecommerce log page', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=Goals_Ecommerce&subcategory=Goals_EcommerceLog");
 
-            expect(await screenshotPageWrap()).to.matchImage('ecommerce_log');
+            expect(await page.screenshotPageWrap()).to.matchImage('ecommerce_log');
         });
 
         it('should load the ecommerce log page with segment', async function () {
             await page.goto("?" + urlBase + "&segment=countryCode%3D%3DCN#?" + generalParams + "&category=Goals_Ecommerce&subcategory=Goals_EcommerceLog&segment=countryCode%3D%3DCN");
 
-            expect(await screenshotPageWrap()).to.matchImage('ecommerce_log_segmented');
+            expect(await page.screenshotPageWrap()).to.matchImage('ecommerce_log_segmented');
         });
 
         it('should load the ecommerce products page', async function () {
@@ -593,7 +581,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         it('should load the Admin home page correct', async function () {
             await page.goto("?" + generalParams + "&module=CoreAdminHome&action=home");
 
-            expect(await screenshotPageWrap()).to.matchImage('admin_home');
+            expect(await page.screenshotPageWrap()).to.matchImage('admin_home');
         });
 
         // Admin user settings (plugins not displayed)
@@ -603,7 +591,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
                 $('.form-help:contains(UTC time is)').hide();
             });
 
-            expect(await screenshotPageWrap()).to.matchImage('admin_manage_websites');
+            expect(await page.screenshotPageWrap()).to.matchImage('admin_manage_websites');
         });
 
         it('should load the Settings > General Settings admin page correctly', async function () {
@@ -615,7 +603,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             });
             await page.waitForTimeout(750);
 
-            expect(await screenshotPageWrap()).to.matchImage('admin_settings_general');
+            expect(await page.screenshotPageWrap()).to.matchImage('admin_settings_general');
         });
 
         it('should load the Privacy Opt out iframe correctly', async function () {
@@ -629,7 +617,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await page.goto("?" + generalParams + "&module=MobileMessaging&action=index");
             await page.waitForNetworkIdle();
 
-            expect(await screenshotPageWrap()).to.matchImage('admin_settings_mobilemessaging');
+            expect(await page.screenshotPageWrap()).to.matchImage('admin_settings_mobilemessaging');
         })
 
         it('should switch the SMS provider correctly', async function () {
@@ -640,19 +628,19 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await page.waitForNetworkIdle();
             await page.waitForTimeout(200);
 
-            expect(await screenshotPageWrap()).to.matchImage('admin_settings_mobilemessaging_provider');
+            expect(await page.screenshotPageWrap()).to.matchImage('admin_settings_mobilemessaging_provider');
         });
 
         it('should load the themes admin page correctly', async function () {
             await page.goto("?" + generalParams + "&module=CorePluginsAdmin&action=themes");
 
-            expect(await screenshotPageWrap()).to.matchImage('admin_themes');
+            expect(await page.screenshotPageWrap()).to.matchImage('admin_themes');
         });
 
         it('should load the plugins admin page correctly', async function () {
             await page.goto("?" + generalParams + "&module=CorePluginsAdmin&action=plugins");
 
-            expect(await screenshotPageWrap()).to.matchImage('admin_plugins');
+            expect(await page.screenshotPageWrap()).to.matchImage('admin_plugins');
         });
 
         it('should load the plugins admin page correctly when internet disabled', async function () {
@@ -663,13 +651,13 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
 
             await page.goto("?" + generalParams + "&module=CorePluginsAdmin&action=plugins");
 
-            expect(await screenshotPageWrap()).to.matchImage('admin_plugins_no_internet');
+            expect(await page.screenshotPageWrap()).to.matchImage('admin_plugins_no_internet');
         });
 
         it('should load the config file page correctly', async function () {
             await page.goto("?" + generalParams + "&module=Diagnostics&action=configfile");
 
-            expect(await screenshotPageWrap()).to.matchImage('admin_diagnostics_configfile');
+            expect(await page.screenshotPageWrap()).to.matchImage('admin_diagnostics_configfile');
         });
 
         it('should load the Settings > Visitor Generator admin page correctly', async function () {
@@ -679,7 +667,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
                 $p.text($p.text().replace(/\(change .*\)/g, ''));
             });
 
-            expect(await screenshotPageWrap()).to.matchImage('admin_visitor_generator');
+            expect(await page.screenshotPageWrap()).to.matchImage('admin_visitor_generator');
         });
     });
 
@@ -689,7 +677,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         it('should load the glossary correctly', async function () {
             await page.goto("?" + generalParams + "&module=API&action=glossary");
 
-            expect(await screenshotPageWrap()).to.matchImage('glossary');
+            expect(await page.screenshotPageWrap()).to.matchImage('glossary');
         });
 
         it('should load the glossary correctly widgetized', async function () {
@@ -740,13 +728,13 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
                 });
             });
 
-            expect(await screenshotPageWrap()).to.matchImage('widgets_listing');
+            expect(await page.screenshotPageWrap()).to.matchImage('widgets_listing');
         });
 
         it('should load the API listing page correctly', async function () {
             await page.goto("?" + generalParams + "&module=API&action=listAllAPI");
 
-            expect(await screenshotPageWrap()).to.matchImage('api_listing');
+            expect(await page.screenshotPageWrap()).to.matchImage('api_listing');
         });
 
         it('should load the email reports page correctly', async function () {
@@ -755,7 +743,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
                 $('#header').hide();
             });
 
-            expect(await screenshotPageWrap()).to.matchImage('email_reports');
+            expect(await page.screenshotPageWrap()).to.matchImage('email_reports');
         });
 
         it('should show the generated report when clicking the download button', async function () {
@@ -772,7 +760,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             await page.goto("?" + generalParams + "&module=ScheduledReports&action=index");
             await page.click('.entityTable tr:nth-child(4) button[title="Edit"]');
 
-            expect(await screenshotPageWrap()).to.matchImage('email_reports_editor');
+            expect(await page.screenshotPageWrap()).to.matchImage('email_reports_editor');
         });
 
         // date range clicked

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -547,21 +547,12 @@ PageRenderer.prototype.getWholeCurrentUrl = function () {
 
 /**
  * Screenshot .pageWrap container with hidden #secondNavBar.
- * Optionally allow for page wrap selector to be customised for plugins.
- *
- * @param args
- * @returns {Promise<*>}
  */
-PageRenderer.prototype.screenshotPageWrap = async function (...args) {
-  let selector = '.pageWrap';
-  if (args.length && typeof args[0] === 'string') {
-    selector = args[0];
-  }
-
+PageRenderer.prototype.screenshotPageWrap = async function () {
   await this.webpage.evaluate(function () {
     $('#secondNavBar').css('visibility', 'hidden'); // hide navbar so shadow isn't shown on screenshot
   });
-  const pageWrap = await this.webpage.$(selector);
+  const pageWrap = await this.webpage.$('.pageWrap');
   const screenshot = await pageWrap.screenshot();
   await this.webpage.evaluate(function () {
     $('#secondNavBar').css('visibility', 'visible'); // show navbar again

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -545,9 +545,17 @@ PageRenderer.prototype.getWholeCurrentUrl = function () {
     return this.webpage.evaluate(() => window.location.href);
 };
 
-PageRenderer.prototype.screenshotPageWrapWithHiddenNav = async function (selector) {
-  if (typeof selector !== 'string') {
-    selector = '.pageWrap';
+/**
+ * Screenshot .pageWrap container with hidden #secondNavBar.
+ * Optionally allow for page wrap selector to be customised for plugins.
+ *
+ * @param args
+ * @returns {Promise<*>}
+ */
+PageRenderer.prototype.screenshotPageWrap = async function (...args) {
+  let selector = '.pageWrap';
+  if (args.length && typeof args[0] === 'string') {
+    selector = args[0];
   }
 
   await this.webpage.evaluate(function () {

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -545,6 +545,22 @@ PageRenderer.prototype.getWholeCurrentUrl = function () {
     return this.webpage.evaluate(() => window.location.href);
 };
 
+PageRenderer.prototype.screenshotPageWrapWithHiddenNav = async function (selector) {
+  if (typeof selector !== 'string') {
+    selector = '.pageWrap';
+  }
+
+  await this.webpage.evaluate(function () {
+    $('#secondNavBar').css('visibility', 'hidden'); // hide navbar so shadow isn't shown on screenshot
+  });
+  const pageWrap = await this.webpage.$(selector);
+  const screenshot = await pageWrap.screenshot();
+  await this.webpage.evaluate(function () {
+    $('#secondNavBar').css('visibility', 'visible'); // show navbar again
+  });
+  return screenshot;
+};
+
 
 
 exports.PageRenderer = PageRenderer;


### PR DESCRIPTION
### Description:

Created a new helper function for hiding the side navigation while taking screenshots. This is based on the [function recently used in CustomAlerts](https://github.com/matomo-org/plugin-CustomAlerts/pull/153/files#diff-fd8e5f49c335ad8bcc2733456df917d7bd7140cc34b67c66efe68e84621b9b73R16). Since we have quite a few plugins with failing UI builds due to recent nav bar changes, I figured that it would be good to add a reusable function instead of duplicating code.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
