### PR TITLE
Fix broken syntax for opt-out

### DIFF
--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -421,7 +421,7 @@ JS;
     
             var div = document.getElementById(settings.divId);
             if (!div) {
-                public const warningDiv = document.createElement("div");
+                const warningDiv = document.createElement("div");
                 var msg = 'Unable to find opt-out content div: "'+settings.divId+'"';
                 warningDiv.id = settings.divId+'-warning';
                 warningDiv.innerHTML = errorBlock+msg+'</p>';


### PR DESCRIPTION
### Description:

A code style refactor introduced a syntax error into the JS of the opt out manager

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
