### PR TITLE
Update UI test around plugins order

### DIFF
--- a/core/Container/ContainerFactory.php
+++ b/core/Container/ContainerFactory.php
@@ -122,6 +122,7 @@ class ContainerFactory
         // add plugin environment configs
         $plugins = $this->pluginList->getActivatedPlugins();
         $plugins = array_unique(array_merge($plugins, Manager::getAlwaysActivatedPlugins()));
+        sort($plugins); // initial alphabetical sort, could be reordered below if custom sorting is provided
 
         if ($this->shouldSortPlugins()) {
             $plugins = $this->sortPlugins($plugins);
@@ -141,6 +142,7 @@ class ContainerFactory
     {
         $plugins = $this->pluginList->getActivatedPlugins();
         $plugins = array_unique(array_merge($plugins, Manager::getAlwaysActivatedPlugins()));
+        sort($plugins); // initial alphabetical sort, could be reordered below if custom sorting is provided
 
         if ($this->shouldSortPlugins()) {
             $plugins = $this->sortPlugins($plugins);

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5bb6e082060a96c9dadee6cffb6010e11e45b5c234ae0f595f8c9901708c451
-size 5468287
+oid sha256:b581b0117f65ed4d7ec8c080b9c5c98abe8864c42e01057b03587dc5cbd89f8f
+size 5468076


### PR DESCRIPTION
### Description:

After the recent change the order of plugins changed in the UI test screenshot. This change adds a default sort (that can be overridden via an existing mechanism, if needed), and updates the screenshot for consistency.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
