### PR TITLE
Determine incomplete/invalidated periods for evolution graphs

### DIFF
--- a/core/API/DataTablePostProcessor.php
+++ b/core/API/DataTablePostProcessor.php
@@ -120,6 +120,7 @@ class DataTablePostProcessor
         }
 
         $dataTable = $this->applyGenericFilters($dataTable);
+        $dataTable = $this->applyArchiveStateFilter($dataTable);
         $this->applyComputeProcessedMetrics($dataTable);
         $dataTable = $this->applyComparison($dataTable);
 
@@ -142,6 +143,23 @@ class DataTablePostProcessor
     {
         $dataTable->filter('AddSegmentBySegmentValue', array($this->report));
         $dataTable->filter('ColumnCallbackDeleteMetadata', array('segmentValue'));
+
+        return $dataTable;
+    }
+
+    /**
+     * @param DataTableInterface $dataTable
+     * @return DataTableInterface
+     */
+    public function applyArchiveStateFilter(DataTableInterface $dataTable): DataTableInterface
+    {
+        $fetchArchiveState = (new \Piwik\Request($this->request))->getBoolParameter('fetch_archive_state', false);
+
+        if (false === $fetchArchiveState) {
+            $dataTable->filter(function (DataTable $table) {
+                $table->deleteMetadata(DataTable::ARCHIVE_STATE_METADATA_NAME);
+            });
+        }
 
         return $dataTable;
     }

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -151,11 +151,21 @@ class ArchiveInvalidator
         return $generalCache[$cacheKey][$idSite][$dateStr];
     }
 
-    public function getRememberedArchivedReportsThatShouldBeInvalidated()
+    public function getDaysWithRememberedInvalidationsForSite(int $idSite): array
     {
-        $reports = Option::getLike('%' . str_replace('_', '\_', $this->rememberArchivedReportIdStart) . '%\_%');
+        return array_keys($this->getRememberedArchivedReportsThatShouldBeInvalidated($idSite));
+    }
 
-        $sitesPerDay = array();
+    public function getRememberedArchivedReportsThatShouldBeInvalidated(int $idSite = null)
+    {
+        if (null === $idSite) {
+            $optionName = $this->rememberArchivedReportIdStart . '%';
+        } else {
+            $optionName = $this->buildRememberArchivedReportIdForSite($idSite);
+        }
+
+        $reports = Option::getLike('%' . str_replace('_', '\_', $optionName) . '\_%');
+        $sitesPerDay = [];
 
         foreach ($reports as $report => $value) {
             $report = substr($report, strpos($report, $this->rememberArchivedReportIdStart));
@@ -169,7 +179,7 @@ class ArchiveInvalidator
             }
 
             if (empty($sitesPerDay[$date])) {
-                $sitesPerDay[$date] = array();
+                $sitesPerDay[$date] = [];
             }
 
             $sitesPerDay[$date][] = $siteId;

--- a/core/Archive/ArchiveState.php
+++ b/core/Archive/ArchiveState.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Archive;
+
+use Piwik\Container\StaticContainer;
+use Piwik\DataAccess\ArchiveWriter;
+use Piwik\DataTable;
+use Piwik\Date;
+use Piwik\Period\Range;
+use Piwik\Site;
+
+class ArchiveState
+{
+    public const COMPLETE = 'complete';
+    public const INCOMPLETE = 'incomplete';
+    public const INVALIDATED = 'invalidated';
+
+    /**
+     * @var ArchiveInvalidator
+     */
+    private $invalidator;
+
+    public function __construct(ArchiveInvalidator $invalidator = null)
+    {
+        $this->invalidator = $invalidator ?? StaticContainer::get(ArchiveInvalidator::class);
+    }
+
+    /**
+     * @param array{date1: string, date2: string, idsite: string, ts_archived: string} $archiveData
+     * @param array<string, array<int>> $archiveIds archives ids indexed by period
+     * @param array<int, array<string, array<int, int>>> $archiveStates archive states indexed by site and period
+     */
+    public function addMetadataToResultCollection(
+        DataCollection $collection,
+        array $archiveData,
+        array $archiveIds,
+        array $archiveStates
+    ): void {
+        $periodsTsArchived = [];
+
+        foreach ($archiveData as $archive) {
+            $idSite = $archive['idsite'];
+            $period = $archive['date1'] . ',' . $archive['date2'];
+
+            $periodsTsArchived[$idSite][$period] = $archive['ts_archived'];
+        }
+
+        foreach ($periodsTsArchived as $idSite => $periods) {
+            $site = new Site($idSite);
+            $incompleteDays = $this->invalidator->getDaysWithRememberedInvalidationsForSite($site->getId());
+
+            foreach ($periods as $period => $tsArchived) {
+                $state = $this->checkArchiveStates($site, $period, $archiveIds, $archiveStates);
+
+                $range = new Range('day', $period);
+                $state = $this->checkTsArchived($state, $site, $range, $tsArchived);
+                $state = $this->checkDaysRememberedToBeIncomplete($state, $range, $incompleteDays);
+
+                if (null === $state) {
+                    // do not set metadata, if no state was determined,
+                    // to avoid generating unexpected default rows
+                    continue;
+                }
+
+                $collection->addMetadata(
+                    $idSite,
+                    $period,
+                    DataTable::ARCHIVE_STATE_METADATA_NAME,
+                    $state
+                );
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array<int>> $archiveIds
+     * @param array<int, array<string, array<int, int>>> $archiveStates
+     */
+    private function checkArchiveStates(
+        Site $site,
+        string $period,
+        array $archiveIds,
+        array $archiveStates
+    ): ?string {
+        $idSite = $site->getId();
+
+        $availableStates = array_intersect_key(
+            $archiveStates[$idSite][$period] ?? [],
+            array_flip($archiveIds[$period] ?? [])
+        );
+
+        if ([] === $availableStates) {
+            // do not determine state if no archives were used
+            return null;
+        }
+
+        if (in_array(ArchiveWriter::DONE_INVALIDATED, $availableStates)) {
+            // archive has been invalidated
+            return self::INVALIDATED;
+        }
+
+        // all archives not invalidated should be complete
+        // includes DONE_OK, DONE_OK_TEMPORARY and DONE_PARTIAL
+        return self::COMPLETE;
+    }
+
+    /**
+     * @param array<string> $incompleteDays
+     */
+    private function checkDaysRememberedToBeIncomplete(
+        ?string $state,
+        Range $range,
+        array $incompleteDays
+    ): ?string {
+        if ([] === $incompleteDays || in_array($state, [self::INCOMPLETE, self::INVALIDATED])) {
+            // only missing archives or those detected as complete are relevant
+            // for remembered invalidations marking them as incomplete
+            return $state;
+        }
+
+        foreach ($range->getSubperiods() as $subPeriod) {
+            $subPeriodDay = $subPeriod->toString('Y-m-d');
+
+            if (!in_array($subPeriodDay, $incompleteDays)) {
+                continue;
+            }
+
+            // archive has received more requests after it was already processed
+            return self::INCOMPLETE;
+        }
+
+        return $state;
+    }
+
+    private function checkTsArchived(
+        ?string $state,
+        Site $site,
+        Range $range,
+        string $tsArchived
+    ): ?string {
+        if (self::COMPLETE !== $state) {
+            // only archives detected as complete can be archived before range end
+            return $state;
+        }
+
+        $rangeEndTimestamp = $range->getDateTimeEnd()->setTimezone($site->getTimezone())->getTimestamp();
+        $tsArchivedTimestamp = Date::factory($tsArchived)->getTimestamp();
+
+        if ($tsArchivedTimestamp <= $rangeEndTimestamp) {
+            return self::INCOMPLETE;
+        }
+
+        return $state;
+    }
+}

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -192,9 +192,66 @@ class ArchiveSelector
      *               )
      * @throws
      */
-    public static function getArchiveIds($siteIds, $periods, $segment, $plugins, $includeInvalidated = true, $_skipSetGroupConcatMaxLen = false)
-    {
+    public static function getArchiveIds(
+        $siteIds,
+        $periods,
+        $segment,
+        $plugins,
+        $includeInvalidated = true,
+        $_skipSetGroupConcatMaxLen = false
+    ) {
+        return self::getArchiveIdsAndStates(
+            $siteIds,
+            $periods,
+            $segment,
+            $plugins,
+            $includeInvalidated,
+            $_skipSetGroupConcatMaxLen
+        )[0];
+    }
+
+    /**
+     * Queries and returns archive IDs and the associated doneFlag
+     * values for a set of sites, periods, and a segment.
+     *
+     * @param int[] $siteIds
+     * @param Period[] $periods
+     * @param Segment $segment
+     * @param string[] $plugins List of plugin names for which data is being requested.
+     * @param bool $includeInvalidated true to include archives that are DONE_INVALIDATED, false if only DONE_OK.
+     * @param bool $_skipSetGroupConcatMaxLen for tests
+     *
+     * @return array Archive IDs are grouped by archive name and period range, ie,
+     *               array(
+     *                   array(
+     *                       'VisitsSummary.done' => array(
+     *                           '2010-01-01' => array(1,2,3)
+     *                       )
+     *                   )
+     *                   array(
+     *                       100 => array(
+     *                           'VisitsSummary.done' => array(
+     *                               '2010-01-01' => array(
+     *                                   1 => 1,
+     *                                   2 => 4,
+     *                                   3 => 5
+     *                               )
+     *                           )
+     *                       )
+     *                   )
+     *               )
+     * @throws
+     */
+    public static function getArchiveIdsAndStates(
+        $siteIds,
+        $periods,
+        $segment,
+        $plugins,
+        $includeInvalidated = true,
+        $_skipSetGroupConcatMaxLen = false
+    ): array {
         $logger = StaticContainer::get(LoggerInterface::class);
+
         if (!$_skipSetGroupConcatMaxLen) {
             try {
                 Db::get()->query('SET SESSION group_concat_max_len=' . (128 * 1024));
@@ -232,11 +289,12 @@ class ArchiveSelector
         $db = Db::get();
 
         // for every month within the archive query, select from numeric table
-        $result = array();
+        $idarchives = [];
+        $idarchiveStates = [];
+
         foreach ($monthToPeriods as $table => $periods) {
             $firstPeriod = reset($periods);
-
-            $bind = array();
+            $bind = [];
 
             if ($firstPeriod instanceof Range) {
                 $dateCondition = "date1 = ? AND date2 = ?";
@@ -267,21 +325,26 @@ class ArchiveSelector
             // everything older than that one is discarded.
             foreach ($archiveIds as $row) {
                 $dateStr = $row['date1'] . ',' . $row['date2'];
+                $idSite = $row['idsite'];
 
                 $archives = $row['archives'];
                 $pairs = explode(',', $archives);
+
                 foreach ($pairs as $pair) {
                     $parts = explode('|', $pair);
+
                     if (count($parts) != 3) { // GROUP_CONCAT got cut off, have to ignore the rest
                         // note: in this edge case, we end up not selecting the all plugins archive because it will be older than the partials.
                         // not ideal, but it avoids an exception.
-                        $logger->info("GROUP_CONCAT got cut off in ArchiveSelector." . __FUNCTION__ . ' for idsite = ' . $row['idsite'] . ', period = ' . $dateStr);
+                        $logger->info("GROUP_CONCAT got cut off in ArchiveSelector." . __FUNCTION__ . ' for idsite = ' . $idSite . ', period = ' . $dateStr);
                         continue;
                     }
 
-                    list($idarchive, $doneFlag, $value) = $parts;
+                    [$idarchive, $doneFlag, $value] = $parts;
 
-                    $result[$doneFlag][$dateStr][] = $idarchive;
+                    $idarchives[$doneFlag][$dateStr][] = $idarchive;
+                    $idarchiveStates[$idSite][$doneFlag][$dateStr][$idarchive] = (int) $value;
+
                     if (strpos($doneFlag, '.') === false // all plugins archive
                         // sanity check: DONE_PARTIAL shouldn't be used w/ done archives, but in case we see one,
                         // don't treat it like an all plugins archive
@@ -293,7 +356,7 @@ class ArchiveSelector
             }
         }
 
-        return $result;
+        return [$idarchives, $idarchiveStates];
     }
 
     /**

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -224,10 +224,6 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
 
     const ROW_IDENTIFIER_METADATA_NAME = 'rowIdentifier';
 
-    const ID_ARCHIVE_STATE_COMPLETE = 'complete';
-    const ID_ARCHIVE_STATE_INCOMPLETE = 'incomplete';
-    const ID_ARCHIVE_STATE_INVALIDATED = 'invalidated';
-
     /**
      * Maximum nesting level.
      */

--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -36,7 +36,8 @@ class Row extends \ArrayObject
     private static $unsummableColumns = array(
         'label' => true,
         'full_url' => true, // column used w/ old Piwik versions,
-        'ts_archived' => true // date column used in metadata for proportional tooltips
+        DataTable::ARCHIVED_DATE_METADATA_NAME => true, // date column used in metadata for proportional tooltips
+        DataTable::ARCHIVE_STATE_METADATA_NAME => true,
     );
 
     // @see sumRow - implementation detail

--- a/plugins/CoreVisualizations/JqplotDataGenerator/Evolution.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator/Evolution.php
@@ -10,6 +10,7 @@
 
 namespace Piwik\Plugins\CoreVisualizations\JqplotDataGenerator;
 
+use Piwik\Archive\ArchiveState;
 use Piwik\Archive\DataTableFactory;
 use Piwik\Common;
 use Piwik\DataTable;
@@ -351,11 +352,11 @@ class Evolution extends JqplotDataGenerator
             $state = $dataTables[$dataTableDate]->getMetadata(DataTable::ARCHIVE_STATE_METADATA_NAME);
 
             if (false === $state) {
-                $state = DataTable::ID_ARCHIVE_STATE_COMPLETE;
+                $state = ArchiveState::COMPLETE;
             }
 
             if ($siteToday <= $period->getDateEnd()->getTimestamp()) {
-                $state = DataTable::ID_ARCHIVE_STATE_INCOMPLETE;
+                $state = ArchiveState::INCOMPLETE;
             }
 
             $dataStates[$dataTableDate] = $state;

--- a/plugins/CoreVisualizations/Visualizations/JqplotGraph/Evolution.php
+++ b/plugins/CoreVisualizations/Visualizations/JqplotGraph/Evolution.php
@@ -53,6 +53,9 @@ class Evolution extends JqplotGraph
 
         parent::beforeLoadDataTable();
 
+        // fetch archive states for incomplete data point visualization
+        $this->requestConfig->request_parameters_to_modify['fetch_archive_state'] = true;
+
         // period will be overridden when 'range' is requested in the UI.
         // The graph will display the range in the most suitable period and
         // it won't show historical data before the range.

--- a/plugins/MultiSites/API.php
+++ b/plugins/MultiSites/API.php
@@ -349,9 +349,10 @@ class API extends \Piwik\Plugin\API
             );
         }
 
-        // Remove <ts_archived> row metadata, it's already been used by any filters that needed it
+        // Remove unnecessary row metadata already been used by any filters that needed them
         $dataTable->queueFilter(function ($dataTable) {
             $dataTable->deleteRowsMetadata(DataTable::ARCHIVED_DATE_METADATA_NAME);
+            $dataTable->deleteRowsMetadata(DataTable::ARCHIVE_STATE_METADATA_NAME);
             $dataTable->deleteColumn('_metadata');
         });
 

--- a/tests/PHPUnit/Integration/Archive/ArchiveStateMetadataTest.php
+++ b/tests/PHPUnit/Integration/Archive/ArchiveStateMetadataTest.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Archive;
+
+use Piwik\Archive;
+use Piwik\Archive\ArchiveState;
+use Piwik\Archive\ArchiveInvalidator;
+use Piwik\Config;
+use Piwik\DataAccess\Model;
+use Piwik\DataTable;
+use Piwik\Date;
+use Piwik\Log\NullLogger;
+use Piwik\Segment;
+use Piwik\Tests\Fixtures\OneVisitorTwoVisits;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group ArchiveStateMetadataTest
+ * @group Core
+ */
+class ArchiveStateMetadataTest extends IntegrationTestCase
+{
+    /**
+     * @var OneVisitorTwoVisits
+     */
+    public static $fixture;
+
+    /**
+     * @var string
+     */
+    private $archiveDate;
+
+    /**
+     * @var Segment|null
+     */
+    private $archiveSegment;
+
+    /**
+     * @var int
+     */
+    private $archiveSite;
+
+    /**
+     * @var ArchiveInvalidator
+     */
+    private $invalidator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->archiveDate = Date::factory(self::$fixture->dateTime)->toString();
+        $this->archiveSite = self::$fixture->idSite;
+
+        $this->invalidator = new ArchiveInvalidator(new Model(), new NullLogger());
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        Date::$now = null;
+    }
+
+    /**
+     * @dataProvider archiveStateData
+     *
+     * @param array<string> $pluginsToInvalidate
+     */
+    public function test_getDataTableFromNumeric_returnsArchiveStateInMetadata(
+        int $nowTimestamp,
+        ?string $segment,
+        array $daysToRememberInvalidationsFor,
+        ?array $pluginsToInvalidate,
+        string $expectedInitialArchiveState,
+        string $expectedFinalArchiveState
+    ): void {
+        Date::$now = $nowTimestamp;
+
+        if (null !== $segment) {
+            $this->archiveSegment = new Segment($segment, [$this->archiveSite]);
+        }
+
+        $this->setUpInitialState($expectedInitialArchiveState);
+        $this->invalidateArchives($daysToRememberInvalidationsFor, $pluginsToInvalidate);
+        $this->disableArchiving();
+
+        $dataTable = $this->getDataTable();
+
+        self::assertSame(
+            $expectedFinalArchiveState,
+            $dataTable->getMetadata(DataTable::ARCHIVE_STATE_METADATA_NAME)
+        );
+    }
+
+    /**
+     * @return iterable<string, array>
+     */
+    public function archiveStateData(): iterable
+    {
+        $timestampToday = strtotime(self::$fixture->dateTime);
+        $timestampTomorrow = $timestampToday + 86400;
+
+        yield 'today, all ok' => [
+            $timestampToday,
+            null,
+            [],
+            null,
+            ArchiveState::INCOMPLETE,
+            ArchiveState::INCOMPLETE
+        ];
+
+        yield 'yesterday, all ok' => [
+            $timestampTomorrow,
+            null,
+            [],
+            null,
+            ArchiveState::COMPLETE,
+            ArchiveState::COMPLETE
+        ];
+
+        yield 'today, everything invalidated' => [
+            $timestampToday,
+            null,
+            [],
+            [],
+            ArchiveState::INCOMPLETE,
+            ArchiveState::INVALIDATED
+        ];
+
+        yield 'yesterday, everything invalidated' => [
+            $timestampTomorrow,
+            null,
+            [],
+            [],
+            ArchiveState::COMPLETE,
+            ArchiveState::INVALIDATED
+        ];
+
+        yield 'yesterday, invalidation remembered after archiving' => [
+            $timestampTomorrow,
+            null,
+            [date('Y-m-d', $timestampToday)],
+            null,
+            ArchiveState::COMPLETE,
+            ArchiveState::INCOMPLETE
+        ];
+
+        yield 'segmented, everything invalidated' => [
+            $timestampTomorrow,
+            'visitorType==new',
+            [],
+            [],
+            ArchiveState::COMPLETE,
+            ArchiveState::INVALIDATED
+        ];
+
+        yield 'segmented, partially invalidated' => [
+            $timestampTomorrow,
+            'visitorType==new',
+            [],
+            ['Goals'],
+            ArchiveState::COMPLETE,
+            ArchiveState::INVALIDATED
+        ];
+    }
+
+    private function disableArchiving(): void
+    {
+        Config::getInstance()->General['enable_browser_archiving_triggering'] = 0;
+        Config::getInstance()->General['browser_archiving_disabled_enforce'] = 1;
+    }
+
+    private function getDataTable(): DataTable
+    {
+        $archive = Archive::build(
+            $this->archiveSite,
+            'day',
+            $this->archiveDate,
+            null === $this->archiveSegment ? null : $this->archiveSegment->getString()
+        );
+
+        return $archive->getDataTableFromNumeric(['Goal_nb_conversions', 'Goals_nb_visits_converted', 'nb_visits']);
+    }
+
+    /**
+     * @param array<string> $daysToRememberInvalidationsFor
+     * @param array<string>|null $plugins
+     */
+    private function invalidateArchives(array $daysToRememberInvalidationsFor, ?array $plugins): void
+    {
+        foreach ($daysToRememberInvalidationsFor as $rememberedDay) {
+            $this->invalidator->rememberToInvalidateArchivedReportsLater(
+                $this->archiveSite,
+                Date::factory($rememberedDay)
+            );
+        }
+
+        if (null === $plugins) {
+            return;
+        }
+
+        if ([] === $plugins) {
+            // invalidate everything
+            $plugins = [null];
+        }
+
+        foreach ($plugins as $plugin) {
+            $this->invalidator->markArchivesAsInvalidated(
+                [$this->archiveSite],
+                [$this->archiveDate],
+                'day',
+                $this->archiveSegment,
+                false,
+                false,
+                $plugin
+            );
+        }
+    }
+
+    private function setUpInitialState(string $expectedInitialArchiveState): void
+    {
+        // remove remembered invalidations created by tracking in setup
+        $this->invalidator->forgetRememberedArchivedReportsToInvalidateForSite($this->archiveSite);
+
+        $dataTable = $this->getDataTable();
+        $archiveState = $dataTable->getMetadata(DataTable::ARCHIVE_STATE_METADATA_NAME);
+
+        self::assertSame($expectedInitialArchiveState, $archiveState);
+    }
+}
+
+ArchiveStateMetadataTest::$fixture = new OneVisitorTwoVisits();

--- a/tests/PHPUnit/Integration/Archive/ArchiveStateMetadataTest.php
+++ b/tests/PHPUnit/Integration/Archive/ArchiveStateMetadataTest.php
@@ -69,7 +69,7 @@ class ArchiveStateMetadataTest extends IntegrationTestCase
     }
 
     /**
-     * @dataProvider archiveStateData
+     * @dataProvider getArchiveStateTestData
      *
      * @param array<string> $pluginsToInvalidate
      */
@@ -102,7 +102,7 @@ class ArchiveStateMetadataTest extends IntegrationTestCase
     /**
      * @return iterable<string, array>
      */
-    public function archiveStateData(): iterable
+    public function getArchiveStateTestData(): iterable
     {
         $timestampToday = strtotime(self::$fixture->dateTime);
         $timestampTomorrow = $timestampToday + 86400;

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
@@ -453,6 +453,40 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
         $this->assertSameReports($this->getRememberedReportsByDate(), $reports);
     }
 
+    public function test_getRememberedArchivedReportsThatShouldBeInvalidatedBySite(): void
+    {
+        $this->rememberReportsForManySitesAndDates();
+
+        $idSite = 2;
+        $reports = $this->invalidator->getRememberedArchivedReportsThatShouldBeInvalidated($idSite);
+        $allReports = $this->getRememberedReportsByDate();
+
+        foreach ($allReports as $day => $idSites) {
+            if (!in_array($idSite, $idSites)) {
+                self::assertArrayNotHasKey($day, $reports);
+            } else {
+                self::assertSame([$idSite], $reports[$day]);
+            }
+        }
+    }
+
+    public function test_getDaysWithRememberedInvalidationsForSite(): void
+    {
+        $this->rememberReportsForManySitesAndDates();
+
+        $idSite = 2;
+        $days = $this->invalidator->getDaysWithRememberedInvalidationsForSite($idSite);
+        $allReports = $this->getRememberedReportsByDate();
+
+        foreach ($allReports as $day => $idSites) {
+            if (!in_array($idSite, $idSites)) {
+                self::assertNotContains($day, $days);
+            } else {
+                self::assertContains($day, $days);
+            }
+        }
+    }
+
     private function assertSameReports($expected, $actual)
     {
         $keys1 = array_keys($expected);

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Conversions_MultiSites.getAll_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Conversions_MultiSites.getAll_firstSite_lastN__API.getProcessedReport_day.xml
@@ -348,6 +348,7 @@
 		<revenue>35</revenue>
 		<_metadata>
 			<ts_archived>today-date-removed-in-tests</ts_archived>
+			<archive_state>complete</archive_state>
 		</_metadata>
 		<visits_evolution_trend>7</visits_evolution_trend>
 		<actions_evolution_trend>7</actions_evolution_trend>

--- a/tests/PHPUnit/Unit/Archive/ArchiveStateTest.php
+++ b/tests/PHPUnit/Unit/Archive/ArchiveStateTest.php
@@ -1,0 +1,304 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Archive;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Archive\ArchiveInvalidator;
+use Piwik\Archive\ArchiveState;
+use Piwik\Archive\DataCollection;
+use Piwik\DataAccess\ArchiveWriter;
+use Piwik\DataTable;
+use Piwik\Period;
+use Piwik\Segment;
+use Piwik\Site;
+
+/**
+ * @group Archive
+ * @group ArchiveStateTest
+ */
+class ArchiveStateTest extends TestCase
+{
+    private const IDSITE = 1;
+
+    /**
+     * @dataProvider dataArchiveState
+     */
+    public function testArchiveState(
+        string $date1,
+        string $date2,
+        string $tsArchived,
+        int $archiveState,
+        array $daysWithRememberedInvalidations,
+        string $expectedMetadataState
+    ): void {
+        $this->setUpSite([]);
+
+        [$archiveData, $archiveIds, $archiveStates] = $this->createArchiveInfo(
+            $date1,
+            $date2,
+            $tsArchived,
+            $archiveState
+        );
+
+        $collection = $this->createCollection($archiveData);
+
+        $archiveInvalidator = self::createMock(ArchiveInvalidator::class);
+        $archiveInvalidator
+            ->method('getDaysWithRememberedInvalidationsForSite')
+            ->willReturn($daysWithRememberedInvalidations);
+
+        $archiveState = new ArchiveState($archiveInvalidator);
+        $archiveState->addMetadataToResultCollection($collection, $archiveData, $archiveIds, $archiveStates);
+
+        $this->assertMetadataState($expectedMetadataState, $collection);
+    }
+
+    public function dataArchiveState(): iterable
+    {
+        yield 'complete' => [
+            '2020-01-31',
+            '2020-01-31',
+            '2020-02-01 10:00:00',
+            ArchiveWriter::DONE_OK,
+            [],
+            ArchiveState::COMPLETE
+        ];
+
+        yield 'day in range remembered as invalidated' => [
+            '2020-01-01',
+            '2020-01-31',
+            '2020-02-01 10:00:00',
+            ArchiveWriter::DONE_OK,
+            ['2020-01-16'],
+            ArchiveState::INCOMPLETE
+        ];
+
+        yield 'date outside range remembered as invalidated' => [
+            '2020-01-01',
+            '2020-01-31',
+            '2020-02-01 10:00:00',
+            ArchiveWriter::DONE_OK,
+            ['2020-03-16'],
+            ArchiveState::COMPLETE
+        ];
+
+        yield 'invalidated archive' => [
+            '2020-01-31',
+            '2020-01-31',
+            '2020-02-01 10:00:00',
+            ArchiveWriter::DONE_INVALIDATED,
+            [],
+            ArchiveState::INVALIDATED
+        ];
+    }
+
+    /**
+     * @dataProvider dataCheckTsArchivedWithBorderTimezones
+     */
+    public function testCheckTsArchivedWithBorderTimezones(
+        string $timezone,
+        string $date,
+        string $tsArchivedUTC,
+        string $expectedState
+    ): void {
+        $this->setUpSite(['timezone' => $timezone]);
+
+        $archiveInvalidator = self::createMock(ArchiveInvalidator::class);
+        $archiveInvalidator->method('getDaysWithRememberedInvalidationsForSite')->willReturn([]);
+
+        [$archiveData, $archiveIds, $archiveStates] = $this->createArchiveInfo(
+            $date,
+            $date,
+            $tsArchivedUTC,
+            ArchiveWriter::DONE_OK
+        );
+
+        $collection = $this->createCollection($archiveData);
+
+        $archiveState = new ArchiveState($archiveInvalidator);
+        $archiveState->addMetadataToResultCollection($collection, $archiveData, $archiveIds, $archiveStates);
+
+        $this->assertMetadataState($expectedState, $collection);
+    }
+
+    public function dataCheckTsArchivedWithBorderTimezones(): iterable
+    {
+        yield 'UTC+14, complete' => [
+            'UTC+14',
+            '2020-10-10',
+            '2020-10-10 12:00:00',
+            ArchiveState::COMPLETE,
+        ];
+
+        yield 'UTC+14, incomplete' => [
+            'UTC+14',
+            '2020-10-10',
+            '2020-10-10 02:00:00',
+            ArchiveState::INCOMPLETE,
+        ];
+
+        yield 'UTC-12, complete' => [
+            'UTC-12',
+            '2020-10-10',
+            '2020-10-11 16:00:00',
+            ArchiveState::COMPLETE,
+        ];
+
+        yield 'UTC-12, incomplete' => [
+            'UTC-12',
+            '2020-10-10',
+            '2020-10-11 02:00:00',
+            ArchiveState::INCOMPLETE,
+        ];
+    }
+
+    public function testNoMetadataSetIfNoInformationAvailable(): void
+    {
+        $this->setUpSite([]);
+
+        $archiveInvalidator = self::createMock(ArchiveInvalidator::class);
+        $archiveInvalidator->method('getDaysWithRememberedInvalidationsForSite')->willReturn([]);
+
+        [$archiveData, $archiveIds] = $this->createArchiveInfo(
+            '2020-01-31',
+            '2020-01-31',
+            '2020-02-01 10:00:00',
+            ArchiveWriter::DONE_INVALIDATED
+        );
+
+        $collection = $this->createCollection($archiveData);
+
+        $archiveState = new ArchiveState($archiveInvalidator);
+        $archiveState->addMetadataToResultCollection($collection, $archiveData, $archiveIds, []);
+
+        $this->assertMetadataState(null, $collection);
+    }
+
+    public function testRememberedInvalidationSetsMissingArchiveIncomplete(): void
+    {
+        $this->setUpSite([]);
+
+        $archiveInvalidator = self::createMock(ArchiveInvalidator::class);
+        $archiveInvalidator->method('getDaysWithRememberedInvalidationsForSite')->willReturn(['2020-01-31']);
+
+        [$archiveData, $archiveIds] = $this->createArchiveInfo(
+            '2020-01-31',
+            '2020-01-31',
+            '2020-02-01 10:00:00',
+            ArchiveWriter::DONE_OK
+        );
+
+        $collection = $this->createCollection($archiveData);
+
+        $archiveState = new ArchiveState($archiveInvalidator);
+        $archiveState->addMetadataToResultCollection($collection, $archiveData, $archiveIds, []);
+
+        $this->assertMetadataState(ArchiveState::INCOMPLETE, $collection);
+    }
+
+    private function assertMetadataState(?string $expectedState, DataCollection $collection): void
+    {
+        $data = $collection->getIndexedArray([]);
+        $metadata = $collection->getDataRowMetadata($data);
+
+        if (null === $expectedState) {
+            self::assertArrayNotHasKey(DataTable::ARCHIVE_STATE_METADATA_NAME, $metadata);
+        } else {
+            self::assertSame($expectedState, $metadata[DataTable::ARCHIVE_STATE_METADATA_NAME]);
+        }
+    }
+
+    private function createArchiveInfo(
+        string $date1,
+        string $date2,
+        string $tsArchived,
+        int $archiveState
+    ): array {
+        $archiveId = 15;
+        $rangeStr = $date1 . ',' . $date2;
+
+        $archiveData = [
+            [
+                'idsite' => self::IDSITE,
+                'date1' => $date1,
+                'date2' => $date2,
+                'name' => 'nb_visits',
+                'value' => 123,
+                'ts_archived' => $tsArchived,
+            ],
+        ];
+
+        $archiveIds = [$rangeStr => [$archiveId]];
+        $archiveStates = [self::IDSITE => [$rangeStr => [$archiveId => $archiveState]]];
+
+        return [$archiveData, $archiveIds, $archiveStates];
+    }
+
+    private function createCollection($archiveData): DataCollection
+    {
+        $periods = [];
+
+        foreach ($archiveData as $row) {
+            if ($row['date1'] === $row['date2']) {
+                $periods[] = Period\Factory::build('day', $row['date1']);
+            } else {
+                $periods[] = Period\Factory::build('range', $row['date1'] . ',' . $row['date2']);
+            }
+        }
+
+        $collection = new DataCollection(
+            ['nb_visits'],
+            'numeric',
+            [1],
+            $periods,
+            $this->createMockSegment(),
+            ['nb_visits' => -1]
+        );
+
+        foreach ($archiveData as $row) {
+            $collection->set(
+                self::IDSITE,
+                $row['date1'] . ',' . $row['date2'],
+                $row['name'],
+                $row['value'],
+                [
+                    DataTable::ARCHIVED_DATE_METADATA_NAME => $row['ts_archived'],
+                ]
+            );
+        }
+
+        return $collection;
+    }
+
+    private function createMockSegment(): Segment
+    {
+        // using mock since Segment makes API queries
+        $segment = $this->getMockBuilder(Segment::class)->disableOriginalConstructor()->getMock();
+        $segment->method('getString')->willReturn('');
+
+        return $segment;
+    }
+
+    private function setUpSite(array $siteInfo): void
+    {
+        $defaults = [
+            'idsite' => self::IDSITE,
+            'ecommerce' => 0,
+            'sitesearch' => 0,
+            'exclude_unknown_urls' => 0,
+            'keep_url_fragment' => 0,
+            'timezone' => 'UTC',
+        ];
+
+        // setting static site information since Site makes API queries
+        Site::setSiteFromArray(self::IDSITE, array_merge($defaults, $siteInfo));
+    }
+}

--- a/tests/PHPUnit/Unit/Archive/ArchiveStateTest.php
+++ b/tests/PHPUnit/Unit/Archive/ArchiveStateTest.php
@@ -29,7 +29,7 @@ class ArchiveStateTest extends TestCase
     private const IDSITE = 1;
 
     /**
-     * @dataProvider dataArchiveState
+     * @dataProvider getArchiveStateTestData
      */
     public function testArchiveState(
         string $date1,
@@ -61,7 +61,7 @@ class ArchiveStateTest extends TestCase
         $this->assertMetadataState($expectedMetadataState, $collection);
     }
 
-    public function dataArchiveState(): iterable
+    public function getArchiveStateTestData(): iterable
     {
         yield 'complete' => [
             '2020-01-31',
@@ -101,7 +101,7 @@ class ArchiveStateTest extends TestCase
     }
 
     /**
-     * @dataProvider dataCheckTsArchivedWithBorderTimezones
+     * @dataProvider getCheckTsArchivedWithBorderTimezonesTestData
      */
     public function testCheckTsArchivedWithBorderTimezones(
         string $timezone,
@@ -129,7 +129,7 @@ class ArchiveStateTest extends TestCase
         $this->assertMetadataState($expectedState, $collection);
     }
 
-    public function dataCheckTsArchivedWithBorderTimezones(): iterable
+    public function getCheckTsArchivedWithBorderTimezonesTestData(): iterable
     {
         yield 'UTC+14, complete' => [
             'UTC+14',


### PR DESCRIPTION
### Description:

Provides archive state information for evolution graphs to display information about incomplete or invalidated data points.

#### State Selection

An `Archive\DataCollection` contains information about "invalidated" or "incomplete" data based on several checks:

- `invalidated`
  - any of the `done` archive entries was `invalidated`
- `incomplete`
  - `ts_archived` has a date earlier than the end of the period
  - a `report_to_invalidate` entry is found for any day of the period (requests have been tracked after the archive was written)

State is only provided for periods with data (matching the availability of `ts_archived` information), and all periods containing a `report_to_invalidate`.

#### State Retrieval

DataTables retrieved using the `Archive::getDataTable*` functions will contain state information.

Unless `fetch_archive_state=1` is passed in the request, this state will be automatically removed by the `DataTablePostProcessor`, making it opt-in.

#### Evolution Graph Display

The state informationen is passed to evolution graphs for display (see #21694).

If no state information is available (no archive found), the displayed values will be flagged as "complete", unless the point follows a point marked as "incomplete". In the latter case, the "incomplete" flag will be used for the missing archive.

Refs DEV-17568

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
