### PR TITLE
Show search engine names in Transitions instead of keywords

### DIFF
--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -373,7 +373,7 @@ class API extends \Piwik\Plugin\API
         // the ranking query.
         $dimensions = array('referrer_data' => 'CASE log_visit.referer_type
 				WHEN ' . Common::REFERRER_TYPE_DIRECT_ENTRY . ' THEN \'\'
-				WHEN ' . Common::REFERRER_TYPE_SEARCH_ENGINE . ' THEN log_visit.referer_keyword
+				WHEN ' . Common::REFERRER_TYPE_SEARCH_ENGINE . ' THEN log_visit.referer_name
 				WHEN ' . Common::REFERRER_TYPE_SOCIAL_NETWORK . ' THEN log_visit.referer_name
 				WHEN ' . Common::REFERRER_TYPE_WEBSITE . ' THEN log_visit.referer_url
 				WHEN ' . Common::REFERRER_TYPE_CAMPAIGN . ' THEN CONCAT(log_visit.referer_name, \' \', log_visit.referer_keyword)

--- a/plugins/Transitions/tests/System/expected/test_Transitions__Transitions.getTransitionsForPageUrl_day.xml
+++ b/plugins/Transitions/tests/System/expected/test_Transitions__Transitions.getTransitionsForPageUrl_day.xml
@@ -81,12 +81,8 @@
 			<visits>2</visits>
 			<details>
 				<row>
-					<label>&lt;&gt;&amp;\&quot;the pdo extension is required for this adapter but the extension is not loaded</label>
-					<referrals>1</referrals>
-				</row>
-				<row>
-					<label>Unknown</label>
-					<referrals>1</referrals>
+					<label>Google</label>
+					<referrals>2</referrals>
 				</row>
 			</details>
 		</row>

--- a/plugins/Transitions/tests/System/expected/test_Transitions__Transitions.getTransitionsForPageUrl_month.xml
+++ b/plugins/Transitions/tests/System/expected/test_Transitions__Transitions.getTransitionsForPageUrl_month.xml
@@ -89,12 +89,8 @@
 			<visits>2</visits>
 			<details>
 				<row>
-					<label>&lt;&gt;&amp;\&quot;the pdo extension is required for this adapter but the extension is not loaded</label>
-					<referrals>1</referrals>
-				</row>
-				<row>
-					<label>Unknown</label>
-					<referrals>1</referrals>
+					<label>Google</label>
+					<referrals>2</referrals>
 				</row>
 			</details>
 		</row>

--- a/plugins/Transitions/tests/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageTitle_day.xml
+++ b/plugins/Transitions/tests/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageTitle_day.xml
@@ -97,12 +97,8 @@
 			<visits>2</visits>
 			<details>
 				<row>
-					<label>&lt;&gt;&amp;\&quot;the pdo extension is required for this adapter but the extension is not loaded</label>
-					<referrals>1</referrals>
-				</row>
-				<row>
-					<label>Unknown</label>
-					<referrals>1</referrals>
+					<label>Google</label>
+					<referrals>2</referrals>
 				</row>
 			</details>
 		</row>

--- a/plugins/Transitions/tests/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageTitle_month.xml
+++ b/plugins/Transitions/tests/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageTitle_month.xml
@@ -109,12 +109,8 @@
 			<visits>2</visits>
 			<details>
 				<row>
-					<label>&lt;&gt;&amp;\&quot;the pdo extension is required for this adapter but the extension is not loaded</label>
-					<referrals>1</referrals>
-				</row>
-				<row>
-					<label>Unknown</label>
-					<referrals>1</referrals>
+					<label>Google</label>
+					<referrals>2</referrals>
 				</row>
 			</details>
 		</row>

--- a/plugins/Transitions/tests/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageUrl_day.xml
+++ b/plugins/Transitions/tests/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageUrl_day.xml
@@ -85,12 +85,8 @@
 			<visits>2</visits>
 			<details>
 				<row>
-					<label>&lt;&gt;&amp;\&quot;the pdo extension is required for this adapter but the extension is not loaded</label>
-					<referrals>1</referrals>
-				</row>
-				<row>
-					<label>Unknown</label>
-					<referrals>1</referrals>
+					<label>Google</label>
+					<referrals>2</referrals>
 				</row>
 			</details>
 		</row>

--- a/plugins/Transitions/tests/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageUrl_month.xml
+++ b/plugins/Transitions/tests/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageUrl_month.xml
@@ -93,12 +93,8 @@
 			<visits>2</visits>
 			<details>
 				<row>
-					<label>&lt;&gt;&amp;\&quot;the pdo extension is required for this adapter but the extension is not loaded</label>
-					<referrals>1</referrals>
-				</row>
-				<row>
-					<label>Unknown</label>
-					<referrals>1</referrals>
+					<label>Google</label>
+					<referrals>2</referrals>
 				</row>
 			</details>
 		</row>

--- a/plugins/Transitions/tests/System/expected/test_Transitions_withSegment__Transitions.getTransitionsForPageTitle_day.xml
+++ b/plugins/Transitions/tests/System/expected/test_Transitions_withSegment__Transitions.getTransitionsForPageTitle_day.xml
@@ -97,12 +97,8 @@
 			<visits>2</visits>
 			<details>
 				<row>
-					<label>&lt;&gt;&amp;\&quot;the pdo extension is required for this adapter but the extension is not loaded</label>
-					<referrals>1</referrals>
-				</row>
-				<row>
-					<label>Unknown</label>
-					<referrals>1</referrals>
+					<label>Google</label>
+					<referrals>2</referrals>
 				</row>
 			</details>
 		</row>

--- a/plugins/Transitions/tests/System/expected/test_Transitions_withSegment__Transitions.getTransitionsForPageUrl_day.xml
+++ b/plugins/Transitions/tests/System/expected/test_Transitions_withSegment__Transitions.getTransitionsForPageUrl_day.xml
@@ -81,12 +81,8 @@
 			<visits>2</visits>
 			<details>
 				<row>
-					<label>&lt;&gt;&amp;\&quot;the pdo extension is required for this adapter but the extension is not loaded</label>
-					<referrals>1</referrals>
-				</row>
-				<row>
-					<label>Unknown</label>
-					<referrals>1</referrals>
+					<label>Google</label>
+					<referrals>2</referrals>
 				</row>
 			</details>
 		</row>

--- a/plugins/Transitions/tests/UI/Transitions_spec.js
+++ b/plugins/Transitions/tests/UI/Transitions_spec.js
@@ -83,6 +83,11 @@ describe("Transitions", function () {
         expect(await page.screenshotSelector('body')).to.matchImage('transitions_report_switch_type_title');
     });
 
+    it('should show the search engines when clicked', async function () {
+        await page.evaluate(() => $('.Transitions_SingleLine:contains(From search engines)').click());
+        expect(await page.screenshotSelector('body')).to.matchImage('transitions_report_search_engines');
+    });
+
     it('should show period not allowed for disabled periods', async function () {
 
         testEnvironment.overrideConfig('Transitions_1', 'max_period_allowed', 'day');

--- a/plugins/Transitions/tests/UI/expected-screenshots/Transitions_transitions_report_search_engines.png
+++ b/plugins/Transitions/tests/UI/expected-screenshots/Transitions_transitions_report_search_engines.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c7b6e8d82699d39a1c7e70ecb51d62ce2b7acd1216955becfb35f02e44e490a
+size 179831


### PR DESCRIPTION
### Description:

The transitions overlay is currently showing how many visitors came from search engines. Below that category it shows the keywords that had been used. While this was very useful years ago, it meanwhile has almost no value anymore.
All major search engines are meanwhile hiding there keywords, resulting in the list to mainly list `Unknown`

![image](https://github.com/matomo-org/matomo/assets/20234985/5fffb19f-0fb9-45b8-94a8-8454e5ce0a98)

To deliver some value in showing that list it's more of use to show the names of search engines that were used:

![image](https://github.com/matomo-org/matomo/assets/1579355/4a620e9d-9d49-4ecb-8ad9-55897e007bbf)

fixes #21143

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
