### PR TITLE
Fix segment invalidation for custom dimensions

### DIFF
--- a/plugins/CoreAdminHome/Commands/InvalidateReportData.php
+++ b/plugins/CoreAdminHome/Commands/InvalidateReportData.php
@@ -233,18 +233,17 @@ class InvalidateReportData extends ConsoleCommand
     private function getSegmentsToInvalidateFor($idSites)
     {
         $input = $this->getInput();
-        $output = $this->getOutput();
         $segments = $input->getOption('segment');
         $segments = array_map('trim', $segments);
         $segments = array_unique($segments);
 
         if (empty($segments)) {
-            return array(null);
+            return [null];
         }
 
-        $result = array();
+        $result = [];
         foreach ($segments as $segmentOptionValue) {
-            $segmentDefinition = $this->findSegment($segmentOptionValue, $idSites, $input, $output);
+            $segmentDefinition = $this->findSegment($segmentOptionValue, $idSites);
             if (empty($segmentDefinition)) {
                 continue;
             }

--- a/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php
@@ -49,14 +49,14 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
      */
     public function test_Command_FailsWhenAnInvalidDateRangeIsUsed($invalidDateRange)
     {
-        $code = $this->applicationTester->run(array(
+        $code = $this->applicationTester->run([
             'command' => 'core:invalidate-report-data',
-            '--dates' => array($invalidDateRange),
+            '--dates' => [$invalidDateRange],
             '--periods' => 'day',
             '--sites' => '1',
             '--dry-run' => true,
             '-vvv' => true,
-        ));
+        ]);
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
         self::assertStringContainsString("Invalid date or date range specifier", $this->getLogOutput());
@@ -64,10 +64,10 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
 
     public function getInvalidDateRanges()
     {
-        return array(
-            array('garbage'),
-            array('2012-01-03 2013-02-01'),
-        );
+        return [
+            ['garbage'],
+            ['2012-01-03 2013-02-01'],
+        ];
     }
 
     /**
@@ -75,14 +75,14 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
      */
     public function test_Command_FailsWhenAnInvalidPeriodTypeIsUsed($invalidPeriodType)
     {
-        $code = $this->applicationTester->run(array(
+        $code = $this->applicationTester->run([
             'command' => 'core:invalidate-report-data',
             '--dates' => '2012-01-01',
             '--periods' => $invalidPeriodType,
             '--sites' => '1',
             '--dry-run' => true,
             '-vvv' => true,
-        ));
+        ]);
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
         self::assertStringContainsString("Invalid period type", $this->getLogOutput());
@@ -90,9 +90,9 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
 
     public function getInvalidPeriodTypes()
     {
-        return array(
-            array('cranberries'),
-        );
+        return [
+            ['cranberries'],
+        ];
     }
 
     /**
@@ -100,14 +100,14 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
      */
     public function test_Command_FailsWhenAnInvalidSiteListIsUsed($invalidSites)
     {
-        $code = $this->applicationTester->run(array(
+        $code = $this->applicationTester->run([
             'command' => 'core:invalidate-report-data',
             '--dates' => '2012-01-01',
             '--periods' => 'day',
             '--sites' => $invalidSites,
             '--dry-run' => true,
             '-vvv' => true,
-        ));
+        ]);
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
         self::assertStringContainsString("Invalid --sites value", $this->getLogOutput());
@@ -115,24 +115,24 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
 
     public function getInvalidSiteLists()
     {
-        return array(
-            array('wolfalice'),
-            array(','),
-            array('1,500'),
-        );
+        return [
+            ['wolfalice'],
+            [','],
+            ['1,500'],
+        ];
     }
 
     public function test_Command_FailsWhenAnInvalidSegmentIsUsed()
     {
-        $code = $this->applicationTester->run(array(
+        $code = $this->applicationTester->run([
             'command' => 'core:invalidate-report-data',
             '--dates' => '2012-01-01',
             '--periods' => 'day',
             '--sites' => '1',
-            '--segment' => array('ablksdjfdslkjf'),
+            '--segment' => ['ablksdjfdslkjf'],
             '--dry-run' => true,
             '-vvv' => true,
-        ));
+        ]);
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
         self::assertStringContainsString("The segment condition 'ablksdjfdslkjf' is not valid", $this->getLogOutput());
@@ -143,16 +143,16 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
      */
     public function test_Command_InvalidatesCorrectSitesAndDates($dates, $periods, $sites, $cascade, $segments, $plugin, $expectedOutputs)
     {
-        $options = array(
+        $options = [
             'command' => 'core:invalidate-report-data',
             '--dates' => $dates,
             '--periods' => $periods,
             '--sites' => $sites,
             '--cascade' => $cascade,
-            '--segment' => $segments ?: array(),
+            '--segment' => $segments ?: [],
             '--dry-run' => true,
             '-vvv' => true,
-        );
+        ];
 
         if (!empty($plugin)) {
             $options['--plugin'] = $plugin;
@@ -169,14 +169,14 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
 
     public function test_Command_InvalidateDateRange()
     {
-        $code = $this->applicationTester->run(array(
+        $code = $this->applicationTester->run([
             'command' => 'core:invalidate-report-data',
-            '--dates' => array('2019-01-01,2019-01-09'),
+            '--dates' => ['2019-01-01,2019-01-09'],
             '--periods' => 'range',
             '--sites' => '1',
             '--dry-run' => true,
             '-vvv' => true,
-        ));
+        ]);
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
         self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
@@ -184,14 +184,14 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
 
     public function test_Command_InvalidateDateRange_invalidDate()
     {
-        $code = $this->applicationTester->run(array(
+        $code = $this->applicationTester->run([
             'command' => 'core:invalidate-report-data',
-            '--dates' => array('2019-01-01,2019-01--09'),
+            '--dates' => ['2019-01-01,2019-01--09'],
             '--periods' => 'range',
             '--sites' => '1',
             '--dry-run' => true,
             '-vvv' => true,
-        ));
+        ]);
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
         self::assertStringContainsString("The date '2019-01-01,2019-01--09' is not a correct date range", $this->getLogOutput());
@@ -199,14 +199,14 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
 
     public function test_Command_InvalidateDateRange_onlyOneDate()
     {
-        $code = $this->applicationTester->run(array(
+        $code = $this->applicationTester->run([
             'command' => 'core:invalidate-report-data',
-            '--dates' => array('2019-01-01'),
+            '--dates' => ['2019-01-01'],
             '--periods' => 'range',
             '--sites' => '1',
             '--dry-run' => true,
             '-vvv' => true,
-        ));
+        ]);
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
         self::assertStringContainsString("The date '2019-01-01' is not a correct date range", $this->getLogOutput());
@@ -214,14 +214,14 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
 
     public function test_Command_InvalidateDateRange_tooManyDatesInRange()
     {
-        $code = $this->applicationTester->run(array(
+        $code = $this->applicationTester->run([
             'command' => 'core:invalidate-report-data',
-            '--dates' => array('2019-01-01,2019-01-09,2019-01-12,2019-01-15'),
+            '--dates' => ['2019-01-01,2019-01-09,2019-01-12,2019-01-15'],
             '--periods' => 'range',
             '--sites' => '1',
             '--dry-run' => true,
             '-vvv' => true,
-        ));
+        ]);
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
         self::assertStringContainsString("The date '2019-01-01,2019-01-09,2019-01-12,2019-01-15' is not a correct date range", $this->getLogOutput());
@@ -229,14 +229,14 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
 
     public function test_Command_InvalidateDateRange_multipleDateRanges()
     {
-        $code = $this->applicationTester->run(array(
+        $code = $this->applicationTester->run([
             'command' => 'core:invalidate-report-data',
-            '--dates' => array('2019-01-01,2019-01-09', '2019-01-12,2019-01-15'),
+            '--dates' => ['2019-01-01,2019-01-09', '2019-01-12,2019-01-15'],
             '--periods' => 'range',
             '--sites' => '1',
             '--dry-run' => true,
             '-vvv' => true,
-        ));
+        ]);
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
         self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-15", $this->getLogOutput());
@@ -244,14 +244,14 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
 
     public function test_Command_InvalidateDateRange_invalidateAllPeriodTypesSkipsRangeWhenNotRangeDAte()
     {
-        $code = $this->applicationTester->run(array(
+        $code = $this->applicationTester->run([
             'command' => 'core:invalidate-report-data',
-            '--dates' => array('2019-01-01'),
+            '--dates' => ['2019-01-01'],
             '--periods' => 'all',
             '--sites' => '1',
             '--dry-run' => true,
             '-vvv' => true,
-        ));
+        ]);
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
         self::assertStringNotContainsString("range", $this->getLogOutput());
@@ -260,14 +260,14 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
 
     public function test_Command_InvalidateDateRange_invalidateAllPeriodTypes()
     {
-        $code = $this->applicationTester->run(array(
+        $code = $this->applicationTester->run([
             'command' => 'core:invalidate-report-data',
-            '--dates' => array('2019-01-01,2019-01-09'),
+            '--dates' => ['2019-01-01,2019-01-09'],
             '--periods' => 'all',
             '--sites' => '1',
             '--dry-run' => true,
             '-vvv' => true,
-        ));
+        ]);
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
         self::assertStringContainsString("Invalidating day periods in 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
@@ -279,161 +279,161 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
 
     public function test_Command_InvalidateAll_multipleDateRanges()
     {
-        $code = $this->applicationTester->run(array(
+        $code = $this->applicationTester->run([
             'command' => 'core:invalidate-report-data',
-            '--dates' => array('2019-01-01,2019-01-09', '2019-01-12,2019-01-13'),
+            '--dates' => ['2019-01-01,2019-01-09', '2019-01-12,2019-01-13'],
             '--periods' => 'all',
             '--sites' => '1',
             '--dry-run' => true,
             '-vvv' => true,
-        ));
+        ]);
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
         self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-13 [segment = ]", $this->getLogOutput());
     }
 
-    public function getTestDataForSuccessTests()
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function getTestDataForSuccessTests(): iterable
     {
-        return array(
-
-            array( // no cascade, single site + single day
-                array('2012-01-01'),
-                'day',
-                '1',
-                false,
-                null,
-                null,
-                array(
-                    '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [  ]',
-                ),
-            ),
-
-            array( // no cascade, single site + single day
-                array('2012-01-01'),
-                'day',
-                '1',
-                true,
-                null,
-                null,
-                array(
-                    '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [  ]',
-                ),
-            ),
-
-            array( // no cascade, single site, date, period
-                array('2012-01-01'),
-                'week',
-                '1',
-                false,
-                null,
-                null,
-                array(
-                    '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2011-12-26 ], period = [ week ], segment = [  ]',
-                ),
-            ),
-
-            array( // no cascade, multiple site, date & period
-                array('2012-01-01,2012-02-05', '2012-01-26,2012-01-27', '2013-03-19'),
-                'month,week',
-                '1,3',
-                false,
-                null,
-                null,
-                array(
-                    '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01, 2012-02-01 ], period = [ month ], segment = [  ], cascade = [ 0 ]',
-                    '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01 ], period = [ month ], segment = [  ], cascade = [ 0 ]',
-                    '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-01 ], period = [ month ], segment = [  ], cascade = [ 0 ]',
-                    '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2011-12-26, 2012-01-02, 2012-01-09, 2012-01-16, 2012-01-23, 2012-01-30 ], period = [ week ], segment = [  ], cascade = [ 0 ]',
-                    '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-23 ], period = [ week ], segment = [  ], cascade = [ 0 ]',
-                    '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-18 ], period = [ week ], segment = [  ], cascade = [ 0 ]',
-                ),
-            ),
-
-            array( // cascade, single site, date, period
-                array('2012-01-30,2012-02-10'),
-                'week',
-                '2',
-                true,
-                null,
-                null,
-                array(
-                    '[Dry-run] invalidating archives for site = [ 2 ], dates = [ 2012-01-30, 2012-02-06 ], period = [ week ], segment = [  ], cascade = [ 1 ]',
-                ),
-            ),
-
-            array( // cascade, multiple site, date & period
-                array('2012-02-03,2012-02-04', '2012-03-15'),
-                'month,week,day',
-                'all',
-                true,
-                null,
-                null,
-                array(
-                    '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-01 ], period = [ month ], segment = [  ], cascade = [ 1 ]',
-                    '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-01 ], period = [ month ], segment = [  ], cascade = [ 1 ]',
-                    '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-01-30 ], period = [ week ], segment = [  ], cascade = [ 1 ]',
-                    '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-12 ], period = [ week ], segment = [  ], cascade = [ 1 ]',
-                    '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-03, 2012-02-04 ], period = [ day ], segment = [  ], cascade = [ 1 ]',
-                    '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-15 ], period = [ day ], segment = [  ], cascade = [ 1 ]',
-                ),
-            ),
-
-            array( // cascade, one week, date & period + segment
-                array('2012-01-01,2012-01-14'),
-                'week',
-                'all',
-                true,
-                array('browserCode==FF'),
-                null,
-                array(
-                    '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2011-12-26, 2012-01-02, 2012-01-09 ], period = [ week ], segment = [ browserCode==FF ], cascade = [ 1 ]',
-                ),
-            ),
-
-            // w/ plugin
+        yield 'no cascade, single site + single day' => [
+            ['2012-01-01'],
+            'day',
+            '1',
+            false,
+            null,
+            null,
             [
-                ['2015-05-04'],
-                'day',
-                '1',
-                false,
-                null,
-                'ExamplePlugin',
-                [
-                    '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [  ], cascade = [ 0 ], plugin = [ ExamplePlugin ]',
-                ],
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [  ]',
             ],
+        ];
 
-            // match segment by id
+        yield 'cascade, single site + single day' => [
+            ['2012-01-01'],
+            'day',
+            '1',
+            true,
+            null,
+            null,
             [
-                ['2015-05-04'],
-                'day',
-                '1',
-                false,
-                [1],
-                null,
-                [
-                    '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [ browserCode==IE ], cascade = [ 0 ]',
-                ],
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [  ]',
             ],
+        ];
 
-            // match segment by name
+        yield 'no cascade, single site, date, period' => [
+            ['2012-01-01'],
+            'week',
+            '1',
+            false,
+            null,
+            null,
             [
-                ['2015-05-04'],
-                'day',
-                '1',
-                false,
-                ['test segment'],
-                null,
-                [
-                    '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [ browserCode==IE ], cascade = [ 0 ]',
-                ],
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2011-12-26 ], period = [ week ], segment = [  ]',
             ],
-        );
+        ];
+
+        yield 'no cascade, multiple site, date & period' => [
+            ['2012-01-01,2012-02-05', '2012-01-26,2012-01-27', '2013-03-19'],
+            'month,week',
+            '1,3',
+            false,
+            null,
+            null,
+            [
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01, 2012-02-01 ], period = [ month ], segment = [  ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01 ], period = [ month ], segment = [  ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-01 ], period = [ month ], segment = [  ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2011-12-26, 2012-01-02, 2012-01-09, 2012-01-16, 2012-01-23, 2012-01-30 ], period = [ week ], segment = [  ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-23 ], period = [ week ], segment = [  ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-18 ], period = [ week ], segment = [  ], cascade = [ 0 ]',
+            ],
+        ];
+
+        yield 'cascade, single site, date, period' => [
+            ['2012-01-30,2012-02-10'],
+            'week',
+            '2',
+            true,
+            null,
+            null,
+            [
+                '[Dry-run] invalidating archives for site = [ 2 ], dates = [ 2012-01-30, 2012-02-06 ], period = [ week ], segment = [  ], cascade = [ 1 ]',
+            ],
+        ];
+
+        yield 'cascade, multiple site, date & period' => [
+            ['2012-02-03,2012-02-04', '2012-03-15'],
+            'month,week,day',
+            'all',
+            true,
+            null,
+            null,
+            [
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-01 ], period = [ month ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-01 ], period = [ month ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-01-30 ], period = [ week ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-12 ], period = [ week ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-03, 2012-02-04 ], period = [ day ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-15 ], period = [ day ], segment = [  ], cascade = [ 1 ]',
+            ],
+        ];
+
+        yield 'cascade, one week, date & period + segment' => [
+            ['2012-01-01,2012-01-14'],
+            'week',
+            'all',
+            true,
+            ['browserCode==FF'],
+            null,
+            [
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2011-12-26, 2012-01-02, 2012-01-09 ], period = [ week ], segment = [ browserCode==FF ], cascade = [ 1 ]',
+            ],
+        ];
+
+        yield 'w/ plugin' => [
+            ['2015-05-04'],
+            'day',
+            '1',
+            false,
+            null,
+            'ExamplePlugin',
+            [
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [  ], cascade = [ 0 ], plugin = [ ExamplePlugin ]',
+            ],
+        ];
+
+        yield 'match segment by id' => [
+            ['2015-05-04'],
+            'day',
+            '1',
+            false,
+            [1],
+            null,
+            [
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [ browserCode==IE ], cascade = [ 0 ]',
+            ],
+        ];
+
+        yield 'match segment by name' => [
+            ['2015-05-04'],
+            'day',
+            '1',
+            false,
+            ['test segment'],
+            null,
+            [
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [ browserCode==IE ], cascade = [ 0 ]',
+            ],
+        ];
     }
 
-    public static function provideContainerConfigBeforeClass()
+    /**
+     * @return array<string, mixed>
+     */
+    public static function provideContainerConfigBeforeClass(): array
     {
-        if (empty(self::$captureHandler)) {
+        if (null === self::$captureHandler) {
             self::$captureHandler = new class extends AbstractProcessingHandler {
                 public $messages = [];
 
@@ -451,7 +451,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ];
     }
 
-    private function getLogOutput()
+    private function getLogOutput(): string
     {
         return implode("\n", self::$captureHandler->messages);
     }

--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -405,20 +405,17 @@ class API extends \Piwik\Plugin\API
      * Filter out any segments which cannot be initialized due to disable plugins or features
      *
      * @param array $segments
-     * @param       $idSite
+     * @param bool|int $idSite
      *
      * @return array
      */
     private function filterSegmentsWithDisabledElements(array $segments, $idSite = false): array
     {
-        $sites = [];
-        if (!empty($idSite)) {
-            $sites = is_array($idSite) ? $idSite : [$idSite];
-        }
+        $idSites = false === $idSite ? [] : [$idSite];
 
         foreach ($segments as $k => $segment) {
             try {
-                new Segment($segment['definition'], $sites);
+                new Segment($segment['definition'], $idSites);
             } catch (Exception $e) {
                 unset($segments[$k]);
             }


### PR DESCRIPTION
### Description

The segment filtering introduced in #21521 filters out segments that use custom dimensions if no `$idSite` parameter is given. This happens during the instantiation try that does not find custom dimensions when eventually [fetching the segment metadata](https://github.com/matomo-org/matomo/blob/b4207ef8dce0a3651956fae697e342b5c5e7b7ec/core/Segment.php#L190).

This patch restores segment invalidation by fetching segments for all to be invalidated sites individually. The behaviour to throw when multiple sites are given but a custom dimension is used was restored ([see test](https://github.com/matomo-org/matomo/blob/c4f903b6031d92dbb850b8a87165fb854bd2270d/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php#L151)). We could, at a later date, change that behaviour to not break but only run the invalidation for sites where the custom dimension exists.

Tests should pass when running them on 5.0.0-rc7 or earlier, 5.0.0-rc8 and later require the fix.

Refs L3-616
Fixes #21678

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
