### PR TITLE
Increase timeout after clicking menu item in test to match animation time

### DIFF
--- a/tests/UI/specs/Menus_spec.js
+++ b/tests/UI/specs/Menus_spec.js
@@ -116,7 +116,7 @@ describe("Menus", function () {
         });
         await page.waitForTimeout(250);
         await (await page.jQuery('#mobile-left-menu>li>ul:contains(Goals)')).click();
-        await page.waitForTimeout(250);
+        await page.waitForTimeout(300);
 
         expect(await page.screenshot({ fullPage: true })).to.matchImage('mobile_left');
     });


### PR DESCRIPTION
### Description:

`should load the admin reporting menu correctly on mobile` is a flaky screenshot test that looks to be failing with a difference of a few pixels.

I think its down to the fact that the screenshot is taken before the collapsible animation has finished, here's an example failure:
<img width="332" alt="image" src="https://github.com/matomo-org/matomo/assets/1169490/fe584fbe-631a-47e6-ba63-94f65e3fddcc">

I found that the default `inDuration` and `outDuration` for `collapsible.js` is `300ms` and I couldn't find any overrides. 

Hopefully increasing the wait from 250 to 300 removes the flakiness, because it's not easy to reproduce this flakiness locally, I've ran it 4 times in the CI and it passed every time. In theory it should have failed every time, but there are probably other things at play that aren't worth investigating now.

[Run #1](https://github.com/matomo-org/matomo/actions/runs/7393304859/job/20113032742?pr=21753#step:3:471)
[Run #2](https://github.com/matomo-org/matomo/actions/runs/7393304859/job/20113489924?pr=21753#step:3:473)
[Run #3](https://github.com/matomo-org/matomo/actions/runs/7393304859/job/20113851481?pr=21753#step:3:470)
[Run #4](https://github.com/matomo-org/matomo/actions/runs/7393304859/job/20114609093?pr=21753#step:3:471)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
