### PR TITLE
Fix scheduled report generation for custom periods

### DIFF
--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -393,9 +393,7 @@ class API extends \Piwik\Plugin\API
             $period = $report['period_param'];
         }
 
-        $this->checkSinglePeriod($period, $date);
-
-        $date = Date::factory($date)->toString('Y-m-d');
+        $this->checkDateAndPeriodCombination($date, $period);
 
         // override report format
         if (!empty($reportFormat)) {
@@ -1108,10 +1106,18 @@ class API extends \Piwik\Plugin\API
         }
     }
 
-    private function checkSinglePeriod($period, $date)
+    private function checkDateAndPeriodCombination($date, $period): void
     {
+        if ('range' === $period) {
+            Period::checkDateFormat($date);
+
+            return;
+        }
+
         if (Period::isMultiplePeriod($date, $period)) {
             throw new Http\BadRequestException("This API method does not support multiple periods.");
         }
+
+        Date::factory($date);
     }
 }

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -571,6 +571,82 @@ class ApiTest extends IntegrationTestCase
         self::assertStringNotContainsString('id="UserCountry_getCountry"', $result);
     }
 
+    /**
+     * @dataProvider getValidDatePeriodCombinationsForGenerateReport
+     *
+     * @param string|false $period
+     */
+    public function test_generateReport_generatesAReportForAllValidDatePeriodCombinations(
+        string $date,
+        $period
+    ): void {
+        $idReport = APIScheduledReports::getInstance()->addReport(
+            1,
+            '',
+            Schedule::PERIOD_DAY,
+            0,
+            ScheduledReports::EMAIL_TYPE,
+            ReportRenderer::HTML_FORMAT,
+            [
+                'VisitsSummary_get',
+            ],
+            [
+                ScheduledReports::DISPLAY_FORMAT_PARAMETER => ScheduledReports::DISPLAY_FORMAT_TABLES_ONLY
+            ]
+        );
+
+        $result = APIScheduledReports::getInstance()->generateReport(
+            $idReport,
+            $date,
+            false,
+            APIScheduledReports::OUTPUT_RETURN,
+            $period
+        );
+
+        self::assertStringContainsString('id="VisitsSummary_get"', $result);
+    }
+
+    /**
+     * @return iterable<string, array{string, string|false}>
+     */
+    public function getValidDatePeriodCombinationsForGenerateReport(): iterable
+    {
+        yield 'default period' => [
+            '2024-01-01',
+            false,
+        ];
+
+        yield 'single day' => [
+            '2024-01-01',
+            'day',
+        ];
+
+        yield 'single week' => [
+            '2024-01-01',
+            'week',
+        ];
+
+        yield 'single month' => [
+            '2024-01-01',
+            'month',
+        ];
+
+        yield 'single year' => [
+            '2024-01-01',
+            'year',
+        ];
+
+        yield 'custom range' => [
+            '2024-01-01,2024-01-02',
+            'range',
+        ];
+
+        yield 'named range' => [
+            'last7',
+            'range',
+        ];
+    }
+
     public function test_generateReport_throwsIfMultiplePeriodsRequested()
     {
         $this->expectException(\Piwik\Http\BadRequestException::class);
@@ -599,8 +675,15 @@ class ApiTest extends IntegrationTestCase
         );
     }
 
-    public function test_generateReport_throwsIfInvalidDateRequested(): void
-    {
+    /**
+     * @dataProvider getInvalidDatePeriodCombinationsForGenerateReport
+     *
+     * @param string|false $period
+     */
+    public function test_generateReport_throwsIfInvalidDatePeriodCombinationRequested(
+        string $date,
+        $period
+    ): void {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('General_ExceptionInvalidDateFormat');
 
@@ -621,10 +704,37 @@ class ApiTest extends IntegrationTestCase
 
         APIScheduledReports::getInstance()->generateReport(
             $idReport,
-            'DoesNotParse',
+            $date,
             false,
-            APIScheduledReports::OUTPUT_RETURN
+            APIScheduledReports::OUTPUT_RETURN,
+            $period
         );
+    }
+
+    /**
+     * @return iterable<string, array{string, string|false}>
+     */
+    public function getInvalidDatePeriodCombinationsForGenerateReport(): iterable
+    {
+        yield 'invalid default period' => [
+            '2024-xx-01',
+            false,
+        ];
+
+        yield 'invalid day' => [
+            '2024.01.01',
+            'day',
+        ];
+
+        yield 'invalid range format' => [
+            '2024-01-01//2024-01-02',
+            'range',
+        ];
+
+        yield 'invalid named range' => [
+            'lastTen',
+            'range',
+        ];
     }
 
     public function test_generateReport_throwsIfInvalidReportRequested(): void


### PR DESCRIPTION
### Description:

A regression was introduced in #21864 effectively breaking scheduled report generation for ranges.

Various tests have been added to check if a date/period combination is usable to generate a report or if it should throw an early exception.

Fixes #21945 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
