### PR TITLE
Prevent exception if gd extension is missing

### DIFF
--- a/core/Visualization/Sparkline.php
+++ b/core/Visualization/Sparkline.php
@@ -221,15 +221,17 @@ class Sparkline implements ViewInterface
 
     public function render()
     {
-        if (empty($this->sparkline->getSeriesCount())) {
+        if (!$this->sparkline instanceof \Davaxi\Sparkline) {
+            return;
+        }
+
+        if (0 === $this->sparkline->getSeriesCount()) {
             // ensure to have at least one series & point in sparkline to avoid possible php notices/errors
             // a sparkline will then be displayed with a zero line
             $this->sparkline->addSeries([0]);
         }
 
-        if ($this->sparkline instanceof \Davaxi\Sparkline) {
-            $this->sparkline->display();
-            $this->sparkline->destroy();
-        }
+        $this->sparkline->display();
+        $this->sparkline->destroy();
     }
 }


### PR DESCRIPTION
### Description:

If the `gd` extension is missing, the sparklines graphs are not rendered. After #21090 a missing extension can lead to exceptions, for example breaking the campaign row evolution popover:

```
Call to a member function getSeriesCount() on null
in /srv/matomo/core/Visualization/Sparkline.php line 228
```

This fix should prevent exceptions, while still displaying the broken image placeholders: 

![](https://github.com/matomo-org/matomo/assets/635801/8ec039e5-97f4-4992-81e8-2f657fa543d3)

Fixes #22001

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
