### PR TITLE
Write archive records with writer reconnection attempt

### DIFF
--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -18,6 +18,7 @@ use Piwik\Date;
 use Piwik\Db;
 use Piwik\Db\BatchInsert;
 use Piwik\Log\LoggerInterface;
+use Piwik\SettingsServer;
 
 /**
  * This class is used to create a new Archive.
@@ -305,8 +306,15 @@ class ArchiveWriter
 
     public function flushSpools()
     {
-        $this->flushSpool('numeric');
-        $this->flushSpool('blob');
+        if (SettingsServer::isArchivePhpTriggered()) {
+            Db::executeWithDatabaseWriterReconnectionAttempt(function () {
+                $this->flushSpool('numeric');
+                $this->flushSpool('blob');
+            });
+        } else {
+            $this->flushSpool('numeric');
+            $this->flushSpool('blob');
+        }
     }
 
     private function flushSpool($valueType)

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -548,11 +548,7 @@ class Model
         $bindSql[] = $value;
         $bindSql[] = $value;
 
-        if (SettingsServer::isArchivePhpTriggered()) {
-            Db::queryWithWriterReconnectionAttempt($query, $bindSql);
-        } else {
-            Db::query($query, $bindSql);
-        }
+        Db::query($query, $bindSql);
 
         return true;
     }

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -548,7 +548,11 @@ class Model
         $bindSql[] = $value;
         $bindSql[] = $value;
 
-        Db::query($query, $bindSql);
+        if (SettingsServer::isArchivePhpTriggered()) {
+            Db::queryWithWriterReconnectionAttempt($query, $bindSql);
+        } else {
+            Db::query($query, $bindSql);
+        }
 
         return true;
     }

--- a/core/Db.php
+++ b/core/Db.php
@@ -309,10 +309,10 @@ class Db
                 throw $ex;
             }
 
-            // only attempt reconnection if we encounter a "MySQL server has gone away" error
+            // only attempt reconnection if we encounter a "server has gone away" error
             if (
                 !self::get()->isErrNo($ex, Updater\Migration\Db::ERROR_CODE_MYSQL_SERVER_HAS_GONE_AWAY)
-                && false === stripos($ex->getMessage(), 'MySQL server has gone away')
+                && false === stripos($ex->getMessage(), 'server has gone away')
             ) {
                 throw $ex;
             }

--- a/core/Db.php
+++ b/core/Db.php
@@ -10,6 +10,7 @@ namespace Piwik;
 
 use Exception;
 use Piwik\Db\Adapter;
+use Zend_Db_Statement;
 
 /**
  * Contains SQL related helper functions for Piwik's MySQL database.
@@ -237,8 +238,8 @@ class Db
      * [Zend_Db_Statement](http://framework.zend.com/manual/1.12/en/zend.db.statement.html) object.
      *
      * @param string $sql The SQL query.
-     * @throws \Exception If there is an error in the SQL.
-     * @return integer|\Zend_Db_Statement
+     * @throws Exception If there is an error in the SQL.
+     * @return integer|Zend_Db_Statement
      */
     public static function exec($sql)
     {
@@ -270,8 +271,8 @@ class Db
      *
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
-     * @throws \Exception If there is a problem with the SQL or bind parameters.
-     * @return \Zend_Db_Statement
+     * @throws Exception If there is a problem with the SQL or bind parameters.
+     * @return Zend_Db_Statement
      */
     public static function query($sql, $parameters = array())
     {
@@ -286,11 +287,61 @@ class Db
     }
 
     /**
+     * Executes a query with potential recovery from a "MySQL server has gone away" error.
+     *
+     * If the query is issued and
+     *
+     *   - a database reader has been configured
+     *   - the MySQL server has "gone away"
+     *
+     * the query will be retried after a single reconnection attempt.
+     *
+     * @param string $sql
+     * @param array<int|string, mixed> $parameters
+     *
+     * @return Zend_Db_Statement
+     *
+     * @throws Exception
+     *
+     * @internal
+     */
+    public static function queryWithWriterReconnectionAttempt(
+        string $sql,
+        array $parameters = []
+    ): Zend_Db_Statement {
+        try {
+            return self::query($sql, $parameters);
+        } catch (Exception $ex) {
+            // only attempt reconnection in a reader/writer configuration
+            if (!self::hasReaderConfigured()) {
+                throw $ex;
+            }
+
+            // only attempt reconnection if we encounter a "MySQL server has gone away" error
+            if (
+                !self::get()->isErrNo($ex, Updater\Migration\Db::ERROR_CODE_MYSQL_SERVER_HAS_GONE_AWAY)
+                && false === stripos($ex->getMessage(), 'MySQL server has gone away')
+            ) {
+                throw $ex;
+            }
+
+            // reconnect and retry query
+            // after a 100ms wait (to avoid re-hitting a network problem immediately)
+            self::$connection = null;
+
+            usleep(100 * 1000);
+            self::createDatabaseObject();
+
+            return self::query($sql, $parameters);
+        }
+    }
+
+    /**
      * Executes an SQL `SELECT` statement and returns all fetched rows from the result set.
      *
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
-     * @throws \Exception If there is a problem with the SQL or bind parameters.
+     * @throws Exception If there is a problem with the SQL or bind parameters.
      * @return array The fetched rows, each element is an associative array mapping column names
      *               with column values.
      */
@@ -311,7 +362,7 @@ class Db
      *
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
-     * @throws \Exception If there is a problem with the SQL or bind parameters.
+     * @throws Exception If there is a problem with the SQL or bind parameters.
      * @return array The fetched row, each element is an associative array mapping column names
      *               with column values.
      */
@@ -333,7 +384,7 @@ class Db
      *
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
-     * @throws \Exception If there is a problem with the SQL or bind parameters.
+     * @throws Exception If there is a problem with the SQL or bind parameters.
      * @return string
      */
     public static function fetchOne($sql, $parameters = array())
@@ -354,7 +405,7 @@ class Db
      *
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
-     * @throws \Exception If there is a problem with the SQL or bind parameters.
+     * @throws Exception If there is a problem with the SQL or bind parameters.
      * @return array eg,
      *               ```
      *               array('col1value1' => array('col2' => '...', 'col3' => ...),
@@ -483,7 +534,7 @@ class Db
      *
      * @param string|array $tables The name of the table to drop or an array of table names to drop.
      *                             Table names must be prefixed (see {@link Piwik\Common::prefixTable()}).
-     * @return \Zend_Db_Statement
+     * @return Zend_Db_Statement
      */
     public static function dropTables($tables)
     {
@@ -513,7 +564,7 @@ class Db
      *                                   be prefixed (see {@link Piwik\Common::prefixTable()}).
      * @param string|array $tablesToWrite The table or tables to obtain 'write' locks on. Table names must
      *                                    be prefixed (see {@link Piwik\Common::prefixTable()}).
-     * @return \Zend_Db_Statement
+     * @return Zend_Db_Statement
      */
     public static function lockTables($tablesToRead, $tablesToWrite = array())
     {
@@ -543,7 +594,7 @@ class Db
      * **NOTE:** Piwik does not require the `LOCK TABLES` privilege to be available. Piwik
      * should still work if it has not been granted.
      *
-     * @return \Zend_Db_Statement
+     * @return Zend_Db_Statement
      */
     public static function unlockAllTables()
     {
@@ -723,13 +774,14 @@ class Db
      *
      * @param string $lockName The lock name.
      * @param int $maxRetries The max number of times to retry.
+     *
      * @return bool `true` if the lock was obtained, `false` if otherwise.
-     * @throws \Exception if Lock name is too long
+     * @throws Exception if Lock name is too long
      */
     public static function getDbLock($lockName, $maxRetries = 30)
     {
         if (strlen($lockName) > 64) {
-            throw new \Exception('DB lock name has to be 64 characters or less for MySQL 5.7 compatibility.');
+            throw new Exception('DB lock name has to be 64 characters or less for MySQL 5.7 compatibility.');
         }
 
         /*
@@ -811,7 +863,7 @@ class Db
 
             // log using exception so backtrace appears in log output
             Log::debug(new Exception("Encountered deadlock: " . print_r($deadlockInfo, true)));
-        } catch(\Exception $e) {
+        } catch(Exception $e) {
             //  1227 Access denied; you need (at least one of) the PROCESS privilege(s) for this operation
         }
     }
@@ -842,7 +894,7 @@ class Db
 
         foreach ($parameters as $index => $parameter) {
             if ($parameter instanceof Date) {
-                throw new \Exception("Found bound parameter (index = $index) is Date instance which will not work correctly in following SQL: $sql");
+                throw new Exception("Found bound parameter (index = $index) is Date instance which will not work correctly in following SQL: $sql");
             }
         }
     }

--- a/core/Db.php
+++ b/core/Db.php
@@ -10,7 +10,6 @@ namespace Piwik;
 
 use Exception;
 use Piwik\Db\Adapter;
-use Zend_Db_Statement;
 
 /**
  * Contains SQL related helper functions for Piwik's MySQL database.
@@ -238,8 +237,8 @@ class Db
      * [Zend_Db_Statement](http://framework.zend.com/manual/1.12/en/zend.db.statement.html) object.
      *
      * @param string $sql The SQL query.
-     * @throws Exception If there is an error in the SQL.
-     * @return integer|Zend_Db_Statement
+     * @throws \Exception If there is an error in the SQL.
+     * @return integer|\Zend_Db_Statement
      */
     public static function exec($sql)
     {
@@ -271,8 +270,8 @@ class Db
      *
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
-     * @throws Exception If there is a problem with the SQL or bind parameters.
-     * @return Zend_Db_Statement
+     * @throws \Exception If there is a problem with the SQL or bind parameters.
+     * @return \Zend_Db_Statement
      */
     public static function query($sql, $parameters = array())
     {
@@ -334,7 +333,7 @@ class Db
      *
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
-     * @throws Exception If there is a problem with the SQL or bind parameters.
+     * @throws \Exception If there is a problem with the SQL or bind parameters.
      * @return array The fetched rows, each element is an associative array mapping column names
      *               with column values.
      */
@@ -355,7 +354,7 @@ class Db
      *
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
-     * @throws Exception If there is a problem with the SQL or bind parameters.
+     * @throws \Exception If there is a problem with the SQL or bind parameters.
      * @return array The fetched row, each element is an associative array mapping column names
      *               with column values.
      */
@@ -377,7 +376,7 @@ class Db
      *
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
-     * @throws Exception If there is a problem with the SQL or bind parameters.
+     * @throws \Exception If there is a problem with the SQL or bind parameters.
      * @return string
      */
     public static function fetchOne($sql, $parameters = array())
@@ -398,7 +397,7 @@ class Db
      *
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
-     * @throws Exception If there is a problem with the SQL or bind parameters.
+     * @throws \Exception If there is a problem with the SQL or bind parameters.
      * @return array eg,
      *               ```
      *               array('col1value1' => array('col2' => '...', 'col3' => ...),
@@ -527,7 +526,7 @@ class Db
      *
      * @param string|array $tables The name of the table to drop or an array of table names to drop.
      *                             Table names must be prefixed (see {@link Piwik\Common::prefixTable()}).
-     * @return Zend_Db_Statement
+     * @return \Zend_Db_Statement
      */
     public static function dropTables($tables)
     {
@@ -557,7 +556,7 @@ class Db
      *                                   be prefixed (see {@link Piwik\Common::prefixTable()}).
      * @param string|array $tablesToWrite The table or tables to obtain 'write' locks on. Table names must
      *                                    be prefixed (see {@link Piwik\Common::prefixTable()}).
-     * @return Zend_Db_Statement
+     * @return \Zend_Db_Statement
      */
     public static function lockTables($tablesToRead, $tablesToWrite = array())
     {
@@ -587,7 +586,7 @@ class Db
      * **NOTE:** Piwik does not require the `LOCK TABLES` privilege to be available. Piwik
      * should still work if it has not been granted.
      *
-     * @return Zend_Db_Statement
+     * @return \Zend_Db_Statement
      */
     public static function unlockAllTables()
     {
@@ -767,14 +766,13 @@ class Db
      *
      * @param string $lockName The lock name.
      * @param int $maxRetries The max number of times to retry.
-     *
      * @return bool `true` if the lock was obtained, `false` if otherwise.
-     * @throws Exception if Lock name is too long
+     * @throws \Exception if Lock name is too long
      */
     public static function getDbLock($lockName, $maxRetries = 30)
     {
         if (strlen($lockName) > 64) {
-            throw new Exception('DB lock name has to be 64 characters or less for MySQL 5.7 compatibility.');
+            throw new \Exception('DB lock name has to be 64 characters or less for MySQL 5.7 compatibility.');
         }
 
         /*
@@ -856,7 +854,7 @@ class Db
 
             // log using exception so backtrace appears in log output
             Log::debug(new Exception("Encountered deadlock: " . print_r($deadlockInfo, true)));
-        } catch(Exception $e) {
+        } catch(\Exception $e) {
             //  1227 Access denied; you need (at least one of) the PROCESS privilege(s) for this operation
         }
     }
@@ -887,7 +885,7 @@ class Db
 
         foreach ($parameters as $index => $parameter) {
             if ($parameter instanceof Date) {
-                throw new Exception("Found bound parameter (index = $index) is Date instance which will not work correctly in following SQL: $sql");
+                throw new \Exception("Found bound parameter (index = $index) is Date instance which will not work correctly in following SQL: $sql");
             }
         }
     }

--- a/tests/PHPUnit/Integration/DbTest.php
+++ b/tests/PHPUnit/Integration/DbTest.php
@@ -185,7 +185,7 @@ class DbTest extends IntegrationTestCase
                 $dbException,
                 \Piwik\Updater\Migration\Db::ERROR_CODE_MYSQL_SERVER_HAS_GONE_AWAY
             )
-            || false !== stripos($dbException->getMessage(), 'MySQL server has gone away')
+            || false !== stripos($dbException->getMessage(), 'server has gone away')
         );
     }
 

--- a/tests/PHPUnit/Integration/DbTest.php
+++ b/tests/PHPUnit/Integration/DbTest.php
@@ -129,7 +129,9 @@ class DbTest extends IntegrationTestCase
         Config::getInstance()->database_reader = Config::getInstance()->database;
 
         $connectionId = $this->setUpMySQLHasGoneAwayConnection();
-        $reconnectionId = Db::queryWithWriterReconnectionAttempt('SELECT CONNECTION_ID()')->fetchColumn();
+        $reconnectionId = Db::executeWithDatabaseWriterReconnectionAttempt(function () {
+            return Db::query('SELECT CONNECTION_ID()')->fetchColumn();
+        });
 
         self::assertNotSame($connectionId, $reconnectionId);
     }
@@ -141,7 +143,9 @@ class DbTest extends IntegrationTestCase
         $dbException = null;
 
         try {
-            Db::queryWithWriterReconnectionAttempt('SELECT CONNECTION_ID()');
+            Db::executeWithDatabaseWriterReconnectionAttempt(function () {
+                Db::query('SELECT 1');
+            });
         } catch (Exception $e) {
             $dbException = $e;
         }


### PR DESCRIPTION
### Description:

When using a reader/writer database configuration, it can happen that the writer connection times out while the archive data is being collected.

For cron archiving, this can this can lead to lengthy re-archiving times.

This PR should only be seen as an intermediate solution to that problem until #21807 is implemented.

Fixes #21873.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
