### PR TITLE
Fix tests:check-direct-dependency-use command not working with plugins when test running on Github

### DIFF
--- a/plugins/TestRunner/Commands/CheckDirectDependencyUse.php
+++ b/plugins/TestRunner/Commands/CheckDirectDependencyUse.php
@@ -83,7 +83,7 @@ class CheckDirectDependencyUse extends ConsoleCommand
         $rgOutput = [];
 
         if ($plugin) {
-            $plugin = '/' . $plugin;
+            $plugin = '/plugins/' . $plugin;
         }
 
         $vendorScan = '--glob=\\!vendor';
@@ -98,7 +98,7 @@ class CheckDirectDependencyUse extends ConsoleCommand
             $regex = '\\b' . preg_quote($prefix) . '_';
         }
 
-        $command = 'rg \'' . $regex . '\' --glob=*.php ' . $vendorScan . ' --json --sort path ' . PIWIK_INCLUDE_PATH . '/plugins' . $plugin;
+        $command = 'rg \'' . $regex . '\' --glob=*.php ' . $vendorScan . ' --json --sort path ' . PIWIK_INCLUDE_PATH . $plugin;
         exec($command, $rgOutput, $returnCode);
 
         if (isset($returnCode) && $returnCode == 127) {
@@ -119,7 +119,7 @@ class CheckDirectDependencyUse extends ConsoleCommand
             array_shift($parts);
             $pluginName = array_shift($parts);
 
-            if (file_exists(PIWIK_INCLUDE_PATH . '/plugins/' . $pluginName . '/.git')) {
+            if ($pluginName) {
                 $remainingPath = implode('/', $parts);
                 $uses[$pluginName][] = $remainingPath;
             }
@@ -138,7 +138,7 @@ class CheckDirectDependencyUse extends ConsoleCommand
         $output->writeln("<info>Found '$prefix' ($type) usage in:</info>");
         foreach ($directUses as $plugin => $files) {
             foreach ($files as $file) {
-                $this->usesFoundList[$plugin][$prefix][] = $plugin . '/' . $file;
+                $this->usesFoundList[rtrim($plugin, '\\')][rtrim($prefix, '\\')][] = $plugin . '/' . $file;
             }
             $output->writeln("  - $plugin, " . count($files) . " files");
         }

--- a/plugins/TestRunner/tests/System/CheckDirectDependencyUseCommandTest.php
+++ b/plugins/TestRunner/tests/System/CheckDirectDependencyUseCommandTest.php
@@ -42,8 +42,8 @@ class CheckDirectDependencyUseCommandTest extends SystemTestCase
     public function getTestDataForDependencyCheck()
     {
         return [
-            ['TestRunner', []],
-            ['Provider', ['Matomo\Network\\' => ['Provider/Columns/Provider.php']]],
+            ['TestRunner', ['Symfony\Component\Console' => ['TestRunner/tests/System/CheckDirectDependencyUseCommandTest.php']]],
+            ['Provider', ['Matomo\Network' => ['Provider/Columns/Provider.php']]],
         ];
     }
 }


### PR DESCRIPTION
### Description:

This [PR](https://github.com/matomo-org/matomo/pull/21969/) worked fine locally, but when the PR was merged and we tried using it with plugins the tests started failing and on debugging we were able to find the cause and fix the same.

Fixes: #PG-3334

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
