### PR TITLE
Ensure to always invalidate older periods when requested

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1065,6 +1065,11 @@ class CronArchive
             return false;
         }
 
+        // periods that don't include today or yesterday should always be invalidated when requested
+        if (!$isPeriodIncludesToday && !$isYesterday) {
+            return false;
+        }
+
         return !empty($idArchive);
     }
 

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -498,7 +498,7 @@ class CronArchiveTest extends IntegrationTestCase
         ]);
 
         // $doNotIncludeTtlInExistingArchiveCheck is set to true when running invalidateRecentDate('yesterday');
-        $actual = $archiver->canWeSkipInvalidatingBecauseThereIsAUsablePeriod($params, $dayToArchive === 'yesterday');
+        $actual = $archiver->canWeSkipInvalidatingBecauseThereIsAUsablePeriod($params, $dayToArchive === 'today');
         $this->assertSame($expected, $actual);
     }
 
@@ -577,8 +577,7 @@ class CronArchiveTest extends IntegrationTestCase
                 true
             ];
 
-            // this test looks actually wrong. As an older period should always be invalidated even if it was archived recently
-            yield "Invalidation should be skipped when checking an older date that was archived within ttl ($timezone)" => [
+            yield "Invalidation should not be skipped when checking an older date that was archived within ttl ($timezone)" => [
                 $timezone,
                 Date::factory('2020-04-05 00:00:00')->subSeconds($offset)->getDatetime(),
                 '2020-03-05',
@@ -598,15 +597,14 @@ class CronArchiveTest extends IntegrationTestCase
                 false
             ];
 
-            // this test looks actually wrong. As an older period should always be invalidated even if it was archived recently
-            yield "Invalidation should be skipped when checking an older period that was archived within ttl ($timezone)" => [
+            yield "Invalidation should not be skipped when checking an older period that was archived within ttl ($timezone)" => [
                 $timezone,
                 Date::factory('2020-04-05 04:00:00')->subSeconds($offset)->getDatetime(),
                 '2020-03-05',
                 'week',
                 Date::factory('2020-04-05 03:55:44')->subSeconds($offset)->getDatetime(),
                 ArchiveWriter::DONE_OK,
-                true
+                false
             ];
 
             // ttl is defined by time_before_today_archive_considered_outdated (default = 900)

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -584,7 +584,7 @@ class CronArchiveTest extends IntegrationTestCase
                 'day',
                 Date::factory('2020-04-04 23:49:44')->subSeconds($offset)->getDatetime(),
                 ArchiveWriter::DONE_OK,
-                true
+                false
             ];
 
             yield "Invalidation should not be skipped when checking an older period that was not archived within ttl ($timezone)" => [


### PR DESCRIPTION
### Description:

When an invalidation for a period older than yesterday was requested (e.g. through tracking an older request), this invalidation was only processed if the last archive was already older than the configured TTL (time_before_today_archive_considered_outdated).

By default this TTL is configured to 900s (15min), but it can be configured a lot higher in theory.

This PR changes the code, so older periods will always be invalidated when requested. Otherwise we might miss to reprocess old periods even if there would be new data available.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
