### PR TITLE
Update UI test environment config override if installed plugins change

### DIFF
--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -457,20 +457,6 @@ PageRenderer.prototype._setupWebpageEvents = function () {
         if (!VERBOSE) {
             this._logMessage('Unable to load resource (URL:' + request.url() + '): ' + errorMessage);
         }
-
-        var type = '';
-        if (type = request.url().match(/action=get(Css|CoreJs|NonCoreJs|UmdJs)/)) {
-            if (errorMessage === 'net::ERR_ABORTED' && (!response || response.status() !== 500)) {
-                console.log(type[1]+' request aborted.');
-            } else if (request.url().indexOf('&reload=') === -1) {
-                console.log('Loading '+type[1]+' failed (' + errorMessage + ')... Try adding it with another tag.');
-                var method = type[1] == 'Css' ? 'addStyleTag' : 'addScriptTag';
-                await this.webpage[method]({url: request.url() + '&reload=' + Date.now()}); // add another get parameter to ensure browser doesn't use cache
-                await this.waitForNetworkIdle(); // wait for request to finish before continuing with tests
-            } else {
-                console.log('Reloading '+type[1]+' failed (' + errorMessage + ').');
-            }
-        }
     });
 
     this.webpage.on('requestfinished', async (request) => {
@@ -488,26 +474,6 @@ PageRenderer.prototype._setupWebpageEvents = function () {
             }
             const message = 'Response (size "' + bodyLength + '", status "' + response.status() + '"): ' + request.url() + "\n" + bodyContent.substring(0, 2000);
             this._logMessage(message);
-        }
-
-        // if response of css or js request does not start with /*, we assume it had an error and try to load it again
-        // Note: We can't do that in requestfailed only, as the response code might be 200 even if it throws an exception
-        var type = '';
-        if (type = request.url().match(/action=get(Css|CoreJs|NonCoreJs)/)) {
-            var body = await response.buffer();
-            if (body.toString().substring(0, 2) === '/*') {
-                return;
-            }
-            if (request.url().indexOf('&reload=') === -1) {
-                console.log('Loading '+type[1]+' failed... Try adding it with another tag.');
-                var method = type[1] == 'Css' ? 'addStyleTag' : 'addScriptTag';
-                await this.waitForNetworkIdle(); // wait for other requests to finish before trying to reload
-                await this.webpage[method]({url: request.url() + '&reload=' + Date.now()}); // add another get parameter to ensure browser doesn't use cache
-                await this.webpage.waitForTimeout(1000);
-            } else {
-                console.log('Reloading '+type[1]+' failed.');
-            }
-            console.log('Response (size "' + body.length + '", status "' + response.status() + ', headers "' + JSON.stringify(response.headers()) + '"): ' + request.url() + "\n" + body.toString());
         }
     });
 


### PR DESCRIPTION
### Description:

The debug logging added to the asset pipeline in #22259 showed a bad behaviour in the logs regarding randomly failing tests and missing assets:

```
// partial output from https://github.com/matomo-org/matomo/actions/runs/9312377863/job/25633085686#step:3:3282

...
WARNING Piwik\ErrorHandler[2024-05-31 03:17:19.544289 UTC] [9f8d2] [DBG] | installPluginIfNecessary | CustomDirPlugin
WARNING Piwik\ErrorHandler[2024-05-31 03:17:19.544935 UTC] [9f8d2] [DBG] | clearCache | CustomDirPlugin
WARNING Piwik\ErrorHandler[2024-05-31 03:17:19.545035 UTC] [9f8d2] [DBG] | deleteAllCacheOnUpdate | CustomDirPlugin,
WARNING Piwik\ErrorHandler[2024-05-31 03:17:19.546392 UTC] [9f8d2] [DBG] | removeMergedAssets | CustomDirPlugin
...
WARNING Piwik\ErrorHandler[2024-05-31 03:17:19.830670 UTC] [ad3ef] [DBG] | installPluginIfNecessary | CustomDirPlugin
WARNING Piwik\ErrorHandler[2024-05-31 03:17:19.831189 UTC] [ad3ef] [DBG] | clearCache | CustomDirPlugin
WARNING Piwik\ErrorHandler[2024-05-31 03:17:19.831278 UTC] [ad3ef] [DBG] | deleteAllCacheOnUpdate | CustomDirPlugin,
WARNING Piwik\ErrorHandler[2024-05-31 03:17:19.833049 UTC] [ad3ef] [DBG] | removeMergedAssets | CustomDirPlugin
...
WARNING Piwik\ErrorHandler[2024-05-31 03:17:19.976828 UTC] [a83b3] [DBG] | installPluginIfNecessary | CustomDirPlugin
WARNING Piwik\ErrorHandler[2024-05-31 03:17:19.977327 UTC] [a83b3] [DBG] | clearCache | CustomDirPlugin
WARNING Piwik\ErrorHandler[2024-05-31 03:17:19.977421 UTC] [a83b3] [DBG] | deleteAllCacheOnUpdate | CustomDirPlugin,
WARNING Piwik\ErrorHandler[2024-05-31 03:17:19.978546 UTC] [a83b3] [DBG] | removeMergedAssets | CustomDirPlugin
...
```

Within a single second the `CustomDirPlugin` was installed three times, and each install [clears all caches](https://github.com/matomo-org/matomo/blob/badd00e797268dc9fcff731b94d94421529985dc/core/Plugin/Manager.php#L1450), removing and rebuilding the assets.

UI tests are set up in a way that the special file `testingPathOverride.json` is used to [remember some settings](https://github.com/matomo-org/matomo/blob/9deb8c76e6f160938586e8cc19213a13458a6bb9/tests/PHPUnit/Framework/Fixture.php#L451) across UI requests, including the list of installed plugins. This file is populated during Fixture setup, and then only read and reused.

If a UI test requires another plugin, for example the [Dashboard spec](https://github.com/matomo-org/matomo/blob/9a3ef94df61682e7d543f3f8b438c368f6eb71a6/plugins/Dashboard/tests/UI/Dashboard_spec.js#L21), this plugin will not be listed in the override JSON, and instead be reinstalled on every request, showing the initial log output.

The PR proposes an alternative to #22268: update the override spec with a list of installed plugin if that list changes.

This should only happen during the first request after the test environment was changed in a UI test. Or if a plugin was installed during the UI test itself. Both events should trigger the save method, and we have the opportunity to update the config.

Ideally without having to modify any other part of the application.

Having a well running asset pipeline it should also be possible to remove the custom retry code from the test runner. If we have control over the requests that invalidate the assets we should not have to reload them due to unforeseen errors.

Refs DEV-18126

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
