### PR TITLE
Improve escaping of values in CSV exports

### DIFF
--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -242,7 +242,12 @@ class Csv extends Renderer
         if (is_string($value)) {
             $value = str_replace(["\t"], ' ', $value);
 
-            if (strpos($value, '"') !== false || strpos($value, $this->separator) !== false) {
+            // surround value with double quotes if it contains a double quote or a commonly used separator
+            if (strpos($value, '"') !== false
+                || strpos($value, $this->separator) !== false
+                || strpos($value, ',') !== false
+                || strpos($value, ';') !== false
+            ) {
                 $value = '"' . str_replace('"', '""', $value) . '"';
             }
         }

--- a/tests/PHPUnit/Unit/DataTable/Renderer/CSVTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/CSVTest.php
@@ -194,10 +194,12 @@ class CSVTest extends \PHPUnit\Framework\TestCase
         $dataTable = $this->_getDataTableSimpleWithCommasInCells();
         $render = new Csv();
         $render->setTable($dataTable);
+        $render->setSeparator('#');
         $render->convertToUnicode = false;
 
-        $expected = '"col,1","col,2"
-"val""1","val"",2"';
+        $expected = '"col,1"#"col;2"
+"val""1"#"val"",2"
+val#"val#2"';
         $actual = $render->render();
         $this->assertEquals($expected, $actual);
     }
@@ -468,7 +470,8 @@ b,d,f,g';
     {
         $table = new DataTable();
         $table->addRowsFromSimpleArray(array(
-            array("col,1" => "val\"1", "col,2" => "val\",2")
+            array("col,1" => "val\"1", "col;2" => "val\",2"),
+            array("col,1" => "val", "col;2" => "val#2")
         ));
         return $table;
     }


### PR DESCRIPTION
### Description:

Our CSV files are using a normal comma as separator. Currently values will be only surrounded by double quotes if they contain such a comma or a double quote. This works perfectly fine when opening such a file and choosing the correct separator.
Some tools allow to use multiple separators. Typically those separator are either comma, semicolon or tab. 
Using all of them at once, would currently only break if a string contains a semicolon, as tabs are removed from values anyway and commas are correctly escaped.

For a better compatibility this PR adds the automatic escaping for all typical separators.

refs AS-288

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
