### PR TITLE
Add null-coalesce safeguard to shell_exec for cases when command fails or returns no output

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -311,7 +311,7 @@ class Process
      */
     public static function getRunningProcesses()
     {
-        $ids = explode("\n", trim(shell_exec(self::PS_COMMAND . ' 2>/dev/null | ' . self::AWK_COMMAND . ' 2>/dev/null')));
+        $ids = explode("\n", trim(shell_exec(self::PS_COMMAND . ' 2>/dev/null | ' . self::AWK_COMMAND . ' 2>/dev/null') ?? ''));
 
         $ids = array_map('intval', $ids);
         $ids = array_filter($ids, function ($id) {

--- a/core/Filechecks.php
+++ b/core/Filechecks.php
@@ -150,7 +150,7 @@ class Filechecks
             return $user . ':' . $user;
         }
 
-        $group = trim(shell_exec('groups ' . $user . ' | cut -f3 -d" "'));
+        $group = trim(shell_exec('groups ' . $user . ' | cut -f3 -d" "') ?? '');
 
         if (empty($group) && function_exists('posix_getegid') && function_exists('posix_getgrgid')) {
             $currentGroupId = posix_getegid();
@@ -173,7 +173,7 @@ class Filechecks
     public static function getUser()
     {
         if (function_exists('shell_exec')) {
-            return trim(shell_exec('whoami'));
+            return trim(shell_exec('whoami') ?? '');
         }
 
         $currentUser = get_current_user();

--- a/plugins/CoreConsole/Commands/GitCommit.php
+++ b/plugins/CoreConsole/Commands/GitCommit.php
@@ -141,7 +141,7 @@ class GitCommit extends ConsoleCommand
     protected function getStatusOfSubmodule($submodule)
     {
         $cmd    = sprintf('cd %s/%s && git status --porcelain', PIWIK_DOCUMENT_ROOT, $submodule);
-        $status = trim(shell_exec($cmd));
+        $status = trim(shell_exec($cmd) ?? '');
 
         return $status;
     }

--- a/plugins/TestRunner/Commands/TestsRun.php
+++ b/plugins/TestRunner/Commands/TestsRun.php
@@ -87,7 +87,7 @@ class TestsRun extends ConsoleCommand
 
             $output->writeln("<info>using $xdebugFile as xdebug extension.</info>");
 
-            $phpunitPath = trim(shell_exec('which phpunit'));
+            $phpunitPath = trim(shell_exec('which phpunit') ?? '');
 
             $command = sprintf('php -d zend_extension=%s %s', $xdebugFile, $phpunitPath);
         }


### PR DESCRIPTION
### Description:

Fixes #22101.

Decided to go with null-coalesce safeguard across all `trim(shell_exec(...))` calls as we already had one place exactly like that.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
