### PR TITLE
[Coding Style] Enable rule PSR2.Classes.PropertyDeclaration.Underscore

### DIFF
--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -60,7 +60,7 @@ class EventDispatcher
 
     private $pluginHooks = array();
 
-    public static $_SKIP_EVENTS_IN_TESTS = false;
+    public static $_SKIP_EVENTS_IN_TESTS = false; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
     /**
      * Constructor.

--- a/core/Visualization/Sparkline.php
+++ b/core/Visualization/Sparkline.php
@@ -29,12 +29,12 @@ class Sparkline implements ViewInterface
      * Width of the sparkline
      * @var int
      */
-    protected $_width = self::DEFAULT_WIDTH;
+    protected $width = self::DEFAULT_WIDTH;
     /**
      * Height of sparkline
      * @var int
      */
-    protected $_height = self::DEFAULT_HEIGHT;
+    protected $height = self::DEFAULT_HEIGHT;
     private $serieses = [];
     /**
      * @var \Davaxi\Sparkline
@@ -120,7 +120,7 @@ class Sparkline implements ViewInterface
      */
     public function getWidth()
     {
-        return $this->_width;
+        return $this->width;
     }
 
     /**
@@ -133,9 +133,9 @@ class Sparkline implements ViewInterface
             return;
         }
         if ($width > self::MAX_WIDTH) {
-            $this->_width = self::MAX_WIDTH;
+            $this->width = self::MAX_WIDTH;
         } else {
-            $this->_width = (int)$width;
+            $this->width = (int)$width;
         }
     }
 
@@ -145,7 +145,7 @@ class Sparkline implements ViewInterface
      */
     public function getHeight()
     {
-        return $this->_height;
+        return $this->height;
     }
 
     /**
@@ -158,9 +158,9 @@ class Sparkline implements ViewInterface
             return;
         }
         if ($height > self::MAX_HEIGHT) {
-            $this->_height = self::MAX_HEIGHT;
+            $this->height = self::MAX_HEIGHT;
         } else {
-            $this->_height = (int)$height;
+            $this->height = (int)$height;
         }
     }
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -29,7 +29,6 @@
 
         <exclude name="Generic.Files.LineLength" />
         <exclude name="Generic.PHP.LowerCaseConstant.Found" />
-        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore" />
     </rule>
 
     <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -70,7 +70,7 @@ class API extends \Piwik\Plugin\API
      * For Testing purpose only
      * @var int
      */
-    public static $_autoSuggestLookBack = 60;
+    public static $_autoSuggestLookBack = 60; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore
 
     public function __construct(SettingsProvider $settingsProvider, ProcessedReport $processedReport)
     {

--- a/plugins/ProfessionalServices/tests/Unit/PromoWidgetApplicableTest.php
+++ b/plugins/ProfessionalServices/tests/Unit/PromoWidgetApplicableTest.php
@@ -46,7 +46,7 @@ class PromoWidgetApplicableTest extends TestCase
         $this->assertEquals($expected, $sut->check('MyPlugin', 'Any'));
     }
 
-    protected function checkDataProvider(): \Generator
+    public function checkDataProvider(): \Generator
     {
         yield [true, true, true, true, false, false];
         yield [true, true, true, false, false, true];

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/DailyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/DailyTest.php
@@ -18,20 +18,20 @@ use Piwik\Scheduler\Schedule\Schedule;
  */
 class DailyTest extends \PHPUnit\Framework\TestCase
 {
-    private static $_JANUARY_01_1971_09_00_00;
-    private static $_JANUARY_01_1971_09_10_00;
-    private static $_JANUARY_01_1971_12_10_00;
-    private static $_JANUARY_02_1971_00_00_00;
-    private static $_JANUARY_02_1971_09_00_00;
+    private static $JANUARY_01_1971_09_00_00;
+    private static $JANUARY_01_1971_09_10_00;
+    private static $JANUARY_01_1971_12_10_00;
+    private static $JANUARY_02_1971_00_00_00;
+    private static $JANUARY_02_1971_09_00_00;
 
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        self::$_JANUARY_01_1971_09_00_00 = mktime(9, 00, 00, 1, 1, 1971);
-        self::$_JANUARY_01_1971_09_10_00 = mktime(9, 10, 00, 1, 1, 1971);
-        self::$_JANUARY_01_1971_12_10_00 = mktime(12, 10, 00, 1, 1, 1971);
-        self::$_JANUARY_02_1971_00_00_00 = mktime(0, 00, 00, 1, 2, 1971);
-        self::$_JANUARY_02_1971_09_00_00 = mktime(9, 00, 00, 1, 2, 1971);
+        self::$JANUARY_01_1971_09_00_00 = mktime(9, 00, 00, 1, 1, 1971);
+        self::$JANUARY_01_1971_09_10_00 = mktime(9, 10, 00, 1, 1, 1971);
+        self::$JANUARY_01_1971_12_10_00 = mktime(12, 10, 00, 1, 1, 1971);
+        self::$JANUARY_02_1971_00_00_00 = mktime(0, 00, 00, 1, 2, 1971);
+        self::$JANUARY_02_1971_09_00_00 = mktime(9, 00, 00, 1, 2, 1971);
     }
 
     /**
@@ -82,17 +82,17 @@ class DailyTest extends \PHPUnit\Framework\TestCase
          * Expected :
          *  getRescheduledTime returns Saturday January 2 1971 00:00:00 UTC
          */
-        $mock = $this->getDailyMock(self::$_JANUARY_01_1971_09_10_00);
-        $this->assertEquals(self::$_JANUARY_02_1971_00_00_00, $mock->getRescheduledTime());
+        $mock = $this->getDailyMock(self::$JANUARY_01_1971_09_10_00);
+        $this->assertEquals(self::$JANUARY_02_1971_00_00_00, $mock->getRescheduledTime());
     }
 
     public function test_setTimezone_ShouldConvertRescheduledTime()
     {
         $oneHourInSeconds = 3600;
 
-        $mock    = $this->getDailyMock(self::$_JANUARY_01_1971_09_10_00);
+        $mock    = $this->getDailyMock(self::$JANUARY_01_1971_09_10_00);
         $timeUTC = $mock->getRescheduledTime();
-        $this->assertEquals(self::$_JANUARY_02_1971_00_00_00, $timeUTC);
+        $this->assertEquals(self::$JANUARY_02_1971_00_00_00, $timeUTC);
 
         $mock->setTimezone('Pacific/Auckland');
         $timeAuckland = $mock->getRescheduledTime();
@@ -118,9 +118,9 @@ class DailyTest extends \PHPUnit\Framework\TestCase
          * Expected :
          *  getRescheduledTime returns Saturday January 2 1971 09:00:00 UTC
          */
-        $mock = $this->getDailyMock(self::$_JANUARY_01_1971_09_00_00);
+        $mock = $this->getDailyMock(self::$JANUARY_01_1971_09_00_00);
         $mock->setHour(9);
-        $this->assertEquals(self::$_JANUARY_02_1971_09_00_00, $mock->getRescheduledTime());
+        $this->assertEquals(self::$JANUARY_02_1971_09_00_00, $mock->getRescheduledTime());
 
         /*
          * Test 2
@@ -133,9 +133,9 @@ class DailyTest extends \PHPUnit\Framework\TestCase
          *  getRescheduledTime returns Saturday January 2 1971 09:00:00 UTC
          */
 
-        $mock = $this->getDailyMock(self::$_JANUARY_01_1971_12_10_00);
+        $mock = $this->getDailyMock(self::$JANUARY_01_1971_12_10_00);
         $mock->setHour(9);
-        $this->assertEquals(self::$_JANUARY_02_1971_09_00_00, $mock->getRescheduledTime());
+        $this->assertEquals(self::$JANUARY_02_1971_09_00_00, $mock->getRescheduledTime());
 
         /*
          * Test 3
@@ -147,9 +147,9 @@ class DailyTest extends \PHPUnit\Framework\TestCase
          * Expected :
          *  getRescheduledTime returns Saturday January 2 1971 00:00:00 UTC
          */
-        $mock = $this->getDailyMock(self::$_JANUARY_01_1971_12_10_00);
+        $mock = $this->getDailyMock(self::$JANUARY_01_1971_12_10_00);
         $mock->setHour(0);
-        $this->assertEquals(self::$_JANUARY_02_1971_00_00_00, $mock->getRescheduledTime());
+        $this->assertEquals(self::$JANUARY_02_1971_00_00_00, $mock->getRescheduledTime());
     }
 
     /**

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/HourlyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/HourlyTest.php
@@ -17,16 +17,16 @@ use Piwik\Scheduler\Schedule\Hourly;
  */
 class HourlyTest extends \PHPUnit\Framework\TestCase
 {
-    private static $_JANUARY_01_1971_09_00_00;
-    private static $_JANUARY_01_1971_09_10_00;
-    private static $_JANUARY_01_1971_10_00_00;
+    private static $JANUARY_01_1971_09_00_00;
+    private static $JANUARY_01_1971_09_10_00;
+    private static $JANUARY_01_1971_10_00_00;
 
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        self::$_JANUARY_01_1971_09_00_00 = mktime(9, 00, 00, 1, 1, 1971);
-        self::$_JANUARY_01_1971_09_10_00 = mktime(9, 10, 00, 1, 1, 1971);
-        self::$_JANUARY_01_1971_10_00_00 = mktime(10, 00, 00, 1, 1, 1971);
+        self::$JANUARY_01_1971_09_00_00 = mktime(9, 00, 00, 1, 1, 1971);
+        self::$JANUARY_01_1971_09_10_00 = mktime(9, 10, 00, 1, 1, 1971);
+        self::$JANUARY_01_1971_10_00_00 = mktime(10, 00, 00, 1, 1, 1971);
     }
 
     /**
@@ -71,8 +71,8 @@ class HourlyTest extends \PHPUnit\Framework\TestCase
         $mock = $this->createPartialMock('Piwik\Scheduler\Schedule\Hourly', array('getTime'));
         $mock->expects($this->any())
             ->method('getTime')
-            ->will($this->returnValue(self::$_JANUARY_01_1971_09_00_00));
-        $this->assertEquals(self::$_JANUARY_01_1971_10_00_00, $mock->getRescheduledTime());
+            ->will($this->returnValue(self::$JANUARY_01_1971_09_00_00));
+        $this->assertEquals(self::$JANUARY_01_1971_10_00_00, $mock->getRescheduledTime());
 
         /*
          * Test 2
@@ -86,7 +86,7 @@ class HourlyTest extends \PHPUnit\Framework\TestCase
         $mock = $this->createPartialMock('Piwik\Scheduler\Schedule\Hourly', array('getTime'));
         $mock->expects($this->any())
             ->method('getTime')
-            ->will($this->returnValue(self::$_JANUARY_01_1971_09_10_00));
-        $this->assertEquals(self::$_JANUARY_01_1971_10_00_00, $mock->getRescheduledTime());
+            ->will($this->returnValue(self::$JANUARY_01_1971_09_10_00));
+        $this->assertEquals(self::$JANUARY_01_1971_10_00_00, $mock->getRescheduledTime());
     }
 }

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/MonthlyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/MonthlyTest.php
@@ -167,7 +167,7 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
              * Expected :
              *  getRescheduledTime returns Monday February 1 1971 00:00:00 UTC
              */
-            array('_JANUARY_01_1971_09_00_00', 1, '_FEBRUARY_01_1971_00_00_00'),
+            array('JANUARY_01_1971_09_00_00', 1, 'FEBRUARY_01_1971_00_00_00'),
             /*
              * Test 2
              *
@@ -179,7 +179,7 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
              * Expected :
              *  getRescheduledTime returns Tuesday February 2 1971 00:00:00 UTC
              */
-            array('_JANUARY_02_1971_09_00_00', 2, '_FEBRUARY_02_1971_00_00_00'),
+            array('JANUARY_02_1971_09_00_00', 2, 'FEBRUARY_02_1971_00_00_00'),
             /*
              * Test 3
              *
@@ -191,7 +191,7 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
              * Expected :
              *  getRescheduledTime returns Tuesday February 1 1971 00:00:00 UTC
              */
-            array('_JANUARY_15_1971_09_00_00', 2, '_FEBRUARY_02_1971_00_00_00'),
+            array('JANUARY_15_1971_09_00_00', 2, 'FEBRUARY_02_1971_00_00_00'),
             /*
              * Test 4
              *
@@ -203,7 +203,7 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
              * Expected :
              *  getRescheduledTime returns Sunday February 28 1971 00:00:00 UTC
              */
-            array('_JANUARY_15_1971_09_00_00', 31, '_FEBRUARY_28_1971_00_00_00')
+            array('JANUARY_15_1971_09_00_00', 31, 'FEBRUARY_28_1971_00_00_00')
         );
     }
 
@@ -213,8 +213,8 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
     public function getValuesToTestSetDayOfWeek()
     {
         return array(
-            array(3, 0, self::$FEBRUARY_03_1971_09_00_00),
-            array(0, 2, self::$FEBRUARY_21_1971_09_00_00),
+            array(3, 0, 'FEBRUARY_03_1971_09_00_00'),
+            array(0, 2, 'FEBRUARY_21_1971_09_00_00'),
         );
     }
 
@@ -224,8 +224,8 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
     public function getValuesToTestSetDayOfWeekByString()
     {
         return array(
-            array('first wednesday', self::$FEBRUARY_03_1971_09_00_00),
-            array('ThIrD sUnDaY', self::$FEBRUARY_21_1971_09_00_00)
+            array('first wednesday', 'FEBRUARY_03_1971_09_00_00'),
+            array('ThIrD sUnDaY', 'FEBRUARY_21_1971_09_00_00')
         );
     }
 
@@ -236,7 +236,7 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
     {
         $mock = $this->getMonthlyMock(self::$JANUARY_15_1971_09_00_00);
         $mock->setDayOfWeek($day, $week);
-        $this->assertEquals($expectedTime, $mock->getRescheduledTime());
+        $this->assertEquals(self::$$expectedTime, $mock->getRescheduledTime());
     }
 
     /**
@@ -246,7 +246,7 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
     {
         $mock = $this->getMonthlyMock(self::$JANUARY_15_1971_09_00_00);
         $mock->setDayOfWeekFromString($dayOfWeekStr);
-        $this->assertEquals($expectedTime, $mock->getRescheduledTime());
+        $this->assertEquals(self::$$expectedTime, $mock->getRescheduledTime());
     }
 
     /**

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/MonthlyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/MonthlyTest.php
@@ -16,19 +16,28 @@ use Piwik\Scheduler\Schedule\Monthly;
  */
 class MonthlyTest extends \PHPUnit\Framework\TestCase
 {
-    public static $JANUARY_01_1971_09_00_00; // initialized below class definition
-    public static $JANUARY_02_1971_09_00_00;
-    public static $JANUARY_05_1971_09_00_00;
-    public static $JANUARY_15_1971_09_00_00;
-    public static $FEBRUARY_01_1971_00_00_00;
-    public static $FEBRUARY_02_1971_00_00_00;
-    public static $FEBRUARY_03_1971_09_00_00;
-    public static $FEBRUARY_21_1971_09_00_00;
-    public static $FEBRUARY_28_1971_00_00_00;
+    private static $JANUARY_01_1971_09_00_00;
+    private static $JANUARY_02_1971_09_00_00;
+    private static $JANUARY_05_1971_09_00_00;
+    private static $JANUARY_15_1971_09_00_00;
+    private static $FEBRUARY_01_1971_00_00_00;
+    private static $FEBRUARY_02_1971_00_00_00;
+    private static $FEBRUARY_03_1971_09_00_00;
+    private static $FEBRUARY_21_1971_09_00_00;
+    private static $FEBRUARY_28_1971_00_00_00;
 
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
+        self::$JANUARY_01_1971_09_00_00 = mktime(9, 00, 00, 1, 1, 1971);
+        self::$JANUARY_02_1971_09_00_00 = mktime(9, 00, 00, 1, 2, 1971);
+        self::$JANUARY_05_1971_09_00_00 = mktime(9, 00, 00, 1, 5, 1971);
+        self::$JANUARY_15_1971_09_00_00 = mktime(9, 00, 00, 1, 15, 1971);
+        self::$FEBRUARY_01_1971_00_00_00 = mktime(0, 00, 00, 2, 1, 1971);
+        self::$FEBRUARY_02_1971_00_00_00 = mktime(0, 00, 00, 2, 2, 1971);
+        self::$FEBRUARY_03_1971_09_00_00 = mktime(0, 00, 00, 2, 3, 1971);
+        self::$FEBRUARY_21_1971_09_00_00 = mktime(0, 00, 00, 2, 21, 1971);
+        self::$FEBRUARY_28_1971_00_00_00 = mktime(0, 00, 00, 2, 28, 1971);
     }
 
     /**
@@ -285,13 +294,3 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
         return $mock;
     }
 }
-
-MonthlyTest::$JANUARY_01_1971_09_00_00 = mktime(9, 00, 00, 1, 1, 1971);
-MonthlyTest::$JANUARY_02_1971_09_00_00 = mktime(9, 00, 00, 1, 2, 1971);
-MonthlyTest::$JANUARY_05_1971_09_00_00 = mktime(9, 00, 00, 1, 5, 1971);
-MonthlyTest::$JANUARY_15_1971_09_00_00 = mktime(9, 00, 00, 1, 15, 1971);
-MonthlyTest::$FEBRUARY_01_1971_00_00_00 = mktime(0, 00, 00, 2, 1, 1971);
-MonthlyTest::$FEBRUARY_02_1971_00_00_00 = mktime(0, 00, 00, 2, 2, 1971);
-MonthlyTest::$FEBRUARY_03_1971_09_00_00 = mktime(0, 00, 00, 2, 3, 1971);
-MonthlyTest::$FEBRUARY_21_1971_09_00_00 = mktime(0, 00, 00, 2, 21, 1971);
-MonthlyTest::$FEBRUARY_28_1971_00_00_00 = mktime(0, 00, 00, 2, 28, 1971);

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/MonthlyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/MonthlyTest.php
@@ -16,15 +16,15 @@ use Piwik\Scheduler\Schedule\Monthly;
  */
 class MonthlyTest extends \PHPUnit\Framework\TestCase
 {
-    public static $_JANUARY_01_1971_09_00_00; // initialized below class definition
-    public static $_JANUARY_02_1971_09_00_00;
-    public static $_JANUARY_05_1971_09_00_00;
-    public static $_JANUARY_15_1971_09_00_00;
-    public static $_FEBRUARY_01_1971_00_00_00;
-    public static $_FEBRUARY_02_1971_00_00_00;
-    public static $_FEBRUARY_03_1971_09_00_00;
-    public static $_FEBRUARY_21_1971_09_00_00;
-    public static $_FEBRUARY_28_1971_00_00_00;
+    public static $JANUARY_01_1971_09_00_00; // initialized below class definition
+    public static $JANUARY_02_1971_09_00_00;
+    public static $JANUARY_05_1971_09_00_00;
+    public static $JANUARY_15_1971_09_00_00;
+    public static $FEBRUARY_01_1971_00_00_00;
+    public static $FEBRUARY_02_1971_00_00_00;
+    public static $FEBRUARY_03_1971_09_00_00;
+    public static $FEBRUARY_21_1971_09_00_00;
+    public static $FEBRUARY_28_1971_00_00_00;
 
     public static function setUpBeforeClass(): void
     {
@@ -91,8 +91,8 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
          * Expected :
          *  getRescheduledTime returns Monday February 1 1971 00:00:00 UTC
          */
-        $mock = $this->getMonthlyMock(self::$_JANUARY_01_1971_09_00_00);
-        $this->assertEquals(self::$_FEBRUARY_01_1971_00_00_00, $mock->getRescheduledTime());
+        $mock = $this->getMonthlyMock(self::$JANUARY_01_1971_09_00_00);
+        $this->assertEquals(self::$FEBRUARY_01_1971_00_00_00, $mock->getRescheduledTime());
 
         /*
          * Test 2
@@ -105,17 +105,17 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
          * Expected :
          *  getRescheduledTime returns Monday February 1 1971 00:00:00 UTC
          */
-        $mock = $this->getMonthlyMock(self::$_JANUARY_05_1971_09_00_00);
-        $this->assertEquals(self::$_FEBRUARY_01_1971_00_00_00, $mock->getRescheduledTime());
+        $mock = $this->getMonthlyMock(self::$JANUARY_05_1971_09_00_00);
+        $this->assertEquals(self::$FEBRUARY_01_1971_00_00_00, $mock->getRescheduledTime());
     }
 
     public function test_setTimezone_ShouldConvertRescheduledTime()
     {
         $oneHourInSeconds = 3600;
 
-        $mock = $this->getMonthlyMock(self::$_JANUARY_05_1971_09_00_00);
+        $mock = $this->getMonthlyMock(self::$JANUARY_05_1971_09_00_00);
         $timeUTC = $mock->getRescheduledTime();
-        $this->assertEquals(self::$_FEBRUARY_01_1971_00_00_00, $timeUTC);
+        $this->assertEquals(self::$FEBRUARY_01_1971_00_00_00, $timeUTC);
 
         $mock->setTimezone('Pacific/Auckland');
         $timeAuckland = $mock->getRescheduledTime();
@@ -204,8 +204,8 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
     public function getValuesToTestSetDayOfWeek()
     {
         return array(
-            array(3, 0, self::$_FEBRUARY_03_1971_09_00_00),
-            array(0, 2, self::$_FEBRUARY_21_1971_09_00_00),
+            array(3, 0, self::$FEBRUARY_03_1971_09_00_00),
+            array(0, 2, self::$FEBRUARY_21_1971_09_00_00),
         );
     }
 
@@ -215,8 +215,8 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
     public function getValuesToTestSetDayOfWeekByString()
     {
         return array(
-            array('first wednesday', self::$_FEBRUARY_03_1971_09_00_00),
-            array('ThIrD sUnDaY', self::$_FEBRUARY_21_1971_09_00_00)
+            array('first wednesday', self::$FEBRUARY_03_1971_09_00_00),
+            array('ThIrD sUnDaY', self::$FEBRUARY_21_1971_09_00_00)
         );
     }
 
@@ -225,7 +225,7 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
      */
     public function testMonthlyDayOfWeek($day, $week, $expectedTime)
     {
-        $mock = $this->getMonthlyMock(self::$_JANUARY_15_1971_09_00_00);
+        $mock = $this->getMonthlyMock(self::$JANUARY_15_1971_09_00_00);
         $mock->setDayOfWeek($day, $week);
         $this->assertEquals($expectedTime, $mock->getRescheduledTime());
     }
@@ -235,7 +235,7 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
      */
     public function testMonthlyDayOfWeekByString($dayOfWeekStr, $expectedTime)
     {
-        $mock = $this->getMonthlyMock(self::$_JANUARY_15_1971_09_00_00);
+        $mock = $this->getMonthlyMock(self::$JANUARY_15_1971_09_00_00);
         $mock->setDayOfWeekFromString($dayOfWeekStr);
         $this->assertEquals($expectedTime, $mock->getRescheduledTime());
     }
@@ -249,7 +249,7 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\Exception::class);
 
-        $mock = $this->getMonthlyMock(self::$_JANUARY_15_1971_09_00_00);
+        $mock = $this->getMonthlyMock(self::$JANUARY_15_1971_09_00_00);
         $mock->setDayOfWeek($day, $week);
     }
 
@@ -286,12 +286,12 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
     }
 }
 
-MonthlyTest::$_JANUARY_01_1971_09_00_00 = mktime(9, 00, 00, 1, 1, 1971);
-MonthlyTest::$_JANUARY_02_1971_09_00_00 = mktime(9, 00, 00, 1, 2, 1971);
-MonthlyTest::$_JANUARY_05_1971_09_00_00 = mktime(9, 00, 00, 1, 5, 1971);
-MonthlyTest::$_JANUARY_15_1971_09_00_00 = mktime(9, 00, 00, 1, 15, 1971);
-MonthlyTest::$_FEBRUARY_01_1971_00_00_00 = mktime(0, 00, 00, 2, 1, 1971);
-MonthlyTest::$_FEBRUARY_02_1971_00_00_00 = mktime(0, 00, 00, 2, 2, 1971);
-MonthlyTest::$_FEBRUARY_03_1971_09_00_00 = mktime(0, 00, 00, 2, 3, 1971);
-MonthlyTest::$_FEBRUARY_21_1971_09_00_00 = mktime(0, 00, 00, 2, 21, 1971);
-MonthlyTest::$_FEBRUARY_28_1971_00_00_00 = mktime(0, 00, 00, 2, 28, 1971);
+MonthlyTest::$JANUARY_01_1971_09_00_00 = mktime(9, 00, 00, 1, 1, 1971);
+MonthlyTest::$JANUARY_02_1971_09_00_00 = mktime(9, 00, 00, 1, 2, 1971);
+MonthlyTest::$JANUARY_05_1971_09_00_00 = mktime(9, 00, 00, 1, 5, 1971);
+MonthlyTest::$JANUARY_15_1971_09_00_00 = mktime(9, 00, 00, 1, 15, 1971);
+MonthlyTest::$FEBRUARY_01_1971_00_00_00 = mktime(0, 00, 00, 2, 1, 1971);
+MonthlyTest::$FEBRUARY_02_1971_00_00_00 = mktime(0, 00, 00, 2, 2, 1971);
+MonthlyTest::$FEBRUARY_03_1971_09_00_00 = mktime(0, 00, 00, 2, 3, 1971);
+MonthlyTest::$FEBRUARY_21_1971_09_00_00 = mktime(0, 00, 00, 2, 21, 1971);
+MonthlyTest::$FEBRUARY_28_1971_00_00_00 = mktime(0, 00, 00, 2, 28, 1971);

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/WeeklyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/WeeklyTest.php
@@ -17,13 +17,13 @@ use Piwik\Scheduler\Schedule\Weekly;
  */
 class WeeklyTest extends \PHPUnit\Framework\TestCase
 {
-    public static $_JANUARY_01_1971_09_10_00; // initialized below class declaration
-    public static $_JANUARY_04_1971_00_00_00;
-    public static $_JANUARY_04_1971_09_00_00;
-    public static $_JANUARY_05_1971_09_00_00;
-    public static $_JANUARY_11_1971_00_00_00;
-    public static $_JANUARY_15_1971_00_00_00;
-    public static $_JANUARY_08_1971_00_00_00;
+    public static $JANUARY_01_1971_09_10_00; // initialized below class declaration
+    public static $JANUARY_04_1971_00_00_00;
+    public static $JANUARY_04_1971_09_00_00;
+    public static $JANUARY_05_1971_09_00_00;
+    public static $JANUARY_11_1971_00_00_00;
+    public static $JANUARY_15_1971_00_00_00;
+    public static $JANUARY_08_1971_00_00_00;
 
     public static function setUpBeforeClass(): void
     {
@@ -90,8 +90,8 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
          * Expected :
          *  getRescheduledTime returns Monday January 4 1971 00:00:00 UTC
          */
-        $mock = $this->getWeeklyMock(self::$_JANUARY_01_1971_09_10_00);
-        $this->assertEquals(self::$_JANUARY_04_1971_00_00_00, $mock->getRescheduledTime());
+        $mock = $this->getWeeklyMock(self::$JANUARY_01_1971_09_10_00);
+        $this->assertEquals(self::$JANUARY_04_1971_00_00_00, $mock->getRescheduledTime());
     }
 
     /**
@@ -110,9 +110,9 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
          * Expected :
          *  getRescheduledTime returns Monday January 4 1971 09:00:00 UTC
          */
-        $mock = $this->getWeeklyMock(self::$_JANUARY_01_1971_09_10_00);
+        $mock = $this->getWeeklyMock(self::$JANUARY_01_1971_09_10_00);
         $mock->setHour(9);
-        $this->assertEquals(self::$_JANUARY_04_1971_09_00_00, $mock->getRescheduledTime());
+        $this->assertEquals(self::$JANUARY_04_1971_09_00_00, $mock->getRescheduledTime());
     }
 
     /**
@@ -121,12 +121,12 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
     public function getSetDayParametersToTest()
     {
         return array(
-            array(1, self::$_JANUARY_11_1971_00_00_00),
-            array(5, self::$_JANUARY_08_1971_00_00_00),
-            array('monday', self::$_JANUARY_11_1971_00_00_00),
-            array('Monday', self::$_JANUARY_11_1971_00_00_00),
-            array('FRIDAY', self::$_JANUARY_08_1971_00_00_00),
-            array('FrIdAy', self::$_JANUARY_08_1971_00_00_00)
+            array(1, self::$JANUARY_11_1971_00_00_00),
+            array(5, self::$JANUARY_08_1971_00_00_00),
+            array('monday', self::$JANUARY_11_1971_00_00_00),
+            array('Monday', self::$JANUARY_11_1971_00_00_00),
+            array('FRIDAY', self::$JANUARY_08_1971_00_00_00),
+            array('FrIdAy', self::$JANUARY_08_1971_00_00_00)
         );
     }
 
@@ -134,9 +134,9 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
     {
         $oneHourInSeconds = 3600;
 
-        $mock    = $this->getWeeklyMock(self::$_JANUARY_01_1971_09_10_00);
+        $mock    = $this->getWeeklyMock(self::$JANUARY_01_1971_09_10_00);
         $timeUTC = $mock->getRescheduledTime();
-        $this->assertEquals(self::$_JANUARY_04_1971_00_00_00, $timeUTC);
+        $this->assertEquals(self::$JANUARY_04_1971_00_00_00, $timeUTC);
 
         $mock->setTimezone('Pacific/Auckland');
         $timeAuckland = $mock->getRescheduledTime();
@@ -159,7 +159,7 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetRescheduledTimeWeeklyUnspecifiedHourSpecifiedDay($dayToSet, $expectedRescheduledTime)
     {
-        $mock = $this->getWeeklyMock(self::$_JANUARY_04_1971_09_00_00);
+        $mock = $this->getWeeklyMock(self::$JANUARY_04_1971_09_00_00);
         $mock->setDay($dayToSet);
 
         $this->assertEquals($expectedRescheduledTime, $mock->getRescheduledTime());
@@ -179,10 +179,10 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
     }
 }
 
-WeeklyTest::$_JANUARY_01_1971_09_10_00 = mktime(9, 10, 00, 1, 1, 1971);
-WeeklyTest::$_JANUARY_04_1971_00_00_00 = mktime(0, 00, 00, 1, 4, 1971);
-WeeklyTest::$_JANUARY_04_1971_09_00_00 = mktime(9, 00, 00, 1, 4, 1971);
-WeeklyTest::$_JANUARY_05_1971_09_00_00 = mktime(9, 00, 00, 1, 5, 1971);
-WeeklyTest::$_JANUARY_11_1971_00_00_00 = mktime(0, 00, 00, 1, 11, 1971);
-WeeklyTest::$_JANUARY_15_1971_00_00_00 = mktime(0, 00, 00, 1, 15, 1971);
-WeeklyTest::$_JANUARY_08_1971_00_00_00 = mktime(0, 00, 00, 1, 8, 1971);
+WeeklyTest::$JANUARY_01_1971_09_10_00 = mktime(9, 10, 00, 1, 1, 1971);
+WeeklyTest::$JANUARY_04_1971_00_00_00 = mktime(0, 00, 00, 1, 4, 1971);
+WeeklyTest::$JANUARY_04_1971_09_00_00 = mktime(9, 00, 00, 1, 4, 1971);
+WeeklyTest::$JANUARY_05_1971_09_00_00 = mktime(9, 00, 00, 1, 5, 1971);
+WeeklyTest::$JANUARY_11_1971_00_00_00 = mktime(0, 00, 00, 1, 11, 1971);
+WeeklyTest::$JANUARY_15_1971_00_00_00 = mktime(0, 00, 00, 1, 15, 1971);
+WeeklyTest::$JANUARY_08_1971_00_00_00 = mktime(0, 00, 00, 1, 8, 1971);

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/WeeklyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/WeeklyTest.php
@@ -128,12 +128,12 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
     public function getSetDayParametersToTest()
     {
         return array(
-            array(1, self::$JANUARY_11_1971_00_00_00),
-            array(5, self::$JANUARY_08_1971_00_00_00),
-            array('monday', self::$JANUARY_11_1971_00_00_00),
-            array('Monday', self::$JANUARY_11_1971_00_00_00),
-            array('FRIDAY', self::$JANUARY_08_1971_00_00_00),
-            array('FrIdAy', self::$JANUARY_08_1971_00_00_00)
+            array(1, 'JANUARY_11_1971_00_00_00'),
+            array(5, 'JANUARY_08_1971_00_00_00'),
+            array('monday', 'JANUARY_11_1971_00_00_00'),
+            array('Monday', 'JANUARY_11_1971_00_00_00'),
+            array('FRIDAY', 'JANUARY_08_1971_00_00_00'),
+            array('FrIdAy', 'JANUARY_08_1971_00_00_00')
         );
     }
 
@@ -169,7 +169,7 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
         $mock = $this->getWeeklyMock(self::$JANUARY_04_1971_09_00_00);
         $mock->setDay($dayToSet);
 
-        $this->assertEquals($expectedRescheduledTime, $mock->getRescheduledTime());
+        $this->assertEquals(self::$$expectedRescheduledTime, $mock->getRescheduledTime());
     }
 
     /**

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/WeeklyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/WeeklyTest.php
@@ -17,17 +17,24 @@ use Piwik\Scheduler\Schedule\Weekly;
  */
 class WeeklyTest extends \PHPUnit\Framework\TestCase
 {
-    public static $JANUARY_01_1971_09_10_00; // initialized below class declaration
-    public static $JANUARY_04_1971_00_00_00;
-    public static $JANUARY_04_1971_09_00_00;
-    public static $JANUARY_05_1971_09_00_00;
-    public static $JANUARY_11_1971_00_00_00;
-    public static $JANUARY_15_1971_00_00_00;
-    public static $JANUARY_08_1971_00_00_00;
+    private static $JANUARY_01_1971_09_10_00;
+    private static $JANUARY_04_1971_00_00_00;
+    private static $JANUARY_04_1971_09_00_00;
+    private static $JANUARY_05_1971_09_00_00;
+    private static $JANUARY_11_1971_00_00_00;
+    private static $JANUARY_15_1971_00_00_00;
+    private static $JANUARY_08_1971_00_00_00;
 
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
+        self::$JANUARY_01_1971_09_10_00 = mktime(9, 10, 00, 1, 1, 1971);
+        self::$JANUARY_04_1971_00_00_00 = mktime(0, 00, 00, 1, 4, 1971);
+        self::$JANUARY_04_1971_09_00_00 = mktime(9, 00, 00, 1, 4, 1971);
+        self::$JANUARY_05_1971_09_00_00 = mktime(9, 00, 00, 1, 5, 1971);
+        self::$JANUARY_11_1971_00_00_00 = mktime(0, 00, 00, 1, 11, 1971);
+        self::$JANUARY_15_1971_00_00_00 = mktime(0, 00, 00, 1, 15, 1971);
+        self::$JANUARY_08_1971_00_00_00 = mktime(0, 00, 00, 1, 8, 1971);
     }
 
     /**
@@ -178,11 +185,3 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
         return $mock;
     }
 }
-
-WeeklyTest::$JANUARY_01_1971_09_10_00 = mktime(9, 10, 00, 1, 1, 1971);
-WeeklyTest::$JANUARY_04_1971_00_00_00 = mktime(0, 00, 00, 1, 4, 1971);
-WeeklyTest::$JANUARY_04_1971_09_00_00 = mktime(9, 00, 00, 1, 4, 1971);
-WeeklyTest::$JANUARY_05_1971_09_00_00 = mktime(9, 00, 00, 1, 5, 1971);
-WeeklyTest::$JANUARY_11_1971_00_00_00 = mktime(0, 00, 00, 1, 11, 1971);
-WeeklyTest::$JANUARY_15_1971_00_00_00 = mktime(0, 00, 00, 1, 15, 1971);
-WeeklyTest::$JANUARY_08_1971_00_00_00 = mktime(0, 00, 00, 1, 8, 1971);


### PR DESCRIPTION
### Description:

I've added two ignore comments for now, as those properties are in use by plugin tests and renaming them could break those tests.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
