### PR TITLE
Hide all sites item in site selector for custom dimension management

### DIFF
--- a/plugins/CustomDimensions/templates/manage.twig
+++ b/plugins/CustomDimensions/templates/manage.twig
@@ -2,7 +2,11 @@
 
 {% block topcontrols %}
     <div class="top_bar_sites_selector piwikTopControl">
-        <div vue-entry="CoreHome.SiteSelector" show-selected-site="true" class="sites_autocomplete"></div>
+        <div vue-entry="CoreHome.SiteSelector"
+             show-selected-site="true"
+             show-all-sites-item="false"
+             class="sites_autocomplete"
+        ></div>
     </div>
 {% endblock %}
 


### PR DESCRIPTION
### Description:

There is no sense in showing the all sites item in the site selector on custom dimensions managemant, as choosing it, would bring the user the the all sites dashboard.

refs https://github.com/matomo-org/tag-manager/issues/736

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
