### PR TITLE
Fix sorting for ecommerce item reports

### DIFF
--- a/plugins/Ecommerce/tests/System/EcommerceOrderWithItemsTest.php
+++ b/plugins/Ecommerce/tests/System/EcommerceOrderWithItemsTest.php
@@ -524,6 +524,20 @@ class EcommerceOrderWithItemsTest extends SystemTestCase
                     ],
                 ],
 
+                [
+                    $goalItemApi,
+                    [
+                        'idSite'     => $idSite,
+                        'date'       => $dateTime,
+                        'periods'    => 'week',
+                        'testSuffix' => '_productSkuSegmentSorted',
+                        'otherRequestParameters' => [
+                            'filter_sort_column' => 'nb_visits',
+                        ],
+                        'segment'    => 'productSku==' . urlencode(urlencode('SKU VERY nice indeed')),
+                    ],
+                ],
+
                 // deleted sku will be deleted
                 [
                     array_merge(['VisitsSummary.get'], $goalItemApi),

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_productSkuSegmentSorted__Goals.getItemsCategory_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_productSkuSegmentSorted__Goals.getItemsCategory_week.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>Category TWO LEFT in cart</label>
+		<nb_visits>3</nb_visits>
+		<nb_actions>3</nb_actions>
+		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+		<avg_price>0</avg_price>
+		<avg_quantity>0</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productCategory==Category+TWO+LEFT+in+cart</segment>
+	</row>
+	<row>
+		<label>Product Category not defined</label>
+		<revenue>611.22</revenue>
+		<quantity>7</quantity>
+		<orders>2</orders>
+		<nb_visits>3</nb_visits>
+		<nb_actions>6</nb_actions>
+		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+		<avg_price>55.61</avg_price>
+		<avg_quantity>3.5</avg_quantity>
+		<conversion_rate>66.67%</conversion_rate>
+		<segment>productCategory==Product+Category+not+defined</segment>
+	</row>
+	<row>
+		<label>second category</label>
+		<nb_visits>3</nb_visits>
+		<nb_actions>3</nb_actions>
+		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+		<avg_price>0</avg_price>
+		<avg_quantity>0</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productCategory==second+category</segment>
+	</row>
+	<row>
+		<label>Electronics &amp; Cameras</label>
+		<revenue>2500</revenue>
+		<quantity>3</quantity>
+		<orders>2</orders>
+		<nb_visits>1</nb_visits>
+		<nb_actions>3</nb_actions>
+		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+		<avg_price>1000</avg_price>
+		<avg_quantity>1.5</avg_quantity>
+		<conversion_rate>200%</conversion_rate>
+		<segment>productCategory==Electronics+%26+Cameras</segment>
+	</row>
+	<row>
+		<label>Multiple Category 1</label>
+		<revenue>1000</revenue>
+		<quantity>2</quantity>
+		<orders>1</orders>
+		<avg_price>500</avg_price>
+		<avg_quantity>2</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productCategory==Multiple+Category+1</segment>
+	</row>
+	<row>
+		<label>Multiple Category 2</label>
+		<revenue>1000</revenue>
+		<quantity>2</quantity>
+		<orders>1</orders>
+		<avg_price>500</avg_price>
+		<avg_quantity>2</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productCategory==Multiple+Category+2</segment>
+	</row>
+	<row>
+		<label>Multiple Category 4</label>
+		<revenue>1000</revenue>
+		<quantity>2</quantity>
+		<orders>1</orders>
+		<avg_price>500</avg_price>
+		<avg_quantity>2</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productCategory==Multiple+Category+4</segment>
+	</row>
+	<row>
+		<label>Multiple Category 5</label>
+		<revenue>1000</revenue>
+		<quantity>2</quantity>
+		<orders>1</orders>
+		<avg_price>500</avg_price>
+		<avg_quantity>2</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productCategory==Multiple+Category+5</segment>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_productSkuSegmentSorted__Goals.getItemsName_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_productSkuSegmentSorted__Goals.getItemsName_week.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>PRODUCT THREE LEFT in cart</label>
+		<nb_visits>3</nb_visits>
+		<nb_actions>6</nb_actions>
+		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+		<avg_price>1332</avg_price>
+		<avg_quantity>0</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productName==PRODUCT+THREE+LEFT+in+cart</segment>
+	</row>
+	<row>
+		<label>PRODUCT TWO LEFT in cart</label>
+		<nb_visits>3</nb_visits>
+		<nb_actions>3</nb_actions>
+		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+		<avg_price>0</avg_price>
+		<avg_quantity>0</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productName==PRODUCT+TWO+LEFT+in+cart</segment>
+	</row>
+	<row>
+		<label>PRODUCT name</label>
+		<revenue>1011.22</revenue>
+		<quantity>3</quantity>
+		<orders>2</orders>
+		<nb_visits>1</nb_visits>
+		<nb_actions>1</nb_actions>
+		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+		<avg_price>255.61</avg_price>
+		<avg_quantity>1.5</avg_quantity>
+		<conversion_rate>200%</conversion_rate>
+		<segment>productName==PRODUCT+name</segment>
+	</row>
+	<row>
+		<label>Canon SLR</label>
+		<revenue>1500</revenue>
+		<quantity>1</quantity>
+		<orders>1</orders>
+		<avg_price>1500</avg_price>
+		<avg_quantity>1</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productName==Canon+SLR</segment>
+	</row>
+	<row>
+		<label>PRODUCT name BIS</label>
+		<revenue>600</revenue>
+		<quantity>6</quantity>
+		<orders>1</orders>
+		<avg_price>100</avg_price>
+		<avg_quantity>6</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productName==PRODUCT+name+BIS</segment>
+	</row>
+</result>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_productSkuSegmentSorted__Goals.getItemsSku_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_productSkuSegmentSorted__Goals.getItemsSku_week.xml
@@ -1,26 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>
-		<label>ANOTHER SKU HERE</label>
-		<revenue>600</revenue>
-		<quantity>6</quantity>
-		<orders>1</orders>
-		<avg_price>100</avg_price>
-		<avg_quantity>6</avg_quantity>
-		<conversion_rate>0%</conversion_rate>
-		<segment>productSku==ANOTHER+SKU+HERE</segment>
-	</row>
-	<row>
-		<label>SKU2</label>
-		<revenue>1500</revenue>
-		<quantity>1</quantity>
-		<orders>1</orders>
-		<avg_price>1500</avg_price>
-		<avg_quantity>1</avg_quantity>
-		<conversion_rate>0%</conversion_rate>
-		<segment>productSku==SKU2</segment>
-	</row>
-	<row>
 		<label>SKU IN ABANDONED CART TWO</label>
 		<nb_visits>3</nb_visits>
 		<nb_actions>3</nb_actions>
@@ -42,5 +22,25 @@
 		<avg_quantity>1.5</avg_quantity>
 		<conversion_rate>66.67%</conversion_rate>
 		<segment>productSku==SKU+VERY+nice+indeed</segment>
+	</row>
+	<row>
+		<label>ANOTHER SKU HERE</label>
+		<revenue>600</revenue>
+		<quantity>6</quantity>
+		<orders>1</orders>
+		<avg_price>100</avg_price>
+		<avg_quantity>6</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productSku==ANOTHER+SKU+HERE</segment>
+	</row>
+	<row>
+		<label>SKU2</label>
+		<revenue>1500</revenue>
+		<quantity>1</quantity>
+		<orders>1</orders>
+		<avg_price>1500</avg_price>
+		<avg_quantity>1</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productSku==SKU2</segment>
 	</row>
 </result>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_productSkuSegmentSorted__Goals.getItemsSku_week.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_productSkuSegmentSorted__Goals.getItemsSku_week.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>ANOTHER SKU HERE</label>
+		<revenue>600</revenue>
+		<quantity>6</quantity>
+		<orders>1</orders>
+		<avg_price>100</avg_price>
+		<avg_quantity>6</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productSku==ANOTHER+SKU+HERE</segment>
+	</row>
+	<row>
+		<label>SKU2</label>
+		<revenue>1500</revenue>
+		<quantity>1</quantity>
+		<orders>1</orders>
+		<avg_price>1500</avg_price>
+		<avg_quantity>1</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productSku==SKU2</segment>
+	</row>
+	<row>
+		<label>SKU IN ABANDONED CART TWO</label>
+		<nb_visits>3</nb_visits>
+		<nb_actions>3</nb_actions>
+		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+		<avg_price>0</avg_price>
+		<avg_quantity>0</avg_quantity>
+		<conversion_rate>0%</conversion_rate>
+		<segment>productSku==SKU+IN+ABANDONED+CART+TWO</segment>
+	</row>
+	<row>
+		<label>SKU VERY nice indeed</label>
+		<revenue>1011.22</revenue>
+		<quantity>3</quantity>
+		<orders>2</orders>
+		<nb_visits>3</nb_visits>
+		<nb_actions>7</nb_actions>
+		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+		<avg_price>255.61</avg_price>
+		<avg_quantity>1.5</avg_quantity>
+		<conversion_rate>66.67%</conversion_rate>
+		<segment>productSku==SKU+VERY+nice+indeed</segment>
+	</row>
+</result>


### PR DESCRIPTION
### Description:

Sorting of ecommerce item reports currently does not work correctly in some case.
Sometimes when trying to sort for e.g. item views, the reports are sorted by label instead.

The reason for that can be found in the way the reports are built. As e.g. item view metrics are only added for those items that actually had any views tracked, not all rows the report contains the same set of columns.

The sorting is then currently broken, if the first row does not contain the column that was requested for sorting. See https://github.com/matomo-org/matomo/issues/21829#issuecomment-1912426832 for further details.

This fix was the one with the lowest required effort. It might nevertheless be good to start a discussion at some point around how to ensure that all rows in a report contain the same set of columns, as this could lead to problems elsewhere as well.

fixes #21829 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
