### PR TITLE
Always invalidate yesterday when not requested through automatic invalidation for recent days

### DIFF
--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -472,6 +472,7 @@ class CronArchiveTest extends IntegrationTestCase
         string $dayToArchive,
         string $periodToArchive,
         string $tsArchived,
+        bool $isAutomaticInvalidationOfRecentPeriod,
         int $archiveStatus,
         bool $expected
     ) {
@@ -498,7 +499,7 @@ class CronArchiveTest extends IntegrationTestCase
         ]);
 
         // $doNotIncludeTtlInExistingArchiveCheck is set to true when running invalidateRecentDate('yesterday');
-        $actual = $archiver->canWeSkipInvalidatingBecauseThereIsAUsablePeriod($params, $dayToArchive === 'today');
+        $actual = $archiver->canWeSkipInvalidatingBecauseThereIsAUsablePeriod($params, $isAutomaticInvalidationOfRecentPeriod);
         $this->assertSame($expected, $actual);
     }
 
@@ -523,6 +524,7 @@ class CronArchiveTest extends IntegrationTestCase
                 'yesterday',
                 'day',
                 Date::factory('2020-04-04 23:45:40')->subSeconds($offset)->getDatetime(),
+                true,
                 ArchiveWriter::DONE_OK,
                 false
             ];
@@ -533,6 +535,7 @@ class CronArchiveTest extends IntegrationTestCase
                 'yesterday',
                 'day',
                 Date::factory('2020-04-04 18:25:35')->subSeconds($offset)->getDatetime(),
+                true,
                 ArchiveWriter::DONE_OK,
                 false
             ];
@@ -543,6 +546,7 @@ class CronArchiveTest extends IntegrationTestCase
                 'yesterday',
                 'day',
                 Date::factory('2020-04-04 09:25:35')->subSeconds($offset)->getDatetime(),
+                true,
                 ArchiveWriter::DONE_OK,
                 false
             ];
@@ -553,6 +557,7 @@ class CronArchiveTest extends IntegrationTestCase
                 'yesterday',
                 'day',
                 Date::factory('2020-04-05 00:05:40')->subSeconds($offset)->getDatetime(),
+                true,
                 ArchiveWriter::DONE_OK,
                 true
             ];
@@ -563,6 +568,7 @@ class CronArchiveTest extends IntegrationTestCase
                 'yesterday',
                 'day',
                 Date::factory('2020-04-05 09:05:40')->subSeconds($offset)->getDatetime(),
+                true,
                 ArchiveWriter::DONE_OK,
                 true
             ];
@@ -573,6 +579,7 @@ class CronArchiveTest extends IntegrationTestCase
                 'yesterday',
                 'day',
                 Date::factory('2020-04-05 19:05:40')->subSeconds($offset)->getDatetime(),
+                true,
                 ArchiveWriter::DONE_OK,
                 true
             ];
@@ -583,6 +590,7 @@ class CronArchiveTest extends IntegrationTestCase
                 '2020-03-05',
                 'day',
                 Date::factory('2020-04-04 23:49:44')->subSeconds($offset)->getDatetime(),
+                false,
                 ArchiveWriter::DONE_OK,
                 false
             ];
@@ -593,6 +601,7 @@ class CronArchiveTest extends IntegrationTestCase
                 '2020-03-05',
                 'week',
                 Date::factory('2020-04-03 23:49:44')->subSeconds($offset)->getDatetime(),
+                false,
                 ArchiveWriter::DONE_OK,
                 false
             ];
@@ -603,6 +612,7 @@ class CronArchiveTest extends IntegrationTestCase
                 '2020-03-05',
                 'week',
                 Date::factory('2020-04-05 03:55:44')->subSeconds($offset)->getDatetime(),
+                false,
                 ArchiveWriter::DONE_OK,
                 false
             ];
@@ -614,6 +624,7 @@ class CronArchiveTest extends IntegrationTestCase
                 'today',
                 'day',
                 Date::factory('2020-04-05 19:05:00')->subSeconds($offset)->getDatetime(),
+                true,
                 ArchiveWriter::DONE_OK,
                 true
             ];
@@ -625,6 +636,7 @@ class CronArchiveTest extends IntegrationTestCase
                 'today',
                 'day',
                 Date::factory('2020-04-05 16:05:00')->subSeconds($offset)->getDatetime(),
+                true,
                 ArchiveWriter::DONE_OK,
                 false
             ];
@@ -635,6 +647,7 @@ class CronArchiveTest extends IntegrationTestCase
                 'today',
                 'week',
                 Date::factory('2020-04-05 19:13:40')->subSeconds($offset)->getDatetime(),
+                false,
                 ArchiveWriter::DONE_OK,
                 true
             ];
@@ -645,6 +658,7 @@ class CronArchiveTest extends IntegrationTestCase
                 'today',
                 'week',
                 Date::factory('2020-04-05 19:13:40')->subSeconds($offset)->getDatetime(),
+                false,
                 ArchiveWriter::DONE_INVALIDATED,
                 true
             ];
@@ -655,6 +669,7 @@ class CronArchiveTest extends IntegrationTestCase
                 'today',
                 'week',
                 Date::factory('2020-04-05 18:28:40')->subSeconds($offset)->getDatetime(),
+                false,
                 ArchiveWriter::DONE_OK,
                 false
             ];


### PR DESCRIPTION
### Description:

Invalidating yesterday's data is currently only processed if the last built archive was not yet built today.
This means that if someone e.g. tracks today a visit for yesterday, and archives for yesterday were already built today, the invalidating for yesterday will be skipped and data will remain outdated.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
