### PR TITLE
Filter special whitespace when rendering ImageGraphs without unifont

### DIFF
--- a/plugins/ImageGraph/StaticGraph.php
+++ b/plugins/ImageGraph/StaticGraph.php
@@ -269,7 +269,7 @@ abstract class StaticGraph extends BaseFactory
         $abscissaSeries = $this->abscissaSeries;
         $formatMethodName = 'formatYAxis';
 
-        if (!str_ends_with($this->font, API::UNICODE_FONT)) {
+        if (false === strpos($this->font, API::UNICODE_FONT)) {
             $abscissaSeries = array_map([$this, 'fixWhitespaceNonUnifont'], $abscissaSeries);
             $formatMethodName = 'formatYAxisNonUnifont';
         }

--- a/plugins/ImageGraph/tests/UI/ImageGraph_spec.js
+++ b/plugins/ImageGraph/tests/UI/ImageGraph_spec.js
@@ -26,6 +26,12 @@ describe("ImageGraph", function () {
         expect(await page.screenshot({ fullPage: true })).to.matchImage('evolution_graph');
     });
 
+    it("should render evolution graphs correctly for week dates", async function() {
+        await page.goto(getImageGraphUrl('VisitsSummary', 'get', 'evolution', 'week', '2011-06-01,2012-06-01'));
+
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('evolution_graph_week');
+    });
+
     it("should render horizontal bar graphs correctly", async function() {
         await page.goto(getImageGraphUrl('DevicesDetection', 'getBrowsers', 'horizontalBar', 'year', '2012-01-01'));
 

--- a/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_evolution_graph_week.png
+++ b/plugins/ImageGraph/tests/UI/expected-screenshots/ImageGraph_evolution_graph_week.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66393f2e1593d9906a19ac95a6b93b380f4e42fa87e13642807b39055894a432
+size 11450


### PR DESCRIPTION
### Description:

When generating an email report after selecting a week period, the dates can be displayed with broken unicode symbols when the default font is used:

![](https://github.com/matomo-org/matomo/assets/635801/072e0dbf-a0af-41d9-8317-294b7ade5f2f)

This appears to have been introduced by #19932 (Intl update for CLDR 42):

- https://unicode-org.atlassian.net/browse/CLDR-14032
- https://icu.unicode.org/download/72 (Common changes -> CLDR 42 -> "In many formatting patterns...")

I have only found `&thinsp;` and `&nnbsp;` in our locale files, simply converting them to a regular space or `&nbsp;` should solve the rendering errors.

Refs #20953 (the initial fix for `&nnbsp;` characters)
Fixes #21867

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
