### PR TITLE
Update UI test screenshots for OneClick after new major Matomo version was released

### DIFF
--- a/core/Version.php
+++ b/core/Version.php
@@ -21,7 +21,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    const VERSION = '5.0.0';
+    const VERSION = '5.0.1';
 
     const MAJOR_VERSION = 5;
 

--- a/tests/UI/expected-screenshots/IncompletePeriodVisualisation_visitors_overview.png
+++ b/tests/UI/expected-screenshots/IncompletePeriodVisualisation_visitors_overview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bdd2487ff586eb7c1fd4906f32e85eb9f0eae57e5462b9418a67e09b7ad23f37
-size 60370
+oid sha256:7cc23155cd4a6f58209118beab019c92db7447dcf0054b397f83a82239ae99bf
+size 61250

--- a/tests/UI/expected-screenshots/OneClickUpdate_latest_version_available.png
+++ b/tests/UI/expected-screenshots/OneClickUpdate_latest_version_available.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:21136ad8a3b203b40bdac6bf7e1b115c5a6f98e6d58b72096b7d32109942633e
-size 3028
+oid sha256:2a19a34cbf46ab7e1a545319976affbb0363481b4fa165574580e5ea7dc6a8d0
+size 3032

--- a/tests/UI/expected-screenshots/OneClickUpdate_update_fail.png
+++ b/tests/UI/expected-screenshots/OneClickUpdate_update_fail.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c9362ebb5b1f6205d2cab427458ec21fe7a54db7a8a4abebadc6ba19ce8a1f4
-size 97953
+oid sha256:a6b6ca61ee00e5ef12cdae15ee6dc292c07abe9976dd9a818fb79621ec42f0b8
+size 100078

--- a/tests/UI/expected-screenshots/OneClickUpdate_update_fail_permission.png
+++ b/tests/UI/expected-screenshots/OneClickUpdate_update_fail_permission.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e609844e83d6a5b993b5d3bc8066f46e0c13d741f1faafcac948ebf5a001fcfd
-size 62808
+oid sha256:f1fc96fae3340b1ff4d53d38e74dbd4b34cfd7b7da5ef9bc3d256e1bed9b1ccc
+size 62953

--- a/tests/UI/expected-screenshots/OneClickUpdate_update_screen.png
+++ b/tests/UI/expected-screenshots/OneClickUpdate_update_screen.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fede0bb8a8ed57ba5473cfe5aa8a16379248d81bd152357f1b9e0de38e537501
-size 43785
+oid sha256:7d22f3e652479f5f7eff533762d2662514e0ba09fdce769e9b309bb062fd43f6
+size 59281

--- a/tests/UI/expected-screenshots/OneClickUpdate_update_screen.png
+++ b/tests/UI/expected-screenshots/OneClickUpdate_update_screen.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81c89acc657bee29aa0017329a92fcd117bcc36195a521610cb9b67bf89207a7
-size 59106
+oid sha256:fede0bb8a8ed57ba5473cfe5aa8a16379248d81bd152357f1b9e0de38e537501
+size 43785


### PR DESCRIPTION
### Description:

As per the title. It's possible the tests could be tweaked to instead alter the content to not depend on an exact version. I looked into that very briefly but updating the screenshots seemed faster at this point, more so when another major Matomo version may be in distant future.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
