### PR TITLE
Improve rendering of incomplete evolution graph data points

### DIFF
--- a/config/environment/ui-test.php
+++ b/config/environment/ui-test.php
@@ -114,9 +114,9 @@ return [
         })],
 
         ['Visualization.beforeRender', Piwik\DI::value(function (Visualization $visualization) {
-            $archiveStates = StaticContainer::get('test.vars.forceArchiveStates');
+            $dataStates = StaticContainer::get('test.vars.forceDataStates');
 
-            if (!is_array($archiveStates) || [] === $archiveStates) {
+            if (!is_array($dataStates) || [] === $dataStates) {
                 return;
             }
 
@@ -127,13 +127,13 @@ return [
             }
 
             foreach ($dataTable->getDataTables() as $date => $subTable) {
-                if (!isset($archiveStates[$date])) {
+                if (!isset($dataStates[$date])) {
                     continue;
                 }
 
                 $subTable->setMetadata(
                     DataTable::ARCHIVE_STATE_METADATA_NAME,
-                    $archiveStates[$date]
+                    $dataStates[$date]
                 );
             }
         })],

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -168,6 +168,9 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
 {
     const MAX_DEPTH_DEFAULT = 15;
 
+    /** Name for metadata that describes the archiving state of a report */
+    const ARCHIVE_STATE_METADATA_NAME = 'archive_state';
+
     /** Name for metadata that describes when a report was archived. */
     const ARCHIVED_DATE_METADATA_NAME = 'ts_archived';
 
@@ -220,6 +223,9 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
     const EXTRA_PROCESSED_METRICS_METADATA_NAME = 'extra_processed_metrics';
 
     const ROW_IDENTIFIER_METADATA_NAME = 'rowIdentifier';
+
+    const ID_ARCHIVE_STATE_COMPLETE = 'complete';
+    const ID_ARCHIVE_STATE_INCOMPLETE = 'incomplete';
 
     /**
      * Maximum nesting level.

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -226,6 +226,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
 
     const ID_ARCHIVE_STATE_COMPLETE = 'complete';
     const ID_ARCHIVE_STATE_INCOMPLETE = 'incomplete';
+    const ID_ARCHIVE_STATE_INVALIDATED = 'invalidated';
 
     /**
      * Maximum nesting level.

--- a/lang/en.json
+++ b/lang/en.json
@@ -266,6 +266,7 @@
         "InvalidDateRange": "Invalid Date Range, Please Try Again",
         "InvalidResponse": "The received data is invalid.",
         "IncompletePeriod": "Incomplete Period",
+        "InvalidatedPeriod": "Invalidated Period",
         "JsTrackingTag": "JavaScript Tracking Code",
         "KpiMetric": "KPI Metric",
         "Language": "Language",

--- a/plugins/CoreVisualizations/CoreVisualizations.php
+++ b/plugins/CoreVisualizations/CoreVisualizations.php
@@ -66,5 +66,6 @@ class CoreVisualizations extends \Piwik\Plugin
         $translationKeys[] = 'General_NoDataForGraph';
         $translationKeys[] = 'General_EvolutionSummaryGeneric';
         $translationKeys[] = 'General_IncompletePeriod';
+        $translationKeys[] = 'General_InvalidatedPeriod';
     }
 }

--- a/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
@@ -20,9 +20,14 @@ class Chart
 {
     // the data kept here conforms to the jqplot data layout
     // @see http://www.jqplot.com/docs/files/jqPlotOptions-txt.html
-    protected $series = array();
-    protected $data = array();
-    protected $axes = array();
+    protected $series = [];
+    protected $data = [];
+    protected $axes = [];
+
+    /**
+     * @var array<string>
+     */
+    protected $archiveStates = [];
 
     // temporary
     public $properties;
@@ -145,13 +150,14 @@ class Chart
         ProxyHttp::overrideCacheControlHeaders();
 
         // See http://www.jqplot.com/docs/files/jqPlotOptions-txt.html
-        $data = array(
-            'params' => array(
-                'axes'   => &$this->axes,
-                'series' => &$this->series
-            ),
-            'data'   => &$this->data
-        );
+        $data = [
+            'params' => [
+                'axes' => &$this->axes,
+                'series' => &$this->series,
+            ],
+            'data' => &$this->data,
+            'archiveStates' => &$this->archiveStates,
+        ];
 
         return $data;
     }
@@ -169,6 +175,14 @@ class Chart
             // to the jqplot config
             $this->series[$seriesIndex]['_xaxis'] = $axisName;
         }
+    }
+
+    /**
+     * @param array<string> $archiveStates
+     */
+    public function setArchiveStates(array $archiveStates): void
+    {
+        $this->archiveStates = $archiveStates;
     }
 
     private function getXAxis($index)

--- a/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
@@ -27,7 +27,7 @@ class Chart
     /**
      * @var array<string>
      */
-    protected $archiveStates = [];
+    protected $dataStates = [];
 
     // temporary
     public $properties;
@@ -156,7 +156,7 @@ class Chart
                 'series' => &$this->series,
             ],
             'data' => &$this->data,
-            'archiveStates' => &$this->archiveStates,
+            'dataStates' => &$this->dataStates,
         ];
 
         return $data;
@@ -178,11 +178,15 @@ class Chart
     }
 
     /**
-     * @param array<string> $archiveStates
+     * Set state information ("complete", "incomplete", ...) for the data points.
+     *
+     * Each entry is associated with all values of all series having the same index (stored in $data).
+     *
+     * @param array<string> $dataStates
      */
-    public function setArchiveStates(array $archiveStates): void
+    public function setDataStates(array $dataStates): void
     {
-        $this->archiveStates = $archiveStates;
+        $this->dataStates = $dataStates;
     }
 
     private function getXAxis($index)

--- a/plugins/CoreVisualizations/JqplotDataGenerator/Evolution.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator/Evolution.php
@@ -73,7 +73,7 @@ class Evolution extends JqplotDataGenerator
 
         $columnsToDisplay = array_values($this->properties['columns_to_display']);
 
-        list($seriesMetadata, $seriesUnits, $seriesLabels, $seriesToXAxis) =
+        [$seriesMetadata, $seriesUnits, $seriesLabels, $seriesToXAxis] =
             $this->getSeriesMetadata($rowsToDisplay, $columnsToDisplay, $units, $dataTables);
 
         // collect series data to show. each row-to-display/column-to-display permutation creates a series.
@@ -139,6 +139,8 @@ class Evolution extends JqplotDataGenerator
             }
             $visualization->setAxisXOnClick($axisXOnClick);
         }
+
+        $this->setArchiveStates($visualization, $dataTables);
     }
 
     private function getSeriesData($rowLabel, $columnName, DataTable\Map $dataTable)
@@ -311,7 +313,7 @@ class Evolution extends JqplotDataGenerator
 
                         $seriesUnits[$wholeSeriesLabel] = $units[$columnName];
 
-                        list($periodIndex, $segmentIndex) = DataComparisonFilter::getIndividualComparisonRowIndices($table, $seriesIndex);
+                        [$periodIndex, $segmentIndex] = DataComparisonFilter::getIndividualComparisonRowIndices($table, $seriesIndex);
                         $seriesToXAxis[] = $periodIndex;
                     }
                 } else {
@@ -322,5 +324,25 @@ class Evolution extends JqplotDataGenerator
         }
 
         return [$seriesMetadata, $seriesUnits, $seriesLabels, $seriesToXAxis];
+    }
+
+    /**
+     * @param array<DataTable> $dataTables
+     */
+    private function setArchiveStates(Chart $visualization, array $dataTables): void
+    {
+        $archiveStates = [];
+
+        foreach (array_values($dataTables) as $index => $dataTable) {
+            $state = $dataTable->getMetadata(DataTable::ARCHIVE_STATE_METADATA_NAME);
+
+            if (false === $state) {
+                $state = DataTable::ID_ARCHIVE_STATE_COMPLETE;
+            }
+
+            $archiveStates[$index] = $state;
+        }
+
+        $visualization->setArchiveStates($archiveStates);
     }
 }

--- a/plugins/CoreVisualizations/JqplotDataGenerator/Evolution.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator/Evolution.php
@@ -141,7 +141,7 @@ class Evolution extends JqplotDataGenerator
             $visualization->setAxisXOnClick($axisXOnClick);
         }
 
-        $this->setArchiveStates($visualization, $dataTables);
+        $this->setDataStates($visualization, $dataTables);
     }
 
     private function getSeriesData($rowLabel, $columnName, DataTable\Map $dataTable)
@@ -330,7 +330,7 @@ class Evolution extends JqplotDataGenerator
     /**
      * @param array<DataTable> $dataTables
      */
-    private function setArchiveStates(Chart $visualization, array $dataTables): void
+    private function setDataStates(Chart $visualization, array $dataTables): void
     {
         if (0 === count($dataTables)) {
             return;
@@ -342,7 +342,7 @@ class Evolution extends JqplotDataGenerator
         /** @var Site $site */
         $site = $dataTables[$mostRecentDate]->getMetadata(DataTableFactory::TABLE_METADATA_SITE_INDEX);
 
-        $archiveStates = [];
+        $dataStates = [];
         $siteToday = Date::factoryInTimezone('today', $site->getTimezone())->getTimestamp();
 
         foreach ($dataTableDates as $dataTableDate) {
@@ -358,9 +358,9 @@ class Evolution extends JqplotDataGenerator
                 $state = DataTable::ID_ARCHIVE_STATE_INCOMPLETE;
             }
 
-            $archiveStates[$dataTableDate] = $state;
+            $dataStates[$dataTableDate] = $state;
         }
 
-        $visualization->setArchiveStates(array_values($archiveStates));
+        $visualization->setDataStates(array_values($dataStates));
     }
 }

--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -1632,10 +1632,17 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
                 if (this.renderer.smooth) {
                     gd = this.gridData;
                 }
-                for (i=0; i<gd.length; i++) {
-                    if (gd[i][0] != null && gd[i][1] != null) {
-                        this.markerRenderer.draw(gd[i][0], gd[i][1], ctx, opts.markerOptions);
+                for (i = 0; i < gd.length; i++) {
+                    if (gd[i][0] === null || gd[i][1] === null) {
+                        continue;
                     }
+
+                    const markerOptions = opts.markerOptions || {};
+
+                    markerOptions.isIncomplete = opts.incompleteDataPoints.includes(i);
+                    markerOptions.incompleteFillColor = plot.grid.background;
+
+                    this.markerRenderer.draw(gd[i][0], gd[i][1], ctx, markerOptions);
                 }
             }
         }
@@ -1670,15 +1677,28 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
 
         if (isarc) {
             ctx.arc(points[0], points[1], points[2], points[3], points[4], true);
+
             if (closePath) {
                 ctx.closePath();
             }
+
             if (fill) {
                 ctx.fill();
             }
             else {
                 ctx.stroke();
             }
+
+            if (opts.isIncomplete && opts.incompleteFillColor) {
+                // graph lines reach into the point
+                // render inner point filled with background color to avoid showing them
+                ctx.beginPath();
+                ctx.arc(points[0], points[1], points[2] / 8, points[3], points[4], true);
+                ctx.strokeStyle = opts.incompleteFillColor;
+                ctx.stroke();
+                ctx.closePath();
+            }
+
             ctx.restore();
             return;
         }

--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -73,7 +73,7 @@ function rowEvolutionGetMetricNameFromRow(tr)
 
             this.data = graphData.data;
             this._setJqplotParameters(graphData.params);
-            this._setIncompleteDataPoints(graphData.incompleteDataPoints);
+            this._setArchiveStates(graphData.archiveStates);
 
             if (this.props.display_percentage_in_tooltip) {
                 this._setTooltipPercentages();
@@ -95,11 +95,11 @@ function rowEvolutionGetMetricNameFromRow(tr)
             setTimeout(function () { self.render(); }, 1);
         },
 
-        _setIncompleteDataPoints: function (incompleteDataPoints) {
-            this.jqplotParams.incompleteDataPoints = [];
+        _setArchiveStates: function (archiveStates) {
+            this.jqplotParams.archiveStates = [];
 
-            if (Array.isArray(incompleteDataPoints)) {
-                this.jqplotParams.incompleteDataPoints = incompleteDataPoints;
+            if (Array.isArray(archiveStates)) {
+                this.jqplotParams.archiveStates = archiveStates;
             }
 
             let tickCount = 0;
@@ -137,7 +137,7 @@ function rowEvolutionGetMetricNameFromRow(tr)
 
             try {
                 if (piwikPeriods.parse(period, this.param.date).containsToday()) {
-                    this.jqplotParams.incompleteDataPoints.push(tickCount - 1);
+                    this.jqplotParams.archiveStates[tickCount - 1] = 'incomplete';
                 }
             } catch (e) {
                 // ignore period parsing error
@@ -1419,12 +1419,12 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
         var xmin, ymin, xmax, ymax;
 
         // Only change in this overridden method, to pass the option to the renderers
-        if (plot.options.hasOwnProperty('incompleteDataPoints')) {
-            opts.incompleteDataPoints = plot.options.incompleteDataPoints;
+        if (plot.options.hasOwnProperty('archiveStates')) {
+            opts.archiveStates = plot.options.archiveStates;
         }
 
-        if (!Array.isArray(opts.incompleteDataPoints)) {
-            opts.incompleteDataPoints = [];
+        if (!Array.isArray(opts.archiveStates)) {
+            opts.archiveStates = [];
         }
 
         ctx.save();
@@ -1639,7 +1639,7 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
 
                     const markerOptions = opts.markerOptions || {};
 
-                    markerOptions.isIncomplete = opts.incompleteDataPoints.includes(i);
+                    markerOptions.isIncomplete = opts.archiveStates[i] && opts.archiveStates[i] !== 'complete';
                     markerOptions.incompleteFillColor = plot.grid.background;
 
                     this.markerRenderer.draw(gd[i][0], gd[i][1], ctx, markerOptions);
@@ -1668,11 +1668,11 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
         ctx.fillStyle = opts.fillStyle || this.fillStyle;
         ctx.beginPath();
 
-        let incompleteDataPoints = [];
+        let archiveStates = [];
 
-        if (!closePath && !fill && Array.isArray(opts.incompleteDataPoints)) {
+        if (!closePath && !fill && Array.isArray(opts.archiveStates)) {
             // only do the incomplete visualization for line charts
-            incompleteDataPoints = opts.incompleteDataPoints;
+            archiveStates = opts.archiveStates;
         }
 
         if (isarc) {
@@ -1738,7 +1738,7 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
             }
 
             // draw line to current point or skip if incomplete data point
-            if (incompleteDataPoints.includes(i)) {
+            if (archiveStates[i] && 'complete' !== archiveStates[i]) {
                 ctxPattern.moveTo(points[i][0], points[i][1]);
             } else {
                 ctxPattern.lineTo(points[i][0], points[i][1]);
@@ -1775,7 +1775,7 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
             }
 
             // draw dashed line to current point or skip if not incomplete data point
-            if (!incompleteDataPoints.includes(i)) {
+            if (!archiveStates[i] || 'complete' === archiveStates[i]) {
                 ctxPattern.moveTo(points[i][0], points[i][1]);
             } else {
                 ctxPattern.lineTo(points[i][0], points[i][1]);
@@ -1805,11 +1805,11 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
         ctx.strokeStyle = opts.strokeStyle || this.strokeStyle || 'rgba(0,0,0,'+alpha+')';
         ctx.fillStyle = opts.fillStyle || this.fillStyle || 'rgba(0,0,0,'+alpha+')';
 
-        let incompleteDataPoints = [];
+        let archiveStates = [];
 
-        if (!closePath && !fill && Array.isArray(opts.incompleteDataPoints)) {
+        if (!closePath && !fill && Array.isArray(opts.archiveStates)) {
             // only do the incomplete visualization for line charts
-            incompleteDataPoints = opts.incompleteDataPoints;
+            archiveStates = opts.archiveStates;
         }
 
         for (let j= 0; j < depth; j++) {
@@ -1841,7 +1841,7 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
                     }
 
                     // draw shadow line to current point or skip if incomplete data point
-                    if (incompleteDataPoints.includes(i)) {
+                    if (archiveStates[i] && 'complete' !== archiveStates[i]) {
                         ctxPattern.moveTo(points[i][0], points[i][1]);
                     } else {
                         ctxPattern.lineTo(points[i][0], points[i][1]);

--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -57,7 +57,8 @@ function rowEvolutionGetMetricNameFromRow(tr)
                 metricsToPlot: _pk_translate('General_MetricsToPlot'),
                 metricToPlot: _pk_translate('General_MetricToPlot'),
                 recordsToPlot: _pk_translate('General_RecordsToPlot'),
-                incompletePeriod: _pk_translate('General_IncompletePeriod')
+                incompletePeriod: _pk_translate('General_IncompletePeriod'),
+                invalidatedPeriod: _pk_translate('General_InvalidatedPeriod')
             };
 
             // set a unique ID for the graph element (required by jqPlot)

--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -102,47 +102,6 @@ function rowEvolutionGetMetricNameFromRow(tr)
             if (Array.isArray(archiveStates)) {
                 this.jqplotParams.archiveStates = archiveStates;
             }
-
-            let tickCount = 0;
-
-            if (this.param.period) {
-                // Fetch evolution graph tick count
-                switch (this.param.period) {
-                    case 'day':
-                        tickCount = this.param.evolution_day_last_n;
-                        break;
-                    case 'week':
-                        tickCount = this.param.evolution_week_last_n;
-                        break;
-                    case 'month':
-                        tickCount = this.param.evolution_month_last_n;
-                        break;
-                    case 'year':
-                        tickCount = this.param.evolution_year_last_n;
-                        break;
-                }
-            }
-
-            if (0 >= tickCount) {
-                return;
-            }
-
-            // Mark today, if included in graph, as incomplete
-            const piwikPeriods = window.CoreHome.Periods;
-            let period = this.param.period;
-
-            if (period === 'day' && this.param.date.indexOf(',') !== -1) {
-                // If date is actually a range then adjust the period type for the containsToday check
-                period = 'range';
-            }
-
-            try {
-                if (piwikPeriods.parse(period, this.param.date).containsToday()) {
-                    this.jqplotParams.archiveStates[tickCount - 1] = 'incomplete';
-                }
-            } catch (e) {
-                // ignore period parsing error
-            }
         },
 
         _setJqplotParameters: function (params) {

--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -1697,53 +1697,74 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
                 return;
             }
         }
-        else if (points && points.length) {
-            var move = true;
-            // Draw the line normally, up to the number of incomplete points
-            for (var i = 0; i < points.length - incompleteDataPoints.length; i++) {
 
-                // skip to the first non-null point and move to it.
-                if (points[i][0] != null && points[i][1] != null) {
-                    if (move) {
-                      ctxPattern.moveTo(points[i][0], points[i][1]);
-                      move = false;
-                    } else {
-                      ctxPattern.lineTo(points[i][0], points[i][1]);
-                    }
-                } else {
-                    move = true;
-                }
+        if (!points || !points.length) {
+            return;
+        }
+
+        let move = true;
+
+        for (let i = 0; i < points.length; i++) {
+            // skip to the first non-null point and move to it.
+            if (points[i][0] === null && points[i][1] === null) {
+                continue;
             }
-            if (closePath) {
-                ctxPattern.closePath();
+
+            if (move) {
+                move = false;
+
+                ctxPattern.moveTo(points[i][0], points[i][1]);
+                continue;
             }
-            if (fill) {
-                ctx.fill();
+
+            // draw line to current point or skip if incomplete data point
+            if (incompleteDataPoints.includes(i)) {
+                ctxPattern.moveTo(points[i][0], points[i][1]);
             } else {
-                ctx.stroke();
+                ctxPattern.lineTo(points[i][0], points[i][1]);
             }
         }
-        ctx.restore();
 
-        // Draw a dashed line to the last point
-        if (0 < incompleteDataPoints.length) {
-          ctx.save();
-          ctx.setLineDash([3, 3]);
-          ctx.lineWidth = opts.lineWidth || this.lineWidth;
-          ctx.lineJoin = opts.lineJoin || this.lineJoin;
-          ctx.lineCap = opts.lineCap || this.lineCap;
-          ctx.strokeStyle = (opts.strokeStyle || opts.color) || this.strokeStyle;
-
-          ctx.beginPath();
-
-          for (let ii = (points.length - incompleteDataPoints.length); ii < points.length; ii++) {
-            ctx.moveTo(points[ii - 1][0], points[ii - 1][1]);
-            ctx.lineTo(points[ii][0], points[ii][1]);
-            ctx.stroke();
-          }
-
-          ctx.restore();
+        if (closePath) {
+            ctxPattern.closePath();
         }
+
+        if (fill) {
+            ctx.fill();
+        } else {
+            ctx.stroke();
+        }
+
+        // draw dashed lines for incomplete data points
+        ctx.beginPath();
+        ctx.setLineDash([3, 3]);
+
+        move = true;
+
+        for (let i = 0; i < points.length; i++) {
+            // skip to the first non-null point and move to it.
+            if (points[i][0] === null && points[i][1] === null) {
+                continue;
+            }
+
+            if (move) {
+                move = false;
+
+                ctxPattern.moveTo(points[i][0], points[i][1]);
+                continue;
+            }
+
+            // draw dashed line to current point or skip if not incomplete data point
+            if (!incompleteDataPoints.includes(i)) {
+                ctxPattern.moveTo(points[i][0], points[i][1]);
+            } else {
+                ctxPattern.lineTo(points[i][0], points[i][1]);
+            }
+        }
+
+        ctx.stroke();
+        ctx.closePath();
+        ctx.restore();
     };
 
     // Only overriding this method to prevent drawing the shadow for the last line segment
@@ -1786,23 +1807,26 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
             else if (points && points.length) {
                 let move = true;
 
-                // Draw the line normally, except for the last point
-                for (let i = 0; i < points.length - incompleteDataPoints.length; i++) {
+                for (let i = 0; i < points.length; i++) {
                     // skip to the first non-null point and move to it.
-                    if (points[i][0] !== null && points[i][1] !== null) {
-                        if (move) {
-                            ctxPattern.moveTo(points[i][0], points[i][1]);
-                            move = false;
-                        }
-                        else {
-                            ctxPattern.lineTo(points[i][0], points[i][1]);
-                        }
+                    if (points[i][0] === null && points[i][1] === null) {
+                        continue;
                     }
-                    else {
-                        move = true;
+
+                    if (move) {
+                        move = false;
+
+                        ctxPattern.moveTo(points[i][0], points[i][1]);
+                        continue;
+                    }
+
+                    // draw shadow line to current point or skip if incomplete data point
+                    if (incompleteDataPoints.includes(i)) {
+                        ctxPattern.moveTo(points[i][0], points[i][1]);
+                    } else {
+                        ctxPattern.lineTo(points[i][0], points[i][1]);
                     }
                 }
-
             }
 
             if (closePath) {

--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -1686,7 +1686,7 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
 
         for (let i = 0; i < points.length; i++) {
             // skip to the first non-null point and move to it.
-            if (points[i][0] === null && points[i][1] === null) {
+            if (null === points[i][0] && null === points[i][1]) {
                 continue;
             }
 

--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -74,7 +74,7 @@ function rowEvolutionGetMetricNameFromRow(tr)
 
             this.data = graphData.data;
             this._setJqplotParameters(graphData.params);
-            this._setArchiveStates(graphData.archiveStates);
+            this._setDataStates(graphData.dataStates);
 
             if (this.props.display_percentage_in_tooltip) {
                 this._setTooltipPercentages();
@@ -96,11 +96,11 @@ function rowEvolutionGetMetricNameFromRow(tr)
             setTimeout(function () { self.render(); }, 1);
         },
 
-        _setArchiveStates: function (archiveStates) {
-            this.jqplotParams.archiveStates = [];
+        _setDataStates: function (dataStates) {
+            this.jqplotParams.dataStates = [];
 
-            if (Array.isArray(archiveStates)) {
-                this.jqplotParams.archiveStates = archiveStates;
+            if (Array.isArray(dataStates)) {
+                this.jqplotParams.dataStates = dataStates;
             }
         },
 
@@ -1379,12 +1379,12 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
         var xmin, ymin, xmax, ymax;
 
         // Only change in this overridden method, to pass the option to the renderers
-        if (plot.options.hasOwnProperty('archiveStates')) {
-            opts.archiveStates = plot.options.archiveStates;
+        if (plot.options.hasOwnProperty('dataStates')) {
+            opts.dataStates = plot.options.dataStates;
         }
 
-        if (!Array.isArray(opts.archiveStates)) {
-            opts.archiveStates = [];
+        if (!Array.isArray(opts.dataStates)) {
+            opts.dataStates = [];
         }
 
         ctx.save();
@@ -1599,7 +1599,7 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
 
                     const markerOptions = opts.markerOptions || {};
 
-                    markerOptions.isIncomplete = opts.archiveStates[i] && opts.archiveStates[i] !== 'complete';
+                    markerOptions.isIncomplete = opts.dataStates[i] && opts.dataStates[i] !== 'complete';
                     markerOptions.incompleteFillColor = plot.grid.background;
 
                     this.markerRenderer.draw(gd[i][0], gd[i][1], ctx, markerOptions);
@@ -1628,11 +1628,11 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
         ctx.fillStyle = opts.fillStyle || this.fillStyle;
         ctx.beginPath();
 
-        let archiveStates = [];
+        let dataStates = [];
 
-        if (!closePath && !fill && Array.isArray(opts.archiveStates)) {
+        if (!closePath && !fill && Array.isArray(opts.dataStates)) {
             // only do the incomplete visualization for line charts
-            archiveStates = opts.archiveStates;
+            dataStates = opts.dataStates;
         }
 
         if (isarc) {
@@ -1698,7 +1698,7 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
             }
 
             // draw line to current point or skip if incomplete data point
-            if (archiveStates[i] && 'complete' !== archiveStates[i]) {
+            if (dataStates[i] && 'complete' !== dataStates[i]) {
                 ctxPattern.moveTo(points[i][0], points[i][1]);
             } else {
                 ctxPattern.lineTo(points[i][0], points[i][1]);
@@ -1735,7 +1735,7 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
             }
 
             // draw dashed line to current point or skip if not incomplete data point
-            if (!archiveStates[i] || 'complete' === archiveStates[i]) {
+            if (!dataStates[i] || 'complete' === dataStates[i]) {
                 ctxPattern.moveTo(points[i][0], points[i][1]);
             } else {
                 ctxPattern.lineTo(points[i][0], points[i][1]);
@@ -1765,11 +1765,11 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
         ctx.strokeStyle = opts.strokeStyle || this.strokeStyle || 'rgba(0,0,0,'+alpha+')';
         ctx.fillStyle = opts.fillStyle || this.fillStyle || 'rgba(0,0,0,'+alpha+')';
 
-        let archiveStates = [];
+        let dataStates = [];
 
-        if (!closePath && !fill && Array.isArray(opts.archiveStates)) {
+        if (!closePath && !fill && Array.isArray(opts.dataStates)) {
             // only do the incomplete visualization for line charts
-            archiveStates = opts.archiveStates;
+            dataStates = opts.dataStates;
         }
 
         for (let j= 0; j < depth; j++) {
@@ -1801,7 +1801,7 @@ RowEvolutionSeriesToggle.prototype.beforeReplot = function () {
                     }
 
                     // draw shadow line to current point or skip if incomplete data point
-                    if (archiveStates[i] && 'complete' !== archiveStates[i]) {
+                    if (dataStates[i] && 'complete' !== dataStates[i]) {
                         ctxPattern.moveTo(points[i][0], points[i][1]);
                     } else {
                         ctxPattern.lineTo(points[i][0], points[i][1]);

--- a/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
+++ b/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
@@ -77,26 +77,6 @@
             JqplotGraphDataTablePrototype._bindEvents.call(this);
 
             const self = this;
-            const hasIncompleteDataPoints = !!this.jqplotParams['incompleteDataPoints'];
-
-            let tickCount = 0;
-
-            switch (this.param.period) {
-                case 'day':
-                    tickCount = this.param.evolution_day_last_n;
-                    break;
-                case 'week':
-                    tickCount = this.param.evolution_week_last_n;
-                    break;
-                case 'month':
-                    tickCount = this.param.evolution_month_last_n;
-                    break;
-                case 'year':
-                    tickCount = this.param.evolution_year_last_n;
-                    break;
-            }
-
-            const lastTick = tickCount - 1;
 
             $('#' + this.targetDivId)
                 .on('jqplotMouseLeave', function (e, s, i, d) {
@@ -185,7 +165,7 @@
                         `;
                     }
 
-                    if (tick === lastTick && hasIncompleteDataPoints) {
+                    if (self.jqplotParams.incompleteDataPoints.includes(tick)) {
                         content += `<br />(${self._lang.incompletePeriod})`;
                     }
 

--- a/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
+++ b/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
@@ -169,6 +169,10 @@
                         case 'incomplete':
                             content += `<br />(${self._lang.incompletePeriod})`;
                             break;
+
+                        case 'invalidated':
+                            content += `<br />(${self._lang.invalidatedPeriod})`;
+                            break;
                     }
 
                     $(this).tooltip({

--- a/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
+++ b/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
@@ -165,8 +165,10 @@
                         `;
                     }
 
-                    if (self.jqplotParams.incompleteDataPoints.includes(tick)) {
-                        content += `<br />(${self._lang.incompletePeriod})`;
+                    switch (self.jqplotParams.archiveStates[tick]) {
+                        case 'incomplete':
+                            content += `<br />(${self._lang.incompletePeriod})`;
+                            break;
                     }
 
                     $(this).tooltip({

--- a/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
+++ b/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
@@ -165,7 +165,7 @@
                         `;
                     }
 
-                    switch (self.jqplotParams.archiveStates[tick]) {
+                    switch (self.jqplotParams.dataStates[tick]) {
                         case 'incomplete':
                             content += `<br />(${self._lang.incompletePeriod})`;
                             break;

--- a/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
+++ b/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
@@ -9,21 +9,19 @@
  */
 
 (function ($, require) {
-
-    var exports = require('piwik/UI'),
-        JqplotGraphDataTable = exports.JqplotGraphDataTable,
-        JqplotGraphDataTablePrototype = JqplotGraphDataTable.prototype;
+    const exports = require('piwik/UI');
+    const JqplotGraphDataTable = exports.JqplotGraphDataTable;
+    const JqplotGraphDataTablePrototype = JqplotGraphDataTable.prototype;
 
     exports.JqplotEvolutionGraphDataTable = function (element) {
         JqplotGraphDataTable.call(this, element);
     };
 
     $.extend(exports.JqplotEvolutionGraphDataTable.prototype, JqplotGraphDataTablePrototype, {
-
         _setJqplotParameters: function (params) {
             JqplotGraphDataTablePrototype._setJqplotParameters.call(this, params);
 
-            var defaultParams = {
+            const defaultParams = {
                 axes: {
                     xaxis: {
                         pad: 1.0,
@@ -63,7 +61,7 @@
                 };
             }
 
-            var overrideParams = {
+            const overrideParams = {
                 legend: {
                     show: false
                 },
@@ -71,14 +69,44 @@
                     show: true
                 }
             };
+
             this.jqplotParams = $.extend(true, {}, defaultParams, this.jqplotParams, overrideParams);
         },
 
         _bindEvents: function () {
             JqplotGraphDataTablePrototype._bindEvents.call(this);
 
-            var self = this;
-            var lastTick = false;
+            const self = this;
+            const RangePeriod = window.CoreHome.Range;
+
+            let tickCount = 0;
+
+            switch (this.param.period) {
+                case 'day':
+                    tickCount = this.param.evolution_day_last_n;
+                    break;
+                case 'week':
+                    tickCount = this.param.evolution_week_last_n;
+                    break;
+                case 'month':
+                    tickCount = this.param.evolution_month_last_n;
+                    break;
+                case 'year':
+                    tickCount = this.param.evolution_year_last_n;
+                    break;
+            }
+
+            const lastTick = tickCount - 1;
+
+            let graphDateRangeEnd = null;
+
+            if (this.param.dateUsedInGraph) {
+                const graphDateRangeParts = this.param.dateUsedInGraph.split(',');
+
+                if (2 === graphDateRangeParts.length) {
+                    graphDateRangeEnd = graphDateRangeParts[1];
+                }
+            }
 
             $('#' + this.targetDivId)
                 .on('jqplotMouseLeave', function (e, s, i, d) {
@@ -86,101 +114,114 @@
                     JqplotGraphDataTablePrototype._destroyDataPointTooltip.call(this, $(this));
                 })
                 .on('jqplotClick', function (e, s, i, d) {
-                    if (lastTick !== false && typeof self.jqplotParams.axes.xaxis.onclick != 'undefined'
-                        && typeof self.jqplotParams.axes.xaxis.onclick[lastTick] == 'string') {
-                        var url = self.jqplotParams.axes.xaxis.onclick[lastTick];
-
-                        broadcast.propagateNewPage(url);
+                    if (!self.jqplotParams.axes.xaxis.onclick ||
+                        !self._plot.plugins.piwikTicks ||
+                        typeof self._plot.plugins.piwikTicks.currentXTick !== 'number'
+                    ) {
+                        return;
                     }
+
+                    const tick = self._plot.plugins.piwikTicks.currentXTick;
+
+                    if (typeof self.jqplotParams.axes.xaxis.onclick[tick] !== 'string') {
+                        return;
+                    }
+
+                    const url = self.jqplotParams.axes.xaxis.onclick[tick];
+
+                    broadcast.propagateNewPage(url);
                 })
                 .on('jqplotPiwikTickOver', function (e, tick) {
-                    lastTick = tick;
-                    var label;
+                    const dataByAxis = {};
 
-                    var dataByAxis = {};
-                    for (var d = 0; d < self.data.length; ++d) {
-                        var valueUnformatted = self.data[d][tick];
+                    let isTickIncomplete = false;
+
+                    if (tick === lastTick && graphDateRangeEnd) {
+                          const hoverDateRange = RangePeriod.getLastNRangeChild(
+                              self.param.period,
+                              graphDateRangeEnd,
+                              lastTick - tick
+                          );
+
+                          isTickIncomplete = hoverDateRange.containsToday();
+                    }
+
+                    for (let d = 0; d < self.data.length; ++d) {
+                        const valueUnformatted = self.data[d][tick];
+
                         if (typeof valueUnformatted === 'undefined' || valueUnformatted === null) {
                             continue;
                         }
 
-                        var axis = self.jqplotParams.series[d]._xaxis || 'xaxis';
+                        const axis = self.jqplotParams.series[d]._xaxis || 'xaxis';
+
                         if (!dataByAxis[axis]) {
                             dataByAxis[axis] = [];
                         }
 
-                        var value = self.formatY(valueUnformatted, d);
-                        var series = self.jqplotParams.series[d].label;
+                        const value = self.formatY(valueUnformatted, d);
+                        const series = self.jqplotParams.series[d].label;
+                        const seriesColor = self.jqplotParams.seriesColors[d];
 
-                        var seriesColor = self.jqplotParams.seriesColors[d];
-
-                        dataByAxis[axis].push('<span class="tooltip-series-color" style="background-color: ' + seriesColor + ';"></span>' + '<strong>' + value + '</strong> ' + piwikHelper.htmlEntities(series));
+                        dataByAxis[axis].push(
+                            `<span class="tooltip-series-color" style="background-color: ${seriesColor}"></span>` +
+                            `<strong>${value}</strong> ${piwikHelper.htmlEntities(series)}`
+                        );
                     }
 
-                    var xAxisCount = 0;
+                    let xAxisCount = 0;
+
                     Object.keys(self.jqplotParams.axes).forEach(function (axis) {
-                        if (axis.substring(0, 1) === 'x') {
-                            ++xAxisCount;
+                        if (!axis.startsWith('x')) {
+                            return;
                         }
+
+                        ++xAxisCount;
                     });
 
-                    var content = '';
-                    for (var i = 0; i < xAxisCount; ++i) {
-                        var axisName = i === 0 ? 'xaxis' : 'x' + (i + 1) + 'axis';
+                    let content = '';
+
+                    for (let i = 0; i < xAxisCount; ++i) {
+                        const axisName = i === 0 ? 'xaxis' : `x${i + 1}axis`;
+
                         if (!dataByAxis[axisName] || !dataByAxis[axisName].length) {
                             continue;
                         }
 
-                        if (typeof self.jqplotParams.axes[axisName].labels != 'undefined') {
+                        let label;
+
+                        if (typeof self.jqplotParams.axes[axisName].labels !== 'undefined') {
                             label = self.jqplotParams.axes[axisName].labels[tick];
                         } else {
                             label = self.jqplotParams.axes[axisName].ticks[tick];
                         }
 
-                        if (typeof label === 'undefined') { // sanity check
+                        if (typeof label === 'undefined') {
+                            // sanity check
                             continue;
                         }
 
-                        content += '<h3 class="evolution-tooltip-header">'+piwikHelper.htmlEntities(label)+'</h3>'+dataByAxis[axisName].join('<br />');
+                        content += `
+                            <h3 class="evolution-tooltip-header">${piwikHelper.htmlEntities(label)}</h3>
+                            ${dataByAxis[axisName].join('<br />')}
+                        `;
+                    }
 
-                        var last_n = null;
-                        switch (self.param.period) {
-                            case 'day':
-                                last_n = self.param.evolution_day_last_n;
-                                break;
-                            case 'week':
-                                last_n = self.param.evolution_week_last_n;
-                                break;
-                            case 'month':
-                                last_n = self.param.evolution_month_last_n;
-                                break;
-                            case 'year':
-                                last_n = self.param.evolution_year_last_n;
-                                break;
-                        }
-                        if (last_n) {
-                            var RangePeriod = window.CoreHome.Range;
-                            if (self.param.hasOwnProperty('dateUsedInGraph') && self.param.dateUsedInGraph.indexOf(',') > 0) {
-                                var graphDateRange = self.param.dateUsedInGraph.split(',');
-                                if (graphDateRange.length == 2) {
-                                    var hoverDateRange = RangePeriod.getLastNRangeChild(self.param.period, graphDateRange[1], (last_n - lastTick)-1);
-                                    if (hoverDateRange.containsToday()) {
-                                        content += '<br />(' + self._lang.incompletePeriod + ')';
-                                    }
-                                }
-                            }
-                        }
+                    if (isTickIncomplete) {
+                        content += `<br />(${self._lang.incompletePeriod})`;
                     }
 
                     $(this).tooltip({
                         track:   true,
                         items:   'div',
                         content: content,
-                        show: false,
-                        hide: false
+                        show:    false,
+                        hide:    false
                     }).trigger('mouseover');
-                    if (typeof self.jqplotParams.axes.xaxis.onclick != 'undefined'
-                        && typeof self.jqplotParams.axes.xaxis.onclick[lastTick] == 'string') {
+
+                    if (typeof self.jqplotParams.axes.xaxis.onclick !== 'undefined' &&
+                        typeof self.jqplotParams.axes.xaxis.onclick[tick] === 'string'
+                    ) {
                         $(this).css('cursor', 'pointer');
                     }
                 });
@@ -195,10 +236,11 @@
         render: function () {
             JqplotGraphDataTablePrototype.render.call(this);
 
-            if (initializeSparklines) {
-                initializeSparklines();
+            if (!initializeSparklines) {
+                return;
             }
+
+            initializeSparklines();
         }
     });
-
 })(jQuery, require);

--- a/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
+++ b/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
@@ -77,7 +77,7 @@
             JqplotGraphDataTablePrototype._bindEvents.call(this);
 
             const self = this;
-            const RangePeriod = window.CoreHome.Range;
+            const hasIncompleteDataPoints = !!this.jqplotParams['incompleteDataPoints'];
 
             let tickCount = 0;
 
@@ -97,16 +97,6 @@
             }
 
             const lastTick = tickCount - 1;
-
-            let graphDateRangeEnd = null;
-
-            if (this.param.dateUsedInGraph) {
-                const graphDateRangeParts = this.param.dateUsedInGraph.split(',');
-
-                if (2 === graphDateRangeParts.length) {
-                    graphDateRangeEnd = graphDateRangeParts[1];
-                }
-            }
 
             $('#' + this.targetDivId)
                 .on('jqplotMouseLeave', function (e, s, i, d) {
@@ -133,18 +123,6 @@
                 })
                 .on('jqplotPiwikTickOver', function (e, tick) {
                     const dataByAxis = {};
-
-                    let isTickIncomplete = false;
-
-                    if (tick === lastTick && graphDateRangeEnd) {
-                          const hoverDateRange = RangePeriod.getLastNRangeChild(
-                              self.param.period,
-                              graphDateRangeEnd,
-                              lastTick - tick
-                          );
-
-                          isTickIncomplete = hoverDateRange.containsToday();
-                    }
 
                     for (let d = 0; d < self.data.length; ++d) {
                         const valueUnformatted = self.data[d][tick];
@@ -207,7 +185,7 @@
                         `;
                     }
 
-                    if (isTickIncomplete) {
+                    if (tick === lastTick && hasIncompleteDataPoints) {
                         content += `<br />(${self._lang.incompletePeriod})`;
                     }
 

--- a/plugins/CoreVisualizations/tests/Unit/JqplotDataGenerator/ChartTest.php
+++ b/plugins/CoreVisualizations/tests/Unit/JqplotDataGenerator/ChartTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link http://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreVisualizations\tests\Unit\JqplotDataGenerator;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Log\LoggerInterface;
+use Piwik\Plugins\CoreVisualizations\JqplotDataGenerator\Chart;
+use Piwik\Tests\Framework\Mock\FakeLogger;
+
+/**
+ * @group Chart
+ * @group CoreVisualizations
+ */
+class ChartTest extends TestCase
+{
+    /**
+     * @dataProvider dataConsistentAmounts
+     *
+     * @param array<int> $dataCounts
+     */
+    public function testItDoesNotLogIfDataAmountIsConsistent(array $dataCounts, int $stateCount): void
+    {
+        $logger = new FakeLogger();
+        $chart = $this->createChart($logger, $dataCounts, $stateCount);
+
+        $chart->render();
+
+        self::assertSame('', $logger->output);
+    }
+
+    /**
+     * @return iterable<string, array{array<int>, int}>
+     */
+    public function dataConsistentAmounts(): iterable
+    {
+        yield 'empty chart' => [
+            [],
+            0,
+        ];
+
+        yield 'single series, no states' => [
+            [3],
+            0,
+        ];
+
+        yield 'multiple series, no states' => [
+            [5, 5, 5],
+            0,
+        ];
+
+        yield 'single series, with state' => [
+            [3],
+            3,
+        ];
+
+        yield 'multiple series, with state' => [
+            [5, 5, 5],
+            5,
+        ];
+    }
+
+    /**
+     * @dataProvider dataInconsistentAmounts
+     *
+     * @param array<int> $dataCounts
+     */
+    public function testItLogsIfDataAmountIsInconsistent(
+        array $dataCounts,
+        int $stateCount,
+        string $expectedMessage
+    ): void {
+        $logger = new FakeLogger();
+        $chart = $this->createChart($logger, $dataCounts, $stateCount);
+
+        $chart->render();
+
+        self::assertStringContainsString($expectedMessage, $logger->output);
+    }
+
+    /**
+     * @return iterable<string, array{array<int>, int, string}>
+     */
+    public function dataInconsistentAmounts(): iterable
+    {
+        $messageDataInconsistency = 'Chart rendered with different data point count per series';
+        $messageStateInconsistency = 'Count of data states does not match count of data points';
+
+        yield 'inconsistent series, no state' => [
+            [3, 5],
+            0,
+            $messageDataInconsistency,
+        ];
+
+        yield 'inconsistent series, state not checked' => [
+            [3, 5],
+            7,
+            $messageDataInconsistency,
+        ];
+
+        yield 'no data, only state' => [
+            [],
+            1,
+            $messageStateInconsistency,
+        ];
+
+        yield 'consistent series, inconsistent state' => [
+            [3, 3, 3],
+            5,
+            $messageStateInconsistency,
+        ];
+    }
+
+    /**
+     * @param array<int> $dataCounts
+     */
+    private function createChart(LoggerInterface $logger, array $dataCounts, int $stateCount): Chart
+    {
+        $chart = new Chart($logger);
+
+        foreach ($dataCounts as $index => $dataCount) {
+            $label = 'yAxis' . $index;
+            $data = array_fill(0, $dataCount, $index);
+            $values = [$label => $data];
+
+            $chart->setAxisYValues($values);
+        }
+
+        if (0 !== $stateCount) {
+            $chart->setDataStates(array_fill(0, $stateCount, 'test'));
+        }
+
+        return $chart;
+    }
+}

--- a/tests/UI/expected-screenshots/Comparison_multi_row_evolution.png
+++ b/tests/UI/expected-screenshots/Comparison_multi_row_evolution.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b6624e5065bf2451a2a517d8447df95e7877936a8a8517fb97826f61f0dd80c
-size 44750
+oid sha256:1f86b3afb389d1a3ffcfea27d40156dabc390d0423973aaec3b5c27817658973
+size 45169

--- a/tests/UI/expected-screenshots/IncompletePeriodVisualisation_visitors_overview.png
+++ b/tests/UI/expected-screenshots/IncompletePeriodVisualisation_visitors_overview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88c63f13fb7fa4b4bba6456ff7f67fb03ea67da1ae5929d9c7e99a69df997479
-size 62405
+oid sha256:cd43a8c278aa88c64bb6400028e195f1b8e83c9921b979ed62e3fef528b4f94f
+size 62443

--- a/tests/UI/expected-screenshots/InvalidatedPeriodVisualisation_comparison.png
+++ b/tests/UI/expected-screenshots/InvalidatedPeriodVisualisation_comparison.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8698c6d2bb45b331457269b287ddf9dffd3f21d1bfe1aee6f1df56ebd92f377
+size 48803

--- a/tests/UI/expected-screenshots/InvalidatedPeriodVisualisation_graph.png
+++ b/tests/UI/expected-screenshots/InvalidatedPeriodVisualisation_graph.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c90a1cd28d0765bbbb79806ebe06a3b7ed3c79d002145ce663906622e9ce5d65
+size 57343

--- a/tests/UI/specs/EvolutionGraphIncompleteData_spec.js
+++ b/tests/UI/specs/EvolutionGraphIncompleteData_spec.js
@@ -1,0 +1,52 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * evolution graph screenshot tests.
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+describe('EvolutionGraphIncompleteData', function () {
+    const url = '?module=Widgetize&action=iframe&idSite=1&period=day&date=2012-01-31&evolution_day_last_n=30'
+              + '&moduleToWidgetize=UserCountry&actionToWidgetize=getCountry&viewDataTable=graphEvolution'
+              + '&isFooterExpandedInDashboard=1';
+
+    before(() => {
+        testEnvironment.forceArchiveStates = {
+          '2012-01-08': 'incomplete',
+          '2012-01-09': 'incomplete',
+          '2012-01-10': 'incomplete',
+          // center point used for tooltip check
+          '2012-01-16': 'incomplete',
+        };
+
+        testEnvironment.save();
+    });
+
+    after(() => {
+        delete testEnvironment.forceArchiveStates;
+        testEnvironment.save();
+    });
+
+    it('should show incomplete data points', async function () {
+        await page.goto(url);
+        await page.waitForNetworkIdle();
+
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('graph');
+    });
+
+    it('tooltip for incomplete period should say "incomplete period"', async function () {
+        const graph = await page.$('.piwik-graph');
+        const boundingBox = await graph.boundingBox();
+
+        await page.mouse.move(
+            boundingBox.x + boundingBox.width / 2,
+            boundingBox.y + boundingBox.height / 2
+        );
+
+        const tooltipContent = await page.evaluate(() => $('.ui-tooltip').text().trim());
+
+        expect(tooltipContent).to.contain('Incomplete Period');
+    });
+});

--- a/tests/UI/specs/IncompletePeriodVisualisation_spec.js
+++ b/tests/UI/specs/IncompletePeriodVisualisation_spec.js
@@ -7,17 +7,31 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-describe("IncompletePeriodVisualisation", function () {
-    this.fixture = "Piwik\\Tests\\Fixtures\\SomeVisitsLastYearAndThisYear";
+describe('IncompletePeriodVisualisation', function () {
+    this.fixture = 'Piwik\\Tests\\Fixtures\\SomeVisitsLastYearAndThisYear';
 
     const generalParams = 'idSite=1&period=year&date=today';
     const pageUrl = '?module=CoreHome&action=index&' + generalParams;
 
     it('should load visitors > overview page and show incomplete period', async function () {
-        await page.goto(pageUrl + generalParams + "&segment=&category=General_Visitors&subcategory=General_Overview#?idSite=1&period=year&date=today&segment=&category=General_Visitors&subcategory=General_Overview");
+        await page.goto(pageUrl + generalParams + '&segment=&category=General_Visitors&subcategory=General_Overview#?idSite=1&period=year&date=today&segment=&category=General_Visitors&subcategory=General_Overview');
         await page.waitForNetworkIdle();
         const pageWrap = await page.$('.pageWrap');
+
         expect(await pageWrap.screenshot()).to.matchImage('visitors_overview');
     });
 
+    it('tooltip for incomplete period should say "incomplete period"', async function () {
+        const graph = await page.$('.piwik-graph');
+        const boundingBox = await graph.boundingBox();
+
+        await page.mouse.move(
+          boundingBox.x + boundingBox.width - 50,
+          boundingBox.y + boundingBox.height - 50
+        );
+
+        const tooltipContent = await page.evaluate(() => $('.ui-tooltip').text().trim());
+
+        expect(tooltipContent).to.contain('Incomplete Period');
+    });
 });

--- a/tests/UI/specs/InvalidatedPeriodVisualisation_spec.js
+++ b/tests/UI/specs/InvalidatedPeriodVisualisation_spec.js
@@ -1,24 +1,24 @@
 /*!
  * Matomo - free/libre analytics platform
  *
- * evolution graph screenshot tests.
+ * Invalidated Period Visualisation Test
  *
  * @link https://matomo.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-describe('EvolutionGraphIncompleteData', function () {
+describe('InvalidatedPeriodVisualisation', function () {
     const url = '?module=Widgetize&action=iframe&idSite=1&period=day&date=2012-01-31&evolution_day_last_n=30'
               + '&moduleToWidgetize=UserCountry&actionToWidgetize=getCountry&viewDataTable=graphEvolution'
               + '&isFooterExpandedInDashboard=1';
 
     before(() => {
         testEnvironment.forceArchiveStates = {
-          '2012-01-08': 'incomplete',
-          '2012-01-09': 'incomplete',
-          '2012-01-10': 'incomplete',
+          '2012-01-08': 'invalidated',
+          '2012-01-09': 'invalidated',
+          '2012-01-10': 'invalidated',
           // center point used for tooltip check
-          '2012-01-16': 'incomplete',
+          '2012-01-16': 'invalidated',
         };
 
         testEnvironment.save();
@@ -29,14 +29,14 @@ describe('EvolutionGraphIncompleteData', function () {
         testEnvironment.save();
     });
 
-    it('should show incomplete data points', async function () {
+    it('should show invalidated data points', async function () {
         await page.goto(url);
         await page.waitForNetworkIdle();
 
         expect(await page.screenshot({ fullPage: true })).to.matchImage('graph');
     });
 
-    it('tooltip for incomplete period should say "incomplete period"', async function () {
+    it('tooltip for invalidated period should say "invalidated period"', async function () {
         const graph = await page.$('.piwik-graph');
         const boundingBox = await graph.boundingBox();
 
@@ -47,6 +47,6 @@ describe('EvolutionGraphIncompleteData', function () {
 
         const tooltipContent = await page.evaluate(() => $('.ui-tooltip').text().trim());
 
-        expect(tooltipContent).to.contain('Incomplete Period');
+        expect(tooltipContent).to.contain('Invalidated Period');
     });
 });

--- a/tests/UI/specs/InvalidatedPeriodVisualisation_spec.js
+++ b/tests/UI/specs/InvalidatedPeriodVisualisation_spec.js
@@ -8,7 +8,7 @@
  */
 
 describe('InvalidatedPeriodVisualisation', function () {
-    const url = '?module=Widgetize&action=iframe&idSite=1&period=day&date=2012-01-31&evolution_day_last_n=30'
+    const url = '?module=Widgetize&action=iframe&idSite=1&evolution_day_last_n=30'
               + '&moduleToWidgetize=UserCountry&actionToWidgetize=getCountry&viewDataTable=graphEvolution'
               + '&isFooterExpandedInDashboard=1';
 
@@ -30,7 +30,7 @@ describe('InvalidatedPeriodVisualisation', function () {
     });
 
     it('should show invalidated data points', async function () {
-        await page.goto(url);
+        await page.goto(url + '&period=day&date=2012-01-31');
         await page.waitForNetworkIdle();
 
         expect(await page.screenshot({ fullPage: true })).to.matchImage('graph');
@@ -48,5 +48,12 @@ describe('InvalidatedPeriodVisualisation', function () {
         const tooltipContent = await page.evaluate(() => $('.ui-tooltip').text().trim());
 
         expect(tooltipContent).to.contain('Invalidated Period');
+    });
+
+    it('should show invalidated data points', async function () {
+        await page.goto(url + '&period=range&date=2012-01-01,2012-01-31&comparePeriods[]=range&compareDates[]=2011-12-01,2011-12-31');
+        await page.waitForNetworkIdle();
+
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('comparison');
     });
 });

--- a/tests/UI/specs/InvalidatedPeriodVisualisation_spec.js
+++ b/tests/UI/specs/InvalidatedPeriodVisualisation_spec.js
@@ -13,7 +13,7 @@ describe('InvalidatedPeriodVisualisation', function () {
               + '&isFooterExpandedInDashboard=1';
 
     before(() => {
-        testEnvironment.forceArchiveStates = {
+        testEnvironment.forceDataStates = {
           '2012-01-08': 'invalidated',
           '2012-01-09': 'invalidated',
           '2012-01-10': 'invalidated',
@@ -25,7 +25,7 @@ describe('InvalidatedPeriodVisualisation', function () {
     });
 
     after(() => {
-        delete testEnvironment.forceArchiveStates;
+        delete testEnvironment.forceDataStates;
         testEnvironment.save();
     });
 


### PR DESCRIPTION
### Current Evolution Graph Rendering

Evolution graphs display the line leading up the to last point as dashed if the last date/period contains today. For example when viewing the visitor overview for the current year (2024):

![](https://github.com/matomo-org/matomo/assets/635801/a9738561-ffec-4569-ae00-d541e5aeddae)

The visual change is only done for the very last point of the graph and can lead to unexpected results. Viewing the comparison of "current week" and "previous week" (current date is around 2024-01-10) displays multiple future dates but only one is incomplete:

![](https://github.com/matomo-org/matomo/assets/635801/ea8af253-cfb2-4ed7-997b-88472eb19797)

### Suggested Evolution Graph Rendering

The PR changes the visual representation of incomplete data points to be a "circle" instead of a "dot" for better visibility, the dashed line leading up to an incomplete data point is also displayed. Additional support is added to represent any point in the graph as incomplete, including an improved detection of future dates that may get displayed (current date is around 2024-01-10):

![](https://github.com/matomo-org/matomo/assets/635801/e77ae92c-4087-4634-bce8-7d0cb735a5e9)

To prepare for an upcoming improvement the state "invalidated" has already been included. If a report contains to-be-reprocessed (invalidated) information it will display this information in the graph for the specific invalidation dates, currently only available in tests:

![](https://github.com/matomo-org/matomo/assets/635801/19ab3905-1d4c-4f1a-b4a6-04e6241c9733)

Refs DEV-17556
Prepares DEV-17568

Moving the incomplete period detection to the backend will be a partial fix for #21560. The period selector will still be broken, but all graphs should be displayed as expected.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
