### PR TITLE
Fix VisitorMap UI test failing on days except Monday

### DIFF
--- a/plugins/UserCountryMap/tests/UI/VisitorMap_spec.js
+++ b/plugins/UserCountryMap/tests/UI/VisitorMap_spec.js
@@ -12,7 +12,7 @@ describe("VisitorMap", function () {
 
     var url = "?module=Widgetize&action=iframe&moduleToWidgetize=UserCountryMap&idSite=1&period=year&date=2012-08-09&"
         + "actionToWidgetize=visitorMap&viewDataTable=table&filter_limit=5&isFooterExpandedInDashboard=1",
-        urlWithCities = "?module=Widgetize&action=iframe&moduleToWidgetize=UserCountryMap&idSite=3&period=week&date=yesterday&"
+        urlWithCities = "?module=Widgetize&action=iframe&moduleToWidgetize=UserCountryMap&idSite=3&period=day&date=yesterday&"
             + "actionToWidgetize=visitorMap&viewDataTable=table&filter_limit=5&isFooterExpandedInDashboard=1";
 
     it("should display the bounce rate metric correctly", async function() {

--- a/plugins/UserCountryMap/tests/UI/expected-screenshots/VisitorMap_cities.png
+++ b/plugins/UserCountryMap/tests/UI/expected-screenshots/VisitorMap_cities.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e78608cb6511fe12c4671ac036d74b87f8557be14edf0601661d6015b7275d9d
-size 112487
+oid sha256:8ea3d772f63e11a59c1ac5ff7d0de0dc0054780ae880d1f7ee7916ce9f6a9dd6
+size 113888

--- a/plugins/UserCountryMap/tests/UI/expected-screenshots/VisitorMap_regions.png
+++ b/plugins/UserCountryMap/tests/UI/expected-screenshots/VisitorMap_regions.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e5ee739257dd15445f529c9c13dfcfe5e6ab6bb92df5b9a3adbb4bae4fa75a6
-size 111261
+oid sha256:816ba48277bca270848ef2e66b466d7847e8f42a9b03370099bbf25cc293d32d
+size 112665


### PR DESCRIPTION
### Description:

The VisitorMap UI tests were currently showing data for the period `week` and date `yesterday`.
The UITestFixture adds a couple of visits for yesterday. 
Running exclusively the VisitorMap UI tests were never a problem, but in the GitHub action other tests are running upfront.
As the same fixture is already set up by another test before, which also adds some visits for today, the VisitorMap UI tests currently fail, when today is included in `yesterday / week`. This is the case for every day except Monday.

Simply using `day / yesterday` fixes the problem, as todays visits will never show up.
Due to switching the period to `day`, the map will show `unique visits` as default instead of `visits`

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
