### PR TITLE
Introduce concurrency lock for scheduled tasks

### DIFF
--- a/core/Concurrency/Lock.php
+++ b/core/Concurrency/Lock.php
@@ -149,7 +149,7 @@ class Lock
     }
 
     /**
-     * Return if the acquired lock is being locked
+     * Return if the acquired lock is currently locked
      *
      * @return bool
      */

--- a/core/Concurrency/Lock.php
+++ b/core/Concurrency/Lock.php
@@ -99,7 +99,7 @@ class Lock
             // Lock key might be too long for DB column, so we hash it but leave the start of the original as well
             // to make it more readable
             $md5Len = 32;
-            $this->lockKey = mb_substr($id, 0, self::MAX_KEY_LEN - $md5Len - 1) . md5($id);
+            $this->lockKey = mb_substr($this->lockKey, 0, self::MAX_KEY_LEN - $md5Len - 1) . md5($id);
         }
 
         $lockValue = substr(Common::generateUniqId(), 0, 12);

--- a/core/Concurrency/Lock.php
+++ b/core/Concurrency/Lock.php
@@ -133,7 +133,7 @@ class Lock
 
         if (mb_strlen($this->lockKey) > self::MAX_KEY_LEN) {
             // Lock key might be too long for DB column, so we hash it but leave the start of the original as well
-            // to make it more readable
+            // to make it more readable and to ensure the namespaceis still containe
             $md5Len = 32;
             $this->lockKey = mb_substr($this->lockKey, 0, self::MAX_KEY_LEN - $md5Len - 1) . md5($id);
         }

--- a/core/Concurrency/Lock.php
+++ b/core/Concurrency/Lock.php
@@ -39,7 +39,7 @@ class Lock
     {
         if (mb_strlen($namespace) > self::MAX_KEY_LEN - 32) {
             // A longer namespace could be cut off for too long ids, so we don't support it
-            throw new \Exception('Lock namespace must be shorter than ' . (self::MAX_KEY_LEN - 32) . ' chars');
+            throw new \InvalidArgumentException('Lock namespace must be shorter than ' . (self::MAX_KEY_LEN - 32) . ' chars');
         }
 
         $this->backend = $backend;

--- a/core/Plugin/Tasks.php
+++ b/core/Plugin/Tasks.php
@@ -63,9 +63,9 @@ class Tasks
      * @return Schedule
      * @api
      */
-    protected function hourly($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY)
+    protected function hourly($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY, int $ttlInSeconds = null)
     {
-        return $this->custom($this, $methodName, $methodParameter, 'hourly', $priority);
+        return $this->custom($this, $methodName, $methodParameter, 'hourly', $priority, $ttlInSeconds);
     }
 
     /**
@@ -74,9 +74,9 @@ class Tasks
      * See {@link hourly()}
      * @api
      */
-    protected function daily($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY)
+    protected function daily($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY, int $ttlInSeconds = null)
     {
-        return $this->custom($this, $methodName, $methodParameter, 'daily', $priority);
+        return $this->custom($this, $methodName, $methodParameter, 'daily', $priority, $ttlInSeconds);
     }
 
     /**
@@ -85,9 +85,9 @@ class Tasks
      * See {@link hourly()}
      * @api
      */
-    protected function weekly($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY)
+    protected function weekly($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY, int $ttlInSeconds = null)
     {
-        return $this->custom($this, $methodName, $methodParameter, 'weekly', $priority);
+        return $this->custom($this, $methodName, $methodParameter, 'weekly', $priority, $ttlInSeconds);
     }
 
     /**
@@ -96,9 +96,9 @@ class Tasks
      * See {@link hourly()}
      * @api
      */
-    protected function monthly($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY)
+    protected function monthly($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY, int $ttlInSeconds = null)
     {
-        return $this->custom($this, $methodName, $methodParameter, 'monthly', $priority);
+        return $this->custom($this, $methodName, $methodParameter, 'monthly', $priority, $ttlInSeconds);
     }
 
     /**
@@ -119,7 +119,7 @@ class Tasks
      *
      * @api
      */
-    protected function custom($objectOrClassName, $methodName, $methodParameter, $time, $priority = self::NORMAL_PRIORITY)
+    protected function custom($objectOrClassName, $methodName, $methodParameter, $time, $priority = self::NORMAL_PRIORITY, int $ttlInSeconds = null)
     {
         $this->checkIsValidTask($objectOrClassName, $methodName);
 
@@ -131,7 +131,7 @@ class Tasks
             throw new \Exception('$time should be an instance of Schedule');
         }
 
-        $this->scheduleTask(new Task($objectOrClassName, $methodName, $methodParameter, $time, $priority));
+        $this->scheduleTask(new Task($objectOrClassName, $methodName, $methodParameter, $time, $priority, $ttlInSeconds));
 
         return $time;
     }

--- a/core/Scheduler/ScheduledTaskLock.php
+++ b/core/Scheduler/ScheduledTaskLock.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Scheduler;
+
+use Piwik\Concurrency\Lock;
+use Piwik\Concurrency\LockBackend;
+
+class ScheduledTaskLock extends Lock
+{
+    public function __construct(LockBackend $backend)
+    {
+        parent::__construct($backend, 'ScheduledTask', 3600);
+    }
+}

--- a/core/Scheduler/Scheduler.php
+++ b/core/Scheduler/Scheduler.php
@@ -82,15 +82,12 @@ class Scheduler
      */
     private $lock = null;
 
-    public function __construct(TaskLoader $loader, LoggerInterface $logger)
+    public function __construct(TaskLoader $loader, LoggerInterface $logger, ScheduledTaskLock $lock)
     {
         $this->timetable = new Timetable();
         $this->loader = $loader;
         $this->logger = $logger;
-        $this->lock = StaticContainer::getContainer()->make(
-            Lock::class,
-            ['namespace' => 'ScheduledTask', 'detaultTtl' => 3600]
-        );
+        $this->lock = $lock;
     }
 
     /**

--- a/core/Scheduler/Scheduler.php
+++ b/core/Scheduler/Scheduler.php
@@ -9,8 +9,6 @@
 namespace Piwik\Scheduler;
 
 use Piwik\Concurrency\Lock;
-use Piwik\Concurrency\LockBackend;
-use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 use Piwik\Timer;
 use Piwik\Log\LoggerInterface;
@@ -78,9 +76,9 @@ class Scheduler
     private $logger;
 
     /**
-     * @var Lock|null
+     * @var Lock
      */
-    private $lock = null;
+    private $lock;
 
     public function __construct(TaskLoader $loader, LoggerInterface $logger, ScheduledTaskLock $lock)
     {
@@ -310,7 +308,6 @@ class Scheduler
     {
         if (-1 === $ttlInSeconds) {
             // lock disabled, so don't try to acquire one
-            $this->lock = null;
             return true;
         }
 

--- a/core/Scheduler/Task.php
+++ b/core/Scheduler/Task.php
@@ -64,7 +64,7 @@ class Task
 
     /**
      * This time is used as TTL when acquiring a lock for running the task.
-     * The same task can't won't be executed again, while a lock for this task is acquired.
+     * The same task won't be executed again, while a lock for this task is acquired.
      * Setting the TTL to -1 will disable acquiring a lock and the same task can run in parallel.
      * If a process running a certain task is killed, without the lock being released, the task won't run again
      * before the ttl is expired.
@@ -201,7 +201,7 @@ class Task
      *
      * @return int
      */
-    public function getTTL()
+    public function getTTL(): int
     {
         return $this->ttlInSeconds;
     }

--- a/core/Scheduler/Task.php
+++ b/core/Scheduler/Task.php
@@ -99,7 +99,7 @@ class Task
 
         // only allow TTLs between 1 second and 1 week
         if ($ttlInSeconds !== -1 && ($ttlInSeconds < 1 || $ttlInSeconds > 604800)) {
-            throw new Exception("Invalid ttl for ScheduledTask '$this->className.$methodName': $ttlInSeconds. The TTL must be -1 or between 1 and 604800.");
+            throw new Exception("Invalid TTL for ScheduledTask '$this->className.$methodName': $ttlInSeconds. The TTL must be -1 or between 1 and 604800 (1 second to 1 week).");
         }
 
         $this->objectInstance = $objectInstance;

--- a/core/Settings/Storage/Backend/BaseSettingsTable.php
+++ b/core/Settings/Storage/Backend/BaseSettingsTable.php
@@ -26,7 +26,7 @@ abstract class BaseSettingsTable implements BackendInterface
     {
         $this->lock = StaticContainer::getContainer()->make(
             Lock::class,
-            array ('lockKeyStart' => 'PluginSettingsTable')
+            array ('namespace' => 'PluginSettingsTable')
         );
     }
 

--- a/tests/PHPUnit/Framework/Mock/Concurrency/LockBackend/InMemoryLockBackend.php
+++ b/tests/PHPUnit/Framework/Mock/Concurrency/LockBackend/InMemoryLockBackend.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Tests\Framework\Mock\Concurrency\LockBackend;
+
+use Piwik\Concurrency\LockBackend;
+
+/**
+ * Lock Backend that stores locks in memory only
+ */
+class InMemoryLockBackend implements LockBackend
+{
+    public $locks = [];
+
+    public function getKeysMatchingPattern($pattern)
+    {
+        $keys = [];
+
+        // convert pattern to regex pattern
+        $pattern = '/^' . str_replace(['*'], ['.*'], $pattern) . '$/i';
+
+        foreach ($this->locks as $key => $lock) {
+            if (preg_match($pattern, $key) && $lock['expiry'] > time()) {
+                $keys[] = $key;
+            }
+        }
+
+        return $keys;
+    }
+
+    public function setIfNotExists($key, $value, $ttlInSeconds)
+    {
+        if (empty($ttlInSeconds)) {
+            $ttlInSeconds = 999999999;
+        }
+
+        if ($this->get($key)) {
+            return false; // a value is set, won't be possible to insert
+        }
+
+        $this->locks[$key] = [
+            'value' => $value,
+            'expiry' => time() + $ttlInSeconds,
+        ];
+
+        // we make sure we got the lock
+        return $this->get($key) === $value;
+    }
+
+    public function get($key)
+    {
+        return $this->locks[$key]['value'] ?? '';
+    }
+
+    public function deleteIfKeyHasValue($key, $value)
+    {
+        if (empty($this->locks[$key]['value'])) {
+            return false;
+        }
+
+        if ($this->locks[$key]['value'] === $value) {
+            unset($this->locks[$key]);
+            return true;
+        }
+
+        return false;
+    }
+
+    public function expireIfKeyHasValue($key, $value, $ttlInSeconds)
+    {
+        if (empty($value) || $this->locks[$key]['value'] !== $value) {
+            return false;
+        }
+
+        $this->locks[$key]['expiry'] = time() + $ttlInSeconds;
+
+        return true;
+    }
+
+    public function keyExists($key)
+    {
+        return !empty($this->locks[$key]);
+    }
+}

--- a/tests/PHPUnit/Integration/Concurrency/LockTest.php
+++ b/tests/PHPUnit/Integration/Concurrency/LockTest.php
@@ -39,7 +39,14 @@ class LockTest extends IntegrationTestCase
         parent::tearDown();
     }
 
-    public function test_acquireLock_ShouldLockInCaseItIsNotLockedYet()
+    public function testTooLongNamespaceIsNotSupported()
+    {
+        $this->expectException(\Exception::class);
+
+        new Lock(new MySqlLockBackend(), 'aLongStringWithOver38CharactersIsNotSupported');
+    }
+
+    public function testAcquireLockShouldLockInCaseItIsNotLockedYet()
     {
         $this->assertTrue($this->lock->acquireLock(0));
         $this->assertFalse($this->lock->acquireLock(0));
@@ -50,7 +57,7 @@ class LockTest extends IntegrationTestCase
         $this->assertFalse($this->lock->acquireLock(0));
     }
 
-    public function test_acquireLock_ShouldBeAbleToLockMany()
+    public function testAcquireLockShouldBeAbleToLockMany()
     {
         $this->assertTrue($this->lock->acquireLock(0));
         $this->assertFalse($this->lock->acquireLock(0));
@@ -59,7 +66,7 @@ class LockTest extends IntegrationTestCase
         $this->assertFalse($this->lock->acquireLock(1));
     }
 
-    public function test_isLocked_ShouldDetermineWhetherALockIsLocked()
+    public function testIsLockedShouldDetermineWhetherALockIsLocked()
     {
         $this->assertFalse($this->lock->isLocked());
         $this->lock->acquireLock(0);
@@ -71,7 +78,7 @@ class LockTest extends IntegrationTestCase
         $this->assertFalse($this->lock->isLocked());
     }
 
-    public function test_unlock_OnlyUnlocksTheLastOne()
+    public function testUnlockOnlyUnlocksTheLastOne()
     {
         $this->assertTrue($this->lock->acquireLock(0));
         $this->assertTrue($this->lock->acquireLock(1));
@@ -84,24 +91,24 @@ class LockTest extends IntegrationTestCase
         $this->assertTrue($this->lock->acquireLock(2));
     }
 
-    public function test_extendLock_ShouldReturnTrueOnSuccess()
+    public function testExtendLockShouldReturnTrueOnSuccess()
     {
         $this->lock->acquireLock(0);
         $this->assertTrue($this->lock->extendLock(2));
     }
 
-    public function test_extendLock_ShouldReturnFalseIfNoTimeoutGiven()
+    public function testExtendLockShouldReturnFalseIfNoTimeoutGiven()
     {
         $this->lock->acquireLock(0);
         $this->assertFalse($this->lock->extendLock(0));
     }
 
-    public function test_extendLock_ShouldReturnFalseIfNotLocked()
+    public function testExtendLockShouldReturnFalseIfNotLocked()
     {
         $this->assertFalse($this->lock->extendLock(2));
     }
 
-    public function test_getNumberOfAcquiredLocks_shouldReturnNumberOfLocks()
+    public function testGetNumberOfAcquiredLocksShouldReturnNumberOfLocks()
     {
         $this->assertNumberOfLocksEquals(0);
 
@@ -116,7 +123,7 @@ class LockTest extends IntegrationTestCase
         $this->assertNumberOfLocksEquals(2);
     }
 
-    public function test_getAllAcquiredLockKeys_shouldReturnUsedKeysThatAreLocked()
+    public function testGetAllAcquiredLockKeysShouldReturnUsedKeysThatAreLocked()
     {
         $this->assertSame([], $this->lock->getAllAcquiredLockKeys());
 
@@ -131,7 +138,7 @@ class LockTest extends IntegrationTestCase
         $this->assertSame(['TestLock0', 'TestLock5', 'TestLockveryverylongidthatwillgetshorc93f8252040e73dacbeaaf93ae9c19d2'], $locks);
     }
 
-    public function test_reacquire_onlyReacquiresWhenCloseToOriginalExpirationTime()
+    public function testReacquireOnlyReacquiresWhenCloseToOriginalExpirationTime()
     {
         Date::$now = strtotime('2015-03-04 03:04:05');
 

--- a/tests/PHPUnit/Integration/Concurrency/LockTest.php
+++ b/tests/PHPUnit/Integration/Concurrency/LockTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
@@ -7,7 +8,6 @@
  */
 
 namespace Piwik\Tests\Integration\Concurrency;
-
 
 use Piwik\Common;
 use Piwik\Concurrency\Lock;
@@ -84,21 +84,21 @@ class LockTest extends IntegrationTestCase
         $this->assertTrue($this->lock->acquireLock(2));
     }
 
-    public function test_expireLock_ShouldReturnTrueOnSuccess()
+    public function test_extendLock_ShouldReturnTrueOnSuccess()
     {
         $this->lock->acquireLock(0);
-        $this->assertTrue($this->lock->expireLock(2));
+        $this->assertTrue($this->lock->extendLock(2));
     }
 
-    public function test_expireLock_ShouldReturnFalseIfNoTimeoutGiven()
+    public function test_extendLock_ShouldReturnFalseIfNoTimeoutGiven()
     {
         $this->lock->acquireLock(0);
-        $this->assertFalse($this->lock->expireLock(0));
+        $this->assertFalse($this->lock->extendLock(0));
     }
 
-    public function test_expireLock_ShouldReturnFalseIfNotLocked()
+    public function test_extendLock_ShouldReturnFalseIfNotLocked()
     {
-        $this->assertFalse($this->lock->expireLock(2));
+        $this->assertFalse($this->lock->extendLock(2));
     }
 
     public function test_getNumberOfAcquiredLocks_shouldReturnNumberOfLocks()
@@ -118,20 +118,20 @@ class LockTest extends IntegrationTestCase
 
     public function test_getAllAcquiredLockKeys_shouldReturnUsedKeysThatAreLocked()
     {
-        $this->assertSame(array(), $this->lock->getAllAcquiredLockKeys());
+        $this->assertSame([], $this->lock->getAllAcquiredLockKeys());
 
         $this->lock->acquireLock(0);
-        $this->assertSame(array('TestLock0'), $this->lock->getAllAcquiredLockKeys());
+        $this->assertSame(['TestLock0'], $this->lock->getAllAcquiredLockKeys());
 
         $this->lock->acquireLock(4);
         $this->lock->acquireLock(5);
 
         $locks = $this->lock->getAllAcquiredLockKeys();
         sort($locks);
-        $this->assertSame(array('TestLock0', 'TestLock4', 'TestLock5'), $locks);
+        $this->assertSame(['TestLock0', 'TestLock4', 'TestLock5'], $locks);
     }
 
-    public function test_rexpire_onlyRexpiresWhenCloseToOriginalExpirationTime()
+    public function test_reacquire_onlyReacquiresWhenCloseToOriginalExpirationTime()
     {
         Date::$now = strtotime('2015-03-04 03:04:05');
 
@@ -140,7 +140,7 @@ class LockTest extends IntegrationTestCase
         $expireTime = $this->getLockExpirationTime();
 
         sleep(1);
-        $this->lock->reexpireLock();
+        $this->lock->reacquireLock();
         $newExpireTime = $this->getLockExpirationTime();
         $this->assertEquals($expireTime, $newExpireTime);
 
@@ -148,7 +148,7 @@ class LockTest extends IntegrationTestCase
         Date::$now = strtotime('2015-03-04 03:04:35');
 
         sleep(1);
-        $this->lock->reexpireLock();
+        $this->lock->reacquireLock();
         $newExpireTime = $this->getLockExpirationTime();
         $this->assertEquals($expireTime, $newExpireTime);
 
@@ -156,7 +156,7 @@ class LockTest extends IntegrationTestCase
         Date::$now = strtotime('2015-03-04 03:04:55');
 
         sleep(1);
-        $this->lock->reexpireLock();
+        $this->lock->reacquireLock();
         $newExpireTime = $this->getLockExpirationTime();
         $this->assertNotEquals($expireTime, $newExpireTime);
 
@@ -166,7 +166,7 @@ class LockTest extends IntegrationTestCase
         Date::$now = strtotime('2015-03-04 03:05:05');
 
         sleep(1);
-        $this->lock->reexpireLock();
+        $this->lock->reacquireLock();
         $newExpireTime = $this->getLockExpirationTime();
         $this->assertEquals($expireTime, $newExpireTime);
 
@@ -174,7 +174,7 @@ class LockTest extends IntegrationTestCase
         Date::$now = strtotime('2015-03-04 03:05:55');
 
         sleep(1);
-        $this->lock->reexpireLock();
+        $this->lock->reacquireLock();
         $newExpireTime = $this->getLockExpirationTime();
         $this->assertNotEquals($expireTime, $newExpireTime);
     }

--- a/tests/PHPUnit/Integration/Concurrency/LockTest.php
+++ b/tests/PHPUnit/Integration/Concurrency/LockTest.php
@@ -123,12 +123,12 @@ class LockTest extends IntegrationTestCase
         $this->lock->acquireLock(0);
         $this->assertSame(['TestLock0'], $this->lock->getAllAcquiredLockKeys());
 
-        $this->lock->acquireLock(4);
+        $this->lock->acquireLock('veryverylongidthatwillgetshortenedasthereisamaximumof70charsinthedatabase');
         $this->lock->acquireLock(5);
 
         $locks = $this->lock->getAllAcquiredLockKeys();
         sort($locks);
-        $this->assertSame(['TestLock0', 'TestLock4', 'TestLock5'], $locks);
+        $this->assertSame(['TestLock0', 'TestLock5', 'TestLockveryverylongidthatwillgetshorc93f8252040e73dacbeaaf93ae9c19d2'], $locks);
     }
 
     public function test_reacquire_onlyReacquiresWhenCloseToOriginalExpirationTime()

--- a/tests/PHPUnit/Integration/RetryScheduledTaskTest.php
+++ b/tests/PHPUnit/Integration/RetryScheduledTaskTest.php
@@ -7,14 +7,17 @@
  */
 
 namespace Piwik\Tests\Integration;
+
+use Piwik\Log\NullLogger;
 use Piwik\Option;
 use Piwik\Scheduler\RetryableException;
-use Piwik\Scheduler\Timetable;
+use Piwik\Scheduler\ScheduledTaskLock;
 use Piwik\Scheduler\Scheduler;
 use Piwik\Scheduler\Task;
+use Piwik\Scheduler\Timetable;
+use Piwik\Tests\Framework\Mock\Concurrency\LockBackend\InMemoryLockBackend;
 use Piwik\Tests\Framework\Mock\PiwikOption;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
-use Piwik\Log\NullLogger;
 
 /**
  * @group Scheduler
@@ -74,7 +77,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
             ->method('loadTasks')
             ->willReturn($tasks);
 
-        $scheduler = new Scheduler($taskLoader, new NullLogger());
+        $scheduler = new Scheduler($taskLoader, new NullLogger(), new ScheduledTaskLock(new InMemoryLockBackend()));
 
         // First run
         $scheduler->run();
@@ -108,7 +111,7 @@ class RetryScheduledTaskTest extends IntegrationTestCase
             ->method('loadTasks')
             ->willReturn($tasks);
 
-        $scheduler = new Scheduler($taskLoader, new NullLogger());
+        $scheduler = new Scheduler($taskLoader, new NullLogger(), new ScheduledTaskLock(new InMemoryLockBackend()));
 
         // First run
         $scheduler->run();

--- a/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
@@ -9,13 +9,15 @@
 namespace Piwik\Tests\Unit\Scheduler;
 
 use Piwik\Date;
+use Piwik\Log\NullLogger;
 use Piwik\Option;
 use Piwik\Plugin;
+use Piwik\Scheduler\ScheduledTaskLock;
 use Piwik\Scheduler\Scheduler;
 use Piwik\Scheduler\Task;
 use Piwik\Scheduler\Timetable;
+use Piwik\Tests\Framework\Mock\Concurrency\LockBackend\InMemoryLockBackend;
 use Piwik\Tests\Framework\Mock\PiwikOption;
-use Piwik\Log\NullLogger;
 
 /**
  * @group Scheduler
@@ -52,7 +54,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
         self::stubPiwikOption($timetable);
 
         $taskLoader = $this->createMock('Piwik\Scheduler\TaskLoader');
-        $scheduler = new Scheduler($taskLoader, new NullLogger());
+        $scheduler = new Scheduler($taskLoader, new NullLogger(), new ScheduledTaskLock(new InMemoryLockBackend()));
 
         $this->assertEquals($expectedTime, $scheduler->getScheduledTimeForMethod($className, $methodName, $methodParameter));
 
@@ -70,7 +72,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
         $taskLoader = $this->getMockBuilder('Piwik\Scheduler\TaskLoader')
             ->disableOriginalConstructor()
             ->getMock();
-        $scheduler = new Scheduler($taskLoader, new NullLogger());
+        $scheduler = new Scheduler($taskLoader, new NullLogger(), new ScheduledTaskLock(new InMemoryLockBackend()));
 
         $scheduler->rescheduleTaskAndRunTomorrow($task);
 
@@ -179,7 +181,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
         // stub the piwik option object to control the returned option value
         self::stubPiwikOption(serialize($timetableBeforeTaskExecution));
 
-        $scheduler = new Scheduler($taskLoader, new NullLogger());
+        $scheduler = new Scheduler($taskLoader, new NullLogger(), new ScheduledTaskLock(new InMemoryLockBackend()));
 
         // execute tasks
         $executionResults = $scheduler->run();
@@ -215,7 +217,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
         $timetable = new Timetable();
         $initialTimetable = $timetable->getTimetable();
 
-        $scheduler = new Scheduler($taskLoader, new NullLogger());
+        $scheduler = new Scheduler($taskLoader, new NullLogger(), new ScheduledTaskLock(new InMemoryLockBackend()));
 
         foreach ($configuredTasks as $task) {
             /** @var Task $task */


### PR DESCRIPTION
### Description:

It can currently happen that multiple processes trigger the scheduled tasks to run. Long running tasks can be triggered multiple times that way, as there is currently no mechanism to prevent this.

This PR introduces a concurrency lock for scheduled tasks. 

When a scheduled task is being triggered it acquires a lock. Once the task finishes this lock is released. To avoid tasks being blocked forever if e.g. a task process is killed for any reason, each task can define a maximum expected run time (TTL). If this TTL is exceeded the lock is released automatically.
If a task process isn't able to acquire a lock (as another process already did that), the task will be skipped.

This should fix problems where e.g. scheduled reports or custom alerts are sometimes sent out twice.

fixes #17868

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
