### PR TITLE
Move UI tests browser config to config.dist.js

### DIFF
--- a/tests/UI/config.dist.js
+++ b/tests/UI/config.dist.js
@@ -8,7 +8,7 @@
  */
 
 /**
- * The root Piwik URL to test against.
+ * The root Matomo URL to test against.
  */
 exports.piwikUrl = "http://localhost/";
 
@@ -67,3 +67,10 @@ exports.processedScreenshotsDir = "./processed-ui-screenshots";
  * The directory that stores screenshot diffs. Relative to the UI repo's root directory.
  */
 exports.screenshotDiffDir = "./screenshot-diffs";
+
+/**
+ * The config object passed to the headless browser used by Puppeteer
+ */
+exports.browserConfig = {
+    args: ['--no-sandbox', '--ignore-certificate-errors']
+};

--- a/tests/lib/screenshot-testing/run-tests.js
+++ b/tests/lib/screenshot-testing/run-tests.js
@@ -20,17 +20,17 @@ require('./support/fs-extras');
 main();
 
 async function main() {
-    const browser = await puppeteer.launch({ args: ['--no-sandbox', '--ignore-certificate-errors'] });
-    const webpage = await browser.newPage();
-    await webpage._client.send('Animation.setPlaybackRate', { playbackRate: 50 }); // make animations run 50 times faster, so we don't have to wait as much
-
-    // required modules
+    // require config and local config overrides
     let config = require("./../../UI/config.dist");
     try {
         config = Object.assign({}, config, require("./../../UI/config"));
     } catch (e) {
         // ignore
     }
+
+    const browser = await puppeteer.launch(config.browserConfig);
+    const webpage = await browser.newPage();
+    await webpage._client.send('Animation.setPlaybackRate', { playbackRate: 50 }); // make animations run 50 times faster, so we don't have to wait as much
 
     // assume the URI points to a folder and make sure Piwik won't cut off the last path segment
     if (config.phpServer.REQUEST_URI.slice(-1) !== '/') {


### PR DESCRIPTION
### Description:

This allows the config to be overridden locally without changing git tracked files and having to stash/un-stash versioned file changes.

For example one can provide an override config with a custom executable when Chromium is installed locally and available under a different path.

After running the `tests:run-ui` command for the first time, change `tests/UI/config.js` from
```
/**
 * File generated by the tests:run-ui command
 */
exports.piwikUrl = "http://your-matomo-domain.com/";
exports.phpServer = {
    HTTP_HOST: 'localhost',
    REQUEST_URI: '/',
    REMOTE_ADDR: '127.0.0.1'
};
```
to
```
exports.piwikUrl = "http://your-matomo-domain.com/";
exports.phpServer = {
    HTTP_HOST: 'localhost',
    REQUEST_URI: '/',
    REMOTE_ADDR: '127.0.0.1'
};
exports.browserConfig = {
    args: ['--no-sandbox', '--ignore-certificate-errors'],
    executablePath: '/opt/homebrew/bin/chromium'
};
```
by removing the comment (so that the code doesn't remove the manual changes) and adding the `exports.browserConfig` stanza. Remember to keep the `args` property unless you want to adjust that at the same time.

This config file is normally auto generated by the UI tests runner and is git ignored, so if you change some other relevant config like your hostname, either delete the file and have it regenerated, then add your custom config, or update it manually.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
