### PR TITLE
Adds test that checks if invalidation for yesterday works as expected...

### DIFF
--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -240,6 +240,51 @@ class ArchiveTest extends IntegrationTestCase
         $this->assertEquals($expected, $archives);
     }
 
+    public function testInvalidatingYesterdayWorksAsExpectedWhenVisitTrackedInPast()
+    {
+        Fixture::createWebsite('2014-12-12 00:01:02');
+
+        self::$fixture->getTestEnvironment()->overrideConfig('General', 'browser_archiving_disabled_enforce', 0);
+        self::$fixture->getTestEnvironment()->overrideConfig('General', 'archiving_range_force_on_browser_request', 1);
+        self::$fixture->getTestEnvironment()->save();
+
+        Config::getInstance()->General['browser_archiving_disabled_enforce'] = 0;
+        Config::getInstance()->General['archiving_range_force_on_browser_request'] = 1;
+
+        Rules::setBrowserTriggerArchiving(false);
+
+        Date::$now = strtotime('2020-05-05 12:00:00');
+
+        $tracker = Fixture::getTracker(1, '2020-05-05 12:00:00');
+        $tracker->setUserId('user1');
+        $tracker->doTrackPageView('test');
+
+        Date::$now = strtotime('2020-05-06 01:00:00');
+
+        $archiver = new CronArchive();
+        $archiver->init();
+        $archiver->run();
+
+        // update ts_archived of archives as archiving doesn't take up Date::$now as it's running in separate requests
+        Db::query("UPDATE " . Common::prefixTable('archive_numeric_2020_05') . " SET ts_archived = ?", [Date::now()->getDatetime()]);
+
+        $dataTable = \Piwik\Plugins\VisitsSummary\API::getInstance()->get(1, 'day', 'yesterday');
+        self::assertEquals(1, $dataTable->getFirstRow()->getColumn('nb_visits'));
+
+        Date::$now = strtotime('2020-05-06 16:11:55');
+
+        $tracker = Fixture::getTracker(1, '2020-05-05 17:51:05');
+        $tracker->setUserId('user2');
+        $tracker->doTrackPageView('test');
+
+        $archiver = new CronArchive();
+        $archiver->init();
+        $archiver->run();
+
+        $dataTable = \Piwik\Plugins\VisitsSummary\API::getInstance()->get(1, 'day', 'yesterday');
+        self::assertEquals(2, $dataTable->getFirstRow()->getColumn('nb_visits'));
+    }
+
     public function testShouldNotArchivePeriodsStartingInTheFuture()
     {
         $idSite = 1;


### PR DESCRIPTION
### Description:

... if archives were built today and a visits for yesterday is tracked (in the past)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
