### PR TITLE
Never send a user creation email to anonymous user

### DIFF
--- a/plugins/UsersManager/Repository/UserRepository.php
+++ b/plugins/UsersManager/Repository/UserRepository.php
@@ -126,12 +126,14 @@ class UserRepository
 
     protected function sendUserCreationNotification(string $createdUserLogin): void
     {
-        $mail = StaticContainer::getContainer()->make(UserCreatedEmail::class, [
-            'login'        => Piwik::getCurrentUserLogin(),
-            'emailAddress' => Piwik::getCurrentUserEmail(),
-            'userLogin'    => $createdUserLogin,
-        ]);
-        $mail->safeSend();
+        if (Piwik::getCurrentUserLogin() !== 'anonymous') {
+            $mail = StaticContainer::getContainer()->make(UserCreatedEmail::class, [
+                'login' => Piwik::getCurrentUserLogin(),
+                'emailAddress' => Piwik::getCurrentUserEmail(),
+                'userLogin' => $createdUserLogin,
+            ]);
+            $mail->safeSend();
+        }
     }
 
     protected function sendInvitationEmail(array $user, string $inviteToken, int $expiryInDays): void


### PR DESCRIPTION
### Description:

When a user is created (not invited), a notification mail is sent to the user, who created the new one.
This currently also happens when users are created by the system (e.g. through plugins or commands).
In this case no user is currently logged in, causing the email being send to the anonymous user.
This PR will avoid this.

fixes #22068

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
