### PR TITLE
Adjust preview channel condition

### DIFF
--- a/.github/scripts/build-package.sh
+++ b/.github/scripts/build-package.sh
@@ -166,7 +166,7 @@ echo "Working directory is '$CURRENT_DIR'..."
 
 echo -e "Going to build Matomo $VERSION (Major version: $MAJOR_VERSION)"
 
-if ! echo "$VERSION" | grep -E 'rc|b|a|alpha|beta|dev|build|preview' -i
+if ! echo "$VERSION" | grep -E 'rc|b|a|alpha|beta|dev|build|p[0-9]{14}' -i
 then
     if curl --output /dev/null --silent --head --fail "https://builds.matomo.org/$F-$VERSION.zip"
     then

--- a/.github/scripts/build-package.sh
+++ b/.github/scripts/build-package.sh
@@ -168,7 +168,7 @@ echo -e "Going to build Matomo $VERSION (Major version: $MAJOR_VERSION)"
 
 if ! echo "$VERSION" | grep -E 'rc|b|a|alpha|beta|dev|build|p[0-9]{14}' -i
 then
-    if curl --output /dev/null --silent --head --fail "https://builds.matomo.org/$F-$VERSION.zip"
+    if curl --output /dev/null --silent --head --fail "https://builds.matomo.org/matomo-$VERSION.zip"
     then
         echo "--> Error: stable version $VERSION has already been built (not expected). <-- "
     fi

--- a/.github/scripts/build-package.sh
+++ b/.github/scripts/build-package.sh
@@ -219,7 +219,10 @@ echo "Git tag: $(git describe --exact-match --tags HEAD)"
 echo "Git path: $CURRENT_DIR/$LOCAL_REPO"
 echo "Matomo version in core/Version.php: $(php -r "include_once 'core/Version.php'; echo \Piwik\Version::VERSION;")"
 
-if [ "$VERSION" != "build" ]; then
+IS_PREVIEW_VERSION=$(php -r "include_once 'core/Version.php'; \$v = new \Piwik\Version(); echo (int) \$v->isPreviewVersion('$VERSION');")
+
+if [ "$VERSION" != "build" ] && [ "$IS_PREVIEW_VERSION" == "0" ]
+then
   [ "$(grep "'$VERSION'" core/Version.php | wc -l)" = "1" ] || die "version $VERSION does not match core/Version.php";
 fi
 

--- a/core/Version.php
+++ b/core/Version.php
@@ -9,6 +9,8 @@
 
 namespace Piwik;
 
+use DateTime;
+
 /**
  * Matomo version information.
  *
@@ -24,18 +26,34 @@ final class Version
 
     public const MAJOR_VERSION = 5;
 
-    public function isStableVersion($version)
+    public function isStableVersion($version): bool
     {
-        return (bool) preg_match('/^(\d+)\.(\d+)\.(\d+)$/', $version);
+        return (bool) preg_match('/^\d+\.\d+\.\d+$/', $version);
     }
 
-    public function isVersionNumber($version)
+    public function isVersionNumber($version): bool
     {
-        return $this->isStableVersion($version) || $this->isNonStableVersion($version);
+        return
+            $this->isStableVersion($version) ||
+            $this->isNonStableVersion($version) ||
+            $this->isPreviewVersion($version);
     }
 
-    private function isNonStableVersion($version)
+    private function isNonStableVersion($version): bool
     {
-        return (bool) preg_match('/^(\d+)\.(\d+)\.(\d+)-.{1,4}(\d+)$/', $version);
+        return (bool) preg_match('/^\d+\.\d+\.\d+((-.{1,4}\d+(-p\d{14})?)|(-dev-p\d{14}))$/i', $version);
+    }
+
+    public function isPreviewVersion($version): bool
+    {
+        if (\preg_match('/^\d+\.\d+\.\d+((-(rc|b|beta)\d+(-p\d{14})?)|(-dev-p\d{14}))?$/i', $version)) {
+            if (\preg_match('/-p(\d{14})$/', $version, $matches)) {
+                $dt = DateTime::createFromFormat('YmdHis', $matches[1]);
+
+                return false !== $dt && !\array_sum((array) $dt::getLastErrors());
+            }
+        }
+
+        return false;
     }
 }

--- a/core/Version.php
+++ b/core/Version.php
@@ -50,7 +50,7 @@ final class Version
             if (\preg_match('/-p(\d{14})$/', $version, $matches)) {
                 $dt = DateTime::createFromFormat('YmdHis', $matches[1]);
 
-                return false !== $dt && !\array_sum((array) $dt::getLastErrors());
+                return false !== $dt && !\array_sum(array_map('intval', (array) $dt::getLastErrors()));
             }
         }
 

--- a/tests/PHPUnit/Unit/VersionTest.php
+++ b/tests/PHPUnit/Unit/VersionTest.php
@@ -55,6 +55,32 @@ class VersionTest extends \PHPUnit\Framework\TestCase
         $this->assertNotVersionNumber('3.3.3-bbeta1'); // max 4 allowed but bbeta is 5
     }
 
+    public function testIsPreviewVersion()
+    {
+        $this->assertIsPreviewVersion('3.3.3-dev-p20240509114000');
+        $this->assertIsPreviewVersion('3.3.3-dev-p33331224183000');
+        $this->assertIsPreviewVersion('3.3.3-b1-p20240509114000');
+        $this->assertIsPreviewVersion('100.999.9191-rc4-p20240509114000');
+
+        $this->assertNotPreviewVersion('3.3');
+        $this->assertNotPreviewVersion('3.3.');
+        $this->assertNotPreviewVersion('3-3-3');
+        $this->assertNotPreviewVersion('a3.3.3');
+        $this->assertNotPreviewVersion('3.0.0b');
+        $this->assertNotPreviewVersion('3.3.3-b1');
+        $this->assertNotPreviewVersion('3.3.3-b1-pp20240509114000');
+        $this->assertNotPreviewVersion('3.3.3-b1-p20240509114000a');
+        $this->assertNotPreviewVersion('3.3.3-rc1');
+        $this->assertNotPreviewVersion('3.3.3-p20240509114000');
+        $this->assertNotPreviewVersion('p20240509114000');
+        $this->assertNotPreviewVersion('3.3.3-b1-p202405091140');
+        $this->assertNotPreviewVersion('3.3.3-b1-p20243309114000');
+        $this->assertNotPreviewVersion('3.3.3-b1-p20240544114000');
+        $this->assertNotPreviewVersion('3.3.3-b1-p20240509554000');
+        $this->assertNotPreviewVersion('3.3.3-b1-p20240509117700');
+        $this->assertNotPreviewVersion('3.3.3-b1-p20240509114088');
+    }
+
     private function assertIsStableVersion($versionNumber)
     {
         $isStable = $this->version->isStableVersion($versionNumber);
@@ -69,13 +95,25 @@ class VersionTest extends \PHPUnit\Framework\TestCase
 
     private function assertIsVersionNumber($versionNumber)
     {
-        $isStable = $this->version->isVersionNumber($versionNumber);
-        $this->assertTrue($isStable);
+        $isVersionNumber = $this->version->isVersionNumber($versionNumber);
+        $this->assertTrue($isVersionNumber);
     }
 
     private function assertNotVersionNumber($versionNumber)
     {
-        $isStable = $this->version->isVersionNumber($versionNumber);
-        $this->assertFalse($isStable);
+        $isVersionNumber = $this->version->isVersionNumber($versionNumber);
+        $this->assertFalse($isVersionNumber);
+    }
+
+    private function assertIsPreviewVersion($versionNumber)
+    {
+        $isPreviewVersion = $this->version->isPreviewVersion($versionNumber);
+        $this->assertTrue($isPreviewVersion);
+    }
+
+    private function assertNotPreviewVersion($versionNumber)
+    {
+        $isPreviewVersion = $this->version->isPreviewVersion($versionNumber);
+        $this->assertFalse($isPreviewVersion);
     }
 }


### PR DESCRIPTION
### Description:

We've changed the approach from `-preview` to `-pYYYYmmddHHiiss` so this is just adjusting the script to be aware of that and not treat tags with the `-p...` suffix as stable releases.

Additionally this fixes the build server check as `$F` wasn't defined at that point so the file never existed and the check always succeeded.

Adds a new check for preview version to `core/Version.php` from where we can use it in other parts of Matomo as well as in the build script to determine if a version is a preview version without duplicating the same logic in a convoluted way in a bash script.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
