### PR TITLE
[Coding Style] use camel case for method names in API plugin tests

### DIFF
--- a/plugins/API/tests/Integration/APITest.php
+++ b/plugins/API/tests/Integration/APITest.php
@@ -52,7 +52,7 @@ class APITest extends IntegrationTestCase
         parent::tearDown();
     }
 
-    public function test_getBulkRequest_IsAbleToHandleManyDifferentRequests()
+    public function testGetBulkRequestIsAbleToHandleManyDifferentRequests()
     {
         $token = Fixture::getTokenAuth();
         $urls = array(

--- a/plugins/API/tests/Integration/Filter/DataComparisonFilter/ComparisonRowGeneratorTest.php
+++ b/plugins/API/tests/Integration/Filter/DataComparisonFilter/ComparisonRowGeneratorTest.php
@@ -27,7 +27,7 @@ class ComparisonRowGeneratorTest extends IntegrationTestCase
         API::getInstance()->add('test segment', self::TEST_SEGMENT);
     }
 
-    public function test_compareTables_shouldCompareTwoDataTablesCorrectly()
+    public function testCompareTablesShouldCompareTwoDataTablesCorrectly()
     {
         $table1 = $this->makeTable([
             ['label' => 'row1', 'nb_visits' => 5, 'nb_actions' => 10],
@@ -116,7 +116,7 @@ END;
         $this->assertEquals($expectedXml, $xmlContent);
     }
 
-    public function test_compareTables_shouldUseFirstTableRowsForComparisons()
+    public function testCompareTablesShouldUseFirstTableRowsForComparisons()
     {
         $table1 = $this->makeTable([
             ['label' => 'row1', 'nb_visits' => 10, 'nb_actions' => 5],
@@ -177,7 +177,7 @@ END;
         $this->assertEquals($expectedXml, $xmlContent);
     }
 
-    public function test_compareTables_shouldCompareTwoDataTableMapsCorrectly()
+    public function testCompareTablesShouldCompareTwoDataTableMapsCorrectly()
     {
         $tableSet1 = $this->makeTableMap([
             '2012-01-01' => [
@@ -324,7 +324,7 @@ END;
         $this->assertEquals($expectedXml, $xmlContent);
     }
 
-    public function test_compareTables_shouldCompareTwoDataTaleMapsOfDifferentLengthsCorrectly_whenFirstIsLonger()
+    public function testCompareTablesShouldCompareTwoDataTaleMapsOfDifferentLengthsCorrectlyWhenFirstIsLonger()
     {
         $tableSet1 = $this->makeTableMap([
             '2012-01-01' => [
@@ -465,7 +465,7 @@ END;
         $this->assertEquals($expectedXml, $xmlContent);
     }
 
-    public function test_compareTables_shouldCompareTwoDataTaleMapsOfDifferentLengthsCorrectly_whenFirstIsShorter()
+    public function testCompareTablesShouldCompareTwoDataTaleMapsOfDifferentLengthsCorrectlyWhenFirstIsShorter()
     {
         $tableSet1 = $this->makeTableMap([
             '2012-01-01' => [

--- a/plugins/API/tests/Integration/RowEvolutionTest.php
+++ b/plugins/API/tests/Integration/RowEvolutionTest.php
@@ -26,7 +26,7 @@ class RowEvolutionTest extends IntegrationTestCase
         Fixture::createWebsite('2014-01-01 00:00:00');
     }
 
-    public function test_getRowEvolution_shouldTriggerAnException_IfReportHasNoDimension()
+    public function testGetRowEvolutionShouldTriggerAnExceptionIfReportHasNoDimension()
     {
         $this->expectException(\Exception::class);
         $this->expectDeprecationMessage("Reports like VisitsSummary.get which do not have a dimension are not supported by row evolution");
@@ -34,7 +34,7 @@ class RowEvolutionTest extends IntegrationTestCase
         $rowEvolution->getRowEvolution(1, 'day', 'last7', 'VisitsSummary', 'get');
     }
 
-    public function test_getRowEvolution_shouldNotTriggerAnException_IfReportHasADimension()
+    public function testGetRowEvolutionShouldNotTriggerAnExceptionIfReportHasADimension()
     {
         $rowEvolution = new RowEvolution();
         $table = $rowEvolution->getRowEvolution(1, 'day', 'last7', 'Actions', 'getPageUrls');

--- a/plugins/API/tests/Integration/RssRendererTest.php
+++ b/plugins/API/tests/Integration/RssRendererTest.php
@@ -37,56 +37,56 @@ class RssRendererTest extends IntegrationTestCase
         $this->builder = $this->makeBuilder(array('method' => 'MultiSites_getAll', 'idSite' => $idSite));
     }
 
-    public function test_renderSuccess_shouldIncludeMessage()
+    public function testRenderSuccessShouldIncludeMessage()
     {
         $response = $this->builder->renderSuccess('ok');
 
         $this->assertEquals('Success:ok', $response);
     }
 
-    public function test_renderException_shouldIncludeTheMessageAndNotExceptionMessage()
+    public function testRenderExceptionShouldIncludeTheMessageAndNotExceptionMessage()
     {
         $response = $this->builder->renderException("The error message", new \Exception('The other message'));
 
         $this->assertEquals('Error: The error message', $response);
     }
 
-    public function test_renderObject_shouldReturAnError()
+    public function testRenderObjectShouldReturAnError()
     {
         $response = $this->builder->renderObject(new \stdClass());
 
         $this->assertEquals('Error: The API cannot handle this data structure.', $response);
     }
 
-    public function test_renderResource_shouldReturAnError()
+    public function testRenderResourceShouldReturAnError()
     {
         $response = $this->builder->renderResource(new \stdClass());
 
         $this->assertEquals('Error: The API cannot handle this data structure.', $response);
     }
 
-    public function test_renderScalar_shouldFailForBooleanScalar()
+    public function testRenderScalarShouldFailForBooleanScalar()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
         $this->builder->renderScalar(true);
     }
 
-    public function test_renderScalar_shouldFailForIntegerScalar()
+    public function testRenderScalarShouldFailForIntegerScalar()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
         $this->builder->renderScalar(5);
     }
 
-    public function test_renderScalar_shouldFailForStringScalar()
+    public function testRenderScalarShouldFailForStringScalar()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
         $this->builder->renderScalar('string');
     }
 
-    public function test_renderDataTable_shouldFailForDataTable()
+    public function testRenderDataTableShouldFailForDataTable()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
@@ -96,7 +96,7 @@ class RssRendererTest extends IntegrationTestCase
         $this->builder->renderDataTable($dataTable);
     }
 
-    public function test_renderDataTable_shouldFailForSubtables()
+    public function testRenderDataTableShouldFailForSubtables()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
@@ -111,7 +111,7 @@ class RssRendererTest extends IntegrationTestCase
         $this->builder->renderDataTable($dataTable);
     }
 
-    public function test_renderDataTable_shouldFail_IfKeynameIsNotDate()
+    public function testRenderDataTableShouldFailIfKeynameIsNotDate()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
@@ -127,7 +127,7 @@ class RssRendererTest extends IntegrationTestCase
         $this->builder->renderDataTable($map);
     }
 
-    public function test_renderDataTable_shouldRenderDataTableMaps_IfKeynameIsDate()
+    public function testRenderDataTableShouldRenderDataTableMapsIfKeynameIsDate()
     {
         $map = new DataTable\Map();
         $map->setKeyName('date');
@@ -153,7 +153,7 @@ class RssRendererTest extends IntegrationTestCase
 </rss>', $response);
     }
 
-    public function test_renderDataTable_shouldFailForSimpleDataTable()
+    public function testRenderDataTableShouldFailForSimpleDataTable()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
@@ -164,7 +164,7 @@ class RssRendererTest extends IntegrationTestCase
         $this->builder->renderDataTable($dataTable);
     }
 
-    public function test_renderArray_ShouldFailForArrays()
+    public function testRenderArrayShouldFailForArrays()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('RSS feeds can be generated for one specific website');

--- a/plugins/API/tests/System/GetSegmentsMetadataAPITest.php
+++ b/plugins/API/tests/System/GetSegmentsMetadataAPITest.php
@@ -17,7 +17,7 @@ use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
 class GetSegmentsMetadataAPITest extends SystemTestCase
 {
-    public function test_it_contains_visitid_by_default()
+    public function testItContainsVisitidByDefault()
     {
         $request = new Request(
             'method=API.getSegmentsMetadata'
@@ -41,7 +41,7 @@ class GetSegmentsMetadataAPITest extends SystemTestCase
         $this->assertTrue($contains);
     }
 
-    public function test_it_does_not_contain_visitid_if_profile_disabled()
+    public function testItDoesNotContainVisitidIfProfileDisabled()
     {
         Cache::flushAll();
 

--- a/plugins/API/tests/Unit/ConsoleRendererTest.php
+++ b/plugins/API/tests/Unit/ConsoleRendererTest.php
@@ -31,21 +31,21 @@ class ConsoleRendererTest extends \PHPUnit\Framework\TestCase
         DataTable\Manager::getInstance()->deleteAll();
     }
 
-    public function test_renderSuccess_shouldAlwaysReturnTrueAndIgnoreMessage()
+    public function testRenderSuccessShouldAlwaysReturnTrueAndIgnoreMessage()
     {
         $response = $this->builder->renderSuccess('ok');
 
         $this->assertEquals('Success:ok', $response);
     }
 
-    public function test_renderException_shouldThrowTheException()
+    public function testRenderExceptionShouldThrowTheException()
     {
         $response = $this->builder->renderException('This message should be used', new \BadMethodCallException('The other message'));
 
         $this->assertEquals('Error: This message should be used', $response);
     }
 
-    public function test_renderScalar_shouldReturnTheSameValue()
+    public function testRenderScalarShouldReturnTheSameValue()
     {
         $response = $this->builder->renderScalar(true);
         $this->assertSame("- 1 ['0' => 1] [] [idsubtable = ]<br />
@@ -60,21 +60,21 @@ class ConsoleRendererTest extends \PHPUnit\Framework\TestCase
 ", $response);
     }
 
-    public function test_renderObject_shouldReturAnError()
+    public function testRenderObjectShouldReturAnError()
     {
         $response = $this->builder->renderObject(new \stdClass());
 
         $this->assertEquals('Error: The API cannot handle this data structure.', $response);
     }
 
-    public function test_renderResource_shouldReturAnError()
+    public function testRenderResourceShouldReturAnError()
     {
         $response = $this->builder->renderResource(new \stdClass());
 
         $this->assertEquals('Error: The API cannot handle this data structure.', $response);
     }
 
-    public function test_renderDataTable_shouldReturnResult()
+    public function testRenderDataTableShouldReturnResult()
     {
         $dataTable = new DataTable();
         $dataTable->addRowFromSimpleArray(array('nb_visits' => 5, 'nb_random' => 10));
@@ -85,7 +85,7 @@ class ConsoleRendererTest extends \PHPUnit\Framework\TestCase
 ", $response);
     }
 
-    public function test_renderDataTableWithObjects_shouldReturnResult()
+    public function testRenderDataTableWithObjectsShouldReturnResult()
     {
         $dataTable = new DataTable();
         $dataTable->addRowFromSimpleArray(array('nb_visits' => 5, 'nb_random' => 10));
@@ -101,7 +101,7 @@ class ConsoleRendererTest extends \PHPUnit\Framework\TestCase
 <hr />Metadata<br /><br /> <b>processedRows</b><br />0 => Object [Piwik\Plugins\CoreHome\Columns\Metrics\AverageTimeOnSite]1 => Object [stdClass]2 => 2016-01-01", $response);
     }
 
-    public function test_renderArray_ShouldReturnConsoleResult()
+    public function testRenderArrayShouldReturnConsoleResult()
     {
         $input = array(1, 2, 5, 'string', 10);
 
@@ -115,7 +115,7 @@ class ConsoleRendererTest extends \PHPUnit\Framework\TestCase
 ", $response);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalAssociativeArrayToJson()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Data structure returned is not convertible in the requested format');

--- a/plugins/API/tests/Unit/CsvRendererTest.php
+++ b/plugins/API/tests/Unit/CsvRendererTest.php
@@ -28,7 +28,7 @@ class CsvRendererTest extends \PHPUnit\Framework\TestCase
         $this->builder = $this->makeBuilder(array('method' => 'MultiSites_getAll', 'convertToUnicode' => 0));
     }
 
-    public function test_renderSuccess_shouldIncludeMessage()
+    public function testRenderSuccessShouldIncludeMessage()
     {
         $response = $this->builder->renderSuccess('ok');
 
@@ -36,14 +36,14 @@ class CsvRendererTest extends \PHPUnit\Framework\TestCase
 ok", $response);
     }
 
-    public function test_renderException_shouldIncludeTheMessageAndNotExceptionMessage()
+    public function testRenderExceptionShouldIncludeTheMessageAndNotExceptionMessage()
     {
         $response = $this->builder->renderException("The error message", new \Exception('The other message'));
 
         $this->assertEquals('Error: The error message', $response);
     }
 
-    public function test_renderException_shouldRespectNewlines()
+    public function testRenderExceptionShouldRespectNewlines()
     {
         $response = $this->builder->renderException("The\nerror\nmessage", new \Exception('The other message'));
 
@@ -52,21 +52,21 @@ error
 message', $response);
     }
 
-    public function test_renderObject_shouldReturAnError()
+    public function testRenderObjectShouldReturAnError()
     {
         $response = $this->builder->renderObject(new \stdClass());
 
         $this->assertEquals('Error: The API cannot handle this data structure.', $response);
     }
 
-    public function test_renderResource_shouldReturAnError()
+    public function testRenderResourceShouldReturAnError()
     {
         $response = $this->builder->renderResource(new \stdClass());
 
         $this->assertEquals('Error: The API cannot handle this data structure.', $response);
     }
 
-    public function test_renderScalar_shouldConvertToUnicodeByDefault()
+    public function testRenderScalarShouldConvertToUnicodeByDefault()
     {
         $builder  = $this->makeBuilder(array('method' => 'MultiSites_getAll'));
         $response = $builder->renderScalar(true);
@@ -74,7 +74,7 @@ message', $response);
         $this->assertStringStartsWith(chr(255) . chr(254), $response);
     }
 
-    public function test_renderScalar_shouldReturnABooleanAsIntegerWrappedInTable()
+    public function testRenderScalarShouldReturnABooleanAsIntegerWrappedInTable()
     {
         $response = $this->builder->renderScalar(true);
 
@@ -82,7 +82,7 @@ message', $response);
 1', $response);
     }
 
-    public function test_renderScalar_shouldReturnAnIntegerWrappedInTable()
+    public function testRenderScalarShouldReturnAnIntegerWrappedInTable()
     {
         $response = $this->builder->renderScalar(5);
 
@@ -90,7 +90,7 @@ message', $response);
 5', $response);
     }
 
-    public function test_renderScalar_shouldReturnAStringWrappedInValue()
+    public function testRenderScalarShouldReturnAStringWrappedInValue()
     {
         $response = $this->builder->renderScalar('The Output');
 
@@ -98,7 +98,7 @@ message', $response);
 The Output', $response);
     }
 
-    public function test_renderScalar_shouldNotRemoveLineBreaks()
+    public function testRenderScalarShouldNotRemoveLineBreaks()
     {
         $response = $this->builder->renderScalar('The\nOutput');
 
@@ -109,7 +109,7 @@ The\nOutput', $response);
     /**
      * @dataProvider getCellValuesToPrefixOrNot
      */
-    public function test_renderScalar_whenCellValueIsFormula_shouldPrefixWithQuote($value, $expectedCsvValue)
+    public function testRenderScalarWhenCellValueIsFormulaShouldPrefixWithQuote($value, $expectedCsvValue)
     {
         $response = $this->builder->renderScalar($value);
 
@@ -159,7 +159,7 @@ The\nOutput', $response);
     /**
      * @dataProvider getCellValuesToPrefixOrNot
      */
-    public function test_renderDataTable_shouldRenderFormulas($value, $expectedValue)
+    public function testRenderDataTableShouldRenderFormulas($value, $expectedValue)
     {
         $dataTable = new DataTable();
         $dataTable->addRowFromSimpleArray(array('nb_visits' => 5, 'nb_random' => $value));
@@ -169,7 +169,7 @@ The\nOutput', $response);
         $this->assertEquals("nb_visits,nb_random\n5,$expectedValue", $response);
     }
 
-    public function test_renderDataTable_shouldRenderABasicDataTable()
+    public function testRenderDataTableShouldRenderABasicDataTable()
     {
         $dataTable = new DataTable();
         $dataTable->addRowFromSimpleArray(array('nb_visits' => 5, 'nb_random' => 10));
@@ -180,7 +180,7 @@ The\nOutput', $response);
 5,10', $response);
     }
 
-    public function test_renderDataTable_shouldNotRenderSubtables_AsItIsNotSupportedYet()
+    public function testRenderDataTableShouldNotRenderSubtablesAsItIsNotSupportedYet()
     {
         $subtable = new DataTable();
         $subtable->addRowFromSimpleArray(array('nb_visits' => 2, 'nb_random' => 6));
@@ -195,7 +195,7 @@ The\nOutput', $response);
 5,10', $response);
     }
 
-    public function test_renderDataTable_shouldRenderDataTableMaps()
+    public function testRenderDataTableShouldRenderDataTableMaps()
     {
         $map = new DataTable\Map();
 
@@ -215,7 +215,7 @@ table1,5,10
 table2,3,6', $response);
     }
 
-    public function test_renderDataTable_shouldRenderSimpleDataTable()
+    public function testRenderDataTableShouldRenderSimpleDataTable()
     {
         $dataTable = new DataTable\Simple();
         $dataTable->addRowsFromArray(array('nb_visits' => 3, 'nb_random' => 6));
@@ -226,7 +226,7 @@ table2,3,6', $response);
 3,6', $response);
     }
 
-    public function test_renderArray_ShouldConvertSimpleArrayToJson()
+    public function testRenderArrayShouldConvertSimpleArrayToJson()
     {
         $input = array(1, 2, 5, 'string', 10);
 
@@ -239,14 +239,14 @@ string
 10', $response);
     }
 
-    public function test_renderArray_ShouldRenderAnEmptyArray()
+    public function testRenderArrayShouldRenderAnEmptyArray()
     {
         $response = $this->builder->renderArray(array());
 
         $this->assertEquals('No data available', $response);
     }
 
-    public function test_renderArray_ShouldConvertAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertAssociativeArrayToJson()
     {
         $input = array('nb_visits' => 6, 'nb_random' => 8);
 
@@ -256,7 +256,7 @@ string
 6,8', $response);
     }
 
-    public function test_renderArray_ShouldConvertsIndexedAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertsIndexedAssociativeArrayToJson()
     {
         $input = array(
             array('nb_visits' => 6, 'nb_random' => 8),
@@ -270,7 +270,7 @@ string
 3,4', $response);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalStandardArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalStandardArrayToJson()
     {
         $input = array("firstElement",
             array(
@@ -286,7 +286,7 @@ firstElement,secondElement,
 ,,thirdElement', $actual);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalAssociativeArrayToJson()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Data structure returned is not convertible in the requested format: Only integer keys supported for array columns on base level. Unsupported string 'secondElement' found for row 'array (
@@ -305,7 +305,7 @@ firstElement,secondElement,
         $this->builder->renderArray($input);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalIndexArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalIndexArrayToJson()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Data structure returned is not convertible in the requested format: Multidimensional column values not supported. Found unexpected array value for column '1' in row '0': 'array (
@@ -323,7 +323,7 @@ firstElement,secondElement,
         $this->builder->renderArray($input);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalMixedArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalMixedArrayToJson()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Data structure returned is not convertible in the requested format: Only integer keys supported for array columns on base level. Unsupported string 'thirdElement' found for row 'array (

--- a/plugins/API/tests/Unit/DataTable/MergeDataTablesTest.php
+++ b/plugins/API/tests/Unit/DataTable/MergeDataTablesTest.php
@@ -25,7 +25,7 @@ class MergeDataTablesTest extends \PHPUnit\Framework\TestCase
         $this->instance = new MergeDataTables();
     }
 
-    public function test_mergeDataTables_ReturnsCorrectDataWhenTwoTablesAreMerged()
+    public function testMergeDataTablesReturnsCorrectDataWhenTwoTablesAreMerged()
     {
         $table1 = new DataTable();
         $table1->addRowsFromArray([
@@ -68,7 +68,7 @@ END;
         $this->assertEquals($expectedXml, $xml);
     }
 
-    public function test_mergeDataTables_ReturnsCorrectDataWhenTwoMapsAreMerged_AndBothHaveTheSameAmountOfData()
+    public function testMergeDataTablesReturnsCorrectDataWhenTwoMapsAreMergedAndBothHaveTheSameAmountOfData()
     {
         $table1 = new DataTable\Map();
         $table1->setKeyName('period');
@@ -155,7 +155,7 @@ END;
         $this->assertEquals($expectedXml, $xml);
     }
 
-    public function test_mergeDataTables_ReturnsCorrectDataWhenTwoMapsAreMerged_AndFirstHasLessThanSecond()
+    public function testMergeDataTablesReturnsCorrectDataWhenTwoMapsAreMergedAndFirstHasLessThanSecond()
     {
         $table1 = new DataTable\Map();
         $table1->setKeyName('period');
@@ -224,7 +224,7 @@ END;
         $this->assertEquals($expectedXml, $xml);
     }
 
-    public function test_mergeDataTables_ReturnsCorrectDataWhenTwoMapsAreMerged_AndSecondHasLessThanFirst()
+    public function testMergeDataTablesReturnsCorrectDataWhenTwoMapsAreMergedAndSecondHasLessThanFirst()
     {
         $table1 = new DataTable\Map();
         $table1->setKeyName('period');
@@ -302,7 +302,7 @@ END;
         $this->assertEquals($expectedXml, $xml);
     }
 
-    public function test_mergeDataTables_ReturnsCorrectDataWhenMapsAreNested()
+    public function testMergeDataTablesReturnsCorrectDataWhenMapsAreNested()
     {
         $table1 = new DataTable\Map();
         $table1->setKeyName('site');

--- a/plugins/API/tests/Unit/HtmlRendererTest.php
+++ b/plugins/API/tests/Unit/HtmlRendererTest.php
@@ -31,21 +31,21 @@ class HtmlRendererTest extends \PHPUnit\Framework\TestCase
         DataTable\Manager::getInstance()->deleteAll();
     }
 
-    public function test_renderSuccess_shouldIncludeMessage()
+    public function testRenderSuccessShouldIncludeMessage()
     {
         $response = $this->builder->renderSuccess('ok');
 
         $this->assertEquals('<!-- Success: ok -->', $response);
     }
 
-    public function test_renderException_shouldIncludeTheMessageAndNotExceptionMessage()
+    public function testRenderExceptionShouldIncludeTheMessageAndNotExceptionMessage()
     {
         $response = $this->builder->renderException("The error message", new \Exception('The other message'));
 
         $this->assertEquals('The error message', $response);
     }
 
-    public function test_renderException_shouldConvertNewLinesToBr()
+    public function testRenderExceptionShouldConvertNewLinesToBr()
     {
         $response = $this->builder->renderException("The\nerror\nmessage", new \Exception('The other message'));
 
@@ -54,21 +54,21 @@ error<br />
 message', $response);
     }
 
-    public function test_renderObject_shouldReturAnError()
+    public function testRenderObjectShouldReturAnError()
     {
         $response = $this->builder->renderObject(new \stdClass());
 
         $this->assertEquals('The API cannot handle this data structure.', $response);
     }
 
-    public function test_renderResource_shouldReturAnError()
+    public function testRenderResourceShouldReturAnError()
     {
         $response = $this->builder->renderResource(new \stdClass());
 
         $this->assertEquals('The API cannot handle this data structure.', $response);
     }
 
-    public function test_renderScalar_shouldReturnABooleanAsIntegerWrappedInTable()
+    public function testRenderScalarShouldReturnABooleanAsIntegerWrappedInTable()
     {
         $response = $this->builder->renderScalar(true);
 
@@ -87,7 +87,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderScalar_shouldReturnAnIntegerWrappedInTable()
+    public function testRenderScalarShouldReturnAnIntegerWrappedInTable()
     {
         $response = $this->builder->renderScalar(5);
 
@@ -106,7 +106,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderScalar_shouldReturnAStringWrappedInValue()
+    public function testRenderScalarShouldReturnAStringWrappedInValue()
     {
         $response = $this->builder->renderScalar('The Output');
 
@@ -125,7 +125,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderScalar_shouldNotRemoveLineBreaks()
+    public function testRenderScalarShouldNotRemoveLineBreaks()
     {
         $response = $this->builder->renderScalar('The\nOutput');
 
@@ -144,7 +144,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderDataTable_shouldRenderABasicDataTable()
+    public function testRenderDataTableShouldRenderABasicDataTable()
     {
         $dataTable = new DataTable();
         $dataTable->addRowFromSimpleArray(array('nb_visits' => 5, 'nb_random' => 10));
@@ -168,7 +168,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderDataTable_shouldRenderSubtables()
+    public function testRenderDataTableShouldRenderSubtables()
     {
         $subtable = new DataTable();
         $subtable->addRowFromSimpleArray(array('nb_visits' => 2, 'nb_random' => 6));
@@ -198,7 +198,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderDataTable_shouldRenderDataTableMaps()
+    public function testRenderDataTableShouldRenderDataTableMaps()
     {
         $map = new DataTable\Map();
 
@@ -237,7 +237,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderDataTable_shouldRenderSimpleDataTable()
+    public function testRenderDataTableShouldRenderSimpleDataTable()
     {
         $dataTable = new DataTable\Simple();
         $dataTable->addRowsFromArray(array('nb_visits' => 3, 'nb_random' => 6));
@@ -261,7 +261,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderDataTable_shouldRenderDataTableWithComplexMetadata()
+    public function testRenderDataTableShouldRenderDataTableWithComplexMetadata()
     {
         $dataTable = new DataTable\Simple();
         $row = new DataTable\Row();
@@ -312,7 +312,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderArray_ShouldConvertSimpleArrayToJson()
+    public function testRenderArrayShouldConvertSimpleArrayToJson()
     {
         $input = array(1, 2, 5, 'string', 10);
 
@@ -345,7 +345,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderArray_ShouldRenderAnEmptyArray()
+    public function testRenderArrayShouldRenderAnEmptyArray()
     {
         $response = $this->builder->renderArray(array());
 
@@ -360,7 +360,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderArray_ShouldConvertAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertAssociativeArrayToJson()
     {
         $input = array('nb_visits' => 6, 'nb_random' => 8);
 
@@ -383,7 +383,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderArray_ShouldConvertsIndexedAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertsIndexedAssociativeArrayToJson()
     {
         $input = array(
             array('nb_visits' => 6, 'nb_random' => 8),
@@ -413,7 +413,7 @@ message', $response);
 ', $response);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalStandardArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalStandardArrayToJson()
     {
         $input = array("firstElement",
             array(
@@ -452,7 +452,7 @@ message', $response);
 ', $actual);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalAssociativeArrayToJson()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Data structure returned is not convertible in the requested format: Only integer keys supported for array columns on base level. Unsupported string 'secondElement' found for row 'array (
@@ -471,7 +471,7 @@ message', $response);
         $this->builder->renderArray($input);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalIndexArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalIndexArrayToJson()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Data structure returned is not convertible in the requested format: Multidimensional column values not supported. Found unexpected array value for column '1' in row '0': 'array (
@@ -489,7 +489,7 @@ message', $response);
         $this->builder->renderArray($input);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalMixedArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalMixedArrayToJson()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage("Data structure returned is not convertible in the requested format: Only integer keys supported for array columns on base level. Unsupported string 'thirdElement' found for row 'array (

--- a/plugins/API/tests/Unit/JsonRendererTest.php
+++ b/plugins/API/tests/Unit/JsonRendererTest.php
@@ -31,7 +31,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         DataTable\Manager::getInstance()->deleteAll();
     }
 
-    public function test_renderSuccess_shouldIncludeMessage()
+    public function testRenderSuccessShouldIncludeMessage()
     {
         $response = $this->jsonBuilder->renderSuccess('ok');
 
@@ -40,7 +40,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderSuccess_shouldWrapIfEnabledAndCallbackShouldBePreferred()
+    public function testRenderSuccessShouldWrapIfEnabledAndCallbackShouldBePreferred()
     {
         $builder  = $this->makeBuilder(array('callback' => 'myName', 'jsoncallback' => 'myOther'));
         $response = $builder->renderSuccess('ok');
@@ -49,7 +49,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderSuccess_shouldWrapIfEnabledAndFallbackToJsonCallbackIfCallbackNotSet()
+    public function testRenderSuccessShouldWrapIfEnabledAndFallbackToJsonCallbackIfCallbackNotSet()
     {
         $builder  = $this->makeBuilder(array('jsoncallback' => 'myOther'));
         $response = $builder->renderSuccess('ok');
@@ -58,7 +58,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderSuccess_shouldNotWrapIfCallbackContainsInvalidCharacters()
+    public function testRenderSuccessShouldNotWrapIfCallbackContainsInvalidCharacters()
     {
         $builder  = $this->makeBuilder(array('callback' => 'myOther#?._kek'));
         $response = $builder->renderSuccess('ok');
@@ -67,7 +67,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderException_shouldIncludeTheMessageAndNotExceptionMessage()
+    public function testRenderExceptionShouldIncludeTheMessageAndNotExceptionMessage()
     {
         $response = $this->jsonBuilder->renderException("The error message", new \Exception('The other message'));
 
@@ -76,7 +76,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderException_shouldRemoveNewlines()
+    public function testRenderExceptionShouldRemoveNewlines()
     {
         $response = $this->jsonBuilder->renderException("The\nerror\r\nmessage", new \Exception());
 
@@ -85,7 +85,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderException_shouldWrapIfEnabled()
+    public function testRenderExceptionShouldWrapIfEnabled()
     {
         $builder  = $this->makeBuilder(array('callback' => 'myName'));
         $response = $builder->renderException('error', new \Exception());
@@ -94,7 +94,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderObject_shouldReturAnError()
+    public function testRenderObjectShouldReturAnError()
     {
         $response = $this->jsonBuilder->renderObject(new \stdClass());
 
@@ -102,7 +102,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderResource_shouldReturAnError()
+    public function testRenderResourceShouldReturAnError()
     {
         $response = $this->jsonBuilder->renderResource(new \stdClass());
 
@@ -110,7 +110,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderScalar_shouldReturnABooleanWrappedInValue()
+    public function testRenderScalarShouldReturnABooleanWrappedInValue()
     {
         $response = $this->jsonBuilder->renderScalar(true);
 
@@ -118,7 +118,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderScalar_shouldReturnAnIntegerWrappedInValue()
+    public function testRenderScalarShouldReturnAnIntegerWrappedInValue()
     {
         $response = $this->jsonBuilder->renderScalar(5);
 
@@ -126,7 +126,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderScalar_shouldReturnAStringWrappedInValue()
+    public function testRenderScalarShouldReturnAStringWrappedInValue()
     {
         $response = $this->jsonBuilder->renderScalar('The Output');
 
@@ -134,7 +134,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderScalar_shouldNotRemoveLineBreaks()
+    public function testRenderScalarShouldNotRemoveLineBreaks()
     {
         $response = $this->jsonBuilder->renderScalar('The\nOutput');
 
@@ -142,7 +142,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderScalar_shouldWrapJsonIfNeeded()
+    public function testRenderScalarShouldWrapJsonIfNeeded()
     {
         $builder  = $this->makeBuilder(array('callback' => 'myName'));
         $response = $builder->renderScalar(true);
@@ -151,7 +151,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderDataTable_shouldRenderABasicDataTable()
+    public function testRenderDataTableShouldRenderABasicDataTable()
     {
         $dataTable = new DataTable();
         $dataTable->addRowFromSimpleArray(array('nb_visits' => 5, 'nb_random' => 10));
@@ -162,7 +162,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderDataTable_shouldRenderSubtables()
+    public function testRenderDataTableShouldRenderSubtables()
     {
         $subtable = new DataTable();
         $subtable->addRowFromSimpleArray(array('nb_visits' => 2, 'nb_random' => 6));
@@ -177,7 +177,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderDataTable_shouldRenderDataTableMaps()
+    public function testRenderDataTableShouldRenderDataTableMaps()
     {
         $map = new DataTable\Map();
 
@@ -196,7 +196,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderDataTable_shouldRenderSimpleDataTable()
+    public function testRenderDataTableShouldRenderSimpleDataTable()
     {
         $dataTable = new DataTable\Simple();
         $dataTable->addRowsFromArray(array('nb_visits' => 3, 'nb_random' => 6));
@@ -207,7 +207,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderDataTable_shouldWrapADataTable()
+    public function testRenderDataTableShouldWrapADataTable()
     {
         $builder  = $this->makeBuilder(array('callback' => 'myName'));
         $dataTable = new DataTable();
@@ -219,7 +219,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderArray_ShouldConvertSimpleArrayToJson()
+    public function testRenderArrayShouldConvertSimpleArrayToJson()
     {
         $input = array(1, 2, 5, 'string', 10);
 
@@ -229,7 +229,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderArray_ShouldWrapJsonIfRequested()
+    public function testRenderArrayShouldWrapJsonIfRequested()
     {
         $input = array(1, 2, 5, 'string', 10);
 
@@ -239,7 +239,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('myName([1,2,5,"string",10])', $response);
     }
 
-    public function test_renderArray_withAssociativeArrayJsonpCorrectlyFormatted()
+    public function testRenderArrayWithAssociativeArrayJsonpCorrectlyFormatted()
     {
         $input = array('key' => 'value');
         $renderer  = $this->makeBuilder(array('callback' => '__myfunc', 'jsoncallback' => '__myfunc'));
@@ -249,7 +249,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($result);
     }
 
-    public function test_renderArray_withMultidimensionalArrayJsonpCorrectlyFormatted()
+    public function testRenderArrayWithMultidimensionalArrayJsonpCorrectlyFormatted()
     {
         $input = array('key' => 'value', 'deepKey' => array('deeper' => 'deepValue'));
         $renderer  = $this->makeBuilder(array('callback' => '__myfunc', 'jsoncallback' => '__myfunc'));
@@ -259,7 +259,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($result);
     }
 
-    public function test_renderArray_ShouldRenderAnEmptyArray()
+    public function testRenderArrayShouldRenderAnEmptyArray()
     {
         $response = $this->jsonBuilder->renderArray(array());
 
@@ -267,7 +267,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderArray_ShouldConvertAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertAssociativeArrayToJson()
     {
         $input = array('nb_visits' => 6, 'nb_random' => 8);
 
@@ -278,7 +278,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderArray_ShouldConvertsIndexedAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertsIndexedAssociativeArrayToJson()
     {
         $input = array(
             array('nb_visits' => 6, 'nb_random' => 8),
@@ -292,7 +292,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($response);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalStandardArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalStandardArrayToJson()
     {
         $input = array("firstElement",
             array(
@@ -308,7 +308,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($actual);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalAssociativeArrayToJson()
     {
         $input = array(
             "firstElement"  => "isFirst",
@@ -325,7 +325,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($actual);
     }
 
-    public function test_renderArray_ShouldConvertSingleDimensionalAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertSingleDimensionalAssociativeArrayToJson()
     {
         $input = array(
             "fistElement" => "isFirst",
@@ -339,7 +339,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($actual);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalIndexArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalIndexArrayToJson()
     {
         $input = array(array("firstElement",
             array(
@@ -355,7 +355,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($actual);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalMixedArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalMixedArrayToJson()
     {
         $input = array(
             "firstElement" => "isFirst",
@@ -376,7 +376,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($actual);
     }
 
-    public function test_json_renderArray_ShouldConvertSingleDimensionalAssociativeArray()
+    public function testJsonRenderArrayShouldConvertSingleDimensionalAssociativeArray()
     {
         $input = array(
             "firstElement" => "isFirst",
@@ -391,7 +391,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertNoJsonError($actual);
     }
 
-    public function test_render_withNestedEmptyArrayWorks()
+    public function testRenderWithNestedEmptyArrayWorks()
     {
         $input = [[]];
         $render = new Json($input);

--- a/plugins/API/tests/Unit/OriginalRendererTest.php
+++ b/plugins/API/tests/Unit/OriginalRendererTest.php
@@ -28,14 +28,14 @@ class OriginalRendererTest extends \PHPUnit\Framework\TestCase
         $this->builder = $this->makeBuilder(array());
     }
 
-    public function test_renderSuccess_shouldAlwaysReturnTrueAndIgnoreMessage()
+    public function testRenderSuccessShouldAlwaysReturnTrueAndIgnoreMessage()
     {
         $response = $this->builder->renderSuccess('ok');
 
         $this->assertTrue($response);
     }
 
-    public function test_renderException_shouldThrowTheException()
+    public function testRenderExceptionShouldThrowTheException()
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('The other message');
@@ -43,7 +43,7 @@ class OriginalRendererTest extends \PHPUnit\Framework\TestCase
         $this->builder->renderException('This message should be ignored', new \BadMethodCallException('The other message'));
     }
 
-    public function test_renderScalar_shouldReturnTheSameValue()
+    public function testRenderScalarShouldReturnTheSameValue()
     {
         $response = $this->builder->renderScalar(true);
         $this->assertSame(true, $response);
@@ -55,7 +55,7 @@ class OriginalRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('string', $response);
     }
 
-    public function test_renderObject_shouldReturnTheSameValue()
+    public function testRenderObjectShouldReturnTheSameValue()
     {
         $response = $this->builder->renderObject($this);
         $this->assertSame($this, $response);
@@ -65,14 +65,14 @@ class OriginalRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($stdObject, $response);
     }
 
-    public function test_renderResource_shouldReturnTheSameValue()
+    public function testRenderResourceShouldReturnTheSameValue()
     {
         $resource = curl_init();
         $response = $this->builder->renderResource($resource);
         $this->assertSame($resource, $response);
     }
 
-    public function test_renderDataTable_shouldReturnSameInstanceAndNotSerializeByDefault()
+    public function testRenderDataTableShouldReturnSameInstanceAndNotSerializeByDefault()
     {
         $dataTable = new DataTable();
         $dataTable->addRowFromSimpleArray(array('nb_visits' => 5, 'nb_random' => 10));
@@ -82,7 +82,7 @@ class OriginalRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($dataTable, $response);
     }
 
-    public function test_renderDataTable_shouldSerializeIfEnabled()
+    public function testRenderDataTableShouldSerializeIfEnabled()
     {
         $dataTable = new DataTable();
         $dataTable->addRowFromSimpleArray(array('nb_visits' => 5, 'nb_random' => 10));
@@ -97,7 +97,7 @@ class OriginalRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $response);
     }
 
-    public function test_renderArray_ShouldReturnSameArrayAndNotSerializeByDefault()
+    public function testRenderArrayShouldReturnSameArrayAndNotSerializeByDefault()
     {
         $input = array(1, 2, 5, 'string', 10);
 
@@ -106,7 +106,7 @@ class OriginalRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($input, $response);
     }
 
-    public function test_renderArray_ShouldSerializeIfEnabled()
+    public function testRenderArrayShouldSerializeIfEnabled()
     {
         $builder  = $this->makeBuilder(array('serialize' => 1));
         $input    = array(1, 2, 5, 'string', 10);
@@ -116,7 +116,7 @@ class OriginalRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('a:5:{i:0;i:1;i:1;i:2;i:2;i:5;i:3;s:6:"string";i:4;i:10;}', $response);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalAssociativeArrayToJson()
     {
         $input = array(
             "firstElement"  => "isFirst",

--- a/plugins/API/tests/Unit/WidgetMetadataTest.php
+++ b/plugins/API/tests/Unit/WidgetMetadataTest.php
@@ -35,7 +35,7 @@ class WidgetMetadataTest extends \PHPUnit\Framework\TestCase
         $this->metadata = new WidgetMetadata();
     }
 
-    public function test_buildWidgetMetadata_ShouldGenerateMetadata()
+    public function testBuildWidgetMetadataShouldGenerateMetadata()
     {
         $config = $this->createWidgetConfig('Test', 'CategoryId', 'SubcategoryId');
         $list = $this->createCategoryList(array('CategoryId' => array('SubcategoryId')));
@@ -69,7 +69,7 @@ class WidgetMetadataTest extends \PHPUnit\Framework\TestCase
         ), $metadata);
     }
 
-    public function test_buildWidgetMetadata_ShouldSetCategoryAndSubcategoryToNull_IfBothGivenButNotExistInList()
+    public function testBuildWidgetMetadataShouldSetCategoryAndSubcategoryToNullIfBothGivenButNotExistInList()
     {
         $config = $this->createWidgetConfig('Test', 'CategoryId', 'SubcategoryId');
         $list = $this->createCategoryList();
@@ -79,7 +79,7 @@ class WidgetMetadataTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($metadata['subcategory']);
     }
 
-    public function test_buildWidgetMetadata_ShouldSetSubcategoryToNull_IfCategoryGivenInListButSubcategoryNot()
+    public function testBuildWidgetMetadataShouldSetSubcategoryToNullIfCategoryGivenInListButSubcategoryNot()
     {
         $config = $this->createWidgetConfig('Test', 'CategoryId', 'SubcategoryId');
         $list = $this->createCategoryList(array('CategoryId' => array()));
@@ -96,7 +96,7 @@ class WidgetMetadataTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($metadata['subcategory']);
     }
 
-    public function test_buildWidgetMetadata_ShouldNotAddCategoryAndSubcategoryToNull_IfNoCategoryListGiven()
+    public function testBuildWidgetMetadataShouldNotAddCategoryAndSubcategoryToNullIfNoCategoryListGiven()
     {
         $config = $this->createWidgetConfig('Test', 'CategoryId', 'SubcategoryId');
         $metadata = $this->metadata->buildWidgetMetadata($config);
@@ -105,7 +105,7 @@ class WidgetMetadataTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayNotHasKey('subcategory', $metadata);
     }
 
-    public function test_buildWidgetMetadata_ShouldAddOptionalMiddlewareParameters()
+    public function testBuildWidgetMetadataShouldAddOptionalMiddlewareParameters()
     {
         $config = $this->createWidgetConfig('Test', 'CategoryId', 'SubcategoryId');
         $config->setMiddlewareParameters(array('module' => 'Goals', 'action' => 'hasAnyConversions'));
@@ -114,7 +114,7 @@ class WidgetMetadataTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array('module' => 'Goals', 'action' => 'hasAnyConversions'), $metadata['middlewareParameters']);
     }
 
-    public function test_buildWidgetMetadata_ShouldAddReportInformtion_IfReportWidgetConfigGiven()
+    public function testBuildWidgetMetadataShouldAddReportInformtionIfReportWidgetConfigGiven()
     {
         $config = new ReportWidgetConfig();
         $config->setDefaultViewDataTable('graph');
@@ -124,7 +124,7 @@ class WidgetMetadataTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($metadata['isReport']);
     }
 
-    public function test_buildWidgetMetadata_ShouldAddContainerInformtion_IfWidgetContainerConfigGiven()
+    public function testBuildWidgetMetadataShouldAddContainerInformtionIfWidgetContainerConfigGiven()
     {
         $config = new WidgetContainerConfig();
         $config->setLayout('ByDimension');
@@ -192,7 +192,7 @@ class WidgetMetadataTest extends \PHPUnit\Framework\TestCase
         ), $widget2);
     }
 
-    public function test_buildWidgetMetadata_ShouldUseOverrideValues_IfSupplied()
+    public function testBuildWidgetMetadataShouldUseOverrideValuesIfSupplied()
     {
         $categoryList = $this->createCategoryList([
             'Category' => ['Subcategory'],
@@ -234,7 +234,7 @@ class WidgetMetadataTest extends \PHPUnit\Framework\TestCase
         ], $metadata);
     }
 
-    public function test_buildPageMetadata_ShouldAddContainerInformtion_IfWidgetContainerConfigGiven()
+    public function testBuildPageMetadataShouldAddContainerInformtionIfWidgetContainerConfigGiven()
     {
         $config = new WidgetContainerConfig();
         $config->setLayout('ByDimension');

--- a/plugins/API/tests/Unit/XmlRendererTest.php
+++ b/plugins/API/tests/Unit/XmlRendererTest.php
@@ -34,7 +34,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
         DataTable\Manager::getInstance()->deleteAll();
     }
 
-    public function test_renderSuccess_shouldIncludeMessage()
+    public function testRenderSuccessShouldIncludeMessage()
     {
         $response = $this->builder->renderSuccess('ok');
 
@@ -44,7 +44,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $response);
     }
 
-    public function test_renderException_shouldIncludeTheMessageAndNotExceptionMessage()
+    public function testRenderExceptionShouldIncludeTheMessageAndNotExceptionMessage()
     {
         $response = $this->builder->renderException("The error message", new \Exception('The other message'));
 
@@ -54,7 +54,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $response);
     }
 
-    public function test_renderObject_shouldReturAnError()
+    public function testRenderObjectShouldReturAnError()
     {
         $response = $this->builder->renderObject(new \stdClass());
 
@@ -64,7 +64,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $response);
     }
 
-    public function test_renderResource_shouldReturAnError()
+    public function testRenderResourceShouldReturAnError()
     {
         $response = $this->builder->renderResource(new \stdClass());
 
@@ -74,7 +74,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $response);
     }
 
-    public function test_renderScalar_shouldReturnABooleanAsIntegerWrappedInResult()
+    public function testRenderScalarShouldReturnABooleanAsIntegerWrappedInResult()
     {
         $response = $this->builder->renderScalar(true);
 
@@ -82,7 +82,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 <result>1</result>', $response);
     }
 
-    public function test_renderScalar_shouldReturnAnIntegerWrappedInResult()
+    public function testRenderScalarShouldReturnAnIntegerWrappedInResult()
     {
         $response = $this->builder->renderScalar(5);
 
@@ -90,7 +90,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 <result>5</result>', $response);
     }
 
-    public function test_renderScalar_shouldReturnAStringWrappedInValue()
+    public function testRenderScalarShouldReturnAStringWrappedInValue()
     {
         $response = $this->builder->renderScalar('The Output');
 
@@ -98,7 +98,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 <result>The Output</result>', $response);
     }
 
-    public function test_renderScalar_shouldNotRemoveLineBreaks()
+    public function testRenderScalarShouldNotRemoveLineBreaks()
     {
         $response = $this->builder->renderScalar('The\nOutput');
 
@@ -106,7 +106,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 <result>The\nOutput</result>', $response);
     }
 
-    public function test_renderDataTable_shouldRenderABasicDataTable()
+    public function testRenderDataTableShouldRenderABasicDataTable()
     {
         $dataTable = new DataTable();
         $dataTable->addRowFromSimpleArray(array('nb_visits' => 5, 'nb_random' => 10));
@@ -122,7 +122,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $response);
     }
 
-    public function test_renderDataTable_shouldRenderSubtables()
+    public function testRenderDataTableShouldRenderSubtables()
     {
         $subtable = new DataTable();
         $subtable->addRowFromSimpleArray(array('nb_visits' => 2, 'nb_random' => 6));
@@ -143,7 +143,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $response);
     }
 
-    public function test_renderDataTable_shouldRenderDataTableMaps()
+    public function testRenderDataTableShouldRenderDataTableMaps()
     {
         $map = new DataTable\Map();
 
@@ -175,7 +175,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </results>', $response);
     }
 
-    public function test_renderDataTable_shouldRenderSimpleDataTable()
+    public function testRenderDataTableShouldRenderSimpleDataTable()
     {
         $dataTable = new DataTable\Simple();
         $dataTable->addRowsFromArray(array('nb_visits' => 3, 'nb_random' => 6));
@@ -189,7 +189,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $response);
     }
 
-    public function test_renderArray_ShouldConvertSimpleArrayToJson()
+    public function testRenderArrayShouldConvertSimpleArrayToJson()
     {
         $input = array(1, 2, 5, 'string', 10);
 
@@ -205,7 +205,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $response);
     }
 
-    public function test_renderArray_ShouldRenderAnEmptyArray()
+    public function testRenderArrayShouldRenderAnEmptyArray()
     {
         $response = $this->builder->renderArray(array());
 
@@ -213,7 +213,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 <result />', $response);
     }
 
-    public function test_renderArray_ShouldConvertAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertAssociativeArrayToJson()
     {
         $input = array('nb_visits' => 6, 'nb_random' => 8);
 
@@ -228,7 +228,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $response);
     }
 
-    public function test_renderArray_ShouldConvertsIndexedAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertsIndexedAssociativeArrayToJson()
     {
         $input = array(
             array('nb_visits' => 6, 'nb_random' => 8),
@@ -250,7 +250,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $response);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalStandardArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalStandardArrayToJson()
     {
         $input = array("firstElement",
             array(
@@ -271,7 +271,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $actual);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalAssociativeArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalAssociativeArrayToJson()
     {
         $input = array(
             "firstElement"  => "isFirst",
@@ -293,7 +293,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $actual);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalIndexArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalIndexArrayToJson()
     {
         $input = array(array("firstElement",
             array(
@@ -316,7 +316,7 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
 </result>', $actual);
     }
 
-    public function test_renderArray_ShouldConvertMultiDimensionalMixedArrayToJson()
+    public function testRenderArrayShouldConvertMultiDimensionalMixedArrayToJson()
     {
         $input = array(
             "firstElement" => "isFirst",


### PR DESCRIPTION
### Description:

refs #22144 

Note: Failing PHPCS can be ignored. It should succeed in the main PR once all chunks are finished and merged.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
