### PR TITLE
Check parameters for scheduled report sending early (4.x)

### DIFF
--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -373,6 +373,7 @@ class API extends \Piwik\Plugin\API
         $reports = $this->getReports($idSite = false, $_period = false, $idReport);
         $report = reset($reports);
 
+        $idReport = $report['idreport'];
         $idSite = $report['idsite'];
         $login  = $report['login'];
         $reportType = $report['type'];
@@ -385,6 +386,8 @@ class API extends \Piwik\Plugin\API
         }
 
         $this->checkSinglePeriod($period, $date);
+
+        $date = Date::factory($date)->toString('Y-m-d');
 
         // override report format
         if (!empty($reportFormat)) {
@@ -667,54 +670,56 @@ class API extends \Piwik\Plugin\API
 
             $reportType = $report['type'];
 
-            /**
-             * Triggered when sending scheduled reports.
-             *
-             * Plugins that provide new scheduled report transport mediums should use this event to
-             * send the scheduled report.
-             *
-             * @param string $reportType A string ID describing how the report is sent, eg,
-             *                           `'sms'` or `'email'`.
-             * @param array $report An array describing the scheduled report that is being
-             *                      generated.
-             * @param string $contents The contents of the scheduled report that was generated
-             *                         and now should be sent.
-             * @param string $filename The path to the file where the scheduled report has
-             *                         been saved.
-             * @param string $prettyDate A prettified date string for the data within the
-             *                           scheduled report.
-             * @param string $reportSubject A string describing what's in the scheduled
-             *                              report.
-             * @param string $reportTitle The scheduled report's given title (given by a Matomo user).
-             * @param array $additionalFiles The list of additional files that should be
-             *                               sent with this report.
-             * @param \Piwik\Period $period The period for which the report has been generated.
-             * @param boolean $force A report can only be sent once per period. Setting this to true
-             *                       will force to send the report even if it has already been sent.
-             */
-            Piwik::postEvent(
-                self::SEND_REPORT_EVENT,
-                [
-                    &$reportType,
-                    $report,
-                    $contents,
-                    $filename = basename($outputFilename),
-                    $prettyDate,
-                    $reportSubject,
-                    $reportTitle,
-                    $additionalFiles,
-                    \Piwik\Period\Factory::build($report['period_param'], $date),
-                    $force
-                ]
-            );
+            try {
+                /**
+                 * Triggered when sending scheduled reports.
+                 *
+                 * Plugins that provide new scheduled report transport mediums should use this event to
+                 * send the scheduled report.
+                 *
+                 * @param string $reportType A string ID describing how the report is sent, eg,
+                 *                           `'sms'` or `'email'`.
+                 * @param array $report An array describing the scheduled report that is being
+                 *                      generated.
+                 * @param string $contents The contents of the scheduled report that was generated
+                 *                         and now should be sent.
+                 * @param string $filename The path to the file where the scheduled report has
+                 *                         been saved.
+                 * @param string $prettyDate A prettified date string for the data within the
+                 *                           scheduled report.
+                 * @param string $reportSubject A string describing what's in the scheduled
+                 *                              report.
+                 * @param string $reportTitle The scheduled report's given title (given by a Matomo user).
+                 * @param array $additionalFiles The list of additional files that should be
+                 *                               sent with this report.
+                 * @param \Piwik\Period $period The period for which the report has been generated.
+                 * @param boolean $force A report can only be sent once per period. Setting this to true
+                 *                       will force to send the report even if it has already been sent.
+                 */
+                Piwik::postEvent(
+                    self::SEND_REPORT_EVENT,
+                    [
+                        &$reportType,
+                        $report,
+                        $contents,
+                        $filename = basename($outputFilename),
+                        $prettyDate,
+                        $reportSubject,
+                        $reportTitle,
+                        $additionalFiles,
+                        \Piwik\Period\Factory::build($report['period_param'], $date),
+                        $force
+                    ]
+                );
 
-            // Update flag in DB
-            $now = Date::now()->getDatetime();
-            $this->getModel()->updateReport($report['idreport'], ['ts_last_sent' => $now]);
-
-            if (!Development::isEnabled()) {
-                @chmod($outputFilename, 0600);
-                Filesystem::deleteFileIfExists($outputFilename);
+                // Update flag in DB
+                $now = Date::now()->getDatetime();
+                $this->getModel()->updateReport($report['idreport'], ['ts_last_sent' => $now]);
+            } finally {
+                if (!Development::isEnabled()) {
+                    @chmod($outputFilename, 0600);
+                    Filesystem::deleteFileIfExists($outputFilename);
+                }
             }
         });
     }

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -559,6 +559,47 @@ class ApiTest extends IntegrationTestCase
             $language = false, $outputType = APIScheduledReports::OUTPUT_RETURN);
     }
 
+    public function test_generateReport_throwsIfInvalidDateRequested(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ExceptionInvalidDateFormat');
+
+        $idReport = APIScheduledReports::getInstance()->addReport(
+            1,
+            '',
+            Schedule::PERIOD_DAY,
+            0,
+            ScheduledReports::EMAIL_TYPE,
+            ReportRenderer::HTML_FORMAT,
+            [
+                'VisitsSummary_get',
+            ],
+            [
+                ScheduledReports::DISPLAY_FORMAT_PARAMETER => ScheduledReports::DISPLAY_FORMAT_TABLES_ONLY
+            ]
+        );
+
+        APIScheduledReports::getInstance()->generateReport(
+            $idReport,
+            'DoesNotParse',
+            false,
+            APIScheduledReports::OUTPUT_RETURN
+        );
+    }
+
+    public function test_generateReport_throwsIfInvalidReportRequested(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Requested report couldn't be found.");
+
+        APIScheduledReports::getInstance()->generateReport(
+            1234567890,
+            Date::factory('now')->toString(),
+            false,
+            APIScheduledReports::OUTPUT_RETURN
+        );
+    }
+
     public function test_addReport_validatesEvolutionPeriodForParam()
     {
         $this->expectException(\Exception::class);


### PR DESCRIPTION
### Description:

Checks parameters for scheduled report sending earlier to avoid unnecessary load.

4.x version of https://github.com/matomo-org/matomo/pull/21864.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
