### PR TITLE
Ensure to perform complex column updates only when supported

### DIFF
--- a/core/Columns/Updater.php
+++ b/core/Columns/Updater.php
@@ -10,6 +10,7 @@
 namespace Piwik\Columns;
 
 use Piwik\Common;
+use Piwik\Db\Schema;
 use Piwik\DbHelper;
 use Piwik\Plugin\Dimension\ActionDimension;
 use Piwik\Plugin\Dimension\VisitDimension;
@@ -83,8 +84,15 @@ class Updater extends \Piwik\Updates
                 continue;
             }
 
-            $sql = "ALTER TABLE `" . Common::prefixTable($table) . "` " . implode(', ', $columns);
-            $sqls[] = new Migration\Db\Sql($sql, $errorCodes);
+            if (Schema::getInstance()->supportsComplexColumnUpdates()) {
+                $sql = "ALTER TABLE `" . Common::prefixTable($table) . "` " . implode(', ', $columns);
+                $sqls[] = new Migration\Db\Sql($sql, $errorCodes);
+            } else {
+                foreach ($columns as $column) {
+                    $sql = "ALTER TABLE `" . Common::prefixTable($table) . "` " . $column;
+                    $sqls[] = new Migration\Db\Sql($sql, $errorCodes);
+                }
+            }
         }
 
         return $sqls;

--- a/core/Db/Schema.php
+++ b/core/Db/Schema.php
@@ -221,4 +221,14 @@ class Schema extends Singleton
     {
         return $this->getSchema()->addMaxExecutionTimeHintToQuery($sql, $limit);
     }
+
+    /**
+     * Returns if the schema support complexe column updates
+     *
+     * @return bool
+     */
+    public function supportsComplexColumnUpdates(): bool
+    {
+        return $this->getSchema()->supportsComplexColumnUpdates();
+    }
 }

--- a/core/Db/Schema.php
+++ b/core/Db/Schema.php
@@ -223,7 +223,7 @@ class Schema extends Singleton
     }
 
     /**
-     * Returns if the schema support complexe column updates
+     * Returns if the schema support complex column updates
      *
      * @return bool
      */

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -670,6 +670,11 @@ class Mysql implements SchemaInterface
         return $sql;
     }
 
+    public function supportsComplexColumnUpdates(): bool
+    {
+        return true;
+    }
+
     private function getTablePrefix()
     {
         return $this->getDbSettings()->getTablePrefix();

--- a/core/Db/Schema/Tidb.php
+++ b/core/Db/Schema/Tidb.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Db\Schema;
+
+/**
+ * Mariadb schema
+ */
+class Tidb extends Mysql
+{
+    /**
+     * TiDB performs a sanity check before performing e.g. ALTER TABLE statements. If any of the used columns does not
+     * exist before the query fails. This also happens if the column would be added in the same query.
+     *
+     * @return bool
+     */
+    public function supportsComplexColumnUpdates(): bool
+    {
+        return false;
+    }
+}

--- a/core/Db/SchemaInterface.php
+++ b/core/Db/SchemaInterface.php
@@ -115,4 +115,13 @@ interface SchemaInterface
      * @return string
      */
     public function addMaxExecutionTimeHintToQuery(string $sql, float $limit): string;
+
+    /**
+     * Returns if the database supports column updates in table updates.
+     * Some database engines are performing sanity checks for table updates. Those might include checking if all columns used
+     * already exist. In such a case queries like this might fail: `ALTER TABLE t ADD COLUMN b, ADD INDEX i (b)`
+     *
+     * @return bool
+     */
+    public function supportsComplexColumnUpdates(): bool;
 }


### PR DESCRIPTION
### Description:

Some database engines, like TiDb, are performing sanity checks for table updates. Those might include checking if all columns used already exist. In such a case a query that adds a new column and e.g. directly uses it for an index will fail.

This PR changes how dimension updates are performed, so queries are executed separately instead of combined, if the database doesn't support it.

The same is applied for the `AddColumns` database migration class. It allows adding multiple columns, while every column will be placed after the one added before. This might also fail, so each column needs to be added separately

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
