### PR TITLE
Improve SegmentSelectorEditor UI test dropdown interactions

### DIFF
--- a/plugins/SegmentEditor/tests/UI/SegmentSelectorEditor_spec.js
+++ b/plugins/SegmentEditor/tests/UI/SegmentSelectorEditor_spec.js
@@ -18,7 +18,14 @@ describe("SegmentSelectorEditorTest", function () {
     async function selectFieldValue(fieldName, textToSelect)
     {
         await (await page.jQuery(fieldName + ' input.select-dropdown', { waitFor: true })).click();
+
+        // wait for animation
+        await page.waitForTimeout(200);
+
         await (await page.jQuery(fieldName + ' .dropdown-content li:contains("' + textToSelect + '"):first', { waitFor: true })).click();
+
+        // wait for animation
+        await page.waitForTimeout(300);
         await page.mouse.move(-10, -10);
     }
 
@@ -150,7 +157,7 @@ describe("SegmentSelectorEditorTest", function () {
         expect(await page.screenshotSelector(selectorsToCapture)).to.matchImage('saved_details');
     });
 
-    it("should correctly should show a confirmation when changing segment definition", async function() {
+    it("should correctly show a confirmation when changing segment definition", async function() {
         await page.click('.segmentEditorPanel .editSegmentName');
 
         await page.$eval('.segmentEditorPanel .segmentRow0 .ui-autocomplete-input', e => e.blur());


### PR DESCRIPTION
### Description:

The `SegmentSelectorEditor` test sometimes fails updating the segment, as some elements are not found when trying to interact with them:

```
  1) SegmentSelectorEditorTest
       should correctly should show a confirmation when changing segment definition:
          Node is either not visible or not an HTMLElement
            Url to reproduce: http://localhost/tests/PHPUnit/proxy/?module=CoreHome&action=index&idSite=1&period=year&date=2012-08-09&updated=1#?period=year&date=2012-08-09&idSite=1&category=General_Actions&subcategory=General_Pages&segment=actionUrl!%3Dvalue%2525200%2CoutlinkUrl%3D%3Dvalue%2525201%3BoutlinkUrl%3D%3Dvalue%2525202
            Screenshot of failure: /home/runner/work/matomo/matomo/matomo/tests/UI/processed-ui-screenshots/should_correctly_should_show_a_confirmation_when_changing_segment_definition_failure.png
            No captured console logs.
  
  Error: Node is either not visible or not an HTMLElement
      at ElementHandle._clickablePoint (node_modules/puppeteer/lib/cjs/puppeteer/common/JSHandle.js:329:19)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async ElementHandle.click (node_modules/puppeteer/lib/cjs/puppeteer/common/JSHandle.js:390:26)
      at async selectFieldValue (/home/runner/work/matomo/matomo/matomo/plugins/SegmentEditor/tests/UI/SegmentSelectorEditor_spec.js:21:9)
      at async Context.<anonymous> (/home/runner/work/matomo/matomo/matomo/plugins/SegmentEditor/tests/UI/SegmentSelectorEditor_spec.js:164:9)
```

Passing `{ waitFor: true }` to `page.jQuery` may return before the element is completely visible and usable. Adding additional timeouts slightly higher than the [internal animations](https://github.com/matomo-org/matomo/blob/aea8f07de8ea3ce6ce39d3a217af5ec6a957db96/node_modules/@materializecss/materialize/js/dropdown.js#L12-L13) (`150ms` for displaying, `250ms` for hiding) should make the test more stable.

Refs DEV-18162

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
