### PR TITLE
Ignore "report_to_invalidate" for archive state detection

### DIFF
--- a/tests/PHPUnit/Integration/Archive/ArchiveStateMetadataTest.php
+++ b/tests/PHPUnit/Integration/Archive/ArchiveStateMetadataTest.php
@@ -77,7 +77,6 @@ class ArchiveStateMetadataTest extends IntegrationTestCase
     public function testGetDataTableFromNumericReturnsArchiveStateInMetadata(
         int $nowTimestamp,
         ?string $segment,
-        array $daysToRememberInvalidationsFor,
         ?array $pluginsToInvalidate,
         string $expectedInitialArchiveState,
         string $expectedFinalArchiveState
@@ -89,7 +88,7 @@ class ArchiveStateMetadataTest extends IntegrationTestCase
         }
 
         $this->setUpInitialState($expectedInitialArchiveState);
-        $this->invalidateArchives($daysToRememberInvalidationsFor, $pluginsToInvalidate);
+        $this->invalidateArchives($pluginsToInvalidate);
         $this->disableArchiving();
 
         $dataTable = $this->getDataTable();
@@ -111,7 +110,6 @@ class ArchiveStateMetadataTest extends IntegrationTestCase
         yield 'today, all ok' => [
             $timestampToday,
             null,
-            [],
             null,
             ArchiveState::INCOMPLETE,
             ArchiveState::INCOMPLETE
@@ -120,7 +118,6 @@ class ArchiveStateMetadataTest extends IntegrationTestCase
         yield 'yesterday, all ok' => [
             $timestampTomorrow,
             null,
-            [],
             null,
             ArchiveState::COMPLETE,
             ArchiveState::COMPLETE
@@ -130,7 +127,6 @@ class ArchiveStateMetadataTest extends IntegrationTestCase
             $timestampToday,
             null,
             [],
-            [],
             ArchiveState::INCOMPLETE,
             ArchiveState::INVALIDATED
         ];
@@ -139,24 +135,13 @@ class ArchiveStateMetadataTest extends IntegrationTestCase
             $timestampTomorrow,
             null,
             [],
-            [],
             ArchiveState::COMPLETE,
             ArchiveState::INVALIDATED
-        ];
-
-        yield 'yesterday, invalidation remembered after archiving' => [
-            $timestampTomorrow,
-            null,
-            [date('Y-m-d', $timestampToday)],
-            null,
-            ArchiveState::COMPLETE,
-            ArchiveState::INCOMPLETE
         ];
 
         yield 'segmented, everything invalidated' => [
             $timestampTomorrow,
             'visitorType==new',
-            [],
             [],
             ArchiveState::COMPLETE,
             ArchiveState::INVALIDATED
@@ -165,7 +150,6 @@ class ArchiveStateMetadataTest extends IntegrationTestCase
         yield 'segmented, partially invalidated' => [
             $timestampTomorrow,
             'visitorType==new',
-            [],
             ['Goals'],
             ArchiveState::COMPLETE,
             ArchiveState::INVALIDATED
@@ -191,18 +175,10 @@ class ArchiveStateMetadataTest extends IntegrationTestCase
     }
 
     /**
-     * @param array<string> $daysToRememberInvalidationsFor
      * @param array<string>|null $plugins
      */
-    private function invalidateArchives(array $daysToRememberInvalidationsFor, ?array $plugins): void
+    private function invalidateArchives(?array $plugins): void
     {
-        foreach ($daysToRememberInvalidationsFor as $rememberedDay) {
-            $this->invalidator->rememberToInvalidateArchivedReportsLater(
-                $this->archiveSite,
-                Date::factory($rememberedDay)
-            );
-        }
-
         if (null === $plugins) {
             return;
         }
@@ -227,9 +203,6 @@ class ArchiveStateMetadataTest extends IntegrationTestCase
 
     private function setUpInitialState(string $expectedInitialArchiveState): void
     {
-        // remove remembered invalidations created by tracking in setup
-        $this->invalidator->forgetRememberedArchivedReportsToInvalidateForSite($this->archiveSite);
-
         $dataTable = $this->getDataTable();
         $archiveState = $dataTable->getMetadata(DataTable::ARCHIVE_STATE_METADATA_NAME);
 


### PR DESCRIPTION
### Description:

The archive state detection introduced in #21813 created a performance regression for the all websites dashboard.

Removing the usage of "report_to_invalidate" options should only slightly decrease the information accuracy while fixing the regression.

Refs DEV-18085

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
