### PR TITLE
Fix: skipping a Tour challenge shows an error message

### DIFF
--- a/plugins/Tour/javascripts/engagement.js
+++ b/plugins/Tour/javascripts/engagement.js
@@ -10,7 +10,7 @@ var tourEngagement = {
         $challenge.find('.icon-hide').removeClass('icon-hide').addClass('icon-ok');
 
         var ajaxRequest = new ajaxHelper();
-        ajaxRequest.addParams({module: 'API', method: 'Tour.skipChallenge', id: key}, 'get');
+        ajaxRequest.addParams({module: 'API', method: 'Tour.skipChallenge', id: key, format: 'json'}, 'get');
         ajaxRequest.withTokenInUrl();
         ajaxRequest.setFormat('json');
         ajaxRequest.send();


### PR DESCRIPTION
### Description:

When clicking the skip icon in the Tour widget, a notification gets displayed that there was a problem with the request.
Actually the request is processed correctly, but it lacks the format parameter, causing XML to be returned instead of the expected JSON.

fixes L3-721

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
