### PR TITLE
Fix incorrect number formatting in prettifyNumberOfDownloads function

### DIFF
--- a/plugins/Marketplace/Plugins.php
+++ b/plugins/Marketplace/Plugins.php
@@ -430,7 +430,7 @@ class Plugins
      * @param $plugin
      * @return void
      */
-    protected function prettifyNumberOfDownloads(&$plugin): void
+    private function prettifyNumberOfDownloads(&$plugin): void
     {
         $num = $nice = $plugin['numDownloads'] ?? 0;
 

--- a/plugins/Marketplace/Plugins.php
+++ b/plugins/Marketplace/Plugins.php
@@ -430,14 +430,14 @@ class Plugins
      * @param $plugin
      * @return void
      */
-    private function prettifyNumberOfDownloads(&$plugin): void
+    protected function prettifyNumberOfDownloads(&$plugin): void
     {
         $num = $nice = $plugin['numDownloads'] ?? 0;
 
         if (($num >= 1000) && ($num < 100000)) {
             $nice = round($num / 1000, 1, PHP_ROUND_HALF_DOWN) . 'k';
         } elseif (($num >= 100000) && ($num < 1000000)) {
-            $nice = floor($num / 100000) . 'k';
+            $nice = floor($num / 1000) . 'k';
         } elseif ($num >= 1000000) {
             $nice = floor($num / 1000000) . 'm';
         }

--- a/plugins/Marketplace/tests/Unit/PluginsTest.php
+++ b/plugins/Marketplace/tests/Unit/PluginsTest.php
@@ -15,7 +15,7 @@ class PluginsTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider getNumberOfDownloadsData
      */
-    public function test_prettifyNumberOfDownloads($numDownloads, $expectedPrettyDownloads)
+    public function testPrettifyNumberOfDownloads($numDownloads, $expectedPrettyDownloads)
     {
         $pluginsClass = new Plugins(
             $this->createMock('Piwik\Plugins\Marketplace\Api\Client'),

--- a/plugins/Marketplace/tests/Unit/PluginsTest.php
+++ b/plugins/Marketplace/tests/Unit/PluginsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Piwik\Plugins\Marketplace\tests\Unit;
+
+use Piwik\Plugins\Marketplace\Plugins;
+use ReflectionClass;
+
+/**
+ * @group Marketplace
+ * @group PluginsTest
+ * @group Plugins
+ */
+class PluginsTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider getNumberOfDownloadsData
+     */
+    public function test_prettifyNumberOfDownloads($numDownloads, $expectedPrettyDownloads)
+    {
+        $pluginsClass = new Plugins(
+            $this->createMock('Piwik\Plugins\Marketplace\Api\Client'),
+            $this->createMock('Piwik\Plugins\Marketplace\Consumer'),
+            $this->createMock('Piwik\ProfessionalServices\Advertising')
+        );
+
+        $pluginsReflection = new ReflectionClass($pluginsClass);
+        $method = $pluginsReflection->getMethod('prettifyNumberOfDownloads');
+        $method->setAccessible(true);
+
+        $plugin = ['numDownloads' => $numDownloads];
+        $method->invokeArgs($pluginsClass, [&$plugin]);
+
+        $this->assertEquals($expectedPrettyDownloads, $plugin['numDownloadsPretty']);
+    }
+
+    public function getNumberOfDownloadsData(): array
+    {
+        return [
+            [-1, -1],
+            [0, 0],
+            [999, 999],
+            [1000, '1k'],
+            [1050, '1k'],
+            [1051, '1.1k'],
+            [1550, '1.5k'],
+            [1551, '1.6k'],
+            [9950, '9.9k'],
+            [9951, '10k'],
+            [9999, '10k'],
+            [10000, '10k'],
+            [10100, '10.1k'],
+            [99950, '99.9k'],
+            [99951, '100k'],
+            [100000, '100k'],
+            [999999, '999k'],
+            [1000000, '1m'],
+            [1100000, '1m'],
+            [9999999, '9m'],
+            [10000000, '10m'],
+            [10000001, '10m'],
+            [99999999, '99m'],
+            [100000000, '100m'],
+            [100000001, '100m'],
+            [999999999, '999m'],
+            [1000000000, '1000m'],
+        ];
+    }
+}


### PR DESCRIPTION
### Description:

Fixed a bug in the "prettifyNumberOfDownloads" function where numbers between 100,000 and 999,999 were incorrectly formatted. For example, 100,000 was formatted as "1k" instead of "100k". Also added a new unit test class to cover test cases for that function.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
