### PR TITLE
Tweak typescript module resolution when building a plugin located outside of Matomo

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -123,6 +123,9 @@ module.exports = {
             declaration: true,
             noEmit: false,
             outDir: `${__dirname}/@types/${pluginName}`,
+            paths: {
+              '*': [`${__dirname}/@types/*`, `${__dirname}/node_modules/*`, '*']
+            },
           };
           return options;
         });


### PR DESCRIPTION
### Description:

**Note: this PR does not require an immediate release since Matomo for WordPress can apply this as a patch.**

TypeScript resolves modules by looking for modules in the current or any parent directory of the file being compiled. When a plugin is located within Matomo, like `matomo/plugins/MyPlugin`, `vue` for example will resolve to `matomo/node_modules/vue`. When a plugin is located outside of Matomo, however:

```
- app/ (matomo install)
  - node_modules
    - vue
- plugins
  - WordPress
```

`vue` will simply fail to resolve.

TypeScript module resolution can be overridden via the `paths` compiler option (which we already do). This PR makes sure those paths are absolute paths, so the matomo node_modules directory does not need to be in a parent directory of the plugin being built.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
