### PR TITLE
Add option to force join order for segment queries

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -877,9 +877,12 @@ enable_referrer_definition_syncs = 1
 ; so it can be disabled here if necessary.
 disable_tracking_matomo_app_links = 0
 
-; Force the order of the first table when building segment queries in MySQL. This can be used to override sub-optimal
-; choices by the MYSQL optimizer and always ensure the query plan starts with the first table in the query.
+; Add a query hint for the order of joined tables when building segment queries in MySQL. This can be used to override
+; sub-optimal choices by the MYSQL optimizer and always ensure the query plan starts with the first table in the query.
 enable_segment_first_table_join_prefix = 0
+
+; Add a query hint for the order of the first table for all log table queries in MySQL.
+enable_first_table_join_prefix = 0
 
 [Tracker]
 

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -49,6 +49,13 @@ charset = utf8
 ;
 ;ignore_error_codes[] = 1105
 
+; Add a query hint for the order of joined tables when building segment queries in MySQL. This can be used to override
+; sub-optimal choices by the MYSQL optimizer and always ensure the query plan starts with the first table in the query.
+enable_segment_first_table_join_prefix = 0
+
+; Add a query hint for the order of the first table for all log table queries in MySQL.
+enable_first_table_join_prefix = 0
+
 ; If configured, the following queries will be executed on the reader instead of the writer.
 ; * archiving queries that hit a log table
 ; * live queries that hit a log table
@@ -876,13 +883,6 @@ enable_referrer_definition_syncs = 1
 ; the link url could be used by third parties monitoring network requests to identify that the Matomo app is being used,
 ; so it can be disabled here if necessary.
 disable_tracking_matomo_app_links = 0
-
-; Add a query hint for the order of joined tables when building segment queries in MySQL. This can be used to override
-; sub-optimal choices by the MYSQL optimizer and always ensure the query plan starts with the first table in the query.
-enable_segment_first_table_join_prefix = 0
-
-; Add a query hint for the order of the first table for all log table queries in MySQL.
-enable_first_table_join_prefix = 0
 
 [Tracker]
 

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -877,6 +877,10 @@ enable_referrer_definition_syncs = 1
 ; so it can be disabled here if necessary.
 disable_tracking_matomo_app_links = 0
 
+; Force the order of the first table when building segment queries in MySQL. This can be used to override sub-optimal
+; choices by the MYSQL optimizer and always ensure the query plan starts with the first table in the query.
+enable_segment_first_table_join_prefix = 0
+
 [Tracker]
 
 ; When enabled and a userId is set, then the visitorId will be automatically set based on the userId. This allows to

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -50,10 +50,10 @@ charset = utf8
 ;ignore_error_codes[] = 1105
 
 ; Add a query hint for the order of joined tables when building segment queries in MySQL. This can be used to override
-; sub-optimal choices by the MYSQL optimizer and always ensure the query plan starts with the first table in the query.
+; sub-optimal choices by the MySQL optimizer and always ensure the query plan starts with the first table in the query.
 enable_segment_first_table_join_prefix = 0
 
-; Add a query hint for the order of the first table for all log table queries in MySQL.
+; Add a query hint for the order of joined tables for all log table queries in MySQL.
 enable_first_table_join_prefix = 0
 
 ; If configured, the following queries will be executed on the reader instead of the writer.

--- a/core/Config/DatabaseConfig.php
+++ b/core/Config/DatabaseConfig.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Config;
+
+class DatabaseConfig extends GeneralConfig
+{
+
+    public static function getSectionName(): string
+    {
+        return 'Database';
+    }
+
+}

--- a/core/Config/DatabaseConfig.php
+++ b/core/Config/DatabaseConfig.php
@@ -8,12 +8,12 @@
  */
 namespace Piwik\Config;
 
-class DatabaseConfig extends GeneralConfig
+class DatabaseConfig extends SectionConfig
 {
 
     public static function getSectionName(): string
     {
-        return 'Database';
+        return 'database';
     }
 
 }

--- a/core/Config/GeneralConfig.php
+++ b/core/Config/GeneralConfig.php
@@ -12,20 +12,36 @@ use Piwik\Config;
 
 class GeneralConfig
 {
+
+    public static function getSectionName(): string
+    {
+        return 'General';
+    }
+
     /**
-     * Update Archive config
+     * Set the value for a setting
      *
      * @param string $name Setting name
      * @param mixed $value Value
+     *
+     * @return void
      */
-    public static function setConfigValue($name, $value)
+    public static function setConfigValue(string $name, $value): void
     {
         $section = self::getConfig();
         $section[$name] = $value;
-        Config::getInstance()->General = $section;
+        Config::getInstance()->{self::getSectionName()} = $section;
     }
 
-    public static function getConfigValue($name, $idSite = null)
+    /**
+     * Get a setting value
+     *
+     * @param string    $name     Setting name
+     * @param int|null  $idSite   Optional site Id
+     *
+     * @return mixed|null
+     */
+    public static function getConfigValue(string $name, ?int $idSite = null)
     {
         $config = self::getConfig();
         if (!empty($idSite)) {
@@ -35,14 +51,26 @@ class GeneralConfig
         return $config[$name] ?? null;
     }
 
+    /**
+     * Get the section config as an array
+     *
+     * @return array|string
+     */
     private static function getConfig()
     {
-        return Config::getInstance()->General;
+        return Config::getInstance()->{self::getSectionName()};
     }
 
-    private static function getSiteSpecificConfig($idSite)
+    /**
+     * Get the site specific config (if any) as an array
+     *
+     * @param   int $idSite
+     *
+     * @return array|string
+     */
+    private static function getSiteSpecificConfig(int $idSite)
     {
-        $key = 'General_' . $idSite;
+        $key = self::getSectionName() . '_' . $idSite;
         return Config::getInstance()->$key;
     }
 }

--- a/core/Config/GeneralConfig.php
+++ b/core/Config/GeneralConfig.php
@@ -8,9 +8,7 @@
  */
 namespace Piwik\Config;
 
-use Piwik\Config;
-
-class GeneralConfig
+class GeneralConfig extends SectionConfig
 {
 
     public static function getSectionName(): string
@@ -18,59 +16,4 @@ class GeneralConfig
         return 'General';
     }
 
-    /**
-     * Set the value for a setting
-     *
-     * @param string $name Setting name
-     * @param mixed $value Value
-     *
-     * @return void
-     */
-    public static function setConfigValue(string $name, $value): void
-    {
-        $section = self::getConfig();
-        $section[$name] = $value;
-        Config::getInstance()->{self::getSectionName()} = $section;
-    }
-
-    /**
-     * Get a setting value
-     *
-     * @param string    $name     Setting name
-     * @param int|null  $idSite   Optional site Id
-     *
-     * @return mixed|null
-     */
-    public static function getConfigValue(string $name, ?int $idSite = null)
-    {
-        $config = self::getConfig();
-        if (!empty($idSite)) {
-            $siteSpecificConfig = self::getSiteSpecificConfig($idSite);
-            $config = array_merge($config, $siteSpecificConfig);
-        }
-        return $config[$name] ?? null;
-    }
-
-    /**
-     * Get the section config as an array
-     *
-     * @return array|string
-     */
-    private static function getConfig()
-    {
-        return Config::getInstance()->{self::getSectionName()};
-    }
-
-    /**
-     * Get the site specific config (if any) as an array
-     *
-     * @param   int $idSite
-     *
-     * @return array|string
-     */
-    private static function getSiteSpecificConfig(int $idSite)
-    {
-        $key = self::getSectionName() . '_' . $idSite;
-        return Config::getInstance()->$key;
-    }
 }

--- a/core/Config/SectionConfig.php
+++ b/core/Config/SectionConfig.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Config;
+
+use Piwik\Config;
+
+abstract class SectionConfig
+{
+
+    public abstract static function getSectionName(): string;
+
+    /**
+     * Set the value for a setting
+     *
+     * @param string $name Setting name
+     * @param mixed $value Value
+     *
+     * @return void
+     */
+    public static function setConfigValue(string $name, $value): void
+    {
+        $section = self::getConfig();
+        $section[$name] = $value;
+        Config::getInstance()->{static::getSectionName()} = $section;
+    }
+
+    /**
+     * Get a setting value
+     *
+     * @param string    $name     Setting name
+     * @param int|null  $idSite   Optional site Id
+     *
+     * @return mixed|null
+     */
+    public static function getConfigValue(string $name, ?int $idSite = null)
+    {
+        $config = self::getConfig();
+        if (!empty($idSite)) {
+            $siteSpecificConfig = self::getSiteSpecificConfig($idSite);
+            $config = array_merge($config, $siteSpecificConfig);
+        }
+        return $config[$name] ?? null;
+    }
+
+    /**
+     * Get the section config as an array
+     *
+     * @return array|string
+     */
+    private static function getConfig()
+    {
+        return Config::getInstance()->{static::getSectionName()};
+    }
+
+    /**
+     * Get the site specific config (if any) as an array
+     *
+     * @param   int $idSite
+     *
+     * @return array|string
+     */
+    private static function getSiteSpecificConfig(int $idSite)
+    {
+        $key = static::getSectionName() . '_' . $idSite;
+        return Config::getInstance()->$key;
+    }
+}

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -408,6 +408,11 @@ class LogAggregator
         $forceGroupByBackup = $logQueryBuilder->getForcedInnerGroupBySubselect();
         $logQueryBuilder->forceInnerGroupBySubselect(LogQueryBuilder::FORCE_INNER_GROUP_BY_NO_SUBSELECT);
         $segmentSql = $this->segment->getSelectQuery('distinct log_visit.idvisit as idvisit', 'log_visit', $segmentWhere, $segmentBind, 'log_visit.idvisit ASC');
+
+        if (is_array($segmentSql) && array_key_exists('sql', $segmentSql)) {
+            $segmentSql['sql'] = DbHelper::addJoinPrefixHintToQuery($segmentSql['sql'], 'log_visit');
+        }
+
         $logQueryBuilder->forceInnerGroupBySubselect($forceGroupByBackup);
 
         $this->createTemporaryTable($segmentTable, $segmentSql['sql'], $segmentSql['bind']);

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -582,9 +582,14 @@ class LogAggregator
                                            $metrics = false, $rankingQuery = false, $orderBy = false, $timeLimitInMs = -1,
                                            $rankingQueryGenerate = false)
     {
-
         $query = $this->getQueryByDimensionSql($dimensions, $where, $additionalSelects, $metrics, $rankingQuery, $orderBy,
             $timeLimitInMs, $rankingQueryGenerate);
+
+        // Ranking queries will return the data directly
+        if ($rankingQuery && !$rankingQueryGenerate) {
+            return $query;
+        }
+
         return $this->getDb()->query($query['sql'], $query['bind']);
     }
 

--- a/core/DbHelper.php
+++ b/core/DbHelper.php
@@ -364,15 +364,12 @@ class DbHelper
      */
     public static function addJoinPrefixHintToQuery(string $sql, string $prefix): string
     {
-        $generalConfig = Config::getInstance()->General;
-        if (empty($generalConfig['enable_segment_first_table_join_prefix']) || $generalConfig['enable_segment_first_table_join_prefix'] != "1") {
-            return $sql;
-        }
-
-        $select = 'SELECT';
-        if (0 === strpos(trim($sql), $select)) {
-            $sql = trim($sql);
-            $sql = 'SELECT /*+ JOIN_PREFIX(' . $prefix . ') */' . substr($sql, strlen($select));
+        if (strpos(trim($sql), '/*+ JOIN_PREFIX(') === false) {
+            $select = 'SELECT';
+            if (0 === strpos(trim($sql), $select)) {
+                $sql = trim($sql);
+                $sql = 'SELECT /*+ JOIN_PREFIX('.$prefix.') */'.substr($sql, strlen($select));
+            }
         }
 
         return $sql;

--- a/core/DbHelper.php
+++ b/core/DbHelper.php
@@ -353,6 +353,32 @@ class DbHelper
     }
 
     /**
+     * Add an optimizer hint to the query to set the first table used by the MySQL join execution plan
+     *
+     * https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html#optimizer-hints-join-order
+     *
+     * @param string $sql       SQL query string
+     * @param string $prefix    Table prefix to be used as the first table in the plan
+     *
+     * @return string           Modified query string with hint added
+     */
+    public static function addJoinPrefixHintToQuery(string $sql, string $prefix): string
+    {
+        $generalConfig = Config::getInstance()->General;
+        if (empty($generalConfig['enable_segment_first_table_join_prefix']) || $generalConfig['enable_segment_first_table_join_prefix'] != "1") {
+            return $sql;
+        }
+
+        $select = 'SELECT';
+        if (0 === strpos(trim($sql), $select)) {
+            $sql = trim($sql);
+            $sql = 'SELECT /*+ JOIN_PREFIX(' . $prefix . ') */' . substr($sql, strlen($select));
+        }
+
+        return $sql;
+    }
+
+    /**
      * Returns true if the string is a valid database name for MySQL. MySQL allows + in the database names.
      * Database names that start with a-Z or 0-9 and contain a-Z, 0-9, underscore(_), dash(-), plus(+), and dot(.) will be accepted.
      * File names beginning with anything but a-Z or 0-9 will be rejected (including .htaccess for example).

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -10,6 +10,7 @@ namespace Piwik\Tests\Integration\DataAccess;
 
 use Piwik\ArchiveProcessor\Parameters;
 use Piwik\Config;
+use Piwik\Config\DatabaseConfig;
 use Piwik\Common;
 use Piwik\DataAccess\LogAggregator;
 use Piwik\Date;
@@ -343,7 +344,7 @@ class LogAggregatorTest extends IntegrationTestCase
 
     public function test_getSegmentTableSql_ShouldAddJoinHintAsCommentIfEnabled()
     {
-        Config::getInstance()->General['enable_segment_first_table_join_prefix'] = '1';
+        DatabaseConfig::setConfigValue('enable_segment_first_table_join_prefix', '1');
 
         $query = $this->getSegmentSql();
         $expected = [
@@ -371,7 +372,7 @@ class LogAggregatorTest extends IntegrationTestCase
 
     public function test_getSegmentTableSql_ShouldNotAddJoinHintAsCommentIfDisabled()
     {
-        Config::getInstance()->General['enable_segment_first_table_join_prefix'] = '0';
+        DatabaseConfig::setConfigValue('enable_segment_first_table_join_prefix', '0');
         $query = $this->getSegmentSql();
 
         $expected = [
@@ -431,7 +432,7 @@ class LogAggregatorTest extends IntegrationTestCase
 
     public function test_generateQuery_ShouldAddJoinQueryHintAsCommentIfEnabled()
     {
-        Config::getInstance()->General['enable_first_table_join_prefix'] = '1';
+        DatabaseConfig::setConfigValue('enable_first_table_join_prefix','1');
         $this->logAggregator->setQueryOriginHint('MyPluginName');
         $query = $this->logAggregator->generateQuery('test, test2', 'log_visit', '1=1', false, '5');
 
@@ -461,7 +462,7 @@ class LogAggregatorTest extends IntegrationTestCase
             'END AS label',
         ];
 
-        Config::getInstance()->General['enable_first_table_join_prefix'] = '1';
+        DatabaseConfig::setConfigValue('enable_first_table_join_prefix','1');
         $this->logAggregator->setQueryOriginHint('MyPluginName');
 
         $query = $this->logAggregator->getQueryByDimensionSql($dimensions, false, [], false, false,

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -432,7 +432,7 @@ class LogAggregatorTest extends IntegrationTestCase
 
     public function test_generateQuery_ShouldAddJoinQueryHintAsCommentIfEnabled()
     {
-        DatabaseConfig::setConfigValue('enable_first_table_join_prefix','1');
+        DatabaseConfig::setConfigValue('enable_first_table_join_prefix', '1');
         $this->logAggregator->setQueryOriginHint('MyPluginName');
         $query = $this->logAggregator->generateQuery('test, test2', 'log_visit', '1=1', false, '5');
 

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -373,8 +373,8 @@ class LogAggregatorTest extends IntegrationTestCase
     public function test_getSegmentTableSql_ShouldNotAddJoinHintAsCommentIfDisabled()
     {
         DatabaseConfig::setConfigValue('enable_segment_first_table_join_prefix', '0');
-        $query = $this->getSegmentSql();
 
+        $query = $this->getSegmentSql();
         $expected = [
             'sql' => "
 			SELECT


### PR DESCRIPTION
### Description:

Fixes #21635

This PR adds two new config options:
```
[database]
enable_segment_first_table_join_prefix = 1
enable_first_table_join_prefix = 1
```
When enabled the first option will cause a query hint to be added to segment selection queries which will suggest the join order of the first table and prevent the MySQL query planner from choosing a different starting table for the join plan.

The second option does the same but for all queries built using [LogAggregator::GenerateQuery()](https://github.com/matomo-org/matomo/blob/7a4217ec6975ff9765b38b330fdbc1ab77a55241/core/DataAccess/LogAggregator.php#L345) 

Before:
```
SELECT 
    DISTINCT log_visit.idvisit AS idvisit
FROM log_visit AS log_visit
LEFT JOIN log_link_visit_action llva ON llva.idvisit = log_visit.idvisit
LEFT JOIN log_action la ON la.idaction = llva.idaction_url
-- etc
```
After:
```
SELECT /*+ JOIN_PREFIX(log_visit) */
    DISTINCT log_visit.idvisit AS idvisit
FROM log_visit AS log_visit
LEFT JOIN log_link_visit_action llva ON llva.idvisit = log_visit.idvisit
LEFT JOIN log_action la ON la.idaction = llva.idaction_url
-- etc
```

Notes:
- ~~This only applies to queries used to build segment temporary tables, it is not currently applied to any other queries.~~
- Only the first table order is specified, the optimizer may choose any order for the other tables.
- The config options default to disabled so this will have no affect unless enabled.
- The hint should be ignored by database engines that do not support it, but it's not recommended to enable it unless running MySQL 8.0+.
- A new DatabaseConfig class has been added to easily retrieve [database] config values.
- The `queryVisitsByDimension()` and `createSegmentTable()` methods have both had their sql generation code moved to sub-methods to allow easier testing of the query sql.
- Various tests have been added to check the addition of query hints based on config values.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
