### PR TITLE
Ensure to correctly parse `lang` tracking parameter

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -314,7 +314,8 @@ class Request
      */
     public function getBrowserLanguage()
     {
-        return Common::getRequestVar('lang', Common::getBrowserLanguage(), 'string', $this->params);
+        $parameterValue = Common::getRequestVar('lang', '', 'string', $this->params);
+        return Common::getBrowserLanguage($parameterValue ?: null);
     }
 
     /**

--- a/tests/PHPUnit/Unit/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestTest.php
@@ -250,13 +250,22 @@ class RequestTest extends UnitTestCase
         $this->assertSame('My Custom UA', $request->getUserAgent());
     }
 
-    public function test_getBrowserLanguage_ShouldReturnACustomSetLangParam_IfOneIsSet()
+    public function testGetBrowserLanguageShouldReturnLanguageHeaderIfProvided()
     {
-        $request = $this->buildRequest(array('lang' => 'CusToMLang'));
-        $this->assertSame('CusToMLang', $request->getBrowserLanguage());
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US,en;q=0.5';
+        $this->assertSame('en-us,en', $this->request->getBrowserLanguage());
+        unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
     }
 
-    public function test_getBrowserLanguage_ShouldReturnADefaultLanguageInCaseNoneIsSet()
+    public function testGetBrowserLanguageShouldPreferACustomSetLangParamOverHeader()
+    {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US,en;q=0.5';
+        $request = $this->buildRequest(array('lang' => 'CusToMLang'));
+        $this->assertSame('customlang', $request->getBrowserLanguage());
+        unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+    }
+
+    public function testGetBrowserLanguageShouldReturnADefaultLanguageInCaseNoneIsSet()
     {
         $envLanguage = getenv('LANG');
         putenv('LANG=en');


### PR DESCRIPTION
### Description:

Matomo by defaults detects the language of a tracked visitor by parsing the http language header. As that one might not be available in all cases, the tracking API in addition allows to overwrite this by send the `lang` parameter.

The tracking api documentation says: `An override value for the Accept-Language HTTP header field` 

This indicates that the provided value should be handled the same as the header value. In fact its the case, that the handling currently differs, as for the header value a `strtolower´ and some sort of clean up is applied here:

https://github.com/matomo-org/matomo/blob/9183cc6280ad6ec17185b21903e37837906f3e13/core/Common.php#L836-L847

This is currently not done for the `lang` parameter, as it is used as is. This PR applies a simple change, so that cleanup will be done in that case as well.

fixes #22077 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
