### PR TITLE
Improve marketplace UI tests

### DIFF
--- a/plugins/Marketplace/tests/UI/Marketplace_spec.js
+++ b/plugins/Marketplace/tests/UI/Marketplace_spec.js
@@ -42,7 +42,7 @@ describe("Marketplace", function () {
 
     async function captureSelector(screenshotName, selector)
     {
-        await page.waitForFunction("$('" + selector + "').length > 0");
+        await page.waitForSelector(selector, { visible: true });
         await page.waitForNetworkIdle();
         expect(await page.screenshotSelector(selector)).to.matchImage(screenshotName);
     }
@@ -125,7 +125,7 @@ describe("Marketplace", function () {
 
                 await page.goto('?module=CorePluginsAdmin&action=plugins&idSite=1&period=day&date=yesterday&activated=');
 
-                await captureSelector('updates_' + mode, '#content .card:first');
+                await captureSelector('updates_' + mode, '#content div[vue-entry="CorePluginsAdmin.PluginsTableWithUpdates"]');
             });
         }
 

--- a/plugins/Marketplace/tests/UI/Marketplace_spec.js
+++ b/plugins/Marketplace/tests/UI/Marketplace_spec.js
@@ -47,15 +47,6 @@ describe("Marketplace", function () {
         expect(await page.screenshotSelector(selector)).to.matchImage(screenshotName);
     }
 
-    async function captureModal(screenshotName, selector)
-    {
-        await page.waitForFunction("$('" + selector + "').length > 0");
-        await page.waitForNetworkIdle();
-
-        const elem = await page.$(selector);
-        expect(await elem.screenshot()).to.matchImage(screenshotName);
-    }
-
     async function captureMarketplace(screenshotName, selector)
     {
         if (!selector) {

--- a/plugins/Marketplace/tests/UI/Marketplace_spec.js
+++ b/plugins/Marketplace/tests/UI/Marketplace_spec.js
@@ -197,6 +197,16 @@ describe("Marketplace", function () {
         });
     });
 
+    [expiredLicense, exceededLicense, validLicense, noLicense].forEach(function (consumer) {
+        it('should show a subscription overview for ' + consumer, async function() {
+            setEnvironment('superuser', consumer);
+
+            await page.goto('?module=Marketplace&action=subscriptionOverview');
+
+            await captureSelector('subscription_overview_' + consumer, '#content');
+        });
+    });
+
     [noLicense, expiredLicense, exceededLicense].forEach(function (consumer) {
         // when there is no license it should not show a warning! as it could be due to network problems etc
         it('should show a warning if license is ' + consumer, async function() {

--- a/plugins/Marketplace/tests/UI/expected-screenshots/Marketplace_subscription_overview_exceededLicense.png
+++ b/plugins/Marketplace/tests/UI/expected-screenshots/Marketplace_subscription_overview_exceededLicense.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ec279d06d66b141385a150dc72fcc2a08ee4ac2d0d095b4492595126672bb20
+size 75659

--- a/plugins/Marketplace/tests/UI/expected-screenshots/Marketplace_subscription_overview_expiredLicense.png
+++ b/plugins/Marketplace/tests/UI/expected-screenshots/Marketplace_subscription_overview_expiredLicense.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0c205080cd1e570b2e2f3b6c65105e0af988105fe8b711d23d847ab30ed3c60
+size 82352

--- a/plugins/Marketplace/tests/UI/expected-screenshots/Marketplace_subscription_overview_noLicense.png
+++ b/plugins/Marketplace/tests/UI/expected-screenshots/Marketplace_subscription_overview_noLicense.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34ca82255c164107fe0dd724a10e173fe9fe38571896d941275b0c2dd35778a7
+size 17464

--- a/plugins/Marketplace/tests/UI/expected-screenshots/Marketplace_subscription_overview_validLicense.png
+++ b/plugins/Marketplace/tests/UI/expected-screenshots/Marketplace_subscription_overview_validLicense.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0021e160e2159fbff9924506ee91308ded0f1725b623d1cc8a8014340368c500
+size 54638


### PR DESCRIPTION
### Description:

In #22237 we changed some of the existing marketplace tests, with more changes than we should have done:

- the UI tests for "subscriptionOverview" were accidentally deleted, these should be restored
- somehow the test for the license check warning message broke, changing the selector wait function from jQuery to `waitForSelector({ visible: true })` seems to fix that.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
