### PR TITLE
Update resolution in subsequent tracking requests if previously unknown

### DIFF
--- a/plugins/Resolution/Columns/Resolution.php
+++ b/plugins/Resolution/Columns/Resolution.php
@@ -39,7 +39,6 @@ class Resolution extends VisitDimension
 
         return $resolution;
     }
-    
     /**
      * @param Request $request
      * @param Visitor $visitor

--- a/plugins/Resolution/Columns/Resolution.php
+++ b/plugins/Resolution/Columns/Resolution.php
@@ -47,7 +47,7 @@ class Resolution extends VisitDimension
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {
-        // In case the value was initially unknown, update it from a subsequent page impression
+        // In case the value was initially unknown, update it from a subsequent action
         if ($visitor->getVisitorColumn($this->columnName) === Request::UNKNOWN_RESOLUTION) {
             return $this->onNewVisit($request, $visitor, $action);
         } else {

--- a/plugins/Resolution/Columns/Resolution.php
+++ b/plugins/Resolution/Columns/Resolution.php
@@ -39,4 +39,20 @@ class Resolution extends VisitDimension
 
         return $resolution;
     }
+    
+    /**
+     * @param Request $request
+     * @param Visitor $visitor
+     * @param Action|null $action
+     * @return mixed 
+     */
+    public function onExistingVisit(Request $request, Visitor $visitor, $action)
+    {
+        // In case the value was initially unknown, update it from a subsequent page impression
+        if ($visitor->getVisitorColumn($this->columnName) === Request::UNKNOWN_RESOLUTION) {
+            return $this->onNewVisit($request, $visitor, $action);
+        } else {
+            return false;
+        }
+    }
 }

--- a/plugins/Resolution/Columns/Resolution.php
+++ b/plugins/Resolution/Columns/Resolution.php
@@ -43,7 +43,7 @@ class Resolution extends VisitDimension
      * @param Request $request
      * @param Visitor $visitor
      * @param Action|null $action
-     * @return mixed 
+     * @return mixed
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/Resolution/tests/Integration/ResolutionTrackingTest.php
+++ b/plugins/Resolution/tests/Integration/ResolutionTrackingTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Resolution\tests\Integration;
+
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Resolution
+ * @group Plugins
+ */
+class ResolutionTrackingTest extends IntegrationTestCase
+{
+    public function testResolutionStoredForFirstPageViewOnlyIfNotUnknown()
+    {
+        $idSite = Fixture::createWebsite('2020-01-01 02:00:00', true, 'test', 'https://matomo.org/');
+        $tracker = Fixture::getTracker($idSite, '2020-01-01 05:00:00');
+        $tracker->setResolution(999, 999);
+        Fixture::checkResponse($tracker->doTrackPageView('home page'));
+
+        $tracker->setForceVisitDateTime('2020-01-01 05:00:02');
+        $tracker->setResolution(111, 111);
+        Fixture::checkResponse($tracker->doTrackPageView('second page'));
+
+        $resolution = Db::fetchAll('SELECT config_resolution FROM ' . Common::prefixTable('log_visit'));
+        self::assertEquals([['config_resolution' => '999x999']], $resolution);
+    }
+
+    public function testResolutionUpdatedIfInitiallyTrackedUnknown()
+    {
+        $idSite = Fixture::createWebsite('2020-01-01 02:00:00', true, 'test', 'https://matomo.org/');
+        $tracker = Fixture::getTracker($idSite, '2020-01-01 05:00:00');
+        $tracker->setResolution(null, null);
+        Fixture::checkResponse($tracker->doTrackPageView('home page'));
+
+        $tracker->setForceVisitDateTime('2020-01-01 05:00:02');
+        $tracker->setResolution(111, 111);
+        Fixture::checkResponse($tracker->doTrackPageView('second page'));
+
+        $resolution = Db::fetchAll('SELECT config_resolution FROM ' . Common::prefixTable('log_visit'));
+        self::assertEquals([['config_resolution' => '111x111']], $resolution);
+    }
+
+    protected static function configureFixture($fixture)
+    {
+        parent::configureFixture($fixture);
+        $fixture->createSuperUser = true;
+    }
+}


### PR DESCRIPTION
Fixes the issue mentioned here:
https://github.com/matomo-org/matomo/issues/22079

Opted for suggestion (2):
If the resolution happens to be "unknown" in the first page impression of a visit, then when a specific value is available from a subsequent page impression, this value will replace the "unknown" value.  For backwards compatibility, once a specific value is set, it will not be overridden by a different value from a subsequent page impression.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
