### PR TITLE
Cache additional site urls in live visitor details

### DIFF
--- a/plugins/Live/VisitorDetails.php
+++ b/plugins/Live/VisitorDetails.php
@@ -317,15 +317,15 @@ class VisitorDetails extends VisitorDetailsAbstract
         $cache = Cache::getTransientCache();
         $cacheKey = 'Live.additionalSiteUrls.' . $this->getIdSite();
 
-        if (!$cache->contains($cacheKey)) {
-            $sitesModel = new \Piwik\Plugins\SitesManager\Model();
-
-            $cache->save(
-                $cacheKey,
-                $sitesModel->getAliasSiteUrlsFromId($this->getIdSite())
-            );
+        if ($cache->contains($cacheKey)) {
+            return $cache->fetch($cacheKey);
         }
 
-        return $cache->fetch($cacheKey);
+        $sitesModel = new \Piwik\Plugins\SitesManager\Model();
+        $aliasSiteUrls = $sitesModel->getAliasSiteUrlsFromId($this->getIdSite());
+
+        $cache->save($cacheKey, $aliasSiteUrls);
+
+        return $aliasSiteUrls;
     }
 }

--- a/plugins/Live/VisitorDetails.php
+++ b/plugins/Live/VisitorDetails.php
@@ -11,7 +11,6 @@
 namespace Piwik\Plugins\Live;
 
 use Piwik\API\Request;
-use Piwik\Cache;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Date;
@@ -318,7 +317,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 
     /**
      * @return array<int, array<string>>
-    */
+     */
     private function getAdditionalUrlsForSite(int $idSite): array
     {
         if (isset($this->cachedAdditionalSiteUrls[$idSite])) {


### PR DESCRIPTION
### Description:

Rendering the details for a visitor (common) action makes use of the site alias URLs to render the action URL.

Every action fetches these URLs from the database without any caching, issuing lots of db queries while always receiving the same data.

Adding a transient cache to the URL lookup should reduce the amount of database queries to one per site.

Fixes #21971.

_Note_: I decided to skip a test for this. Only checking the cache usage seems extremely narrow for the setup/maintenance overhead. Will happily add a small test that checks for cache calls (and more?), if there is benefit in having one.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
