### PR TITLE
Ensure segmentation form is correctly reset

### DIFF
--- a/plugins/SegmentEditor/javascripts/Segmentation.js
+++ b/plugins/SegmentEditor/javascripts/Segmentation.js
@@ -592,9 +592,7 @@ Segmentation = (function($) {
         var addForm = function(mode, segment){
 
             self.target.find(".segment-element:visible").unbind().remove();
-            if (typeof self.form !== "undefined") {
-                closeForm();
-            }
+            closeForm();
             // remove any remaining forms
 
 
@@ -670,19 +668,21 @@ Segmentation = (function($) {
             });
             app.mount(segmentGeneratorContainer);
 
-            this.addEventListener('matomoVueDestroy', function () {
+            segmentGeneratorContainer.addEventListener('matomoVueDestroy', function () {
               app.unmount();
             });
         };
 
         var closeForm = function () {
-            $(self.form).find('.segment-generator-container')[0].dispatchEvent(
-              new CustomEvent('matomoVueDestroy'),
-            );
-
             self.currentSegmentStr = '';
 
-            $(self.form).unbind().remove();
+            if (typeof self.form !== "undefined") {
+              $(self.form).find('.segment-generator-container')[0].dispatchEvent(
+                new CustomEvent('matomoVueDestroy'),
+              );
+
+              $(self.form).unbind().remove();
+            }
             self.target.closest('.segmentEditorPanel').removeClass('editing');
         };
 


### PR DESCRIPTION
### Description:

When a segment is currently selected in Matomo and the `add new segment` button is clicked within the segment editor, the displayed form might show the currently selected segments definition instead of being empty. This PR fixes the behavior, so it is always displayed empty, when adding a new segment.

fixes #22045

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
