### PR TITLE
Fixing small bug in the formatPercent method

### DIFF
--- a/core/NumberFormatter.php
+++ b/core/NumberFormatter.php
@@ -247,7 +247,7 @@ class NumberFormatter
             }
         }
         // Assemble the final number and insert it into the pattern.
-        $value = $minorDigits ? $majorDigits . '.' . $minorDigits : $majorDigits;
+        $value = strlen($minorDigits) ? $majorDigits . '.' . $minorDigits : $majorDigits;
         $value = preg_replace('/#(?:[\.,]#+)*0(?:[,\.][0#]+)*/', $value, $pattern);
         // Localize the number.
         $value = $this->replaceSymbols($value);

--- a/tests/PHPUnit/Integration/NumberFormatterTest.php
+++ b/tests/PHPUnit/Integration/NumberFormatterTest.php
@@ -119,6 +119,7 @@ class NumberFormatterTest extends \PHPUnit\Framework\TestCase
             array('en', 5.299, 0, 0, '5%'),
             array('en', 5.299, 3, 0, '5.299%'),
             array('en', -50, 3, 3, '-50.000%'),
+            array('en', -50, 1, 1, '-50.0%'),
             array('en', -50.1, 3, 3, '-50.100%'),
             array('en', 5000, 0, 0, '5,000%'),
             array('en', +5000, 0, 0, '5,000%'),


### PR DESCRIPTION
### Description:

There was a small bug where the minimum fraction digits value provided is equal to 1. If the value was a whole number, it wouldn't append the `.0`. This PR fixes that.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
