### PR TITLE
Make page performance overlay work with flattened reports

### DIFF
--- a/plugins/PagePerformance/Controller.php
+++ b/plugins/PagePerformance/Controller.php
@@ -60,6 +60,7 @@ class Controller extends PluginController
             'segment'   => $request->getStringParameter('segment', ''),
             'date'      => 'range' === $period ? $date : EvolutionViz::getDateRangeAndLastN($period, $date)[0],
             'format'    => 'original',
+            'flat'      => $request->getIntegerParameter('flat', 0),
             'serialize' => '0',
         ];
 

--- a/plugins/PagePerformance/javascripts/PagePerformance.js
+++ b/plugins/PagePerformance/javascripts/PagePerformance.js
@@ -96,7 +96,7 @@ var PagePerformance = function() {
         Piwik_Popover.setTitle(title);
     }
 
-    function show(apiMethod, label) {
+    function show(apiMethod, label, isReportFlat) {
 
         // open the popover
         var box = Piwik_Popover.showLoading('Page performance report');
@@ -125,6 +125,7 @@ var PagePerformance = function() {
             action: 'indexPagePerformance',
             apiMethod: apiMethod,
             label: encodeURIComponent(label),
+            flat: isReportFlat,
         };
 
         var ajaxRequest = new ajaxHelper();

--- a/plugins/PagePerformance/javascripts/rowaction.js
+++ b/plugins/PagePerformance/javascripts/rowaction.js
@@ -33,11 +33,11 @@
 
     DataTable_RowActions_PagePerformance.prototype.performAction = function (label, tr, e, originalRow) {
         var apiMethod = this.dataTable.param.module + '.' + this.dataTable.param.action;
-        this.openPopover(apiMethod, label);
+        this.openPopover(apiMethod, label, this.dataTable.param.flat || 0);
     };
 
-    DataTable_RowActions_PagePerformance.prototype.openPopover = function (apiMethod, label) {
-        var urlParam = apiMethod + ':' + label;
+    DataTable_RowActions_PagePerformance.prototype.openPopover = function (apiMethod, label, isReportFlat) {
+        var urlParam = apiMethod + ':' + label + ':' + isReportFlat;
         DataTable_RowAction.prototype.openPopover.apply(this, [urlParam]);
     };
 
@@ -45,8 +45,9 @@
         var urlParamParts = urlParam.split(':');
         var apiMethod = urlParamParts.shift();
         var label = decodeURIComponent(urlParamParts.shift());
+        var isReportFlat = urlParamParts.shift();
 
-        PagePerformance.show(apiMethod, label);
+        PagePerformance.show(apiMethod, label, isReportFlat);
     };
 
     DataTable_RowActions_Registry.register({

--- a/plugins/PagePerformance/javascripts/rowaction.js
+++ b/plugins/PagePerformance/javascripts/rowaction.js
@@ -33,7 +33,8 @@
 
     DataTable_RowActions_PagePerformance.prototype.performAction = function (label, tr, e, originalRow) {
         var apiMethod = this.dataTable.param.module + '.' + this.dataTable.param.action;
-        this.openPopover(apiMethod, label, this.dataTable.param.flat || 0);
+        var isReportFlat = this.dataTable.param.flat || 0;
+        this.openPopover(apiMethod, label, isReportFlat);
     };
 
     DataTable_RowActions_PagePerformance.prototype.openPopover = function (apiMethod, label, isReportFlat) {

--- a/plugins/PagePerformance/tests/UI/PagePerformance_spec.js
+++ b/plugins/PagePerformance/tests/UI/PagePerformance_spec.js
@@ -79,6 +79,34 @@ describe("PagePerformance", function () {
         expect(await pageWrap.screenshot()).to.matchImage('pageurl_overlay');
     });
 
+    it("should work with flattened report", async function () {
+        await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Actions&subcategory=General_Pages");
+
+        // make report flattened
+        await page.click('.dropdownConfigureIcon');
+        await page.click('.dataTableFlatten');
+        await page.waitForNetworkIdle();
+
+        // click page performance icon
+        const row = await page.waitForSelector('.dataTable tbody tr:first-child');
+        await row.hover();
+
+        const icon = await page.waitForSelector('.dataTable tbody tr:first-child a.actionPagePerformance');
+        await icon.click();
+
+        await page.waitForNetworkIdle();
+
+        const pageWrap = await page.waitForSelector('.ui-dialog');
+
+        await page.hover('.piwik-graph');
+        await page.waitForSelector('.ui-tooltip', { visible: true });
+
+        await ensureTooltipIsVisibleInScreenshot();
+        await page.waitForTimeout(100);
+
+        expect(await pageWrap.screenshot()).to.matchImage('pageurl_overlay_flattened');
+    });
+
     it("should show new table with performance metrics visualization in selection", async function () {
         await page.goto("?module=Widgetize&action=iframe&disableLink=0&widget=1&moduleToWidgetize=Actions&actionToWidgetize=getPageUrls&" + generalParams);
 

--- a/plugins/PagePerformance/tests/UI/expected-screenshots/PagePerformance_pageurl_overlay_flattened.png
+++ b/plugins/PagePerformance/tests/UI/expected-screenshots/PagePerformance_pageurl_overlay_flattened.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2b5558e455837b6ad455638ca72a3d5887478fbecad12ac52cd85a037a719a9
+size 161503


### PR DESCRIPTION
### Description:

Pages reports provide a row action that will open the page performance report for a specific row. When viewing any action report in normal view that works like a charm. But when the report is changed to be flattened the overlay doesn't show any data anymore.

The reason for this is, that the API request performed for the overlay didn't get the `flat` parameter passed through. This causes the provided label (action url) not to be found in the report.

Passing through the `flat`  parameter fixes this problem and the data is displayed correctly again.

fixes #17807 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
