### PR TITLE
Avoid possible exception in checkSiteHasTrackedVisits task

### DIFF
--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -161,9 +161,14 @@ class Tasks extends \Piwik\Plugin\Tasks
             return;
         }
 
-        $user = Request::processRequest('UsersManager.getUser', [
-            'userLogin' => $creatingUser,
-        ]);
+        try {
+            $user = Request::processRequest('UsersManager.getUser', [
+                'userLogin' => $creatingUser,
+            ]);
+        } catch (\Exception $e) {
+            return;
+        }
+
         if (empty($user['email'])) {
             return;
         }


### PR DESCRIPTION
### Description:

Just came across that problem locally and created this quick fix.

The task `checkSiteHasTrackedVisits` is executed periodically to inform the user who created a site if no visit are tracked.
This currently fails with an exception if the user has meanwhile been deleted, as the `getUser` API throws an exception when called with a non-existent userlogin.

This does only suppress the exception to avoid the task from failing. There would be further work required to improve the handling that actually leads to this problem, e.g. the site creator might need to get updated when a user gets removed, or the email should be sent to someone else instead of being skipped. So we should keep #19907 open to look for a cleaner solution.

refs #19907 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
