### PR TITLE
Define default collation for TiDB tables

### DIFF
--- a/core/Db/Schema.php
+++ b/core/Db/Schema.php
@@ -90,6 +90,16 @@ class Schema extends Singleton
     }
 
     /**
+     * Get the table options to use for a CREATE TABLE statement.
+     *
+     * @return string
+     */
+    public function getTableCreateOptions(): string
+    {
+        return $this->getSchema()->getTableCreateOptions();
+    }
+
+    /**
      * Get the SQL to create a specific Piwik table
      *
      * @param string $tableName name of the table to create

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -39,9 +39,8 @@ class Mysql implements SchemaInterface
      */
     public function getTablesCreateSql()
     {
-        $engine       = $this->getTableEngine();
         $prefixTables = $this->getTablePrefix();
-        $charset      = $this->getUsedCharset();
+        $tableOptions = $this->getTableCreateOptions();
 
         $tables = array(
             'user'    => "CREATE TABLE {$prefixTables}user (
@@ -61,7 +60,7 @@ class Mysql implements SchemaInterface
                           ts_changes_shown TIMESTAMP NULL,
                             PRIMARY KEY(login),
                             UNIQUE INDEX `uniq_email` (`email`)
-                          ) ENGINE=$engine DEFAULT CHARSET=$charset
+                          ) $tableOptions
             ",
             'user_token_auth' => "CREATE TABLE {$prefixTables}user_token_auth (
                           idusertokenauth BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -76,7 +75,7 @@ class Mysql implements SchemaInterface
                           secure_only TINYINT(2) unsigned NOT NULL DEFAULT '0',
                             PRIMARY KEY(idusertokenauth),
                             UNIQUE KEY uniq_password(password)
-                          ) ENGINE=$engine DEFAULT CHARSET=$charset
+                          ) $tableOptions
             ",
 
             'twofactor_recovery_code'    => "CREATE TABLE {$prefixTables}twofactor_recovery_code (
@@ -84,7 +83,7 @@ class Mysql implements SchemaInterface
                           login VARCHAR(100) NOT NULL,
                           recovery_code VARCHAR(40) NOT NULL,
                             PRIMARY KEY(idrecoverycode)
-                          ) ENGINE=$engine DEFAULT CHARSET=$charset
+                          ) $tableOptions
             ",
 
             'access'  => "CREATE TABLE {$prefixTables}access (
@@ -94,7 +93,7 @@ class Mysql implements SchemaInterface
                           access VARCHAR(50) NULL,
                             PRIMARY KEY(idaccess),
                             INDEX index_loginidsite (login, idsite)
-                          ) ENGINE=$engine DEFAULT CHARSET=$charset
+                          ) $tableOptions
             ",
 
             'site'    => "CREATE TABLE {$prefixTables}site (
@@ -118,7 +117,7 @@ class Mysql implements SchemaInterface
                             keep_url_fragment TINYINT NOT NULL DEFAULT 0,
                             creator_login VARCHAR(100) NULL,
                               PRIMARY KEY(idsite)
-                            ) ENGINE=$engine DEFAULT CHARSET=$charset
+                            ) $tableOptions
             ",
 
             'plugin_setting' => "CREATE TABLE {$prefixTables}plugin_setting (
@@ -130,7 +129,7 @@ class Mysql implements SchemaInterface
                               `idplugin_setting` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
                               PRIMARY KEY (idplugin_setting),
                               INDEX(plugin_name, user_login)
-                            ) ENGINE=$engine DEFAULT CHARSET=$charset
+                            ) $tableOptions
             ",
 
             'site_setting'    => "CREATE TABLE {$prefixTables}site_setting (
@@ -142,14 +141,14 @@ class Mysql implements SchemaInterface
                               `idsite_setting` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
                               PRIMARY KEY (idsite_setting),
                               INDEX(idsite, plugin_name)
-                            ) ENGINE=$engine DEFAULT CHARSET=$charset
+                            ) $tableOptions
             ",
 
             'site_url'    => "CREATE TABLE {$prefixTables}site_url (
                               idsite INTEGER(10) UNSIGNED NOT NULL,
                               url VARCHAR(190) NOT NULL,
                                 PRIMARY KEY(idsite, url)
-                              ) ENGINE=$engine DEFAULT CHARSET=$charset
+                              ) $tableOptions
             ",
 
             'goal'       => "CREATE TABLE `{$prefixTables}goal` (
@@ -166,7 +165,7 @@ class Mysql implements SchemaInterface
                               `deleted` tinyint(4) NOT NULL default '0',
                               `event_value_as_revenue` tinyint(4) NOT NULL default '0',
                                 PRIMARY KEY  (`idsite`,`idgoal`)
-                              ) ENGINE=$engine DEFAULT CHARSET=$charset
+                              ) $tableOptions
             ",
 
             'logger_message'      => "CREATE TABLE {$prefixTables}logger_message (
@@ -176,7 +175,7 @@ class Mysql implements SchemaInterface
                                       level VARCHAR(16) NULL,
                                       message TEXT NULL,
                                         PRIMARY KEY(idlogger_message)
-                                      ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                      ) $tableOptions
             ",
 
             'log_action'          => "CREATE TABLE {$prefixTables}log_action (
@@ -187,7 +186,7 @@ class Mysql implements SchemaInterface
                                       url_prefix TINYINT(2) NULL,
                                         PRIMARY KEY(idaction),
                                         INDEX index_type_hash (type, hash)
-                                      ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                      ) $tableOptions
             ",
 
             'log_visit'   => "CREATE TABLE {$prefixTables}log_visit (
@@ -201,7 +200,7 @@ class Mysql implements SchemaInterface
                                 INDEX index_idsite_config_datetime (idsite, config_id, visit_last_action_time),
                                 INDEX index_idsite_datetime (idsite, visit_last_action_time),
                                 INDEX index_idsite_idvisitor_time (idsite, idvisitor, visit_last_action_time DESC)
-                              ) ENGINE=$engine DEFAULT CHARSET=$charset
+                              ) $tableOptions
             ",
 
             'log_conversion_item'   => "CREATE TABLE `{$prefixTables}log_conversion_item` (
@@ -222,7 +221,7 @@ class Mysql implements SchemaInterface
                                         deleted TINYINT(1) UNSIGNED NOT NULL,
                                           PRIMARY KEY(idvisit, idorder, idaction_sku),
                                           INDEX index_idsite_servertime ( idsite, server_time )
-                                        ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                        ) $tableOptions
             ",
 
             'log_conversion'      => "CREATE TABLE `{$prefixTables}log_conversion` (
@@ -246,7 +245,7 @@ class Mysql implements SchemaInterface
                                         PRIMARY KEY (idvisit, idgoal, buster),
                                         UNIQUE KEY unique_idsite_idorder (idsite, idorder),
                                         INDEX index_idsite_datetime ( idsite, server_time )
-                                      ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                      ) $tableOptions
             ",
 
             'log_link_visit_action' => "CREATE TABLE {$prefixTables}log_link_visit_action (
@@ -260,7 +259,7 @@ class Mysql implements SchemaInterface
                                         pageview_position MEDIUMINT UNSIGNED DEFAULT NULL,
                                           PRIMARY KEY(idlink_va),
                                           INDEX index_idvisit(idvisit)
-                                        ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                        ) $tableOptions
             ",
 
             'log_profiling'   => "CREATE TABLE {$prefixTables}log_profiling (
@@ -270,7 +269,7 @@ class Mysql implements SchemaInterface
                                   idprofiling BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
                                     PRIMARY KEY (idprofiling),
                                     UNIQUE KEY query(query(100))
-                                  ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                  ) $tableOptions
             ",
 
             'option'        => "CREATE TABLE `{$prefixTables}option` (
@@ -279,7 +278,7 @@ class Mysql implements SchemaInterface
                                 autoload TINYINT NOT NULL DEFAULT '1',
                                   PRIMARY KEY ( option_name ),
                                   INDEX autoload( autoload )
-                                ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                ) $tableOptions
             ",
 
             'session'       => "CREATE TABLE {$prefixTables}session (
@@ -288,7 +287,7 @@ class Mysql implements SchemaInterface
                                 lifetime INTEGER,
                                 data MEDIUMTEXT,
                                   PRIMARY KEY ( id )
-                                ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                ) $tableOptions
             ",
 
             'archive_numeric'     => "CREATE TABLE {$prefixTables}archive_numeric (
@@ -303,7 +302,7 @@ class Mysql implements SchemaInterface
                                         PRIMARY KEY(idarchive, name),
                                         INDEX index_idsite_dates_period(idsite, date1, date2, period, name(6)),
                                         INDEX index_period_archived(period, ts_archived)
-                                      ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                      ) $tableOptions
             ",
 
             'archive_blob'        => "CREATE TABLE {$prefixTables}archive_blob (
@@ -317,7 +316,7 @@ class Mysql implements SchemaInterface
                                       value MEDIUMBLOB NULL,
                                         PRIMARY KEY(idarchive, name),
                                         INDEX index_period_archived(period, ts_archived)
-                                      ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                      ) $tableOptions
             ",
 
             'archive_invalidations' => "CREATE TABLE `{$prefixTables}archive_invalidations` (
@@ -334,14 +333,14 @@ class Mysql implements SchemaInterface
                                             `report` VARCHAR(255) NULL,
                                             PRIMARY KEY(idinvalidation),
                                             INDEX index_idsite_dates_period_name(idsite, date1, period)
-                                        ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                        ) $tableOptions
             ",
 
             'sequence'        => "CREATE TABLE {$prefixTables}sequence (
                                       `name` VARCHAR(120) NOT NULL,
                                       `value` BIGINT(20) UNSIGNED NOT NULL ,
                                       PRIMARY KEY(`name`)
-                                  ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                  ) $tableOptions
             ",
 
             'brute_force_log'        => "CREATE TABLE {$prefixTables}brute_force_log (
@@ -351,7 +350,7 @@ class Mysql implements SchemaInterface
                                       `login` VARCHAR(100) NULL,
                                         INDEX index_ip_address(ip_address),
                                       PRIMARY KEY(`id_brute_force_log`)
-                                      ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                      ) $tableOptions
             ",
 
             'tracking_failure'        => "CREATE TABLE {$prefixTables}tracking_failure (
@@ -360,14 +359,14 @@ class Mysql implements SchemaInterface
                                       `date_first_occurred` DATETIME NOT NULL ,
                                       `request_url` MEDIUMTEXT NOT NULL ,
                                       PRIMARY KEY(`idsite`, `idfailure`)
-                                  ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                  ) $tableOptions
             ",
             'locks'                   => "CREATE TABLE `{$prefixTables}locks` (
                                       `key` VARCHAR(" . Lock::MAX_KEY_LEN . ") NOT NULL,
                                       `value` VARCHAR(255) NULL DEFAULT NULL,
                                       `expiry_time` BIGINT UNSIGNED DEFAULT 9999999999,
                                       PRIMARY KEY (`key`)
-                                  ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                  ) $tableOptions
             ",
             'changes'             => "CREATE TABLE `{$prefixTables}changes` (
                                       `idchange` INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -380,7 +379,7 @@ class Mysql implements SchemaInterface
                                       `link` VARCHAR(255) NULL,       
                                       PRIMARY KEY(`idchange`),
                                       UNIQUE KEY unique_plugin_version_title (`plugin_name`, `version`, `title`(100))                            
-                                  ) ENGINE=$engine DEFAULT CHARSET=$charset
+                                  ) $tableOptions
             ",
         );
 
@@ -537,14 +536,11 @@ class Mysql implements SchemaInterface
      */
     public function createTable($nameWithoutPrefix, $createDefinition)
     {
-        $charset = $this->getUsedCharset();
-
         $statement = sprintf(
-            "CREATE TABLE IF NOT EXISTS `%s` ( %s ) ENGINE=%s DEFAULT CHARSET=%s %s;",
+            "CREATE TABLE IF NOT EXISTS `%s` ( %s ) %s %s;",
             Common::prefixTable($nameWithoutPrefix),
             $createDefinition,
-            $this->getTableEngine(),
-            $charset,
+            $this->getTableCreateOptions(),
             $this->getTableRowFormat()
         );
 
@@ -686,6 +682,14 @@ class Mysql implements SchemaInterface
     private function getTableEngine()
     {
         return $this->getDbSettings()->getEngine();
+    }
+
+    private function getTableCreateOptions(): string
+    {
+        $engine = $this->getTableEngine();
+        $charset = $this->getUsedCharset();
+
+        return "ENGINE=$engine DEFAULT CHARSET=$charset";
     }
 
     private function getTableRowFormat(): string

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -537,11 +537,10 @@ class Mysql implements SchemaInterface
     public function createTable($nameWithoutPrefix, $createDefinition)
     {
         $statement = sprintf(
-            "CREATE TABLE IF NOT EXISTS `%s` ( %s ) %s %s;",
+            "CREATE TABLE IF NOT EXISTS `%s` ( %s ) %s;",
             Common::prefixTable($nameWithoutPrefix),
             $createDefinition,
-            $this->getTableCreateOptions(),
-            $this->getTableRowFormat()
+            $this->getTableCreateOptions()
         );
 
         try {
@@ -688,8 +687,15 @@ class Mysql implements SchemaInterface
     {
         $engine = $this->getTableEngine();
         $charset = $this->getUsedCharset();
+        $rowFormat = $this->getTableRowFormat();
 
-        return "ENGINE=$engine DEFAULT CHARSET=$charset";
+        $options = "ENGINE=$engine DEFAULT CHARSET=$charset";
+
+        if ('' !== $rowFormat) {
+            $options .= " $rowFormat";
+        }
+
+        return $options;
     }
 
     private function getTableRowFormat(): string

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -673,7 +673,7 @@ class Mysql implements SchemaInterface
         return 3306;
     }
 
-    protected function getTableCreateOptions(): string
+    public function getTableCreateOptions(): string
     {
         $engine = $this->getTableEngine();
         $charset = $this->getUsedCharset();

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -673,17 +673,7 @@ class Mysql implements SchemaInterface
         return 3306;
     }
 
-    private function getTablePrefix()
-    {
-        return $this->getDbSettings()->getTablePrefix();
-    }
-
-    private function getTableEngine()
-    {
-        return $this->getDbSettings()->getEngine();
-    }
-
-    private function getTableCreateOptions(): string
+    protected function getTableCreateOptions(): string
     {
         $engine = $this->getTableEngine();
         $charset = $this->getUsedCharset();
@@ -698,9 +688,24 @@ class Mysql implements SchemaInterface
         return $options;
     }
 
-    private function getTableRowFormat(): string
+    protected function getTableEngine()
+    {
+        return $this->getDbSettings()->getEngine();
+    }
+
+    protected function getTableRowFormat(): string
     {
         return $this->getDbSettings()->getRowFormat();
+    }
+
+    protected function getUsedCharset(): string
+    {
+        return $this->getDbSettings()->getUsedCharset();
+    }
+
+    private function getTablePrefix()
+    {
+        return $this->getDbSettings()->getTablePrefix();
     }
 
     private function getDb()
@@ -733,10 +738,5 @@ class Mysql implements SchemaInterface
         // '_' matches any character; force it to be literal
         $prefixTables = str_replace('_', '\_', $prefixTables);
         return $prefixTables;
-    }
-
-    private function getUsedCharset(): string
-    {
-        return $this->getDbSettings()->getUsedCharset();
     }
 }

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -41,8 +41,7 @@ class Mysql implements SchemaInterface
     {
         $engine       = $this->getTableEngine();
         $prefixTables = $this->getTablePrefix();
-        $dbSettings   = new Db\Settings();
-        $charset      = $dbSettings->getUsedCharset();
+        $charset      = $this->getUsedCharset();
 
         $tables = array(
             'user'    => "CREATE TABLE {$prefixTables}user (
@@ -538,8 +537,7 @@ class Mysql implements SchemaInterface
      */
     public function createTable($nameWithoutPrefix, $createDefinition)
     {
-        $dbSettings   = new Db\Settings();
-        $charset      = $dbSettings->getUsedCharset();
+        $charset = $this->getUsedCharset();
 
         $statement = sprintf(
             "CREATE TABLE IF NOT EXISTS `%s` ( %s ) ENGINE=%s DEFAULT CHARSET=%s %s;",
@@ -547,7 +545,7 @@ class Mysql implements SchemaInterface
             $createDefinition,
             $this->getTableEngine(),
             $charset,
-            $dbSettings->getRowFormat()
+            $this->getTableRowFormat()
         );
 
         try {
@@ -690,6 +688,11 @@ class Mysql implements SchemaInterface
         return $this->getDbSettings()->getEngine();
     }
 
+    private function getTableRowFormat(): string
+    {
+        return $this->getDbSettings()->getRowFormat();
+    }
+
     private function getDb()
     {
         return Db::get();
@@ -720,5 +723,10 @@ class Mysql implements SchemaInterface
         // '_' matches any character; force it to be literal
         $prefixTables = str_replace('_', '\_', $prefixTables);
         return $prefixTables;
+    }
+
+    private function getUsedCharset(): string
+    {
+        return $this->getDbSettings()->getUsedCharset();
     }
 }

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -520,10 +520,10 @@ class Mysql implements SchemaInterface
             $dbName = $this->getDbName();
         }
 
+        $createOptions = $this->getDatabaseCreateOptions();
         $dbName = str_replace('`', '', $dbName);
-        $charset    = DbHelper::getDefaultCharset();
 
-        Db::exec("CREATE DATABASE IF NOT EXISTS `" . $dbName . "` DEFAULT CHARACTER SET " . $charset);
+        Db::exec("CREATE DATABASE IF NOT EXISTS `$dbName` $createOptions");
     }
 
     /**
@@ -686,6 +686,13 @@ class Mysql implements SchemaInterface
         }
 
         return $options;
+    }
+
+    protected function getDatabaseCreateOptions(): string
+    {
+        $charset = DbHelper::getDefaultCharset();
+
+        return "DEFAULT CHARACTER SET $charset";
     }
 
     protected function getTableEngine()

--- a/core/Db/Schema/Tidb.php
+++ b/core/Db/Schema/Tidb.php
@@ -29,4 +29,23 @@ class Tidb extends Mysql
     {
         return 4000;
     }
+
+    protected function getTableCreateOptions(): string
+    {
+        $engine = $this->getTableEngine();
+        $charset = $this->getUsedCharset();
+        $rowFormat = $this->getTableRowFormat();
+
+        $options = "ENGINE=$engine DEFAULT CHARSET=$charset";
+
+        if ('utf8mb4' === $charset) {
+            $options .= ' COLLATE=utf8mb4_0900_ai_ci';
+        }
+
+        if ('' !== $rowFormat) {
+            $options .= " $rowFormat";
+        }
+
+        return $options;
+    }
 }

--- a/core/Db/Schema/Tidb.php
+++ b/core/Db/Schema/Tidb.php
@@ -9,6 +9,8 @@
 
 namespace Piwik\Db\Schema;
 
+use Piwik\DbHelper;
+
 /**
  * Mariadb schema
  */
@@ -44,6 +46,18 @@ class Tidb extends Mysql
 
         if ('' !== $rowFormat) {
             $options .= " $rowFormat";
+        }
+
+        return $options;
+    }
+
+    protected function getDatabaseCreateOptions(): string
+    {
+        $charset = DbHelper::getDefaultCharset();
+        $options = "DEFAULT CHARACTER SET $charset";
+
+        if ('utf8mb4' === $charset) {
+            $options .= ' COLLATE=utf8mb4_0900_ai_ci';
         }
 
         return $options;

--- a/core/Db/Schema/Tidb.php
+++ b/core/Db/Schema/Tidb.php
@@ -30,7 +30,7 @@ class Tidb extends Mysql
         return 4000;
     }
 
-    protected function getTableCreateOptions(): string
+    public function getTableCreateOptions(): string
     {
         $engine = $this->getTableEngine();
         $charset = $this->getUsedCharset();

--- a/core/Db/SchemaInterface.php
+++ b/core/Db/SchemaInterface.php
@@ -131,4 +131,11 @@ interface SchemaInterface
      * @return int
      */
     public function getDefaultPort(): int;
+
+    /**
+     * Return the table options to use for a CREATE TABLE statement.
+     *
+     * @return string
+     */
+    public function getTableCreateOptions(): string;
 }

--- a/core/Updater/Migration/Db/CreateTable.php
+++ b/core/Updater/Migration/Db/CreateTable.php
@@ -9,7 +9,7 @@
 
 namespace Piwik\Updater\Migration\Db;
 
-use Piwik\Db;
+use Piwik\Db\Schema;
 
 /**
  * @see Factory::createTable()
@@ -19,12 +19,11 @@ class CreateTable extends Sql
 {
     /**
      * Constructor.
-     * @param Db\Settings $dbSettings
      * @param string $table Prefixed table name
      * @param string|string[] $columnNames array(columnName => columnValue)
      * @param string|string[] $primaryKey one or multiple columns that define the primary key
      */
-    public function __construct(Db\Settings $dbSettings, $table, $columnNames, $primaryKey)
+    public function __construct($table, $columnNames, $primaryKey)
     {
         $columns = array();
         foreach ($columnNames as $column => $type) {
@@ -35,15 +34,12 @@ class CreateTable extends Sql
             $columns[] = sprintf('PRIMARY KEY ( `%s` )', implode('`, `', $primaryKey));
         }
 
-
-        $sql = rtrim(sprintf(
-            'CREATE TABLE `%s` (%s) ENGINE=%s DEFAULT CHARSET=%s %s',
+        $sql = sprintf(
+            'CREATE TABLE `%s` (%s) %s',
             $table,
             implode(', ', $columns),
-            $dbSettings->getEngine(),
-            $dbSettings->getUsedCharset(),
-            $dbSettings->getRowFormat()
-        ));
+            Schema::getInstance()->getTableCreateOptions()
+        );
 
         parent::__construct($sql, static::ERROR_CODE_TABLE_EXISTS);
     }

--- a/tests/resources/OmniFixture-dump.sql
+++ b/tests/resources/OmniFixture-dump.sql
@@ -29,7 +29,7 @@ CREATE TABLE `access` (
   `access` varchar(50) DEFAULT NULL,
   PRIMARY KEY (`idaccess`),
   KEY `index_loginidsite` (`login`,`idsite`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -161,7 +161,7 @@ CREATE TABLE `archive_invalidations` (
   `report` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`idinvalidation`),
   KEY `index_idsite_dates_period_name` (`idsite`,`date1`,`period`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -187,7 +187,7 @@ CREATE TABLE `brute_force_log` (
   `login` varchar(100) DEFAULT NULL,
   PRIMARY KEY (`id_brute_force_log`),
   KEY `index_ip_address` (`ip_address`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -217,7 +217,7 @@ CREATE TABLE `changes` (
   `link` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`idchange`),
   UNIQUE KEY `unique_plugin_version_title` (`plugin_name`,`version`,`title`(100))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -281,7 +281,7 @@ CREATE TABLE `goal` (
   `deleted` tinyint(4) NOT NULL DEFAULT '0',
   `event_value_as_revenue` tinyint(4) NOT NULL DEFAULT '0',
   PRIMARY KEY (`idsite`,`idgoal`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -306,7 +306,7 @@ CREATE TABLE `locks` (
   `value` varchar(255) DEFAULT NULL,
   `expiry_time` bigint(20) unsigned DEFAULT '9999999999',
   PRIMARY KEY (`key`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -333,7 +333,7 @@ CREATE TABLE `log_action` (
   `url_prefix` tinyint(2) DEFAULT NULL,
   PRIMARY KEY (`idaction`),
   KEY `index_type_hash` (`type`,`hash`)
-) ENGINE=InnoDB AUTO_INCREMENT=2764 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=2764 DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -406,7 +406,7 @@ CREATE TABLE `log_conversion` (
   PRIMARY KEY (`idvisit`,`idgoal`,`buster`),
   UNIQUE KEY `unique_idsite_idorder` (`idsite`,`idorder`),
   KEY `index_idsite_datetime` (`idsite`,`server_time`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -444,7 +444,7 @@ CREATE TABLE `log_conversion_item` (
   `deleted` tinyint(1) unsigned NOT NULL,
   PRIMARY KEY (`idvisit`,`idorder`,`idaction_sku`),
   KEY `index_idsite_servertime` (`idsite`,`server_time`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -520,7 +520,7 @@ CREATE TABLE `log_link_visit_action` (
   PRIMARY KEY (`idlink_va`),
   KEY `index_idvisit` (`idvisit`),
   KEY `index_idsite_servertime` (`idsite`,`server_time`)
-) ENGINE=InnoDB AUTO_INCREMENT=2833 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=2833 DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -547,7 +547,7 @@ CREATE TABLE `log_profiling` (
   `idprofiling` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`idprofiling`),
   UNIQUE KEY `query` (`query`(100))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -641,7 +641,7 @@ CREATE TABLE `log_visit` (
   KEY `index_idsite_config_datetime` (`idsite`,`config_id`,`visit_last_action_time`),
   KEY `index_idsite_datetime` (`idsite`,`visit_last_action_time`),
   KEY `index_idsite_idvisitor_time` (`idsite`,`idvisitor`,`visit_last_action_time`)
-) ENGINE=InnoDB AUTO_INCREMENT=500 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=500 DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -668,7 +668,7 @@ CREATE TABLE `logger_message` (
   `level` varchar(16) DEFAULT NULL,
   `message` text,
   PRIMARY KEY (`idlogger_message`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -693,7 +693,7 @@ CREATE TABLE `option` (
   `autoload` tinyint(4) NOT NULL DEFAULT '1',
   PRIMARY KEY (`option_name`),
   KEY `autoload` (`autoload`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -722,7 +722,7 @@ CREATE TABLE `plugin_setting` (
   `idplugin_setting` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`idplugin_setting`),
   KEY `plugin_name` (`plugin_name`,`user_login`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -904,7 +904,7 @@ CREATE TABLE `sequence` (
   `name` varchar(120) NOT NULL,
   `value` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -929,7 +929,7 @@ CREATE TABLE `session` (
   `lifetime` int(11) DEFAULT NULL,
   `data` mediumtext,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -969,7 +969,7 @@ CREATE TABLE `site` (
   `keep_url_fragment` tinyint(4) NOT NULL DEFAULT '0',
   `creator_login` varchar(100) DEFAULT NULL,
   PRIMARY KEY (`idsite`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -998,7 +998,7 @@ CREATE TABLE `site_setting` (
   `idsite_setting` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`idsite_setting`),
   KEY `idsite` (`idsite`,`plugin_name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1021,7 +1021,7 @@ CREATE TABLE `site_url` (
   `idsite` int(10) unsigned NOT NULL,
   `url` varchar(190) NOT NULL,
   PRIMARY KEY (`idsite`,`url`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1257,7 +1257,7 @@ CREATE TABLE `tracking_failure` (
   `date_first_occurred` datetime NOT NULL,
   `request_url` mediumtext NOT NULL,
   PRIMARY KEY (`idsite`,`idfailure`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1281,7 +1281,7 @@ CREATE TABLE `twofactor_recovery_code` (
   `login` varchar(100) NOT NULL,
   `recovery_code` varchar(40) NOT NULL,
   PRIMARY KEY (`idrecoverycode`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1345,7 +1345,7 @@ CREATE TABLE `user` (
   `ts_changes_shown` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`login`),
   UNIQUE KEY `uniq_email` (`email`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1428,7 +1428,7 @@ CREATE TABLE `user_token_auth` (
   `secure_only` tinyint(2) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`idusertokenauth`),
   UNIQUE KEY `uniq_password` (`password`)
-) ENGINE=InnoDB AUTO_INCREMENT=22 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=22 DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --


### PR DESCRIPTION
### Description:

TiDB uses `utf8mb4_general_bin` as the default collation when creating a table. Compared to the MySQL default of `utf8mb4_general_ci` the sorting of some database results will be different.

This PR changes the table/database creation code to be more consistent across engines and actions:

1. Always define `ROW_FORMAT=dynamic`

   Previously, the row format was only defined for tables created during a migration.

   For InnoDB, all tables currently should default to `ROW_FORMAT=DYNAMIC`, adding it to all tables by default should (as far as I know) not be an issue.

   _Note_: TiDB currently ignores the `ROW_FORMAT` and always uses `COMPACT` ([docs](https://docs.pingcap.com/tidb/v8.1/information-schema-tables)).

2. Set a default collation for TiDB tables

   When TiDB is configured, and the (default) `utf8mb4` charset is used, all created tables will be created with a matching `COLLATE=utf8mb4_0900_ai_ci`.

4. Set a default collation for TiDB databases

   Creating a database also sets the default collation if TiDB is configured.

Refs DEV-18061

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
