### PR TITLE
Fix row evolution for reports where visits metric is not available

### DIFF
--- a/plugins/API/RowEvolution.php
+++ b/plugins/API/RowEvolution.php
@@ -63,9 +63,14 @@ class RowEvolution
 
         // if goal metrics should be shown, we replace the metrics
         if ($showGoalMetricsForGoal !== false) {
-            $metadata['metrics'] = [
-                'nb_visits' => $metadata['metrics']['nb_visits'],
-            ];
+            if (array_key_exists('nb_visits', $metadata['metrics'])) {
+                $metadata['metrics'] = [
+                    'nb_visits' => $metadata['metrics']['nb_visits'],
+                ];
+            } else {
+                // if no visits are available, simply use the first available metric
+                $metadata['metrics'] = array_slice($metadata['metrics'], 0, 1);
+            }
 
             // Use ecommerce specific metrics / column names when only showing ecommerce metrics
             if ($showGoalMetricsForGoal === Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER) {

--- a/plugins/Goals/tests/UI/Goals_spec.js
+++ b/plugins/Goals/tests/UI/Goals_spec.js
@@ -95,6 +95,19 @@ describe("Goals", function () {
         expect(await report.screenshot()).to.matchImage('goals_by_entry_page_titles');
     });
 
+    it('should load row evolution with goal metrics', async function() {
+        const row = await page.waitForSelector('.reportsByDimensionView tbody tr:first-child');
+        await row.hover();
+
+        const icon = await page.waitForSelector('.reportsByDimensionView tbody tr:first-child a.actionRowEvolution');
+        await icon.click();
+
+        await page.waitForSelector('.ui-dialog');
+        await page.waitForNetworkIdle();
+
+        const dialog = await page.$('.ui-dialog');
+        expect(await dialog.screenshot()).to.matchImage('goals_by_entry_page_titles_row_evolution');
+    });
 
     it('should show action goals visualization for page urls', async function() {
 

--- a/plugins/Goals/tests/UI/expected-screenshots/Goals_goals_by_entry_page_titles_row_evolution.png
+++ b/plugins/Goals/tests/UI/expected-screenshots/Goals_goals_by_entry_page_titles_row_evolution.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d601aca6b4ab2a7bae8bcdd5c6e17143258846c31f1c2c88002c7060e503267b
+size 98330


### PR DESCRIPTION
### Description:

Row evolution for reports, that don't contain the nb_visits metric currently does not work correctly:

![Ecommerce report - entry page ev chart](https://github.com/matomo-org/matomo/assets/20234985/07c88b8a-5fd5-40f4-9446-e1fa23ca8225)

fixes #22236

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
