### PR TITLE
Replace usage of SQL_CALC_FOUND_ROWS with separate queries

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -1093,7 +1093,12 @@ class Common
     public static function sendHeader($header, $replace = true)
     {
         if (defined('PIWIK_TEST_MODE') && PIWIK_TEST_MODE) {
-            [$headerName, $headerValue] = explode(':', $header, 2);
+            if (strpos($header, ':') !== false) {
+                [$headerName, $headerValue] = explode(':', $header, 2);
+            } else {
+                $headerName = $header;
+                $headerValue = '';
+            }
 
             if (!array_key_exists($headerName, self::$headersSentInTests) || $replace) {
                 self::$headersSentInTests[$headerName] = $headerValue;

--- a/core/Common.php
+++ b/core/Common.php
@@ -36,6 +36,12 @@ class Common
 
     public static $isCliMode = null;
 
+    /**
+     * Filled and used during tests only
+     * @var array
+     */
+    public static $headersSentInTests = [];
+
     /*
      * Database
      */
@@ -1086,6 +1092,14 @@ class Common
      */
     public static function sendHeader($header, $replace = true)
     {
+        if (defined('PIWIK_TEST_MODE') && PIWIK_TEST_MODE) {
+            [$headerName, $headerValue] = explode(':', $header, 2);
+
+            if (!array_key_exists($headerName, self::$headersSentInTests) || $replace) {
+                self::$headersSentInTests[$headerName] = $headerValue;
+            }
+        }
+
         // don't send header in CLI mode
         if (!Common::isPhpCliMode() and !headers_sent()) {
             header($header, $replace);
@@ -1099,6 +1113,10 @@ class Common
      */
     public static function stripHeader($name)
     {
+        if (defined('PIWIK_TEST_MODE') && PIWIK_TEST_MODE) {
+            unset(self::$headersSentInTests[$name]);
+        }
+
         // don't strip header in CLI mode
         if (!Common::isPhpCliMode() and !headers_sent()) {
             header_remove($name);

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -210,7 +210,7 @@ class Model
             $joins .= " LEFT JOIN " . Common::prefixTable('access') . " b on a.idsite = b.idsite AND a.login = b.login";
         }
 
-        $sql = 'SELECT SQL_CALC_FOUND_ROWS s.idsite as idsite, s.name as site_name, GROUP_CONCAT(' . $selector . ' SEPARATOR "|") as access
+        $sql = 'SELECT s.idsite as idsite, s.name as site_name, GROUP_CONCAT(' . $selector . ' SEPARATOR "|") as access
                   FROM ' . Common::prefixTable('access') . " a
                 $joins
                 $where
@@ -224,7 +224,12 @@ class Model
             $entry['access'] = explode('|', $entry['access'] ?? '');
         }
 
-        $count = $db->fetchOne("SELECT FOUND_ROWS()");
+        $sql = 'SELECT COUNT(DISTINCT s.idsite)
+                 FROM ' . Common::prefixTable('access') . " a
+                $joins
+                $where";
+
+        $count = $db->fetchOne($sql, $bind);
 
         return [$access, $count];
     }
@@ -811,7 +816,7 @@ class Model
             }
         }
 
-        $sql = 'SELECT SQL_CALC_FOUND_ROWS u.*, GROUP_CONCAT(a.access SEPARATOR "|") as access
+        $sql = 'SELECT u.*, GROUP_CONCAT(a.access SEPARATOR "|") as access
                   FROM ' . $this->userTable . " u
                 $joins
                 $where
@@ -826,7 +831,12 @@ class Model
             $user['access'] = explode('|', $user['access'] ?? '');
         }
 
-        $count = $db->fetchOne("SELECT FOUND_ROWS()");
+        $sql = 'SELECT COUNT(DISTINCT u.login)
+                  FROM ' . $this->userTable . " u
+                $joins
+                $where";
+
+        $count = $db->fetchOne($sql, $bind);
 
         return [$users, $count];
     }

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -15,6 +15,7 @@ use Piwik\Access\Role\View;
 use Piwik\Access\Role\Write;
 use Piwik\API\Request;
 use Piwik\Auth\Password;
+use Piwik\Common;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
@@ -181,13 +182,13 @@ class APITest extends IntegrationTestCase
         $self           = $this;
         Piwik::addAction('UsersManager.removeSiteAccess', function ($login, $idSites) use (&$eventTriggered, $self) {
             $eventTriggered = true;
-            $self->assertEquals($self->login, $login);
-            $self->assertEquals([1, 2], $idSites);
+            self::assertEquals($self->login, $login);
+            self::assertEquals([1, 2], $idSites);
         });
 
         $this->api->setUserAccess($this->login, 'noaccess', [1, 2]);
 
-        $this->assertTrue($eventTriggered, 'UsersManager.removeSiteAccess event was not triggered');
+        self::assertTrue($eventTriggered, 'UsersManager.removeSiteAccess event was not triggered');
     }
 
     public function testSetUserAccessShouldNotTriggerRemoveSiteAccessEventIfAccessIsAdded()
@@ -199,25 +200,25 @@ class APITest extends IntegrationTestCase
 
         $this->api->setUserAccess($this->login, 'admin', [1, 2]);
 
-        $this->assertFalse($eventTriggered, 'UsersManager.removeSiteAccess event was triggered but should not');
+        self::assertFalse($eventTriggered, 'UsersManager.removeSiteAccess event was triggered but should not');
     }
 
     public function testGetAllUsersPreferencesIsEmptyWhenNoPreference()
     {
         $preferences = $this->api->getAllUsersPreferences(['preferenceName']);
-        $this->assertEmpty($preferences);
+        self::assertEmpty($preferences);
     }
 
     public function testGetAllUsersPreferencesIsEmptyWhenNoPreferenceAndMultipleRequested()
     {
         $preferences = $this->api->getAllUsersPreferences(['preferenceName', 'randomDoesNotExist']);
-        $this->assertEmpty($preferences);
+        self::assertEmpty($preferences);
     }
 
     public function testGetUserPreferenceShouldReturnADefaultPreferenceIfNoneIsSet()
     {
         $siteId = $this->api->getUserPreference(API::PREFERENCE_DEFAULT_REPORT, $this->login);
-        $this->assertEquals('1', $siteId);
+        self::assertEquals('1', $siteId);
     }
 
     public function testGetUserPreferenceShouldReturnASetreferenceIfNoneIsSet()
@@ -225,20 +226,20 @@ class APITest extends IntegrationTestCase
         $this->api->setUserPreference($this->login, API::PREFERENCE_DEFAULT_REPORT, 5);
 
         $siteId = $this->api->getUserPreference(API::PREFERENCE_DEFAULT_REPORT, $this->login);
-        $this->assertEquals('5', $siteId);
+        self::assertEquals('5', $siteId);
     }
 
     public function testInitUserPreferenceWithDefaultShouldSaveTheDefaultPreferenceIfPreferenceIsNotSet()
     {
         // make sure there is no value saved so it will use default preference
         $siteId = Option::get($this->getPreferenceId(API::PREFERENCE_DEFAULT_REPORT));
-        $this->assertFalse($siteId);
+        self::assertFalse($siteId);
 
         $this->api->initUserPreferenceWithDefault($this->login, API::PREFERENCE_DEFAULT_REPORT);
 
         // make sure it did save the preference
         $siteId = Option::get($this->getPreferenceId(API::PREFERENCE_DEFAULT_REPORT));
-        $this->assertEquals('1', $siteId);
+        self::assertEquals('1', $siteId);
     }
 
     public function testInitUserPreferenceWithDefaultShouldNotSaveTheDefaultPreferenceIfPreferenceIsAlreadySet()
@@ -247,13 +248,13 @@ class APITest extends IntegrationTestCase
         Option::set($this->getPreferenceId(API::PREFERENCE_DEFAULT_REPORT), '999');
 
         $siteId = Option::get($this->getPreferenceId(API::PREFERENCE_DEFAULT_REPORT));
-        $this->assertEquals('999', $siteId);
+        self::assertEquals('999', $siteId);
 
         $this->api->initUserPreferenceWithDefault($this->login, API::PREFERENCE_DEFAULT_REPORT);
 
         // make sure it did not save the preference
         $siteId = Option::get($this->getPreferenceId(API::PREFERENCE_DEFAULT_REPORT));
-        $this->assertEquals('999', $siteId);
+        self::assertEquals('999', $siteId);
     }
 
     public function testGetAllUsersPreferencesShouldGetMultiplePreferences()
@@ -284,7 +285,7 @@ class APITest extends IntegrationTestCase
                                                            'randomDoesNotExist',
                                                        ]);
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function testGetAllUsersPreferencesWhenLoginContainsUnderscore()
@@ -301,7 +302,7 @@ class APITest extends IntegrationTestCase
         ];
         $result   = $this->api->getAllUsersPreferences([API::PREFERENCE_DEFAULT_REPORT, 'randomDoesNotExist']);
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function testSetUserPreferenceThrowsWhenPreferenceNameContainsUnderscore()
@@ -338,16 +339,16 @@ class APITest extends IntegrationTestCase
         $model = new Model();
         $user  = $model->getUser($this->login);
 
-        $this->assertSame('email@example.com', $user['email']);
+        self::assertSame('email@example.com', $user['email']);
 
         $passwordHelper = new Password();
 
-        $this->assertTrue($passwordHelper->verify(UsersManager::getPasswordHash('newPassword'), $user['password']));
+        self::assertTrue($passwordHelper->verify(UsersManager::getPasswordHash('newPassword'), $user['password']));
 
         $subjects = array_map(function (Mail $mail) {
             return $mail->getSubject();
         }, $capturedMails);
-        $this->assertEquals([
+        self::assertEquals([
                                 'UsersManager_EmailChangeNotificationSubject', // sent twice to old email and new
                                 'UsersManager_EmailChangeNotificationSubject',
                                 'UsersManager_PasswordChangeNotificationSubject',
@@ -383,7 +384,7 @@ class APITest extends IntegrationTestCase
         $subjects = array_map(function (Mail $mail) {
             return $mail->getSubject();
         }, $capturedMails);
-        $this->assertEquals([], $subjects);
+        self::assertEquals([], $subjects);
     }
 
 
@@ -399,7 +400,7 @@ class APITest extends IntegrationTestCase
         $this->api->updateUser($this->login, false, strtoupper($this->email));
         FakeAccess::$identity = $identity;
 
-        $this->assertEquals([], $capturedMails);
+        self::assertEquals([], $capturedMails);
     }
 
     public function testUpdateUserDoesNotChangePasswordIfFalsey()
@@ -414,8 +415,8 @@ class APITest extends IntegrationTestCase
 
         $user = $model->getUser($this->login);
 
-        $this->assertSame($userBefore['password'], $user['password']);
-        $this->assertSame($userBefore['ts_password_modified'], $user['ts_password_modified']);
+        self::assertSame($userBefore['password'], $user['password']);
+        self::assertSame($userBefore['ts_password_modified'], $user['ts_password_modified']);
     }
 
     public function testUpdateUserFailsIfPasswordTooLong()
@@ -453,7 +454,7 @@ class APITest extends IntegrationTestCase
         $this->api->updateUser($user2, $password, $user2, false, $password);
 
         $user2Array = $this->api->getUser($user2);
-        $this->assertEquals($user2Array['email'], $user2);
+        self::assertEquals($user2Array['email'], $user2);
     }
 
     public function testCannotCreateUserIfEmailExistsAsUsername()
@@ -482,7 +483,7 @@ class APITest extends IntegrationTestCase
 
         // new user doesn't have access to anything
         $access = $this->api->getSitesAccessFromUser($user2);
-        $this->assertEmpty($access);
+        self::assertEmpty($access);
 
         $userUpdater = new UserUpdater();
         $userUpdater->setSuperUserAccessWithoutCurrentPassword($user2, true);
@@ -503,7 +504,7 @@ class APITest extends IntegrationTestCase
                 'access' => 'admin',
             ],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
     }
 
     public function testGetUsersPlusRoleShouldReturnNothingForAnonymousUser()
@@ -512,7 +513,8 @@ class APITest extends IntegrationTestCase
         $this->setCurrentUser('anonymous', 'view', 1);
 
         $users = $this->api->getUsersPlusRole(1);
-        $this->assertEquals([], $users);
+        self::assertEquals([], $users);
+        self::assertResultCountHeader(0);
     }
 
     public function testGetUsersPlusRoleShouldReturnSelfIfUserDoesNotHaveAdminAccessToSite()
@@ -531,7 +533,8 @@ class APITest extends IntegrationTestCase
                 'superuser_access' => '0',
             ],
         ];
-        $this->assertEquals($expected, $users);
+        self::assertEquals($expected, $users);
+        self::assertResultCountHeader(1);
     }
 
     public function testGetUsersPlusRoleShouldIgnoreOffsetIfLimitIsNotSupplied()
@@ -550,7 +553,8 @@ class APITest extends IntegrationTestCase
                 'superuser_access' => '0',
             ],
         ];
-        $this->assertEquals($expected, $users);
+        self::assertEquals($expected, $users);
+        self::assertResultCountHeader(1);
     }
 
     public function testGetUsersPlusRoleShouldNotAllowSuperuserFilterIfUserIsNotSuperUser()
@@ -570,7 +574,8 @@ class APITest extends IntegrationTestCase
                 'superuser_access' => '0',
             ],
         ];
-        $this->assertEquals($expected, $users);
+        self::assertEquals($expected, $users);
+        self::assertResultCountHeader(1);
     }
 
     public function testGetUsersPlusRoleShouldReturnAllUsersAndAccessIfUserHasAdminAccess()
@@ -604,7 +609,8 @@ class APITest extends IntegrationTestCase
                 'superuser_access' => false,
             ],
         ];
-        $this->assertEquals($expected, $users);
+        self::assertEquals($expected, $users);
+        self::assertResultCountHeader(3);
     }
 
     public function testGetUsersPlusRoleForAdminShouldLimitUsersToThoseWithAccessToSitesAsCurrentUsersAdminSites()
@@ -645,7 +651,8 @@ class APITest extends IntegrationTestCase
                 'superuser_access' => false,
             ],
         ];
-        $this->assertEquals($expected, $users);
+        self::assertEquals($expected, $users);
+        self::assertResultCountHeader(4);
     }
 
     public function testGetUsersPlusRoleShouldReturnAllUsersAndAccessIfUserHasSuperuserAccess()
@@ -700,7 +707,8 @@ class APITest extends IntegrationTestCase
                 'uses_2fa'         => false,
             ],
         ];
-        $this->assertEquals($expected, $users);
+        self::assertEquals($expected, $users);
+        self::assertResultCountHeader(5);
     }
 
     public function testGetUsersPlusRoleShouldFilterUsersByAccessCorrectly()
@@ -729,7 +737,8 @@ class APITest extends IntegrationTestCase
                 'superuser_access' => false,
             ],
         ];
-        $this->assertEquals($expected, $users);
+        self::assertEquals($expected, $users);
+        self::assertResultCountHeader(2);
 
         // check new write role filtering works
         $users = $this->api->getUsersPlusRole(1, null, null, null, 'write');
@@ -737,7 +746,9 @@ class APITest extends IntegrationTestCase
         $expected = [
             ['login' => 'userLogin6', 'role' => 'write', 'capabilities' => [], 'superuser_access' => false],
         ];
-        $this->assertEquals($expected, $users);
+        self::assertEquals($expected, $users);
+        self::assertResultCountHeader(1);
+
     }
 
     public function testGetUsersPlusRoleShouldReturnUsersWithNoAccessCorrectly()
@@ -775,7 +786,8 @@ class APITest extends IntegrationTestCase
                 'uses_2fa'         => false,
             ],
         ];
-        $this->assertEquals($expected, $users);
+        self::assertEquals($expected, $users);
+        self::assertResultCountHeader(3);
     }
 
     public function testGetUsersPlusRoleShouldSearchForSuperUsersCorrectly()
@@ -808,7 +820,8 @@ class APITest extends IntegrationTestCase
                 'uses_2fa'         => false,
             ],
         ];
-        $this->assertEquals($expected, $users);
+        self::assertEquals($expected, $users);
+        self::assertResultCountHeader(2);
     }
 
     public function testGetUsersPlusRoleShouldSearchByTextCorrectly()
@@ -839,7 +852,8 @@ class APITest extends IntegrationTestCase
                 'uses_2fa'         => false,
             ],
         ];
-        $this->assertEquals($expected, $users);
+        self::assertEquals($expected, $users);
+        self::assertResultCountHeader(2);
     }
 
     public function testGetUsersPlusRoleShouldApplyLimitAndOffsetCorrectly()
@@ -870,7 +884,8 @@ class APITest extends IntegrationTestCase
                 'uses_2fa'         => false,
             ],
         ];
-        $this->assertEquals($expected, $users);
+        self::assertEquals($expected, $users);
+        self::assertResultCountHeader(5);
     }
 
     public function testGetSitesAccessForUserShouldReturnAccessForUser()
@@ -885,7 +900,8 @@ class APITest extends IntegrationTestCase
             ['idsite' => '2', 'site_name' => 'Piwik test', 'role' => 'view', 'capabilities' => []],
             ['idsite' => '3', 'site_name' => 'Piwik test', 'role' => 'view', 'capabilities' => []],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
+        self::assertResultCountHeader(3);
     }
 
     public function testGetUserCapabilitiesAfterFilter()
@@ -895,7 +911,8 @@ class APITest extends IntegrationTestCase
 
         $access = $this->api->getSitesAccessForUser('userLoginCapabilities', null, 1, null, 'view');
 
-        $this->assertEquals(['tagmanager_write'], $access[0]['capabilities']);
+        self::assertEquals(['tagmanager_write'], $access[0]['capabilities']);
+        self::assertResultCountHeader(1);
     }
 
     public function testGetSitesAccessForUserShouldIgnoreOffsetIfLimitNotSupplied()
@@ -910,7 +927,8 @@ class APITest extends IntegrationTestCase
             ['idsite' => '2', 'site_name' => 'Piwik test', 'role' => 'view', 'capabilities' => []],
             ['idsite' => '3', 'site_name' => 'Piwik test', 'role' => 'view', 'capabilities' => []],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
+        self::assertResultCountHeader(3);
     }
 
     public function testGetSitesAccessForUserShouldApplyLimitAndOffsetCorrectly()
@@ -924,7 +942,8 @@ class APITest extends IntegrationTestCase
             ['idsite' => '2', 'site_name' => 'Piwik test', 'role' => 'view', 'capabilities' => []],
             ['idsite' => '3', 'site_name' => 'Piwik test', 'role' => 'view', 'capabilities' => []],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
+        self::assertResultCountHeader(3);
     }
 
     public function testGetSitesAccessForUserShouldSearchSitesCorrectly()
@@ -959,7 +978,8 @@ class APITest extends IntegrationTestCase
             ['idsite' => '3', 'site_name' => 'Piwik test', 'role' => 'view', 'capabilities' => []],
             ['idsite' => '1', 'site_name' => 'searchTerm site', 'role' => 'admin', 'capabilities' => []],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
+        self::assertResultCountHeader(3);
     }
 
     public function testGetSitesAccessForUserShouldFilterByAccessCorrectly()
@@ -973,7 +993,8 @@ class APITest extends IntegrationTestCase
             ['idsite' => '2', 'site_name' => 'Piwik test', 'role' => 'view', 'capabilities' => []],
             ['idsite' => '3', 'site_name' => 'Piwik test', 'role' => 'view', 'capabilities' => []],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
+        self::assertResultCountHeader(2);
     }
 
     public function testGetSitesAccessForUserShouldLimitSitesIfUserIsAdmin()
@@ -990,7 +1011,8 @@ class APITest extends IntegrationTestCase
             ['idsite' => '1', 'site_name' => 'Piwik test', 'role' => 'view', 'capabilities' => []],
             ['idsite' => '2', 'site_name' => 'Piwik test', 'role' => 'view', 'capabilities' => []],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
+        self::assertResultCountHeader(2);
     }
 
     public function testGetSitesAccessForUserShouldLimitSitesIfUserIsAdminAndStillSelectNoAccessSitesCorrectly()
@@ -1006,7 +1028,8 @@ class APITest extends IntegrationTestCase
             ['idsite' => '2', 'site_name' => 'Piwik test', 'role' => 'noaccess', 'capabilities' => []],
             ['idsite' => '3', 'site_name' => 'Piwik test', 'role' => 'noaccess', 'capabilities' => []],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
+        self::assertResultCountHeader(2);
     }
 
     public function testGetSitesAccessForUserShouldSelectSitesCorrectlyIfAtLeastViewRequested()
@@ -1019,7 +1042,8 @@ class APITest extends IntegrationTestCase
             ['idsite' => '1', 'site_name' => 'Piwik test', 'role' => 'view', 'capabilities' => []],
             ['idsite' => '2', 'site_name' => 'Piwik test', 'role' => 'admin', 'capabilities' => []],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
+        self::assertResultCountHeader(2);
     }
 
     public function testGetSitesAccessForUserShouldReportIfUserHasNoAccessToSites()
@@ -1030,14 +1054,15 @@ class APITest extends IntegrationTestCase
             ['idsite' => '2', 'site_name' => 'Piwik test', 'role' => 'noaccess', 'capabilities' => []],
             ['idsite' => '3', 'site_name' => 'Piwik test', 'role' => 'noaccess', 'capabilities' => []],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
 
         // test when search returns empty result
         $this->api->setUserAccess('userLogin', 'view', 1);
 
         $access   = $this->api->getSitesAccessForUser('userLogin', null, null, 'asdklfjds');
         $expected = [];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
+        self::assertResultCountHeader(0);
     }
 
     public function testSetUserAccessMultipleRolesCannotBeSet()
@@ -1129,7 +1154,7 @@ class APITest extends IntegrationTestCase
             ['site' => '1', 'access' => TestCap2::ID],
             ['site' => '1', 'access' => TestCap3::ID],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
     }
 
     public function testSetUserAccessSetRoleAsString()
@@ -1137,7 +1162,7 @@ class APITest extends IntegrationTestCase
         $this->api->setUserAccess($this->login, View::ID, [1]);
 
         $access = $this->model->getSitesAccessFromUser($this->login);
-        $this->assertEquals([['site' => '1', 'access' => 'view']], $access);
+        self::assertEquals([['site' => '1', 'access' => 'view']], $access);
     }
 
     public function testSetUserAccessSetRoleAsArray()
@@ -1145,7 +1170,7 @@ class APITest extends IntegrationTestCase
         $this->api->setUserAccess($this->login, [View::ID], [1]);
 
         $access = $this->model->getSitesAccessFromUser($this->login);
-        $this->assertEquals([['site' => '1', 'access' => 'view']], $access);
+        self::assertEquals([['site' => '1', 'access' => 'view']], $access);
     }
 
     public function testAddCapabilitiesFailsWhenNotCapabilityIsGivenAsString()
@@ -1184,18 +1209,18 @@ class APITest extends IntegrationTestCase
             ['site' => '1', 'access' => TestCap2::ID],
             ['site' => '1', 'access' => TestCap3::ID],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
 
         $this->api->addCapabilities($this->login, [TestCap2::ID, TestCap3::ID], [1]);
 
         $access = $this->model->getSitesAccessFromUser($this->login);
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
 
         $this->api->addCapabilities($this->login, [TestCap2::ID, TestCap1::ID, TestCap3::ID], [1]);
 
         $expected[] = ['site' => '1', 'access' => TestCap1::ID];
         $access     = $this->model->getSitesAccessFromUser($this->login);
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
     }
 
     public function testAddCapabilitiesDoesNotAddCapabilityToUserWithNoRole()
@@ -1205,7 +1230,7 @@ class APITest extends IntegrationTestCase
 
         $access = $this->model->getSitesAccessFromUser($this->login);
 
-        $this->assertEquals([], $access);
+        self::assertEquals([], $access);
 
         $this->api->addCapabilities($this->login, array(TestCap2::ID, TestCap3::ID), array(1));
     }
@@ -1219,7 +1244,7 @@ class APITest extends IntegrationTestCase
         $expected = [
             ['site' => '1', 'access' => 'write'],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
 
         $this->api->addCapabilities($this->login, [TestCap2::ID, TestCap3::ID], [1]);
 
@@ -1227,7 +1252,7 @@ class APITest extends IntegrationTestCase
         $access     = $this->model->getSitesAccessFromUser($this->login);
 
         // did not add TestCap2
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
     }
 
     public function testAddCapabilitiesDoesAddCapabilitiesWhichAreNotIncludedInRoleYetAlready()
@@ -1239,12 +1264,12 @@ class APITest extends IntegrationTestCase
         $expected = [
             ['site' => '1', 'access' => 'admin'],
         ];
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
 
         $this->api->addCapabilities($this->login, [TestCap2::ID, TestCap1::ID, TestCap3::ID], [1]);
 
         $access = $this->model->getSitesAccessFromUser($this->login);
-        $this->assertEquals($expected, $access);
+        self::assertEquals($expected, $access);
     }
 
     public function testRemoveCapabilitiesFailsWhenNotCapabilityIsGivenAsString()
@@ -1277,12 +1302,12 @@ class APITest extends IntegrationTestCase
         $this->api->setUserAccess($this->login, $addAccess, [1]);
 
         $access = $this->getAccessInSite($this->login, 1);
-        $this->assertEquals($addAccess, $access);
+        self::assertEquals($addAccess, $access);
 
         $this->api->removeCapabilities($this->login, [TestCap3::ID, TestCap2::ID], 1);
 
         $access = $this->getAccessInSite($this->login, 1);
-        $this->assertEquals([View::ID, TestCap1::ID], $access);
+        self::assertEquals([View::ID, TestCap1::ID], $access);
     }
 
     public function testSetSuperUserAccessFailsIfCurrentPasswordIsIncorrect()
@@ -1357,8 +1382,8 @@ class APITest extends IntegrationTestCase
 
         $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
         $user = $this->model->isPendingUser('pendingLoginTest');
-        $this->assertTrue($user);
-        $this->assertTrue($eventWasFired);
+        self::assertTrue($user);
+        self::assertTrue($eventWasFired);
     }
 
     public function testInviteUserAsAdmin()
@@ -1368,7 +1393,7 @@ class APITest extends IntegrationTestCase
 
         $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
         $user = $this->model->isPendingUser('pendingLoginTest');
-        $this->assertTrue($user);
+        self::assertTrue($user);
     }
 
     public function testInviteUserAsAdminForAnotherSiteDoesntWork()
@@ -1410,14 +1435,14 @@ class APITest extends IntegrationTestCase
         $expired = Date::factory($user['invite_expired_at'])->getTimestamp();
         $now     = Date::now()->getTimestamp();
         $diff    = $expired - $now;
-        $this->assertEquals($expiredDays, $diff / 3600 / 24);
+        self::assertEquals($expiredDays, $diff / 3600 / 24);
     }
 
     public function testResendInviteAsSuperUser()
     {
         $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
         $user = $this->model->isPendingUser('pendingLoginTest');
-        $this->assertTrue($user);
+        self::assertTrue($user);
 
         $eventWasFired = false;
 
@@ -1448,7 +1473,7 @@ class APITest extends IntegrationTestCase
 
         $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
         $user = $this->model->isPendingUser('pendingLoginTest');
-        $this->assertTrue($user);
+        self::assertTrue($user);
 
         $eventWasFired = false;
 
@@ -1475,7 +1500,7 @@ class APITest extends IntegrationTestCase
 
         $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
         $user = $this->model->isPendingUser('pendingLoginTest');
-        $this->assertTrue($user);
+        self::assertTrue($user);
 
         // degraded to write access
         $this->setCurrentUser('adminUser', 'admin', []);
@@ -1496,7 +1521,7 @@ class APITest extends IntegrationTestCase
 
         $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
         $user = $this->model->isPendingUser('pendingLoginTest');
-        $this->assertTrue($user);
+        self::assertTrue($user);
 
         // another admin tries to resend invite
         $this->setCurrentUser('anotherAdminUser', 'admin', 1);
@@ -1512,7 +1537,7 @@ class APITest extends IntegrationTestCase
 
         $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
         $user = $this->model->isPendingUser('pendingLoginTest');
-        $this->assertTrue($user);
+        self::assertTrue($user);
 
         $this->setCurrentUser('superUserLogin', 'superuser', 1);
 
@@ -1528,7 +1553,7 @@ class APITest extends IntegrationTestCase
 
         $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
         $user = $this->model->isPendingUser('pendingLoginTest');
-        $this->assertTrue($user);
+        self::assertTrue($user);
 
         $this->api->deleteUser('pendingLoginTest');
         self::assertEmpty($this->model->getUser('pendingLoginTest'));
@@ -1545,7 +1570,7 @@ class APITest extends IntegrationTestCase
 
         $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
         $user = $this->model->isPendingUser('pendingLoginTest');
-        $this->assertTrue($user);
+        self::assertTrue($user);
 
         $this->setCurrentUser('adminUser2', 'admin', 1);
 
@@ -1617,6 +1642,12 @@ class APITest extends IntegrationTestCase
         } elseif ($accessLevel == 'write') {
             FakeAccess::$idSitesWrite = is_array($idSite) ? $idSite : [$idSite];
         }
+    }
+
+    private static function assertResultCountHeader($expected)
+    {
+        self::assertArrayHasKey('X-Matomo-Total-Results', Common::$headersSentInTests, 'X-Matomo-Total-Results header not sent');
+        self::assertEquals($expected, Common::$headersSentInTests['X-Matomo-Total-Results']);
     }
 
     private function cleanUsers(&$users)

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -748,7 +748,6 @@ class APITest extends IntegrationTestCase
         ];
         self::assertEquals($expected, $users);
         self::assertResultCountHeader(1);
-
     }
 
     public function testGetUsersPlusRoleShouldReturnUsersWithNoAccessCorrectly()

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -399,6 +399,7 @@ class Fixture extends \PHPUnit\Framework\Assert
         FrontController::$requestId = null;
         Cache::$cache = null;
         Common::$isCliMode = null;
+        Common::$headersSentInTests = [];
         MockFileMethods::reset();
         Archive::clearStaticCache();
         DataTableManager::getInstance()->deleteAll();


### PR DESCRIPTION
### Description:

With MySQL 8.0.17 the `SQL_CALC_FOUND_ROWS` feature has been deprecated.

To ensure we stay compatible with upcoming MySQL releases, where this might be removed, this PR replaces all usages with separate queries to fetch the count.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
