### PR TITLE
[Test stability] Improve stability of Tracker\RequestSetTest

### DIFF
--- a/tests/PHPUnit/Unit/Tracker/RequestSetTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestSetTest.php
@@ -116,18 +116,22 @@ class RequestSetTest extends UnitTestCase
 
     public function testSetRequestsShouldIgnoreEmptyRequestsButNotArrays()
     {
-        $requests = array(
-            $this->buildRequest(5),
+        $request1 = $this->buildRequest(5);
+        $request2 = $this->buildRequest(2);
+        $request3 = $this->buildRequest(6);
+
+        $requests = [
+            $request1,
             null,
-            $this->buildRequest(2),
+            $request2,
             0,
-            $this->buildRequest(6),
-            array()
-        );
+            $request3,
+            []
+        ];
 
         $this->requestSet->setRequests($requests);
 
-        $expected = array($this->buildRequest(5), $this->buildRequest(2), $this->buildRequest(6), new Request(array()));
+        $expected = [$request1, $request2, $request3, new Request([])];
         $this->assertEquals($expected, $this->requestSet->getRequests());
     }
 


### PR DESCRIPTION
### Description:

The test currently sometimes randomly fails. The reason for this is, that a request contains a timestamp, which might get higher between the calls of `buildRequest`

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
