### PR TITLE
Fix OptOutJS test breaking CI headless browser

### DIFF
--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -367,9 +367,10 @@ PageRenderer.prototype._logMessage = function (message) {
     this.pageLogs.push(message);
 };
 
-PageRenderer.prototype.clearCookies = function () {
+PageRenderer.prototype.clearCookies = async function () {
     // see https://github.com/GoogleChrome/puppeteer/issues/1632#issuecomment-353086292
-    return this.webpage._client.send('Network.clearBrowserCookies');
+    await this.webpage._client.send('Network.clearBrowserCookies');
+    await this.webpage.waitForTimeout(250);
 };
 
 PageRenderer.prototype._setupWebpageEvents = function () {

--- a/tests/resources/overlay-test-site/opt-out.php
+++ b/tests/resources/overlay-test-site/opt-out.php
@@ -30,7 +30,8 @@
                     $optOutArgs = [
                         'divId' => $_GET['divId'] ?? 'matomo-opt-out',
                         'showIntro' => '1',
-                        'useCookiesIfNoTracker' => $loadTracker ? '0' : '1'
+                        'useCookiesIfNoTracker' => $loadTracker ? '0' : '1',
+                        'useCookiesTimeout' => $loadTracker ? '' : '1',
                     ];
                 ?>
                 <script src="../../../index.php?module=CoreAdminHome&action=optOutJS&language=auto&<?= http_build_query($optOutArgs) ?>"></script>


### PR DESCRIPTION
### Description:

The tests for the OptOutJS integration (#22244) seem to trigger some breaking behaviour in Puppeteer.

A `page.goto` following a `page.clearCookies` seems to regularly break the CI in various runs:

```
✖ OptOutJS should work correctly when using opt out twice (with tracker) Timeout of 240000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/runner/work/matomo/matomo/matomo/tests/lib/screenshot-testing/mocha-super-suite.js)
{"errno":-2,"syscall":"open","code":"ENOENT","path":"node:internal/timers"}
     Timeout of 240000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/runner/work/matomo/matomo/matomo/tests/lib/screenshot-testing/mocha-super-suite.js)
```

Waiting for an additional 250 milliseconds after clearing the cookies seems to fix those error in a local environment completely.

Additionally, the `useCookiesTimeout` option for the trackerless opt out implementation was set to 1 second. By default it is configured to wait 10 seconds for the tracker to appear. But we know it won't appear so we can set that value to a minimum.

Refs DEV-18158

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
