### PR TITLE
Removes unused method from Tracker class

### DIFF
--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -325,22 +325,6 @@ class Tracker
         }
     }
 
-    protected function loadTrackerPlugins()
-    {
-        try {
-            $pluginManager  = PluginManager::getInstance();
-            $pluginsTracker = $pluginManager->loadTrackerPlugins();
-
-            $this->logger->debug("Loading plugins: { {plugins} }", [
-                'plugins' => implode(", ", $pluginsTracker),
-            ]);
-        } catch (Exception $e) {
-            $this->logger->error('Error loading tracker plugins: {exception}', [
-                'exception' => $e,
-            ]);
-        }
-    }
-
     private function handleFatalErrors()
     {
         register_shutdown_function(function () {

--- a/plugins/BulkTracking/tests/Integration/TrackerTest.php
+++ b/plugins/BulkTracking/tests/Integration/TrackerTest.php
@@ -17,14 +17,6 @@ use Piwik\Tests\Framework\Fixture;
 use Piwik\Tracker;
 use Piwik\Tests\Framework\Mock\Tracker\RequestSet;
 
-class TestIntegrationTracker extends Tracker
-{
-    protected function loadTrackerPlugins()
-    {
-        // if we reload the plugins we would lose the injected data :(
-    }
-}
-
 /**
  * @group TrackerTest
  * @group Tracker
@@ -32,7 +24,7 @@ class TestIntegrationTracker extends Tracker
 class TrackerTest extends BulkTrackingTestCase
 {
     /**
-     * @var TestIntegrationTracker
+     * @var Tracker
      */
     private $tracker;
 
@@ -40,7 +32,7 @@ class TrackerTest extends BulkTrackingTestCase
     {
         parent::setUp();
 
-        $this->tracker = new TestIntegrationTracker();
+        $this->tracker = new Tracker();
 
         Fixture::createWebsite('2014-01-01 00:00:00');
         Fixture::createWebsite('2014-01-01 00:00:00');


### PR DESCRIPTION
### Description:

While investigating something I came across a method, that is actually unused in the code itself. Only a test class was overwriting it, in order to disable its functionality.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
