### PR TITLE
Include date in CLI logging

### DIFF
--- a/plugins/Monolog/config/cli.php
+++ b/plugins/Monolog/config/cli.php
@@ -33,6 +33,7 @@ return array(
         );
         $handler = new ConsoleHandler(null, true, $verbosityMap);
         $handler->setFormatter(new \Piwik\Plugins\Monolog\Formatter\ConsoleFormatter([
+            'date_format' => 'Y-m-d H:i:s',
             'format' => $c->get('log.console.format'),
             'multiline' => true
         ]));


### PR DESCRIPTION
### Description:

Log output on CLI seems to have changed slightly with Matomo 5:

before Matomo 5: INFO [2024-02-01 22:27:07] 8632  INIT
Matomo 5: INFO      [08:03:33] 11096  INIT

As the date is quite useful, this PR readds it to the logging on CLI.

fixes #21924

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
