### PR TITLE
Ensure values of fields with type password are redacted in API response

### DIFF
--- a/plugins/CorePluginsAdmin/SettingsMetadata.php
+++ b/plugins/CorePluginsAdmin/SettingsMetadata.php
@@ -10,12 +10,15 @@ namespace Piwik\Plugins\CorePluginsAdmin;
 
 use Piwik\Common;
 use Piwik\Piwik;
+use Piwik\Settings\FieldConfig;
 use Piwik\Settings\Setting;
 use Piwik\Settings\Settings;
 use Exception;
 
 class SettingsMetadata
 {
+    const PASSWORD_PLACEHOLDER = '******';
+
     /**
      * @param Settings[]  $settingsInstances
      * @param array $settingValues   array('pluginName' => array('settingName' => 'settingValue'))
@@ -29,7 +32,12 @@ class SettingsMetadata
 
                     $value = $this->findSettingValueFromRequest($settingValues, $pluginName, $setting->getName());
 
-                    if (isset($value)) {
+                    $fieldConfig = $setting->configureField();
+
+                    if (isset($value) && (
+                        $fieldConfig->uiControl !== FieldConfig::UI_CONTROL_PASSWORD ||
+                        $value !== self::PASSWORD_PLACEHOLDER
+                    )) {
                         $setting->setValue($value);
                     }
                 }
@@ -111,10 +119,16 @@ class SettingsMetadata
             $availableValues = (object) $availableValues;
         }
 
+        $value = $setting->getValue();
+
+        if (!empty($value) && $config->uiControl === FieldConfig::UI_CONTROL_PASSWORD) {
+            $value = self::PASSWORD_PLACEHOLDER;
+        }
+
         $result = array(
             'name' => $setting->getName(),
             'title' => $config->title,
-            'value' => $setting->getValue(),
+            'value' => $value,
             'defaultValue' => $setting->getDefaultValue(),
             'type' => $setting->getType(),
             'uiControl' => $config->uiControl,

--- a/plugins/CorePluginsAdmin/tests/Integration/ApiTest.php
+++ b/plugins/CorePluginsAdmin/tests/Integration/ApiTest.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\CorePluginsAdmin\tests\Integration;
 use Piwik\Access;
 use Piwik\Auth;
 use Piwik\Container\StaticContainer;
+use Piwik\Plugins\CorePluginsAdmin\SettingsMetadata;
 use Piwik\Plugins\CoreUpdater\SystemSettings;
 use Piwik\Plugins\UsersManager\API;
 use Piwik\Tests\Framework\Fixture;
@@ -72,6 +73,60 @@ class ApiTest extends IntegrationTestCase
         $coreUpdaterSettings = StaticContainer::get(SystemSettings::class);
         $value = $coreUpdaterSettings->releaseChannel->getValue();
         $this->assertEquals('latest_beta', $value);
+    }
+
+    public function test_getSystemSettingsRedactsPasswordValues()
+    {
+        $pluginSettings = StaticContainer::get(\Piwik\Plugins\ExampleSettingsPlugin\SystemSettings::class);
+        $settings = $this->getPluginSettings('ExampleSettingsPlugin', 'password');
+
+        self::assertEquals('password', $settings['name']);
+        self::assertEquals('', $settings['value']);
+        self::assertEquals('', $pluginSettings->getSetting('password')->getValue());
+
+        $settingValues = [
+            'ExampleSettingsPlugin' => [
+                ['name' => 'password', 'value' => 'newPassword'],
+            ],
+        ];
+        \Piwik\Plugins\CorePluginsAdmin\API::getInstance()->setSystemSettings($settingValues, self::TEST_PASSWORD);
+
+        $newSettings = $this->getPluginSettings('ExampleSettingsPlugin', 'password');
+
+        self::assertEquals('password', $newSettings['name']);
+        self::assertEquals(SettingsMetadata::PASSWORD_PLACEHOLDER, $newSettings['value']); // API returns value redacted
+        self::assertTrue(password_verify('newPassword', $pluginSettings->getSetting('password')->getValue()));
+
+        // check that sending the placeholder as value doesn't update the setting
+        $settingValues = [
+            'ExampleSettingsPlugin' => [
+                ['name' => 'password', 'value' => SettingsMetadata::PASSWORD_PLACEHOLDER],
+            ],
+        ];
+        \Piwik\Plugins\CorePluginsAdmin\API::getInstance()->setSystemSettings($settingValues, self::TEST_PASSWORD);
+
+        $newSettings = $this->getPluginSettings('ExampleSettingsPlugin', 'password');
+
+        self::assertEquals('password', $newSettings['name']);
+        self::assertEquals(SettingsMetadata::PASSWORD_PLACEHOLDER, $newSettings['value']); // API returns value redacted
+        self::assertTrue(password_verify('newPassword', $pluginSettings->getSetting('password')->getValue()));
+    }
+
+    private function getPluginSettings(string $pluginName, string $settingName): array
+    {
+        $settings = \Piwik\Plugins\CorePluginsAdmin\API::getInstance()->getSystemSettings();
+
+        foreach ($settings as $pluginSettings) {
+            if ($pluginSettings['pluginName'] === $pluginName) {
+                foreach ($pluginSettings['settings'] as $pSetting) {
+                    if ($pSetting['name'] === $settingName) {
+                        return $pSetting;
+                    }
+                }
+            }
+        }
+
+        return [];
     }
 
     protected static function configureFixture($fixture)


### PR DESCRIPTION
### Description:

Plugins are able to define the own system, user and/or measurable settings. See https://developer.matomo.org/guides/plugin-settings
The system settings for all plugins are currently available using the API `CorePluginsAdmin.getSystemSettings`
The response includes all defined settings including their current value.

This currently makes it possible for a super user to also see values of fields, that are defined as password field.
For certain values it might be unwanted that a super user sees the value another super user might have configured.
Therefor this PR aims to replace values of password fields with `*****`, so they are no longer visible in the API response.

fixes DEV-16785

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
