### PR TITLE
Ensure old ecommerce item data is handled correctly

### DIFF
--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -438,6 +438,8 @@ class API extends \Piwik\Plugin\API
             $rowView->deleteColumn(Metrics::INDEX_ECOMMERCE_ITEM_PRICE_VIEWED);
         }
 
+        $ecommerceViews->filter('ReplaceColumnNames');
+
         $dataTable->addDataTable($ecommerceViews);
     }
 


### PR DESCRIPTION
### Description:

Seems with #21863 the ecommerce item data that might previously been tracked as custom variables isn't used correctly anymore, as we now try to combine a table with renamed metrics, with one with still indexed ones.

Some UI tests around item views started to fail.... See e.g. https://builds-artifacts.matomo.org/matomo-org/matomo/dev-17568/7742649847/GoalsTable_goals_table_ecommerce_view.png

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
