### PR TITLE
[PHP 8.4] Fix: Curl `CURLOPT_BINARYTRANSFER` deprecated

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -636,8 +636,6 @@ class Http
             }
 
             $curl_options = array(
-                // internal to ext/curl
-                CURLOPT_BINARYTRANSFER => is_resource($file),
 
                 // curl options (sorted oldest to newest)
                 CURLOPT_URL            => $aUrl,


### PR DESCRIPTION
### Description:

The `CURLOPT_BINARYTRANSFER` PHP constant from the Curl extension was no-op since PHP 5.1, and is deprecated in PHP 8.4. This removes the constant usage to avoid the deprecation notice in PHP 8.4 and later.

Because this constant was no-op since PHP 5.1 (circa 2005), this change has no impact.

See:

 - [PHP.Watch - PHP 8.4 - Curl: CURLOPT_BINARYTRANSFER deprecated](https://php.watch/versions/8.4/CURLOPT_BINARYTRANSFER-deprecated)
 - [commit](https://github.com/php/php-src/commit/fc16285538e96ecb35d017231051f83dcbd8b55b)

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
