### PR TITLE
Use unique merged assets filenames when requested from UI tests via Proxy

### DIFF
--- a/config/environment/ui-test.php
+++ b/config/environment/ui-test.php
@@ -12,6 +12,8 @@ use Piwik\Tests\Framework\Mock\FakeSiteContentDetector;
 
 return [
 
+    'tests.ui' => true,
+
     // UI tests will remove the port from all URLs to the test server. if a test
     // requires the ports in UI tests (eg, Overlay), add the api/controller methods
     // to one of these blacklists

--- a/config/global.php
+++ b/config/global.php
@@ -261,5 +261,7 @@ return [
 
     \Piwik\Segment\SegmentsList::class => function () {
         return \Piwik\Segment\SegmentsList::get();
-    }
+    },
+
+    'tests.ui' => false,
 ];

--- a/core/AssetManager.php
+++ b/core/AssetManager.php
@@ -195,11 +195,12 @@ class AssetManager extends Singleton
      * Return the css merged file absolute location.
      * If there is none, the generation process will be triggered.
      *
+     * @param bool $useUniqueFilenames
      * @return UIAsset
      */
-    public function getMergedStylesheet()
+    public function getMergedStylesheet(bool $useUniqueFilenames = false)
     {
-        $mergedAsset = $this->getMergedStylesheetAsset();
+        $mergedAsset = $this->getMergedStylesheetAsset($useUniqueFilenames);
 
         $assetFetcher = new StylesheetUIAssetFetcher(Manager::getInstance()->getLoadedPluginsName(), $this->theme);
 
@@ -214,22 +215,24 @@ class AssetManager extends Singleton
      * Return the core js merged file absolute location.
      * If there is none, the generation process will be triggered.
      *
+     * @param bool $useUniqueFilenames
      * @return UIAsset
      */
-    public function getMergedCoreJavaScript()
+    public function getMergedCoreJavaScript(bool $useUniqueFilenames = false)
     {
-        return $this->getMergedJavascript($this->getCoreJScriptFetcher(), $this->getMergedCoreJSAsset());
+        return $this->getMergedJavascript($this->getCoreJScriptFetcher(), $this->getMergedCoreJSAsset($useUniqueFilenames));
     }
 
     /**
      * Return the non core js merged file absolute location.
      * If there is none, the generation process will be triggered.
      *
+     * @param bool $useUniqueFilenames
      * @return UIAsset
      */
-    public function getMergedNonCoreJavaScript()
+    public function getMergedNonCoreJavaScript(bool $useUniqueFilenames = false)
     {
-        return $this->getMergedJavascript($this->getNonCoreJScriptFetcher(), $this->getMergedNonCoreJSAsset());
+        return $this->getMergedJavascript($this->getNonCoreJScriptFetcher(), $this->getMergedNonCoreJSAsset($useUniqueFilenames));
     }
 
     /**

--- a/core/AssetManager.php
+++ b/core/AssetManager.php
@@ -470,7 +470,7 @@ class AssetManager extends Singleton
     private function getUniqueFileName(string $name): string
     {
         $cacheId = CacheId::pluginAware($name);
-        $cache = PiwikCache::getTransientCache();
+        $cache = Cache::getTransientCache();
         if ($cache->contains($cacheId)) {
             $filename = $cache->fetch($cacheId);
         } else {

--- a/core/AssetManager.php
+++ b/core/AssetManager.php
@@ -464,28 +464,57 @@ class AssetManager extends Singleton
         }
     }
 
-    /**
-     * @return UIAsset
-     */
-    public function getMergedStylesheetAsset()
+    private function getUniqueFileName(string $name): string
     {
-        return $this->getMergedUIAsset(self::MERGED_CSS_FILE);
+        $cacheId = CacheId::pluginAware($name);
+        $cache = PiwikCache::getTransientCache();
+        if ($cache->contains($cacheId)) {
+            $filename = $cache->fetch($cacheId);
+        } else {
+            $ts = str_replace('.', '_', microtime(true));
+            $filename = str_replace(
+                ['.css', '.js'],
+                [sprintf('.%s.css', $ts), sprintf('.%s.js', $ts)],
+                $name
+            );
+
+            $cache->save($cacheId, $filename);
+        }
+
+        return $filename;
     }
 
     /**
      * @return UIAsset
      */
-    private function getMergedCoreJSAsset()
+    public function getMergedStylesheetAsset(bool $useUniqueFilenames = false)
     {
-        return $this->getMergedUIAsset(self::MERGED_CORE_JS_FILE);
+        $filename = $useUniqueFilenames
+            ? $this->getUniqueFileName(self::MERGED_CSS_FILE)
+            : self::MERGED_CSS_FILE;
+        return $this->getMergedUIAsset($filename);
     }
 
     /**
      * @return UIAsset
      */
-    protected function getMergedNonCoreJSAsset()
+    private function getMergedCoreJSAsset(bool $useUniqueFilenames = false)
     {
-        return $this->getMergedUIAsset(self::MERGED_NON_CORE_JS_FILE);
+        $filename = $useUniqueFilenames
+            ? $this->getUniqueFileName(self::MERGED_CORE_JS_FILE)
+            : self::MERGED_CORE_JS_FILE;
+        return $this->getMergedUIAsset($filename);
+    }
+
+    /**
+     * @return UIAsset
+     */
+    protected function getMergedNonCoreJSAsset(bool $useUniqueFilenames = false)
+    {
+        $filename = $useUniqueFilenames
+            ? $this->getUniqueFileName(self::MERGED_NON_CORE_JS_FILE)
+            : self::MERGED_NON_CORE_JS_FILE;
+        return $this->getMergedUIAsset($filename);
     }
 
     /**

--- a/plugins/Proxy/Controller.php
+++ b/plugins/Proxy/Controller.php
@@ -33,9 +33,9 @@ class Controller extends \Piwik\Plugin\Controller
     public function getCss()
     {
         try {
-            $cssMergedFile = AssetManager::getInstance()->getMergedStylesheet();
+            $cssMergedFile = AssetManager::getInstance()->getMergedStylesheet(true);
         } catch (StylesheetLessCompileException $exception) {
-            $cssMergedFile = AssetManager::getInstance()->getMergedStylesheet();
+            $cssMergedFile = AssetManager::getInstance()->getMergedStylesheet(true);
         }
         ProxyHttp::serverStaticFile($cssMergedFile->getAbsoluteLocation(), "text/css");
     }
@@ -48,7 +48,7 @@ class Controller extends \Piwik\Plugin\Controller
      */
     public function getCoreJs()
     {
-        $jsMergedFile = AssetManager::getInstance()->getMergedCoreJavaScript();
+        $jsMergedFile = AssetManager::getInstance()->getMergedCoreJavaScript(true);
         $this->serveJsFile($jsMergedFile);
     }
 
@@ -60,7 +60,7 @@ class Controller extends \Piwik\Plugin\Controller
      */
     public function getNonCoreJs()
     {
-        $jsMergedFile = AssetManager::getInstance()->getMergedNonCoreJavaScript();
+        $jsMergedFile = AssetManager::getInstance()->getMergedNonCoreJavaScript(true);
         $this->serveJsFile($jsMergedFile);
     }
 

--- a/plugins/Proxy/Controller.php
+++ b/plugins/Proxy/Controller.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\Proxy;
 use Piwik\AssetManager;
 use Piwik\AssetManager\UIAsset;
 use Piwik\Common;
+use Piwik\Container\StaticContainer;
 use Piwik\Exception\StylesheetLessCompileException;
 use Piwik\Plugin\Manager;
 use Piwik\ProxyHttp;
@@ -33,9 +34,9 @@ class Controller extends \Piwik\Plugin\Controller
     public function getCss()
     {
         try {
-            $cssMergedFile = AssetManager::getInstance()->getMergedStylesheet(true);
+            $cssMergedFile = AssetManager::getInstance()->getMergedStylesheet(StaticContainer::get('tests.ui'));
         } catch (StylesheetLessCompileException $exception) {
-            $cssMergedFile = AssetManager::getInstance()->getMergedStylesheet(true);
+            $cssMergedFile = AssetManager::getInstance()->getMergedStylesheet(StaticContainer::get('tests.ui'));
         }
         ProxyHttp::serverStaticFile($cssMergedFile->getAbsoluteLocation(), "text/css");
     }
@@ -48,19 +49,19 @@ class Controller extends \Piwik\Plugin\Controller
      */
     public function getCoreJs()
     {
-        $jsMergedFile = AssetManager::getInstance()->getMergedCoreJavaScript(true);
+        $jsMergedFile = AssetManager::getInstance()->getMergedCoreJavaScript(StaticContainer::get('tests.ui'));
         $this->serveJsFile($jsMergedFile);
     }
 
     /**
-     * Output the merged non core JavaScript file.
+     * Output the merged non-core JavaScript file.
      * This method is called when the asset manager is enabled.
      *
      * @see core/AssetManager.php
      */
     public function getNonCoreJs()
     {
-        $jsMergedFile = AssetManager::getInstance()->getMergedNonCoreJavaScript(true);
+        $jsMergedFile = AssetManager::getInstance()->getMergedNonCoreJavaScript(StaticContainer::get('tests.ui'));
         $this->serveJsFile($jsMergedFile);
     }
 


### PR DESCRIPTION
### Description:

First go at fixing UI test failures when merged assets are not available when requested via the Proxy mechanism.

Ref. DEV-18126

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
