### PR TITLE
Fix possible deprecation warning in UsersManager.getUsersPlusRole API

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -362,11 +362,14 @@ class API extends \Piwik\Plugin\API
                 return [];
             }
 
+            $users = [];
             $user = $this->model->getUser($this->access->getLogin());
-            $user['role'] = $this->access->getRoleForSite($idSite);
-            $user['capabilities'] = $this->access->getCapabilitiesForSite($idSite);
-            $users = [$user];
-            $totalResults = 1;
+            if ($user) {
+                $user['role'] = $this->access->getRoleForSite($idSite);
+                $user['capabilities'] = $this->access->getCapabilitiesForSite($idSite);
+                $users = [$user];
+            }
+            $totalResults = count($users);
         } else {
             // if the current user is not the superuser, only select users that have access to a site this user
             // has admin access to

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -351,7 +351,11 @@ class API extends \Piwik\Plugin\API
      */
     public function getUsersPlusRole($idSite, $limit = null, $offset = 0, $filter_search = null, $filter_access = null, $filter_status = null)
     {
-        if (!$this->isUserHasAdminAccessTo($idSite)) {
+        if (Piwik::isUserIsAnonymous()) {
+            // anonymous user should never see any results.
+            Common::sendHeader('X-Matomo-Total-Results: 0');
+            return [];
+        } else if (!$this->isUserHasAdminAccessTo($idSite)) {
             // if the user is not an admin to $idSite, they can only see their own user
             if ($offset > 1) {
                 Common::sendHeader('X-Matomo-Total-Results: 1');

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -506,6 +506,15 @@ class APITest extends IntegrationTestCase
         $this->assertEquals($expected, $access);
     }
 
+    public function testGetUsersPlusRoleShouldReturnNothingForAnonymousUser()
+    {
+        $this->addUserWithAccess('userLogin2', 'view', 1);
+        $this->setCurrentUser('anonymous', 'view', 1);
+
+        $users = $this->api->getUsersPlusRole(1);
+        $this->assertEquals([], $users);
+    }
+
     public function testGetUsersPlusRoleShouldReturnSelfIfUserDoesNotHaveAdminAccessToSite()
     {
         $this->addUserWithAccess('userLogin2', 'view', 1);


### PR DESCRIPTION
### Description:

When `UsersManager.getUsersPlusRole` is being called as anonymous user, the API currently throws a deprecation warning on PHP 8+.

As the anonymous user actually doesn't need to see any users or roles this PR changes the behavior, so the method always returns an empty data set in that case.

fixes #21253 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
