### PR TITLE
Deactivate Materialize animations

### DIFF
--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -121,7 +121,8 @@ return array(
         array('AssetManager.getJavaScriptFiles', \Piwik\DI::value(function (&$jsFiles) {
             $useOverrideJs = \Piwik\Container\StaticContainer::get('test.vars.useOverrideJs');
             if ($useOverrideJs) {
-                $jsFiles[] = 'tests/resources/screenshot-override/override.js';
+                $jsFiles[] = 'tests/resources/screenshot-override/override.init.js';
+                $jsFiles[] = 'tests/resources/screenshot-override/override.end.js';
             }
         })),
 

--- a/core/AssetManager/UIAssetFetcher/JScriptUIAssetFetcher.php
+++ b/core/AssetManager/UIAssetFetcher/JScriptUIAssetFetcher.php
@@ -69,6 +69,7 @@ class JScriptUIAssetFetcher extends UIAssetFetcher
     protected function getPriorityOrder()
     {
         return array(
+            'tests/resources/screenshot-override/override.init.js', // we need this to load as early as possible
             'node_modules/jquery/dist/jquery.min.js',
             'node_modules/jquery/dist/jquery.js',
             'node_modules/@materializecss/materialize/dist/js/materialize.min.js', // so jquery ui datepicker overrides materializecss

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -566,9 +566,12 @@ class Controller extends ControllerAdmin
 
         if (
             defined('PIWIK_TEST_MODE') && PIWIK_TEST_MODE
-            && file_exists(PIWIK_DOCUMENT_ROOT . '/tests/resources/screenshot-override/override.js')
+            && file_exists(PIWIK_DOCUMENT_ROOT . '/tests/resources/screenshot-override/override.init.js')
+            && file_exists(PIWIK_DOCUMENT_ROOT . '/tests/resources/screenshot-override/override.end.js')
         ) {
-            $files[] = 'tests/resources/screenshot-override/override.js';
+            array_unshift($files, 'tests/resources/screenshot-override/override.init.js');
+
+            $files[] = 'tests/resources/screenshot-override/override.end.js';
         }
 
         return AssetManager::compileCustomJs($files);

--- a/tests/resources/screenshot-override/override.end.js
+++ b/tests/resources/screenshot-override/override.end.js
@@ -1,5 +1,4 @@
 $(document).ready(function () {
-
     function updateSystemCheck() {
         $('.system-check tr:contains(Time) td:nth-child(2)').text('Not showing in tests');
         $('.system-check tr:contains(Datetime) td:nth-child(2)').text('Not showing in tests');
@@ -9,6 +8,7 @@ $(document).ready(function () {
         $('.system-check tr:contains(Server Info) td:nth-child(2)').text('Not showing in tests');
         $('.system-check tr:contains(PHP Disabled functions)').hide();
     }
+
     updateSystemCheck();
 
     if (window.piwikHelper) {
@@ -24,20 +24,4 @@ $(document).ready(function () {
     $('.ui-inline-help:contains(UTC time is)').hide();
 
     $('[notification-id=ControllerAdmin_HttpIsUsed]').hide();
-
-    $.fx.off = true;
-
-    // disable materialize animations (Materialize version > 1)
-    if (typeof M !== 'undefined' && M.anime) {
-        var oldAnime = M.anime;
-        M.anime = function (params) {
-            if (!params) {
-                params = {};
-            }
-            params.duration = 0;
-            return oldAnime(params);
-        };
-    } else if ($.Velocity) {
-        $.Velocity.mock = true;
-    }
 });

--- a/tests/resources/screenshot-override/override.init.js
+++ b/tests/resources/screenshot-override/override.init.js
@@ -1,0 +1,42 @@
+(function () {
+  if (window.M) {
+    return;
+  }
+
+  // define "window.M" and prevent overriding it
+  // to allow patching Materialize internals
+  const _materializeWrapper = {};
+
+  Object.defineProperty(window, 'M', {
+    get() {
+      return _materializeWrapper;
+    },
+    set() {
+      // prevent wrapper overriding
+    },
+  });
+
+  // wrap "window.M.anime" and deactivate animations
+  let _materializeAnimate;
+
+  Object.defineProperty(_materializeWrapper, 'anime', {
+    get() {
+      return _materializeAnimate;
+    },
+    set(newAnimate) {
+      _materializeAnimate = function (params) {
+        if (!params) {
+          params = {};
+        }
+
+        params.duration = 0;
+
+        return newAnimate(params);
+      }
+
+      for (const [key, value] of Object.entries(newAnimate)) {
+        _materializeAnimate[key] = value;
+      }
+    },
+  });
+})();


### PR DESCRIPTION
### Description:

A lot of UI tests are using timeouts to wait for animations to complete, with varying degrees of success and unnecessary runtime increase.

There are already some places that try to deactivate animations for UI tests:

- [CSS](https://github.com/matomo-org/matomo/blob/05017ba88ec611f63bf223728990351212ff560f/tests/resources/screenshot-override/override.css#L51-L65)
- [jQuery](https://github.com/matomo-org/matomo/blob/6fb983d7c44afa2f6e3699c226f8dec70f72f55f/tests/resources/screenshot-override/override.js#L28)
- [Materialize](https://github.com/matomo-org/matomo/blob/6fb983d7c44afa2f6e3699c226f8dec70f72f55f/tests/resources/screenshot-override/override.js#L32-L39)

Both CSS and jQuery should work as expected, but the Materialize does not. Probably because `M.anime` is not accessed from the global namespace, but [passed directly](https://github.com/matomo-org/matomo/blob/aea8f07de8ea3ce6ce39d3a217af5ec6a957db96/node_modules/@materializecss/materialize/dist/js/materialize.js#L3520) to the components. 

This is an attempt to change the override to work until we can for example upgrade to Materialize 2.

@matomo-org/core-reviewers I tried two CI runs to check the benefit/problems with this solution:

- [CI run](https://github.com/matomo-org/matomo/actions/runs/9403374447) with lots of `page.waitForTimeout` removed
- [CI run](https://github.com/matomo-org/matomo/actions/runs/9403865457) with the modification applied

To remove the statements I used `sed -i '/waitForTimeout.*animation/d' **/*_spec.js`, so I would not expect it to catch all the right places or even the most impactful ones.

Refs DEV-18077

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
