### PR TITLE
Set autocomplete for password fields on invitation screen

### DIFF
--- a/plugins/Login/templates/invitation.twig
+++ b/plugins/Login/templates/invitation.twig
@@ -29,8 +29,8 @@
                         <label for="email">{{ 'UsersManager_Email'|translate }}</label>
                     </div>
                     <div class="col l10 s12 input-field invite-user-pwd-div">
-                        <input type="password" placeholder="" name="password" id="password" class="input" value=""
-                               size="20"
+                        <input type="password" placeholder="" name="password" id="password"
+                               class="input" value="" size="20"  autocomplete="new-password"
                                autocorrect="off" autocapitalize="none" spellcheck="false"
                                tabindex="1" required/>
                         <label for="password">{{ 'General_Password'|translate }}
@@ -38,7 +38,7 @@
                     </div>
                     <div class="col l10 s12 input-field invite-user-pwd-div">
                         <input type="password" placeholder="" name="passwordConfirmation" id="password_confirm"
-                               class="input" value="" size="20"
+                               class="input" value="" size="20" autocomplete="new-password"
                                autocorrect="off" autocapitalize="none" spellcheck="false"
                                tabindex="2" required/>
                         <label for="password_confirm">{{ 'General_PasswordConfirmation'|translate }}</label>


### PR DESCRIPTION
### Description:

This will allow password managers to fill in newly generated passwords more easily on the accept invitation screen.

fixes #22303 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
