### PR TITLE
Add newly expected plugin fields to system test

### DIFF
--- a/plugins/Marketplace/tests/System/Api/ClientTest.php
+++ b/plugins/Marketplace/tests/System/Api/ClientTest.php
@@ -71,6 +71,7 @@ class ClientTest extends SystemTestCase
             'latestVersion',
             'numDownloads',
             'screenshots',
+            'coverImage',
             'previews',
             'activity',
             'featured',
@@ -84,7 +85,9 @@ class ClientTest extends SystemTestCase
             'versions',
             'isDownloadable',
             'changelog',
-            'consumer');
+            'consumer',
+            'category',
+        );
 
         $this->assertNotEmpty($plugin);
         $this->assertEquals($expectedPluginKeys, array_keys($plugin));
@@ -97,6 +100,8 @@ class ClientTest extends SystemTestCase
         $this->assertFalse($plugin['isPaid']);
         $this->assertFalse($plugin['isCustomPlugin']);
         $this->assertNotEmpty($plugin['versions']);
+        $this->assertNotEmpty($plugin['coverImage']);
+        $this->assertNotEmpty($plugin['category']);
 
         $lastVersion = $plugin['versions'][count($plugin['versions']) - 1];
         $this->assertEquals(


### PR DESCRIPTION
### Description:

Adding new fields returned by the plugins marketplace to a system test.
This can be merged once the marketplace PR is merged and deployed in order for this test to succeed.

Follow up to #21879

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
