### PR TITLE
Already valid archives for yesterday might get invalidated when using another timezone than UTC

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -295,23 +295,6 @@ class ArchiveInvalidator
 
         $invalidationInfo = new InvalidationResult();
 
-        // quick fix for #15086, if we're only invalidating today's date for a site, don't add the site to the list of sites
-        // to reprocess.
-        $hasMoreThanJustToday = [];
-        foreach ($idSites as $idSite) {
-            $hasMoreThanJustToday[$idSite] = true;
-            $tz = Site::getTimezoneFor($idSite);
-
-            if (
-                ($period == 'day' || $period === false)
-                && count($dates) == 1
-                && ((string)$dates[0]) == ((string)Date::factoryInTimezone('today', $tz))
-            ) {
-                // date is for today
-                $hasMoreThanJustToday[$idSite] = false;
-            }
-        }
-
         /**
          * Triggered when a Matomo user requested the invalidation of some reporting archives. Using this event, plugin
          * developers can automatically invalidate another site, when a site is being invalidated. A plugin may even

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -517,7 +517,7 @@ class CronArchiveTest extends IntegrationTestCase
         foreach ($timezones as $timezone) {
             $offset = Date::getUtcOffset($timezone);
 
-            yield "Invalidating yesterday should not be skipped if an archive for yesterday was built before day switch in sites timezone ($timezone)" => [
+            yield "Invalidating yesterday should not be skipped if an archive for yesterday was built before midnight in site's timezone ($timezone)" => [
                 $timezone,
                 Date::factory('2020-04-05 00:22:00')->subSeconds($offset)->getDatetime(),
                 'yesterday',
@@ -527,7 +527,7 @@ class CronArchiveTest extends IntegrationTestCase
                 false
             ];
 
-            yield "Invalidating yesterday should not be skipped if an archive for yesterday was built some time before day switch in sites timezone ($timezone)" => [
+            yield "Invalidating yesterday should not be skipped if an archive for yesterday was built some time before midnight in site's timezone ($timezone)" => [
                 $timezone,
                 Date::factory('2020-04-05 06:22:00')->subSeconds($offset)->getDatetime(),
                 'yesterday',
@@ -537,7 +537,7 @@ class CronArchiveTest extends IntegrationTestCase
                 false
             ];
 
-            yield "Invalidating yesterday should not be skipped if an archive for yesterday was built long before day switch in sites timezone ($timezone)" => [
+            yield "Invalidating yesterday should not be skipped if an archive for yesterday was built long before midnight in site's timezone ($timezone)" => [
                 $timezone,
                 Date::factory('2020-04-05 19:22:00')->subSeconds($offset)->getDatetime(),
                 'yesterday',
@@ -547,7 +547,7 @@ class CronArchiveTest extends IntegrationTestCase
                 false
             ];
 
-            yield "Invalidating yesterday should be skipped if an archive for yesterday was built after day switch in sites timezone ($timezone)" => [
+            yield "Invalidating yesterday should be skipped if an archive for yesterday was built after midnight in site's timezone ($timezone)" => [
                 $timezone,
                 Date::factory('2020-04-05 00:22:00')->subSeconds($offset)->getDatetime(),
                 'yesterday',
@@ -557,7 +557,7 @@ class CronArchiveTest extends IntegrationTestCase
                 true
             ];
 
-            yield "Invalidating yesterday should be skipped if an archive for yesterday was built some time after day switch in sites timezone ($timezone)" => [
+            yield "Invalidating yesterday should be skipped if an archive for yesterday was built some time after midnight in site's timezone ($timezone)" => [
                 $timezone,
                 Date::factory('2020-04-05 16:22:00')->subSeconds($offset)->getDatetime(),
                 'yesterday',
@@ -567,7 +567,7 @@ class CronArchiveTest extends IntegrationTestCase
                 true
             ];
 
-            yield "Invalidating yesterday should be skipped if an archive for yesterday was built long after day switch in sites timezone ($timezone)" => [
+            yield "Invalidating yesterday should be skipped if an archive for yesterday was built long after midnight in site's timezone ($timezone)" => [
                 $timezone,
                 Date::factory('2020-04-05 22:22:00')->subSeconds($offset)->getDatetime(),
                 'yesterday',

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -577,8 +577,7 @@ class CronArchiveTest extends IntegrationTestCase
                 true
             ];
 
-            // this test looks actually wrong. As an older period should always be invalidated even if it was archived recently
-            yield "Invalidation should be skipped when checking an older date that was archived within ttl ($timezone)" => [
+            yield "Invalidation should be skipped when checking an older date that was archived within ttl, as invalidation will be processed later ($timezone)" => [
                 $timezone,
                 Date::factory('2020-04-05 00:00:00')->subSeconds($offset)->getDatetime(),
                 '2020-03-05',
@@ -598,8 +597,7 @@ class CronArchiveTest extends IntegrationTestCase
                 false
             ];
 
-            // this test looks actually wrong. As an older period should always be invalidated even if it was archived recently
-            yield "Invalidation should be skipped when checking an older period that was archived within ttl ($timezone)" => [
+            yield "Invalidation should be skipped when checking an older period that was archived within ttl, as invalidation will be processed later ($timezone)" => [
                 $timezone,
                 Date::factory('2020-04-05 04:00:00')->subSeconds($offset)->getDatetime(),
                 '2020-03-05',
@@ -610,7 +608,7 @@ class CronArchiveTest extends IntegrationTestCase
             ];
 
             // ttl is defined by time_before_today_archive_considered_outdated (default = 900)
-            yield "Invalidating today should be skipped when checking today archive, which is newer than ttl ($timezone)" => [
+            yield "Invalidating today should be skipped when checking today archive, which is newer than ttl, as invalidation will be processed later ($timezone)" => [
                 $timezone,
                 Date::factory('2020-04-05 19:15:00')->subSeconds($offset)->getDatetime(),
                 'today',


### PR DESCRIPTION
### Description:

Archiving automatically invalidates archives for today and yesterday if needed.

The checks for this including comparing the archived period for including today, as well as checking if the `ts_archived` for yesterdays archived was done after `yesterday`.

It seems that those checks are not performed using the correct timezones.
While the archiving period is provided in the sites timezone, `ts_archived` is always stored as `UTC`. Therefore checks with those dates need to use the same timezone.

There actually had been tests for the method, which were all using `UTC`. Running the tests with other timezones actually caused failures. With the adjustments I did in the PR the tests are now passing for all timezones.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
