### PR TITLE
Improve handling of float request values

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -553,10 +553,12 @@ class Common
                     $ok = true;
                 }
             } elseif ($varType === 'float') {
-                $valueToCompare = (string)(float)$value;
-                $valueToCompare = Common::forceDotAsSeparatorForDecimalPoint($valueToCompare);
+                $valueToCompare = Common::forceDotAsSeparatorForDecimalPoint($value);
 
-                if ($value == $valueToCompare) {
+                // simplyfied regex for float; without support for underscore notation
+                $floatRegex = "/^[+-]?((([0-9]+)|(([0-9]+)?\.([0-9]+))|(([0-9]+)\.([0-9]+)?))([eE][+-]?([0-9]+))?)$/";
+
+                if (preg_match($floatRegex, $valueToCompare)) {
                     $ok = true;
                 }
             } elseif ($varType === 'array') {

--- a/core/Common.php
+++ b/core/Common.php
@@ -555,7 +555,7 @@ class Common
             } elseif ($varType === 'float') {
                 $valueToCompare = Common::forceDotAsSeparatorForDecimalPoint($value);
 
-                // simplyfied regex for float; without support for underscore notation
+                // simplified regex for float; without support for underscore notation
                 $floatRegex = "/^[+-]?((([0-9]+)|(([0-9]+)?\.([0-9]+))|(([0-9]+)\.([0-9]+)?))([eE][+-]?([0-9]+))?)$/";
 
                 if (preg_match($floatRegex, $valueToCompare)) {

--- a/core/Common.php
+++ b/core/Common.php
@@ -555,7 +555,9 @@ class Common
             } elseif ($varType === 'float') {
                 $valueToCompare = Common::forceDotAsSeparatorForDecimalPoint($value);
 
-                // simplified regex for float; without support for underscore notation
+                // Simplified regex for float without support for underscore notation
+                // will match:  1.234, 1.2e3, 7E-10
+                // won't match: 1_234.567
                 $floatRegex = "/^[+-]?((([0-9]+)|(([0-9]+)?\.([0-9]+))|(([0-9]+)\.([0-9]+)?))([eE][+-]?([0-9]+))?)$/";
 
                 if (preg_match($floatRegex, $valueToCompare)) {

--- a/core/Request.php
+++ b/core/Request.php
@@ -169,7 +169,7 @@ class Request
             return (float)$parameter;
         }
 
-        // Regex for all supported float notations in PHP. See https://www.php.net/manual/en/language.types.float.php
+        // Regex for all supported float notations in PHP (see https://www.php.net/manual/en/language.types.float.php)
         $floatRegex = "/^[-+]?((([0-9]+(_[0-9]+)*)|(([0-9]+(_[0-9]+)*)?\.([0-9]+(_[0-9]+)*))|(([0-9]+(_[0-9]+)*)\.([0-9]+(_[0-9]+)*)?))([eE][+-]?([0-9]+(_[0-9]+)*))?)$/";
 
         if (is_string($parameter) && preg_match($floatRegex, $parameter)) {

--- a/core/Request.php
+++ b/core/Request.php
@@ -165,12 +165,16 @@ class Request
     {
         $parameter = $this->getParameter($name, $default);
 
-        if (
-            (is_string($parameter) || is_numeric($parameter)) &&
-            ((string)$parameter === (string)(float)$parameter ||
-            (string)$parameter === (string)(int)$parameter)
-        ) {
+        if (is_float($parameter) || is_int($parameter)) {
             return (float)$parameter;
+        }
+
+        // Regex for all supported float notations in PHP. See https://www.php.net/manual/en/language.types.float.php
+        $floatRegex = "/^[-+]?((([0-9]+(_[0-9]+)*)|(([0-9]+(_[0-9]+)*)?\.([0-9]+(_[0-9]+)*))|(([0-9]+(_[0-9]+)*)\.([0-9]+(_[0-9]+)*)?))([eE][+-]?([0-9]+(_[0-9]+)*))?)$/";
+
+        if (is_string($parameter) && preg_match($floatRegex, $parameter)) {
+            // underscores would break numbers if not removed before
+            return (float) str_replace('_', '', $parameter);
         }
 
         if (null !== $default) {

--- a/tests/PHPUnit/Unit/CommonTest.php
+++ b/tests/PHPUnit/Unit/CommonTest.php
@@ -173,11 +173,33 @@ class CommonTest extends TestCase
         $this->assertEquals($_GET['test'], Common::getRequestVar('test'));
     }
 
-    public function testGetRequestVar_GetStringFloatGiven()
+    /**
+     * @dataProvider getValidFloatValues
+     */
+    public function testGetRequestVarFloatValues($requestValue, $expectedValue)
     {
-        $_GET['test'] = 1413.431413;
+        $_GET['test'] = $requestValue;
         $value        = Common::getRequestVar('test', null, 'string');
-        $this->assertEquals('1413.431413', $value);
+        $this->assertEquals($expectedValue, $value);
+    }
+
+    public function getValidFloatValues(): iterable
+    {
+        yield 'Integer value' => [17, 17.0];
+        yield 'Float value' => [17.123, 17.123];
+        yield 'String value' => ['17.123', 17.123];
+        yield 'Negative string value' => ['-17.123', -17.123];
+        yield 'Positive string value' => ['+17.123', 17.123];
+        yield 'String value, only fraction digits' => ['.123', 0.123];
+        yield 'String value, no fraction digits' => ['123.e-3', 0.123];
+        yield 'Negative string value, only fraction digits' => ['-.123', -0.123];
+        yield 'Exp value' => [2e-2, 0.02];
+        yield 'String exp value' => ['2e-3', 0.002];
+        yield 'String Exp value' => ['1.2E-26', 1.2E-26];
+        yield 'Octal exp value' => [0123e-2, 1.23];
+        yield 'Octal value as string' => ['0123', 123.0];
+        yield 'String value with many digits' => ['1254254645455484545.1', 1.2542546454554847E+18];
+        yield 'String value with many fraction digits' => ['14.051545421864646123', 14.051545421864645];
     }
 
     public function testGetRequestVar_GetStringIntegerGiven()

--- a/tests/PHPUnit/Unit/RequestTest.php
+++ b/tests/PHPUnit/Unit/RequestTest.php
@@ -177,8 +177,19 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         yield 'Integer value' => [17, 17.0];
         yield 'Float value' => [17.123, 17.123];
         yield 'String value' => ['17.123', 17.123];
+        yield 'Negative string value' => ['-17.123', -17.123];
+        yield 'Positive string value' => ['+17.123', 17.123];
+        yield 'String value, only fraction digits' => ['.123', 0.123];
+        yield 'String value, no fraction digits' => ['123.e-3', 0.123];
+        yield 'Negative string value, only fraction digits' => ['-.123', -0.123];
         yield 'Exp value' => [2e-2, 0.02];
+        yield 'String exp value' => ['2e-3', 0.002];
+        yield 'String Exp value' => ['1.2E-26', 1.2E-26];
         yield 'Octal exp value' => [0123e-2, 1.23];
+        yield 'Octal value as string' => ['0123', 123.0];
+        yield 'Underscore notation as string' => ['1_123.123_33', 1123.12333];
+        yield 'String value with many digits' => ['1254254645455484545.1', 1.2542546454554847E+18];
+        yield 'String value with many fraction digits' => ['14.051545421864646123', 14.051545421864645];
     }
 
     /**
@@ -209,10 +220,9 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         yield 'random string' => ['random string'];
         yield 'array' => [['x' => 'y']];
         yield 'object' => [new \stdClass()];
-        yield 'Exp value as string' => ['2e-3'];
         yield 'Hex value as string' => ['0x3'];
         yield 'Binary value as string' => ['0b11'];
-        yield 'Octal value as string' => ['0123'];
+        yield 'Invalid exp float string' => ['4e5.5'];
     }
 
     /**


### PR DESCRIPTION
### Description:

The code responsible for parsing request values was inaccurate in some cases, when the expected type is a floating digit.
This could cause numbers with more than 14 digits or in unexpected notations to simply get thrown away.

This PR ensures that we check strings for a correct float format correctly. All format supported by PHP should then be detected and used correctly.

fixes #21314 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
