### PR TITLE
Wait for end event before exiting UI Tests

### DIFF
--- a/tests/lib/screenshot-testing/support/app.js
+++ b/tests/lib/screenshot-testing/support/app.js
@@ -311,8 +311,6 @@ Application.prototype.doRunTests = function (mocha) {
                 }
             });
         }
-
-        process.exit(failures);
     });
 
     this.runner.on('suite', function() {
@@ -322,10 +320,11 @@ Application.prototype.doRunTests = function (mocha) {
     this.runner.on('test', function () {
         page._reset();
     });
-};
 
-Application.prototype.finish = function () {
-    process.exit(this.runner ? this.runner.failures : -1);
+    this.runner.on('end', function() {
+      // we are terminating but we are waiting for all other events to finish
+      setTimeout(() => process.exit(this.failures), 10000);
+    })
 };
 
 Application.prototype.appendMissingExpected = function (screenName) {


### PR DESCRIPTION
### Description:

replaces #21473

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
