### PR TITLE
Add correct mapping for --quiet for console output

### DIFF
--- a/plugins/Monolog/config/cli.php
+++ b/plugins/Monolog/config/cli.php
@@ -29,6 +29,7 @@ return array(
             OutputInterface::VERBOSITY_VERBOSE => Logger::DEBUG,
             OutputInterface::VERBOSITY_VERY_VERBOSE => Logger::DEBUG,
             OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG,
+            OutputInterface::VERBOSITY_QUIET => Logger::ERROR,
         );
         $handler = new ConsoleHandler(null, true, $verbosityMap);
         $handler->setFormatter(new \Piwik\Plugins\Monolog\Formatter\ConsoleFormatter([


### PR DESCRIPTION
### Description:

With Matomo 5.0 we have updated the symfony console dependency. This seems to have changed the handling of the `--quiet` option. Currently this no longer disables the debug/info output.

It seems due to internal changes in symfony console it is now required to define the quiet output mode in the verbosity mapping we have defined. Adding it there allows to suppress info/debug outputs again.

fixes #21800 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
