### PR TITLE
Improve handling of database port during installation process

### DIFF
--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -87,18 +87,6 @@ class Adapter
     }
 
     /**
-     * Get default port for named adapter
-     *
-     * @param string $adapterName
-     * @return int
-     */
-    public static function getDefaultPortForAdapter($adapterName)
-    {
-        $className = self::getAdapterClassName($adapterName);
-        return call_user_func(array($className, 'getDefaultPort'));
-    }
-
-    /**
      * Get list of adapters
      *
      * @return array
@@ -118,7 +106,7 @@ class Adapter
         foreach ($adapterNames as $adapterName) {
             $className = '\Piwik\Db\Adapter\\' . $adapterName;
             if (call_user_func(array($className, 'isEnabled'))) {
-                $adapters[strtoupper($adapterName)] = call_user_func(array($className, 'getDefaultPort'));
+                $adapters[] = strtoupper($adapterName);
             }
         }
 

--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -87,6 +87,19 @@ class Adapter
     }
 
     /**
+     * Get default port for named adapter
+     *
+     * @deprecated use Schema::getDefaultPortForSchema instead
+     * @param string $adapterName
+     * @return int
+     */
+    public static function getDefaultPortForAdapter($adapterName)
+    {
+        $className = self::getAdapterClassName($adapterName);
+        return call_user_func(array($className, 'getDefaultPort'));
+    }
+
+    /**
      * Get list of adapters
      *
      * @return array

--- a/core/Db/Adapter/Mysqli.php
+++ b/core/Db/Adapter/Mysqli.php
@@ -67,6 +67,17 @@ class Mysqli extends Zend_Db_Adapter_Mysqli implements AdapterInterface
         $this->_config = array();
     }
 
+    /**
+     * Return default port.
+     *
+     * @deprecated Use Schema::getDefaultPortForSchema instead
+     * @return int
+     */
+    public static function getDefaultPort()
+    {
+        return 3306;
+    }
+
     protected function _connect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_connection) {

--- a/core/Db/Adapter/Mysqli.php
+++ b/core/Db/Adapter/Mysqli.php
@@ -67,16 +67,6 @@ class Mysqli extends Zend_Db_Adapter_Mysqli implements AdapterInterface
         $this->_config = array();
     }
 
-    /**
-     * Return default port.
-     *
-     * @return int
-     */
-    public static function getDefaultPort()
-    {
-        return 3306;
-    }
-
     protected function _connect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_connection) {

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -134,16 +134,6 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     }
 
     /**
-     * Return default port.
-     *
-     * @return int
-     */
-    public static function getDefaultPort()
-    {
-        return 3306;
-    }
-
-    /**
      * Check MySQL version
      *
      * @throws Exception

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -134,6 +134,17 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     }
 
     /**
+     * Return default port.
+     *
+     * @deprecated Use Schema::getDefaultPortForSchema instead
+     * @return int
+     */
+    public static function getDefaultPort()
+    {
+        return 3306;
+    }
+
+    /**
      * Check MySQL version
      *
      * @throws Exception

--- a/core/Db/AdapterInterface.php
+++ b/core/Db/AdapterInterface.php
@@ -21,6 +21,14 @@ interface AdapterInterface
     public function resetConfig();
 
     /**
+     * Return default port.
+     * @deprecated Use Schema::getDefaultPortForSchema instead
+     *
+     * @return int
+     */
+    public static function getDefaultPort();
+
+    /**
      * Check database server version
      *
      * @throws Exception if database version is less than required version

--- a/core/Db/AdapterInterface.php
+++ b/core/Db/AdapterInterface.php
@@ -21,13 +21,6 @@ interface AdapterInterface
     public function resetConfig();
 
     /**
-     * Return default port.
-     *
-     * @return int
-     */
-    public static function getDefaultPort();
-
-    /**
      * Check database server version
      *
      * @throws Exception if database version is less than required version

--- a/core/Db/Schema.php
+++ b/core/Db/Schema.php
@@ -48,6 +48,19 @@ class Schema extends Singleton
         return '\Piwik\Db\Schema\\' . $class;
     }
 
+    /**
+     * Return the default port for the provided database schema
+     *
+     * @param string $schemaName
+     * @return int
+     */
+    public static function getDefaultPortForSchema(string $schemaName): int
+    {
+        $schemaClassName = self::getSchemaClassName($schemaName);
+        /** @var SchemaInterface $schemaClass */
+        $schemaClass = new $schemaClassName();
+        return $schemaClass->getDefaultPort();
+    }
 
     /**
      * Load schema

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -675,6 +675,11 @@ class Mysql implements SchemaInterface
         return true;
     }
 
+    public function getDefaultPort(): int
+    {
+        return 3306;
+    }
+
     private function getTablePrefix()
     {
         return $this->getDbSettings()->getTablePrefix();

--- a/core/Db/Schema/Tidb.php
+++ b/core/Db/Schema/Tidb.php
@@ -24,4 +24,9 @@ class Tidb extends Mysql
     {
         return false;
     }
+
+    public function getDefaultPort(): int
+    {
+        return 4000;
+    }
 }

--- a/core/Db/SchemaInterface.php
+++ b/core/Db/SchemaInterface.php
@@ -124,4 +124,11 @@ interface SchemaInterface
      * @return bool
      */
     public function supportsComplexColumnUpdates(): bool;
+
+    /**
+     * Return the default port used by this database engine
+     *
+     * @return int
+     */
+    public function getDefaultPort(): int;
 }

--- a/plugins/Diagnostics/Diagnostic/DbAdapterCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DbAdapterCheck.php
@@ -55,7 +55,7 @@ class DbAdapterCheck implements Diagnostic
         $results = array();
         $adapters = Adapter::getAdapters();
 
-        foreach ($adapters as $adapter => $port) {
+        foreach ($adapters as $adapter) {
             $label = $adapter . ' ' . $this->translator->translate('Installation_Extension');
 
             $results[] = DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_OK);

--- a/plugins/Installation/FormDatabaseSetup.php
+++ b/plugins/Installation/FormDatabaseSetup.php
@@ -46,7 +46,7 @@ class FormDatabaseSetup extends QuickForm2
 
         $availableAdapters = Adapter::getAdapters();
         $adapters = array();
-        foreach ($availableAdapters as $adapter => $port) {
+        foreach ($availableAdapters as $adapter) {
             $adapters[$adapter] = $adapter;
             if (Adapter::isRecommendedAdapter($adapter)) {
                 $adapters[$adapter] .= ' (' . Piwik::translate('General_Recommended') . ')';
@@ -56,6 +56,10 @@ class FormDatabaseSetup extends QuickForm2
         $this->addElement('text', 'host')
             ->setLabel(Piwik::translate('Installation_DatabaseSetupServer'))
             ->addRule('required', Piwik::translate('General_Required', Piwik::translate('Installation_DatabaseSetupServer')));
+
+        $this->addElement('text', 'port')
+            ->setLabel(Piwik::translate('Installation_DatabaseSetupServerPort'))
+            ->addRule('required', Piwik::translate('General_Required', Piwik::translate('Installation_DatabaseSetupServerPort')));
 
         $user = $this->addElement('text', 'username')
             ->setLabel(Piwik::translate('Installation_DatabaseSetupLogin'));
@@ -98,9 +102,10 @@ class FormDatabaseSetup extends QuickForm2
             'type'          => $defaultDatabaseType,
             'tables_prefix' => 'matomo_',
             'schema'        => 'Mysql',
+            'port'          => '3306',
         );
 
-        $defaultsEnvironment = array('host', 'adapter', 'tables_prefix', 'username', 'schema', 'password', 'dbname');
+        $defaultsEnvironment = array('host', 'adapter', 'tables_prefix', 'username', 'schema', 'password', 'dbname', 'port');
         foreach ($defaultsEnvironment as $name) {
             $envName = 'DATABASE_' . strtoupper($name); // fyi getenv is case insensitive
             $envNameMatomo = 'MATOMO_' . $envName;
@@ -130,11 +135,9 @@ class FormDatabaseSetup extends QuickForm2
         }
 
         $adapter = $this->getSubmitValue('adapter');
-        $port = Adapter::getDefaultPortForAdapter($adapter);
-
         $host = $this->getSubmitValue('host');
         $tables_prefix = $this->getSubmitValue('tables_prefix');
-        
+
         $dbInfos = array(
             'host'          => (is_null($host)) ? $host : trim($host),
             'username'      => $this->getSubmitValue('username'),
@@ -142,7 +145,7 @@ class FormDatabaseSetup extends QuickForm2
             'dbname'        => $dbname,
             'tables_prefix' => (is_null($tables_prefix)) ? $tables_prefix : trim($tables_prefix),
             'adapter'       => $adapter,
-            'port'          => $port,
+            'port'          => $this->getSubmitValue('port'),
             'schema'        => $this->getSubmitValue('schema'),
             'type'          => $this->getSubmitValue('type'),
             'enable_ssl'    => false

--- a/plugins/Installation/FormDatabaseSetup.php
+++ b/plugins/Installation/FormDatabaseSetup.php
@@ -107,12 +107,12 @@ class FormDatabaseSetup extends QuickForm2
         foreach ($defaultsEnvironment as $name) {
             $envValue = $this->getEnvironmentSetting($name);
 
-            if (!empty($envValue)) {
+            if (null !== $envValue) {
                 $defaults[$name] = $envValue;
             }
         }
 
-        if (!empty($defaults['password'])) {
+        if (array_key_exists('password', $defaults)) {
             $defaults['password'] = self::MASKED_PASSWORD_VALUE; // ensure not to show password in UI
         }
 
@@ -120,13 +120,13 @@ class FormDatabaseSetup extends QuickForm2
         $this->addDataSource(new HTML_QuickForm2_DataSource_Array($defaults));
     }
 
-    private function getEnvironmentSetting(string $name)
+    private function getEnvironmentSetting(string $name): ?string
     {
         $envName = 'DATABASE_' . strtoupper($name); // fyi getenv is case insensitive
         $envNameMatomo = 'MATOMO_' . $envName;
-        if (getenv($envNameMatomo)) {
+        if (is_string(getenv($envNameMatomo))) {
             return getenv($envNameMatomo);
-        } elseif (getenv($envName)) {
+        } elseif (is_string(getenv($envName))) {
             return getenv($envName);
         }
 
@@ -152,9 +152,10 @@ class FormDatabaseSetup extends QuickForm2
         $tables_prefix = $this->getSubmitValue('tables_prefix');
 
         $password = $this->getSubmitValue('password');
+        $passwordFromEnv = $this->getEnvironmentSetting('password');
 
-        if ($password === self::MASKED_PASSWORD_VALUE) {
-            $password = $this->getEnvironmentSetting('password');
+        if ($password === self::MASKED_PASSWORD_VALUE && null !== $passwordFromEnv) {
+            $password = $passwordFromEnv;
         }
 
         $schema = $this->getSubmitValue('schema');

--- a/plugins/Installation/FormDatabaseSetup.php
+++ b/plugins/Installation/FormDatabaseSetup.php
@@ -59,10 +59,6 @@ class FormDatabaseSetup extends QuickForm2
             ->setLabel(Piwik::translate('Installation_DatabaseSetupServer'))
             ->addRule('required', Piwik::translate('General_Required', Piwik::translate('Installation_DatabaseSetupServer')));
 
-        $this->addElement('text', 'port')
-            ->setLabel(Piwik::translate('Installation_DatabaseSetupServerPort'))
-            ->addRule('required', Piwik::translate('General_Required', Piwik::translate('Installation_DatabaseSetupServerPort')));
-
         $user = $this->addElement('text', 'username')
             ->setLabel(Piwik::translate('Installation_DatabaseSetupLogin'));
         $user->addRule('required', Piwik::translate('General_Required', Piwik::translate('Installation_DatabaseSetupLogin')));
@@ -107,7 +103,7 @@ class FormDatabaseSetup extends QuickForm2
             'port'          => '3306',
         );
 
-        $defaultsEnvironment = array('host', 'adapter', 'tables_prefix', 'username', 'schema', 'password', 'dbname', 'port');
+        $defaultsEnvironment = array('host', 'adapter', 'tables_prefix', 'username', 'schema', 'password', 'dbname');
         foreach ($defaultsEnvironment as $name) {
             $envValue = $this->getEnvironmentSetting($name);
 
@@ -161,6 +157,8 @@ class FormDatabaseSetup extends QuickForm2
             $password = $this->getEnvironmentSetting('password');
         }
 
+        $schema = $this->getSubmitValue('schema');
+
         $dbInfos = array(
             'host'          => (is_null($host)) ? $host : trim($host),
             'username'      => $this->getSubmitValue('username'),
@@ -168,8 +166,8 @@ class FormDatabaseSetup extends QuickForm2
             'dbname'        => $dbname,
             'tables_prefix' => (is_null($tables_prefix)) ? $tables_prefix : trim($tables_prefix),
             'adapter'       => $adapter,
-            'port'          => $this->getSubmitValue('port'),
-            'schema'        => $this->getSubmitValue('schema'),
+            'port'          => Db\Schema::getDefaultPortForSchema($schema),
+            'schema'        => $schema,
             'type'          => $this->getSubmitValue('type'),
             'enable_ssl'    => false
         );

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -14,7 +14,6 @@
         "DatabaseSetupDatabaseName": "Database Name",
         "DatabaseSetupLogin": "Login",
         "DatabaseSetupServer": "Database Server",
-        "DatabaseSetupServerPort": "Database Server Port",
         "DatabaseSetupEngine": "Database Engine",
         "DatabaseSetupTablePrefix": "Table Prefix",
         "Email": "Email",

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -14,6 +14,7 @@
         "DatabaseSetupDatabaseName": "Database Name",
         "DatabaseSetupLogin": "Login",
         "DatabaseSetupServer": "Database Server",
+        "DatabaseSetupServerPort": "Database Server Port",
         "DatabaseSetupEngine": "Database Engine",
         "DatabaseSetupTablePrefix": "Table Prefix",
         "Email": "Email",


### PR DESCRIPTION
### Description:

With supporting different database schemas, the definition of the default database port no longer makes sense as part of the adapter. Instead this should be part of the schema, so e.g. TiDb can define it's own default port.

In addition this PR contains a security improvement to hide the password from the UI during installation if it was provided through an env variable already.

fixes #22051

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
