### PR TITLE
Fix scheduled report generation for custom periods (4.x)

### DIFF
--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -385,9 +385,7 @@ class API extends \Piwik\Plugin\API
             $period = $report['period_param'];
         }
 
-        $this->checkSinglePeriod($period, $date);
-
-        $date = Date::factory($date)->toString('Y-m-d');
+        $this->checkDateAndPeriodCombination($date, $period);
 
         // override report format
         if (!empty($reportFormat)) {
@@ -1088,10 +1086,18 @@ class API extends \Piwik\Plugin\API
         }
     }
 
-    private function checkSinglePeriod($period, $date)
+    private function checkDateAndPeriodCombination($date, $period): void
     {
+        if ('range' === $period) {
+            Period::checkDateFormat($date);
+
+            return;
+        }
+
         if (Period::isMultiplePeriod($date, $period)) {
             throw new Http\BadRequestException("This API method does not support multiple periods.");
         }
+
+        Date::factory($date);
     }
 }


### PR DESCRIPTION
### Description:

A regression was introduced in #21865 effectively breaking scheduled report generation for ranges.

Various tests have been added to check if a date/period combination is usable to generate a report or if it should throw an early exception.

4.x version of #22030.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
