### PR TITLE
Ensure to only abort the loading request for a popover when closing it

### DIFF
--- a/plugins/CoreHome/javascripts/popover.js
+++ b/plugins/CoreHome/javascripts/popover.js
@@ -12,6 +12,7 @@ var Piwik_Popover = (function () {
     var closeCallback = false;
     var isProgrammaticClose = false;
     var scrollTopPosition = 0;
+    var ajaxLoadingRequest = null;
 
     var createContainer = function () {
         if (container === false) {
@@ -63,7 +64,11 @@ var Piwik_Popover = (function () {
                 container.find('div.jqplot-target').trigger('piwikDestroyPlot');
                 container[0].innerHTML = '';
                 container.dialog('destroy').remove();
-                globalAjaxQueue.abort();
+
+                if (ajaxLoadingRequest) {
+                    ajaxLoadingRequest.abort();
+                }
+
                 $('.ui-widget-overlay').off('click.popover');
                 isOpen = false;
                 require('piwik/UI').UIControl.cleanupUnusedControls();
@@ -310,6 +315,8 @@ var Piwik_Popover = (function () {
             ajaxRequest.setCallback(callback);
             ajaxRequest.setFormat('html');
             ajaxRequest.send();
+
+            ajaxLoadingRequest = ajaxRequest;
         },
 
         isOpen: function() {


### PR DESCRIPTION
### Description:

Closing a modal / popover currently aborts all running requests. This can lead to problems if there are still some request running that are unrelated to the popover.

It can e.g. be reproduced when the What's new overlay is being loaded.
If you close the modal while the dashboard in background has not yet finished loaded, all dashboard related requests will be terminated and Matomo ends up being in a state where nothing can be performed anymore.

This PR changes the behavior, so that only the initial request to load the content for the popover will be aborted.
If the content being loaded would trigger further ajax requests, those additional requests will no longer be terminated by the popover being closed. This means that popovers need to handle their request-aborting themselves if required.

fixes #21511

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
