### PR TITLE
Run each UI test suite in its own browser context

### DIFF
--- a/plugins/CoreHome/tests/UI/VersionInfoHeaderMessage_spec.js
+++ b/plugins/CoreHome/tests/UI/VersionInfoHeaderMessage_spec.js
@@ -149,6 +149,7 @@ describe('VersionInfoHeaderMessage', function() {
             messageDropdown.innerHTML = messageDropdown.innerHTML.replace(matomoVersion, '5.x-uitest');
           }, selectorComponent, selectorMessageDropdown);
 
+          await page.mouse.move(-10, -10);
           await page.hover(selectorMessage);
           await page.waitForSelector(selectorMessageDropdown, {visible: true, timeout: 250});
 

--- a/plugins/Login/tests/UI/Login_spec.js
+++ b/plugins/Login/tests/UI/Login_spec.js
@@ -19,8 +19,6 @@ describe("Login", function () {
         testEnvironment.testUseMockAuth = 0;
         testEnvironment.queryParamOverride = {date: "2012-01-01", period: "year"};
         testEnvironment.save();
-
-        await page.clearCookies();
     });
 
     beforeEach(function () {
@@ -37,8 +35,6 @@ describe("Login", function () {
         delete testEnvironment.queryParamOverride;
         delete testEnvironment.configOverride.General;
         testEnvironment.save();
-
-        await page.clearCookies();
     });
 
     afterEach(function () {

--- a/plugins/Login/tests/UI/NoAccess_spec.js
+++ b/plugins/Login/tests/UI/NoAccess_spec.js
@@ -14,19 +14,14 @@ describe("NoAccess", function () {
         testEnvironment.testUseMockAuth = 0;
         testEnvironment.overrideConfig('General', 'login_session_not_remembered_idle_timeout', 1)
         testEnvironment.save();
-
-        await page.clearCookies();
     });
 
     after(async function () {
         testEnvironment.testUseMockAuth = 1;
         testEnvironment.save();
-
-        await page.clearCookies();
     });
 
     it("should login successfully with user credentials and show error when a site without access is viewed", async function() {
-        await page.clearCookies();
         await page.goto("?idSite=2");
         await page.waitForNetworkIdle();
         await page.type("#login_form_login", "oliverqueen");

--- a/tests/UI/specs/OptOutIframe_spec.js
+++ b/tests/UI/specs/OptOutIframe_spec.js
@@ -22,9 +22,6 @@ describe("OptOutIframe", function () {
     }
 
     after(async () => {
-        await page.clearCookies();
-    });
-    after(async () => {
         await page.setUserAgent(page.originalUserAgent);
     });
 

--- a/tests/UI/specs/OptOutJS_spec.js
+++ b/tests/UI/specs/OptOutJS_spec.js
@@ -12,10 +12,6 @@ describe('OptOutJS', function () {
 
     const siteUrl = '/tests/resources/overlay-test-site-real/opt-out.php?implementation=js';
 
-    after(async () => {
-        await page.clearCookies();
-    });
-
     async function expectHasConsentToBe(useTracker, expectedState) {
         let hasConsent;
 

--- a/tests/lib/screenshot-testing/run-tests.js
+++ b/tests/lib/screenshot-testing/run-tests.js
@@ -29,17 +29,14 @@ async function main() {
     }
 
     const browser = await puppeteer.launch(config.browserConfig);
-    const webpage = await browser.newPage();
-    await webpage._client.send('Animation.setPlaybackRate', { playbackRate: 50 }); // make animations run 50 times faster, so we don't have to wait as much
+    const originalUserAgent = await browser.userAgent();
 
     // assume the URI points to a folder and make sure Piwik won't cut off the last path segment
     if (config.phpServer.REQUEST_URI.slice(-1) !== '/') {
         config.phpServer.REQUEST_URI += '/';
     }
 
-    const originalUserAgent = await browser.userAgent();
-
-    setUpGlobals(config, webpage, originalUserAgent);
+    setUpGlobals(config, browser, originalUserAgent);
 
     mocha = new Mocha({
         ui: 'bdd',

--- a/tests/lib/screenshot-testing/support/app.js
+++ b/tests/lib/screenshot-testing/support/app.js
@@ -212,7 +212,7 @@ Application.prototype.loadTestModules = function () {
             });
         });
 
-        // move to before other hooks
+        // move in front of other beforeAll hooks (called twice as we're adding two beforeAll handlers)
         suite._beforeAll.unshift(suite._beforeAll.pop());
         suite._beforeAll.unshift(suite._beforeAll.pop());
 

--- a/tests/lib/screenshot-testing/support/app.js
+++ b/tests/lib/screenshot-testing/support/app.js
@@ -191,6 +191,10 @@ Application.prototype.loadTestModules = function () {
     mocha.suite.suites.forEach(function (suite) {
         var fixture = typeof suite.fixture === 'undefined' ? "Piwik\\Tests\\Fixtures\\UITestFixture" : suite.fixture;
 
+        suite.beforeAll(async function () {
+            await page.createPage();
+        });
+
         suite.beforeAll(function (done) {
             this.timeout(0); // no timeout for fixture setup (this requires normal anonymous function, not fat arrow function)
 
@@ -209,6 +213,7 @@ Application.prototype.loadTestModules = function () {
         });
 
         // move to before other hooks
+        suite._beforeAll.unshift(suite._beforeAll.pop());
         suite._beforeAll.unshift(suite._beforeAll.pop());
 
         suite.afterAll(function (done) {
@@ -311,10 +316,6 @@ Application.prototype.doRunTests = function (mocha) {
                 }
             });
         }
-    });
-
-    this.runner.on('suite', function() {
-        page.webpage.mouse.move(-10, -10);
     });
 
     this.runner.on('test', function () {

--- a/tests/lib/screenshot-testing/support/globals.js
+++ b/tests/lib/screenshot-testing/support/globals.js
@@ -10,7 +10,7 @@ const path = require('path');
 const chai = require('chai');
 const { PageRenderer } = require('./page-renderer');
 
-module.exports = function setUpGlobals(config, page, originalUserAgent) {
+module.exports = function setUpGlobals(config, browser, originalUserAgent) {
     global.config = config;
 
     global.PIWIK_INCLUDE_PATH = path.join(__dirname, '..', '..', '..', '..');
@@ -23,7 +23,7 @@ module.exports = function setUpGlobals(config, page, originalUserAgent) {
     global.testEnvironment = require('./test-environment').TestingEnvironment;
     global.app = require('./app').Application;
     global.expect = chai.expect;
-    global.page = new PageRenderer(config.piwikUrl + path.join("tests", "PHPUnit", "proxy"), page, originalUserAgent);
+    global.page = new PageRenderer(config.piwikUrl + path.join("tests", "PHPUnit", "proxy"), browser, originalUserAgent);
     // The following variables need to be in sync with Fixture::ADMIN_USER_LOGIN and Fixture::ADMIN_USER_PASSWORD
     global.superUserLogin = 'superUserLogin';
     global.superUserPassword = 'pas3!"§$%&/()=?\'ㄨ<|-_#*+~>word';

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -77,8 +77,9 @@ const AUTO_WAIT_METHODS = {// TODO: remove this to keep it consistent?
     'reload': true,
 };
 
-var PageRenderer = function (baseUrl, page, originalUserAgent) {
-    this.webpage = page;
+var PageRenderer = function (baseUrl, browser, originalUserAgent) {
+
+    this.browser = browser;
     this.originalUserAgent = originalUserAgent;
 
     this.selectorMarkerClass = 0;
@@ -90,19 +91,6 @@ var PageRenderer = function (baseUrl, page, originalUserAgent) {
     if (this.baseUrl.substring(-1) !== '/') {
         this.baseUrl = this.baseUrl + '/';
     }
-
-    PAGE_PROPERTIES_TO_PROXY.forEach((propertyName) => {
-        Object.defineProperty(this, propertyName, {
-            value: page[propertyName],
-            writable: false,
-        });
-    });
-
-    this.webpage.setViewport({
-        width: 1350,
-        height: 768,
-    });
-    this._setupWebpageEvents();
 };
 
 PageRenderer.prototype._reset = function () {
@@ -111,6 +99,28 @@ PageRenderer.prototype._reset = function () {
         width: 1350,
         height: 768,
     });
+};
+
+PageRenderer.prototype.createPage = async function () {
+    if (this.browserContext) {
+      await this.browserContext.close();
+    }
+    this.browserContext = await this.browser.createIncognitoBrowserContext();
+    this.webpage = await this.browserContext.newPage();
+
+    PAGE_PROPERTIES_TO_PROXY.forEach((propertyName) => {
+      Object.defineProperty(this, propertyName, {
+        value: this.webpage[propertyName],
+        writable: true,
+      });
+    });
+
+    await this.webpage._client.send('Animation.setPlaybackRate', { playbackRate: 50 }); // make animations run 50 times faster, so we don't have to wait as much
+    await this.webpage.setViewport({
+      width: 1350,
+      height: 768,
+    });
+    this._setupWebpageEvents();
 };
 
 /**

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -120,6 +120,9 @@ PageRenderer.prototype.createPage = async function () {
       width: 1350,
       height: 768,
     });
+    await this.webpage.setExtraHTTPHeaders({
+      'Accept-Language': 'en-US'
+    });
     this._setupWebpageEvents();
 };
 

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -120,6 +120,7 @@ PageRenderer.prototype.createPage = async function () {
       width: 1350,
       height: 768,
     });
+    await this.webpage.mouse.move(0, 0);
     await this.webpage.setExtraHTTPHeaders({
       'Accept-Language': 'en-US'
     });


### PR DESCRIPTION
### Description:

Some of our UI tests are sometimes failing or having timeouts due to actions that were performed in the previous test suite.

Currently there is a problem that after running the Login UI tests the following test always times out after setting up the fixture. 

To ensure each test suites runs independently from each other this pull request introduces some changes to run each suite in its own incognito browser context.

This will also ensure that e.g. no cookies or cache will be left over from previous tests.
Things like clearing cookies in the beginning or ending of a test suite will also no longer be required.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
