### PR TITLE
Set autocomplete property on login form fields

### DIFF
--- a/plugins/Login/templates/login.twig
+++ b/plugins/Login/templates/login.twig
@@ -37,7 +37,7 @@
                             <input type="hidden" name="form_nonce" id="login_form_nonce" value="{{ nonce }}"/>
                             <input type="hidden" name="form_redirect" id="login_form_redirect" value=""/>
                             <input type="password" placeholder="" name="form_password" id="login_form_password" class="input" value="" size="20"
-                                   autocorrect="off" autocapitalize="none" spellcheck="false"
+                                   autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false"
                                    tabindex="20" />
                             <label for="login_form_password"><i class="icon-locked icon"></i> {{ 'General_Password'|translate }}</label>
                         </div>

--- a/plugins/Login/templates/login.twig
+++ b/plugins/Login/templates/login.twig
@@ -25,8 +25,8 @@
                 <form {{ form_data.attributes|raw }} ng-non-bindable>
                     <div class="row">
                         <div class="col s12 input-field">
-                            <input type="text" name="form_login" placeholder="" id="login_form_login" class="input" value="" size="20"
-                                   autocorrect="off" autocapitalize="none"
+                            <input type="text" name="form_login" id="login_form_login" class="input" value="" size="20"
+                                   placeholder="" autocomplete="username" autocorrect="off" autocapitalize="none" spellcheck="false"
                                    tabindex="10" autofocus="autofocus"/>
                             <label for="login_form_login"><i class="icon-user icon"></i> {{ 'Login_LoginOrEmail'|translate }}</label>
                         </div>
@@ -36,8 +36,8 @@
                         <div class="col s12 input-field">
                             <input type="hidden" name="form_nonce" id="login_form_nonce" value="{{ nonce }}"/>
                             <input type="hidden" name="form_redirect" id="login_form_redirect" value=""/>
-                            <input type="password" placeholder="" name="form_password" id="login_form_password" class="input" value="" size="20"
-                                   autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false"
+                            <input type="password" name="form_password" id="login_form_password" class="input" value="" size="20"
+                                   placeholder="" autocomplete="current-password" autocorrect="off" autocapitalize="none" spellcheck="false"
                                    tabindex="20" />
                             <label for="login_form_password"><i class="icon-locked icon"></i> {{ 'General_Password'|translate }}</label>
                         </div>


### PR DESCRIPTION
### Description:

This PR sets `autocomplete='current-password'` for the password field and `autocomplete='username'` for the userlogin field on the main Matomo login page as the missing property sometime gets flagged as a security risk by security software.

Based on this [this comment](https://github.com/matomo-org/matomo/issues/6347#issuecomment-1357669041) from a previous issue we should have `autocomplete` property set on all password fields.

Fixes #22020

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
