### PR TITLE
Added code to allow empty passwordConfirmation value by default for skipPasswordConfiirmation action to work without password

### DIFF
--- a/plugins/TwoFactorAuth/API.php
+++ b/plugins/TwoFactorAuth/API.php
@@ -22,7 +22,7 @@ class API extends \Piwik\Plugin\API
         $this->twoFa = $twoFa;
     }
 
-    public function resetTwoFactorAuth($userLogin, $passwordConfirmation)
+    public function resetTwoFactorAuth($userLogin, $passwordConfirmation = '')
     {
         Piwik::checkUserHasSuperUserAccess();
 

--- a/plugins/TwoFactorAuth/config/test.php
+++ b/plugins/TwoFactorAuth/config/test.php
@@ -66,12 +66,5 @@ return array(
         });
 
         return $previous;
-    }),
-    'observers.global' => \Piwik\DI::add([
-        ['Login.userRequiresPasswordConfirmation', \Piwik\DI::value(function (&$requiresPasswordConfirmation, $login) {
-            if ($login === 'superUserLogin') {
-                $requiresPasswordConfirmation = false;
-            }
-        })],
-    ]),
+    })
 );

--- a/plugins/TwoFactorAuth/config/test.php
+++ b/plugins/TwoFactorAuth/config/test.php
@@ -66,5 +66,12 @@ return array(
         });
 
         return $previous;
-    })
+    }),
+    'observers.global' => \Piwik\DI::add([
+        ['Login.userRequiresPasswordConfirmation', \Piwik\DI::value(function (&$requiresPasswordConfirmation, $login) {
+            if ($login === 'superUserLogin') {
+                $requiresPasswordConfirmation = false;
+            }
+        })],
+    ]),
 );

--- a/plugins/TwoFactorAuth/tests/Integration/APITest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/APITest.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\TwoFactorAuth\tests\Integration;
 
 use Piwik\Container\StaticContainer;
+use Piwik\Piwik;
 use Piwik\Plugins\TwoFactorAuth\API;
 use Piwik\Plugins\TwoFactorAuth\Dao\RecoveryCodeDao;
 use Piwik\Plugins\TwoFactorAuth\TwoFactorAuthentication;
@@ -81,6 +82,9 @@ class APITest extends IntegrationTestCase
         $this->assertEquals([], $this->recoveryCodes->getAllRecoveryCodesForLogin('mylogin1'));
 
         //Reset without a password
+        Piwik::addAction('Login.userRequiresPasswordConfirmation', function (&$requiresPasswordConfirmation) {
+            $requiresPasswordConfirmation = false;
+        });
         $this->api->resetTwoFactorAuth('mylogin2');
         $this->assertFalse(TwoFactorAuthentication::isUserUsingTwoFactorAuthentication('mylogin2'));
     }

--- a/plugins/TwoFactorAuth/tests/Integration/APITest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/APITest.php
@@ -79,6 +79,10 @@ class APITest extends IntegrationTestCase
         $this->assertTrue(TwoFactorAuthentication::isUserUsingTwoFactorAuthentication('mylogin2'));
 
         $this->assertEquals([], $this->recoveryCodes->getAllRecoveryCodesForLogin('mylogin1'));
+
+        //Reset without a password
+        $this->api->resetTwoFactorAuth('mylogin2');
+        $this->assertFalse(TwoFactorAuthentication::isUserUsingTwoFactorAuthentication('mylogin2'));
     }
 
     protected function setAdminUser()


### PR DESCRIPTION
### Description:

Added code to allow empty passwordConfirmation value by default for skipPasswordConfiirmation action to work without password
Fixes: #PG-3290

To test this issue, add the below code to any of your `config/config.php` in any Activated plugin and try to reset a 2FA without entering any password
```
return [
    'observers.global' => \DI\add([
        ['Login.userRequiresPasswordConfirmation', \DI\value(function (&$requiresPasswordConfirmation, $login) {
            $requiresPasswordConfirmation = false;
        })],
    ]),
];
```

a. Definition of done achieved - Yes
b. Testcases added - Yes (Added an Integration to test the behaviour)
c. If unable to add a testcases, do mention a reason as sometime, it is difficult to add testcases for some scenarios - N/A
d. Textual changes sourced from product team ? - N/A (No new translations)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
