### PR TITLE
Ignore anonymous user when checking for allowed domains

### DIFF
--- a/plugins/UsersManager/Validators/AllowedEmailDomain.php
+++ b/plugins/UsersManager/Validators/AllowedEmailDomain.php
@@ -48,7 +48,9 @@ class AllowedEmailDomain extends BaseValidator
         $users = Request::processRequest('UsersManager.getUsers');
         $domains = [];
         foreach ($users as $user) {
-            $domains[] = AllowedEmailDomain::getDomainFromEmail($user['email']);
+            if ($user['login'] !== 'anonymous') {
+                $domains[] = AllowedEmailDomain::getDomainFromEmail($user['email']);
+            }
         }
         return array_values(array_unique($domains));
     }

--- a/plugins/UsersManager/Validators/AllowedEmailDomain.php
+++ b/plugins/UsersManager/Validators/AllowedEmailDomain.php
@@ -52,7 +52,11 @@ class AllowedEmailDomain extends BaseValidator
                 $domains[] = AllowedEmailDomain::getDomainFromEmail($user['email']);
             }
         }
-        return array_values(array_unique($domains));
+
+        $domains = array_values(array_unique($domains));
+        sort($domains);
+
+        return $domains;
     }
 
     public function validate($value)

--- a/plugins/UsersManager/tests/Integration/SystemSettingsTest.php
+++ b/plugins/UsersManager/tests/Integration/SystemSettingsTest.php
@@ -8,6 +8,8 @@
 
 namespace Piwik\Plugins\UsersManager\tests\Integration;
 
+use Piwik\Db\Schema\Mysql;
+use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\UsersManager\SystemSettings;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -78,8 +80,10 @@ class SystemSettingsTest extends IntegrationTestCase
     public function test_allowedEmailDomain_wontAllowSavingDomainsIfOtherDomainsExist()
     {
         Fixture::loadAllTranslations();
-        $this->expectExceptionMessage('Setting the domains is not possible as other domains (example.org) are already in use by other users. To change this setting, you either need to delete users with other domains or you need to allow these domains as well.');
-        Fixture::createSuperUser();
+        $this->expectExceptionMessage('Setting the domains is not possible as other domains (limited.com) are already in use by other users. To change this setting, you either need to delete users with other domains or you need to allow these domains as well.');
+        $schema = new Mysql();
+        $schema->createAnonymousUser(); // anonymous user should be ignore in checks
+        UsersManagerAPI::getInstance()->addUser('randomUser', 'smartypants', 'user@limited.com');
         $this->settings->allowedEmailDomains->setValue(['maToMo.org', 'matomo.org', '', 'examPle.CoM']);
     }
 }

--- a/plugins/UsersManager/tests/Integration/Validators/AllowedEmailDomainTest.php
+++ b/plugins/UsersManager/tests/Integration/Validators/AllowedEmailDomainTest.php
@@ -105,7 +105,7 @@ class AllowedEmailDomainTest extends IntegrationTestCase
         $userApi->addUser('foo6', 'foo' . time(), 'foobar2@example.org');
 
         $this->assertEquals([
-            'matomo.org', 'matomo.com', 'example.com', 'example.org'
+            'example.com', 'example.org', 'matomo.com', 'matomo.org',
         ], $this->validator->getEmailDomainsInUse());
     }
 

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_settings_general.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_settings_general.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b0b98ab50ecd6ec488c95560453408ecf7e25e40e1c15cbd7c5622041ecb331
+oid sha256:22e36fe5ba5ff54073aa3de64c76d0d61d118811e6a0f9a98ed1e8d4ffbb8809
 size 1338072


### PR DESCRIPTION
### Description:

Matomo allows to configure allowed email domains. Only email addresses that matches those domains can then be used.
To avoid any current users to become "invalid" the list always needs to contain all domains for existent users.
This at the moment also contains the domain of the automatically created `anonymous` user, which is `example.org`. As it doesn't make sense to always allow addresses for this domain only because of the anonymous user, this PR changes the code, so the anonymous user's email domain is ignored for this setting and checks.

fixes #22009

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
