### PR TITLE
Remove using specific column collation for some dimensions

### DIFF
--- a/plugins/DevicesDetection/Columns/DeviceBrand.php
+++ b/plugins/DevicesDetection/Columns/DeviceBrand.php
@@ -19,7 +19,7 @@ use Piwik\Tracker\Action;
 class DeviceBrand extends Base
 {
     protected $columnName = 'config_device_brand';
-    protected $columnType = 'VARCHAR( 100 ) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL';
+    protected $columnType = 'VARCHAR( 100 ) NULL DEFAULT NULL';
     protected $type = self::TYPE_TEXT;
     protected $nameSingular = 'DevicesDetection_DeviceBrand';
     protected $namePlural = 'DevicesDetection_DeviceBrands';

--- a/plugins/DevicesDetection/Columns/DeviceModel.php
+++ b/plugins/DevicesDetection/Columns/DeviceModel.php
@@ -16,7 +16,7 @@ use Piwik\Tracker\Action;
 class DeviceModel extends Base
 {
     protected $columnName = 'config_device_model';
-    protected $columnType = 'VARCHAR( 100 ) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL';
+    protected $columnType = 'VARCHAR( 100 ) NULL DEFAULT NULL';
     protected $type = self::TYPE_TEXT;
     protected $nameSingular = 'DevicesDetection_DeviceModel';
     protected $namePlural = 'DevicesDetection_DeviceModels';

--- a/plugins/DevicesDetection/Columns/DeviceModel.php
+++ b/plugins/DevicesDetection/Columns/DeviceModel.php
@@ -17,7 +17,7 @@ use Piwik\Tracker\Action;
 class DeviceModel extends Base
 {
     protected $columnName = 'config_device_model';
-    protected $columnType = 'VARCHAR( 100 ) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL';
+    protected $columnType = 'VARCHAR( 100 ) NULL DEFAULT NULL';
     protected $type = self::TYPE_TEXT;
     protected $nameSingular = 'DevicesDetection_DeviceModel';
     protected $namePlural = 'DevicesDetection_DeviceModels';

--- a/plugins/DevicesDetection/Columns/OsVersion.php
+++ b/plugins/DevicesDetection/Columns/OsVersion.php
@@ -16,7 +16,7 @@ use Piwik\Tracker\Action;
 class OsVersion extends Base
 {
     protected $columnName = 'config_os_version';
-    protected $columnType = 'VARCHAR( 100 ) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL';
+    protected $columnType = 'VARCHAR( 100 ) NULL DEFAULT NULL';
     protected $nameSingular = 'DevicesDetection_ColumnOperatingSystemVersion';
     protected $namePlural = 'DevicesDetection_OperatingSystemVersions';
     protected $segmentName = 'operatingSystemVersion';

--- a/plugins/DevicesDetection/Columns/OsVersion.php
+++ b/plugins/DevicesDetection/Columns/OsVersion.php
@@ -17,7 +17,7 @@ use Piwik\Tracker\Action;
 class OsVersion extends Base
 {
     protected $columnName = 'config_os_version';
-    protected $columnType = 'VARCHAR( 100 ) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL';
+    protected $columnType = 'VARCHAR( 100 ) NULL DEFAULT NULL';
     protected $nameSingular = 'DevicesDetection_ColumnOperatingSystemVersion';
     protected $namePlural = 'DevicesDetection_OperatingSystemVersions';
     protected $segmentName = 'operatingSystemVersion';


### PR DESCRIPTION
### Description:

Some dimensions currently have a specific collation / charset defined in their definitions. This causes only those dimension columns not to use the default charset (utf8_mb4).

Removing this will trigger an automated updated for those dimensions. As it affects the log tables, we should include this in the next major release.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
