### PR TITLE
Pass number of users and sites along when starting a free trial

### DIFF
--- a/plugins/Marketplace/API.php
+++ b/plugins/Marketplace/API.php
@@ -42,16 +42,23 @@ class API extends \Piwik\Plugin\API
      */
     private $pluginManager;
 
+    /**
+     * @var Environment
+     */
+    private $environment;
+
     public function __construct(
         Service $service,
         Client $client,
         InvalidLicenses $expired,
-        PluginManager $pluginManager
+        PluginManager $pluginManager,
+        Environment $environment
     ) {
         $this->marketplaceService = $service;
         $this->marketplaceClient  = $client;
         $this->expired = $expired;
         $this->pluginManager = $pluginManager;
+        $this->environment = $environment;
     }
 
     /**
@@ -90,7 +97,10 @@ class API extends \Piwik\Plugin\API
         try {
             $result = $this->marketplaceService->fetch(
                 'plugins/' . $pluginName . '/freeTrial',
-                [],
+                [
+                    'num_users' => $this->environment->getNumUsers(),
+                    'num_websites' => $this->environment->getNumWebsites(),
+                ],
                 true
             );
         } catch (Service\Exception $e) {


### PR DESCRIPTION
### Description:

There are two API clients for the marketplace and one is caching the responses and is passing along the information, and then one that is around the licensing that doesn't cache and wasn't passing the information, so this PR adds the number of users and number of sites to the start free trial API call.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
