### PR TITLE
Never show changes older than 6 months in What's new popover

### DIFF
--- a/plugins/CoreHome/tests/Integration/ChangesTest.php
+++ b/plugins/CoreHome/tests/Integration/ChangesTest.php
@@ -24,9 +24,17 @@ class ChangesTest extends IntegrationTestCase
      */
     public static $fixture;
 
-    public function test_CoreHomeChanges_ShouldSortChangeListMostRecentFirst()
+    public function testCoreHomeChangesShouldNotReturnChangesOlderThan6Months()
     {
-        $json = '{"idchange":3,"plugin_name":"CoreHome","version":"4.6.0b5","title":"New feature x added","description":"Now you can do a with b like this","link_name":"For more information go here","link":"https:\/\/www.matomo.org"}';
+        $changesModel = new ChangesModel();
+        $changes = $changesModel->getChangeItems();
+        self::assertCount(3, $changes);
+        self::assertNotContains(1, array_column($changes, 'idchange'));
+    }
+
+    public function testCoreHomeChangesShouldSortChangeListMostRecentFirst()
+    {
+        $json = '{"idchange":4,"plugin_name":"CoreHome","version":"4.6.0b5","title":"New feature x added","description":"Now you can do a with b like this","link_name":"For more information go here","link":"https:\/\/www.matomo.org"}';
         $changesModel = new ChangesModel();
         $changes = $changesModel->getChangeItems();
         $r = reset($changes);
@@ -34,9 +42,9 @@ class ChangesTest extends IntegrationTestCase
         $this->assertEquals($json, json_encode($r, true));
     }
 
-    public function test_CoreHomeChanges_ShouldAllowChangeItemAddWithoutLink()
+    public function testCoreHomeChangesShouldAllowChangeItemAddWithoutLink()
     {
-        $json = '{"idchange":2,"plugin_name":"CoreHome","version":"4.5.0","title":"New feature y added","description":"Now you can do c with d like this","link_name":null,"link":null}';
+        $json = '{"idchange":3,"plugin_name":"CoreHome","version":"4.5.0","title":"New feature y added","description":"Now you can do c with d like this","link_name":null,"link":null}';
         $changesModel = new ChangesModel();
         $changes = $changesModel->getChangeItems();
         $r = $changes[1];

--- a/tests/PHPUnit/Fixtures/CreateChanges.php
+++ b/tests/PHPUnit/Fixtures/CreateChanges.php
@@ -1,14 +1,18 @@
 <?php
+
 /**
  * Matomo - free/libre analytics platform
  *
  * @link https://matomo.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
+
 namespace Piwik\Tests\Fixtures;
 
 use Piwik\Changes\Model as ChangesModel;
+use Piwik\Common;
 use Piwik\Date;
+use Piwik\Db;
 use Piwik\Tests\Framework\Fixture;
 
 class CreateChanges extends Fixture
@@ -28,6 +32,14 @@ class CreateChanges extends Fixture
 
     private function createChanges()
     {
+        // Manually insert a change that is older than 6 months
+        Db::query(
+            "INSERT INTO `" . Common::prefixTable('changes') . "`
+                   (`idchange`, `created_time`, `plugin_name`, `version`, `title`, `description`, `link_name`, `link`)
+               VALUES
+                   (1, '2021-12-17 12:46:04', 'ExamplePlugin', '4.0.1', 'New feature y added', 'Now you can do c with d like this.', NULL, NULL);"
+        );
+
 
         $changes = [
             [


### PR DESCRIPTION
### Description:

What's new entries might currently be shown very long. Even months after they had been initially added.
This happens because the current logic tries to show at least 10 records even if they are older.

This PR changes the logic, so that the popover will always show all entries, that were added within the last 6 months.
Any older records will be hidden. 

fixes #20334

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
