### PR TITLE
Send a notification mail to all super users when anonymous access is enabled

### DIFF
--- a/plugins/CoreAdminHome/Emails/AnonymousAccessEnabledEmail.php
+++ b/plugins/CoreAdminHome/Emails/AnonymousAccessEnabledEmail.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\Emails;
+
+use Piwik\Piwik;
+use Piwik\Plugins\CoreAdminHome\Emails\SecurityNotificationEmail;
+
+class AnonymousAccessEnabledEmail extends SecurityNotificationEmail
+{
+    /**
+     * @var string
+     */
+    private $siteName;
+
+    public function __construct($login, $emailAddress, $siteName)
+    {
+        $this->siteName = html_entity_decode($siteName);
+
+        parent::__construct($login, $emailAddress);
+    }
+
+    protected function getBody()
+    {
+        return Piwik::translate('CoreAdminHome_SecurityNotificationAnonymousAccessEnabledBody', [$this->siteName]);
+    }
+}

--- a/plugins/CoreAdminHome/Emails/AnonymousAccessEnabledEmail.php
+++ b/plugins/CoreAdminHome/Emails/AnonymousAccessEnabledEmail.php
@@ -22,6 +22,8 @@ class AnonymousAccessEnabledEmail extends SecurityNotificationEmail
 
     public function __construct($login, $emailAddress, $siteName)
     {
+        // this property is used in a twig template, where it is escaped automatically
+        // so we decode it here, to avoid double encoding
         $this->siteName = html_entity_decode($siteName);
 
         parent::__construct($login, $emailAddress);

--- a/plugins/CoreAdminHome/lang/en.json
+++ b/plugins/CoreAdminHome/lang/en.json
@@ -115,6 +115,7 @@
         "ProtocolNotDetectedCorrectlySolution": "To make sure Matomo securely requests and serves your content over HTTPS, you may edit your %1$s file and either configure your proxy settings, or you may add the line %2$s below the %3$s section. %4$sLearn more%5$s",
         "ReleaseChannel": "Release channel",
         "SecurityNotificationAllTokenAuthDeletedBody": "Someone deleted all of the auth tokens in your account.",
+        "SecurityNotificationAnonymousAccessEnabledBody": "Someone enabled the anonymous user feature for %1$s. This means that the data for this site is publicly accessible. If this is ok, feel free to ignore this email.",
         "SecurityNotificationCheckTwoFactor": "Please check your two-factor authentication app or device.",
         "SecurityNotificationEmailSubject": "Security Notification",
         "SecurityNotificationIfItWasYou": "If it was you, carry on. If you don't recognize this activity, please reset your password.",

--- a/plugins/CoreAdminHome/lang/en.json
+++ b/plugins/CoreAdminHome/lang/en.json
@@ -115,7 +115,7 @@
         "ProtocolNotDetectedCorrectlySolution": "To make sure Matomo securely requests and serves your content over HTTPS, you may edit your %1$s file and either configure your proxy settings, or you may add the line %2$s below the %3$s section. %4$sLearn more%5$s",
         "ReleaseChannel": "Release channel",
         "SecurityNotificationAllTokenAuthDeletedBody": "Someone deleted all of the auth tokens in your account.",
-        "SecurityNotificationAnonymousAccessEnabledBody": "Someone enabled the anonymous user feature for %1$s. This means that the data for this site is publicly accessible. If this is ok, feel free to ignore this email.",
+        "SecurityNotificationAnonymousAccessEnabledBody": "Someone enabled anonymous user access for %1$s. This means that the data for this site is now publicly accessible. If this is ok, feel free to ignore this email.",
         "SecurityNotificationCheckTwoFactor": "Please check your two-factor authentication app or device.",
         "SecurityNotificationEmailSubject": "Security Notification",
         "SecurityNotificationIfItWasYou": "If it was you, carry on. If you don't recognize this activity, please reset your password.",

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -23,6 +23,7 @@ use Piwik\Date;
 use Piwik\NoAccessException;
 use Piwik\Option;
 use Piwik\Piwik;
+use Piwik\Plugins\CoreAdminHome\Emails\AnonymousAccessEnabledEmail;
 use Piwik\Plugins\CoreAdminHome\Emails\UserDeletedEmail;
 use Piwik\Plugins\Login\PasswordVerifier;
 use Piwik\Plugins\UsersManager\Emails\UserInfoChangedEmail;
@@ -1152,6 +1153,27 @@ class API extends \Piwik\Plugin\API
 
         if (!empty($capabilities)) {
             $this->addCapabilities($userLogin, $capabilities, $idSites);
+        }
+
+        // Send notification to all super users if anonymous access is set for a site
+        if ($userLogin === 'anonymous' && $access === 'view') {
+            $container = StaticContainer::getContainer();
+
+            $siteNames = [];
+
+            foreach ($idSites as $idSite) {
+                $siteNames[] = Site::getNameFor($idSite);
+            }
+
+            $superUsers = Piwik::getAllSuperUserAccessEmailAddresses();
+            foreach ($superUsers as $login => $email) {
+                $email = $container->make(AnonymousAccessEnabledEmail::class, array(
+                    'login' => $login,
+                    'emailAddress' => $email,
+                    'siteName' => implode(', ', $siteNames)
+                ));
+                $email->safeSend();
+            }
         }
 
         // we reload the access list which doesn't yet take in consideration this new user access


### PR DESCRIPTION
### Description:

With this PR giving view access to the anonymous user will send out a security notification to all super users.
This will be done to lower the risk that someone makes their Matomo data publicly accessible by accident.

refs DEV-13927

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
