### PR TITLE
Check privilege sql has been successful on install script

### DIFF
--- a/plugins/Installation/FormDatabaseSetup.php
+++ b/plugins/Installation/FormDatabaseSetup.php
@@ -233,9 +233,13 @@ class RuleCheckUserPrivileges extends HTML_QuickForm2_Rule
             foreach ($queries as $sql) {
                 try {
                     if (in_array($privilegeType, array('SELECT'))) {
-                        $db->fetchAll($sql);
+                        $ret = $db->fetchAll($sql);
                     } else {
-                        $db->exec($sql);
+                        $ret = $db->exec($sql);
+                    }
+                    // In case an exception is not thrown check the return
+                    if ($ret === -1) {
+                        return false;
                     }
                 } catch (Exception $ex) {
                     if ($this->isAccessDenied($ex)) {


### PR DESCRIPTION
### Description:

The installation script expects an exception to be thrown when testing installation queries.
However the MYSQLI adapter does not behave like this so it is possible to install with a DB user who has not been granted the "CREATE TEMPORARY TABLES" privilege.
This PR add a check on the return to confirm if the query has actually been successful.

fixes https://github.com/matomo-org/matomo/issues/22187

[checkSqlReturn.webm](https://github.com/matomo-org/matomo/assets/1495580/5d121131-3d42-4e7b-91b7-c8096819f098)


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
