### PR TITLE
Fix aggregation of additional action metrics

### DIFF
--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -521,7 +521,13 @@ class Row extends \ArrayObject
                 $newValue = null;
                 break;
             case 'max':
-                $newValue = max($thisColumnValue, $columnToSumValue);
+                if (!$thisColumnValue) {
+                    $newValue = $columnToSumValue;
+                } elseif (!$columnToSumValue) {
+                    $newValue = $thisColumnValue;
+                } else {
+                    $newValue = max($thisColumnValue, $columnToSumValue);
+                }
                 break;
             case 'min':
                 if (!$thisColumnValue) {

--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -521,18 +521,18 @@ class Row extends \ArrayObject
                 $newValue = null;
                 break;
             case 'max':
-                if (!$thisColumnValue) {
+                if (!is_numeric($thisColumnValue)) {
                     $newValue = $columnToSumValue;
-                } elseif (!$columnToSumValue) {
+                } elseif (!is_numeric($columnToSumValue)) {
                     $newValue = $thisColumnValue;
                 } else {
                     $newValue = max($thisColumnValue, $columnToSumValue);
                 }
                 break;
             case 'min':
-                if (!$thisColumnValue) {
+                if (!is_numeric($thisColumnValue)) {
                     $newValue = $columnToSumValue;
-                } elseif (!$columnToSumValue) {
+                } elseif (!is_numeric($columnToSumValue)) {
                     $newValue = $thisColumnValue;
                 } else {
                     $newValue = min($thisColumnValue, $columnToSumValue);

--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -521,18 +521,18 @@ class Row extends \ArrayObject
                 $newValue = null;
                 break;
             case 'max':
-                if (null === $thisColumnValue || false === $thisColumnValue || '' === $thisColumnValue) {
+                if ($this->isValueConsideredEmpty($thisColumnValue)) {
                     $newValue = $columnToSumValue;
-                } elseif (null === $columnToSumValue || false === $columnToSumValue || '' === $columnToSumValue) {
+                } elseif ($this->isValueConsideredEmpty($columnToSumValue)) {
                     $newValue = $thisColumnValue;
                 } else {
                     $newValue = max($thisColumnValue, $columnToSumValue);
                 }
                 break;
             case 'min':
-                if (null === $thisColumnValue || false === $thisColumnValue || '' === $thisColumnValue) {
+                if ($this->isValueConsideredEmpty($thisColumnValue)) {
                     $newValue = $columnToSumValue;
-                } elseif (null === $columnToSumValue || false === $columnToSumValue || '' === $columnToSumValue) {
+                } elseif ($this->isValueConsideredEmpty($columnToSumValue)) {
                     $newValue = $thisColumnValue;
                 } else {
                     $newValue = min($thisColumnValue, $columnToSumValue);
@@ -562,6 +562,11 @@ class Row extends \ArrayObject
                 throw new Exception("Unknown operation '$operation'.");
         }
         return $newValue;
+    }
+
+    private function isValueConsideredEmpty($value): bool
+    {
+        return in_array($value, [null, false, ''], true);
     }
 
     /**

--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -521,18 +521,18 @@ class Row extends \ArrayObject
                 $newValue = null;
                 break;
             case 'max':
-                if (!is_numeric($thisColumnValue)) {
+                if (null === $thisColumnValue || false === $thisColumnValue || '' === $thisColumnValue) {
                     $newValue = $columnToSumValue;
-                } elseif (!is_numeric($columnToSumValue)) {
+                } elseif (null === $columnToSumValue || false === $columnToSumValue || '' === $columnToSumValue) {
                     $newValue = $thisColumnValue;
                 } else {
                     $newValue = max($thisColumnValue, $columnToSumValue);
                 }
                 break;
             case 'min':
-                if (!is_numeric($thisColumnValue)) {
+                if (null === $thisColumnValue || false === $thisColumnValue || '' === $thisColumnValue) {
                     $newValue = $columnToSumValue;
-                } elseif (!is_numeric($columnToSumValue)) {
+                } elseif (null === $columnToSumValue || false === $columnToSumValue || '' === $columnToSumValue) {
                     $newValue = $thisColumnValue;
                 } else {
                     $newValue = min($thisColumnValue, $columnToSumValue);

--- a/plugins/Actions/API.php
+++ b/plugins/Actions/API.php
@@ -513,11 +513,13 @@ class API extends \Piwik\Plugin\API
      */
     private function filterActionsDataTable($dataTable, $isPageTitleType)
     {
+        $dataTable->filter(function ($dataTable) {
+            $dataTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
+        });
         // Must be applied before Sort in this case, since the DataTable can contain both int and strings indexes
         // (in the transition period between pre 1.2 and post 1.2 datatable structure)
         $dataTable->filter('Piwik\Plugins\Actions\DataTable\Filter\Actions', [$isPageTitleType]);
         $dataTable->filter('Piwik\Plugins\Goals\DataTable\Filter\CalculateConversionPageRate');
-
         return $dataTable;
     }
 

--- a/plugins/Actions/Metrics.php
+++ b/plugins/Actions/Metrics.php
@@ -39,10 +39,19 @@ class Metrics
         PiwikMetrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS,
     );
 
-    public static $columnsAggregationOperation = array(
-        PiwikMetrics::INDEX_PAGE_MAX_TIME_GENERATION => 'max',
-        PiwikMetrics::INDEX_PAGE_MIN_TIME_GENERATION => 'min'
-    );
+    public static function getColumnsAggregationOperation()
+    {
+        $operations = [];
+        $actionMetrics = self::getActionMetrics();
+
+        foreach ($actionMetrics as $actionMetric => $definition) {
+            if (!empty($definition['aggregation']) && $definition['aggregation'] !== 'sum') {
+                $operations[$actionMetric] = $definition['aggregation'];
+            }
+        }
+
+        return $operations;
+    }
 
     public static function getActionMetrics()
     {

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -46,9 +46,9 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
                 ->setMaxRowsInTable(ArchivingHelper::$maximumRowsInDataTableSiteSearch),
 
             Record::make(Record::TYPE_BLOB, Archiver::PAGE_URLS_RECORD_NAME)
-                ->setBlobColumnAggregationOps(Metrics::$columnsAggregationOperation),
+                ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation()),
             Record::make(Record::TYPE_BLOB, Archiver::PAGE_TITLES_RECORD_NAME)
-                ->setBlobColumnAggregationOps(Metrics::$columnsAggregationOperation),
+                ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation()),
 
             Record::make(Record::TYPE_BLOB, Archiver::DOWNLOADS_RECORD_NAME),
             Record::make(Record::TYPE_BLOB, Archiver::OUTLINKS_RECORD_NAME),
@@ -184,7 +184,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
                 || $type == Action::TYPE_PAGE_TITLE
             ) {
                 // for page urls and page titles, performance metrics exist and have to be aggregated correctly
-                $dataTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::$columnsAggregationOperation);
+                $dataTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
             }
 
             $result[$type] = $dataTable;

--- a/plugins/Contents/tests/System/expected/test_Contents__Actions.getPageUrls_month.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents__Actions.getPageUrls_month.xml
@@ -6,23 +6,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>540</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.033</min_time_network>
-		<max_time_network>0.033</max_time_network>
+		<min_time_network>0.0330</min_time_network>
+		<max_time_network>0.0330</max_time_network>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.325</min_time_server>
-		<max_time_server>0.325</max_time_server>
+		<min_time_server>0.3250</min_time_server>
+		<max_time_server>0.3250</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.124</min_time_transfer>
-		<max_time_transfer>0.124</max_time_transfer>
+		<min_time_transfer>0.1240</min_time_transfer>
+		<max_time_transfer>0.1240</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.356</min_time_dom_processing>
-		<max_time_dom_processing>0.356</max_time_dom_processing>
+		<min_time_dom_processing>0.3560</min_time_dom_processing>
+		<max_time_dom_processing>0.3560</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.215</min_time_dom_completion>
-		<max_time_dom_completion>0.215</max_time_dom_completion>
+		<min_time_dom_completion>0.2150</min_time_dom_completion>
+		<max_time_dom_completion>0.2150</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.099</min_time_on_load>
-		<max_time_on_load>0.099</max_time_on_load>
+		<min_time_on_load>0.0990</min_time_on_load>
+		<max_time_on_load>0.0990</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/plugins/Events/API.php
+++ b/plugins/Events/API.php
@@ -10,6 +10,8 @@
 namespace Piwik\Plugins\Events;
 
 use Piwik\Archive;
+use Piwik\DataTable;
+use Piwik\Metrics;
 use Piwik\Piwik;
 
 /**
@@ -153,6 +155,13 @@ class API extends \Piwik\Plugin\API
         $recordName = $this->getRecordNameForAction($name, $secondaryDimension);
 
         $dataTable = Archive::createDataTableFromArchive($recordName, $idSite, $period, $date, $segment, $expanded, $flat, $idSubtable);
+
+        $dataTable->filter(function ($dataTable) {
+            $dataTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, [
+                Metrics::INDEX_EVENT_MIN_EVENT_VALUE => 'min',
+                Metrics::INDEX_EVENT_MAX_EVENT_VALUE => 'max',
+            ]);
+        });
 
         if ($flat) {
             $dataTable->filterSubtables('Piwik\Plugins\Events\DataTable\Filter\ReplaceEventNameNotSet');

--- a/plugins/Events/RecordBuilders/EventReports.php
+++ b/plugins/Events/RecordBuilders/EventReports.php
@@ -51,7 +51,8 @@ class EventReports extends RecordBuilder
 
         foreach ($records as $record) {
             $record->setMaxRowsInTable($maximumRowsInDataTable)
-                ->setMaxRowsInSubtable($maximumRowsInSubDataTable);
+                ->setMaxRowsInSubtable($maximumRowsInSubDataTable)
+                ->setBlobColumnAggregationOps($this->columnAggregationOps);
         }
 
         return $records;

--- a/plugins/Events/RecordBuilders/EventReports.php
+++ b/plugins/Events/RecordBuilders/EventReports.php
@@ -198,8 +198,8 @@ class EventReports extends RecordBuilder
                 Metrics::INDEX_EVENT_NB_HITS            => $row[Metrics::INDEX_EVENT_NB_HITS] ?? 0,
                 Metrics::INDEX_EVENT_NB_HITS_WITH_VALUE => $row[Metrics::INDEX_EVENT_NB_HITS_WITH_VALUE] ?? 0,
                 Metrics::INDEX_EVENT_SUM_EVENT_VALUE    => round($row[Metrics::INDEX_EVENT_SUM_EVENT_VALUE] ?? 0, 2),
-                Metrics::INDEX_EVENT_MIN_EVENT_VALUE    => round($row[Metrics::INDEX_EVENT_MIN_EVENT_VALUE] ?? false, 2),
-                Metrics::INDEX_EVENT_MAX_EVENT_VALUE    => round($row[Metrics::INDEX_EVENT_MAX_EVENT_VALUE] ?? 0, 2),
+                Metrics::INDEX_EVENT_MIN_EVENT_VALUE    => is_numeric($row[Metrics::INDEX_EVENT_MIN_EVENT_VALUE]) ? round($row[Metrics::INDEX_EVENT_MIN_EVENT_VALUE], 2) : null,
+                Metrics::INDEX_EVENT_MAX_EVENT_VALUE    => is_numeric($row[Metrics::INDEX_EVENT_MAX_EVENT_VALUE]) ? round($row[Metrics::INDEX_EVENT_MAX_EVENT_VALUE], 2) : null,
             ];
 
             $topLevelRow = $table->sumRowWithLabel($mainLabel, $columns, $this->columnAggregationOps);

--- a/plugins/PagePerformance/tests/System/expected/test___Actions.getPageTitles_month.xml
+++ b/plugins/PagePerformance/tests/System/expected/test___Actions.getPageTitles_month.xml
@@ -6,23 +6,23 @@
 		<nb_hits>10</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>10</nb_hits_with_time_network>
-		<min_time_network>0.094</min_time_network>
-		<max_time_network>0.276</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0980</max_time_network>
 		<nb_hits_with_time_server>10</nb_hits_with_time_server>
-		<min_time_server>0.496</min_time_server>
-		<max_time_server>0.801</max_time_server>
+		<min_time_server>0.0770</min_time_server>
+		<max_time_server>0.2690</max_time_server>
 		<nb_hits_with_time_transfer>10</nb_hits_with_time_transfer>
-		<min_time_transfer>1.268</min_time_transfer>
-		<max_time_transfer>1.683</max_time_transfer>
+		<min_time_transfer>0.1950</min_time_transfer>
+		<max_time_transfer>0.4120</max_time_transfer>
 		<nb_hits_with_time_dom_processing>10</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>4.989</min_time_dom_processing>
-		<max_time_dom_processing>5.678</max_time_dom_processing>
+		<min_time_dom_processing>0.8990</min_time_dom_processing>
+		<max_time_dom_processing>1.3000</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>10</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.464</min_time_dom_completion>
-		<max_time_dom_completion>1.683</max_time_dom_completion>
+		<min_time_dom_completion>0.1950</min_time_dom_completion>
+		<max_time_dom_completion>0.4440</max_time_dom_completion>
 		<nb_hits_with_time_on_load>10</nb_hits_with_time_on_load>
-		<min_time_on_load>0.498</min_time_on_load>
-		<max_time_on_load>1.126</max_time_on_load>
+		<min_time_on_load>0.0660</min_time_on_load>
+		<max_time_on_load>0.2580</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -49,23 +49,23 @@
 		<nb_hits>5</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>5</nb_hits_with_time_network>
-		<min_time_network>0.132</min_time_network>
-		<max_time_network>0.132</max_time_network>
+		<min_time_network>0.0120</min_time_network>
+		<max_time_network>0.0660</max_time_network>
 		<nb_hits_with_time_server>5</nb_hits_with_time_server>
-		<min_time_server>1.162</min_time_server>
-		<max_time_server>1.162</max_time_server>
+		<min_time_server>0.1500</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>5</nb_hits_with_time_transfer>
-		<min_time_transfer>1.512</min_time_transfer>
-		<max_time_transfer>1.512</max_time_transfer>
+		<min_time_transfer>0.1360</min_time_transfer>
+		<max_time_transfer>0.4440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>5</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>5.549</min_time_dom_processing>
-		<max_time_dom_processing>5.549</max_time_dom_processing>
+		<min_time_dom_processing>0.8880</min_time_dom_processing>
+		<max_time_dom_processing>1.3000</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>5</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.975</min_time_dom_completion>
-		<max_time_dom_completion>1.975</max_time_dom_completion>
+		<min_time_dom_completion>0.2990</min_time_dom_completion>
+		<max_time_dom_completion>0.5120</max_time_dom_completion>
 		<nb_hits_with_time_on_load>5</nb_hits_with_time_on_load>
-		<min_time_on_load>1.129</min_time_on_load>
-		<max_time_on_load>1.129</max_time_on_load>
+		<min_time_on_load>0.0990</min_time_on_load>
+		<max_time_on_load>0.3330</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/plugins/PagePerformance/tests/System/expected/test___Actions.getPageUrls_day.xml
+++ b/plugins/PagePerformance/tests/System/expected/test___Actions.getPageUrls_day.xml
@@ -48,23 +48,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.012</min_time_network>
-		<max_time_network>0.012</max_time_network>
+		<min_time_network>0.0120</min_time_network>
+		<max_time_network>0.0120</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.15</min_time_server>
-		<max_time_server>0.15</max_time_server>
+		<min_time_server>0.1500</min_time_server>
+		<max_time_server>0.1500</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.333</min_time_transfer>
-		<max_time_transfer>0.333</max_time_transfer>
+		<min_time_transfer>0.3330</min_time_transfer>
+		<max_time_transfer>0.3330</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>1.101</min_time_dom_processing>
-		<max_time_dom_processing>1.101</max_time_dom_processing>
+		<min_time_dom_processing>1.1010</min_time_dom_processing>
+		<max_time_dom_processing>1.1010</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.369</min_time_dom_completion>
-		<max_time_dom_completion>0.369</max_time_dom_completion>
+		<min_time_dom_completion>0.3690</min_time_dom_completion>
+		<max_time_dom_completion>0.3690</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.15</min_time_on_load>
-		<max_time_on_load>0.15</max_time_on_load>
+		<min_time_on_load>0.1500</min_time_on_load>
+		<max_time_on_load>0.1500</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -133,23 +133,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.036</min_time_network>
-		<max_time_network>0.036</max_time_network>
+		<min_time_network>0.0360</min_time_network>
+		<max_time_network>0.0360</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.077</min_time_server>
-		<max_time_server>0.077</max_time_server>
+		<min_time_server>0.0770</min_time_server>
+		<max_time_server>0.0770</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.412</min_time_transfer>
-		<max_time_transfer>0.412</max_time_transfer>
+		<min_time_transfer>0.4120</min_time_transfer>
+		<max_time_transfer>0.4120</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>1.055</min_time_dom_processing>
-		<max_time_dom_processing>1.055</max_time_dom_processing>
+		<min_time_dom_processing>1.0550</min_time_dom_processing>
+		<max_time_dom_processing>1.0550</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.333</min_time_dom_completion>
-		<max_time_dom_completion>0.333</max_time_dom_completion>
+		<min_time_dom_completion>0.3330</min_time_dom_completion>
+		<max_time_dom_completion>0.3330</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.077</min_time_on_load>
-		<max_time_on_load>0.077</max_time_on_load>
+		<min_time_on_load>0.0770</min_time_on_load>
+		<max_time_on_load>0.0770</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/plugins/PagePerformance/tests/System/expected/test___Actions.getPageUrls_month.xml
+++ b/plugins/PagePerformance/tests/System/expected/test___Actions.getPageUrls_month.xml
@@ -6,23 +6,23 @@
 		<nb_hits>5</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>5</nb_hits_with_time_network>
-		<min_time_network>0.205</min_time_network>
-		<max_time_network>0.205</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0980</max_time_network>
 		<nb_hits_with_time_server>5</nb_hits_with_time_server>
-		<min_time_server>0.54</min_time_server>
-		<max_time_server>0.54</max_time_server>
+		<min_time_server>0.0990</min_time_server>
+		<max_time_server>0.1320</max_time_server>
 		<nb_hits_with_time_transfer>5</nb_hits_with_time_transfer>
-		<min_time_transfer>1.278</min_time_transfer>
-		<max_time_transfer>1.278</max_time_transfer>
+		<min_time_transfer>0.1990</min_time_transfer>
+		<max_time_transfer>0.2980</max_time_transfer>
 		<nb_hits_with_time_dom_processing>5</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>5.311</min_time_dom_processing>
-		<max_time_dom_processing>5.311</max_time_dom_processing>
+		<min_time_dom_processing>0.8990</min_time_dom_processing>
+		<max_time_dom_processing>1.3000</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>5</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.587</min_time_dom_completion>
-		<max_time_dom_completion>1.587</max_time_dom_completion>
+		<min_time_dom_completion>0.2360</min_time_dom_completion>
+		<max_time_dom_completion>0.4120</max_time_dom_completion>
 		<nb_hits_with_time_on_load>5</nb_hits_with_time_on_load>
-		<min_time_on_load>0.732</min_time_on_load>
-		<max_time_on_load>0.732</max_time_on_load>
+		<min_time_on_load>0.0660</min_time_on_load>
+		<max_time_on_load>0.2320</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -48,23 +48,23 @@
 		<nb_hits>5</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>5</nb_hits_with_time_network>
-		<min_time_network>0.132</min_time_network>
-		<max_time_network>0.132</max_time_network>
+		<min_time_network>0.0120</min_time_network>
+		<max_time_network>0.0660</max_time_network>
 		<nb_hits_with_time_server>5</nb_hits_with_time_server>
-		<min_time_server>1.162</min_time_server>
-		<max_time_server>1.162</max_time_server>
+		<min_time_server>0.1500</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>5</nb_hits_with_time_transfer>
-		<min_time_transfer>1.512</min_time_transfer>
-		<max_time_transfer>1.512</max_time_transfer>
+		<min_time_transfer>0.1360</min_time_transfer>
+		<max_time_transfer>0.4440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>5</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>5.549</min_time_dom_processing>
-		<max_time_dom_processing>5.549</max_time_dom_processing>
+		<min_time_dom_processing>0.8880</min_time_dom_processing>
+		<max_time_dom_processing>1.3000</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>5</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.975</min_time_dom_completion>
-		<max_time_dom_completion>1.975</max_time_dom_completion>
+		<min_time_dom_completion>0.2990</min_time_dom_completion>
+		<max_time_dom_completion>0.5120</max_time_dom_completion>
 		<nb_hits_with_time_on_load>5</nb_hits_with_time_on_load>
-		<min_time_on_load>1.129</min_time_on_load>
-		<max_time_on_load>1.129</max_time_on_load>
+		<min_time_on_load>0.0990</min_time_on_load>
+		<max_time_on_load>0.3330</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -92,23 +92,23 @@
 				<nb_hits>5</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>5</nb_hits_with_time_network>
-				<min_time_network>0.132</min_time_network>
-				<max_time_network>0.132</max_time_network>
+				<min_time_network>0.0120</min_time_network>
+				<max_time_network>0.0660</max_time_network>
 				<nb_hits_with_time_server>5</nb_hits_with_time_server>
-				<min_time_server>1.162</min_time_server>
-				<max_time_server>1.162</max_time_server>
+				<min_time_server>0.1500</min_time_server>
+				<max_time_server>0.3550</max_time_server>
 				<nb_hits_with_time_transfer>5</nb_hits_with_time_transfer>
-				<min_time_transfer>1.512</min_time_transfer>
-				<max_time_transfer>1.512</max_time_transfer>
+				<min_time_transfer>0.1360</min_time_transfer>
+				<max_time_transfer>0.4440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>5</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>5.549</min_time_dom_processing>
-				<max_time_dom_processing>5.549</max_time_dom_processing>
+				<min_time_dom_processing>0.8880</min_time_dom_processing>
+				<max_time_dom_processing>1.3000</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>5</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>1.975</min_time_dom_completion>
-				<max_time_dom_completion>1.975</max_time_dom_completion>
+				<min_time_dom_completion>0.2990</min_time_dom_completion>
+				<max_time_dom_completion>0.5120</max_time_dom_completion>
 				<nb_hits_with_time_on_load>5</nb_hits_with_time_on_load>
-				<min_time_on_load>1.129</min_time_on_load>
-				<max_time_on_load>1.129</max_time_on_load>
+				<min_time_on_load>0.0990</min_time_on_load>
+				<max_time_on_load>0.3330</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -133,23 +133,23 @@
 		<nb_hits>5</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>5</nb_hits_with_time_network>
-		<min_time_network>0.165</min_time_network>
-		<max_time_network>0.165</max_time_network>
+		<min_time_network>0.0230</min_time_network>
+		<max_time_network>0.0400</max_time_network>
 		<nb_hits_with_time_server>5</nb_hits_with_time_server>
-		<min_time_server>0.757</min_time_server>
-		<max_time_server>0.757</max_time_server>
+		<min_time_server>0.0770</min_time_server>
+		<max_time_server>0.2690</max_time_server>
 		<nb_hits_with_time_transfer>5</nb_hits_with_time_transfer>
-		<min_time_transfer>1.673</min_time_transfer>
-		<max_time_transfer>1.673</max_time_transfer>
+		<min_time_transfer>0.1950</min_time_transfer>
+		<max_time_transfer>0.4120</max_time_transfer>
 		<nb_hits_with_time_dom_processing>5</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>5.356</min_time_dom_processing>
-		<max_time_dom_processing>5.356</max_time_dom_processing>
+		<min_time_dom_processing>0.9630</min_time_dom_processing>
+		<max_time_dom_processing>1.2000</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>5</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.56</min_time_dom_completion>
-		<max_time_dom_completion>1.56</max_time_dom_completion>
+		<min_time_dom_completion>0.1950</min_time_dom_completion>
+		<max_time_dom_completion>0.4440</max_time_dom_completion>
 		<nb_hits_with_time_on_load>5</nb_hits_with_time_on_load>
-		<min_time_on_load>0.892</min_time_on_load>
-		<max_time_on_load>0.892</max_time_on_load>
+		<min_time_on_load>0.0770</min_time_on_load>
+		<max_time_on_load>0.2580</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -174,23 +174,23 @@
 				<nb_hits>5</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>5</nb_hits_with_time_network>
-				<min_time_network>0.165</min_time_network>
-				<max_time_network>0.165</max_time_network>
+				<min_time_network>0.0230</min_time_network>
+				<max_time_network>0.0400</max_time_network>
 				<nb_hits_with_time_server>5</nb_hits_with_time_server>
-				<min_time_server>0.757</min_time_server>
-				<max_time_server>0.757</max_time_server>
+				<min_time_server>0.0770</min_time_server>
+				<max_time_server>0.2690</max_time_server>
 				<nb_hits_with_time_transfer>5</nb_hits_with_time_transfer>
-				<min_time_transfer>1.673</min_time_transfer>
-				<max_time_transfer>1.673</max_time_transfer>
+				<min_time_transfer>0.1950</min_time_transfer>
+				<max_time_transfer>0.4120</max_time_transfer>
 				<nb_hits_with_time_dom_processing>5</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>5.356</min_time_dom_processing>
-				<max_time_dom_processing>5.356</max_time_dom_processing>
+				<min_time_dom_processing>0.9630</min_time_dom_processing>
+				<max_time_dom_processing>1.2000</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>5</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>1.56</min_time_dom_completion>
-				<max_time_dom_completion>1.56</max_time_dom_completion>
+				<min_time_dom_completion>0.1950</min_time_dom_completion>
+				<max_time_dom_completion>0.4440</max_time_dom_completion>
 				<nb_hits_with_time_on_load>5</nb_hits_with_time_on_load>
-				<min_time_on_load>0.892</min_time_on_load>
-				<max_time_on_load>0.892</max_time_on_load>
+				<min_time_on_load>0.0770</min_time_on_load>
+				<max_time_on_load>0.2580</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_flat__API.getProcessedReport_day.xml
@@ -587,7 +587,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>18.66</min_event_value>
-		<max_event_value>42.66</max_event_value>
+		<min_event_value>0</min_event_value>
+		<max_event_value>23</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_lastN__API.getProcessedReport_day.xml
@@ -427,7 +427,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>18.66</min_event_value>
-		<max_event_value>42.66</max_event_value>
+		<min_event_value>0</min_event_value>
+		<max_event_value>23</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_flat__API.getProcessedReport_day.xml
@@ -538,7 +538,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>28.32</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_flat__API.getProcessedReport_day.xml
@@ -538,7 +538,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>28.32</min_event_value>
-		<max_event_value>52.32</max_event_value>
+		<min_event_value>0</min_event_value>
+		<max_event_value>23</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_flat__API.getProcessedReport_day.xml
@@ -538,7 +538,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>28.32</min_event_value>
 		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
@@ -62,7 +62,7 @@
 				<nb_events>28</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19.32</sum_event_value>
-				<min_event_value>9.66</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -71,7 +71,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>4</nb_events_with_value>
 				<sum_event_value>38</sum_event_value>
-				<min_event_value>9</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -100,7 +100,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>1</nb_events_with_value>
 				<sum_event_value>9.66</sum_event_value>
-				<min_event_value>9.66</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -109,7 +109,7 @@
 				<nb_events>7</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19</sum_event_value>
-				<min_event_value>9</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -181,7 +181,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>28.32</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
@@ -62,7 +62,7 @@
 				<nb_events>28</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19.32</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -71,7 +71,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>4</nb_events_with_value>
 				<sum_event_value>38</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -100,7 +100,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>1</nb_events_with_value>
 				<sum_event_value>9.66</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -109,7 +109,7 @@
 				<nb_events>7</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -181,7 +181,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>28.32</min_event_value>
 		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
@@ -181,7 +181,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>28.32</min_event_value>
-		<max_event_value>52.32</max_event_value>
+		<min_event_value>0</min_event_value>
+		<max_event_value>23</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_flat__API.getProcessedReport_day.xml
@@ -616,7 +616,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>28.32</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_flat__API.getProcessedReport_day.xml
@@ -617,6 +617,6 @@
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
 		<min_event_value>9.66</min_event_value>
-		<max_event_value>52.32</max_event_value>
+		<max_event_value>9.66</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_flat__API.getProcessedReport_day.xml
@@ -616,7 +616,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>9.66</min_event_value>
-		<max_event_value>9.66</max_event_value>
+		<min_event_value>0</min_event_value>
+		<max_event_value>23</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
@@ -62,7 +62,7 @@
 				<nb_events>16</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19.32</sum_event_value>
-				<min_event_value>9.66</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -71,7 +71,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>4</nb_events_with_value>
 				<sum_event_value>38</sum_event_value>
-				<min_event_value>9</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -127,7 +127,7 @@
 				<nb_events>8</nb_events>
 				<nb_events_with_value>1</nb_events_with_value>
 				<sum_event_value>9.66</sum_event_value>
-				<min_event_value>9.66</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -136,7 +136,7 @@
 				<nb_events>7</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19</sum_event_value>
-				<min_event_value>9</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -277,7 +277,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>28.32</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
@@ -62,7 +62,7 @@
 				<nb_events>16</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19.32</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -71,7 +71,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>4</nb_events_with_value>
 				<sum_event_value>38</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -127,7 +127,7 @@
 				<nb_events>8</nb_events>
 				<nb_events_with_value>1</nb_events_with_value>
 				<sum_event_value>9.66</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -136,7 +136,7 @@
 				<nb_events>7</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -278,6 +278,6 @@
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
 		<min_event_value>9.66</min_event_value>
-		<max_event_value>52.32</max_event_value>
+		<max_event_value>9.66</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
@@ -277,7 +277,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>9.66</min_event_value>
-		<max_event_value>9.66</max_event_value>
+		<min_event_value>0</min_event_value>
+		<max_event_value>23</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Actions.getPageUrls_month.xml
@@ -6,23 +6,23 @@
 		<nb_hits>3</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>3</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>3</nb_hits_with_time_server>
-		<min_time_server>0.91</min_time_server>
-		<max_time_server>0.91</max_time_server>
+		<min_time_server>0.4550</min_time_server>
+		<max_time_server>0.4550</max_time_server>
 		<nb_hits_with_time_transfer>3</nb_hits_with_time_transfer>
-		<min_time_transfer>0.338</min_time_transfer>
-		<max_time_transfer>0.338</max_time_transfer>
+		<min_time_transfer>0.1690</min_time_transfer>
+		<max_time_transfer>0.1690</max_time_transfer>
 		<nb_hits_with_time_dom_processing>3</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.04</min_time_dom_processing>
-		<max_time_dom_processing>0.04</max_time_dom_processing>
+		<min_time_dom_processing>0.0200</min_time_dom_processing>
+		<max_time_dom_processing>0.0200</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>3</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.198</min_time_dom_completion>
-		<max_time_dom_completion>0.198</max_time_dom_completion>
+		<min_time_dom_completion>0.0990</min_time_dom_completion>
+		<max_time_dom_completion>0.0990</max_time_dom_completion>
 		<nb_hits_with_time_on_load>3</nb_hits_with_time_on_load>
-		<min_time_on_load>0.32</min_time_on_load>
-		<max_time_on_load>0.32</max_time_on_load>
+		<min_time_on_load>0.1600</min_time_on_load>
+		<max_time_on_load>0.1600</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -55,23 +55,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>1499</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.005</min_time_network>
-		<max_time_network>0.005</max_time_network>
+		<min_time_network>0.0050</min_time_network>
+		<max_time_network>0.0050</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.111</min_time_server>
-		<max_time_server>0.111</max_time_server>
+		<min_time_server>0.1110</min_time_server>
+		<max_time_server>0.1110</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.245</min_time_transfer>
-		<max_time_transfer>0.245</max_time_transfer>
+		<min_time_transfer>0.2450</min_time_transfer>
+		<max_time_transfer>0.2450</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.145</min_time_dom_processing>
-		<max_time_dom_processing>0.145</max_time_dom_processing>
+		<min_time_dom_processing>0.1450</min_time_dom_processing>
+		<max_time_dom_processing>0.1450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.066</min_time_dom_completion>
-		<max_time_dom_completion>0.066</max_time_dom_completion>
+		<min_time_dom_completion>0.0660</min_time_dom_completion>
+		<max_time_dom_completion>0.0660</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getAction_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getAction_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playTrailer</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -54,8 +54,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Search</segment>
 		<subtable>
@@ -66,8 +66,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -79,8 +79,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play25%25</segment>
 		<subtable>
@@ -91,8 +91,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -102,8 +102,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -115,8 +115,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play50%25</segment>
 		<subtable>
@@ -127,8 +127,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -138,8 +138,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -151,8 +151,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play75%25</segment>
 		<subtable>
@@ -163,8 +163,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -174,8 +174,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -187,8 +187,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playEnd</segment>
 		<subtable>
@@ -199,8 +199,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -210,8 +210,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -259,8 +259,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==clickBuyNow</segment>
 		<subtable>
@@ -271,8 +271,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -309,8 +309,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play</segment>
 		<subtable>
@@ -321,8 +321,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -334,8 +334,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playStart</segment>
 		<subtable>
@@ -346,8 +346,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -359,8 +359,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Purchase</segment>
 	</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getAction_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getAction_month.xml
@@ -6,8 +6,8 @@
 		<nb_events>9</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>9</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playTrailer</segment>
@@ -18,8 +18,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -29,8 +29,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -40,8 +40,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -53,8 +53,8 @@
 		<nb_events>9</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Search</segment>
@@ -65,8 +65,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -78,8 +78,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play25%25</segment>
@@ -90,8 +90,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -101,8 +101,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -114,8 +114,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play50%25</segment>
@@ -126,8 +126,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -137,8 +137,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -150,8 +150,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play75%25</segment>
@@ -162,8 +162,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -173,8 +173,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -186,8 +186,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playEnd</segment>
@@ -198,8 +198,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -209,8 +209,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -258,8 +258,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==clickBuyNow</segment>
@@ -270,8 +270,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -308,8 +308,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play</segment>
@@ -320,8 +320,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -333,8 +333,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playStart</segment>
@@ -345,8 +345,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -358,8 +358,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Purchase</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>28</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -131,7 +131,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>28</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -19,8 +19,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -52,8 +52,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -63,8 +63,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -74,8 +74,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -85,8 +85,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -96,8 +96,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -107,8 +107,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -131,7 +131,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>
@@ -143,8 +143,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -154,8 +154,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -165,8 +165,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -176,8 +176,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -187,8 +187,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getCategory_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getCategory_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>42</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>39</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -130,7 +130,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getCategory_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getCategory_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>42</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>39</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -18,8 +18,8 @@
 				<nb_events>9</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>9</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -29,8 +29,8 @@
 				<nb_events>9</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -40,8 +40,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -51,8 +51,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -62,8 +62,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -73,8 +73,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -84,8 +84,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -95,8 +95,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -106,8 +106,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -130,7 +130,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>
@@ -142,8 +142,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -153,8 +153,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -164,8 +164,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -175,8 +175,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -186,8 +186,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -19,8 +19,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -52,8 +52,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -63,8 +63,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -74,8 +74,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -85,8 +85,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>
@@ -121,8 +121,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -132,8 +132,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -143,8 +143,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -154,8 +154,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -165,8 +165,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -200,8 +200,8 @@
 				<nb_events>4</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -211,8 +211,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -260,8 +260,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Ponyo+%28%E5%B4%96%E3%81%AE%E4%B8%8A%E3%81%AE%E3%83%9D%E3%83%8B%E3%83%A7%29</segment>
 		<subtable>
@@ -272,8 +272,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -285,8 +285,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Princess+Mononoke+%28%E3%82%82%E3%81%AE%E3%81%AE%E3%81%91%E5%A7%AB%29</segment>
 		<subtable>
@@ -297,8 +297,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -310,8 +310,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Search+query+here</segment>
 		<subtable>
@@ -322,8 +322,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getName_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getName_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>24</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -108,7 +108,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getName_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getName_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>24</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -18,8 +18,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -29,8 +29,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -40,8 +40,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -51,8 +51,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -62,8 +62,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -73,8 +73,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -84,8 +84,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -108,7 +108,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>
@@ -120,8 +120,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -131,8 +131,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -142,8 +142,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -153,8 +153,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -164,8 +164,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -199,8 +199,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -210,8 +210,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -259,8 +259,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Ponyo+%28%E5%B4%96%E3%81%AE%E4%B8%8A%E3%81%AE%E3%83%9D%E3%83%8B%E3%83%A7%29</segment>
@@ -271,8 +271,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -284,8 +284,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Princess+Mononoke+%28%E3%82%82%E3%81%AE%E3%81%AE%E3%81%91%E5%A7%AB%29</segment>
@@ -296,8 +296,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -309,8 +309,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Search+query+here</segment>
@@ -321,8 +321,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getAction_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getAction_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playTrailer</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -54,8 +54,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Search</segment>
 		<subtable>
@@ -66,8 +66,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -79,8 +79,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play25%25</segment>
 		<subtable>
@@ -91,8 +91,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -102,8 +102,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -115,8 +115,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play50%25</segment>
 		<subtable>
@@ -127,8 +127,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -138,8 +138,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -151,8 +151,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play75%25</segment>
 		<subtable>
@@ -163,8 +163,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -174,8 +174,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -187,8 +187,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playEnd</segment>
 		<subtable>
@@ -199,8 +199,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -210,8 +210,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -259,8 +259,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==clickBuyNow</segment>
 		<subtable>
@@ -271,8 +271,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -309,8 +309,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play</segment>
 		<subtable>
@@ -321,8 +321,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -334,8 +334,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playStart</segment>
 		<subtable>
@@ -346,8 +346,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -359,8 +359,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Purchase</segment>
 	</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>28</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -131,7 +131,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>28</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -19,8 +19,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -52,8 +52,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -63,8 +63,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -74,8 +74,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -85,8 +85,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -96,8 +96,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -107,8 +107,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -131,7 +131,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>
@@ -143,8 +143,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -154,8 +154,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -165,8 +165,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -176,8 +176,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -187,8 +187,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -19,8 +19,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -52,8 +52,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -63,8 +63,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -74,8 +74,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -85,8 +85,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>
@@ -121,8 +121,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -132,8 +132,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -143,8 +143,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -154,8 +154,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -165,8 +165,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -200,8 +200,8 @@
 				<nb_events>4</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -211,8 +211,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -260,8 +260,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Ponyo+%28%E5%B4%96%E3%81%AE%E4%B8%8A%E3%81%AE%E3%83%9D%E3%83%8B%E3%83%A7%29</segment>
 		<subtable>
@@ -272,8 +272,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -285,8 +285,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Princess+Mononoke+%28%E3%82%82%E3%81%AE%E3%81%AE%E3%81%91%E5%A7%AB%29</segment>
 		<subtable>
@@ -297,8 +297,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -310,8 +310,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Search+query+here</segment>
 		<subtable>
@@ -322,8 +322,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getAction_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getAction_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playTrailer</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -54,8 +54,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play25%25</segment>
 		<subtable>
@@ -66,8 +66,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -77,8 +77,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -90,8 +90,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play50%25</segment>
 		<subtable>
@@ -102,8 +102,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -113,8 +113,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -126,8 +126,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play75%25</segment>
 		<subtable>
@@ -138,8 +138,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -149,8 +149,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -162,8 +162,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playEnd</segment>
 		<subtable>
@@ -174,8 +174,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -185,8 +185,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -234,8 +234,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==clickBuyNow</segment>
 		<subtable>
@@ -246,8 +246,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -284,8 +284,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play</segment>
 		<subtable>
@@ -296,8 +296,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -309,8 +309,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playStart</segment>
 		<subtable>
@@ -321,8 +321,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -334,8 +334,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Search</segment>
 		<subtable>
@@ -346,8 +346,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>22</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -120,7 +120,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>22</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -19,8 +19,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -52,8 +52,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -63,8 +63,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -74,8 +74,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -85,8 +85,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -107,8 +107,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -120,7 +120,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>
@@ -132,8 +132,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -143,8 +143,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -154,8 +154,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -165,8 +165,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -176,8 +176,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -19,8 +19,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -52,8 +52,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -63,8 +63,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -74,8 +74,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -85,8 +85,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>
@@ -121,8 +121,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -132,8 +132,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -143,8 +143,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -154,8 +154,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -165,8 +165,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -214,8 +214,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Ponyo+%28%E5%B4%96%E3%81%AE%E4%B8%8A%E3%81%AE%E3%83%9D%E3%83%8B%E3%83%A7%29</segment>
 		<subtable>
@@ -226,8 +226,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -239,8 +239,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Princess+Mononoke+%28%E3%82%82%E3%81%AE%E3%81%AE%E3%81%91%E5%A7%AB%29</segment>
 		<subtable>
@@ -251,8 +251,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -264,8 +264,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Search+query+here</segment>
 		<subtable>
@@ -276,8 +276,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>28</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -131,7 +131,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>28</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -19,8 +19,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -52,8 +52,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -63,8 +63,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -74,8 +74,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -85,8 +85,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -96,8 +96,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -107,8 +107,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -131,7 +131,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>
@@ -143,8 +143,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -154,8 +154,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -165,8 +165,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -176,8 +176,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -187,8 +187,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getCategory_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getCategory_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>42</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>39</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -130,7 +130,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getCategory_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getCategory_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>42</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>39</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -18,8 +18,8 @@
 				<nb_events>9</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>9</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -29,8 +29,8 @@
 				<nb_events>9</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -40,8 +40,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -51,8 +51,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -62,8 +62,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -73,8 +73,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -84,8 +84,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -95,8 +95,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -106,8 +106,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -130,7 +130,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>
@@ -142,8 +142,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -153,8 +153,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -164,8 +164,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -175,8 +175,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -186,8 +186,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -19,8 +19,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -52,8 +52,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -63,8 +63,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -74,8 +74,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -85,8 +85,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>
@@ -121,8 +121,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -132,8 +132,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -143,8 +143,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -154,8 +154,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -165,8 +165,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -200,8 +200,8 @@
 				<nb_events>4</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -211,8 +211,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -260,8 +260,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Ponyo+%28%E5%B4%96%E3%81%AE%E4%B8%8A%E3%81%AE%E3%83%9D%E3%83%8B%E3%83%A7%29</segment>
 		<subtable>
@@ -272,8 +272,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -285,8 +285,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Princess+Mononoke+%28%E3%82%82%E3%81%AE%E3%81%AE%E3%81%91%E5%A7%AB%29</segment>
 		<subtable>
@@ -297,8 +297,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -310,8 +310,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Search+query+here</segment>
 		<subtable>
@@ -322,8 +322,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getName_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getName_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>24</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -108,7 +108,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getName_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getName_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>24</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -18,8 +18,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -29,8 +29,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -40,8 +40,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -51,8 +51,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -62,8 +62,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -73,8 +73,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -84,8 +84,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -108,7 +108,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>
@@ -120,8 +120,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -131,8 +131,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -142,8 +142,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -153,8 +153,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -164,8 +164,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -199,8 +199,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -210,8 +210,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -259,8 +259,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Ponyo+%28%E5%B4%96%E3%81%AE%E4%B8%8A%E3%81%AE%E3%83%9D%E3%83%8B%E3%83%A7%29</segment>
@@ -271,8 +271,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -284,8 +284,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Princess+Mononoke+%28%E3%82%82%E3%81%AE%E3%81%AE%E3%81%91%E5%A7%AB%29</segment>
@@ -296,8 +296,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -309,8 +309,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Search+query+here</segment>
@@ -321,8 +321,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getAction_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getAction_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playTrailer</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Search</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play25%25</segment>
 		<subtable>
@@ -69,8 +69,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -80,8 +80,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -93,8 +93,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play50%25</segment>
 		<subtable>
@@ -105,8 +105,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -116,8 +116,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -129,8 +129,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play75%25</segment>
 		<subtable>
@@ -141,8 +141,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -152,8 +152,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -165,8 +165,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playEnd</segment>
 		<subtable>
@@ -177,8 +177,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -188,8 +188,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -237,8 +237,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==clickBuyNow</segment>
 		<subtable>
@@ -249,8 +249,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -287,8 +287,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play</segment>
 		<subtable>
@@ -299,8 +299,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -312,8 +312,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playStart</segment>
 		<subtable>
@@ -324,8 +324,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -337,8 +337,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Purchase</segment>
 		<subtable>
@@ -349,8 +349,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getAction_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getAction_month.xml
@@ -6,8 +6,8 @@
 		<nb_events>9</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>9</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playTrailer</segment>
@@ -18,8 +18,8 @@
 				<nb_events>9</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>9</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -31,8 +31,8 @@
 		<nb_events>9</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Search</segment>
@@ -43,8 +43,8 @@
 				<nb_events>9</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -56,8 +56,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play25%25</segment>
@@ -68,8 +68,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -79,8 +79,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -92,8 +92,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play50%25</segment>
@@ -104,8 +104,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -115,8 +115,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -128,8 +128,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play75%25</segment>
@@ -140,8 +140,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -151,8 +151,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -164,8 +164,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playEnd</segment>
@@ -176,8 +176,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -187,8 +187,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -236,8 +236,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==clickBuyNow</segment>
@@ -248,8 +248,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -286,8 +286,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play</segment>
@@ -298,8 +298,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -311,8 +311,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playStart</segment>
@@ -323,8 +323,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -336,8 +336,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Purchase</segment>
@@ -348,8 +348,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -19,7 +19,7 @@
 				<nb_events>16</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19.32</sum_event_value>
-				<min_event_value>9.66</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -32,7 +32,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>
@@ -44,7 +44,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>4</nb_events_with_value>
 				<sum_event_value>38</sum_event_value>
-				<min_event_value>9</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -19,7 +19,7 @@
 				<nb_events>16</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19.32</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -32,7 +32,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>
@@ -44,7 +44,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>4</nb_events_with_value>
 				<sum_event_value>38</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -68,8 +68,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -117,8 +117,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Ponyo+%28%E5%B4%96%E3%81%AE%E4%B8%8A%E3%81%AE%E3%83%9D%E3%83%8B%E3%83%A7%29</segment>
 		<subtable>
@@ -129,8 +129,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -142,8 +142,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Princess+Mononoke+%28%E3%82%82%E3%81%AE%E3%81%AE%E3%81%91%E5%A7%AB%29</segment>
 		<subtable>
@@ -154,8 +154,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -167,8 +167,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Search+query+here</segment>
 		<subtable>
@@ -179,8 +179,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getName_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getName_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>24</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -18,7 +18,7 @@
 				<nb_events>24</nb_events>
 				<nb_events_with_value>3</nb_events_with_value>
 				<sum_event_value>28.98</sum_event_value>
-				<min_event_value>9.66</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 				<avg_event_value>9.66</avg_event_value>
@@ -31,7 +31,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>
@@ -43,7 +43,7 @@
 				<nb_events>21</nb_events>
 				<nb_events_with_value>6</nb_events_with_value>
 				<sum_event_value>57</sum_event_value>
-				<min_event_value>9</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>10</max_event_value>
 				<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 				<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getName_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getName_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>24</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -18,7 +18,7 @@
 				<nb_events>24</nb_events>
 				<nb_events_with_value>3</nb_events_with_value>
 				<sum_event_value>28.98</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 				<avg_event_value>9.66</avg_event_value>
@@ -31,7 +31,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>
@@ -43,7 +43,7 @@
 				<nb_events>21</nb_events>
 				<nb_events_with_value>6</nb_events_with_value>
 				<sum_event_value>57</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 				<avg_event_value>9.5</avg_event_value>
@@ -67,8 +67,8 @@
 				<nb_events>9</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -116,8 +116,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Ponyo+%28%E5%B4%96%E3%81%AE%E4%B8%8A%E3%81%AE%E3%83%9D%E3%83%8B%E3%83%A7%29</segment>
@@ -128,8 +128,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -141,8 +141,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Princess+Mononoke+%28%E3%82%82%E3%81%AE%E3%81%AE%E3%81%91%E5%A7%AB%29</segment>
@@ -153,8 +153,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -166,8 +166,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Search+query+here</segment>
@@ -178,8 +178,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getAction_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getAction_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playTrailer</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -54,8 +54,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Search</segment>
 		<subtable>
@@ -66,8 +66,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -79,8 +79,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play25%25</segment>
 		<subtable>
@@ -91,8 +91,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -102,8 +102,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -115,8 +115,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play50%25</segment>
 		<subtable>
@@ -127,8 +127,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -138,8 +138,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -151,8 +151,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play75%25</segment>
 		<subtable>
@@ -163,8 +163,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -174,8 +174,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -187,8 +187,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playEnd</segment>
 		<subtable>
@@ -199,8 +199,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -210,8 +210,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -259,8 +259,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==clickBuyNow</segment>
 		<subtable>
@@ -271,8 +271,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -309,8 +309,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play</segment>
 		<subtable>
@@ -321,8 +321,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -334,8 +334,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playStart</segment>
 		<subtable>
@@ -346,8 +346,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -359,8 +359,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Purchase</segment>
 	</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getAction_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getAction_month.xml
@@ -6,8 +6,8 @@
 		<nb_events>9</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>9</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playTrailer</segment>
@@ -18,8 +18,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -29,8 +29,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -40,8 +40,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -53,8 +53,8 @@
 		<nb_events>9</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Search</segment>
@@ -65,8 +65,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -78,8 +78,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play25%25</segment>
@@ -90,8 +90,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -101,8 +101,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -114,8 +114,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play50%25</segment>
@@ -126,8 +126,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -137,8 +137,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -150,8 +150,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play75%25</segment>
@@ -162,8 +162,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -173,8 +173,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -186,8 +186,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playEnd</segment>
@@ -198,8 +198,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -209,8 +209,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -258,8 +258,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==clickBuyNow</segment>
@@ -270,8 +270,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -308,8 +308,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play</segment>
@@ -320,8 +320,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -333,8 +333,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playStart</segment>
@@ -345,8 +345,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -358,8 +358,8 @@
 		<nb_events>3</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Purchase</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>28</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -19,7 +19,7 @@
 				<nb_events>16</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19.32</sum_event_value>
-				<min_event_value>9.66</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -65,7 +65,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>
@@ -77,7 +77,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>4</nb_events_with_value>
 				<sum_event_value>38</sum_event_value>
-				<min_event_value>9</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>28</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -19,7 +19,7 @@
 				<nb_events>16</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19.32</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -52,8 +52,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -65,7 +65,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>
@@ -77,7 +77,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>4</nb_events_with_value>
 				<sum_event_value>38</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getCategory_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getCategory_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>42</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>39</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -18,7 +18,7 @@
 				<nb_events>24</nb_events>
 				<nb_events_with_value>3</nb_events_with_value>
 				<sum_event_value>28.98</sum_event_value>
-				<min_event_value>9.66</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 				<avg_event_value>9.66</avg_event_value>
@@ -64,7 +64,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>
@@ -76,7 +76,7 @@
 				<nb_events>21</nb_events>
 				<nb_events_with_value>6</nb_events_with_value>
 				<sum_event_value>57</sum_event_value>
-				<min_event_value>9</min_event_value>
+				<min_event_value>0</min_event_value>
 				<max_event_value>10</max_event_value>
 				<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 				<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getCategory_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getCategory_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>42</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>39</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -18,7 +18,7 @@
 				<nb_events>24</nb_events>
 				<nb_events_with_value>3</nb_events_with_value>
 				<sum_event_value>28.98</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 				<avg_event_value>9.66</avg_event_value>
@@ -29,8 +29,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -40,8 +40,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -51,8 +51,8 @@
 				<nb_events>3</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -64,7 +64,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>
@@ -76,7 +76,7 @@
 				<nb_events>21</nb_events>
 				<nb_events_with_value>6</nb_events_with_value>
 				<sum_event_value>57</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 				<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getAction_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getAction_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>6</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playTrailer</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -54,8 +54,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play25%25</segment>
 		<subtable>
@@ -66,8 +66,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -77,8 +77,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -90,8 +90,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play50%25</segment>
 		<subtable>
@@ -102,8 +102,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -113,8 +113,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -126,8 +126,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play75%25</segment>
 		<subtable>
@@ -138,8 +138,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -149,8 +149,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -162,8 +162,8 @@
 		<nb_events>4</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playEnd</segment>
 		<subtable>
@@ -174,8 +174,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -185,8 +185,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -234,8 +234,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==clickBuyNow</segment>
 		<subtable>
@@ -246,8 +246,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -284,8 +284,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play</segment>
 		<subtable>
@@ -296,8 +296,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -309,8 +309,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==playStart</segment>
 		<subtable>
@@ -321,8 +321,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -334,8 +334,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==Search</segment>
 		<subtable>
@@ -346,8 +346,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>22</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -120,7 +120,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>22</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -19,8 +19,8 @@
 				<nb_events>6</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -52,8 +52,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -63,8 +63,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -74,8 +74,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -85,8 +85,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -107,8 +107,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -120,7 +120,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>
@@ -132,8 +132,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -143,8 +143,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -154,8 +154,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -165,8 +165,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -176,8 +176,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>9</min_event_value>
+		<min_event_value>0</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -19,8 +19,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -30,8 +30,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -41,8 +41,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -52,8 +52,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -63,8 +63,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -74,8 +74,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -85,8 +85,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>
@@ -121,8 +121,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -132,8 +132,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -143,8 +143,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -154,8 +154,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -165,8 +165,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 			<row>
@@ -214,8 +214,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Ponyo+%28%E5%B4%96%E3%81%AE%E4%B8%8A%E3%81%AE%E3%83%9D%E3%83%8B%E3%83%A7%29</segment>
 		<subtable>
@@ -226,8 +226,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -239,8 +239,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Princess+Mononoke+%28%E3%82%82%E3%81%AE%E3%81%AE%E3%81%91%E5%A7%AB%29</segment>
 		<subtable>
@@ -251,8 +251,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -264,8 +264,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==Search+query+here</segment>
 		<subtable>
@@ -276,8 +276,8 @@
 				<nb_events>2</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_flat__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_flat__Actions.getPageUrls_month.xml
@@ -10,8 +10,8 @@
 		<max_time_server />
 		<sum_bandwidth>32166</sum_bandwidth>
 		<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>9</entry_nb_visits>
 		<entry_nb_actions>9</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -51,8 +51,8 @@
 				<nb_hits_with_time_server>0</nb_hits_with_time_server>
 				<sum_bandwidth>32166</sum_bandwidth>
 				<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>9</entry_nb_visits>
 				<entry_nb_actions>9</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -140,10 +140,10 @@
 				<sum_bandwidth_change_from>+800%</sum_bandwidth_change_from>
 				<nb_hits_with_bandwidth_change>-88.9%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+800%</nb_hits_with_bandwidth_change_from>
-				<min_bandwidth_change>-75%</min_bandwidth_change>
-				<min_bandwidth_change_from>+300%</min_bandwidth_change_from>
-				<max_bandwidth_change>-75%</max_bandwidth_change>
-				<max_bandwidth_change_from>+300%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
 				<entry_nb_visits_change>-88.9%</entry_nb_visits_change>
 				<entry_nb_visits_change_from>+800%</entry_nb_visits_change_from>
 				<entry_nb_actions_change>-88.9%</entry_nb_actions_change>
@@ -271,8 +271,8 @@
 		<max_time_server />
 		<sum_bandwidth>7148</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>7148</min_bandwidth>
-		<max_bandwidth>7148</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -312,8 +312,8 @@
 				<nb_hits_with_time_server>0</nb_hits_with_time_server>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -538,8 +538,8 @@
 		<max_time_server />
 		<sum_bandwidth>7148</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>7148</min_bandwidth>
-		<max_bandwidth>7148</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -579,8 +579,8 @@
 				<nb_hits_with_time_server>0</nb_hits_with_time_server>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -805,8 +805,8 @@
 		<max_time_server />
 		<sum_bandwidth>7148</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>7148</min_bandwidth>
-		<max_bandwidth>7148</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -846,8 +846,8 @@
 				<nb_hits_with_time_server>0</nb_hits_with_time_server>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -5526,8 +5526,8 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<sum_bandwidth>182</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>182</min_bandwidth>
@@ -5569,8 +5569,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<sum_bandwidth>182</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>182</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_invertCompare__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_invertCompare__Actions.getPageUrls_month.xml
@@ -10,8 +10,8 @@
 		<max_time_server />
 		<sum_bandwidth>39314</sum_bandwidth>
 		<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-		<min_bandwidth>21444</min_bandwidth>
-		<max_bandwidth>21444</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>11</entry_nb_visits>
 		<entry_nb_actions>11</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -51,8 +51,8 @@
 				<entry_bounce_count>11</entry_bounce_count>
 				<exit_nb_visits>11</exit_nb_visits>
 				<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-				<max_bandwidth>21444</max_bandwidth>
-				<min_bandwidth>21444</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>39314</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -80,10 +80,10 @@
 				<exit_nb_visits_change_from>-72.7%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>+266.7%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>-72.7%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>+200%</max_bandwidth_change>
-				<max_bandwidth_change_from>-66.7%</max_bandwidth_change_from>
-				<min_bandwidth_change>+200%</min_bandwidth_change>
-				<min_bandwidth_change_from>-66.7%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>+266.7%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>-72.7%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -257,8 +257,8 @@
 				<entry_bounce_count>3</entry_bounce_count>
 				<exit_nb_visits>3</exit_nb_visits>
 				<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>10722</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -346,8 +346,8 @@
 				<max_time_server />
 				<sum_bandwidth>35740</sum_bandwidth>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<min_bandwidth>17870</min_bandwidth>
-				<max_bandwidth>17870</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>10</entry_nb_visits>
 				<entry_nb_actions>10</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -428,8 +428,8 @@
 						<max_time_server />
 						<sum_bandwidth>32166</sum_bandwidth>
 						<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-						<min_bandwidth>14296</min_bandwidth>
-						<max_bandwidth>14296</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>9</entry_nb_visits>
 						<entry_nb_actions>9</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -510,8 +510,8 @@
 								<max_time_server />
 								<sum_bandwidth>32166</sum_bandwidth>
 								<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-								<min_bandwidth>14296</min_bandwidth>
-								<max_bandwidth>14296</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>9</entry_nb_visits>
 								<entry_nb_actions>9</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1110,8 +1110,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1151,8 +1151,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -1180,10 +1180,10 @@
 				<exit_nb_visits_change_from>-75%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>+300%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>-75%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>+300%</max_bandwidth_change>
-				<max_bandwidth_change_from>-75%</max_bandwidth_change_from>
-				<min_bandwidth_change>+300%</min_bandwidth_change>
-				<min_bandwidth_change_from>-75%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>+300%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>-75%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -1217,8 +1217,8 @@
 				<entry_bounce_count>2</entry_bounce_count>
 				<exit_nb_visits>2</exit_nb_visits>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -1431,8 +1431,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1577,8 +1577,8 @@
 						<max_time_server />
 						<sum_bandwidth>7148</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>7148</min_bandwidth>
-						<max_bandwidth>7148</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>2</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2167,8 +2167,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2208,8 +2208,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -2237,10 +2237,10 @@
 				<exit_nb_visits_change_from>-50%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>+100%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>-50%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>+100%</max_bandwidth_change>
-				<max_bandwidth_change_from>-50%</max_bandwidth_change_from>
-				<min_bandwidth_change>+100%</min_bandwidth_change>
-				<min_bandwidth_change_from>-50%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>+100%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>-50%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -2411,8 +2411,8 @@
 				<entry_bounce_count>2</entry_bounce_count>
 				<exit_nb_visits>2</exit_nb_visits>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -2497,8 +2497,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -3131,8 +3131,8 @@
 		<max_time_server />
 		<sum_bandwidth>7148</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>7148</min_bandwidth>
-		<max_bandwidth>7148</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -3178,8 +3178,8 @@
 				<sum_daily_entry_nb_uniq_visitors>2</sum_daily_entry_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>2</sum_daily_exit_nb_uniq_visitors>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -8392,8 +8392,8 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<sum_bandwidth>182</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>182</min_bandwidth>
@@ -8431,8 +8431,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>1</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -8580,8 +8580,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>1</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -8752,8 +8752,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<sum_bandwidth>182</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>182</min_bandwidth>
@@ -8788,8 +8788,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -8812,8 +8812,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -8839,8 +8839,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<sum_bandwidth>182</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>182</min_bandwidth>
@@ -8878,8 +8878,8 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.001</min_time_server>
-								<max_time_server>0.001</max_time_server>
+								<min_time_server>0.0010</min_time_server>
+								<max_time_server>0.0010</max_time_server>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>1</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -8905,8 +8905,8 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.001</min_time_server>
-								<max_time_server>0.001</max_time_server>
+								<min_time_server>0.0010</min_time_server>
+								<max_time_server>0.0010</max_time_server>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>1</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_labelFilter__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_labelFilter__Actions.getPageUrls_month.xml
@@ -10,8 +10,8 @@
 		<max_time_server />
 		<sum_bandwidth>39314</sum_bandwidth>
 		<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-		<min_bandwidth>21444</min_bandwidth>
-		<max_bandwidth>21444</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>11</entry_nb_visits>
 		<entry_nb_actions>11</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -51,8 +51,8 @@
 				<entry_bounce_count>11</entry_bounce_count>
 				<exit_nb_visits>11</exit_nb_visits>
 				<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-				<max_bandwidth>21444</max_bandwidth>
-				<min_bandwidth>21444</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>39314</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -105,10 +105,10 @@
 				<exit_nb_visits_change_from>+1,000%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-90.9%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+1,000%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-83.3%</max_bandwidth_change>
-				<max_bandwidth_change_from>+500%</max_bandwidth_change_from>
-				<min_bandwidth_change>-83.3%</min_bandwidth_change>
-				<min_bandwidth_change_from>+500%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-90.9%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+1,000%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -142,8 +142,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -183,8 +183,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_multipleMultiPeriods__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_multipleMultiPeriods__Actions.getPageUrls_day.xml
@@ -8,8 +8,8 @@
 			<sum_time_spent>0</sum_time_spent>
 			<sum_bandwidth>14296</sum_bandwidth>
 			<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-			<min_bandwidth>7148</min_bandwidth>
-			<max_bandwidth>7148</max_bandwidth>
+			<min_bandwidth>3574</min_bandwidth>
+			<max_bandwidth>3574</max_bandwidth>
 			<entry_nb_visits>4</entry_nb_visits>
 			<entry_nb_actions>4</entry_nb_actions>
 			<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -47,8 +47,8 @@
 					<entry_bounce_count>4</entry_bounce_count>
 					<exit_nb_visits>4</exit_nb_visits>
 					<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>14296</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>
@@ -128,8 +128,8 @@
 					<entry_bounce_count>4</entry_bounce_count>
 					<exit_nb_visits>4</exit_nb_visits>
 					<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>14296</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>
@@ -493,8 +493,8 @@
 					<sum_time_spent>0</sum_time_spent>
 					<sum_bandwidth>14296</sum_bandwidth>
 					<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
 					<entry_nb_visits>4</entry_nb_visits>
 					<entry_nb_actions>4</entry_nb_actions>
 					<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -911,8 +911,8 @@
 			<sum_time_spent>0</sum_time_spent>
 			<sum_bandwidth>10722</sum_bandwidth>
 			<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-			<min_bandwidth>10722</min_bandwidth>
-			<max_bandwidth>10722</max_bandwidth>
+			<min_bandwidth>3574</min_bandwidth>
+			<max_bandwidth>3574</max_bandwidth>
 			<entry_nb_visits>3</entry_nb_visits>
 			<entry_nb_actions>3</entry_nb_actions>
 			<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -950,8 +950,8 @@
 					<entry_bounce_count>3</entry_bounce_count>
 					<exit_nb_visits>3</exit_nb_visits>
 					<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-					<max_bandwidth>10722</max_bandwidth>
-					<min_bandwidth>10722</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>10722</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>
@@ -977,8 +977,8 @@
 					<entry_bounce_count>2</entry_bounce_count>
 					<exit_nb_visits>2</exit_nb_visits>
 					<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>7148</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>
@@ -1031,8 +1031,8 @@
 					<entry_bounce_count>3</entry_bounce_count>
 					<exit_nb_visits>3</exit_nb_visits>
 					<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-					<max_bandwidth>10722</max_bandwidth>
-					<min_bandwidth>10722</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>10722</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>
@@ -1092,8 +1092,8 @@
 					<entry_bounce_count>2</entry_bounce_count>
 					<exit_nb_visits>2</exit_nb_visits>
 					<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>7148</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>
@@ -4369,8 +4369,8 @@
 			<sum_time_spent>0</sum_time_spent>
 			<sum_bandwidth>10722</sum_bandwidth>
 			<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-			<min_bandwidth>7148</min_bandwidth>
-			<max_bandwidth>7148</max_bandwidth>
+			<min_bandwidth>3574</min_bandwidth>
+			<max_bandwidth>3574</max_bandwidth>
 			<entry_nb_visits>3</entry_nb_visits>
 			<entry_nb_actions>3</entry_nb_actions>
 			<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -4408,8 +4408,8 @@
 					<entry_bounce_count>3</entry_bounce_count>
 					<exit_nb_visits>3</exit_nb_visits>
 					<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>10722</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>
@@ -4489,8 +4489,8 @@
 					<entry_bounce_count>3</entry_bounce_count>
 					<exit_nb_visits>3</exit_nb_visits>
 					<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>10722</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>
@@ -5432,8 +5432,8 @@
 			<sum_time_spent>0</sum_time_spent>
 			<sum_bandwidth>7148</sum_bandwidth>
 			<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-			<min_bandwidth>7148</min_bandwidth>
-			<max_bandwidth>7148</max_bandwidth>
+			<min_bandwidth>3574</min_bandwidth>
+			<max_bandwidth>3574</max_bandwidth>
 			<entry_nb_visits>2</entry_nb_visits>
 			<entry_nb_actions>2</entry_nb_actions>
 			<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -5471,8 +5471,8 @@
 					<entry_bounce_count>2</entry_bounce_count>
 					<exit_nb_visits>2</exit_nb_visits>
 					<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>7148</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>
@@ -5552,8 +5552,8 @@
 					<entry_bounce_count>2</entry_bounce_count>
 					<exit_nb_visits>2</exit_nb_visits>
 					<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>7148</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_multipleSites_multipleCompare__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_multipleSites_multipleCompare__Actions.getPageUrls_month.xml
@@ -11,8 +11,8 @@
 			<max_time_server />
 			<sum_bandwidth>39314</sum_bandwidth>
 			<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-			<min_bandwidth>21444</min_bandwidth>
-			<max_bandwidth>21444</max_bandwidth>
+			<min_bandwidth>3574</min_bandwidth>
+			<max_bandwidth>3574</max_bandwidth>
 			<entry_nb_visits>11</entry_nb_visits>
 			<entry_nb_actions>11</entry_nb_actions>
 			<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -52,8 +52,8 @@
 					<entry_bounce_count>11</entry_bounce_count>
 					<exit_nb_visits>11</exit_nb_visits>
 					<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-					<max_bandwidth>21444</max_bandwidth>
-					<min_bandwidth>21444</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>39314</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_time_server>0</avg_time_server>
@@ -140,8 +140,8 @@
 					<entry_bounce_count>3</entry_bounce_count>
 					<exit_nb_visits>3</exit_nb_visits>
 					<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>10722</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>
@@ -166,10 +166,10 @@
 					<exit_nb_visits_change_from>+266.7%</exit_nb_visits_change_from>
 					<nb_hits_with_bandwidth_change>-72.7%</nb_hits_with_bandwidth_change>
 					<nb_hits_with_bandwidth_change_from>+266.7%</nb_hits_with_bandwidth_change_from>
-					<max_bandwidth_change>-66.7%</max_bandwidth_change>
-					<max_bandwidth_change_from>+200%</max_bandwidth_change_from>
-					<min_bandwidth_change>-66.7%</min_bandwidth_change>
-					<min_bandwidth_change_from>+200%</min_bandwidth_change_from>
+					<max_bandwidth_change>+0%</max_bandwidth_change>
+					<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+					<min_bandwidth_change>+0%</min_bandwidth_change>
+					<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 					<sum_bandwidth_change>-72.7%</sum_bandwidth_change>
 					<sum_bandwidth_change_from>+266.7%</sum_bandwidth_change_from>
 					<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -367,10 +367,10 @@
 					<exit_nb_visits_change_from>+1,000%</exit_nb_visits_change_from>
 					<nb_hits_with_bandwidth_change>-90.9%</nb_hits_with_bandwidth_change>
 					<nb_hits_with_bandwidth_change_from>+1,000%</nb_hits_with_bandwidth_change_from>
-					<max_bandwidth_change>-83.3%</max_bandwidth_change>
-					<max_bandwidth_change_from>+500%</max_bandwidth_change_from>
-					<min_bandwidth_change>-83.3%</min_bandwidth_change>
-					<min_bandwidth_change_from>+500%</min_bandwidth_change_from>
+					<max_bandwidth_change>+0%</max_bandwidth_change>
+					<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+					<min_bandwidth_change>+0%</min_bandwidth_change>
+					<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 					<sum_bandwidth_change>-90.9%</sum_bandwidth_change>
 					<sum_bandwidth_change_from>+1,000%</sum_bandwidth_change_from>
 					<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -544,8 +544,8 @@
 					<max_time_server />
 					<sum_bandwidth>35740</sum_bandwidth>
 					<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-					<min_bandwidth>17870</min_bandwidth>
-					<max_bandwidth>17870</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
 					<entry_nb_visits>10</entry_nb_visits>
 					<entry_nb_actions>10</entry_nb_actions>
 					<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -647,8 +647,8 @@
 							<max_time_server />
 							<sum_bandwidth>32166</sum_bandwidth>
 							<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-							<min_bandwidth>14296</min_bandwidth>
-							<max_bandwidth>14296</max_bandwidth>
+							<min_bandwidth>3574</min_bandwidth>
+							<max_bandwidth>3574</max_bandwidth>
 							<entry_nb_visits>9</entry_nb_visits>
 							<entry_nb_actions>9</entry_nb_actions>
 							<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -750,8 +750,8 @@
 									<max_time_server />
 									<sum_bandwidth>32166</sum_bandwidth>
 									<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-									<min_bandwidth>14296</min_bandwidth>
-									<max_bandwidth>14296</max_bandwidth>
+									<min_bandwidth>3574</min_bandwidth>
+									<max_bandwidth>3574</max_bandwidth>
 									<entry_nb_visits>9</entry_nb_visits>
 									<entry_nb_actions>9</entry_nb_actions>
 									<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1428,8 +1428,8 @@
 			<max_time_server />
 			<sum_bandwidth>14296</sum_bandwidth>
 			<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-			<min_bandwidth>14296</min_bandwidth>
-			<max_bandwidth>14296</max_bandwidth>
+			<min_bandwidth>3574</min_bandwidth>
+			<max_bandwidth>3574</max_bandwidth>
 			<entry_nb_visits>4</entry_nb_visits>
 			<entry_nb_actions>4</entry_nb_actions>
 			<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1469,8 +1469,8 @@
 					<entry_bounce_count>4</entry_bounce_count>
 					<exit_nb_visits>4</exit_nb_visits>
 					<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-					<max_bandwidth>14296</max_bandwidth>
-					<min_bandwidth>14296</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>14296</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_time_server>0</avg_time_server>
@@ -1497,8 +1497,8 @@
 					<entry_bounce_count>2</entry_bounce_count>
 					<exit_nb_visits>2</exit_nb_visits>
 					<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>7148</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>
@@ -1579,10 +1579,10 @@
 					<exit_nb_visits_change_from>+300%</exit_nb_visits_change_from>
 					<nb_hits_with_bandwidth_change>-75%</nb_hits_with_bandwidth_change>
 					<nb_hits_with_bandwidth_change_from>+300%</nb_hits_with_bandwidth_change_from>
-					<max_bandwidth_change>-75%</max_bandwidth_change>
-					<max_bandwidth_change_from>+300%</max_bandwidth_change_from>
-					<min_bandwidth_change>-75%</min_bandwidth_change>
-					<min_bandwidth_change_from>+300%</min_bandwidth_change_from>
+					<max_bandwidth_change>+0%</max_bandwidth_change>
+					<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+					<min_bandwidth_change>+0%</min_bandwidth_change>
+					<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 					<sum_bandwidth_change>-75%</sum_bandwidth_change>
 					<sum_bandwidth_change_from>+300%</sum_bandwidth_change_from>
 					<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -1957,8 +1957,8 @@
 					<max_time_server />
 					<sum_bandwidth>7148</sum_bandwidth>
 					<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
 					<entry_nb_visits>2</entry_nb_visits>
 					<entry_nb_actions>2</entry_nb_actions>
 					<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2103,8 +2103,8 @@
 							<max_time_server />
 							<sum_bandwidth>7148</sum_bandwidth>
 							<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-							<min_bandwidth>7148</min_bandwidth>
-							<max_bandwidth>7148</max_bandwidth>
+							<min_bandwidth>3574</min_bandwidth>
+							<max_bandwidth>3574</max_bandwidth>
 							<entry_nb_visits>2</entry_nb_visits>
 							<entry_nb_actions>2</entry_nb_actions>
 							<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2693,8 +2693,8 @@
 			<max_time_server />
 			<sum_bandwidth>14296</sum_bandwidth>
 			<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-			<min_bandwidth>14296</min_bandwidth>
-			<max_bandwidth>14296</max_bandwidth>
+			<min_bandwidth>3574</min_bandwidth>
+			<max_bandwidth>3574</max_bandwidth>
 			<entry_nb_visits>4</entry_nb_visits>
 			<entry_nb_actions>4</entry_nb_actions>
 			<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2734,8 +2734,8 @@
 					<entry_bounce_count>4</entry_bounce_count>
 					<exit_nb_visits>4</exit_nb_visits>
 					<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-					<max_bandwidth>14296</max_bandwidth>
-					<min_bandwidth>14296</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>14296</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_time_server>0</avg_time_server>
@@ -2821,8 +2821,8 @@
 					<entry_bounce_count>2</entry_bounce_count>
 					<exit_nb_visits>2</exit_nb_visits>
 					<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>7148</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_page_load_time>0</avg_page_load_time>
@@ -2847,10 +2847,10 @@
 					<exit_nb_visits_change_from>+100%</exit_nb_visits_change_from>
 					<nb_hits_with_bandwidth_change>-50%</nb_hits_with_bandwidth_change>
 					<nb_hits_with_bandwidth_change_from>+100%</nb_hits_with_bandwidth_change_from>
-					<max_bandwidth_change>-50%</max_bandwidth_change>
-					<max_bandwidth_change_from>+100%</max_bandwidth_change_from>
-					<min_bandwidth_change>-50%</min_bandwidth_change>
-					<min_bandwidth_change_from>+100%</min_bandwidth_change_from>
+					<max_bandwidth_change>+0%</max_bandwidth_change>
+					<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+					<min_bandwidth_change>+0%</min_bandwidth_change>
+					<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 					<sum_bandwidth_change>-50%</sum_bandwidth_change>
 					<sum_bandwidth_change_from>+100%</sum_bandwidth_change_from>
 					<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -3225,8 +3225,8 @@
 					<max_time_server />
 					<sum_bandwidth>7148</sum_bandwidth>
 					<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
 					<entry_nb_visits>2</entry_nb_visits>
 					<entry_nb_actions>2</entry_nb_actions>
 					<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -3859,8 +3859,8 @@
 			<max_time_server />
 			<sum_bandwidth>7148</sum_bandwidth>
 			<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-			<min_bandwidth>7148</min_bandwidth>
-			<max_bandwidth>7148</max_bandwidth>
+			<min_bandwidth>3574</min_bandwidth>
+			<max_bandwidth>3574</max_bandwidth>
 			<entry_nb_visits>2</entry_nb_visits>
 			<entry_nb_actions>2</entry_nb_actions>
 			<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -3906,8 +3906,8 @@
 					<sum_daily_entry_nb_uniq_visitors>2</sum_daily_entry_nb_uniq_visitors>
 					<sum_daily_exit_nb_uniq_visitors>2</sum_daily_exit_nb_uniq_visitors>
 					<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-					<max_bandwidth>7148</max_bandwidth>
-					<min_bandwidth>7148</min_bandwidth>
+					<max_bandwidth>3574</max_bandwidth>
+					<min_bandwidth>3574</min_bandwidth>
 					<sum_bandwidth>7148</sum_bandwidth>
 					<avg_bandwidth>3574</avg_bandwidth>
 					<avg_time_server>0</avg_time_server>
@@ -11726,8 +11726,8 @@
 			<nb_hits>1</nb_hits>
 			<sum_time_spent>0</sum_time_spent>
 			<nb_hits_with_time_server>1</nb_hits_with_time_server>
-			<min_time_server>0.001</min_time_server>
-			<max_time_server>0.001</max_time_server>
+			<min_time_server>0.0010</min_time_server>
+			<max_time_server>0.0010</max_time_server>
 			<sum_bandwidth>182</sum_bandwidth>
 			<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 			<min_bandwidth>182</min_bandwidth>
@@ -11765,8 +11765,8 @@
 					<nb_hits>1</nb_hits>
 					<sum_time_spent>0</sum_time_spent>
 					<nb_hits_with_time_server>1</nb_hits_with_time_server>
-					<min_time_server>0.001</min_time_server>
-					<max_time_server>0.001</max_time_server>
+					<min_time_server>0.0010</min_time_server>
+					<max_time_server>0.0010</max_time_server>
 					<entry_nb_visits>1</entry_nb_visits>
 					<entry_nb_actions>1</entry_nb_actions>
 					<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -11828,8 +11828,8 @@
 					<nb_hits>1</nb_hits>
 					<sum_time_spent>0</sum_time_spent>
 					<nb_hits_with_time_server>1</nb_hits_with_time_server>
-					<min_time_server>0.001</min_time_server>
-					<max_time_server>0.001</max_time_server>
+					<min_time_server>0.0010</min_time_server>
+					<max_time_server>0.0010</max_time_server>
 					<entry_nb_visits>1</entry_nb_visits>
 					<entry_nb_actions>1</entry_nb_actions>
 					<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -12318,8 +12318,8 @@
 					<nb_hits>1</nb_hits>
 					<sum_time_spent>0</sum_time_spent>
 					<nb_hits_with_time_server>1</nb_hits_with_time_server>
-					<min_time_server>0.001</min_time_server>
-					<max_time_server>0.001</max_time_server>
+					<min_time_server>0.0010</min_time_server>
+					<max_time_server>0.0010</max_time_server>
 					<sum_bandwidth>182</sum_bandwidth>
 					<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 					<min_bandwidth>182</min_bandwidth>
@@ -12354,8 +12354,8 @@
 							<nb_hits>1</nb_hits>
 							<sum_time_spent>0</sum_time_spent>
 							<nb_hits_with_time_server>1</nb_hits_with_time_server>
-							<min_time_server>0.001</min_time_server>
-							<max_time_server>0.001</max_time_server>
+							<min_time_server>0.0010</min_time_server>
+							<max_time_server>0.0010</max_time_server>
 							<entry_nb_visits>1</entry_nb_visits>
 							<entry_nb_actions>1</entry_nb_actions>
 							<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -12378,8 +12378,8 @@
 							<nb_hits>1</nb_hits>
 							<sum_time_spent>0</sum_time_spent>
 							<nb_hits_with_time_server>1</nb_hits_with_time_server>
-							<min_time_server>0.001</min_time_server>
-							<max_time_server>0.001</max_time_server>
+							<min_time_server>0.0010</min_time_server>
+							<max_time_server>0.0010</max_time_server>
 							<entry_nb_visits>1</entry_nb_visits>
 							<entry_nb_actions>1</entry_nb_actions>
 							<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -12405,8 +12405,8 @@
 							<nb_hits>1</nb_hits>
 							<sum_time_spent>0</sum_time_spent>
 							<nb_hits_with_time_server>1</nb_hits_with_time_server>
-							<min_time_server>0.001</min_time_server>
-							<max_time_server>0.001</max_time_server>
+							<min_time_server>0.0010</min_time_server>
+							<max_time_server>0.0010</max_time_server>
 							<sum_bandwidth>182</sum_bandwidth>
 							<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 							<min_bandwidth>182</min_bandwidth>
@@ -12444,8 +12444,8 @@
 									<nb_hits>1</nb_hits>
 									<sum_time_spent>0</sum_time_spent>
 									<nb_hits_with_time_server>1</nb_hits_with_time_server>
-									<min_time_server>0.001</min_time_server>
-									<max_time_server>0.001</max_time_server>
+									<min_time_server>0.0010</min_time_server>
+									<max_time_server>0.0010</max_time_server>
 									<entry_nb_visits>1</entry_nb_visits>
 									<entry_nb_actions>1</entry_nb_actions>
 									<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -12471,8 +12471,8 @@
 									<nb_hits>1</nb_hits>
 									<sum_time_spent>0</sum_time_spent>
 									<nb_hits_with_time_server>1</nb_hits_with_time_server>
-									<min_time_server>0.001</min_time_server>
-									<max_time_server>0.001</max_time_server>
+									<min_time_server>0.0010</min_time_server>
+									<max_time_server>0.0010</max_time_server>
 									<entry_nb_visits>1</entry_nb_visits>
 									<entry_nb_actions>1</entry_nb_actions>
 									<entry_sum_visit_length>0</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_periods__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_periods__Actions.getPageUrls_month.xml
@@ -10,8 +10,8 @@
 		<max_time_server />
 		<sum_bandwidth>39314</sum_bandwidth>
 		<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-		<min_bandwidth>21444</min_bandwidth>
-		<max_bandwidth>21444</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>11</entry_nb_visits>
 		<entry_nb_actions>11</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -51,8 +51,8 @@
 				<entry_bounce_count>11</entry_bounce_count>
 				<exit_nb_visits>11</exit_nb_visits>
 				<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-				<max_bandwidth>21444</max_bandwidth>
-				<min_bandwidth>21444</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>39314</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -79,8 +79,8 @@
 				<entry_bounce_count>3</entry_bounce_count>
 				<exit_nb_visits>3</exit_nb_visits>
 				<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>10722</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -105,10 +105,10 @@
 				<exit_nb_visits_change_from>+266.7%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-72.7%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+266.7%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-66.7%</max_bandwidth_change>
-				<max_bandwidth_change_from>+200%</max_bandwidth_change_from>
-				<min_bandwidth_change>-66.7%</min_bandwidth_change>
-				<min_bandwidth_change_from>+200%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-72.7%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+266.7%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -166,10 +166,10 @@
 				<exit_nb_visits_change_from>+1,000%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-90.9%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+1,000%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-83.3%</max_bandwidth_change>
-				<max_bandwidth_change_from>+500%</max_bandwidth_change_from>
-				<min_bandwidth_change>-83.3%</min_bandwidth_change>
-				<min_bandwidth_change_from>+500%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-90.9%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+1,000%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -203,8 +203,8 @@
 				<max_time_server />
 				<sum_bandwidth>35740</sum_bandwidth>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<min_bandwidth>17870</min_bandwidth>
-				<max_bandwidth>17870</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>10</entry_nb_visits>
 				<entry_nb_actions>10</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -306,8 +306,8 @@
 						<max_time_server />
 						<sum_bandwidth>32166</sum_bandwidth>
 						<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-						<min_bandwidth>14296</min_bandwidth>
-						<max_bandwidth>14296</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>9</entry_nb_visits>
 						<entry_nb_actions>9</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -409,8 +409,8 @@
 								<max_time_server />
 								<sum_bandwidth>32166</sum_bandwidth>
 								<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-								<min_bandwidth>14296</min_bandwidth>
-								<max_bandwidth>14296</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>9</entry_nb_visits>
 								<entry_nb_actions>9</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1087,8 +1087,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1128,8 +1128,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -1182,10 +1182,10 @@
 				<exit_nb_visits_change_from>+300%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-75%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+300%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-75%</max_bandwidth_change>
-				<max_bandwidth_change_from>+300%</max_bandwidth_change_from>
-				<min_bandwidth_change>-75%</min_bandwidth_change>
-				<min_bandwidth_change_from>+300%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-75%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+300%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -1289,8 +1289,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1371,8 +1371,8 @@
 						<max_time_server />
 						<sum_bandwidth>7148</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>7148</min_bandwidth>
-						<max_bandwidth>7148</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>2</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1723,8 +1723,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1764,8 +1764,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -1792,8 +1792,8 @@
 				<entry_bounce_count>2</entry_bounce_count>
 				<exit_nb_visits>2</exit_nb_visits>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -1818,10 +1818,10 @@
 				<exit_nb_visits_change_from>+100%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-50%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+100%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-50%</max_bandwidth_change>
-				<max_bandwidth_change_from>+100%</max_bandwidth_change_from>
-				<min_bandwidth_change>-50%</min_bandwidth_change>
-				<min_bandwidth_change_from>+100%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-50%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+100%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -1925,8 +1925,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2353,8 +2353,8 @@
 		<max_time_server />
 		<sum_bandwidth>7148</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>7148</min_bandwidth>
-		<max_bandwidth>7148</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2400,8 +2400,8 @@
 				<sum_daily_entry_nb_uniq_visitors>2</sum_daily_entry_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>2</sum_daily_exit_nb_uniq_visitors>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -5959,8 +5959,8 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<sum_bandwidth>182</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>182</min_bandwidth>
@@ -5998,8 +5998,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>1</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -6184,8 +6184,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<sum_bandwidth>182</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>182</min_bandwidth>
@@ -6220,8 +6220,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -6247,8 +6247,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<sum_bandwidth>182</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>182</min_bandwidth>
@@ -6286,8 +6286,8 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.001</min_time_server>
-								<max_time_server>0.001</max_time_server>
+								<min_time_server>0.0010</min_time_server>
+								<max_time_server>0.0010</max_time_server>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>1</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_rangePeriodAgainstSingle__Actions.getPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_rangePeriodAgainstSingle__Actions.getPageUrls_range.xml
@@ -7,8 +7,8 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_bandwidth>35740</sum_bandwidth>
 		<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-		<min_bandwidth>17870</min_bandwidth>
-		<max_bandwidth>17870</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>10</entry_nb_visits>
 		<entry_nb_actions>10</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -46,8 +46,8 @@
 				<entry_bounce_count>10</entry_bounce_count>
 				<exit_nb_visits>10</exit_nb_visits>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<max_bandwidth>17870</max_bandwidth>
-				<min_bandwidth>17870</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>35740</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -127,8 +127,8 @@
 				<entry_bounce_count>3</entry_bounce_count>
 				<exit_nb_visits>3</exit_nb_visits>
 				<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>10722</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -153,10 +153,10 @@
 				<exit_nb_visits_change_from>+233.3%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-70%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+233.3%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-60%</max_bandwidth_change>
-				<max_bandwidth_change_from>+150%</max_bandwidth_change_from>
-				<min_bandwidth_change>-60%</min_bandwidth_change>
-				<min_bandwidth_change_from>+150%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-70%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+233.3%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -336,10 +336,10 @@
 				<exit_nb_visits_change_from>+900%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-90%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+900%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-80%</max_bandwidth_change>
-				<max_bandwidth_change_from>+400%</max_bandwidth_change_from>
-				<min_bandwidth_change>-80%</min_bandwidth_change>
-				<min_bandwidth_change_from>+400%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-90%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+900%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -492,8 +492,8 @@
 				<sum_time_spent>0</sum_time_spent>
 				<sum_bandwidth>32166</sum_bandwidth>
 				<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>9</entry_nb_visits>
 				<entry_nb_actions>9</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -591,8 +591,8 @@
 						<sum_time_spent>0</sum_time_spent>
 						<sum_bandwidth>28592</sum_bandwidth>
 						<nb_hits_with_bandwidth>8</nb_hits_with_bandwidth>
-						<min_bandwidth>10722</min_bandwidth>
-						<max_bandwidth>10722</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>8</entry_nb_visits>
 						<entry_nb_actions>8</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -690,8 +690,8 @@
 								<sum_time_spent>0</sum_time_spent>
 								<sum_bandwidth>28592</sum_bandwidth>
 								<nb_hits_with_bandwidth>8</nb_hits_with_bandwidth>
-								<min_bandwidth>10722</min_bandwidth>
-								<max_bandwidth>10722</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>8</entry_nb_visits>
 								<entry_nb_actions>8</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1334,8 +1334,8 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1373,8 +1373,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -1400,8 +1400,8 @@
 				<entry_bounce_count>2</entry_bounce_count>
 				<exit_nb_visits>2</exit_nb_visits>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -1480,10 +1480,10 @@
 				<exit_nb_visits_change_from>+300%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-75%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+300%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-75%</max_bandwidth_change>
-				<max_bandwidth_change_from>+300%</max_bandwidth_change_from>
-				<min_bandwidth_change>-75%</min_bandwidth_change>
-				<min_bandwidth_change_from>+300%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-75%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+300%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -1819,8 +1819,8 @@
 				<sum_time_spent>0</sum_time_spent>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1960,8 +1960,8 @@
 						<sum_time_spent>0</sum_time_spent>
 						<sum_bandwidth>7148</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>7148</min_bandwidth>
-						<max_bandwidth>7148</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>2</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2519,8 +2519,8 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2558,8 +2558,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -2639,8 +2639,8 @@
 				<entry_bounce_count>2</entry_bounce_count>
 				<exit_nb_visits>2</exit_nb_visits>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -2665,10 +2665,10 @@
 				<exit_nb_visits_change_from>+100%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-50%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+100%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-50%</max_bandwidth_change>
-				<max_bandwidth_change_from>+100%</max_bandwidth_change_from>
-				<min_bandwidth_change>-50%</min_bandwidth_change>
-				<min_bandwidth_change_from>+100%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-50%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+100%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -3004,8 +3004,8 @@
 				<sum_time_spent>0</sum_time_spent>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -3606,8 +3606,8 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_bandwidth>7148</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>7148</min_bandwidth>
-		<max_bandwidth>7148</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -3651,8 +3651,8 @@
 				<sum_daily_entry_nb_uniq_visitors>2</sum_daily_entry_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>2</sum_daily_exit_nb_uniq_visitors>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_segmentsAndPeriods__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_segmentsAndPeriods__Actions.getPageUrls_month.xml
@@ -10,8 +10,8 @@
 		<max_time_server />
 		<sum_bandwidth>39314</sum_bandwidth>
 		<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-		<min_bandwidth>21444</min_bandwidth>
-		<max_bandwidth>21444</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>11</entry_nb_visits>
 		<entry_nb_actions>11</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -51,8 +51,8 @@
 				<entry_bounce_count>11</entry_bounce_count>
 				<exit_nb_visits>11</exit_nb_visits>
 				<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-				<max_bandwidth>21444</max_bandwidth>
-				<min_bandwidth>21444</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>39314</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -139,8 +139,8 @@
 				<entry_bounce_count>3</entry_bounce_count>
 				<exit_nb_visits>3</exit_nb_visits>
 				<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>10722</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -165,10 +165,10 @@
 				<exit_nb_visits_change_from>+266.7%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-72.7%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+266.7%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-66.7%</max_bandwidth_change>
-				<max_bandwidth_change_from>+200%</max_bandwidth_change_from>
-				<min_bandwidth_change>-66.7%</min_bandwidth_change>
-				<min_bandwidth_change_from>+200%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-72.7%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+266.7%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -366,10 +366,10 @@
 				<exit_nb_visits_change_from>+1,000%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-90.9%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+1,000%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-83.3%</max_bandwidth_change>
-				<max_bandwidth_change_from>+500%</max_bandwidth_change_from>
-				<min_bandwidth_change>-83.3%</min_bandwidth_change>
-				<min_bandwidth_change_from>+500%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-90.9%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+1,000%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -543,8 +543,8 @@
 				<max_time_server />
 				<sum_bandwidth>35740</sum_bandwidth>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<min_bandwidth>17870</min_bandwidth>
-				<max_bandwidth>17870</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>10</entry_nb_visits>
 				<entry_nb_actions>10</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -646,8 +646,8 @@
 						<max_time_server />
 						<sum_bandwidth>32166</sum_bandwidth>
 						<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-						<min_bandwidth>14296</min_bandwidth>
-						<max_bandwidth>14296</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>9</entry_nb_visits>
 						<entry_nb_actions>9</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -749,8 +749,8 @@
 								<max_time_server />
 								<sum_bandwidth>32166</sum_bandwidth>
 								<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-								<min_bandwidth>14296</min_bandwidth>
-								<max_bandwidth>14296</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>9</entry_nb_visits>
 								<entry_nb_actions>9</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1427,8 +1427,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1468,8 +1468,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -1496,8 +1496,8 @@
 				<entry_bounce_count>2</entry_bounce_count>
 				<exit_nb_visits>2</exit_nb_visits>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -1578,10 +1578,10 @@
 				<exit_nb_visits_change_from>+300%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-75%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+300%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-75%</max_bandwidth_change>
-				<max_bandwidth_change_from>+300%</max_bandwidth_change_from>
-				<min_bandwidth_change>-75%</min_bandwidth_change>
-				<min_bandwidth_change_from>+300%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-75%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+300%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -1956,8 +1956,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2102,8 +2102,8 @@
 						<max_time_server />
 						<sum_bandwidth>7148</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>7148</min_bandwidth>
-						<max_bandwidth>7148</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>2</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2692,8 +2692,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2733,8 +2733,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -2820,8 +2820,8 @@
 				<entry_bounce_count>2</entry_bounce_count>
 				<exit_nb_visits>2</exit_nb_visits>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -2846,10 +2846,10 @@
 				<exit_nb_visits_change_from>+100%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-50%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+100%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-50%</max_bandwidth_change>
-				<max_bandwidth_change_from>+100%</max_bandwidth_change_from>
-				<min_bandwidth_change>-50%</min_bandwidth_change>
-				<min_bandwidth_change_from>+100%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-50%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+100%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -3224,8 +3224,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -3858,8 +3858,8 @@
 		<max_time_server />
 		<sum_bandwidth>7148</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>7148</min_bandwidth>
-		<max_bandwidth>7148</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -3905,8 +3905,8 @@
 				<sum_daily_entry_nb_uniq_visitors>2</sum_daily_entry_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>2</sum_daily_exit_nb_uniq_visitors>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -11725,8 +11725,8 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<sum_bandwidth>182</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>182</min_bandwidth>
@@ -11764,8 +11764,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>1</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -11827,8 +11827,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>1</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -12317,8 +12317,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<sum_bandwidth>182</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>182</min_bandwidth>
@@ -12353,8 +12353,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -12377,8 +12377,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -12404,8 +12404,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<sum_bandwidth>182</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>182</min_bandwidth>
@@ -12443,8 +12443,8 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.001</min_time_server>
-								<max_time_server>0.001</max_time_server>
+								<min_time_server>0.0010</min_time_server>
+								<max_time_server>0.0010</max_time_server>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>1</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -12470,8 +12470,8 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.001</min_time_server>
-								<max_time_server>0.001</max_time_server>
+								<min_time_server>0.0010</min_time_server>
+								<max_time_server>0.0010</max_time_server>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>1</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_segments__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_segments__Actions.getPageUrls_month.xml
@@ -10,8 +10,8 @@
 		<max_time_server />
 		<sum_bandwidth>39314</sum_bandwidth>
 		<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-		<min_bandwidth>21444</min_bandwidth>
-		<max_bandwidth>21444</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>11</entry_nb_visits>
 		<entry_nb_actions>11</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -51,8 +51,8 @@
 				<entry_bounce_count>11</entry_bounce_count>
 				<exit_nb_visits>11</exit_nb_visits>
 				<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-				<max_bandwidth>21444</max_bandwidth>
-				<min_bandwidth>21444</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>39314</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -141,8 +141,8 @@
 				<max_time_server />
 				<sum_bandwidth>35740</sum_bandwidth>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<min_bandwidth>17870</min_bandwidth>
-				<max_bandwidth>17870</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>10</entry_nb_visits>
 				<entry_nb_actions>10</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -202,8 +202,8 @@
 						<max_time_server />
 						<sum_bandwidth>32166</sum_bandwidth>
 						<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-						<min_bandwidth>14296</min_bandwidth>
-						<max_bandwidth>14296</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>9</entry_nb_visits>
 						<entry_nb_actions>9</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -263,8 +263,8 @@
 								<max_time_server />
 								<sum_bandwidth>32166</sum_bandwidth>
 								<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-								<min_bandwidth>14296</min_bandwidth>
-								<max_bandwidth>14296</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>9</entry_nb_visits>
 								<entry_nb_actions>9</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -725,8 +725,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -766,8 +766,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -794,8 +794,8 @@
 				<entry_bounce_count>2</entry_bounce_count>
 				<exit_nb_visits>2</exit_nb_visits>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -852,8 +852,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -956,8 +956,8 @@
 						<max_time_server />
 						<sum_bandwidth>7148</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>7148</min_bandwidth>
-						<max_bandwidth>7148</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>2</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1384,8 +1384,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1425,8 +1425,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -1514,8 +1514,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1950,8 +1950,8 @@
 		<max_time_server />
 		<sum_bandwidth>7148</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>7148</min_bandwidth>
-		<max_bandwidth>7148</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1997,8 +1997,8 @@
 				<sum_daily_entry_nb_uniq_visitors>2</sum_daily_entry_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>2</sum_daily_exit_nb_uniq_visitors>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_time_server>0</avg_time_server>
@@ -4561,8 +4561,8 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<sum_bandwidth>182</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>182</min_bandwidth>
@@ -4600,8 +4600,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>1</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -4663,8 +4663,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>1</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -4697,8 +4697,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<sum_bandwidth>182</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>182</min_bandwidth>
@@ -4733,8 +4733,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -4757,8 +4757,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -4784,8 +4784,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<sum_bandwidth>182</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>182</min_bandwidth>
@@ -4823,8 +4823,8 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.001</min_time_server>
-								<max_time_server>0.001</max_time_server>
+								<min_time_server>0.0010</min_time_server>
+								<max_time_server>0.0010</max_time_server>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>1</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -4850,8 +4850,8 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.001</min_time_server>
-								<max_time_server>0.001</max_time_server>
+								<min_time_server>0.0010</min_time_server>
+								<max_time_server>0.0010</max_time_server>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>1</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_singleAgainstRange__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_singleAgainstRange__Actions.getPageUrls_day.xml
@@ -7,8 +7,8 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_bandwidth>10722</sum_bandwidth>
 		<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-		<min_bandwidth>7148</min_bandwidth>
-		<max_bandwidth>7148</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>3</entry_nb_visits>
 		<entry_nb_actions>3</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -46,8 +46,8 @@
 				<entry_bounce_count>3</entry_bounce_count>
 				<exit_nb_visits>3</exit_nb_visits>
 				<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>10722</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -73,8 +73,8 @@
 				<entry_bounce_count>10</entry_bounce_count>
 				<exit_nb_visits>10</exit_nb_visits>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<max_bandwidth>17870</max_bandwidth>
-				<min_bandwidth>17870</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>35740</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -99,10 +99,10 @@
 				<exit_nb_visits_change_from>-70%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>+233.3%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>-70%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>+150%</max_bandwidth_change>
-				<max_bandwidth_change_from>-60%</max_bandwidth_change_from>
-				<min_bandwidth_change>+150%</min_bandwidth_change>
-				<min_bandwidth_change_from>-60%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>+233.3%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>-70%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -711,8 +711,8 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_bandwidth>7148</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>7148</min_bandwidth>
-		<max_bandwidth>7148</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -750,8 +750,8 @@
 				<entry_bounce_count>2</entry_bounce_count>
 				<exit_nb_visits>2</exit_nb_visits>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>7148</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -777,8 +777,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -803,10 +803,10 @@
 				<exit_nb_visits_change_from>-50%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>+100%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>-50%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>+100%</max_bandwidth_change>
-				<max_bandwidth_change_from>-50%</max_bandwidth_change_from>
-				<min_bandwidth_change>+100%</min_bandwidth_change>
-				<min_bandwidth_change_from>-50%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>+100%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>-50%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -1161,8 +1161,8 @@
 				<entry_bounce_count>4</entry_bounce_count>
 				<exit_nb_visits>4</exit_nb_visits>
 				<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>14296</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -1187,10 +1187,10 @@
 				<exit_nb_visits_change_from>-75%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>+300%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>-75%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>+300%</max_bandwidth_change>
-				<max_bandwidth_change_from>-75%</max_bandwidth_change_from>
-				<min_bandwidth_change>+300%</min_bandwidth_change>
-				<min_bandwidth_change_from>-75%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>+300%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>-75%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_subtableActions__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_subtableActions__Actions.getPageUrls_month.xml
@@ -7,8 +7,8 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_bandwidth>35740</sum_bandwidth>
 		<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-		<min_bandwidth>17870</min_bandwidth>
-		<max_bandwidth>17870</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>10</entry_nb_visits>
 		<entry_nb_actions>10</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -46,8 +46,8 @@
 				<entry_bounce_count>10</entry_bounce_count>
 				<exit_nb_visits>10</exit_nb_visits>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<max_bandwidth>17870</max_bandwidth>
-				<min_bandwidth>17870</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
 				<sum_bandwidth>35740</sum_bandwidth>
 				<avg_bandwidth>3574</avg_bandwidth>
 				<avg_page_load_time>0</avg_page_load_time>
@@ -153,10 +153,10 @@
 				<exit_nb_visits_change_from>+400%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-80%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+400%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-80%</max_bandwidth_change>
-				<max_bandwidth_change_from>+400%</max_bandwidth_change_from>
-				<min_bandwidth_change>-80%</min_bandwidth_change>
-				<min_bandwidth_change_from>+400%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-80%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+400%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -336,10 +336,10 @@
 				<exit_nb_visits_change_from>+900%</exit_nb_visits_change_from>
 				<nb_hits_with_bandwidth_change>-90%</nb_hits_with_bandwidth_change>
 				<nb_hits_with_bandwidth_change_from>+900%</nb_hits_with_bandwidth_change_from>
-				<max_bandwidth_change>-80%</max_bandwidth_change>
-				<max_bandwidth_change_from>+400%</max_bandwidth_change_from>
-				<min_bandwidth_change>-80%</min_bandwidth_change>
-				<min_bandwidth_change_from>+400%</min_bandwidth_change_from>
+				<max_bandwidth_change>+0%</max_bandwidth_change>
+				<max_bandwidth_change_from>+0%</max_bandwidth_change_from>
+				<min_bandwidth_change>+0%</min_bandwidth_change>
+				<min_bandwidth_change_from>+0%</min_bandwidth_change_from>
 				<sum_bandwidth_change>-90%</sum_bandwidth_change>
 				<sum_bandwidth_change_from>+900%</sum_bandwidth_change_from>
 				<avg_bandwidth_change>+0%</avg_bandwidth_change>
@@ -492,8 +492,8 @@
 				<sum_time_spent>0</sum_time_spent>
 				<sum_bandwidth>32166</sum_bandwidth>
 				<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-				<min_bandwidth>14296</min_bandwidth>
-				<max_bandwidth>14296</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>9</entry_nb_visits>
 				<entry_nb_actions>9</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -591,8 +591,8 @@
 						<sum_time_spent>0</sum_time_spent>
 						<sum_bandwidth>32166</sum_bandwidth>
 						<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-						<min_bandwidth>14296</min_bandwidth>
-						<max_bandwidth>14296</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>9</entry_nb_visits>
 						<entry_nb_actions>9</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageTitles_month.xml
@@ -49,8 +49,8 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.359</min_time_server>
-		<max_time_server>0.359</max_time_server>
+		<min_time_server>0.3590</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageTitles_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageTitles_range.xml
@@ -6,27 +6,27 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>34</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.067</min_time_network>
-		<max_time_network>0.067</max_time_network>
+		<min_time_network>0.0260</min_time_network>
+		<max_time_network>0.0410</max_time_network>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.116</min_time_server>
-		<max_time_server>0.116</max_time_server>
+		<min_time_server>0.0580</min_time_server>
+		<max_time_server>0.0580</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.521</min_time_transfer>
-		<max_time_transfer>0.521</max_time_transfer>
+		<min_time_transfer>0.1550</min_time_transfer>
+		<max_time_transfer>0.3660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.654</min_time_dom_processing>
-		<max_time_dom_processing>0.654</max_time_dom_processing>
+		<min_time_dom_processing>0.2550</min_time_dom_processing>
+		<max_time_dom_processing>0.3990</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.7</min_time_dom_completion>
-		<max_time_dom_completion>0.7</max_time_dom_completion>
+		<min_time_dom_completion>0.1550</min_time_dom_completion>
+		<max_time_dom_completion>0.5450</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.135</min_time_on_load>
-		<max_time_on_load>0.135</max_time_on_load>
+		<min_time_on_load>0.0450</min_time_on_load>
+		<max_time_on_load>0.0900</max_time_on_load>
 		<sum_bandwidth>172</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>43</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>7</entry_nb_actions>
 		<entry_sum_visit_length>44</entry_sum_visit_length>
@@ -135,8 +135,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.359</min_time_server>
-		<max_time_server>0.359</max_time_server>
+		<min_time_server>0.3590</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -195,23 +195,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.355</min_time_server>
-		<max_time_server>0.355</max_time_server>
+		<min_time_server>0.3550</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.099</min_time_transfer>
-		<max_time_transfer>0.099</max_time_transfer>
+		<min_time_transfer>0.0990</min_time_transfer>
+		<max_time_transfer>0.0990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.341</min_time_dom_processing>
-		<max_time_dom_processing>0.341</max_time_dom_processing>
+		<min_time_dom_processing>0.3410</min_time_dom_processing>
+		<max_time_dom_processing>0.3410</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2</min_time_dom_completion>
-		<max_time_dom_completion>0.2</max_time_dom_completion>
+		<min_time_dom_completion>0.2000</min_time_dom_completion>
+		<max_time_dom_completion>0.2000</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.11</min_time_on_load>
-		<max_time_on_load>0.11</max_time_on_load>
+		<min_time_on_load>0.1100</min_time_on_load>
+		<max_time_on_load>0.1100</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -632,23 +632,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.013</min_time_network>
-		<max_time_network>0.013</max_time_network>
+		<min_time_network>0.0130</min_time_network>
+		<max_time_network>0.0130</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.121</min_time_server>
-		<max_time_server>0.121</max_time_server>
+		<min_time_server>0.1210</min_time_server>
+		<max_time_server>0.1210</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.244</min_time_transfer>
-		<max_time_transfer>0.244</max_time_transfer>
+		<min_time_transfer>0.2440</min_time_transfer>
+		<max_time_transfer>0.2440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.345</min_time_dom_processing>
-		<max_time_dom_processing>0.345</max_time_dom_processing>
+		<min_time_dom_processing>0.3450</min_time_dom_processing>
+		<max_time_dom_processing>0.3450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.09</min_time_dom_completion>
-		<max_time_dom_completion>0.09</max_time_dom_completion>
+		<min_time_dom_completion>0.0900</min_time_dom_completion>
+		<max_time_dom_completion>0.0900</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -821,23 +821,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.01</min_time_network>
-		<max_time_network>0.01</max_time_network>
+		<min_time_network>0.0100</min_time_network>
+		<max_time_network>0.0100</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.096</min_time_server>
-		<max_time_server>0.096</max_time_server>
+		<min_time_server>0.0960</min_time_server>
+		<max_time_server>0.0960</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.232</min_time_transfer>
-		<max_time_transfer>0.232</max_time_transfer>
+		<min_time_transfer>0.2320</min_time_transfer>
+		<max_time_transfer>0.2320</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.312</min_time_dom_processing>
-		<max_time_dom_processing>0.312</max_time_dom_processing>
+		<min_time_dom_processing>0.3120</min_time_dom_processing>
+		<max_time_dom_processing>0.3120</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.255</min_time_dom_completion>
-		<max_time_dom_completion>0.255</max_time_dom_completion>
+		<min_time_dom_completion>0.2550</min_time_dom_completion>
+		<max_time_dom_completion>0.2550</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_month.xml
@@ -10,8 +10,8 @@
 		<max_time_server />
 		<sum_bandwidth>39314</sum_bandwidth>
 		<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-		<min_bandwidth>21444</min_bandwidth>
-		<max_bandwidth>21444</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>11</entry_nb_visits>
 		<entry_nb_actions>11</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -50,8 +50,8 @@
 				<max_time_server />
 				<sum_bandwidth>35740</sum_bandwidth>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<min_bandwidth>17870</min_bandwidth>
-				<max_bandwidth>17870</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>10</entry_nb_visits>
 				<entry_nb_actions>10</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -87,8 +87,8 @@
 						<max_time_server />
 						<sum_bandwidth>32166</sum_bandwidth>
 						<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-						<min_bandwidth>14296</min_bandwidth>
-						<max_bandwidth>14296</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>9</entry_nb_visits>
 						<entry_nb_actions>9</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -124,8 +124,8 @@
 								<max_time_server />
 								<sum_bandwidth>32166</sum_bandwidth>
 								<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-								<min_bandwidth>14296</min_bandwidth>
-								<max_bandwidth>14296</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>9</entry_nb_visits>
 								<entry_nb_actions>9</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -409,8 +409,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -449,8 +449,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -486,8 +486,8 @@
 						<max_time_server />
 						<sum_bandwidth>7148</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>7148</min_bandwidth>
-						<max_bandwidth>7148</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>2</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -652,8 +652,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -692,8 +692,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -891,12 +891,12 @@
 		<nb_hits>3</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<sum_bandwidth>8063</sum_bandwidth>
 		<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-		<min_bandwidth>8063</min_bandwidth>
-		<max_bandwidth>8063</max_bandwidth>
+		<min_bandwidth>915</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>3</entry_nb_visits>
 		<entry_nb_actions>3</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -935,8 +935,8 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>4</nb_hits_with_time_server>
-		<min_time_server>0.718</min_time_server>
-		<max_time_server>0.718</max_time_server>
+		<min_time_server>0.3590</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -975,8 +975,8 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.359</min_time_server>
-				<max_time_server>0.359</max_time_server>
+				<min_time_server>0.3590</min_time_server>
+				<max_time_server>0.3590</max_time_server>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -1012,8 +1012,8 @@
 						<nb_hits>2</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.359</min_time_server>
-						<max_time_server>0.359</max_time_server>
+						<min_time_server>0.3590</min_time_server>
+						<max_time_server>0.3590</max_time_server>
 						<sum_bandwidth>0</sum_bandwidth>
 						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 						<min_bandwidth />
@@ -1055,8 +1055,8 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.359</min_time_server>
-				<max_time_server>0.359</max_time_server>
+				<min_time_server>0.3590</min_time_server>
+				<max_time_server>0.3590</max_time_server>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -1092,8 +1092,8 @@
 						<nb_hits>2</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.359</min_time_server>
-						<max_time_server>0.359</max_time_server>
+						<min_time_server>0.3590</min_time_server>
+						<max_time_server>0.3590</max_time_server>
 						<sum_bandwidth>0</sum_bandwidth>
 						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 						<min_bandwidth />
@@ -1129,8 +1129,8 @@
 								<nb_hits>2</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_server>2</nb_hits_with_time_server>
-								<min_time_server>0.359</min_time_server>
-								<max_time_server>0.359</max_time_server>
+								<min_time_server>0.3590</min_time_server>
+								<max_time_server>0.3590</max_time_server>
 								<sum_bandwidth>0</sum_bandwidth>
 								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 								<min_bandwidth />
@@ -1166,8 +1166,8 @@
 										<nb_hits>2</nb_hits>
 										<sum_time_spent>0</sum_time_spent>
 										<nb_hits_with_time_server>2</nb_hits_with_time_server>
-										<min_time_server>0.359</min_time_server>
-										<max_time_server>0.359</max_time_server>
+										<min_time_server>0.3590</min_time_server>
+										<max_time_server>0.3590</max_time_server>
 										<sum_bandwidth>0</sum_bandwidth>
 										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 										<min_bandwidth />
@@ -1219,8 +1219,8 @@
 		<max_time_server />
 		<sum_bandwidth>5964</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>5964</min_bandwidth>
-		<max_bandwidth>5964</max_bandwidth>
+		<min_bandwidth>355</min_bandwidth>
+		<max_bandwidth>5609</max_bandwidth>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -1259,8 +1259,8 @@
 				<max_time_server />
 				<sum_bandwidth>5964</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>5964</min_bandwidth>
-				<max_bandwidth>5964</max_bandwidth>
+				<min_bandwidth>355</min_bandwidth>
+				<max_bandwidth>5609</max_bandwidth>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -1296,8 +1296,8 @@
 						<max_time_server />
 						<sum_bandwidth>5964</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>5964</min_bandwidth>
-						<max_bandwidth>5964</max_bandwidth>
+						<min_bandwidth>355</min_bandwidth>
+						<max_bandwidth>5609</max_bandwidth>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -1333,8 +1333,8 @@
 								<max_time_server />
 								<sum_bandwidth>5964</sum_bandwidth>
 								<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-								<min_bandwidth>5964</min_bandwidth>
-								<max_bandwidth>5964</max_bandwidth>
+								<min_bandwidth>355</min_bandwidth>
+								<max_bandwidth>5609</max_bandwidth>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>2</entry_nb_actions>
 								<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -1670,8 +1670,8 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.009</min_time_server>
-		<max_time_server>0.009</max_time_server>
+		<min_time_server>0.0090</min_time_server>
+		<max_time_server>0.0090</max_time_server>
 		<sum_bandwidth>267</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>267</min_bandwidth>
@@ -1710,8 +1710,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.009</min_time_server>
-				<max_time_server>0.009</max_time_server>
+				<min_time_server>0.0090</min_time_server>
+				<max_time_server>0.0090</max_time_server>
 				<sum_bandwidth>267</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>267</min_bandwidth>
@@ -2124,8 +2124,8 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.109</min_time_server>
-		<max_time_server>0.109</max_time_server>
+		<min_time_server>0.1090</min_time_server>
+		<max_time_server>0.1090</max_time_server>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -2164,8 +2164,8 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.109</min_time_server>
-				<max_time_server>0.109</max_time_server>
+				<min_time_server>0.1090</min_time_server>
+				<max_time_server>0.1090</max_time_server>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -2685,8 +2685,8 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<sum_bandwidth>182</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>182</min_bandwidth>
@@ -2725,8 +2725,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<sum_bandwidth>182</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>182</min_bandwidth>
@@ -2762,8 +2762,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<sum_bandwidth>182</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>182</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_range.xml
@@ -6,27 +6,27 @@
 		<nb_hits>18</nb_hits>
 		<sum_time_spent>60</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.01</min_time_network>
-		<max_time_network>0.01</max_time_network>
+		<min_time_network>0.0100</min_time_network>
+		<max_time_network>0.0100</max_time_network>
 		<nb_hits_with_time_server>6</nb_hits_with_time_server>
-		<min_time_server>0.743</min_time_server>
-		<max_time_server>1.543</max_time_server>
+		<min_time_server>0.0230</min_time_server>
+		<max_time_server>1.3240</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.232</min_time_transfer>
-		<max_time_transfer>0.232</max_time_transfer>
+		<min_time_transfer>0.2320</min_time_transfer>
+		<max_time_transfer>0.2320</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.312</min_time_dom_processing>
-		<max_time_dom_processing>0.312</max_time_dom_processing>
+		<min_time_dom_processing>0.3120</min_time_dom_processing>
+		<max_time_dom_processing>0.3120</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.255</min_time_dom_completion>
-		<max_time_dom_completion>0.255</max_time_dom_completion>
+		<min_time_dom_completion>0.2550</min_time_dom_completion>
+		<max_time_dom_completion>0.2550</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>39400</sum_bandwidth>
 		<nb_hits_with_bandwidth>13</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>14</entry_nb_visits>
 		<entry_nb_actions>23</entry_nb_actions>
 		<entry_sum_visit_length>54</entry_sum_visit_length>
@@ -69,8 +69,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>5</nb_hits_with_time_server>
-				<min_time_server>0.647</min_time_server>
-				<max_time_server>1.447</max_time_server>
+				<min_time_server>0.0230</min_time_server>
+				<max_time_server>1.3240</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -85,8 +85,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>35740</sum_bandwidth>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<min_bandwidth>0</min_bandwidth>
-				<max_bandwidth>0</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>11</entry_nb_visits>
 				<entry_nb_actions>20</entry_nb_actions>
 				<entry_sum_visit_length>54</entry_sum_visit_length>
@@ -121,8 +121,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>3</nb_hits_with_time_server>
-						<min_time_server>0.023</min_time_server>
-						<max_time_server>0.123</max_time_server>
+						<min_time_server>0.0230</min_time_server>
+						<max_time_server>0.1230</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -137,8 +137,8 @@
 						<max_time_on_load />
 						<sum_bandwidth>32166</sum_bandwidth>
 						<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-						<min_bandwidth>0</min_bandwidth>
-						<max_bandwidth>0</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>10</entry_nb_visits>
 						<entry_nb_actions>19</entry_nb_actions>
 						<entry_sum_visit_length>54</entry_sum_visit_length>
@@ -173,8 +173,8 @@
 								<min_time_network />
 								<max_time_network />
 								<nb_hits_with_time_server>3</nb_hits_with_time_server>
-								<min_time_server>0.023</min_time_server>
-								<max_time_server>0.123</max_time_server>
+								<min_time_server>0.0230</min_time_server>
+								<max_time_server>0.1230</max_time_server>
 								<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 								<min_time_transfer />
 								<max_time_transfer />
@@ -189,8 +189,8 @@
 								<max_time_on_load />
 								<sum_bandwidth>32166</sum_bandwidth>
 								<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-								<min_bandwidth>0</min_bandwidth>
-								<max_bandwidth>0</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>10</entry_nb_visits>
 								<entry_nb_actions>19</entry_nb_actions>
 								<entry_sum_visit_length>54</entry_sum_visit_length>
@@ -231,8 +231,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.624</min_time_server>
-						<max_time_server>1.324</max_time_server>
+						<min_time_server>0.6240</min_time_server>
+						<max_time_server>1.3240</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -247,8 +247,8 @@
 						<max_time_on_load />
 						<sum_bandwidth>3574</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
-						<min_bandwidth>0</min_bandwidth>
-						<max_bandwidth>0</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -283,8 +283,8 @@
 								<min_time_network />
 								<max_time_network />
 								<nb_hits_with_time_server>2</nb_hits_with_time_server>
-								<min_time_server>0.624</min_time_server>
-								<max_time_server>1.324</max_time_server>
+								<min_time_server>0.6240</min_time_server>
+								<max_time_server>1.3240</max_time_server>
 								<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 								<min_time_transfer />
 								<max_time_transfer />
@@ -299,8 +299,8 @@
 								<max_time_on_load />
 								<sum_bandwidth>3574</sum_bandwidth>
 								<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
-								<min_bandwidth>0</min_bandwidth>
-								<max_bandwidth>0</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>1</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -359,8 +359,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>3617</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>3617</min_bandwidth>
-				<max_bandwidth>3617</max_bandwidth>
+				<min_bandwidth>43</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -722,23 +722,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.01</min_time_network>
-				<max_time_network>0.01</max_time_network>
+				<min_time_network>0.0100</min_time_network>
+				<max_time_network>0.0100</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.096</min_time_server>
-				<max_time_server>0.096</max_time_server>
+				<min_time_server>0.0960</min_time_server>
+				<max_time_server>0.0960</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.232</min_time_transfer>
-				<max_time_transfer>0.232</max_time_transfer>
+				<min_time_transfer>0.2320</min_time_transfer>
+				<max_time_transfer>0.2320</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.312</min_time_dom_processing>
-				<max_time_dom_processing>0.312</max_time_dom_processing>
+				<min_time_dom_processing>0.3120</min_time_dom_processing>
+				<max_time_dom_processing>0.3120</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.255</min_time_dom_completion>
-				<max_time_dom_completion>0.255</max_time_dom_completion>
+				<min_time_dom_completion>0.2550</min_time_dom_completion>
+				<max_time_dom_completion>0.2550</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0</min_time_on_load>
-				<max_time_on_load>0</max_time_on_load>
+				<min_time_on_load>0.0000</min_time_on_load>
+				<max_time_on_load>0.0000</max_time_on_load>
 				<sum_bandwidth>43</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -774,23 +774,23 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_network>1</nb_hits_with_time_network>
-						<min_time_network>0.01</min_time_network>
-						<max_time_network>0.01</max_time_network>
+						<min_time_network>0.0100</min_time_network>
+						<max_time_network>0.0100</max_time_network>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.096</min_time_server>
-						<max_time_server>0.096</max_time_server>
+						<min_time_server>0.0960</min_time_server>
+						<max_time_server>0.0960</max_time_server>
 						<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-						<min_time_transfer>0.232</min_time_transfer>
-						<max_time_transfer>0.232</max_time_transfer>
+						<min_time_transfer>0.2320</min_time_transfer>
+						<max_time_transfer>0.2320</max_time_transfer>
 						<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-						<min_time_dom_processing>0.312</min_time_dom_processing>
-						<max_time_dom_processing>0.312</max_time_dom_processing>
+						<min_time_dom_processing>0.3120</min_time_dom_processing>
+						<max_time_dom_processing>0.3120</max_time_dom_processing>
 						<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-						<min_time_dom_completion>0.255</min_time_dom_completion>
-						<max_time_dom_completion>0.255</max_time_dom_completion>
+						<min_time_dom_completion>0.2550</min_time_dom_completion>
+						<max_time_dom_completion>0.2550</max_time_dom_completion>
 						<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-						<min_time_on_load>0</min_time_on_load>
-						<max_time_on_load>0</max_time_on_load>
+						<min_time_on_load>0.0000</min_time_on_load>
+						<max_time_on_load>0.0000</max_time_on_load>
 						<sum_bandwidth>43</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>43</min_bandwidth>
@@ -826,23 +826,23 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_network>1</nb_hits_with_time_network>
-								<min_time_network>0.01</min_time_network>
-								<max_time_network>0.01</max_time_network>
+								<min_time_network>0.0100</min_time_network>
+								<max_time_network>0.0100</max_time_network>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.096</min_time_server>
-								<max_time_server>0.096</max_time_server>
+								<min_time_server>0.0960</min_time_server>
+								<max_time_server>0.0960</max_time_server>
 								<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-								<min_time_transfer>0.232</min_time_transfer>
-								<max_time_transfer>0.232</max_time_transfer>
+								<min_time_transfer>0.2320</min_time_transfer>
+								<max_time_transfer>0.2320</max_time_transfer>
 								<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-								<min_time_dom_processing>0.312</min_time_dom_processing>
-								<max_time_dom_processing>0.312</max_time_dom_processing>
+								<min_time_dom_processing>0.3120</min_time_dom_processing>
+								<max_time_dom_processing>0.3120</max_time_dom_processing>
 								<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-								<min_time_dom_completion>0.255</min_time_dom_completion>
-								<max_time_dom_completion>0.255</max_time_dom_completion>
+								<min_time_dom_completion>0.2550</min_time_dom_completion>
+								<max_time_dom_completion>0.2550</max_time_dom_completion>
 								<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-								<min_time_on_load>0</min_time_on_load>
-								<max_time_on_load>0</max_time_on_load>
+								<min_time_on_load>0.0000</min_time_on_load>
+								<max_time_on_load>0.0000</max_time_on_load>
 								<sum_bandwidth>43</sum_bandwidth>
 								<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 								<min_bandwidth>43</min_bandwidth>
@@ -878,23 +878,23 @@
 										<nb_hits>1</nb_hits>
 										<sum_time_spent>0</sum_time_spent>
 										<nb_hits_with_time_network>1</nb_hits_with_time_network>
-										<min_time_network>0.01</min_time_network>
-										<max_time_network>0.01</max_time_network>
+										<min_time_network>0.0100</min_time_network>
+										<max_time_network>0.0100</max_time_network>
 										<nb_hits_with_time_server>1</nb_hits_with_time_server>
-										<min_time_server>0.096</min_time_server>
-										<max_time_server>0.096</max_time_server>
+										<min_time_server>0.0960</min_time_server>
+										<max_time_server>0.0960</max_time_server>
 										<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-										<min_time_transfer>0.232</min_time_transfer>
-										<max_time_transfer>0.232</max_time_transfer>
+										<min_time_transfer>0.2320</min_time_transfer>
+										<max_time_transfer>0.2320</max_time_transfer>
 										<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-										<min_time_dom_processing>0.312</min_time_dom_processing>
-										<max_time_dom_processing>0.312</max_time_dom_processing>
+										<min_time_dom_processing>0.3120</min_time_dom_processing>
+										<max_time_dom_processing>0.3120</max_time_dom_processing>
 										<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-										<min_time_dom_completion>0.255</min_time_dom_completion>
-										<max_time_dom_completion>0.255</max_time_dom_completion>
+										<min_time_dom_completion>0.2550</min_time_dom_completion>
+										<max_time_dom_completion>0.2550</max_time_dom_completion>
 										<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-										<min_time_on_load>0</min_time_on_load>
-										<max_time_on_load>0</max_time_on_load>
+										<min_time_on_load>0.0000</min_time_on_load>
+										<max_time_on_load>0.0000</max_time_on_load>
 										<sum_bandwidth>43</sum_bandwidth>
 										<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 										<min_bandwidth>43</min_bandwidth>
@@ -942,27 +942,27 @@
 		<nb_hits>7</nb_hits>
 		<sum_time_spent>34</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.067</min_time_network>
-		<max_time_network>0.067</max_time_network>
+		<min_time_network>0.0260</min_time_network>
+		<max_time_network>0.0410</max_time_network>
 		<nb_hits_with_time_server>3</nb_hits_with_time_server>
-		<min_time_server>0.117</min_time_server>
-		<max_time_server>0.117</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0580</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.521</min_time_transfer>
-		<max_time_transfer>0.521</max_time_transfer>
+		<min_time_transfer>0.1550</min_time_transfer>
+		<max_time_transfer>0.3660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.654</min_time_dom_processing>
-		<max_time_dom_processing>0.654</max_time_dom_processing>
+		<min_time_dom_processing>0.2550</min_time_dom_processing>
+		<max_time_dom_processing>0.3990</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.7</min_time_dom_completion>
-		<max_time_dom_completion>0.7</max_time_dom_completion>
+		<min_time_dom_completion>0.1550</min_time_dom_completion>
+		<max_time_dom_completion>0.5450</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.135</min_time_on_load>
-		<max_time_on_load>0.135</max_time_on_load>
+		<min_time_on_load>0.0450</min_time_on_load>
+		<max_time_on_load>0.0900</max_time_on_load>
 		<sum_bandwidth>8235</sum_bandwidth>
 		<nb_hits_with_bandwidth>7</nb_hits_with_bandwidth>
-		<min_bandwidth>8149</min_bandwidth>
-		<max_bandwidth>8149</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>7</entry_nb_visits>
 		<entry_nb_actions>10</entry_nb_actions>
 		<entry_sum_visit_length>44</entry_sum_visit_length>
@@ -1006,27 +1006,27 @@
 		<nb_hits>7</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.013</min_time_network>
-		<max_time_network>0.013</max_time_network>
+		<min_time_network>0.0130</min_time_network>
+		<max_time_network>0.0130</max_time_network>
 		<nb_hits_with_time_server>3</nb_hits_with_time_server>
-		<min_time_server>0.464</min_time_server>
-		<max_time_server>0.664</max_time_server>
+		<min_time_server>0.1210</min_time_server>
+		<max_time_server>0.5430</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.244</min_time_transfer>
-		<max_time_transfer>0.244</max_time_transfer>
+		<min_time_transfer>0.2440</min_time_transfer>
+		<max_time_transfer>0.2440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.345</min_time_dom_processing>
-		<max_time_dom_processing>0.345</max_time_dom_processing>
+		<min_time_dom_processing>0.3450</min_time_dom_processing>
+		<max_time_dom_processing>0.3450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.09</min_time_dom_completion>
-		<max_time_dom_completion>0.09</max_time_dom_completion>
+		<min_time_dom_completion>0.0900</min_time_dom_completion>
+		<max_time_dom_completion>0.0900</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>14339</sum_bandwidth>
 		<nb_hits_with_bandwidth>5</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
-		<max_bandwidth>43</max_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>5</entry_nb_visits>
 		<entry_nb_actions>5</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1069,8 +1069,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.343</min_time_server>
-				<max_time_server>0.543</max_time_server>
+				<min_time_server>0.3430</min_time_server>
+				<max_time_server>0.5430</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -1085,8 +1085,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>0</min_bandwidth>
-				<max_bandwidth>0</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1121,8 +1121,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.343</min_time_server>
-						<max_time_server>0.543</max_time_server>
+						<min_time_server>0.3430</min_time_server>
+						<max_time_server>0.5430</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -1137,8 +1137,8 @@
 						<max_time_on_load />
 						<sum_bandwidth>7148</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>0</min_bandwidth>
-						<max_bandwidth>0</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>2</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1232,23 +1232,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.013</min_time_network>
-				<max_time_network>0.013</max_time_network>
+				<min_time_network>0.0130</min_time_network>
+				<max_time_network>0.0130</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.121</min_time_server>
-				<max_time_server>0.121</max_time_server>
+				<min_time_server>0.1210</min_time_server>
+				<max_time_server>0.1210</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.244</min_time_transfer>
-				<max_time_transfer>0.244</max_time_transfer>
+				<min_time_transfer>0.2440</min_time_transfer>
+				<max_time_transfer>0.2440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.345</min_time_dom_processing>
-				<max_time_dom_processing>0.345</max_time_dom_processing>
+				<min_time_dom_processing>0.3450</min_time_dom_processing>
+				<max_time_dom_processing>0.3450</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.09</min_time_dom_completion>
-				<max_time_dom_completion>0.09</max_time_dom_completion>
+				<min_time_dom_completion>0.0900</min_time_dom_completion>
+				<max_time_dom_completion>0.0900</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0</min_time_on_load>
-				<max_time_on_load>0</max_time_on_load>
+				<min_time_on_load>0.0000</min_time_on_load>
+				<max_time_on_load>0.0000</max_time_on_load>
 				<sum_bandwidth>43</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -1284,23 +1284,23 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_network>1</nb_hits_with_time_network>
-						<min_time_network>0.013</min_time_network>
-						<max_time_network>0.013</max_time_network>
+						<min_time_network>0.0130</min_time_network>
+						<max_time_network>0.0130</max_time_network>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.121</min_time_server>
-						<max_time_server>0.121</max_time_server>
+						<min_time_server>0.1210</min_time_server>
+						<max_time_server>0.1210</max_time_server>
 						<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-						<min_time_transfer>0.244</min_time_transfer>
-						<max_time_transfer>0.244</max_time_transfer>
+						<min_time_transfer>0.2440</min_time_transfer>
+						<max_time_transfer>0.2440</max_time_transfer>
 						<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-						<min_time_dom_processing>0.345</min_time_dom_processing>
-						<max_time_dom_processing>0.345</max_time_dom_processing>
+						<min_time_dom_processing>0.3450</min_time_dom_processing>
+						<max_time_dom_processing>0.3450</max_time_dom_processing>
 						<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-						<min_time_dom_completion>0.09</min_time_dom_completion>
-						<max_time_dom_completion>0.09</max_time_dom_completion>
+						<min_time_dom_completion>0.0900</min_time_dom_completion>
+						<max_time_dom_completion>0.0900</max_time_dom_completion>
 						<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-						<min_time_on_load>0</min_time_on_load>
-						<max_time_on_load>0</max_time_on_load>
+						<min_time_on_load>0.0000</min_time_on_load>
+						<max_time_on_load>0.0000</max_time_on_load>
 						<sum_bandwidth>43</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>43</min_bandwidth>
@@ -1457,8 +1457,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>3</nb_hits_with_time_server>
-		<min_time_server>0.234</min_time_server>
-		<max_time_server>0.294</max_time_server>
+		<min_time_server>0.2340</min_time_server>
+		<max_time_server>0.2940</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -1473,8 +1473,8 @@
 		<max_time_on_load />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>0</min_bandwidth>
-		<max_bandwidth>0</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1517,8 +1517,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>3</nb_hits_with_time_server>
-				<min_time_server>0.234</min_time_server>
-				<max_time_server>0.294</max_time_server>
+				<min_time_server>0.2340</min_time_server>
+				<max_time_server>0.2940</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -1533,8 +1533,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>0</min_bandwidth>
-				<max_bandwidth>0</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1795,8 +1795,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>4</nb_hits_with_time_server>
-		<min_time_server>0.718</min_time_server>
-		<max_time_server>0.718</max_time_server>
+		<min_time_server>0.3590</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -1855,8 +1855,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.359</min_time_server>
-				<max_time_server>0.359</max_time_server>
+				<min_time_server>0.3590</min_time_server>
+				<max_time_server>0.3590</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -1907,8 +1907,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.359</min_time_server>
-						<max_time_server>0.359</max_time_server>
+						<min_time_server>0.3590</min_time_server>
+						<max_time_server>0.3590</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -1965,8 +1965,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.359</min_time_server>
-				<max_time_server>0.359</max_time_server>
+				<min_time_server>0.3590</min_time_server>
+				<max_time_server>0.3590</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -2017,8 +2017,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.359</min_time_server>
-						<max_time_server>0.359</max_time_server>
+						<min_time_server>0.3590</min_time_server>
+						<max_time_server>0.3590</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -2069,8 +2069,8 @@
 								<min_time_network />
 								<max_time_network />
 								<nb_hits_with_time_server>2</nb_hits_with_time_server>
-								<min_time_server>0.359</min_time_server>
-								<max_time_server>0.359</max_time_server>
+								<min_time_server>0.3590</min_time_server>
+								<max_time_server>0.3590</max_time_server>
 								<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 								<min_time_transfer />
 								<max_time_transfer />
@@ -2121,8 +2121,8 @@
 										<min_time_network />
 										<max_time_network />
 										<nb_hits_with_time_server>2</nb_hits_with_time_server>
-										<min_time_server>0.359</min_time_server>
-										<max_time_server>0.359</max_time_server>
+										<min_time_server>0.3590</min_time_server>
+										<max_time_server>0.3590</max_time_server>
 										<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 										<min_time_transfer />
 										<max_time_transfer />
@@ -2201,8 +2201,8 @@
 		<max_time_on_load />
 		<sum_bandwidth>5964</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>5964</min_bandwidth>
-		<max_bandwidth>5964</max_bandwidth>
+		<min_bandwidth>355</min_bandwidth>
+		<max_bandwidth>5609</max_bandwidth>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -2261,8 +2261,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>5964</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>5964</min_bandwidth>
-				<max_bandwidth>5964</max_bandwidth>
+				<min_bandwidth>355</min_bandwidth>
+				<max_bandwidth>5609</max_bandwidth>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -2313,8 +2313,8 @@
 						<max_time_on_load />
 						<sum_bandwidth>5964</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>5964</min_bandwidth>
-						<max_bandwidth>5964</max_bandwidth>
+						<min_bandwidth>355</min_bandwidth>
+						<max_bandwidth>5609</max_bandwidth>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -2365,8 +2365,8 @@
 								<max_time_on_load />
 								<sum_bandwidth>5964</sum_bandwidth>
 								<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-								<min_bandwidth>5964</min_bandwidth>
-								<max_bandwidth>5964</max_bandwidth>
+								<min_bandwidth>355</min_bandwidth>
+								<max_bandwidth>5609</max_bandwidth>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>2</entry_nb_actions>
 								<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -2479,8 +2479,8 @@
 		<max_time_on_load />
 		<sum_bandwidth>3617</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>3617</min_bandwidth>
-		<max_bandwidth>3617</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>1</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2632,23 +2632,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.355</min_time_server>
-		<max_time_server>0.355</max_time_server>
+		<min_time_server>0.3550</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.099</min_time_transfer>
-		<max_time_transfer>0.099</max_time_transfer>
+		<min_time_transfer>0.0990</min_time_transfer>
+		<max_time_transfer>0.0990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.341</min_time_dom_processing>
-		<max_time_dom_processing>0.341</max_time_dom_processing>
+		<min_time_dom_processing>0.3410</min_time_dom_processing>
+		<max_time_dom_processing>0.3410</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2</min_time_dom_completion>
-		<max_time_dom_completion>0.2</max_time_dom_completion>
+		<min_time_dom_completion>0.2000</min_time_dom_completion>
+		<max_time_dom_completion>0.2000</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.11</min_time_on_load>
-		<max_time_on_load>0.11</max_time_on_load>
+		<min_time_on_load>0.1100</min_time_on_load>
+		<max_time_on_load>0.1100</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -2692,23 +2692,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.355</min_time_server>
-				<max_time_server>0.355</max_time_server>
+				<min_time_server>0.3550</min_time_server>
+				<max_time_server>0.3550</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.099</min_time_transfer>
-				<max_time_transfer>0.099</max_time_transfer>
+				<min_time_transfer>0.0990</min_time_transfer>
+				<max_time_transfer>0.0990</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.341</min_time_dom_processing>
-				<max_time_dom_processing>0.341</max_time_dom_processing>
+				<min_time_dom_processing>0.3410</min_time_dom_processing>
+				<max_time_dom_processing>0.3410</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.2</min_time_dom_completion>
-				<max_time_dom_completion>0.2</max_time_dom_completion>
+				<min_time_dom_completion>0.2000</min_time_dom_completion>
+				<max_time_dom_completion>0.2000</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.11</min_time_on_load>
-				<max_time_on_load>0.11</max_time_on_load>
+				<min_time_on_load>0.1100</min_time_on_load>
+				<max_time_on_load>0.1100</max_time_on_load>
 				<sum_bandwidth>86</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -3189,8 +3189,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.009</min_time_server>
-		<max_time_server>0.009</max_time_server>
+		<min_time_server>0.0090</min_time_server>
+		<max_time_server>0.0090</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -3249,8 +3249,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.009</min_time_server>
-				<max_time_server>0.009</max_time_server>
+				<min_time_server>0.0090</min_time_server>
+				<max_time_server>0.0090</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -3776,8 +3776,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.109</min_time_server>
-		<max_time_server>0.109</max_time_server>
+		<min_time_server>0.1090</min_time_server>
+		<max_time_server>0.1090</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -3836,8 +3836,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.109</min_time_server>
-				<max_time_server>0.109</max_time_server>
+				<min_time_server>0.1090</min_time_server>
+				<max_time_server>0.1090</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -4562,8 +4562,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -4622,8 +4622,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -4674,8 +4674,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageTitles_month.xml
@@ -49,8 +49,8 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.359</min_time_server>
-		<max_time_server>0.359</max_time_server>
+		<min_time_server>0.3590</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageTitles_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageTitles_range.xml
@@ -6,27 +6,27 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>34</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.067</min_time_network>
-		<max_time_network>0.067</max_time_network>
+		<min_time_network>0.0260</min_time_network>
+		<max_time_network>0.0410</max_time_network>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.116</min_time_server>
-		<max_time_server>0.116</max_time_server>
+		<min_time_server>0.0580</min_time_server>
+		<max_time_server>0.0580</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.521</min_time_transfer>
-		<max_time_transfer>0.521</max_time_transfer>
+		<min_time_transfer>0.1550</min_time_transfer>
+		<max_time_transfer>0.3660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.654</min_time_dom_processing>
-		<max_time_dom_processing>0.654</max_time_dom_processing>
+		<min_time_dom_processing>0.2550</min_time_dom_processing>
+		<max_time_dom_processing>0.3990</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.7</min_time_dom_completion>
-		<max_time_dom_completion>0.7</max_time_dom_completion>
+		<min_time_dom_completion>0.1550</min_time_dom_completion>
+		<max_time_dom_completion>0.5450</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.135</min_time_on_load>
-		<max_time_on_load>0.135</max_time_on_load>
+		<min_time_on_load>0.0450</min_time_on_load>
+		<max_time_on_load>0.0900</max_time_on_load>
 		<sum_bandwidth>172</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>43</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>7</entry_nb_actions>
 		<entry_sum_visit_length>44</entry_sum_visit_length>
@@ -135,8 +135,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.359</min_time_server>
-		<max_time_server>0.359</max_time_server>
+		<min_time_server>0.3590</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -195,23 +195,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.355</min_time_server>
-		<max_time_server>0.355</max_time_server>
+		<min_time_server>0.3550</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.099</min_time_transfer>
-		<max_time_transfer>0.099</max_time_transfer>
+		<min_time_transfer>0.0990</min_time_transfer>
+		<max_time_transfer>0.0990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.341</min_time_dom_processing>
-		<max_time_dom_processing>0.341</max_time_dom_processing>
+		<min_time_dom_processing>0.3410</min_time_dom_processing>
+		<max_time_dom_processing>0.3410</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2</min_time_dom_completion>
-		<max_time_dom_completion>0.2</max_time_dom_completion>
+		<min_time_dom_completion>0.2000</min_time_dom_completion>
+		<max_time_dom_completion>0.2000</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.11</min_time_on_load>
-		<max_time_on_load>0.11</max_time_on_load>
+		<min_time_on_load>0.1100</min_time_on_load>
+		<max_time_on_load>0.1100</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -639,23 +639,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.013</min_time_network>
-		<max_time_network>0.013</max_time_network>
+		<min_time_network>0.0130</min_time_network>
+		<max_time_network>0.0130</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.121</min_time_server>
-		<max_time_server>0.121</max_time_server>
+		<min_time_server>0.1210</min_time_server>
+		<max_time_server>0.1210</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.244</min_time_transfer>
-		<max_time_transfer>0.244</max_time_transfer>
+		<min_time_transfer>0.2440</min_time_transfer>
+		<max_time_transfer>0.2440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.345</min_time_dom_processing>
-		<max_time_dom_processing>0.345</max_time_dom_processing>
+		<min_time_dom_processing>0.3450</min_time_dom_processing>
+		<max_time_dom_processing>0.3450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.09</min_time_dom_completion>
-		<max_time_dom_completion>0.09</max_time_dom_completion>
+		<min_time_dom_completion>0.0900</min_time_dom_completion>
+		<max_time_dom_completion>0.0900</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -828,23 +828,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.01</min_time_network>
-		<max_time_network>0.01</max_time_network>
+		<min_time_network>0.0100</min_time_network>
+		<max_time_network>0.0100</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.096</min_time_server>
-		<max_time_server>0.096</max_time_server>
+		<min_time_server>0.0960</min_time_server>
+		<max_time_server>0.0960</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.232</min_time_transfer>
-		<max_time_transfer>0.232</max_time_transfer>
+		<min_time_transfer>0.2320</min_time_transfer>
+		<max_time_transfer>0.2320</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.312</min_time_dom_processing>
-		<max_time_dom_processing>0.312</max_time_dom_processing>
+		<min_time_dom_processing>0.3120</min_time_dom_processing>
+		<max_time_dom_processing>0.3120</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.255</min_time_dom_completion>
-		<max_time_dom_completion>0.255</max_time_dom_completion>
+		<min_time_dom_completion>0.2550</min_time_dom_completion>
+		<max_time_dom_completion>0.2550</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_month.xml
@@ -10,8 +10,8 @@
 		<max_time_server />
 		<sum_bandwidth>39314</sum_bandwidth>
 		<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-		<min_bandwidth>21444</min_bandwidth>
-		<max_bandwidth>21444</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>11</entry_nb_visits>
 		<entry_nb_actions>11</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -50,8 +50,8 @@
 				<max_time_server />
 				<sum_bandwidth>35740</sum_bandwidth>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<min_bandwidth>17870</min_bandwidth>
-				<max_bandwidth>17870</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>10</entry_nb_visits>
 				<entry_nb_actions>10</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -87,8 +87,8 @@
 						<max_time_server />
 						<sum_bandwidth>32166</sum_bandwidth>
 						<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-						<min_bandwidth>14296</min_bandwidth>
-						<max_bandwidth>14296</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>9</entry_nb_visits>
 						<entry_nb_actions>9</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -124,8 +124,8 @@
 								<max_time_server />
 								<sum_bandwidth>32166</sum_bandwidth>
 								<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-								<min_bandwidth>14296</min_bandwidth>
-								<max_bandwidth>14296</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>9</entry_nb_visits>
 								<entry_nb_actions>9</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -409,8 +409,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -449,8 +449,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -486,8 +486,8 @@
 						<max_time_server />
 						<sum_bandwidth>7148</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>7148</min_bandwidth>
-						<max_bandwidth>7148</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>2</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -652,8 +652,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -692,8 +692,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -891,12 +891,12 @@
 		<nb_hits>3</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<sum_bandwidth>8063</sum_bandwidth>
 		<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-		<min_bandwidth>8063</min_bandwidth>
-		<max_bandwidth>8063</max_bandwidth>
+		<min_bandwidth>915</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>3</entry_nb_visits>
 		<entry_nb_actions>3</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -935,8 +935,8 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>4</nb_hits_with_time_server>
-		<min_time_server>0.718</min_time_server>
-		<max_time_server>0.718</max_time_server>
+		<min_time_server>0.3590</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -975,8 +975,8 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.359</min_time_server>
-				<max_time_server>0.359</max_time_server>
+				<min_time_server>0.3590</min_time_server>
+				<max_time_server>0.3590</max_time_server>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -1012,8 +1012,8 @@
 						<nb_hits>2</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.359</min_time_server>
-						<max_time_server>0.359</max_time_server>
+						<min_time_server>0.3590</min_time_server>
+						<max_time_server>0.3590</max_time_server>
 						<sum_bandwidth>0</sum_bandwidth>
 						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 						<min_bandwidth />
@@ -1055,8 +1055,8 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.359</min_time_server>
-				<max_time_server>0.359</max_time_server>
+				<min_time_server>0.3590</min_time_server>
+				<max_time_server>0.3590</max_time_server>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -1092,8 +1092,8 @@
 						<nb_hits>2</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.359</min_time_server>
-						<max_time_server>0.359</max_time_server>
+						<min_time_server>0.3590</min_time_server>
+						<max_time_server>0.3590</max_time_server>
 						<sum_bandwidth>0</sum_bandwidth>
 						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 						<min_bandwidth />
@@ -1129,8 +1129,8 @@
 								<nb_hits>2</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_server>2</nb_hits_with_time_server>
-								<min_time_server>0.359</min_time_server>
-								<max_time_server>0.359</max_time_server>
+								<min_time_server>0.3590</min_time_server>
+								<max_time_server>0.3590</max_time_server>
 								<sum_bandwidth>0</sum_bandwidth>
 								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 								<min_bandwidth />
@@ -1166,8 +1166,8 @@
 										<nb_hits>2</nb_hits>
 										<sum_time_spent>0</sum_time_spent>
 										<nb_hits_with_time_server>2</nb_hits_with_time_server>
-										<min_time_server>0.359</min_time_server>
-										<max_time_server>0.359</max_time_server>
+										<min_time_server>0.3590</min_time_server>
+										<max_time_server>0.3590</max_time_server>
 										<sum_bandwidth>0</sum_bandwidth>
 										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 										<min_bandwidth />
@@ -1219,8 +1219,8 @@
 		<max_time_server />
 		<sum_bandwidth>5964</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>5964</min_bandwidth>
-		<max_bandwidth>5964</max_bandwidth>
+		<min_bandwidth>355</min_bandwidth>
+		<max_bandwidth>5609</max_bandwidth>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -1259,8 +1259,8 @@
 				<max_time_server />
 				<sum_bandwidth>5964</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>5964</min_bandwidth>
-				<max_bandwidth>5964</max_bandwidth>
+				<min_bandwidth>355</min_bandwidth>
+				<max_bandwidth>5609</max_bandwidth>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -1296,8 +1296,8 @@
 						<max_time_server />
 						<sum_bandwidth>5964</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>5964</min_bandwidth>
-						<max_bandwidth>5964</max_bandwidth>
+						<min_bandwidth>355</min_bandwidth>
+						<max_bandwidth>5609</max_bandwidth>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -1333,8 +1333,8 @@
 								<max_time_server />
 								<sum_bandwidth>5964</sum_bandwidth>
 								<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-								<min_bandwidth>5964</min_bandwidth>
-								<max_bandwidth>5964</max_bandwidth>
+								<min_bandwidth>355</min_bandwidth>
+								<max_bandwidth>5609</max_bandwidth>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>2</entry_nb_actions>
 								<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -1634,8 +1634,8 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.009</min_time_server>
-		<max_time_server>0.009</max_time_server>
+		<min_time_server>0.0090</min_time_server>
+		<max_time_server>0.0090</max_time_server>
 		<sum_bandwidth>267</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>267</min_bandwidth>
@@ -1674,8 +1674,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.009</min_time_server>
-				<max_time_server>0.009</max_time_server>
+				<min_time_server>0.0090</min_time_server>
+				<max_time_server>0.0090</max_time_server>
 				<sum_bandwidth>267</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>267</min_bandwidth>
@@ -2088,8 +2088,8 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.109</min_time_server>
-		<max_time_server>0.109</max_time_server>
+		<min_time_server>0.1090</min_time_server>
+		<max_time_server>0.1090</max_time_server>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -2128,8 +2128,8 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.109</min_time_server>
-				<max_time_server>0.109</max_time_server>
+				<min_time_server>0.1090</min_time_server>
+				<max_time_server>0.1090</max_time_server>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -2649,8 +2649,8 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<sum_bandwidth>182</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>182</min_bandwidth>
@@ -2689,8 +2689,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<sum_bandwidth>182</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>182</min_bandwidth>
@@ -2726,8 +2726,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<sum_bandwidth>182</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>182</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_range.xml
@@ -6,27 +6,27 @@
 		<nb_hits>18</nb_hits>
 		<sum_time_spent>60</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.01</min_time_network>
-		<max_time_network>0.01</max_time_network>
+		<min_time_network>0.0100</min_time_network>
+		<max_time_network>0.0100</max_time_network>
 		<nb_hits_with_time_server>6</nb_hits_with_time_server>
-		<min_time_server>0.743</min_time_server>
-		<max_time_server>1.543</max_time_server>
+		<min_time_server>0.0230</min_time_server>
+		<max_time_server>1.3240</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.232</min_time_transfer>
-		<max_time_transfer>0.232</max_time_transfer>
+		<min_time_transfer>0.2320</min_time_transfer>
+		<max_time_transfer>0.2320</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.312</min_time_dom_processing>
-		<max_time_dom_processing>0.312</max_time_dom_processing>
+		<min_time_dom_processing>0.3120</min_time_dom_processing>
+		<max_time_dom_processing>0.3120</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.255</min_time_dom_completion>
-		<max_time_dom_completion>0.255</max_time_dom_completion>
+		<min_time_dom_completion>0.2550</min_time_dom_completion>
+		<max_time_dom_completion>0.2550</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>39400</sum_bandwidth>
 		<nb_hits_with_bandwidth>13</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>14</entry_nb_visits>
 		<entry_nb_actions>23</entry_nb_actions>
 		<entry_sum_visit_length>54</entry_sum_visit_length>
@@ -69,8 +69,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>5</nb_hits_with_time_server>
-				<min_time_server>0.647</min_time_server>
-				<max_time_server>1.447</max_time_server>
+				<min_time_server>0.0230</min_time_server>
+				<max_time_server>1.3240</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -85,8 +85,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>35740</sum_bandwidth>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<min_bandwidth>0</min_bandwidth>
-				<max_bandwidth>0</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>11</entry_nb_visits>
 				<entry_nb_actions>20</entry_nb_actions>
 				<entry_sum_visit_length>54</entry_sum_visit_length>
@@ -121,8 +121,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>3</nb_hits_with_time_server>
-						<min_time_server>0.023</min_time_server>
-						<max_time_server>0.123</max_time_server>
+						<min_time_server>0.0230</min_time_server>
+						<max_time_server>0.1230</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -137,8 +137,8 @@
 						<max_time_on_load />
 						<sum_bandwidth>32166</sum_bandwidth>
 						<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-						<min_bandwidth>0</min_bandwidth>
-						<max_bandwidth>0</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>10</entry_nb_visits>
 						<entry_nb_actions>19</entry_nb_actions>
 						<entry_sum_visit_length>54</entry_sum_visit_length>
@@ -173,8 +173,8 @@
 								<min_time_network />
 								<max_time_network />
 								<nb_hits_with_time_server>3</nb_hits_with_time_server>
-								<min_time_server>0.023</min_time_server>
-								<max_time_server>0.123</max_time_server>
+								<min_time_server>0.0230</min_time_server>
+								<max_time_server>0.1230</max_time_server>
 								<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 								<min_time_transfer />
 								<max_time_transfer />
@@ -189,8 +189,8 @@
 								<max_time_on_load />
 								<sum_bandwidth>32166</sum_bandwidth>
 								<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-								<min_bandwidth>0</min_bandwidth>
-								<max_bandwidth>0</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>10</entry_nb_visits>
 								<entry_nb_actions>19</entry_nb_actions>
 								<entry_sum_visit_length>54</entry_sum_visit_length>
@@ -231,8 +231,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.624</min_time_server>
-						<max_time_server>1.324</max_time_server>
+						<min_time_server>0.6240</min_time_server>
+						<max_time_server>1.3240</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -247,8 +247,8 @@
 						<max_time_on_load />
 						<sum_bandwidth>3574</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
-						<min_bandwidth>0</min_bandwidth>
-						<max_bandwidth>0</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -283,8 +283,8 @@
 								<min_time_network />
 								<max_time_network />
 								<nb_hits_with_time_server>2</nb_hits_with_time_server>
-								<min_time_server>0.624</min_time_server>
-								<max_time_server>1.324</max_time_server>
+								<min_time_server>0.6240</min_time_server>
+								<max_time_server>1.3240</max_time_server>
 								<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 								<min_time_transfer />
 								<max_time_transfer />
@@ -299,8 +299,8 @@
 								<max_time_on_load />
 								<sum_bandwidth>3574</sum_bandwidth>
 								<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
-								<min_bandwidth>0</min_bandwidth>
-								<max_bandwidth>0</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>1</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -359,8 +359,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>3617</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>3617</min_bandwidth>
-				<max_bandwidth>3617</max_bandwidth>
+				<min_bandwidth>43</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -722,23 +722,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.01</min_time_network>
-				<max_time_network>0.01</max_time_network>
+				<min_time_network>0.0100</min_time_network>
+				<max_time_network>0.0100</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.096</min_time_server>
-				<max_time_server>0.096</max_time_server>
+				<min_time_server>0.0960</min_time_server>
+				<max_time_server>0.0960</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.232</min_time_transfer>
-				<max_time_transfer>0.232</max_time_transfer>
+				<min_time_transfer>0.2320</min_time_transfer>
+				<max_time_transfer>0.2320</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.312</min_time_dom_processing>
-				<max_time_dom_processing>0.312</max_time_dom_processing>
+				<min_time_dom_processing>0.3120</min_time_dom_processing>
+				<max_time_dom_processing>0.3120</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.255</min_time_dom_completion>
-				<max_time_dom_completion>0.255</max_time_dom_completion>
+				<min_time_dom_completion>0.2550</min_time_dom_completion>
+				<max_time_dom_completion>0.2550</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0</min_time_on_load>
-				<max_time_on_load>0</max_time_on_load>
+				<min_time_on_load>0.0000</min_time_on_load>
+				<max_time_on_load>0.0000</max_time_on_load>
 				<sum_bandwidth>43</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -774,23 +774,23 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_network>1</nb_hits_with_time_network>
-						<min_time_network>0.01</min_time_network>
-						<max_time_network>0.01</max_time_network>
+						<min_time_network>0.0100</min_time_network>
+						<max_time_network>0.0100</max_time_network>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.096</min_time_server>
-						<max_time_server>0.096</max_time_server>
+						<min_time_server>0.0960</min_time_server>
+						<max_time_server>0.0960</max_time_server>
 						<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-						<min_time_transfer>0.232</min_time_transfer>
-						<max_time_transfer>0.232</max_time_transfer>
+						<min_time_transfer>0.2320</min_time_transfer>
+						<max_time_transfer>0.2320</max_time_transfer>
 						<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-						<min_time_dom_processing>0.312</min_time_dom_processing>
-						<max_time_dom_processing>0.312</max_time_dom_processing>
+						<min_time_dom_processing>0.3120</min_time_dom_processing>
+						<max_time_dom_processing>0.3120</max_time_dom_processing>
 						<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-						<min_time_dom_completion>0.255</min_time_dom_completion>
-						<max_time_dom_completion>0.255</max_time_dom_completion>
+						<min_time_dom_completion>0.2550</min_time_dom_completion>
+						<max_time_dom_completion>0.2550</max_time_dom_completion>
 						<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-						<min_time_on_load>0</min_time_on_load>
-						<max_time_on_load>0</max_time_on_load>
+						<min_time_on_load>0.0000</min_time_on_load>
+						<max_time_on_load>0.0000</max_time_on_load>
 						<sum_bandwidth>43</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>43</min_bandwidth>
@@ -826,23 +826,23 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_network>1</nb_hits_with_time_network>
-								<min_time_network>0.01</min_time_network>
-								<max_time_network>0.01</max_time_network>
+								<min_time_network>0.0100</min_time_network>
+								<max_time_network>0.0100</max_time_network>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.096</min_time_server>
-								<max_time_server>0.096</max_time_server>
+								<min_time_server>0.0960</min_time_server>
+								<max_time_server>0.0960</max_time_server>
 								<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-								<min_time_transfer>0.232</min_time_transfer>
-								<max_time_transfer>0.232</max_time_transfer>
+								<min_time_transfer>0.2320</min_time_transfer>
+								<max_time_transfer>0.2320</max_time_transfer>
 								<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-								<min_time_dom_processing>0.312</min_time_dom_processing>
-								<max_time_dom_processing>0.312</max_time_dom_processing>
+								<min_time_dom_processing>0.3120</min_time_dom_processing>
+								<max_time_dom_processing>0.3120</max_time_dom_processing>
 								<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-								<min_time_dom_completion>0.255</min_time_dom_completion>
-								<max_time_dom_completion>0.255</max_time_dom_completion>
+								<min_time_dom_completion>0.2550</min_time_dom_completion>
+								<max_time_dom_completion>0.2550</max_time_dom_completion>
 								<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-								<min_time_on_load>0</min_time_on_load>
-								<max_time_on_load>0</max_time_on_load>
+								<min_time_on_load>0.0000</min_time_on_load>
+								<max_time_on_load>0.0000</max_time_on_load>
 								<sum_bandwidth>43</sum_bandwidth>
 								<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 								<min_bandwidth>43</min_bandwidth>
@@ -878,23 +878,23 @@
 										<nb_hits>1</nb_hits>
 										<sum_time_spent>0</sum_time_spent>
 										<nb_hits_with_time_network>1</nb_hits_with_time_network>
-										<min_time_network>0.01</min_time_network>
-										<max_time_network>0.01</max_time_network>
+										<min_time_network>0.0100</min_time_network>
+										<max_time_network>0.0100</max_time_network>
 										<nb_hits_with_time_server>1</nb_hits_with_time_server>
-										<min_time_server>0.096</min_time_server>
-										<max_time_server>0.096</max_time_server>
+										<min_time_server>0.0960</min_time_server>
+										<max_time_server>0.0960</max_time_server>
 										<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-										<min_time_transfer>0.232</min_time_transfer>
-										<max_time_transfer>0.232</max_time_transfer>
+										<min_time_transfer>0.2320</min_time_transfer>
+										<max_time_transfer>0.2320</max_time_transfer>
 										<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-										<min_time_dom_processing>0.312</min_time_dom_processing>
-										<max_time_dom_processing>0.312</max_time_dom_processing>
+										<min_time_dom_processing>0.3120</min_time_dom_processing>
+										<max_time_dom_processing>0.3120</max_time_dom_processing>
 										<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-										<min_time_dom_completion>0.255</min_time_dom_completion>
-										<max_time_dom_completion>0.255</max_time_dom_completion>
+										<min_time_dom_completion>0.2550</min_time_dom_completion>
+										<max_time_dom_completion>0.2550</max_time_dom_completion>
 										<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-										<min_time_on_load>0</min_time_on_load>
-										<max_time_on_load>0</max_time_on_load>
+										<min_time_on_load>0.0000</min_time_on_load>
+										<max_time_on_load>0.0000</max_time_on_load>
 										<sum_bandwidth>43</sum_bandwidth>
 										<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 										<min_bandwidth>43</min_bandwidth>
@@ -942,27 +942,27 @@
 		<nb_hits>7</nb_hits>
 		<sum_time_spent>34</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.067</min_time_network>
-		<max_time_network>0.067</max_time_network>
+		<min_time_network>0.0260</min_time_network>
+		<max_time_network>0.0410</max_time_network>
 		<nb_hits_with_time_server>3</nb_hits_with_time_server>
-		<min_time_server>0.117</min_time_server>
-		<max_time_server>0.117</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0580</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.521</min_time_transfer>
-		<max_time_transfer>0.521</max_time_transfer>
+		<min_time_transfer>0.1550</min_time_transfer>
+		<max_time_transfer>0.3660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.654</min_time_dom_processing>
-		<max_time_dom_processing>0.654</max_time_dom_processing>
+		<min_time_dom_processing>0.2550</min_time_dom_processing>
+		<max_time_dom_processing>0.3990</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.7</min_time_dom_completion>
-		<max_time_dom_completion>0.7</max_time_dom_completion>
+		<min_time_dom_completion>0.1550</min_time_dom_completion>
+		<max_time_dom_completion>0.5450</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.135</min_time_on_load>
-		<max_time_on_load>0.135</max_time_on_load>
+		<min_time_on_load>0.0450</min_time_on_load>
+		<max_time_on_load>0.0900</max_time_on_load>
 		<sum_bandwidth>8235</sum_bandwidth>
 		<nb_hits_with_bandwidth>7</nb_hits_with_bandwidth>
-		<min_bandwidth>8149</min_bandwidth>
-		<max_bandwidth>8149</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>7</entry_nb_visits>
 		<entry_nb_actions>10</entry_nb_actions>
 		<entry_sum_visit_length>44</entry_sum_visit_length>
@@ -1006,27 +1006,27 @@
 		<nb_hits>7</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.013</min_time_network>
-		<max_time_network>0.013</max_time_network>
+		<min_time_network>0.0130</min_time_network>
+		<max_time_network>0.0130</max_time_network>
 		<nb_hits_with_time_server>3</nb_hits_with_time_server>
-		<min_time_server>0.464</min_time_server>
-		<max_time_server>0.664</max_time_server>
+		<min_time_server>0.1210</min_time_server>
+		<max_time_server>0.5430</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.244</min_time_transfer>
-		<max_time_transfer>0.244</max_time_transfer>
+		<min_time_transfer>0.2440</min_time_transfer>
+		<max_time_transfer>0.2440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.345</min_time_dom_processing>
-		<max_time_dom_processing>0.345</max_time_dom_processing>
+		<min_time_dom_processing>0.3450</min_time_dom_processing>
+		<max_time_dom_processing>0.3450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.09</min_time_dom_completion>
-		<max_time_dom_completion>0.09</max_time_dom_completion>
+		<min_time_dom_completion>0.0900</min_time_dom_completion>
+		<max_time_dom_completion>0.0900</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>14339</sum_bandwidth>
 		<nb_hits_with_bandwidth>5</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
-		<max_bandwidth>43</max_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>5</entry_nb_visits>
 		<entry_nb_actions>5</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1069,8 +1069,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.343</min_time_server>
-				<max_time_server>0.543</max_time_server>
+				<min_time_server>0.3430</min_time_server>
+				<max_time_server>0.5430</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -1085,8 +1085,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>0</min_bandwidth>
-				<max_bandwidth>0</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1121,8 +1121,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.343</min_time_server>
-						<max_time_server>0.543</max_time_server>
+						<min_time_server>0.3430</min_time_server>
+						<max_time_server>0.5430</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -1137,8 +1137,8 @@
 						<max_time_on_load />
 						<sum_bandwidth>7148</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>0</min_bandwidth>
-						<max_bandwidth>0</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>2</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1232,23 +1232,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.013</min_time_network>
-				<max_time_network>0.013</max_time_network>
+				<min_time_network>0.0130</min_time_network>
+				<max_time_network>0.0130</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.121</min_time_server>
-				<max_time_server>0.121</max_time_server>
+				<min_time_server>0.1210</min_time_server>
+				<max_time_server>0.1210</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.244</min_time_transfer>
-				<max_time_transfer>0.244</max_time_transfer>
+				<min_time_transfer>0.2440</min_time_transfer>
+				<max_time_transfer>0.2440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.345</min_time_dom_processing>
-				<max_time_dom_processing>0.345</max_time_dom_processing>
+				<min_time_dom_processing>0.3450</min_time_dom_processing>
+				<max_time_dom_processing>0.3450</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.09</min_time_dom_completion>
-				<max_time_dom_completion>0.09</max_time_dom_completion>
+				<min_time_dom_completion>0.0900</min_time_dom_completion>
+				<max_time_dom_completion>0.0900</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0</min_time_on_load>
-				<max_time_on_load>0</max_time_on_load>
+				<min_time_on_load>0.0000</min_time_on_load>
+				<max_time_on_load>0.0000</max_time_on_load>
 				<sum_bandwidth>43</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -1284,23 +1284,23 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_network>1</nb_hits_with_time_network>
-						<min_time_network>0.013</min_time_network>
-						<max_time_network>0.013</max_time_network>
+						<min_time_network>0.0130</min_time_network>
+						<max_time_network>0.0130</max_time_network>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.121</min_time_server>
-						<max_time_server>0.121</max_time_server>
+						<min_time_server>0.1210</min_time_server>
+						<max_time_server>0.1210</max_time_server>
 						<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-						<min_time_transfer>0.244</min_time_transfer>
-						<max_time_transfer>0.244</max_time_transfer>
+						<min_time_transfer>0.2440</min_time_transfer>
+						<max_time_transfer>0.2440</max_time_transfer>
 						<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-						<min_time_dom_processing>0.345</min_time_dom_processing>
-						<max_time_dom_processing>0.345</max_time_dom_processing>
+						<min_time_dom_processing>0.3450</min_time_dom_processing>
+						<max_time_dom_processing>0.3450</max_time_dom_processing>
 						<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-						<min_time_dom_completion>0.09</min_time_dom_completion>
-						<max_time_dom_completion>0.09</max_time_dom_completion>
+						<min_time_dom_completion>0.0900</min_time_dom_completion>
+						<max_time_dom_completion>0.0900</max_time_dom_completion>
 						<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-						<min_time_on_load>0</min_time_on_load>
-						<max_time_on_load>0</max_time_on_load>
+						<min_time_on_load>0.0000</min_time_on_load>
+						<max_time_on_load>0.0000</max_time_on_load>
 						<sum_bandwidth>43</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>43</min_bandwidth>
@@ -1457,8 +1457,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>3</nb_hits_with_time_server>
-		<min_time_server>0.234</min_time_server>
-		<max_time_server>0.294</max_time_server>
+		<min_time_server>0.2340</min_time_server>
+		<max_time_server>0.2940</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -1473,8 +1473,8 @@
 		<max_time_on_load />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>0</min_bandwidth>
-		<max_bandwidth>0</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1517,8 +1517,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>3</nb_hits_with_time_server>
-				<min_time_server>0.234</min_time_server>
-				<max_time_server>0.294</max_time_server>
+				<min_time_server>0.2340</min_time_server>
+				<max_time_server>0.2940</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -1533,8 +1533,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>0</min_bandwidth>
-				<max_bandwidth>0</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1795,8 +1795,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>4</nb_hits_with_time_server>
-		<min_time_server>0.718</min_time_server>
-		<max_time_server>0.718</max_time_server>
+		<min_time_server>0.3590</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -1855,8 +1855,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.359</min_time_server>
-				<max_time_server>0.359</max_time_server>
+				<min_time_server>0.3590</min_time_server>
+				<max_time_server>0.3590</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -1907,8 +1907,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.359</min_time_server>
-						<max_time_server>0.359</max_time_server>
+						<min_time_server>0.3590</min_time_server>
+						<max_time_server>0.3590</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -1965,8 +1965,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.359</min_time_server>
-				<max_time_server>0.359</max_time_server>
+				<min_time_server>0.3590</min_time_server>
+				<max_time_server>0.3590</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -2017,8 +2017,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.359</min_time_server>
-						<max_time_server>0.359</max_time_server>
+						<min_time_server>0.3590</min_time_server>
+						<max_time_server>0.3590</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -2069,8 +2069,8 @@
 								<min_time_network />
 								<max_time_network />
 								<nb_hits_with_time_server>2</nb_hits_with_time_server>
-								<min_time_server>0.359</min_time_server>
-								<max_time_server>0.359</max_time_server>
+								<min_time_server>0.3590</min_time_server>
+								<max_time_server>0.3590</max_time_server>
 								<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 								<min_time_transfer />
 								<max_time_transfer />
@@ -2121,8 +2121,8 @@
 										<min_time_network />
 										<max_time_network />
 										<nb_hits_with_time_server>2</nb_hits_with_time_server>
-										<min_time_server>0.359</min_time_server>
-										<max_time_server>0.359</max_time_server>
+										<min_time_server>0.3590</min_time_server>
+										<max_time_server>0.3590</max_time_server>
 										<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 										<min_time_transfer />
 										<max_time_transfer />
@@ -2201,8 +2201,8 @@
 		<max_time_on_load />
 		<sum_bandwidth>5964</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>5964</min_bandwidth>
-		<max_bandwidth>5964</max_bandwidth>
+		<min_bandwidth>355</min_bandwidth>
+		<max_bandwidth>5609</max_bandwidth>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -2261,8 +2261,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>5964</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>5964</min_bandwidth>
-				<max_bandwidth>5964</max_bandwidth>
+				<min_bandwidth>355</min_bandwidth>
+				<max_bandwidth>5609</max_bandwidth>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -2313,8 +2313,8 @@
 						<max_time_on_load />
 						<sum_bandwidth>5964</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>5964</min_bandwidth>
-						<max_bandwidth>5964</max_bandwidth>
+						<min_bandwidth>355</min_bandwidth>
+						<max_bandwidth>5609</max_bandwidth>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -2365,8 +2365,8 @@
 								<max_time_on_load />
 								<sum_bandwidth>5964</sum_bandwidth>
 								<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-								<min_bandwidth>5964</min_bandwidth>
-								<max_bandwidth>5964</max_bandwidth>
+								<min_bandwidth>355</min_bandwidth>
+								<max_bandwidth>5609</max_bandwidth>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>2</entry_nb_actions>
 								<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -2461,8 +2461,8 @@
 		<max_time_on_load />
 		<sum_bandwidth>3617</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>3617</min_bandwidth>
-		<max_bandwidth>3617</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>1</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2650,23 +2650,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.355</min_time_server>
-		<max_time_server>0.355</max_time_server>
+		<min_time_server>0.3550</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.099</min_time_transfer>
-		<max_time_transfer>0.099</max_time_transfer>
+		<min_time_transfer>0.0990</min_time_transfer>
+		<max_time_transfer>0.0990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.341</min_time_dom_processing>
-		<max_time_dom_processing>0.341</max_time_dom_processing>
+		<min_time_dom_processing>0.3410</min_time_dom_processing>
+		<max_time_dom_processing>0.3410</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2</min_time_dom_completion>
-		<max_time_dom_completion>0.2</max_time_dom_completion>
+		<min_time_dom_completion>0.2000</min_time_dom_completion>
+		<max_time_dom_completion>0.2000</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.11</min_time_on_load>
-		<max_time_on_load>0.11</max_time_on_load>
+		<min_time_on_load>0.1100</min_time_on_load>
+		<max_time_on_load>0.1100</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -2710,23 +2710,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.355</min_time_server>
-				<max_time_server>0.355</max_time_server>
+				<min_time_server>0.3550</min_time_server>
+				<max_time_server>0.3550</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.099</min_time_transfer>
-				<max_time_transfer>0.099</max_time_transfer>
+				<min_time_transfer>0.0990</min_time_transfer>
+				<max_time_transfer>0.0990</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.341</min_time_dom_processing>
-				<max_time_dom_processing>0.341</max_time_dom_processing>
+				<min_time_dom_processing>0.3410</min_time_dom_processing>
+				<max_time_dom_processing>0.3410</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.2</min_time_dom_completion>
-				<max_time_dom_completion>0.2</max_time_dom_completion>
+				<min_time_dom_completion>0.2000</min_time_dom_completion>
+				<max_time_dom_completion>0.2000</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.11</min_time_on_load>
-				<max_time_on_load>0.11</max_time_on_load>
+				<min_time_on_load>0.1100</min_time_on_load>
+				<max_time_on_load>0.1100</max_time_on_load>
 				<sum_bandwidth>86</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -3189,8 +3189,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.009</min_time_server>
-		<max_time_server>0.009</max_time_server>
+		<min_time_server>0.0090</min_time_server>
+		<max_time_server>0.0090</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -3249,8 +3249,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.009</min_time_server>
-				<max_time_server>0.009</max_time_server>
+				<min_time_server>0.0090</min_time_server>
+				<max_time_server>0.0090</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -3740,8 +3740,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.109</min_time_server>
-		<max_time_server>0.109</max_time_server>
+		<min_time_server>0.1090</min_time_server>
+		<max_time_server>0.1090</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -3800,8 +3800,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.109</min_time_server>
-				<max_time_server>0.109</max_time_server>
+				<min_time_server>0.1090</min_time_server>
+				<max_time_server>0.1090</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -4526,8 +4526,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -4586,8 +4586,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -4638,8 +4638,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageTitles_month.xml
@@ -6,12 +6,12 @@
 		<nb_hits>34</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>7</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<sum_bandwidth>99897</sum_bandwidth>
 		<nb_hits_with_bandwidth>30</nb_hits_with_bandwidth>
-		<min_bandwidth>20087</min_bandwidth>
-		<max_bandwidth>20087</max_bandwidth>
+		<min_bandwidth>182</min_bandwidth>
+		<max_bandwidth>5609</max_bandwidth>
 		<sum_daily_nb_uniq_visitors>32</sum_daily_nb_uniq_visitors>
 		<avg_bandwidth>3329</avg_bandwidth>
 		<avg_time_server>0.135</avg_time_server>
@@ -70,8 +70,8 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.359</min_time_server>
-		<max_time_server>0.359</max_time_server>
+		<min_time_server>0.3590</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageTitles_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageTitles_range.xml
@@ -9,8 +9,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>17</nb_hits_with_time_server>
-		<min_time_server>0.024</min_time_server>
-		<max_time_server>1.325</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>1.3240</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -25,8 +25,8 @@
 		<max_time_on_load />
 		<sum_bandwidth>99897</sum_bandwidth>
 		<nb_hits_with_bandwidth>30</nb_hits_with_bandwidth>
-		<min_bandwidth>0</min_bandwidth>
-		<max_bandwidth>0</max_bandwidth>
+		<min_bandwidth>182</min_bandwidth>
+		<max_bandwidth>5609</max_bandwidth>
 		<sum_daily_nb_uniq_visitors>33</sum_daily_nb_uniq_visitors>
 		<avg_bandwidth>3329</avg_bandwidth>
 		<avg_time_network>0</avg_time_network>
@@ -47,27 +47,27 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>34</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.067</min_time_network>
-		<max_time_network>0.067</max_time_network>
+		<min_time_network>0.0260</min_time_network>
+		<max_time_network>0.0410</max_time_network>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.116</min_time_server>
-		<max_time_server>0.116</max_time_server>
+		<min_time_server>0.0580</min_time_server>
+		<max_time_server>0.0580</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.521</min_time_transfer>
-		<max_time_transfer>0.521</max_time_transfer>
+		<min_time_transfer>0.1550</min_time_transfer>
+		<max_time_transfer>0.3660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.654</min_time_dom_processing>
-		<max_time_dom_processing>0.654</max_time_dom_processing>
+		<min_time_dom_processing>0.2550</min_time_dom_processing>
+		<max_time_dom_processing>0.3990</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.7</min_time_dom_completion>
-		<max_time_dom_completion>0.7</max_time_dom_completion>
+		<min_time_dom_completion>0.1550</min_time_dom_completion>
+		<max_time_dom_completion>0.5450</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.135</min_time_on_load>
-		<max_time_on_load>0.135</max_time_on_load>
+		<min_time_on_load>0.0450</min_time_on_load>
+		<max_time_on_load>0.0900</max_time_on_load>
 		<sum_bandwidth>172</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>43</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>7</entry_nb_actions>
 		<entry_sum_visit_length>44</entry_sum_visit_length>
@@ -176,8 +176,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.359</min_time_server>
-		<max_time_server>0.359</max_time_server>
+		<min_time_server>0.3590</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -236,23 +236,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.355</min_time_server>
-		<max_time_server>0.355</max_time_server>
+		<min_time_server>0.3550</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.099</min_time_transfer>
-		<max_time_transfer>0.099</max_time_transfer>
+		<min_time_transfer>0.0990</min_time_transfer>
+		<max_time_transfer>0.0990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.341</min_time_dom_processing>
-		<max_time_dom_processing>0.341</max_time_dom_processing>
+		<min_time_dom_processing>0.3410</min_time_dom_processing>
+		<max_time_dom_processing>0.3410</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2</min_time_dom_completion>
-		<max_time_dom_completion>0.2</max_time_dom_completion>
+		<min_time_dom_completion>0.2000</min_time_dom_completion>
+		<max_time_dom_completion>0.2000</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.11</min_time_on_load>
-		<max_time_on_load>0.11</max_time_on_load>
+		<min_time_on_load>0.1100</min_time_on_load>
+		<max_time_on_load>0.1100</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -802,23 +802,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.013</min_time_network>
-		<max_time_network>0.013</max_time_network>
+		<min_time_network>0.0130</min_time_network>
+		<max_time_network>0.0130</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.121</min_time_server>
-		<max_time_server>0.121</max_time_server>
+		<min_time_server>0.1210</min_time_server>
+		<max_time_server>0.1210</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.244</min_time_transfer>
-		<max_time_transfer>0.244</max_time_transfer>
+		<min_time_transfer>0.2440</min_time_transfer>
+		<max_time_transfer>0.2440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.345</min_time_dom_processing>
-		<max_time_dom_processing>0.345</max_time_dom_processing>
+		<min_time_dom_processing>0.3450</min_time_dom_processing>
+		<max_time_dom_processing>0.3450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.09</min_time_dom_completion>
-		<max_time_dom_completion>0.09</max_time_dom_completion>
+		<min_time_dom_completion>0.0900</min_time_dom_completion>
+		<max_time_dom_completion>0.0900</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -991,23 +991,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.01</min_time_network>
-		<max_time_network>0.01</max_time_network>
+		<min_time_network>0.0100</min_time_network>
+		<max_time_network>0.0100</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.096</min_time_server>
-		<max_time_server>0.096</max_time_server>
+		<min_time_server>0.0960</min_time_server>
+		<max_time_server>0.0960</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.232</min_time_transfer>
-		<max_time_transfer>0.232</max_time_transfer>
+		<min_time_transfer>0.2320</min_time_transfer>
+		<max_time_transfer>0.2320</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.312</min_time_dom_processing>
-		<max_time_dom_processing>0.312</max_time_dom_processing>
+		<min_time_dom_processing>0.3120</min_time_dom_processing>
+		<max_time_dom_processing>0.3120</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.255</min_time_dom_completion>
-		<max_time_dom_completion>0.255</max_time_dom_completion>
+		<min_time_dom_completion>0.2550</min_time_dom_completion>
+		<max_time_dom_completion>0.2550</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_day.xml
@@ -6,8 +6,8 @@
 		<nb_hits>5</nb_hits>
 		<sum_time_spent>60</sum_time_spent>
 		<nb_hits_with_time_server>5</nb_hits_with_time_server>
-		<min_time_server>0.647</min_time_server>
-		<max_time_server>1.447</max_time_server>
+		<min_time_server>0.0230</min_time_server>
+		<max_time_server>1.3240</max_time_server>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -45,8 +45,8 @@
 				<nb_hits>5</nb_hits>
 				<sum_time_spent>60</sum_time_spent>
 				<nb_hits_with_time_server>5</nb_hits_with_time_server>
-				<min_time_server>0.647</min_time_server>
-				<max_time_server>1.447</max_time_server>
+				<min_time_server>0.0230</min_time_server>
+				<max_time_server>1.3240</max_time_server>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -81,8 +81,8 @@
 						<nb_hits>2</nb_hits>
 						<sum_time_spent>8</sum_time_spent>
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.624</min_time_server>
-						<max_time_server>1.324</max_time_server>
+						<min_time_server>0.6240</min_time_server>
+						<max_time_server>1.3240</max_time_server>
 						<sum_bandwidth>0</sum_bandwidth>
 						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 						<min_bandwidth />
@@ -119,8 +119,8 @@
 						<nb_hits>3</nb_hits>
 						<sum_time_spent>52</sum_time_spent>
 						<nb_hits_with_time_server>3</nb_hits_with_time_server>
-						<min_time_server>0.023</min_time_server>
-						<max_time_server>0.123</max_time_server>
+						<min_time_server>0.0230</min_time_server>
+						<max_time_server>0.1230</max_time_server>
 						<sum_bandwidth>0</sum_bandwidth>
 						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 						<min_bandwidth />
@@ -200,8 +200,8 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.343</min_time_server>
-		<max_time_server>0.543</max_time_server>
+		<min_time_server>0.3430</min_time_server>
+		<max_time_server>0.5430</max_time_server>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -220,8 +220,8 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.343</min_time_server>
-				<max_time_server>0.543</max_time_server>
+				<min_time_server>0.3430</min_time_server>
+				<max_time_server>0.5430</max_time_server>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -260,8 +260,8 @@
 		<nb_hits>3</nb_hits>
 		<sum_time_spent>26</sum_time_spent>
 		<nb_hits_with_time_server>3</nb_hits_with_time_server>
-		<min_time_server>0.234</min_time_server>
-		<max_time_server>0.294</max_time_server>
+		<min_time_server>0.2340</min_time_server>
+		<max_time_server>0.2940</max_time_server>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_month.xml
@@ -10,8 +10,8 @@
 		<max_time_server />
 		<sum_bandwidth>39314</sum_bandwidth>
 		<nb_hits_with_bandwidth>11</nb_hits_with_bandwidth>
-		<min_bandwidth>21444</min_bandwidth>
-		<max_bandwidth>21444</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>11</entry_nb_visits>
 		<entry_nb_actions>11</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -50,8 +50,8 @@
 				<max_time_server />
 				<sum_bandwidth>35740</sum_bandwidth>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<min_bandwidth>17870</min_bandwidth>
-				<max_bandwidth>17870</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>10</entry_nb_visits>
 				<entry_nb_actions>10</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -87,8 +87,8 @@
 						<max_time_server />
 						<sum_bandwidth>32166</sum_bandwidth>
 						<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-						<min_bandwidth>14296</min_bandwidth>
-						<max_bandwidth>14296</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>9</entry_nb_visits>
 						<entry_nb_actions>9</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -124,8 +124,8 @@
 								<max_time_server />
 								<sum_bandwidth>32166</sum_bandwidth>
 								<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-								<min_bandwidth>14296</min_bandwidth>
-								<max_bandwidth>14296</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>9</entry_nb_visits>
 								<entry_nb_actions>9</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -409,8 +409,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -449,8 +449,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -486,8 +486,8 @@
 						<max_time_server />
 						<sum_bandwidth>7148</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>7148</min_bandwidth>
-						<max_bandwidth>7148</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>2</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -652,8 +652,8 @@
 		<max_time_server />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>14296</min_bandwidth>
-		<max_bandwidth>14296</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -692,8 +692,8 @@
 				<max_time_server />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>7148</min_bandwidth>
-				<max_bandwidth>7148</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -891,12 +891,12 @@
 		<nb_hits>3</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<sum_bandwidth>8063</sum_bandwidth>
 		<nb_hits_with_bandwidth>3</nb_hits_with_bandwidth>
-		<min_bandwidth>8063</min_bandwidth>
-		<max_bandwidth>8063</max_bandwidth>
+		<min_bandwidth>915</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>3</entry_nb_visits>
 		<entry_nb_actions>3</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -935,8 +935,8 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>4</nb_hits_with_time_server>
-		<min_time_server>0.718</min_time_server>
-		<max_time_server>0.718</max_time_server>
+		<min_time_server>0.3590</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -975,8 +975,8 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.359</min_time_server>
-				<max_time_server>0.359</max_time_server>
+				<min_time_server>0.3590</min_time_server>
+				<max_time_server>0.3590</max_time_server>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -1012,8 +1012,8 @@
 						<nb_hits>2</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.359</min_time_server>
-						<max_time_server>0.359</max_time_server>
+						<min_time_server>0.3590</min_time_server>
+						<max_time_server>0.3590</max_time_server>
 						<sum_bandwidth>0</sum_bandwidth>
 						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 						<min_bandwidth />
@@ -1055,8 +1055,8 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.359</min_time_server>
-				<max_time_server>0.359</max_time_server>
+				<min_time_server>0.3590</min_time_server>
+				<max_time_server>0.3590</max_time_server>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -1092,8 +1092,8 @@
 						<nb_hits>2</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.359</min_time_server>
-						<max_time_server>0.359</max_time_server>
+						<min_time_server>0.3590</min_time_server>
+						<max_time_server>0.3590</max_time_server>
 						<sum_bandwidth>0</sum_bandwidth>
 						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 						<min_bandwidth />
@@ -1129,8 +1129,8 @@
 								<nb_hits>2</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_server>2</nb_hits_with_time_server>
-								<min_time_server>0.359</min_time_server>
-								<max_time_server>0.359</max_time_server>
+								<min_time_server>0.3590</min_time_server>
+								<max_time_server>0.3590</max_time_server>
 								<sum_bandwidth>0</sum_bandwidth>
 								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 								<min_bandwidth />
@@ -1166,8 +1166,8 @@
 										<nb_hits>2</nb_hits>
 										<sum_time_spent>0</sum_time_spent>
 										<nb_hits_with_time_server>2</nb_hits_with_time_server>
-										<min_time_server>0.359</min_time_server>
-										<max_time_server>0.359</max_time_server>
+										<min_time_server>0.3590</min_time_server>
+										<max_time_server>0.3590</max_time_server>
 										<sum_bandwidth>0</sum_bandwidth>
 										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 										<min_bandwidth />
@@ -1219,8 +1219,8 @@
 		<max_time_server />
 		<sum_bandwidth>5964</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>5964</min_bandwidth>
-		<max_bandwidth>5964</max_bandwidth>
+		<min_bandwidth>355</min_bandwidth>
+		<max_bandwidth>5609</max_bandwidth>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -1259,8 +1259,8 @@
 				<max_time_server />
 				<sum_bandwidth>5964</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>5964</min_bandwidth>
-				<max_bandwidth>5964</max_bandwidth>
+				<min_bandwidth>355</min_bandwidth>
+				<max_bandwidth>5609</max_bandwidth>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -1296,8 +1296,8 @@
 						<max_time_server />
 						<sum_bandwidth>5964</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>5964</min_bandwidth>
-						<max_bandwidth>5964</max_bandwidth>
+						<min_bandwidth>355</min_bandwidth>
+						<max_bandwidth>5609</max_bandwidth>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -1333,8 +1333,8 @@
 								<max_time_server />
 								<sum_bandwidth>5964</sum_bandwidth>
 								<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-								<min_bandwidth>5964</min_bandwidth>
-								<max_bandwidth>5964</max_bandwidth>
+								<min_bandwidth>355</min_bandwidth>
+								<max_bandwidth>5609</max_bandwidth>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>2</entry_nb_actions>
 								<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -1715,8 +1715,8 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.009</min_time_server>
-		<max_time_server>0.009</max_time_server>
+		<min_time_server>0.0090</min_time_server>
+		<max_time_server>0.0090</max_time_server>
 		<sum_bandwidth>267</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>267</min_bandwidth>
@@ -1755,8 +1755,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.009</min_time_server>
-				<max_time_server>0.009</max_time_server>
+				<min_time_server>0.0090</min_time_server>
+				<max_time_server>0.0090</max_time_server>
 				<sum_bandwidth>267</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>267</min_bandwidth>
@@ -2169,8 +2169,8 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.109</min_time_server>
-		<max_time_server>0.109</max_time_server>
+		<min_time_server>0.1090</min_time_server>
+		<max_time_server>0.1090</max_time_server>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
@@ -2209,8 +2209,8 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.109</min_time_server>
-				<max_time_server>0.109</max_time_server>
+				<min_time_server>0.1090</min_time_server>
+				<max_time_server>0.1090</max_time_server>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -2730,8 +2730,8 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<sum_bandwidth>182</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>182</min_bandwidth>
@@ -2770,8 +2770,8 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<sum_bandwidth>182</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>182</min_bandwidth>
@@ -2807,8 +2807,8 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<sum_bandwidth>182</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>182</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_range.xml
@@ -6,27 +6,27 @@
 		<nb_hits>18</nb_hits>
 		<sum_time_spent>60</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.01</min_time_network>
-		<max_time_network>0.01</max_time_network>
+		<min_time_network>0.0100</min_time_network>
+		<max_time_network>0.0100</max_time_network>
 		<nb_hits_with_time_server>6</nb_hits_with_time_server>
-		<min_time_server>0.743</min_time_server>
-		<max_time_server>1.543</max_time_server>
+		<min_time_server>0.0230</min_time_server>
+		<max_time_server>1.3240</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.232</min_time_transfer>
-		<max_time_transfer>0.232</max_time_transfer>
+		<min_time_transfer>0.2320</min_time_transfer>
+		<max_time_transfer>0.2320</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.312</min_time_dom_processing>
-		<max_time_dom_processing>0.312</max_time_dom_processing>
+		<min_time_dom_processing>0.3120</min_time_dom_processing>
+		<max_time_dom_processing>0.3120</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.255</min_time_dom_completion>
-		<max_time_dom_completion>0.255</max_time_dom_completion>
+		<min_time_dom_completion>0.2550</min_time_dom_completion>
+		<max_time_dom_completion>0.2550</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>39400</sum_bandwidth>
 		<nb_hits_with_bandwidth>13</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>14</entry_nb_visits>
 		<entry_nb_actions>23</entry_nb_actions>
 		<entry_sum_visit_length>54</entry_sum_visit_length>
@@ -69,8 +69,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>5</nb_hits_with_time_server>
-				<min_time_server>0.647</min_time_server>
-				<max_time_server>1.447</max_time_server>
+				<min_time_server>0.0230</min_time_server>
+				<max_time_server>1.3240</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -85,8 +85,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>35740</sum_bandwidth>
 				<nb_hits_with_bandwidth>10</nb_hits_with_bandwidth>
-				<min_bandwidth>0</min_bandwidth>
-				<max_bandwidth>0</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>11</entry_nb_visits>
 				<entry_nb_actions>20</entry_nb_actions>
 				<entry_sum_visit_length>54</entry_sum_visit_length>
@@ -121,8 +121,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>3</nb_hits_with_time_server>
-						<min_time_server>0.023</min_time_server>
-						<max_time_server>0.123</max_time_server>
+						<min_time_server>0.0230</min_time_server>
+						<max_time_server>0.1230</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -137,8 +137,8 @@
 						<max_time_on_load />
 						<sum_bandwidth>32166</sum_bandwidth>
 						<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-						<min_bandwidth>0</min_bandwidth>
-						<max_bandwidth>0</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>10</entry_nb_visits>
 						<entry_nb_actions>19</entry_nb_actions>
 						<entry_sum_visit_length>54</entry_sum_visit_length>
@@ -173,8 +173,8 @@
 								<min_time_network />
 								<max_time_network />
 								<nb_hits_with_time_server>3</nb_hits_with_time_server>
-								<min_time_server>0.023</min_time_server>
-								<max_time_server>0.123</max_time_server>
+								<min_time_server>0.0230</min_time_server>
+								<max_time_server>0.1230</max_time_server>
 								<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 								<min_time_transfer />
 								<max_time_transfer />
@@ -189,8 +189,8 @@
 								<max_time_on_load />
 								<sum_bandwidth>32166</sum_bandwidth>
 								<nb_hits_with_bandwidth>9</nb_hits_with_bandwidth>
-								<min_bandwidth>0</min_bandwidth>
-								<max_bandwidth>0</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>10</entry_nb_visits>
 								<entry_nb_actions>19</entry_nb_actions>
 								<entry_sum_visit_length>54</entry_sum_visit_length>
@@ -231,8 +231,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.624</min_time_server>
-						<max_time_server>1.324</max_time_server>
+						<min_time_server>0.6240</min_time_server>
+						<max_time_server>1.3240</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -247,8 +247,8 @@
 						<max_time_on_load />
 						<sum_bandwidth>3574</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
-						<min_bandwidth>0</min_bandwidth>
-						<max_bandwidth>0</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -283,8 +283,8 @@
 								<min_time_network />
 								<max_time_network />
 								<nb_hits_with_time_server>2</nb_hits_with_time_server>
-								<min_time_server>0.624</min_time_server>
-								<max_time_server>1.324</max_time_server>
+								<min_time_server>0.6240</min_time_server>
+								<max_time_server>1.3240</max_time_server>
 								<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 								<min_time_transfer />
 								<max_time_transfer />
@@ -299,8 +299,8 @@
 								<max_time_on_load />
 								<sum_bandwidth>3574</sum_bandwidth>
 								<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
-								<min_bandwidth>0</min_bandwidth>
-								<max_bandwidth>0</max_bandwidth>
+								<min_bandwidth>3574</min_bandwidth>
+								<max_bandwidth>3574</max_bandwidth>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>1</entry_nb_actions>
 								<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -359,8 +359,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>3617</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>3617</min_bandwidth>
-				<max_bandwidth>3617</max_bandwidth>
+				<min_bandwidth>43</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -722,23 +722,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.01</min_time_network>
-				<max_time_network>0.01</max_time_network>
+				<min_time_network>0.0100</min_time_network>
+				<max_time_network>0.0100</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.096</min_time_server>
-				<max_time_server>0.096</max_time_server>
+				<min_time_server>0.0960</min_time_server>
+				<max_time_server>0.0960</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.232</min_time_transfer>
-				<max_time_transfer>0.232</max_time_transfer>
+				<min_time_transfer>0.2320</min_time_transfer>
+				<max_time_transfer>0.2320</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.312</min_time_dom_processing>
-				<max_time_dom_processing>0.312</max_time_dom_processing>
+				<min_time_dom_processing>0.3120</min_time_dom_processing>
+				<max_time_dom_processing>0.3120</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.255</min_time_dom_completion>
-				<max_time_dom_completion>0.255</max_time_dom_completion>
+				<min_time_dom_completion>0.2550</min_time_dom_completion>
+				<max_time_dom_completion>0.2550</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0</min_time_on_load>
-				<max_time_on_load>0</max_time_on_load>
+				<min_time_on_load>0.0000</min_time_on_load>
+				<max_time_on_load>0.0000</max_time_on_load>
 				<sum_bandwidth>43</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -774,23 +774,23 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_network>1</nb_hits_with_time_network>
-						<min_time_network>0.01</min_time_network>
-						<max_time_network>0.01</max_time_network>
+						<min_time_network>0.0100</min_time_network>
+						<max_time_network>0.0100</max_time_network>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.096</min_time_server>
-						<max_time_server>0.096</max_time_server>
+						<min_time_server>0.0960</min_time_server>
+						<max_time_server>0.0960</max_time_server>
 						<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-						<min_time_transfer>0.232</min_time_transfer>
-						<max_time_transfer>0.232</max_time_transfer>
+						<min_time_transfer>0.2320</min_time_transfer>
+						<max_time_transfer>0.2320</max_time_transfer>
 						<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-						<min_time_dom_processing>0.312</min_time_dom_processing>
-						<max_time_dom_processing>0.312</max_time_dom_processing>
+						<min_time_dom_processing>0.3120</min_time_dom_processing>
+						<max_time_dom_processing>0.3120</max_time_dom_processing>
 						<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-						<min_time_dom_completion>0.255</min_time_dom_completion>
-						<max_time_dom_completion>0.255</max_time_dom_completion>
+						<min_time_dom_completion>0.2550</min_time_dom_completion>
+						<max_time_dom_completion>0.2550</max_time_dom_completion>
 						<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-						<min_time_on_load>0</min_time_on_load>
-						<max_time_on_load>0</max_time_on_load>
+						<min_time_on_load>0.0000</min_time_on_load>
+						<max_time_on_load>0.0000</max_time_on_load>
 						<sum_bandwidth>43</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>43</min_bandwidth>
@@ -826,23 +826,23 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_network>1</nb_hits_with_time_network>
-								<min_time_network>0.01</min_time_network>
-								<max_time_network>0.01</max_time_network>
+								<min_time_network>0.0100</min_time_network>
+								<max_time_network>0.0100</max_time_network>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.096</min_time_server>
-								<max_time_server>0.096</max_time_server>
+								<min_time_server>0.0960</min_time_server>
+								<max_time_server>0.0960</max_time_server>
 								<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-								<min_time_transfer>0.232</min_time_transfer>
-								<max_time_transfer>0.232</max_time_transfer>
+								<min_time_transfer>0.2320</min_time_transfer>
+								<max_time_transfer>0.2320</max_time_transfer>
 								<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-								<min_time_dom_processing>0.312</min_time_dom_processing>
-								<max_time_dom_processing>0.312</max_time_dom_processing>
+								<min_time_dom_processing>0.3120</min_time_dom_processing>
+								<max_time_dom_processing>0.3120</max_time_dom_processing>
 								<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-								<min_time_dom_completion>0.255</min_time_dom_completion>
-								<max_time_dom_completion>0.255</max_time_dom_completion>
+								<min_time_dom_completion>0.2550</min_time_dom_completion>
+								<max_time_dom_completion>0.2550</max_time_dom_completion>
 								<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-								<min_time_on_load>0</min_time_on_load>
-								<max_time_on_load>0</max_time_on_load>
+								<min_time_on_load>0.0000</min_time_on_load>
+								<max_time_on_load>0.0000</max_time_on_load>
 								<sum_bandwidth>43</sum_bandwidth>
 								<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 								<min_bandwidth>43</min_bandwidth>
@@ -878,23 +878,23 @@
 										<nb_hits>1</nb_hits>
 										<sum_time_spent>0</sum_time_spent>
 										<nb_hits_with_time_network>1</nb_hits_with_time_network>
-										<min_time_network>0.01</min_time_network>
-										<max_time_network>0.01</max_time_network>
+										<min_time_network>0.0100</min_time_network>
+										<max_time_network>0.0100</max_time_network>
 										<nb_hits_with_time_server>1</nb_hits_with_time_server>
-										<min_time_server>0.096</min_time_server>
-										<max_time_server>0.096</max_time_server>
+										<min_time_server>0.0960</min_time_server>
+										<max_time_server>0.0960</max_time_server>
 										<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-										<min_time_transfer>0.232</min_time_transfer>
-										<max_time_transfer>0.232</max_time_transfer>
+										<min_time_transfer>0.2320</min_time_transfer>
+										<max_time_transfer>0.2320</max_time_transfer>
 										<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-										<min_time_dom_processing>0.312</min_time_dom_processing>
-										<max_time_dom_processing>0.312</max_time_dom_processing>
+										<min_time_dom_processing>0.3120</min_time_dom_processing>
+										<max_time_dom_processing>0.3120</max_time_dom_processing>
 										<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-										<min_time_dom_completion>0.255</min_time_dom_completion>
-										<max_time_dom_completion>0.255</max_time_dom_completion>
+										<min_time_dom_completion>0.2550</min_time_dom_completion>
+										<max_time_dom_completion>0.2550</max_time_dom_completion>
 										<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-										<min_time_on_load>0</min_time_on_load>
-										<max_time_on_load>0</max_time_on_load>
+										<min_time_on_load>0.0000</min_time_on_load>
+										<max_time_on_load>0.0000</max_time_on_load>
 										<sum_bandwidth>43</sum_bandwidth>
 										<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 										<min_bandwidth>43</min_bandwidth>
@@ -942,27 +942,27 @@
 		<nb_hits>7</nb_hits>
 		<sum_time_spent>34</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.067</min_time_network>
-		<max_time_network>0.067</max_time_network>
+		<min_time_network>0.0260</min_time_network>
+		<max_time_network>0.0410</max_time_network>
 		<nb_hits_with_time_server>3</nb_hits_with_time_server>
-		<min_time_server>0.117</min_time_server>
-		<max_time_server>0.117</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0580</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.521</min_time_transfer>
-		<max_time_transfer>0.521</max_time_transfer>
+		<min_time_transfer>0.1550</min_time_transfer>
+		<max_time_transfer>0.3660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.654</min_time_dom_processing>
-		<max_time_dom_processing>0.654</max_time_dom_processing>
+		<min_time_dom_processing>0.2550</min_time_dom_processing>
+		<max_time_dom_processing>0.3990</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.7</min_time_dom_completion>
-		<max_time_dom_completion>0.7</max_time_dom_completion>
+		<min_time_dom_completion>0.1550</min_time_dom_completion>
+		<max_time_dom_completion>0.5450</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.135</min_time_on_load>
-		<max_time_on_load>0.135</max_time_on_load>
+		<min_time_on_load>0.0450</min_time_on_load>
+		<max_time_on_load>0.0900</max_time_on_load>
 		<sum_bandwidth>8235</sum_bandwidth>
 		<nb_hits_with_bandwidth>7</nb_hits_with_bandwidth>
-		<min_bandwidth>8149</min_bandwidth>
-		<max_bandwidth>8149</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>7</entry_nb_visits>
 		<entry_nb_actions>10</entry_nb_actions>
 		<entry_sum_visit_length>44</entry_sum_visit_length>
@@ -1006,27 +1006,27 @@
 		<nb_hits>7</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.013</min_time_network>
-		<max_time_network>0.013</max_time_network>
+		<min_time_network>0.0130</min_time_network>
+		<max_time_network>0.0130</max_time_network>
 		<nb_hits_with_time_server>3</nb_hits_with_time_server>
-		<min_time_server>0.464</min_time_server>
-		<max_time_server>0.664</max_time_server>
+		<min_time_server>0.1210</min_time_server>
+		<max_time_server>0.5430</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.244</min_time_transfer>
-		<max_time_transfer>0.244</max_time_transfer>
+		<min_time_transfer>0.2440</min_time_transfer>
+		<max_time_transfer>0.2440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.345</min_time_dom_processing>
-		<max_time_dom_processing>0.345</max_time_dom_processing>
+		<min_time_dom_processing>0.3450</min_time_dom_processing>
+		<max_time_dom_processing>0.3450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.09</min_time_dom_completion>
-		<max_time_dom_completion>0.09</max_time_dom_completion>
+		<min_time_dom_completion>0.0900</min_time_dom_completion>
+		<max_time_dom_completion>0.0900</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>14339</sum_bandwidth>
 		<nb_hits_with_bandwidth>5</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
-		<max_bandwidth>43</max_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>5</entry_nb_visits>
 		<entry_nb_actions>5</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1069,8 +1069,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.343</min_time_server>
-				<max_time_server>0.543</max_time_server>
+				<min_time_server>0.3430</min_time_server>
+				<max_time_server>0.5430</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -1085,8 +1085,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>0</min_bandwidth>
-				<max_bandwidth>0</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1121,8 +1121,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.343</min_time_server>
-						<max_time_server>0.543</max_time_server>
+						<min_time_server>0.3430</min_time_server>
+						<max_time_server>0.5430</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -1137,8 +1137,8 @@
 						<max_time_on_load />
 						<sum_bandwidth>7148</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>0</min_bandwidth>
-						<max_bandwidth>0</max_bandwidth>
+						<min_bandwidth>3574</min_bandwidth>
+						<max_bandwidth>3574</max_bandwidth>
 						<entry_nb_visits>2</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1232,23 +1232,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.013</min_time_network>
-				<max_time_network>0.013</max_time_network>
+				<min_time_network>0.0130</min_time_network>
+				<max_time_network>0.0130</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.121</min_time_server>
-				<max_time_server>0.121</max_time_server>
+				<min_time_server>0.1210</min_time_server>
+				<max_time_server>0.1210</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.244</min_time_transfer>
-				<max_time_transfer>0.244</max_time_transfer>
+				<min_time_transfer>0.2440</min_time_transfer>
+				<max_time_transfer>0.2440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.345</min_time_dom_processing>
-				<max_time_dom_processing>0.345</max_time_dom_processing>
+				<min_time_dom_processing>0.3450</min_time_dom_processing>
+				<max_time_dom_processing>0.3450</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.09</min_time_dom_completion>
-				<max_time_dom_completion>0.09</max_time_dom_completion>
+				<min_time_dom_completion>0.0900</min_time_dom_completion>
+				<max_time_dom_completion>0.0900</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0</min_time_on_load>
-				<max_time_on_load>0</max_time_on_load>
+				<min_time_on_load>0.0000</min_time_on_load>
+				<max_time_on_load>0.0000</max_time_on_load>
 				<sum_bandwidth>43</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -1284,23 +1284,23 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_network>1</nb_hits_with_time_network>
-						<min_time_network>0.013</min_time_network>
-						<max_time_network>0.013</max_time_network>
+						<min_time_network>0.0130</min_time_network>
+						<max_time_network>0.0130</max_time_network>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.121</min_time_server>
-						<max_time_server>0.121</max_time_server>
+						<min_time_server>0.1210</min_time_server>
+						<max_time_server>0.1210</max_time_server>
 						<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-						<min_time_transfer>0.244</min_time_transfer>
-						<max_time_transfer>0.244</max_time_transfer>
+						<min_time_transfer>0.2440</min_time_transfer>
+						<max_time_transfer>0.2440</max_time_transfer>
 						<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-						<min_time_dom_processing>0.345</min_time_dom_processing>
-						<max_time_dom_processing>0.345</max_time_dom_processing>
+						<min_time_dom_processing>0.3450</min_time_dom_processing>
+						<max_time_dom_processing>0.3450</max_time_dom_processing>
 						<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-						<min_time_dom_completion>0.09</min_time_dom_completion>
-						<max_time_dom_completion>0.09</max_time_dom_completion>
+						<min_time_dom_completion>0.0900</min_time_dom_completion>
+						<max_time_dom_completion>0.0900</max_time_dom_completion>
 						<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-						<min_time_on_load>0</min_time_on_load>
-						<max_time_on_load>0</max_time_on_load>
+						<min_time_on_load>0.0000</min_time_on_load>
+						<max_time_on_load>0.0000</max_time_on_load>
 						<sum_bandwidth>43</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>43</min_bandwidth>
@@ -1457,8 +1457,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>3</nb_hits_with_time_server>
-		<min_time_server>0.234</min_time_server>
-		<max_time_server>0.294</max_time_server>
+		<min_time_server>0.2340</min_time_server>
+		<max_time_server>0.2940</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -1473,8 +1473,8 @@
 		<max_time_on_load />
 		<sum_bandwidth>14296</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>0</min_bandwidth>
-		<max_bandwidth>0</max_bandwidth>
+		<min_bandwidth>3574</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1517,8 +1517,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>3</nb_hits_with_time_server>
-				<min_time_server>0.234</min_time_server>
-				<max_time_server>0.294</max_time_server>
+				<min_time_server>0.2340</min_time_server>
+				<max_time_server>0.2940</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -1533,8 +1533,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>7148</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>0</min_bandwidth>
-				<max_bandwidth>0</max_bandwidth>
+				<min_bandwidth>3574</min_bandwidth>
+				<max_bandwidth>3574</max_bandwidth>
 				<entry_nb_visits>2</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -1795,8 +1795,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>4</nb_hits_with_time_server>
-		<min_time_server>0.718</min_time_server>
-		<max_time_server>0.718</max_time_server>
+		<min_time_server>0.3590</min_time_server>
+		<max_time_server>0.3590</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -1855,8 +1855,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.359</min_time_server>
-				<max_time_server>0.359</max_time_server>
+				<min_time_server>0.3590</min_time_server>
+				<max_time_server>0.3590</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -1907,8 +1907,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.359</min_time_server>
-						<max_time_server>0.359</max_time_server>
+						<min_time_server>0.3590</min_time_server>
+						<max_time_server>0.3590</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -1965,8 +1965,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.359</min_time_server>
-				<max_time_server>0.359</max_time_server>
+				<min_time_server>0.3590</min_time_server>
+				<max_time_server>0.3590</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -2017,8 +2017,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>2</nb_hits_with_time_server>
-						<min_time_server>0.359</min_time_server>
-						<max_time_server>0.359</max_time_server>
+						<min_time_server>0.3590</min_time_server>
+						<max_time_server>0.3590</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />
@@ -2069,8 +2069,8 @@
 								<min_time_network />
 								<max_time_network />
 								<nb_hits_with_time_server>2</nb_hits_with_time_server>
-								<min_time_server>0.359</min_time_server>
-								<max_time_server>0.359</max_time_server>
+								<min_time_server>0.3590</min_time_server>
+								<max_time_server>0.3590</max_time_server>
 								<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 								<min_time_transfer />
 								<max_time_transfer />
@@ -2121,8 +2121,8 @@
 										<min_time_network />
 										<max_time_network />
 										<nb_hits_with_time_server>2</nb_hits_with_time_server>
-										<min_time_server>0.359</min_time_server>
-										<max_time_server>0.359</max_time_server>
+										<min_time_server>0.3590</min_time_server>
+										<max_time_server>0.3590</max_time_server>
 										<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 										<min_time_transfer />
 										<max_time_transfer />
@@ -2201,8 +2201,8 @@
 		<max_time_on_load />
 		<sum_bandwidth>5964</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>5964</min_bandwidth>
-		<max_bandwidth>5964</max_bandwidth>
+		<min_bandwidth>355</min_bandwidth>
+		<max_bandwidth>5609</max_bandwidth>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -2261,8 +2261,8 @@
 				<max_time_on_load />
 				<sum_bandwidth>5964</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-				<min_bandwidth>5964</min_bandwidth>
-				<max_bandwidth>5964</max_bandwidth>
+				<min_bandwidth>355</min_bandwidth>
+				<max_bandwidth>5609</max_bandwidth>
 				<entry_nb_visits>1</entry_nb_visits>
 				<entry_nb_actions>2</entry_nb_actions>
 				<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -2313,8 +2313,8 @@
 						<max_time_on_load />
 						<sum_bandwidth>5964</sum_bandwidth>
 						<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-						<min_bandwidth>5964</min_bandwidth>
-						<max_bandwidth>5964</max_bandwidth>
+						<min_bandwidth>355</min_bandwidth>
+						<max_bandwidth>5609</max_bandwidth>
 						<entry_nb_visits>1</entry_nb_visits>
 						<entry_nb_actions>2</entry_nb_actions>
 						<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -2365,8 +2365,8 @@
 								<max_time_on_load />
 								<sum_bandwidth>5964</sum_bandwidth>
 								<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-								<min_bandwidth>5964</min_bandwidth>
-								<max_bandwidth>5964</max_bandwidth>
+								<min_bandwidth>355</min_bandwidth>
+								<max_bandwidth>5609</max_bandwidth>
 								<entry_nb_visits>1</entry_nb_visits>
 								<entry_nb_actions>2</entry_nb_actions>
 								<entry_sum_visit_length>242</entry_sum_visit_length>
@@ -2515,8 +2515,8 @@
 		<max_time_on_load />
 		<sum_bandwidth>3617</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>3617</min_bandwidth>
-		<max_bandwidth>3617</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>3574</max_bandwidth>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>1</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -2704,23 +2704,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.355</min_time_server>
-		<max_time_server>0.355</max_time_server>
+		<min_time_server>0.3550</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.099</min_time_transfer>
-		<max_time_transfer>0.099</max_time_transfer>
+		<min_time_transfer>0.0990</min_time_transfer>
+		<max_time_transfer>0.0990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.341</min_time_dom_processing>
-		<max_time_dom_processing>0.341</max_time_dom_processing>
+		<min_time_dom_processing>0.3410</min_time_dom_processing>
+		<max_time_dom_processing>0.3410</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2</min_time_dom_completion>
-		<max_time_dom_completion>0.2</max_time_dom_completion>
+		<min_time_dom_completion>0.2000</min_time_dom_completion>
+		<max_time_dom_completion>0.2000</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.11</min_time_on_load>
-		<max_time_on_load>0.11</max_time_on_load>
+		<min_time_on_load>0.1100</min_time_on_load>
+		<max_time_on_load>0.1100</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -2764,23 +2764,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.355</min_time_server>
-				<max_time_server>0.355</max_time_server>
+				<min_time_server>0.3550</min_time_server>
+				<max_time_server>0.3550</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.099</min_time_transfer>
-				<max_time_transfer>0.099</max_time_transfer>
+				<min_time_transfer>0.0990</min_time_transfer>
+				<max_time_transfer>0.0990</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.341</min_time_dom_processing>
-				<max_time_dom_processing>0.341</max_time_dom_processing>
+				<min_time_dom_processing>0.3410</min_time_dom_processing>
+				<max_time_dom_processing>0.3410</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.2</min_time_dom_completion>
-				<max_time_dom_completion>0.2</max_time_dom_completion>
+				<min_time_dom_completion>0.2000</min_time_dom_completion>
+				<max_time_dom_completion>0.2000</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.11</min_time_on_load>
-				<max_time_on_load>0.11</max_time_on_load>
+				<min_time_on_load>0.1100</min_time_on_load>
+				<max_time_on_load>0.1100</max_time_on_load>
 				<sum_bandwidth>86</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -3305,8 +3305,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.009</min_time_server>
-		<max_time_server>0.009</max_time_server>
+		<min_time_server>0.0090</min_time_server>
+		<max_time_server>0.0090</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -3365,8 +3365,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.009</min_time_server>
-				<max_time_server>0.009</max_time_server>
+				<min_time_server>0.0090</min_time_server>
+				<max_time_server>0.0090</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -3971,8 +3971,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.109</min_time_server>
-		<max_time_server>0.109</max_time_server>
+		<min_time_server>0.1090</min_time_server>
+		<max_time_server>0.1090</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -4031,8 +4031,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.109</min_time_server>
-				<max_time_server>0.109</max_time_server>
+				<min_time_server>0.1090</min_time_server>
+				<max_time_server>0.1090</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -4757,8 +4757,8 @@
 		<min_time_network />
 		<max_time_network />
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.001</min_time_server>
-		<max_time_server>0.001</max_time_server>
+		<min_time_server>0.0010</min_time_server>
+		<max_time_server>0.0010</max_time_server>
 		<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 		<min_time_transfer />
 		<max_time_transfer />
@@ -4817,8 +4817,8 @@
 				<min_time_network />
 				<max_time_network />
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.001</min_time_server>
-				<max_time_server>0.001</max_time_server>
+				<min_time_server>0.0010</min_time_server>
+				<max_time_server>0.0010</max_time_server>
 				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 				<min_time_transfer />
 				<max_time_transfer />
@@ -4869,8 +4869,8 @@
 						<min_time_network />
 						<max_time_network />
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.001</min_time_server>
-						<max_time_server>0.001</max_time_server>
+						<min_time_server>0.0010</min_time_server>
+						<max_time_server>0.0010</max_time_server>
 						<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
 						<min_time_transfer />
 						<max_time_transfer />

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Events.getAction_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Events.getAction_month.xml
@@ -6,8 +6,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==connect</segment>
@@ -18,8 +18,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==play</segment>
@@ -30,8 +30,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Events.getCategory_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Events.getCategory_month.xml
@@ -6,8 +6,8 @@
 		<nb_events>2</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventCategory==cloudfront_rtmp</segment>
@@ -18,8 +18,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -29,8 +29,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Events.getName_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Events.getName_month.xml
@@ -6,8 +6,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<subtable>
@@ -17,8 +17,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -30,8 +30,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==myvideo</segment>
@@ -42,8 +42,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Actions.getEntryPageTitles_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Actions.getEntryPageTitles_range.xml
@@ -6,27 +6,27 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>34</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.067</min_time_network>
-		<max_time_network>0.067</max_time_network>
+		<min_time_network>0.0260</min_time_network>
+		<max_time_network>0.0410</max_time_network>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.116</min_time_server>
-		<max_time_server>0.116</max_time_server>
+		<min_time_server>0.0580</min_time_server>
+		<max_time_server>0.0580</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.521</min_time_transfer>
-		<max_time_transfer>0.521</max_time_transfer>
+		<min_time_transfer>0.1550</min_time_transfer>
+		<max_time_transfer>0.3660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.654</min_time_dom_processing>
-		<max_time_dom_processing>0.654</max_time_dom_processing>
+		<min_time_dom_processing>0.2550</min_time_dom_processing>
+		<max_time_dom_processing>0.3990</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.7</min_time_dom_completion>
-		<max_time_dom_completion>0.7</max_time_dom_completion>
+		<min_time_dom_completion>0.1550</min_time_dom_completion>
+		<max_time_dom_completion>0.5450</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.135</min_time_on_load>
-		<max_time_on_load>0.135</max_time_on_load>
+		<min_time_on_load>0.0450</min_time_on_load>
+		<max_time_on_load>0.0900</max_time_on_load>
 		<sum_bandwidth>172</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>43</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>7</entry_nb_actions>
 		<entry_sum_visit_length>43</entry_sum_visit_length>
@@ -54,23 +54,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.355</min_time_server>
-		<max_time_server>0.355</max_time_server>
+		<min_time_server>0.3550</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.099</min_time_transfer>
-		<max_time_transfer>0.099</max_time_transfer>
+		<min_time_transfer>0.0990</min_time_transfer>
+		<max_time_transfer>0.0990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.341</min_time_dom_processing>
-		<max_time_dom_processing>0.341</max_time_dom_processing>
+		<min_time_dom_processing>0.3410</min_time_dom_processing>
+		<max_time_dom_processing>0.3410</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2</min_time_dom_completion>
-		<max_time_dom_completion>0.2</max_time_dom_completion>
+		<min_time_dom_completion>0.2000</min_time_dom_completion>
+		<max_time_dom_completion>0.2000</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.11</min_time_on_load>
-		<max_time_on_load>0.11</max_time_on_load>
+		<min_time_on_load>0.1100</min_time_on_load>
+		<max_time_on_load>0.1100</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -196,23 +196,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.013</min_time_network>
-		<max_time_network>0.013</max_time_network>
+		<min_time_network>0.0130</min_time_network>
+		<max_time_network>0.0130</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.121</min_time_server>
-		<max_time_server>0.121</max_time_server>
+		<min_time_server>0.1210</min_time_server>
+		<max_time_server>0.1210</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.244</min_time_transfer>
-		<max_time_transfer>0.244</max_time_transfer>
+		<min_time_transfer>0.2440</min_time_transfer>
+		<max_time_transfer>0.2440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.345</min_time_dom_processing>
-		<max_time_dom_processing>0.345</max_time_dom_processing>
+		<min_time_dom_processing>0.3450</min_time_dom_processing>
+		<max_time_dom_processing>0.3450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.09</min_time_dom_completion>
-		<max_time_dom_completion>0.09</max_time_dom_completion>
+		<min_time_dom_completion>0.0900</min_time_dom_completion>
+		<max_time_dom_completion>0.0900</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -388,23 +388,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.01</min_time_network>
-		<max_time_network>0.01</max_time_network>
+		<min_time_network>0.0100</min_time_network>
+		<max_time_network>0.0100</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.096</min_time_server>
-		<max_time_server>0.096</max_time_server>
+		<min_time_server>0.0960</min_time_server>
+		<max_time_server>0.0960</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.232</min_time_transfer>
-		<max_time_transfer>0.232</max_time_transfer>
+		<min_time_transfer>0.2320</min_time_transfer>
+		<max_time_transfer>0.2320</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.312</min_time_dom_processing>
-		<max_time_dom_processing>0.312</max_time_dom_processing>
+		<min_time_dom_processing>0.3120</min_time_dom_processing>
+		<max_time_dom_processing>0.3120</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.255</min_time_dom_completion>
-		<max_time_dom_completion>0.255</max_time_dom_completion>
+		<min_time_dom_completion>0.2550</min_time_dom_completion>
+		<max_time_dom_completion>0.2550</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Actions.getEntryPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Actions.getEntryPageUrls_range.xml
@@ -6,27 +6,27 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>34</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.067</min_time_network>
-		<max_time_network>0.067</max_time_network>
+		<min_time_network>0.0260</min_time_network>
+		<max_time_network>0.0410</max_time_network>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.116</min_time_server>
-		<max_time_server>0.116</max_time_server>
+		<min_time_server>0.0580</min_time_server>
+		<max_time_server>0.0580</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.521</min_time_transfer>
-		<max_time_transfer>0.521</max_time_transfer>
+		<min_time_transfer>0.1550</min_time_transfer>
+		<max_time_transfer>0.3660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.654</min_time_dom_processing>
-		<max_time_dom_processing>0.654</max_time_dom_processing>
+		<min_time_dom_processing>0.2550</min_time_dom_processing>
+		<max_time_dom_processing>0.3990</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.7</min_time_dom_completion>
-		<max_time_dom_completion>0.7</max_time_dom_completion>
+		<min_time_dom_completion>0.1550</min_time_dom_completion>
+		<max_time_dom_completion>0.5450</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.135</min_time_on_load>
-		<max_time_on_load>0.135</max_time_on_load>
+		<min_time_on_load>0.0450</min_time_on_load>
+		<max_time_on_load>0.0900</max_time_on_load>
 		<sum_bandwidth>172</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>43</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>7</entry_nb_actions>
 		<entry_sum_visit_length>43</entry_sum_visit_length>
@@ -104,27 +104,27 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.01</min_time_network>
-		<max_time_network>0.01</max_time_network>
+		<min_time_network>0.0100</min_time_network>
+		<max_time_network>0.0100</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.096</min_time_server>
-		<max_time_server>0.096</max_time_server>
+		<min_time_server>0.0960</min_time_server>
+		<max_time_server>0.0960</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.232</min_time_transfer>
-		<max_time_transfer>0.232</max_time_transfer>
+		<min_time_transfer>0.2320</min_time_transfer>
+		<max_time_transfer>0.2320</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.312</min_time_dom_processing>
-		<max_time_dom_processing>0.312</max_time_dom_processing>
+		<min_time_dom_processing>0.3120</min_time_dom_processing>
+		<max_time_dom_processing>0.3120</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.255</min_time_dom_completion>
-		<max_time_dom_completion>0.255</max_time_dom_completion>
+		<min_time_dom_completion>0.2550</min_time_dom_completion>
+		<max_time_dom_completion>0.2550</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>43</max_bandwidth>
 		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -307,23 +307,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.01</min_time_network>
-				<max_time_network>0.01</max_time_network>
+				<min_time_network>0.0100</min_time_network>
+				<max_time_network>0.0100</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.096</min_time_server>
-				<max_time_server>0.096</max_time_server>
+				<min_time_server>0.0960</min_time_server>
+				<max_time_server>0.0960</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.232</min_time_transfer>
-				<max_time_transfer>0.232</max_time_transfer>
+				<min_time_transfer>0.2320</min_time_transfer>
+				<max_time_transfer>0.2320</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.312</min_time_dom_processing>
-				<max_time_dom_processing>0.312</max_time_dom_processing>
+				<min_time_dom_processing>0.3120</min_time_dom_processing>
+				<max_time_dom_processing>0.3120</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.255</min_time_dom_completion>
-				<max_time_dom_completion>0.255</max_time_dom_completion>
+				<min_time_dom_completion>0.2550</min_time_dom_completion>
+				<max_time_dom_completion>0.2550</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0</min_time_on_load>
-				<max_time_on_load>0</max_time_on_load>
+				<min_time_on_load>0.0000</min_time_on_load>
+				<max_time_on_load>0.0000</max_time_on_load>
 				<sum_bandwidth>43</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -344,23 +344,23 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_network>1</nb_hits_with_time_network>
-						<min_time_network>0.01</min_time_network>
-						<max_time_network>0.01</max_time_network>
+						<min_time_network>0.0100</min_time_network>
+						<max_time_network>0.0100</max_time_network>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.096</min_time_server>
-						<max_time_server>0.096</max_time_server>
+						<min_time_server>0.0960</min_time_server>
+						<max_time_server>0.0960</max_time_server>
 						<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-						<min_time_transfer>0.232</min_time_transfer>
-						<max_time_transfer>0.232</max_time_transfer>
+						<min_time_transfer>0.2320</min_time_transfer>
+						<max_time_transfer>0.2320</max_time_transfer>
 						<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-						<min_time_dom_processing>0.312</min_time_dom_processing>
-						<max_time_dom_processing>0.312</max_time_dom_processing>
+						<min_time_dom_processing>0.3120</min_time_dom_processing>
+						<max_time_dom_processing>0.3120</max_time_dom_processing>
 						<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-						<min_time_dom_completion>0.255</min_time_dom_completion>
-						<max_time_dom_completion>0.255</max_time_dom_completion>
+						<min_time_dom_completion>0.2550</min_time_dom_completion>
+						<max_time_dom_completion>0.2550</max_time_dom_completion>
 						<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-						<min_time_on_load>0</min_time_on_load>
-						<max_time_on_load>0</max_time_on_load>
+						<min_time_on_load>0.0000</min_time_on_load>
+						<max_time_on_load>0.0000</max_time_on_load>
 						<sum_bandwidth>43</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>43</min_bandwidth>
@@ -381,23 +381,23 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_network>1</nb_hits_with_time_network>
-								<min_time_network>0.01</min_time_network>
-								<max_time_network>0.01</max_time_network>
+								<min_time_network>0.0100</min_time_network>
+								<max_time_network>0.0100</max_time_network>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.096</min_time_server>
-								<max_time_server>0.096</max_time_server>
+								<min_time_server>0.0960</min_time_server>
+								<max_time_server>0.0960</max_time_server>
 								<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-								<min_time_transfer>0.232</min_time_transfer>
-								<max_time_transfer>0.232</max_time_transfer>
+								<min_time_transfer>0.2320</min_time_transfer>
+								<max_time_transfer>0.2320</max_time_transfer>
 								<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-								<min_time_dom_processing>0.312</min_time_dom_processing>
-								<max_time_dom_processing>0.312</max_time_dom_processing>
+								<min_time_dom_processing>0.3120</min_time_dom_processing>
+								<max_time_dom_processing>0.3120</max_time_dom_processing>
 								<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-								<min_time_dom_completion>0.255</min_time_dom_completion>
-								<max_time_dom_completion>0.255</max_time_dom_completion>
+								<min_time_dom_completion>0.2550</min_time_dom_completion>
+								<max_time_dom_completion>0.2550</max_time_dom_completion>
 								<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-								<min_time_on_load>0</min_time_on_load>
-								<max_time_on_load>0</max_time_on_load>
+								<min_time_on_load>0.0000</min_time_on_load>
+								<max_time_on_load>0.0000</max_time_on_load>
 								<sum_bandwidth>43</sum_bandwidth>
 								<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 								<min_bandwidth>43</min_bandwidth>
@@ -418,23 +418,23 @@
 										<nb_hits>1</nb_hits>
 										<sum_time_spent>0</sum_time_spent>
 										<nb_hits_with_time_network>1</nb_hits_with_time_network>
-										<min_time_network>0.01</min_time_network>
-										<max_time_network>0.01</max_time_network>
+										<min_time_network>0.0100</min_time_network>
+										<max_time_network>0.0100</max_time_network>
 										<nb_hits_with_time_server>1</nb_hits_with_time_server>
-										<min_time_server>0.096</min_time_server>
-										<max_time_server>0.096</max_time_server>
+										<min_time_server>0.0960</min_time_server>
+										<max_time_server>0.0960</max_time_server>
 										<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-										<min_time_transfer>0.232</min_time_transfer>
-										<max_time_transfer>0.232</max_time_transfer>
+										<min_time_transfer>0.2320</min_time_transfer>
+										<max_time_transfer>0.2320</max_time_transfer>
 										<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-										<min_time_dom_processing>0.312</min_time_dom_processing>
-										<max_time_dom_processing>0.312</max_time_dom_processing>
+										<min_time_dom_processing>0.3120</min_time_dom_processing>
+										<max_time_dom_processing>0.3120</max_time_dom_processing>
 										<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-										<min_time_dom_completion>0.255</min_time_dom_completion>
-										<max_time_dom_completion>0.255</max_time_dom_completion>
+										<min_time_dom_completion>0.2550</min_time_dom_completion>
+										<max_time_dom_completion>0.2550</max_time_dom_completion>
 										<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-										<min_time_on_load>0</min_time_on_load>
-										<max_time_on_load>0</max_time_on_load>
+										<min_time_on_load>0.0000</min_time_on_load>
+										<max_time_on_load>0.0000</max_time_on_load>
 										<sum_bandwidth>43</sum_bandwidth>
 										<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 										<min_bandwidth>43</min_bandwidth>
@@ -467,23 +467,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.355</min_time_server>
-		<max_time_server>0.355</max_time_server>
+		<min_time_server>0.3550</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.099</min_time_transfer>
-		<max_time_transfer>0.099</max_time_transfer>
+		<min_time_transfer>0.0990</min_time_transfer>
+		<max_time_transfer>0.0990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.341</min_time_dom_processing>
-		<max_time_dom_processing>0.341</max_time_dom_processing>
+		<min_time_dom_processing>0.3410</min_time_dom_processing>
+		<max_time_dom_processing>0.3410</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2</min_time_dom_completion>
-		<max_time_dom_completion>0.2</max_time_dom_completion>
+		<min_time_dom_completion>0.2000</min_time_dom_completion>
+		<max_time_dom_completion>0.2000</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.11</min_time_on_load>
-		<max_time_on_load>0.11</max_time_on_load>
+		<min_time_on_load>0.1100</min_time_on_load>
+		<max_time_on_load>0.1100</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -512,23 +512,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.355</min_time_server>
-				<max_time_server>0.355</max_time_server>
+				<min_time_server>0.3550</min_time_server>
+				<max_time_server>0.3550</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.099</min_time_transfer>
-				<max_time_transfer>0.099</max_time_transfer>
+				<min_time_transfer>0.0990</min_time_transfer>
+				<max_time_transfer>0.0990</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.341</min_time_dom_processing>
-				<max_time_dom_processing>0.341</max_time_dom_processing>
+				<min_time_dom_processing>0.3410</min_time_dom_processing>
+				<max_time_dom_processing>0.3410</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.2</min_time_dom_completion>
-				<max_time_dom_completion>0.2</max_time_dom_completion>
+				<min_time_dom_completion>0.2000</min_time_dom_completion>
+				<max_time_dom_completion>0.2000</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.11</min_time_on_load>
-				<max_time_on_load>0.11</max_time_on_load>
+				<min_time_on_load>0.1100</min_time_on_load>
+				<max_time_on_load>0.1100</max_time_on_load>
 				<sum_bandwidth>86</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -738,23 +738,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.013</min_time_network>
-		<max_time_network>0.013</max_time_network>
+		<min_time_network>0.0130</min_time_network>
+		<max_time_network>0.0130</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.121</min_time_server>
-		<max_time_server>0.121</max_time_server>
+		<min_time_server>0.1210</min_time_server>
+		<max_time_server>0.1210</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.244</min_time_transfer>
-		<max_time_transfer>0.244</max_time_transfer>
+		<min_time_transfer>0.2440</min_time_transfer>
+		<max_time_transfer>0.2440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.345</min_time_dom_processing>
-		<max_time_dom_processing>0.345</max_time_dom_processing>
+		<min_time_dom_processing>0.3450</min_time_dom_processing>
+		<max_time_dom_processing>0.3450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.09</min_time_dom_completion>
-		<max_time_dom_completion>0.09</max_time_dom_completion>
+		<min_time_dom_completion>0.0900</min_time_dom_completion>
+		<max_time_dom_completion>0.0900</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -783,23 +783,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.013</min_time_network>
-				<max_time_network>0.013</max_time_network>
+				<min_time_network>0.0130</min_time_network>
+				<max_time_network>0.0130</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.121</min_time_server>
-				<max_time_server>0.121</max_time_server>
+				<min_time_server>0.1210</min_time_server>
+				<max_time_server>0.1210</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.244</min_time_transfer>
-				<max_time_transfer>0.244</max_time_transfer>
+				<min_time_transfer>0.2440</min_time_transfer>
+				<max_time_transfer>0.2440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.345</min_time_dom_processing>
-				<max_time_dom_processing>0.345</max_time_dom_processing>
+				<min_time_dom_processing>0.3450</min_time_dom_processing>
+				<max_time_dom_processing>0.3450</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.09</min_time_dom_completion>
-				<max_time_dom_completion>0.09</max_time_dom_completion>
+				<min_time_dom_completion>0.0900</min_time_dom_completion>
+				<max_time_dom_completion>0.0900</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0</min_time_on_load>
-				<max_time_on_load>0</max_time_on_load>
+				<min_time_on_load>0.0000</min_time_on_load>
+				<max_time_on_load>0.0000</max_time_on_load>
 				<sum_bandwidth>43</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -820,23 +820,23 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_network>1</nb_hits_with_time_network>
-						<min_time_network>0.013</min_time_network>
-						<max_time_network>0.013</max_time_network>
+						<min_time_network>0.0130</min_time_network>
+						<max_time_network>0.0130</max_time_network>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.121</min_time_server>
-						<max_time_server>0.121</max_time_server>
+						<min_time_server>0.1210</min_time_server>
+						<max_time_server>0.1210</max_time_server>
 						<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-						<min_time_transfer>0.244</min_time_transfer>
-						<max_time_transfer>0.244</max_time_transfer>
+						<min_time_transfer>0.2440</min_time_transfer>
+						<max_time_transfer>0.2440</max_time_transfer>
 						<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-						<min_time_dom_processing>0.345</min_time_dom_processing>
-						<max_time_dom_processing>0.345</max_time_dom_processing>
+						<min_time_dom_processing>0.3450</min_time_dom_processing>
+						<max_time_dom_processing>0.3450</max_time_dom_processing>
 						<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-						<min_time_dom_completion>0.09</min_time_dom_completion>
-						<max_time_dom_completion>0.09</max_time_dom_completion>
+						<min_time_dom_completion>0.0900</min_time_dom_completion>
+						<max_time_dom_completion>0.0900</max_time_dom_completion>
 						<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-						<min_time_on_load>0</min_time_on_load>
-						<max_time_on_load>0</max_time_on_load>
+						<min_time_on_load>0.0000</min_time_on_load>
+						<max_time_on_load>0.0000</max_time_on_load>
 						<sum_bandwidth>43</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>43</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Actions.getExitPageTitles_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Actions.getExitPageTitles_range.xml
@@ -6,27 +6,27 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>34</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.067</min_time_network>
-		<max_time_network>0.067</max_time_network>
+		<min_time_network>0.0260</min_time_network>
+		<max_time_network>0.0410</max_time_network>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.116</min_time_server>
-		<max_time_server>0.116</max_time_server>
+		<min_time_server>0.0580</min_time_server>
+		<max_time_server>0.0580</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.521</min_time_transfer>
-		<max_time_transfer>0.521</max_time_transfer>
+		<min_time_transfer>0.1550</min_time_transfer>
+		<max_time_transfer>0.3660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.654</min_time_dom_processing>
-		<max_time_dom_processing>0.654</max_time_dom_processing>
+		<min_time_dom_processing>0.2550</min_time_dom_processing>
+		<max_time_dom_processing>0.3990</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.7</min_time_dom_completion>
-		<max_time_dom_completion>0.7</max_time_dom_completion>
+		<min_time_dom_completion>0.1550</min_time_dom_completion>
+		<max_time_dom_completion>0.5450</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.135</min_time_on_load>
-		<max_time_on_load>0.135</max_time_on_load>
+		<min_time_on_load>0.0450</min_time_on_load>
+		<max_time_on_load>0.0900</max_time_on_load>
 		<sum_bandwidth>172</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>43</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>7</entry_nb_actions>
 		<entry_sum_visit_length>43</entry_sum_visit_length>
@@ -54,23 +54,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.355</min_time_server>
-		<max_time_server>0.355</max_time_server>
+		<min_time_server>0.3550</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.099</min_time_transfer>
-		<max_time_transfer>0.099</max_time_transfer>
+		<min_time_transfer>0.0990</min_time_transfer>
+		<max_time_transfer>0.0990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.341</min_time_dom_processing>
-		<max_time_dom_processing>0.341</max_time_dom_processing>
+		<min_time_dom_processing>0.3410</min_time_dom_processing>
+		<max_time_dom_processing>0.3410</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2</min_time_dom_completion>
-		<max_time_dom_completion>0.2</max_time_dom_completion>
+		<min_time_dom_completion>0.2000</min_time_dom_completion>
+		<max_time_dom_completion>0.2000</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.11</min_time_on_load>
-		<max_time_on_load>0.11</max_time_on_load>
+		<min_time_on_load>0.1100</min_time_on_load>
+		<max_time_on_load>0.1100</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -236,23 +236,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.013</min_time_network>
-		<max_time_network>0.013</max_time_network>
+		<min_time_network>0.0130</min_time_network>
+		<max_time_network>0.0130</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.121</min_time_server>
-		<max_time_server>0.121</max_time_server>
+		<min_time_server>0.1210</min_time_server>
+		<max_time_server>0.1210</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.244</min_time_transfer>
-		<max_time_transfer>0.244</max_time_transfer>
+		<min_time_transfer>0.2440</min_time_transfer>
+		<max_time_transfer>0.2440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.345</min_time_dom_processing>
-		<max_time_dom_processing>0.345</max_time_dom_processing>
+		<min_time_dom_processing>0.3450</min_time_dom_processing>
+		<max_time_dom_processing>0.3450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.09</min_time_dom_completion>
-		<max_time_dom_completion>0.09</max_time_dom_completion>
+		<min_time_dom_completion>0.0900</min_time_dom_completion>
+		<max_time_dom_completion>0.0900</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -428,23 +428,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.01</min_time_network>
-		<max_time_network>0.01</max_time_network>
+		<min_time_network>0.0100</min_time_network>
+		<max_time_network>0.0100</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.096</min_time_server>
-		<max_time_server>0.096</max_time_server>
+		<min_time_server>0.0960</min_time_server>
+		<max_time_server>0.0960</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.232</min_time_transfer>
-		<max_time_transfer>0.232</max_time_transfer>
+		<min_time_transfer>0.2320</min_time_transfer>
+		<max_time_transfer>0.2320</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.312</min_time_dom_processing>
-		<max_time_dom_processing>0.312</max_time_dom_processing>
+		<min_time_dom_processing>0.3120</min_time_dom_processing>
+		<max_time_dom_processing>0.3120</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.255</min_time_dom_completion>
-		<max_time_dom_completion>0.255</max_time_dom_completion>
+		<min_time_dom_completion>0.2550</min_time_dom_completion>
+		<max_time_dom_completion>0.2550</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Actions.getExitPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Actions.getExitPageUrls_range.xml
@@ -6,27 +6,27 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>34</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.067</min_time_network>
-		<max_time_network>0.067</max_time_network>
+		<min_time_network>0.0260</min_time_network>
+		<max_time_network>0.0410</max_time_network>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.116</min_time_server>
-		<max_time_server>0.116</max_time_server>
+		<min_time_server>0.0580</min_time_server>
+		<max_time_server>0.0580</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.521</min_time_transfer>
-		<max_time_transfer>0.521</max_time_transfer>
+		<min_time_transfer>0.1550</min_time_transfer>
+		<max_time_transfer>0.3660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.654</min_time_dom_processing>
-		<max_time_dom_processing>0.654</max_time_dom_processing>
+		<min_time_dom_processing>0.2550</min_time_dom_processing>
+		<max_time_dom_processing>0.3990</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.7</min_time_dom_completion>
-		<max_time_dom_completion>0.7</max_time_dom_completion>
+		<min_time_dom_completion>0.1550</min_time_dom_completion>
+		<max_time_dom_completion>0.5450</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.135</min_time_on_load>
-		<max_time_on_load>0.135</max_time_on_load>
+		<min_time_on_load>0.0450</min_time_on_load>
+		<max_time_on_load>0.0900</max_time_on_load>
 		<sum_bandwidth>172</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>43</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>7</entry_nb_actions>
 		<entry_sum_visit_length>43</entry_sum_visit_length>
@@ -104,27 +104,27 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.01</min_time_network>
-		<max_time_network>0.01</max_time_network>
+		<min_time_network>0.0100</min_time_network>
+		<max_time_network>0.0100</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.096</min_time_server>
-		<max_time_server>0.096</max_time_server>
+		<min_time_server>0.0960</min_time_server>
+		<max_time_server>0.0960</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.232</min_time_transfer>
-		<max_time_transfer>0.232</max_time_transfer>
+		<min_time_transfer>0.2320</min_time_transfer>
+		<max_time_transfer>0.2320</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.312</min_time_dom_processing>
-		<max_time_dom_processing>0.312</max_time_dom_processing>
+		<min_time_dom_processing>0.3120</min_time_dom_processing>
+		<max_time_dom_processing>0.3120</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.255</min_time_dom_completion>
-		<max_time_dom_completion>0.255</max_time_dom_completion>
+		<min_time_dom_completion>0.2550</min_time_dom_completion>
+		<max_time_dom_completion>0.2550</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>43</max_bandwidth>
 		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -307,23 +307,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.01</min_time_network>
-				<max_time_network>0.01</max_time_network>
+				<min_time_network>0.0100</min_time_network>
+				<max_time_network>0.0100</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.096</min_time_server>
-				<max_time_server>0.096</max_time_server>
+				<min_time_server>0.0960</min_time_server>
+				<max_time_server>0.0960</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.232</min_time_transfer>
-				<max_time_transfer>0.232</max_time_transfer>
+				<min_time_transfer>0.2320</min_time_transfer>
+				<max_time_transfer>0.2320</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.312</min_time_dom_processing>
-				<max_time_dom_processing>0.312</max_time_dom_processing>
+				<min_time_dom_processing>0.3120</min_time_dom_processing>
+				<max_time_dom_processing>0.3120</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.255</min_time_dom_completion>
-				<max_time_dom_completion>0.255</max_time_dom_completion>
+				<min_time_dom_completion>0.2550</min_time_dom_completion>
+				<max_time_dom_completion>0.2550</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0</min_time_on_load>
-				<max_time_on_load>0</max_time_on_load>
+				<min_time_on_load>0.0000</min_time_on_load>
+				<max_time_on_load>0.0000</max_time_on_load>
 				<sum_bandwidth>43</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -344,23 +344,23 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_network>1</nb_hits_with_time_network>
-						<min_time_network>0.01</min_time_network>
-						<max_time_network>0.01</max_time_network>
+						<min_time_network>0.0100</min_time_network>
+						<max_time_network>0.0100</max_time_network>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.096</min_time_server>
-						<max_time_server>0.096</max_time_server>
+						<min_time_server>0.0960</min_time_server>
+						<max_time_server>0.0960</max_time_server>
 						<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-						<min_time_transfer>0.232</min_time_transfer>
-						<max_time_transfer>0.232</max_time_transfer>
+						<min_time_transfer>0.2320</min_time_transfer>
+						<max_time_transfer>0.2320</max_time_transfer>
 						<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-						<min_time_dom_processing>0.312</min_time_dom_processing>
-						<max_time_dom_processing>0.312</max_time_dom_processing>
+						<min_time_dom_processing>0.3120</min_time_dom_processing>
+						<max_time_dom_processing>0.3120</max_time_dom_processing>
 						<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-						<min_time_dom_completion>0.255</min_time_dom_completion>
-						<max_time_dom_completion>0.255</max_time_dom_completion>
+						<min_time_dom_completion>0.2550</min_time_dom_completion>
+						<max_time_dom_completion>0.2550</max_time_dom_completion>
 						<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-						<min_time_on_load>0</min_time_on_load>
-						<max_time_on_load>0</max_time_on_load>
+						<min_time_on_load>0.0000</min_time_on_load>
+						<max_time_on_load>0.0000</max_time_on_load>
 						<sum_bandwidth>43</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>43</min_bandwidth>
@@ -381,23 +381,23 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_network>1</nb_hits_with_time_network>
-								<min_time_network>0.01</min_time_network>
-								<max_time_network>0.01</max_time_network>
+								<min_time_network>0.0100</min_time_network>
+								<max_time_network>0.0100</max_time_network>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.096</min_time_server>
-								<max_time_server>0.096</max_time_server>
+								<min_time_server>0.0960</min_time_server>
+								<max_time_server>0.0960</max_time_server>
 								<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-								<min_time_transfer>0.232</min_time_transfer>
-								<max_time_transfer>0.232</max_time_transfer>
+								<min_time_transfer>0.2320</min_time_transfer>
+								<max_time_transfer>0.2320</max_time_transfer>
 								<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-								<min_time_dom_processing>0.312</min_time_dom_processing>
-								<max_time_dom_processing>0.312</max_time_dom_processing>
+								<min_time_dom_processing>0.3120</min_time_dom_processing>
+								<max_time_dom_processing>0.3120</max_time_dom_processing>
 								<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-								<min_time_dom_completion>0.255</min_time_dom_completion>
-								<max_time_dom_completion>0.255</max_time_dom_completion>
+								<min_time_dom_completion>0.2550</min_time_dom_completion>
+								<max_time_dom_completion>0.2550</max_time_dom_completion>
 								<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-								<min_time_on_load>0</min_time_on_load>
-								<max_time_on_load>0</max_time_on_load>
+								<min_time_on_load>0.0000</min_time_on_load>
+								<max_time_on_load>0.0000</max_time_on_load>
 								<sum_bandwidth>43</sum_bandwidth>
 								<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 								<min_bandwidth>43</min_bandwidth>
@@ -418,23 +418,23 @@
 										<nb_hits>1</nb_hits>
 										<sum_time_spent>0</sum_time_spent>
 										<nb_hits_with_time_network>1</nb_hits_with_time_network>
-										<min_time_network>0.01</min_time_network>
-										<max_time_network>0.01</max_time_network>
+										<min_time_network>0.0100</min_time_network>
+										<max_time_network>0.0100</max_time_network>
 										<nb_hits_with_time_server>1</nb_hits_with_time_server>
-										<min_time_server>0.096</min_time_server>
-										<max_time_server>0.096</max_time_server>
+										<min_time_server>0.0960</min_time_server>
+										<max_time_server>0.0960</max_time_server>
 										<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-										<min_time_transfer>0.232</min_time_transfer>
-										<max_time_transfer>0.232</max_time_transfer>
+										<min_time_transfer>0.2320</min_time_transfer>
+										<max_time_transfer>0.2320</max_time_transfer>
 										<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-										<min_time_dom_processing>0.312</min_time_dom_processing>
-										<max_time_dom_processing>0.312</max_time_dom_processing>
+										<min_time_dom_processing>0.3120</min_time_dom_processing>
+										<max_time_dom_processing>0.3120</max_time_dom_processing>
 										<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-										<min_time_dom_completion>0.255</min_time_dom_completion>
-										<max_time_dom_completion>0.255</max_time_dom_completion>
+										<min_time_dom_completion>0.2550</min_time_dom_completion>
+										<max_time_dom_completion>0.2550</max_time_dom_completion>
 										<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-										<min_time_on_load>0</min_time_on_load>
-										<max_time_on_load>0</max_time_on_load>
+										<min_time_on_load>0.0000</min_time_on_load>
+										<max_time_on_load>0.0000</max_time_on_load>
 										<sum_bandwidth>43</sum_bandwidth>
 										<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 										<min_bandwidth>43</min_bandwidth>
@@ -467,23 +467,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.355</min_time_server>
-		<max_time_server>0.355</max_time_server>
+		<min_time_server>0.3550</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.099</min_time_transfer>
-		<max_time_transfer>0.099</max_time_transfer>
+		<min_time_transfer>0.0990</min_time_transfer>
+		<max_time_transfer>0.0990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.341</min_time_dom_processing>
-		<max_time_dom_processing>0.341</max_time_dom_processing>
+		<min_time_dom_processing>0.3410</min_time_dom_processing>
+		<max_time_dom_processing>0.3410</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2</min_time_dom_completion>
-		<max_time_dom_completion>0.2</max_time_dom_completion>
+		<min_time_dom_completion>0.2000</min_time_dom_completion>
+		<max_time_dom_completion>0.2000</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.11</min_time_on_load>
-		<max_time_on_load>0.11</max_time_on_load>
+		<min_time_on_load>0.1100</min_time_on_load>
+		<max_time_on_load>0.1100</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -512,23 +512,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.355</min_time_server>
-				<max_time_server>0.355</max_time_server>
+				<min_time_server>0.3550</min_time_server>
+				<max_time_server>0.3550</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.099</min_time_transfer>
-				<max_time_transfer>0.099</max_time_transfer>
+				<min_time_transfer>0.0990</min_time_transfer>
+				<max_time_transfer>0.0990</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.341</min_time_dom_processing>
-				<max_time_dom_processing>0.341</max_time_dom_processing>
+				<min_time_dom_processing>0.3410</min_time_dom_processing>
+				<max_time_dom_processing>0.3410</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.2</min_time_dom_completion>
-				<max_time_dom_completion>0.2</max_time_dom_completion>
+				<min_time_dom_completion>0.2000</min_time_dom_completion>
+				<max_time_dom_completion>0.2000</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.11</min_time_on_load>
-				<max_time_on_load>0.11</max_time_on_load>
+				<min_time_on_load>0.1100</min_time_on_load>
+				<max_time_on_load>0.1100</max_time_on_load>
 				<sum_bandwidth>86</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -732,23 +732,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.013</min_time_network>
-		<max_time_network>0.013</max_time_network>
+		<min_time_network>0.0130</min_time_network>
+		<max_time_network>0.0130</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.121</min_time_server>
-		<max_time_server>0.121</max_time_server>
+		<min_time_server>0.1210</min_time_server>
+		<max_time_server>0.1210</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.244</min_time_transfer>
-		<max_time_transfer>0.244</max_time_transfer>
+		<min_time_transfer>0.2440</min_time_transfer>
+		<max_time_transfer>0.2440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.345</min_time_dom_processing>
-		<max_time_dom_processing>0.345</max_time_dom_processing>
+		<min_time_dom_processing>0.3450</min_time_dom_processing>
+		<max_time_dom_processing>0.3450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.09</min_time_dom_completion>
-		<max_time_dom_completion>0.09</max_time_dom_completion>
+		<min_time_dom_completion>0.0900</min_time_dom_completion>
+		<max_time_dom_completion>0.0900</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -777,23 +777,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.013</min_time_network>
-				<max_time_network>0.013</max_time_network>
+				<min_time_network>0.0130</min_time_network>
+				<max_time_network>0.0130</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.121</min_time_server>
-				<max_time_server>0.121</max_time_server>
+				<min_time_server>0.1210</min_time_server>
+				<max_time_server>0.1210</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.244</min_time_transfer>
-				<max_time_transfer>0.244</max_time_transfer>
+				<min_time_transfer>0.2440</min_time_transfer>
+				<max_time_transfer>0.2440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.345</min_time_dom_processing>
-				<max_time_dom_processing>0.345</max_time_dom_processing>
+				<min_time_dom_processing>0.3450</min_time_dom_processing>
+				<max_time_dom_processing>0.3450</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.09</min_time_dom_completion>
-				<max_time_dom_completion>0.09</max_time_dom_completion>
+				<min_time_dom_completion>0.0900</min_time_dom_completion>
+				<max_time_dom_completion>0.0900</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0</min_time_on_load>
-				<max_time_on_load>0</max_time_on_load>
+				<min_time_on_load>0.0000</min_time_on_load>
+				<max_time_on_load>0.0000</max_time_on_load>
 				<sum_bandwidth>43</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -814,23 +814,23 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_network>1</nb_hits_with_time_network>
-						<min_time_network>0.013</min_time_network>
-						<max_time_network>0.013</max_time_network>
+						<min_time_network>0.0130</min_time_network>
+						<max_time_network>0.0130</max_time_network>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.121</min_time_server>
-						<max_time_server>0.121</max_time_server>
+						<min_time_server>0.1210</min_time_server>
+						<max_time_server>0.1210</max_time_server>
 						<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-						<min_time_transfer>0.244</min_time_transfer>
-						<max_time_transfer>0.244</max_time_transfer>
+						<min_time_transfer>0.2440</min_time_transfer>
+						<max_time_transfer>0.2440</max_time_transfer>
 						<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-						<min_time_dom_processing>0.345</min_time_dom_processing>
-						<max_time_dom_processing>0.345</max_time_dom_processing>
+						<min_time_dom_processing>0.3450</min_time_dom_processing>
+						<max_time_dom_processing>0.3450</max_time_dom_processing>
 						<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-						<min_time_dom_completion>0.09</min_time_dom_completion>
-						<max_time_dom_completion>0.09</max_time_dom_completion>
+						<min_time_dom_completion>0.0900</min_time_dom_completion>
+						<max_time_dom_completion>0.0900</max_time_dom_completion>
 						<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-						<min_time_on_load>0</min_time_on_load>
-						<max_time_on_load>0</max_time_on_load>
+						<min_time_on_load>0.0000</min_time_on_load>
+						<max_time_on_load>0.0000</max_time_on_load>
 						<sum_bandwidth>43</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>43</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Actions.getPageTitles_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Actions.getPageTitles_range.xml
@@ -6,27 +6,27 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>34</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.067</min_time_network>
-		<max_time_network>0.067</max_time_network>
+		<min_time_network>0.0260</min_time_network>
+		<max_time_network>0.0410</max_time_network>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.116</min_time_server>
-		<max_time_server>0.116</max_time_server>
+		<min_time_server>0.0580</min_time_server>
+		<max_time_server>0.0580</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.521</min_time_transfer>
-		<max_time_transfer>0.521</max_time_transfer>
+		<min_time_transfer>0.1550</min_time_transfer>
+		<max_time_transfer>0.3660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.654</min_time_dom_processing>
-		<max_time_dom_processing>0.654</max_time_dom_processing>
+		<min_time_dom_processing>0.2550</min_time_dom_processing>
+		<max_time_dom_processing>0.3990</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.7</min_time_dom_completion>
-		<max_time_dom_completion>0.7</max_time_dom_completion>
+		<min_time_dom_completion>0.1550</min_time_dom_completion>
+		<max_time_dom_completion>0.5450</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.135</min_time_on_load>
-		<max_time_on_load>0.135</max_time_on_load>
+		<min_time_on_load>0.0450</min_time_on_load>
+		<max_time_on_load>0.0900</max_time_on_load>
 		<sum_bandwidth>172</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>43</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>7</entry_nb_actions>
 		<entry_sum_visit_length>43</entry_sum_visit_length>
@@ -54,23 +54,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.355</min_time_server>
-		<max_time_server>0.355</max_time_server>
+		<min_time_server>0.3550</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.099</min_time_transfer>
-		<max_time_transfer>0.099</max_time_transfer>
+		<min_time_transfer>0.0990</min_time_transfer>
+		<max_time_transfer>0.0990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.341</min_time_dom_processing>
-		<max_time_dom_processing>0.341</max_time_dom_processing>
+		<min_time_dom_processing>0.3410</min_time_dom_processing>
+		<max_time_dom_processing>0.3410</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2</min_time_dom_completion>
-		<max_time_dom_completion>0.2</max_time_dom_completion>
+		<min_time_dom_completion>0.2000</min_time_dom_completion>
+		<max_time_dom_completion>0.2000</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.11</min_time_on_load>
-		<max_time_on_load>0.11</max_time_on_load>
+		<min_time_on_load>0.1100</min_time_on_load>
+		<max_time_on_load>0.1100</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -323,23 +323,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.013</min_time_network>
-		<max_time_network>0.013</max_time_network>
+		<min_time_network>0.0130</min_time_network>
+		<max_time_network>0.0130</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.121</min_time_server>
-		<max_time_server>0.121</max_time_server>
+		<min_time_server>0.1210</min_time_server>
+		<max_time_server>0.1210</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.244</min_time_transfer>
-		<max_time_transfer>0.244</max_time_transfer>
+		<min_time_transfer>0.2440</min_time_transfer>
+		<max_time_transfer>0.2440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.345</min_time_dom_processing>
-		<max_time_dom_processing>0.345</max_time_dom_processing>
+		<min_time_dom_processing>0.3450</min_time_dom_processing>
+		<max_time_dom_processing>0.3450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.09</min_time_dom_completion>
-		<max_time_dom_completion>0.09</max_time_dom_completion>
+		<min_time_dom_completion>0.0900</min_time_dom_completion>
+		<max_time_dom_completion>0.0900</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -515,23 +515,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.01</min_time_network>
-		<max_time_network>0.01</max_time_network>
+		<min_time_network>0.0100</min_time_network>
+		<max_time_network>0.0100</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.096</min_time_server>
-		<max_time_server>0.096</max_time_server>
+		<min_time_server>0.0960</min_time_server>
+		<max_time_server>0.0960</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.232</min_time_transfer>
-		<max_time_transfer>0.232</max_time_transfer>
+		<min_time_transfer>0.2320</min_time_transfer>
+		<max_time_transfer>0.2320</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.312</min_time_dom_processing>
-		<max_time_dom_processing>0.312</max_time_dom_processing>
+		<min_time_dom_processing>0.3120</min_time_dom_processing>
+		<max_time_dom_processing>0.3120</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.255</min_time_dom_completion>
-		<max_time_dom_completion>0.255</max_time_dom_completion>
+		<min_time_dom_completion>0.2550</min_time_dom_completion>
+		<max_time_dom_completion>0.2550</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Actions.getPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Actions.getPageUrls_range.xml
@@ -6,27 +6,27 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>34</sum_time_spent>
 		<nb_hits_with_time_network>2</nb_hits_with_time_network>
-		<min_time_network>0.067</min_time_network>
-		<max_time_network>0.067</max_time_network>
+		<min_time_network>0.0260</min_time_network>
+		<max_time_network>0.0410</max_time_network>
 		<nb_hits_with_time_server>2</nb_hits_with_time_server>
-		<min_time_server>0.116</min_time_server>
-		<max_time_server>0.116</max_time_server>
+		<min_time_server>0.0580</min_time_server>
+		<max_time_server>0.0580</max_time_server>
 		<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-		<min_time_transfer>0.521</min_time_transfer>
-		<max_time_transfer>0.521</max_time_transfer>
+		<min_time_transfer>0.1550</min_time_transfer>
+		<max_time_transfer>0.3660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.654</min_time_dom_processing>
-		<max_time_dom_processing>0.654</max_time_dom_processing>
+		<min_time_dom_processing>0.2550</min_time_dom_processing>
+		<max_time_dom_processing>0.3990</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.7</min_time_dom_completion>
-		<max_time_dom_completion>0.7</max_time_dom_completion>
+		<min_time_dom_completion>0.1550</min_time_dom_completion>
+		<max_time_dom_completion>0.5450</max_time_dom_completion>
 		<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-		<min_time_on_load>0.135</min_time_on_load>
-		<max_time_on_load>0.135</max_time_on_load>
+		<min_time_on_load>0.0450</min_time_on_load>
+		<max_time_on_load>0.0900</max_time_on_load>
 		<sum_bandwidth>172</sum_bandwidth>
 		<nb_hits_with_bandwidth>4</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>43</max_bandwidth>
 		<entry_nb_visits>4</entry_nb_visits>
 		<entry_nb_actions>7</entry_nb_actions>
 		<entry_sum_visit_length>43</entry_sum_visit_length>
@@ -104,27 +104,27 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.01</min_time_network>
-		<max_time_network>0.01</max_time_network>
+		<min_time_network>0.0100</min_time_network>
+		<max_time_network>0.0100</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.096</min_time_server>
-		<max_time_server>0.096</max_time_server>
+		<min_time_server>0.0960</min_time_server>
+		<max_time_server>0.0960</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.232</min_time_transfer>
-		<max_time_transfer>0.232</max_time_transfer>
+		<min_time_transfer>0.2320</min_time_transfer>
+		<max_time_transfer>0.2320</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.312</min_time_dom_processing>
-		<max_time_dom_processing>0.312</max_time_dom_processing>
+		<min_time_dom_processing>0.3120</min_time_dom_processing>
+		<max_time_dom_processing>0.3120</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.255</min_time_dom_completion>
-		<max_time_dom_completion>0.255</max_time_dom_completion>
+		<min_time_dom_completion>0.2550</min_time_dom_completion>
+		<max_time_dom_completion>0.2550</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
-		<min_bandwidth>86</min_bandwidth>
-		<max_bandwidth>86</max_bandwidth>
+		<min_bandwidth>43</min_bandwidth>
+		<max_bandwidth>43</max_bandwidth>
 		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>2</entry_nb_actions>
 		<entry_sum_visit_length>0</entry_sum_visit_length>
@@ -307,23 +307,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.01</min_time_network>
-				<max_time_network>0.01</max_time_network>
+				<min_time_network>0.0100</min_time_network>
+				<max_time_network>0.0100</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.096</min_time_server>
-				<max_time_server>0.096</max_time_server>
+				<min_time_server>0.0960</min_time_server>
+				<max_time_server>0.0960</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.232</min_time_transfer>
-				<max_time_transfer>0.232</max_time_transfer>
+				<min_time_transfer>0.2320</min_time_transfer>
+				<max_time_transfer>0.2320</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.312</min_time_dom_processing>
-				<max_time_dom_processing>0.312</max_time_dom_processing>
+				<min_time_dom_processing>0.3120</min_time_dom_processing>
+				<max_time_dom_processing>0.3120</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.255</min_time_dom_completion>
-				<max_time_dom_completion>0.255</max_time_dom_completion>
+				<min_time_dom_completion>0.2550</min_time_dom_completion>
+				<max_time_dom_completion>0.2550</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0</min_time_on_load>
-				<max_time_on_load>0</max_time_on_load>
+				<min_time_on_load>0.0000</min_time_on_load>
+				<max_time_on_load>0.0000</max_time_on_load>
 				<sum_bandwidth>43</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -344,23 +344,23 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_network>1</nb_hits_with_time_network>
-						<min_time_network>0.01</min_time_network>
-						<max_time_network>0.01</max_time_network>
+						<min_time_network>0.0100</min_time_network>
+						<max_time_network>0.0100</max_time_network>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.096</min_time_server>
-						<max_time_server>0.096</max_time_server>
+						<min_time_server>0.0960</min_time_server>
+						<max_time_server>0.0960</max_time_server>
 						<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-						<min_time_transfer>0.232</min_time_transfer>
-						<max_time_transfer>0.232</max_time_transfer>
+						<min_time_transfer>0.2320</min_time_transfer>
+						<max_time_transfer>0.2320</max_time_transfer>
 						<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-						<min_time_dom_processing>0.312</min_time_dom_processing>
-						<max_time_dom_processing>0.312</max_time_dom_processing>
+						<min_time_dom_processing>0.3120</min_time_dom_processing>
+						<max_time_dom_processing>0.3120</max_time_dom_processing>
 						<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-						<min_time_dom_completion>0.255</min_time_dom_completion>
-						<max_time_dom_completion>0.255</max_time_dom_completion>
+						<min_time_dom_completion>0.2550</min_time_dom_completion>
+						<max_time_dom_completion>0.2550</max_time_dom_completion>
 						<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-						<min_time_on_load>0</min_time_on_load>
-						<max_time_on_load>0</max_time_on_load>
+						<min_time_on_load>0.0000</min_time_on_load>
+						<max_time_on_load>0.0000</max_time_on_load>
 						<sum_bandwidth>43</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>43</min_bandwidth>
@@ -381,23 +381,23 @@
 								<nb_hits>1</nb_hits>
 								<sum_time_spent>0</sum_time_spent>
 								<nb_hits_with_time_network>1</nb_hits_with_time_network>
-								<min_time_network>0.01</min_time_network>
-								<max_time_network>0.01</max_time_network>
+								<min_time_network>0.0100</min_time_network>
+								<max_time_network>0.0100</max_time_network>
 								<nb_hits_with_time_server>1</nb_hits_with_time_server>
-								<min_time_server>0.096</min_time_server>
-								<max_time_server>0.096</max_time_server>
+								<min_time_server>0.0960</min_time_server>
+								<max_time_server>0.0960</max_time_server>
 								<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-								<min_time_transfer>0.232</min_time_transfer>
-								<max_time_transfer>0.232</max_time_transfer>
+								<min_time_transfer>0.2320</min_time_transfer>
+								<max_time_transfer>0.2320</max_time_transfer>
 								<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-								<min_time_dom_processing>0.312</min_time_dom_processing>
-								<max_time_dom_processing>0.312</max_time_dom_processing>
+								<min_time_dom_processing>0.3120</min_time_dom_processing>
+								<max_time_dom_processing>0.3120</max_time_dom_processing>
 								<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-								<min_time_dom_completion>0.255</min_time_dom_completion>
-								<max_time_dom_completion>0.255</max_time_dom_completion>
+								<min_time_dom_completion>0.2550</min_time_dom_completion>
+								<max_time_dom_completion>0.2550</max_time_dom_completion>
 								<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-								<min_time_on_load>0</min_time_on_load>
-								<max_time_on_load>0</max_time_on_load>
+								<min_time_on_load>0.0000</min_time_on_load>
+								<max_time_on_load>0.0000</max_time_on_load>
 								<sum_bandwidth>43</sum_bandwidth>
 								<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 								<min_bandwidth>43</min_bandwidth>
@@ -418,23 +418,23 @@
 										<nb_hits>1</nb_hits>
 										<sum_time_spent>0</sum_time_spent>
 										<nb_hits_with_time_network>1</nb_hits_with_time_network>
-										<min_time_network>0.01</min_time_network>
-										<max_time_network>0.01</max_time_network>
+										<min_time_network>0.0100</min_time_network>
+										<max_time_network>0.0100</max_time_network>
 										<nb_hits_with_time_server>1</nb_hits_with_time_server>
-										<min_time_server>0.096</min_time_server>
-										<max_time_server>0.096</max_time_server>
+										<min_time_server>0.0960</min_time_server>
+										<max_time_server>0.0960</max_time_server>
 										<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-										<min_time_transfer>0.232</min_time_transfer>
-										<max_time_transfer>0.232</max_time_transfer>
+										<min_time_transfer>0.2320</min_time_transfer>
+										<max_time_transfer>0.2320</max_time_transfer>
 										<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-										<min_time_dom_processing>0.312</min_time_dom_processing>
-										<max_time_dom_processing>0.312</max_time_dom_processing>
+										<min_time_dom_processing>0.3120</min_time_dom_processing>
+										<max_time_dom_processing>0.3120</max_time_dom_processing>
 										<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-										<min_time_dom_completion>0.255</min_time_dom_completion>
-										<max_time_dom_completion>0.255</max_time_dom_completion>
+										<min_time_dom_completion>0.2550</min_time_dom_completion>
+										<max_time_dom_completion>0.2550</max_time_dom_completion>
 										<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-										<min_time_on_load>0</min_time_on_load>
-										<max_time_on_load>0</max_time_on_load>
+										<min_time_on_load>0.0000</min_time_on_load>
+										<max_time_on_load>0.0000</max_time_on_load>
 										<sum_bandwidth>43</sum_bandwidth>
 										<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 										<min_bandwidth>43</min_bandwidth>
@@ -467,23 +467,23 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0</min_time_network>
-		<max_time_network>0</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0000</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.355</min_time_server>
-		<max_time_server>0.355</max_time_server>
+		<min_time_server>0.3550</min_time_server>
+		<max_time_server>0.3550</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.099</min_time_transfer>
-		<max_time_transfer>0.099</max_time_transfer>
+		<min_time_transfer>0.0990</min_time_transfer>
+		<max_time_transfer>0.0990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.341</min_time_dom_processing>
-		<max_time_dom_processing>0.341</max_time_dom_processing>
+		<min_time_dom_processing>0.3410</min_time_dom_processing>
+		<max_time_dom_processing>0.3410</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2</min_time_dom_completion>
-		<max_time_dom_completion>0.2</max_time_dom_completion>
+		<min_time_dom_completion>0.2000</min_time_dom_completion>
+		<max_time_dom_completion>0.2000</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.11</min_time_on_load>
-		<max_time_on_load>0.11</max_time_on_load>
+		<min_time_on_load>0.1100</min_time_on_load>
+		<max_time_on_load>0.1100</max_time_on_load>
 		<sum_bandwidth>86</sum_bandwidth>
 		<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -512,23 +512,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.355</min_time_server>
-				<max_time_server>0.355</max_time_server>
+				<min_time_server>0.3550</min_time_server>
+				<max_time_server>0.3550</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.099</min_time_transfer>
-				<max_time_transfer>0.099</max_time_transfer>
+				<min_time_transfer>0.0990</min_time_transfer>
+				<max_time_transfer>0.0990</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.341</min_time_dom_processing>
-				<max_time_dom_processing>0.341</max_time_dom_processing>
+				<min_time_dom_processing>0.3410</min_time_dom_processing>
+				<max_time_dom_processing>0.3410</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.2</min_time_dom_completion>
-				<max_time_dom_completion>0.2</max_time_dom_completion>
+				<min_time_dom_completion>0.2000</min_time_dom_completion>
+				<max_time_dom_completion>0.2000</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.11</min_time_on_load>
-				<max_time_on_load>0.11</max_time_on_load>
+				<min_time_on_load>0.1100</min_time_on_load>
+				<max_time_on_load>0.1100</max_time_on_load>
 				<sum_bandwidth>86</sum_bandwidth>
 				<nb_hits_with_bandwidth>2</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -817,23 +817,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.013</min_time_network>
-		<max_time_network>0.013</max_time_network>
+		<min_time_network>0.0130</min_time_network>
+		<max_time_network>0.0130</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.121</min_time_server>
-		<max_time_server>0.121</max_time_server>
+		<min_time_server>0.1210</min_time_server>
+		<max_time_server>0.1210</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.244</min_time_transfer>
-		<max_time_transfer>0.244</max_time_transfer>
+		<min_time_transfer>0.2440</min_time_transfer>
+		<max_time_transfer>0.2440</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.345</min_time_dom_processing>
-		<max_time_dom_processing>0.345</max_time_dom_processing>
+		<min_time_dom_processing>0.3450</min_time_dom_processing>
+		<max_time_dom_processing>0.3450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.09</min_time_dom_completion>
-		<max_time_dom_completion>0.09</max_time_dom_completion>
+		<min_time_dom_completion>0.0900</min_time_dom_completion>
+		<max_time_dom_completion>0.0900</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0</min_time_on_load>
-		<max_time_on_load>0</max_time_on_load>
+		<min_time_on_load>0.0000</min_time_on_load>
+		<max_time_on_load>0.0000</max_time_on_load>
 		<sum_bandwidth>43</sum_bandwidth>
 		<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 		<min_bandwidth>43</min_bandwidth>
@@ -862,23 +862,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.013</min_time_network>
-				<max_time_network>0.013</max_time_network>
+				<min_time_network>0.0130</min_time_network>
+				<max_time_network>0.0130</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.121</min_time_server>
-				<max_time_server>0.121</max_time_server>
+				<min_time_server>0.1210</min_time_server>
+				<max_time_server>0.1210</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.244</min_time_transfer>
-				<max_time_transfer>0.244</max_time_transfer>
+				<min_time_transfer>0.2440</min_time_transfer>
+				<max_time_transfer>0.2440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.345</min_time_dom_processing>
-				<max_time_dom_processing>0.345</max_time_dom_processing>
+				<min_time_dom_processing>0.3450</min_time_dom_processing>
+				<max_time_dom_processing>0.3450</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.09</min_time_dom_completion>
-				<max_time_dom_completion>0.09</max_time_dom_completion>
+				<min_time_dom_completion>0.0900</min_time_dom_completion>
+				<max_time_dom_completion>0.0900</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0</min_time_on_load>
-				<max_time_on_load>0</max_time_on_load>
+				<min_time_on_load>0.0000</min_time_on_load>
+				<max_time_on_load>0.0000</max_time_on_load>
 				<sum_bandwidth>43</sum_bandwidth>
 				<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 				<min_bandwidth>43</min_bandwidth>
@@ -899,23 +899,23 @@
 						<nb_hits>1</nb_hits>
 						<sum_time_spent>0</sum_time_spent>
 						<nb_hits_with_time_network>1</nb_hits_with_time_network>
-						<min_time_network>0.013</min_time_network>
-						<max_time_network>0.013</max_time_network>
+						<min_time_network>0.0130</min_time_network>
+						<max_time_network>0.0130</max_time_network>
 						<nb_hits_with_time_server>1</nb_hits_with_time_server>
-						<min_time_server>0.121</min_time_server>
-						<max_time_server>0.121</max_time_server>
+						<min_time_server>0.1210</min_time_server>
+						<max_time_server>0.1210</max_time_server>
 						<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-						<min_time_transfer>0.244</min_time_transfer>
-						<max_time_transfer>0.244</max_time_transfer>
+						<min_time_transfer>0.2440</min_time_transfer>
+						<max_time_transfer>0.2440</max_time_transfer>
 						<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-						<min_time_dom_processing>0.345</min_time_dom_processing>
-						<max_time_dom_processing>0.345</max_time_dom_processing>
+						<min_time_dom_processing>0.3450</min_time_dom_processing>
+						<max_time_dom_processing>0.3450</max_time_dom_processing>
 						<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-						<min_time_dom_completion>0.09</min_time_dom_completion>
-						<max_time_dom_completion>0.09</max_time_dom_completion>
+						<min_time_dom_completion>0.0900</min_time_dom_completion>
+						<max_time_dom_completion>0.0900</max_time_dom_completion>
 						<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-						<min_time_on_load>0</min_time_on_load>
-						<max_time_on_load>0</max_time_on_load>
+						<min_time_on_load>0.0000</min_time_on_load>
+						<max_time_on_load>0.0000</max_time_on_load>
 						<sum_bandwidth>43</sum_bandwidth>
 						<nb_hits_with_bandwidth>1</nb_hits_with_bandwidth>
 						<min_bandwidth>43</min_bandwidth>

--- a/tests/PHPUnit/System/expected/test_LabelFilter_dir__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_LabelFilter_dir__Actions.getPageUrls_day.xml
@@ -6,23 +6,23 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>720</sum_time_spent>
 		<nb_hits_with_time_network>4</nb_hits_with_time_network>
-		<min_time_network>0.362</min_time_network>
-		<max_time_network>0.362</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.2500</max_time_network>
 		<nb_hits_with_time_server>4</nb_hits_with_time_server>
-		<min_time_server>1.256</min_time_server>
-		<max_time_server>1.256</max_time_server>
+		<min_time_server>0.0630</min_time_server>
+		<max_time_server>0.7850</max_time_server>
 		<nb_hits_with_time_transfer>4</nb_hits_with_time_transfer>
-		<min_time_transfer>1.308</min_time_transfer>
-		<max_time_transfer>1.308</max_time_transfer>
+		<min_time_transfer>0.0560</min_time_transfer>
+		<max_time_transfer>0.6990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>4</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>1.262</min_time_dom_processing>
-		<max_time_dom_processing>1.262</max_time_dom_processing>
+		<min_time_dom_processing>0.2450</min_time_dom_processing>
+		<max_time_dom_processing>0.3850</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>4</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.715</min_time_dom_completion>
-		<max_time_dom_completion>0.715</max_time_dom_completion>
+		<min_time_dom_completion>0.1650</min_time_dom_completion>
+		<max_time_dom_completion>0.1960</max_time_dom_completion>
 		<nb_hits_with_time_on_load>4</nb_hits_with_time_on_load>
-		<min_time_on_load>0.355</min_time_on_load>
-		<max_time_on_load>0.355</max_time_on_load>
+		<min_time_on_load>0.0550</min_time_on_load>
+		<max_time_on_load>0.1200</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_LabelFilter_dir_range__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_LabelFilter_dir_range__Actions.getPageUrls_day.xml
@@ -7,23 +7,23 @@
 			<nb_hits>4</nb_hits>
 			<sum_time_spent>720</sum_time_spent>
 			<nb_hits_with_time_network>4</nb_hits_with_time_network>
-			<min_time_network>0.362</min_time_network>
-			<max_time_network>0.362</max_time_network>
+			<min_time_network>0.0000</min_time_network>
+			<max_time_network>0.2500</max_time_network>
 			<nb_hits_with_time_server>4</nb_hits_with_time_server>
-			<min_time_server>1.256</min_time_server>
-			<max_time_server>1.256</max_time_server>
+			<min_time_server>0.0630</min_time_server>
+			<max_time_server>0.7850</max_time_server>
 			<nb_hits_with_time_transfer>4</nb_hits_with_time_transfer>
-			<min_time_transfer>1.308</min_time_transfer>
-			<max_time_transfer>1.308</max_time_transfer>
+			<min_time_transfer>0.0560</min_time_transfer>
+			<max_time_transfer>0.6990</max_time_transfer>
 			<nb_hits_with_time_dom_processing>4</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>1.262</min_time_dom_processing>
-			<max_time_dom_processing>1.262</max_time_dom_processing>
+			<min_time_dom_processing>0.2450</min_time_dom_processing>
+			<max_time_dom_processing>0.3850</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>4</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.715</min_time_dom_completion>
-			<max_time_dom_completion>0.715</max_time_dom_completion>
+			<min_time_dom_completion>0.1650</min_time_dom_completion>
+			<max_time_dom_completion>0.1960</max_time_dom_completion>
 			<nb_hits_with_time_on_load>4</nb_hits_with_time_on_load>
-			<min_time_on_load>0.355</min_time_on_load>
-			<max_time_on_load>0.355</max_time_on_load>
+			<min_time_on_load>0.0550</min_time_on_load>
+			<max_time_on_load>0.1200</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_LabelFilter_terminalOperator_selectBranch__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_LabelFilter_terminalOperator_selectBranch__Actions.getPageTitles_day.xml
@@ -6,23 +6,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>36</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.25</min_time_network>
-		<max_time_network>0.25</max_time_network>
+		<min_time_network>0.2500</min_time_network>
+		<max_time_network>0.2500</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.212</min_time_server>
-		<max_time_server>0.212</max_time_server>
+		<min_time_server>0.2120</min_time_server>
+		<max_time_server>0.2120</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.699</min_time_transfer>
-		<max_time_transfer>0.699</max_time_transfer>
+		<min_time_transfer>0.6990</min_time_transfer>
+		<max_time_transfer>0.6990</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>0.245</min_time_dom_processing>
-		<max_time_dom_processing>0.245</max_time_dom_processing>
+		<min_time_dom_processing>0.2450</min_time_dom_processing>
+		<max_time_dom_processing>0.2450</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.196</min_time_dom_completion>
-		<max_time_dom_completion>0.196</max_time_dom_completion>
+		<min_time_dom_completion>0.1960</min_time_dom_completion>
+		<max_time_dom_completion>0.1960</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.12</min_time_on_load>
-		<max_time_on_load>0.12</max_time_on_load>
+		<min_time_on_load>0.1200</min_time_on_load>
+		<max_time_on_load>0.1200</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getEntryPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getEntryPageTitles_day.xml
@@ -7,28 +7,28 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_time_network>0.022</sum_time_network>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<sum_time_server>0.157</sum_time_server>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<sum_time_transfer>0.266</sum_time_transfer>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<sum_time_dom_processing>2</sum_time_dom_processing>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<sum_time_dom_completion>1.002</sum_time_dom_completion>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<sum_time_on_load>0.666</sum_time_on_load>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>1</entry_nb_actions>
 		<entry_sum_visit_length>1</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getEntryPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getEntryPageUrls_day.xml
@@ -71,28 +71,28 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_time_network>0.022</sum_time_network>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<sum_time_server>0.157</sum_time_server>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<sum_time_transfer>0.266</sum_time_transfer>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<sum_time_dom_processing>2</sum_time_dom_processing>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<sum_time_dom_completion>1.002</sum_time_dom_completion>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<sum_time_on_load>0.666</sum_time_on_load>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>1</entry_nb_actions>
 		<entry_sum_visit_length>1</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getExitPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getExitPageTitles_day.xml
@@ -7,28 +7,28 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_time_network>0.022</sum_time_network>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<sum_time_server>0.157</sum_time_server>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<sum_time_transfer>0.266</sum_time_transfer>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<sum_time_dom_processing>2</sum_time_dom_processing>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<sum_time_dom_completion>1.002</sum_time_dom_completion>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<sum_time_on_load>0.666</sum_time_on_load>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>1</entry_nb_actions>
 		<entry_sum_visit_length>1</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getExitPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getExitPageUrls_day.xml
@@ -53,28 +53,28 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_time_network>0.022</sum_time_network>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<sum_time_server>0.157</sum_time_server>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<sum_time_transfer>0.266</sum_time_transfer>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<sum_time_dom_processing>2</sum_time_dom_processing>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<sum_time_dom_completion>1.002</sum_time_dom_completion>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<sum_time_on_load>0.666</sum_time_on_load>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>1</entry_nb_actions>
 		<entry_sum_visit_length>1</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getPageTitles_day.xml
@@ -7,28 +7,28 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_time_network>0.022</sum_time_network>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<sum_time_server>0.157</sum_time_server>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<sum_time_transfer>0.266</sum_time_transfer>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<sum_time_dom_processing>2</sum_time_dom_processing>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<sum_time_dom_completion>1.002</sum_time_dom_completion>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<sum_time_on_load>0.666</sum_time_on_load>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>1</entry_nb_actions>
 		<entry_sum_visit_length>1</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getPageUrls_day.xml
@@ -172,28 +172,28 @@
 		<sum_time_spent>0</sum_time_spent>
 		<sum_time_network>0.022</sum_time_network>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<sum_time_server>0.157</sum_time_server>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<sum_time_transfer>0.266</sum_time_transfer>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<sum_time_dom_processing>2</sum_time_dom_processing>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<sum_time_dom_completion>1.002</sum_time_dom_completion>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<sum_time_on_load>0.666</sum_time_on_load>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<entry_nb_visits>1</entry_nb_visits>
 		<entry_nb_actions>1</entry_nb_actions>
 		<entry_sum_visit_length>1</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__subtable__API.getProcessedReport_week.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__subtable__API.getProcessedReport_week.xml
@@ -98,23 +98,23 @@
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>1080</sum_time_spent>
 		<nb_hits_with_time_network>4</nb_hits_with_time_network>
-		<min_time_network>0.117</min_time_network>
-		<max_time_network>0.117</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0620</max_time_network>
 		<nb_hits_with_time_server>4</nb_hits_with_time_server>
-		<min_time_server>0.682</min_time_server>
-		<max_time_server>0.682</max_time_server>
+		<min_time_server>0.1050</min_time_server>
+		<max_time_server>0.2220</max_time_server>
 		<nb_hits_with_time_transfer>4</nb_hits_with_time_transfer>
-		<min_time_transfer>1.057</min_time_transfer>
-		<max_time_transfer>1.057</max_time_transfer>
+		<min_time_transfer>0.2050</min_time_transfer>
+		<max_time_transfer>0.3330</max_time_transfer>
 		<nb_hits_with_time_dom_processing>4</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>5.995</min_time_dom_processing>
-		<max_time_dom_processing>5.995</max_time_dom_processing>
+		<min_time_dom_processing>1.1110</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>4</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>2.28</min_time_dom_completion>
-		<max_time_dom_completion>2.28</max_time_dom_completion>
+		<min_time_dom_completion>0.2220</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<nb_hits_with_time_on_load>4</nb_hits_with_time_on_load>
-		<min_time_on_load>1.373</min_time_on_load>
-		<max_time_on_load>1.373</max_time_on_load>
+		<min_time_on_load>0.1520</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<goals>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
@@ -95,28 +95,28 @@
 		<sum_time_spent>1080</sum_time_spent>
 		<sum_time_network>0.117</sum_time_network>
 		<nb_hits_with_time_network>4</nb_hits_with_time_network>
-		<min_time_network>0.117</min_time_network>
-		<max_time_network>0.117</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0620</max_time_network>
 		<sum_time_server>0.682</sum_time_server>
 		<nb_hits_with_time_server>4</nb_hits_with_time_server>
-		<min_time_server>0.682</min_time_server>
-		<max_time_server>0.682</max_time_server>
+		<min_time_server>0.1050</min_time_server>
+		<max_time_server>0.2220</max_time_server>
 		<sum_time_transfer>1.057</sum_time_transfer>
 		<nb_hits_with_time_transfer>4</nb_hits_with_time_transfer>
-		<min_time_transfer>1.057</min_time_transfer>
-		<max_time_transfer>1.057</max_time_transfer>
+		<min_time_transfer>0.2050</min_time_transfer>
+		<max_time_transfer>0.3330</max_time_transfer>
 		<sum_time_dom_processing>5.995</sum_time_dom_processing>
 		<nb_hits_with_time_dom_processing>4</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>5.995</min_time_dom_processing>
-		<max_time_dom_processing>5.995</max_time_dom_processing>
+		<min_time_dom_processing>1.1110</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<sum_time_dom_completion>2.28</sum_time_dom_completion>
 		<nb_hits_with_time_dom_completion>4</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>2.28</min_time_dom_completion>
-		<max_time_dom_completion>2.28</max_time_dom_completion>
+		<min_time_dom_completion>0.2220</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<sum_time_on_load>1.373</sum_time_on_load>
 		<nb_hits_with_time_on_load>4</nb_hits_with_time_on_load>
-		<min_time_on_load>1.373</min_time_on_load>
-		<max_time_on_load>1.373</max_time_on_load>
+		<min_time_on_load>0.1520</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<entry_nb_actions>8</entry_nb_actions>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___Actions.getPageTitles_day.xml
@@ -4,28 +4,28 @@
 		<label>Checkout</label>
 		<sum_time_network>0.022</sum_time_network>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<sum_time_server>0.157</sum_time_server>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<sum_time_transfer>0.266</sum_time_transfer>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<sum_time_dom_processing>2</sum_time_dom_processing>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<sum_time_dom_completion>1.002</sum_time_dom_completion>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<sum_time_on_load>0.666</sum_time_on_load>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getEntryPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getEntryPageTitles_day.xml
@@ -6,23 +6,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getEntryPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getEntryPageUrls_day.xml
@@ -68,23 +68,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getExitPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getExitPageTitles_day.xml
@@ -6,23 +6,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getExitPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getExitPageUrls_day.xml
@@ -51,23 +51,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getPageTitles_day.xml
@@ -6,23 +6,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getPageUrls_day.xml
@@ -166,23 +166,23 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_network>1</nb_hits_with_time_network>
-		<min_time_network>0.022</min_time_network>
-		<max_time_network>0.022</max_time_network>
+		<min_time_network>0.0220</min_time_network>
+		<max_time_network>0.0220</max_time_network>
 		<nb_hits_with_time_server>1</nb_hits_with_time_server>
-		<min_time_server>0.157</min_time_server>
-		<max_time_server>0.157</max_time_server>
+		<min_time_server>0.1570</min_time_server>
+		<max_time_server>0.1570</max_time_server>
 		<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-		<min_time_transfer>0.266</min_time_transfer>
-		<max_time_transfer>0.266</max_time_transfer>
+		<min_time_transfer>0.2660</min_time_transfer>
+		<max_time_transfer>0.2660</max_time_transfer>
 		<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2</min_time_dom_processing>
-		<max_time_dom_processing>2</max_time_dom_processing>
+		<min_time_dom_processing>2.0000</min_time_dom_processing>
+		<max_time_dom_processing>2.0000</max_time_dom_processing>
 		<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>1.002</min_time_dom_completion>
-		<max_time_dom_completion>1.002</max_time_dom_completion>
+		<min_time_dom_completion>1.0020</min_time_dom_completion>
+		<max_time_dom_completion>1.0020</max_time_dom_completion>
 		<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-		<min_time_on_load>0.666</min_time_on_load>
-		<max_time_on_load>0.666</max_time_on_load>
+		<min_time_on_load>0.6660</min_time_on_load>
+		<max_time_on_load>0.6660</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
@@ -303,28 +303,28 @@
 		<sum_time_spent>4500</sum_time_spent>
 		<sum_time_network>0.398</sum_time_network>
 		<nb_hits_with_time_network>17</nb_hits_with_time_network>
-		<min_time_network>0.0360</min_time_network>
+		<min_time_network>0.0000</min_time_network>
 		<max_time_network>0.0620</max_time_network>
 		<sum_time_server>4.648</sum_time_server>
 		<nb_hits_with_time_server>17</nb_hits_with_time_server>
-		<min_time_server>0.2280</min_time_server>
-		<max_time_server>0.823</max_time_server>
+		<min_time_server>0.1990</min_time_server>
+		<max_time_server>0.3560</max_time_server>
 		<sum_time_transfer>6.26</sum_time_transfer>
 		<nb_hits_with_time_transfer>17</nb_hits_with_time_transfer>
-		<min_time_transfer>0.3350</min_time_transfer>
-		<max_time_transfer>1.097</max_time_transfer>
+		<min_time_transfer>0.2890</min_time_transfer>
+		<max_time_transfer>0.4520</max_time_transfer>
 		<sum_time_dom_processing>19.784</sum_time_dom_processing>
 		<nb_hits_with_time_dom_processing>17</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>1.0150</min_time_dom_processing>
-		<max_time_dom_processing>3.522</max_time_dom_processing>
+		<min_time_dom_processing>0.9980</min_time_dom_processing>
+		<max_time_dom_processing>1.4990</max_time_dom_processing>
 		<sum_time_dom_completion>4.815</sum_time_dom_completion>
 		<nb_hits_with_time_dom_completion>17</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.2090</min_time_dom_completion>
-		<max_time_dom_completion>0.85</max_time_dom_completion>
+		<min_time_dom_completion>0.1980</min_time_dom_completion>
+		<max_time_dom_completion>0.3560</max_time_dom_completion>
 		<sum_time_on_load>5.256</sum_time_on_load>
 		<nb_hits_with_time_on_load>17</nb_hits_with_time_on_load>
-		<min_time_on_load>0.3010</min_time_on_load>
-		<max_time_on_load>0.903</max_time_on_load>
+		<min_time_on_load>0.2690</min_time_on_load>
+		<max_time_on_load>0.4400</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<entry_nb_uniq_visitors>7</entry_nb_uniq_visitors>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
@@ -332,28 +332,28 @@
 		<sum_time_spent>4500</sum_time_spent>
 		<sum_time_network>0.398</sum_time_network>
 		<nb_hits_with_time_network>17</nb_hits_with_time_network>
-		<min_time_network>0.027</min_time_network>
-		<max_time_network>0.098</max_time_network>
+		<min_time_network>0.0000</min_time_network>
+		<max_time_network>0.0620</max_time_network>
 		<sum_time_server>4.648</sum_time_server>
 		<nb_hits_with_time_server>17</nb_hits_with_time_server>
-		<min_time_server>0.467</min_time_server>
-		<max_time_server>0.624</max_time_server>
+		<min_time_server>0.1990</min_time_server>
+		<max_time_server>0.3560</max_time_server>
 		<sum_time_transfer>6.26</sum_time_transfer>
 		<nb_hits_with_time_transfer>17</nb_hits_with_time_transfer>
-		<min_time_transfer>0.645</min_time_transfer>
-		<max_time_transfer>0.808</max_time_transfer>
+		<min_time_transfer>0.2890</min_time_transfer>
+		<max_time_transfer>0.4520</max_time_transfer>
 		<sum_time_dom_processing>19.784</sum_time_dom_processing>
 		<nb_hits_with_time_dom_processing>17</nb_hits_with_time_dom_processing>
-		<min_time_dom_processing>2.023</min_time_dom_processing>
-		<max_time_dom_processing>2.524</max_time_dom_processing>
+		<min_time_dom_processing>0.9980</min_time_dom_processing>
+		<max_time_dom_processing>1.4990</max_time_dom_processing>
 		<sum_time_dom_completion>4.815</sum_time_dom_completion>
 		<nb_hits_with_time_dom_completion>17</nb_hits_with_time_dom_completion>
-		<min_time_dom_completion>0.494</min_time_dom_completion>
-		<max_time_dom_completion>0.652</max_time_dom_completion>
+		<min_time_dom_completion>0.1980</min_time_dom_completion>
+		<max_time_dom_completion>0.3560</max_time_dom_completion>
 		<sum_time_on_load>5.256</sum_time_on_load>
 		<nb_hits_with_time_on_load>17</nb_hits_with_time_on_load>
-		<min_time_on_load>0.604</min_time_on_load>
-		<max_time_on_load>0.741</max_time_on_load>
+		<min_time_on_load>0.2690</min_time_on_load>
+		<max_time_on_load>0.4400</max_time_on_load>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<entry_nb_uniq_visitors>7</entry_nb_uniq_visitors>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_month.xml
@@ -8,23 +8,23 @@
 				<nb_hits>8</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>8</nb_hits_with_time_network>
-				<min_time_network>0.264</min_time_network>
-				<max_time_network>0.264</max_time_network>
+				<min_time_network>0.0330</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>8</nb_hits_with_time_server>
-				<min_time_server>2.848</min_time_server>
-				<max_time_server>2.848</max_time_server>
+				<min_time_server>0.3560</min_time_server>
+				<max_time_server>0.3560</max_time_server>
 				<nb_hits_with_time_transfer>8</nb_hits_with_time_transfer>
-				<min_time_transfer>3.616</min_time_transfer>
-				<max_time_transfer>3.616</max_time_transfer>
+				<min_time_transfer>0.4520</min_time_transfer>
+				<max_time_transfer>0.4520</max_time_transfer>
 				<nb_hits_with_time_dom_processing>8</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>11.992</min_time_dom_processing>
-				<max_time_dom_processing>11.992</max_time_dom_processing>
+				<min_time_dom_processing>1.4990</min_time_dom_processing>
+				<max_time_dom_processing>1.4990</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>8</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>2.848</min_time_dom_completion>
-				<max_time_dom_completion>2.848</max_time_dom_completion>
+				<min_time_dom_completion>0.3560</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>8</nb_hits_with_time_on_load>
-				<min_time_on_load>2.152</min_time_on_load>
-				<max_time_on_load>2.152</max_time_on_load>
+				<min_time_on_load>0.2690</min_time_on_load>
+				<max_time_on_load>0.2690</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -51,23 +51,23 @@
 				<nb_hits>8</nb_hits>
 				<sum_time_spent>2880</sum_time_spent>
 				<nb_hits_with_time_network>8</nb_hits_with_time_network>
-				<min_time_network>0.216</min_time_network>
-				<max_time_network>0.216</max_time_network>
+				<min_time_network>0.0270</min_time_network>
+				<max_time_network>0.0270</max_time_network>
 				<nb_hits_with_time_server>8</nb_hits_with_time_server>
-				<min_time_server>2.144</min_time_server>
-				<max_time_server>2.144</max_time_server>
+				<min_time_server>0.2680</min_time_server>
+				<max_time_server>0.2680</max_time_server>
 				<nb_hits_with_time_transfer>8</nb_hits_with_time_transfer>
-				<min_time_transfer>2.848</min_time_transfer>
-				<max_time_transfer>2.848</max_time_transfer>
+				<min_time_transfer>0.3560</min_time_transfer>
+				<max_time_transfer>0.3560</max_time_transfer>
 				<nb_hits_with_time_dom_processing>8</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>8.2</min_time_dom_processing>
-				<max_time_dom_processing>8.2</max_time_dom_processing>
+				<min_time_dom_processing>1.0250</min_time_dom_processing>
+				<max_time_dom_processing>1.0250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>8</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>2.368</min_time_dom_completion>
-				<max_time_dom_completion>2.368</max_time_dom_completion>
+				<min_time_dom_completion>0.2960</min_time_dom_completion>
+				<max_time_dom_completion>0.2960</max_time_dom_completion>
 				<nb_hits_with_time_on_load>8</nb_hits_with_time_on_load>
-				<min_time_on_load>2.68</min_time_on_load>
-				<max_time_on_load>2.68</max_time_on_load>
+				<min_time_on_load>0.3350</min_time_on_load>
+				<max_time_on_load>0.3350</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -97,23 +97,23 @@
 				<nb_hits>8</nb_hits>
 				<sum_time_spent>4320</sum_time_spent>
 				<nb_hits_with_time_network>8</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>8</nb_hits_with_time_server>
-				<min_time_server>1.592</min_time_server>
-				<max_time_server>1.592</max_time_server>
+				<min_time_server>0.1990</min_time_server>
+				<max_time_server>0.1990</max_time_server>
 				<nb_hits_with_time_transfer>8</nb_hits_with_time_transfer>
-				<min_time_transfer>2.312</min_time_transfer>
-				<max_time_transfer>2.312</max_time_transfer>
+				<min_time_transfer>0.2890</min_time_transfer>
+				<max_time_transfer>0.2890</max_time_transfer>
 				<nb_hits_with_time_dom_processing>8</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>7.984</min_time_dom_processing>
-				<max_time_dom_processing>7.984</max_time_dom_processing>
+				<min_time_dom_processing>0.9980</min_time_dom_processing>
+				<max_time_dom_processing>0.9980</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>8</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>1.584</min_time_dom_completion>
-				<max_time_dom_completion>1.584</max_time_dom_completion>
+				<min_time_dom_completion>0.1980</min_time_dom_completion>
+				<max_time_dom_completion>0.1980</max_time_dom_completion>
 				<nb_hits_with_time_on_load>8</nb_hits_with_time_on_load>
-				<min_time_on_load>2.392</min_time_on_load>
-				<max_time_on_load>2.392</max_time_on_load>
+				<min_time_on_load>0.2990</min_time_on_load>
+				<max_time_on_load>0.2990</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -138,23 +138,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0.036</min_time_network>
-				<max_time_network>0.062</max_time_network>
+				<min_time_network>0.0360</min_time_network>
+				<max_time_network>0.0620</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.228</min_time_server>
-				<max_time_server>0.305</max_time_server>
+				<min_time_server>0.2280</min_time_server>
+				<max_time_server>0.3050</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.335</min_time_transfer>
-				<max_time_transfer>0.44</max_time_transfer>
+				<min_time_transfer>0.3350</min_time_transfer>
+				<max_time_transfer>0.4400</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>1.015</min_time_dom_processing>
-				<max_time_dom_processing>1.159</max_time_dom_processing>
+				<min_time_dom_processing>1.0150</min_time_dom_processing>
+				<max_time_dom_processing>1.1590</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.209</min_time_dom_completion>
-				<max_time_dom_completion>0.356</max_time_dom_completion>
+				<min_time_dom_completion>0.2090</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.301</min_time_on_load>
-				<max_time_on_load>0.44</max_time_on_load>
+				<min_time_on_load>0.3010</min_time_on_load>
+				<max_time_on_load>0.4400</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -237,23 +237,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0.021</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0210</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.258</min_time_server>
-				<max_time_server>0.344</max_time_server>
+				<min_time_server>0.2580</min_time_server>
+				<max_time_server>0.3440</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.299</min_time_transfer>
-				<max_time_transfer>0.444</max_time_transfer>
+				<min_time_transfer>0.2990</min_time_transfer>
+				<max_time_transfer>0.4440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.245</min_time_dom_processing>
-				<max_time_dom_processing>0.325</max_time_dom_processing>
+				<min_time_dom_processing>0.2450</min_time_dom_processing>
+				<max_time_dom_processing>0.3250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.189</min_time_dom_completion>
-				<max_time_dom_completion>0.999</max_time_dom_completion>
+				<min_time_dom_completion>0.1890</min_time_dom_completion>
+				<max_time_dom_completion>0.9990</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.12</min_time_on_load>
-				<max_time_on_load>0.35</max_time_on_load>
+				<min_time_on_load>0.1200</min_time_on_load>
+				<max_time_on_load>0.3500</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -278,23 +278,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.033</min_time_network>
-				<max_time_network>0.033</max_time_network>
+				<min_time_network>0.0330</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.144</min_time_server>
-				<max_time_server>0.144</max_time_server>
+				<min_time_server>0.1440</min_time_server>
+				<max_time_server>0.1440</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.318</min_time_transfer>
-				<max_time_transfer>0.318</max_time_transfer>
+				<min_time_transfer>0.3180</min_time_transfer>
+				<max_time_transfer>0.3180</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.289</min_time_dom_processing>
-				<max_time_dom_processing>0.289</max_time_dom_processing>
+				<min_time_dom_processing>0.2890</min_time_dom_processing>
+				<max_time_dom_processing>0.2890</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.035</min_time_dom_completion>
-				<max_time_dom_completion>0.035</max_time_dom_completion>
+				<min_time_dom_completion>0.0350</min_time_dom_completion>
+				<max_time_dom_completion>0.0350</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.05</min_time_on_load>
-				<max_time_on_load>0.05</max_time_on_load>
+				<min_time_on_load>0.0500</min_time_on_load>
+				<max_time_on_load>0.0500</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_week.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_week.xml
@@ -8,23 +8,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0.036</min_time_network>
-				<max_time_network>0.062</max_time_network>
+				<min_time_network>0.0360</min_time_network>
+				<max_time_network>0.0620</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.228</min_time_server>
-				<max_time_server>0.305</max_time_server>
+				<min_time_server>0.2280</min_time_server>
+				<max_time_server>0.3050</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.335</min_time_transfer>
-				<max_time_transfer>0.44</max_time_transfer>
+				<min_time_transfer>0.3350</min_time_transfer>
+				<max_time_transfer>0.4400</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>1.015</min_time_dom_processing>
-				<max_time_dom_processing>1.159</max_time_dom_processing>
+				<min_time_dom_processing>1.0150</min_time_dom_processing>
+				<max_time_dom_processing>1.1590</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.209</min_time_dom_completion>
-				<max_time_dom_completion>0.356</max_time_dom_completion>
+				<min_time_dom_completion>0.2090</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.301</min_time_on_load>
-				<max_time_on_load>0.44</max_time_on_load>
+				<min_time_on_load>0.3010</min_time_on_load>
+				<max_time_on_load>0.4400</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -58,23 +58,23 @@
 				<nb_hits>6</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>6</nb_hits_with_time_network>
-				<min_time_network>0.198</min_time_network>
-				<max_time_network>0.198</max_time_network>
+				<min_time_network>0.0330</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>6</nb_hits_with_time_server>
-				<min_time_server>2.136</min_time_server>
-				<max_time_server>2.136</max_time_server>
+				<min_time_server>0.3560</min_time_server>
+				<max_time_server>0.3560</max_time_server>
 				<nb_hits_with_time_transfer>6</nb_hits_with_time_transfer>
-				<min_time_transfer>2.712</min_time_transfer>
-				<max_time_transfer>2.712</max_time_transfer>
+				<min_time_transfer>0.4520</min_time_transfer>
+				<max_time_transfer>0.4520</max_time_transfer>
 				<nb_hits_with_time_dom_processing>6</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>8.994</min_time_dom_processing>
-				<max_time_dom_processing>8.994</max_time_dom_processing>
+				<min_time_dom_processing>1.4990</min_time_dom_processing>
+				<max_time_dom_processing>1.4990</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>6</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>2.136</min_time_dom_completion>
-				<max_time_dom_completion>2.136</max_time_dom_completion>
+				<min_time_dom_completion>0.3560</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>6</nb_hits_with_time_on_load>
-				<min_time_on_load>1.614</min_time_on_load>
-				<max_time_on_load>1.614</max_time_on_load>
+				<min_time_on_load>0.2690</min_time_on_load>
+				<max_time_on_load>0.2690</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -101,23 +101,23 @@
 				<nb_hits>6</nb_hits>
 				<sum_time_spent>2160</sum_time_spent>
 				<nb_hits_with_time_network>6</nb_hits_with_time_network>
-				<min_time_network>0.162</min_time_network>
-				<max_time_network>0.162</max_time_network>
+				<min_time_network>0.0270</min_time_network>
+				<max_time_network>0.0270</max_time_network>
 				<nb_hits_with_time_server>6</nb_hits_with_time_server>
-				<min_time_server>1.608</min_time_server>
-				<max_time_server>1.608</max_time_server>
+				<min_time_server>0.2680</min_time_server>
+				<max_time_server>0.2680</max_time_server>
 				<nb_hits_with_time_transfer>6</nb_hits_with_time_transfer>
-				<min_time_transfer>2.136</min_time_transfer>
-				<max_time_transfer>2.136</max_time_transfer>
+				<min_time_transfer>0.3560</min_time_transfer>
+				<max_time_transfer>0.3560</max_time_transfer>
 				<nb_hits_with_time_dom_processing>6</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>6.15</min_time_dom_processing>
-				<max_time_dom_processing>6.15</max_time_dom_processing>
+				<min_time_dom_processing>1.0250</min_time_dom_processing>
+				<max_time_dom_processing>1.0250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>6</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>1.776</min_time_dom_completion>
-				<max_time_dom_completion>1.776</max_time_dom_completion>
+				<min_time_dom_completion>0.2960</min_time_dom_completion>
+				<max_time_dom_completion>0.2960</max_time_dom_completion>
 				<nb_hits_with_time_on_load>6</nb_hits_with_time_on_load>
-				<min_time_on_load>2.01</min_time_on_load>
-				<max_time_on_load>2.01</max_time_on_load>
+				<min_time_on_load>0.3350</min_time_on_load>
+				<max_time_on_load>0.3350</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -147,23 +147,23 @@
 				<nb_hits>6</nb_hits>
 				<sum_time_spent>3240</sum_time_spent>
 				<nb_hits_with_time_network>6</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>6</nb_hits_with_time_server>
-				<min_time_server>1.194</min_time_server>
-				<max_time_server>1.194</max_time_server>
+				<min_time_server>0.1990</min_time_server>
+				<max_time_server>0.1990</max_time_server>
 				<nb_hits_with_time_transfer>6</nb_hits_with_time_transfer>
-				<min_time_transfer>1.734</min_time_transfer>
-				<max_time_transfer>1.734</max_time_transfer>
+				<min_time_transfer>0.2890</min_time_transfer>
+				<max_time_transfer>0.2890</max_time_transfer>
 				<nb_hits_with_time_dom_processing>6</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>5.988</min_time_dom_processing>
-				<max_time_dom_processing>5.988</max_time_dom_processing>
+				<min_time_dom_processing>0.9980</min_time_dom_processing>
+				<max_time_dom_processing>0.9980</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>6</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>1.188</min_time_dom_completion>
-				<max_time_dom_completion>1.188</max_time_dom_completion>
+				<min_time_dom_completion>0.1980</min_time_dom_completion>
+				<max_time_dom_completion>0.1980</max_time_dom_completion>
 				<nb_hits_with_time_on_load>6</nb_hits_with_time_on_load>
-				<min_time_on_load>1.794</min_time_on_load>
-				<max_time_on_load>1.794</max_time_on_load>
+				<min_time_on_load>0.2990</min_time_on_load>
+				<max_time_on_load>0.2990</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -231,23 +231,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0.066</min_time_network>
-				<max_time_network>0.066</max_time_network>
+				<min_time_network>0.0330</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.712</min_time_server>
-				<max_time_server>0.712</max_time_server>
+				<min_time_server>0.3560</min_time_server>
+				<max_time_server>0.3560</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.904</min_time_transfer>
-				<max_time_transfer>0.904</max_time_transfer>
+				<min_time_transfer>0.4520</min_time_transfer>
+				<max_time_transfer>0.4520</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>2.998</min_time_dom_processing>
-				<max_time_dom_processing>2.998</max_time_dom_processing>
+				<min_time_dom_processing>1.4990</min_time_dom_processing>
+				<max_time_dom_processing>1.4990</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.712</min_time_dom_completion>
-				<max_time_dom_completion>0.712</max_time_dom_completion>
+				<min_time_dom_completion>0.3560</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.538</min_time_on_load>
-				<max_time_on_load>0.538</max_time_on_load>
+				<min_time_on_load>0.2690</min_time_on_load>
+				<max_time_on_load>0.2690</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -274,23 +274,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>720</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0.054</min_time_network>
-				<max_time_network>0.054</max_time_network>
+				<min_time_network>0.0270</min_time_network>
+				<max_time_network>0.0270</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.536</min_time_server>
-				<max_time_server>0.536</max_time_server>
+				<min_time_server>0.2680</min_time_server>
+				<max_time_server>0.2680</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.712</min_time_transfer>
-				<max_time_transfer>0.712</max_time_transfer>
+				<min_time_transfer>0.3560</min_time_transfer>
+				<max_time_transfer>0.3560</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>2.05</min_time_dom_processing>
-				<max_time_dom_processing>2.05</max_time_dom_processing>
+				<min_time_dom_processing>1.0250</min_time_dom_processing>
+				<max_time_dom_processing>1.0250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.592</min_time_dom_completion>
-				<max_time_dom_completion>0.592</max_time_dom_completion>
+				<min_time_dom_completion>0.2960</min_time_dom_completion>
+				<max_time_dom_completion>0.2960</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.67</min_time_on_load>
-				<max_time_on_load>0.67</max_time_on_load>
+				<min_time_on_load>0.3350</min_time_on_load>
+				<max_time_on_load>0.3350</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -320,23 +320,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>1080</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.398</min_time_server>
-				<max_time_server>0.398</max_time_server>
+				<min_time_server>0.1990</min_time_server>
+				<max_time_server>0.1990</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.578</min_time_transfer>
-				<max_time_transfer>0.578</max_time_transfer>
+				<min_time_transfer>0.2890</min_time_transfer>
+				<max_time_transfer>0.2890</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>1.996</min_time_dom_processing>
-				<max_time_dom_processing>1.996</max_time_dom_processing>
+				<min_time_dom_processing>0.9980</min_time_dom_processing>
+				<max_time_dom_processing>0.9980</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.396</min_time_dom_completion>
-				<max_time_dom_completion>0.396</max_time_dom_completion>
+				<min_time_dom_completion>0.1980</min_time_dom_completion>
+				<max_time_dom_completion>0.1980</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.598</min_time_on_load>
-				<max_time_on_load>0.598</max_time_on_load>
+				<min_time_on_load>0.2990</min_time_on_load>
+				<max_time_on_load>0.2990</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -370,23 +370,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0.021</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0210</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.258</min_time_server>
-				<max_time_server>0.344</max_time_server>
+				<min_time_server>0.2580</min_time_server>
+				<max_time_server>0.3440</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.299</min_time_transfer>
-				<max_time_transfer>0.444</max_time_transfer>
+				<min_time_transfer>0.2990</min_time_transfer>
+				<max_time_transfer>0.4440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.245</min_time_dom_processing>
-				<max_time_dom_processing>0.325</max_time_dom_processing>
+				<min_time_dom_processing>0.2450</min_time_dom_processing>
+				<max_time_dom_processing>0.3250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.189</min_time_dom_completion>
-				<max_time_dom_completion>0.999</max_time_dom_completion>
+				<min_time_dom_completion>0.1890</min_time_dom_completion>
+				<max_time_dom_completion>0.9990</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.12</min_time_on_load>
-				<max_time_on_load>0.35</max_time_on_load>
+				<min_time_on_load>0.1200</min_time_on_load>
+				<max_time_on_load>0.3500</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -411,23 +411,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.033</min_time_network>
-				<max_time_network>0.033</max_time_network>
+				<min_time_network>0.0330</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.144</min_time_server>
-				<max_time_server>0.144</max_time_server>
+				<min_time_server>0.1440</min_time_server>
+				<max_time_server>0.1440</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.318</min_time_transfer>
-				<max_time_transfer>0.318</max_time_transfer>
+				<min_time_transfer>0.3180</min_time_transfer>
+				<max_time_transfer>0.3180</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.289</min_time_dom_processing>
-				<max_time_dom_processing>0.289</max_time_dom_processing>
+				<min_time_dom_processing>0.2890</min_time_dom_processing>
+				<max_time_dom_processing>0.2890</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.035</min_time_dom_completion>
-				<max_time_dom_completion>0.035</max_time_dom_completion>
+				<min_time_dom_completion>0.0350</min_time_dom_completion>
+				<max_time_dom_completion>0.0350</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.05</min_time_on_load>
-				<max_time_on_load>0.05</max_time_on_load>
+				<min_time_on_load>0.0500</min_time_on_load>
+				<max_time_on_load>0.0500</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_year.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_year.xml
@@ -8,23 +8,23 @@
 				<nb_hits>8</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>8</nb_hits_with_time_network>
-				<min_time_network>0.264</min_time_network>
-				<max_time_network>0.264</max_time_network>
+				<min_time_network>0.0330</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>8</nb_hits_with_time_server>
-				<min_time_server>2.848</min_time_server>
-				<max_time_server>2.848</max_time_server>
+				<min_time_server>0.3560</min_time_server>
+				<max_time_server>0.3560</max_time_server>
 				<nb_hits_with_time_transfer>8</nb_hits_with_time_transfer>
-				<min_time_transfer>3.616</min_time_transfer>
-				<max_time_transfer>3.616</max_time_transfer>
+				<min_time_transfer>0.4520</min_time_transfer>
+				<max_time_transfer>0.4520</max_time_transfer>
 				<nb_hits_with_time_dom_processing>8</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>11.992</min_time_dom_processing>
-				<max_time_dom_processing>11.992</max_time_dom_processing>
+				<min_time_dom_processing>1.4990</min_time_dom_processing>
+				<max_time_dom_processing>1.4990</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>8</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>2.848</min_time_dom_completion>
-				<max_time_dom_completion>2.848</max_time_dom_completion>
+				<min_time_dom_completion>0.3560</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>8</nb_hits_with_time_on_load>
-				<min_time_on_load>2.152</min_time_on_load>
-				<max_time_on_load>2.152</max_time_on_load>
+				<min_time_on_load>0.2690</min_time_on_load>
+				<max_time_on_load>0.2690</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -51,23 +51,23 @@
 				<nb_hits>8</nb_hits>
 				<sum_time_spent>2880</sum_time_spent>
 				<nb_hits_with_time_network>8</nb_hits_with_time_network>
-				<min_time_network>0.216</min_time_network>
-				<max_time_network>0.216</max_time_network>
+				<min_time_network>0.0270</min_time_network>
+				<max_time_network>0.0270</max_time_network>
 				<nb_hits_with_time_server>8</nb_hits_with_time_server>
-				<min_time_server>2.144</min_time_server>
-				<max_time_server>2.144</max_time_server>
+				<min_time_server>0.2680</min_time_server>
+				<max_time_server>0.2680</max_time_server>
 				<nb_hits_with_time_transfer>8</nb_hits_with_time_transfer>
-				<min_time_transfer>2.848</min_time_transfer>
-				<max_time_transfer>2.848</max_time_transfer>
+				<min_time_transfer>0.3560</min_time_transfer>
+				<max_time_transfer>0.3560</max_time_transfer>
 				<nb_hits_with_time_dom_processing>8</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>8.2</min_time_dom_processing>
-				<max_time_dom_processing>8.2</max_time_dom_processing>
+				<min_time_dom_processing>1.0250</min_time_dom_processing>
+				<max_time_dom_processing>1.0250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>8</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>2.368</min_time_dom_completion>
-				<max_time_dom_completion>2.368</max_time_dom_completion>
+				<min_time_dom_completion>0.2960</min_time_dom_completion>
+				<max_time_dom_completion>0.2960</max_time_dom_completion>
 				<nb_hits_with_time_on_load>8</nb_hits_with_time_on_load>
-				<min_time_on_load>2.68</min_time_on_load>
-				<max_time_on_load>2.68</max_time_on_load>
+				<min_time_on_load>0.3350</min_time_on_load>
+				<max_time_on_load>0.3350</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -97,23 +97,23 @@
 				<nb_hits>8</nb_hits>
 				<sum_time_spent>4320</sum_time_spent>
 				<nb_hits_with_time_network>8</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>8</nb_hits_with_time_server>
-				<min_time_server>1.592</min_time_server>
-				<max_time_server>1.592</max_time_server>
+				<min_time_server>0.1990</min_time_server>
+				<max_time_server>0.1990</max_time_server>
 				<nb_hits_with_time_transfer>8</nb_hits_with_time_transfer>
-				<min_time_transfer>2.312</min_time_transfer>
-				<max_time_transfer>2.312</max_time_transfer>
+				<min_time_transfer>0.2890</min_time_transfer>
+				<max_time_transfer>0.2890</max_time_transfer>
 				<nb_hits_with_time_dom_processing>8</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>7.984</min_time_dom_processing>
-				<max_time_dom_processing>7.984</max_time_dom_processing>
+				<min_time_dom_processing>0.9980</min_time_dom_processing>
+				<max_time_dom_processing>0.9980</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>8</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>1.584</min_time_dom_completion>
-				<max_time_dom_completion>1.584</max_time_dom_completion>
+				<min_time_dom_completion>0.1980</min_time_dom_completion>
+				<max_time_dom_completion>0.1980</max_time_dom_completion>
 				<nb_hits_with_time_on_load>8</nb_hits_with_time_on_load>
-				<min_time_on_load>2.392</min_time_on_load>
-				<max_time_on_load>2.392</max_time_on_load>
+				<min_time_on_load>0.2990</min_time_on_load>
+				<max_time_on_load>0.2990</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -138,23 +138,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0.036</min_time_network>
-				<max_time_network>0.062</max_time_network>
+				<min_time_network>0.0360</min_time_network>
+				<max_time_network>0.0620</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.228</min_time_server>
-				<max_time_server>0.305</max_time_server>
+				<min_time_server>0.2280</min_time_server>
+				<max_time_server>0.3050</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.335</min_time_transfer>
-				<max_time_transfer>0.44</max_time_transfer>
+				<min_time_transfer>0.3350</min_time_transfer>
+				<max_time_transfer>0.4400</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>1.015</min_time_dom_processing>
-				<max_time_dom_processing>1.159</max_time_dom_processing>
+				<min_time_dom_processing>1.0150</min_time_dom_processing>
+				<max_time_dom_processing>1.1590</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.209</min_time_dom_completion>
-				<max_time_dom_completion>0.356</max_time_dom_completion>
+				<min_time_dom_completion>0.2090</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.301</min_time_on_load>
-				<max_time_on_load>0.44</max_time_on_load>
+				<min_time_on_load>0.3010</min_time_on_load>
+				<max_time_on_load>0.4400</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -237,23 +237,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0.021</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0210</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.258</min_time_server>
-				<max_time_server>0.344</max_time_server>
+				<min_time_server>0.2580</min_time_server>
+				<max_time_server>0.3440</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.299</min_time_transfer>
-				<max_time_transfer>0.444</max_time_transfer>
+				<min_time_transfer>0.2990</min_time_transfer>
+				<max_time_transfer>0.4440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.245</min_time_dom_processing>
-				<max_time_dom_processing>0.325</max_time_dom_processing>
+				<min_time_dom_processing>0.2450</min_time_dom_processing>
+				<max_time_dom_processing>0.3250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.189</min_time_dom_completion>
-				<max_time_dom_completion>0.999</max_time_dom_completion>
+				<min_time_dom_completion>0.1890</min_time_dom_completion>
+				<max_time_dom_completion>0.9990</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.12</min_time_on_load>
-				<max_time_on_load>0.35</max_time_on_load>
+				<min_time_on_load>0.1200</min_time_on_load>
+				<max_time_on_load>0.3500</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -278,23 +278,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.033</min_time_network>
-				<max_time_network>0.033</max_time_network>
+				<min_time_network>0.0330</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.144</min_time_server>
-				<max_time_server>0.144</max_time_server>
+				<min_time_server>0.1440</min_time_server>
+				<max_time_server>0.1440</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.318</min_time_transfer>
-				<max_time_transfer>0.318</max_time_transfer>
+				<min_time_transfer>0.3180</min_time_transfer>
+				<max_time_transfer>0.3180</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.289</min_time_dom_processing>
-				<max_time_dom_processing>0.289</max_time_dom_processing>
+				<min_time_dom_processing>0.2890</min_time_dom_processing>
+				<max_time_dom_processing>0.2890</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.035</min_time_dom_completion>
-				<max_time_dom_completion>0.035</max_time_dom_completion>
+				<min_time_dom_completion>0.0350</min_time_dom_completion>
+				<max_time_dom_completion>0.0350</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.05</min_time_on_load>
-				<max_time_on_load>0.05</max_time_on_load>
+				<min_time_on_load>0.0500</min_time_on_load>
+				<max_time_on_load>0.0500</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_month.xml
@@ -8,23 +8,23 @@
 				<nb_hits>9</nb_hits>
 				<sum_time_spent>2880</sum_time_spent>
 				<nb_hits_with_time_network>9</nb_hits_with_time_network>
-				<min_time_network>0.252</min_time_network>
-				<max_time_network>0.252</max_time_network>
+				<min_time_network>0.0270</min_time_network>
+				<max_time_network>0.0360</max_time_network>
 				<nb_hits_with_time_server>9</nb_hits_with_time_server>
-				<min_time_server>2.372</min_time_server>
-				<max_time_server>2.372</max_time_server>
+				<min_time_server>0.2280</min_time_server>
+				<max_time_server>0.2680</max_time_server>
 				<nb_hits_with_time_transfer>9</nb_hits_with_time_transfer>
-				<min_time_transfer>3.183</min_time_transfer>
-				<max_time_transfer>3.183</max_time_transfer>
+				<min_time_transfer>0.3350</min_time_transfer>
+				<max_time_transfer>0.3560</max_time_transfer>
 				<nb_hits_with_time_dom_processing>9</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>9.215</min_time_dom_processing>
-				<max_time_dom_processing>9.215</max_time_dom_processing>
+				<min_time_dom_processing>1.0150</min_time_dom_processing>
+				<max_time_dom_processing>1.0250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>9</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>2.577</min_time_dom_completion>
-				<max_time_dom_completion>2.577</max_time_dom_completion>
+				<min_time_dom_completion>0.2090</min_time_dom_completion>
+				<max_time_dom_completion>0.2960</max_time_dom_completion>
 				<nb_hits_with_time_on_load>9</nb_hits_with_time_on_load>
-				<min_time_on_load>2.981</min_time_on_load>
-				<max_time_on_load>2.981</max_time_on_load>
+				<min_time_on_load>0.3010</min_time_on_load>
+				<max_time_on_load>0.3350</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -99,23 +99,23 @@
 				<nb_hits>16</nb_hits>
 				<sum_time_spent>4320</sum_time_spent>
 				<nb_hits_with_time_network>16</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0.264</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>16</nb_hits_with_time_server>
-				<min_time_server>1.592</min_time_server>
-				<max_time_server>2.848</max_time_server>
+				<min_time_server>0.1990</min_time_server>
+				<max_time_server>0.3560</max_time_server>
 				<nb_hits_with_time_transfer>16</nb_hits_with_time_transfer>
-				<min_time_transfer>2.312</min_time_transfer>
-				<max_time_transfer>3.616</max_time_transfer>
+				<min_time_transfer>0.2890</min_time_transfer>
+				<max_time_transfer>0.4520</max_time_transfer>
 				<nb_hits_with_time_dom_processing>16</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>7.984</min_time_dom_processing>
-				<max_time_dom_processing>11.992</max_time_dom_processing>
+				<min_time_dom_processing>0.9980</min_time_dom_processing>
+				<max_time_dom_processing>1.4990</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>16</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>1.584</min_time_dom_completion>
-				<max_time_dom_completion>2.848</max_time_dom_completion>
+				<min_time_dom_completion>0.1980</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>16</nb_hits_with_time_on_load>
-				<min_time_on_load>2.152</min_time_on_load>
-				<max_time_on_load>2.392</max_time_on_load>
+				<min_time_on_load>0.2690</min_time_on_load>
+				<max_time_on_load>0.2990</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -143,23 +143,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.062</min_time_network>
-				<max_time_network>0.062</max_time_network>
+				<min_time_network>0.0620</min_time_network>
+				<max_time_network>0.0620</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.305</min_time_server>
-				<max_time_server>0.305</max_time_server>
+				<min_time_server>0.3050</min_time_server>
+				<max_time_server>0.3050</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.44</min_time_transfer>
-				<max_time_transfer>0.44</max_time_transfer>
+				<min_time_transfer>0.4400</min_time_transfer>
+				<max_time_transfer>0.4400</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>1.159</min_time_dom_processing>
-				<max_time_dom_processing>1.159</max_time_dom_processing>
+				<min_time_dom_processing>1.1590</min_time_dom_processing>
+				<max_time_dom_processing>1.1590</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.356</min_time_dom_completion>
-				<max_time_dom_completion>0.356</max_time_dom_completion>
+				<min_time_dom_completion>0.3560</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.44</min_time_on_load>
-				<max_time_on_load>0.44</max_time_on_load>
+				<min_time_on_load>0.4400</min_time_on_load>
+				<max_time_on_load>0.4400</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -202,23 +202,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0.021</min_time_network>
-				<max_time_network>0.033</max_time_network>
+				<min_time_network>0.0210</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.144</min_time_server>
-				<max_time_server>0.344</max_time_server>
+				<min_time_server>0.1440</min_time_server>
+				<max_time_server>0.3440</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.299</min_time_transfer>
-				<max_time_transfer>0.318</max_time_transfer>
+				<min_time_transfer>0.2990</min_time_transfer>
+				<max_time_transfer>0.3180</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.245</min_time_dom_processing>
-				<max_time_dom_processing>0.289</max_time_dom_processing>
+				<min_time_dom_processing>0.2450</min_time_dom_processing>
+				<max_time_dom_processing>0.2890</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.035</min_time_dom_completion>
-				<max_time_dom_completion>0.189</max_time_dom_completion>
+				<min_time_dom_completion>0.0350</min_time_dom_completion>
+				<max_time_dom_completion>0.1890</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.05</min_time_on_load>
-				<max_time_on_load>0.35</max_time_on_load>
+				<min_time_on_load>0.0500</min_time_on_load>
+				<max_time_on_load>0.3500</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -251,23 +251,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.258</min_time_server>
-				<max_time_server>0.258</max_time_server>
+				<min_time_server>0.2580</min_time_server>
+				<max_time_server>0.2580</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.444</min_time_transfer>
-				<max_time_transfer>0.444</max_time_transfer>
+				<min_time_transfer>0.4440</min_time_transfer>
+				<max_time_transfer>0.4440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.325</min_time_dom_processing>
-				<max_time_dom_processing>0.325</max_time_dom_processing>
+				<min_time_dom_processing>0.3250</min_time_dom_processing>
+				<max_time_dom_processing>0.3250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.999</min_time_dom_completion>
-				<max_time_dom_completion>0.999</max_time_dom_completion>
+				<min_time_dom_completion>0.9990</min_time_dom_completion>
+				<max_time_dom_completion>0.9990</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.12</min_time_on_load>
-				<max_time_on_load>0.12</max_time_on_load>
+				<min_time_on_load>0.1200</min_time_on_load>
+				<max_time_on_load>0.1200</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_week.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_week.xml
@@ -8,23 +8,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.036</min_time_network>
-				<max_time_network>0.036</max_time_network>
+				<min_time_network>0.0360</min_time_network>
+				<max_time_network>0.0360</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.228</min_time_server>
-				<max_time_server>0.228</max_time_server>
+				<min_time_server>0.2280</min_time_server>
+				<max_time_server>0.2280</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.335</min_time_transfer>
-				<max_time_transfer>0.335</max_time_transfer>
+				<min_time_transfer>0.3350</min_time_transfer>
+				<max_time_transfer>0.3350</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>1.015</min_time_dom_processing>
-				<max_time_dom_processing>1.015</max_time_dom_processing>
+				<min_time_dom_processing>1.0150</min_time_dom_processing>
+				<max_time_dom_processing>1.0150</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.209</min_time_dom_completion>
-				<max_time_dom_completion>0.209</max_time_dom_completion>
+				<min_time_dom_completion>0.2090</min_time_dom_completion>
+				<max_time_dom_completion>0.2090</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.301</min_time_on_load>
-				<max_time_on_load>0.301</max_time_on_load>
+				<min_time_on_load>0.3010</min_time_on_load>
+				<max_time_on_load>0.3010</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -57,23 +57,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.062</min_time_network>
-				<max_time_network>0.062</max_time_network>
+				<min_time_network>0.0620</min_time_network>
+				<max_time_network>0.0620</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.305</min_time_server>
-				<max_time_server>0.305</max_time_server>
+				<min_time_server>0.3050</min_time_server>
+				<max_time_server>0.3050</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.44</min_time_transfer>
-				<max_time_transfer>0.44</max_time_transfer>
+				<min_time_transfer>0.4400</min_time_transfer>
+				<max_time_transfer>0.4400</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>1.159</min_time_dom_processing>
-				<max_time_dom_processing>1.159</max_time_dom_processing>
+				<min_time_dom_processing>1.1590</min_time_dom_processing>
+				<max_time_dom_processing>1.1590</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.356</min_time_dom_completion>
-				<max_time_dom_completion>0.356</max_time_dom_completion>
+				<min_time_dom_completion>0.3560</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.44</min_time_on_load>
-				<max_time_on_load>0.44</max_time_on_load>
+				<min_time_on_load>0.4400</min_time_on_load>
+				<max_time_on_load>0.4400</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -150,23 +150,23 @@
 				<nb_hits>6</nb_hits>
 				<sum_time_spent>2160</sum_time_spent>
 				<nb_hits_with_time_network>6</nb_hits_with_time_network>
-				<min_time_network>0.162</min_time_network>
-				<max_time_network>0.162</max_time_network>
+				<min_time_network>0.0270</min_time_network>
+				<max_time_network>0.0270</max_time_network>
 				<nb_hits_with_time_server>6</nb_hits_with_time_server>
-				<min_time_server>1.608</min_time_server>
-				<max_time_server>1.608</max_time_server>
+				<min_time_server>0.2680</min_time_server>
+				<max_time_server>0.2680</max_time_server>
 				<nb_hits_with_time_transfer>6</nb_hits_with_time_transfer>
-				<min_time_transfer>2.136</min_time_transfer>
-				<max_time_transfer>2.136</max_time_transfer>
+				<min_time_transfer>0.3560</min_time_transfer>
+				<max_time_transfer>0.3560</max_time_transfer>
 				<nb_hits_with_time_dom_processing>6</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>6.15</min_time_dom_processing>
-				<max_time_dom_processing>6.15</max_time_dom_processing>
+				<min_time_dom_processing>1.0250</min_time_dom_processing>
+				<max_time_dom_processing>1.0250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>6</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>1.776</min_time_dom_completion>
-				<max_time_dom_completion>1.776</max_time_dom_completion>
+				<min_time_dom_completion>0.2960</min_time_dom_completion>
+				<max_time_dom_completion>0.2960</max_time_dom_completion>
 				<nb_hits_with_time_on_load>6</nb_hits_with_time_on_load>
-				<min_time_on_load>2.01</min_time_on_load>
-				<max_time_on_load>2.01</max_time_on_load>
+				<min_time_on_load>0.3350</min_time_on_load>
+				<max_time_on_load>0.3350</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -197,23 +197,23 @@
 				<nb_hits>12</nb_hits>
 				<sum_time_spent>3240</sum_time_spent>
 				<nb_hits_with_time_network>12</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0.198</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>12</nb_hits_with_time_server>
-				<min_time_server>1.194</min_time_server>
-				<max_time_server>2.136</max_time_server>
+				<min_time_server>0.1990</min_time_server>
+				<max_time_server>0.3560</max_time_server>
 				<nb_hits_with_time_transfer>12</nb_hits_with_time_transfer>
-				<min_time_transfer>1.734</min_time_transfer>
-				<max_time_transfer>2.712</max_time_transfer>
+				<min_time_transfer>0.2890</min_time_transfer>
+				<max_time_transfer>0.4520</max_time_transfer>
 				<nb_hits_with_time_dom_processing>12</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>5.988</min_time_dom_processing>
-				<max_time_dom_processing>8.994</max_time_dom_processing>
+				<min_time_dom_processing>0.9980</min_time_dom_processing>
+				<max_time_dom_processing>1.4990</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>12</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>1.188</min_time_dom_completion>
-				<max_time_dom_completion>2.136</max_time_dom_completion>
+				<min_time_dom_completion>0.1980</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>12</nb_hits_with_time_on_load>
-				<min_time_on_load>1.614</min_time_on_load>
-				<max_time_on_load>1.794</max_time_on_load>
+				<min_time_on_load>0.2690</min_time_on_load>
+				<max_time_on_load>0.2990</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -243,23 +243,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>720</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0.054</min_time_network>
-				<max_time_network>0.054</max_time_network>
+				<min_time_network>0.0270</min_time_network>
+				<max_time_network>0.0270</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.536</min_time_server>
-				<max_time_server>0.536</max_time_server>
+				<min_time_server>0.2680</min_time_server>
+				<max_time_server>0.2680</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.712</min_time_transfer>
-				<max_time_transfer>0.712</max_time_transfer>
+				<min_time_transfer>0.3560</min_time_transfer>
+				<max_time_transfer>0.3560</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>2.05</min_time_dom_processing>
-				<max_time_dom_processing>2.05</max_time_dom_processing>
+				<min_time_dom_processing>1.0250</min_time_dom_processing>
+				<max_time_dom_processing>1.0250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.592</min_time_dom_completion>
-				<max_time_dom_completion>0.592</max_time_dom_completion>
+				<min_time_dom_completion>0.2960</min_time_dom_completion>
+				<max_time_dom_completion>0.2960</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.67</min_time_on_load>
-				<max_time_on_load>0.67</max_time_on_load>
+				<min_time_on_load>0.3350</min_time_on_load>
+				<max_time_on_load>0.3350</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -290,23 +290,23 @@
 				<nb_hits>4</nb_hits>
 				<sum_time_spent>1080</sum_time_spent>
 				<nb_hits_with_time_network>4</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0.066</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>4</nb_hits_with_time_server>
-				<min_time_server>0.398</min_time_server>
-				<max_time_server>0.712</max_time_server>
+				<min_time_server>0.1990</min_time_server>
+				<max_time_server>0.3560</max_time_server>
 				<nb_hits_with_time_transfer>4</nb_hits_with_time_transfer>
-				<min_time_transfer>0.578</min_time_transfer>
-				<max_time_transfer>0.904</max_time_transfer>
+				<min_time_transfer>0.2890</min_time_transfer>
+				<max_time_transfer>0.4520</max_time_transfer>
 				<nb_hits_with_time_dom_processing>4</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>1.996</min_time_dom_processing>
-				<max_time_dom_processing>2.998</max_time_dom_processing>
+				<min_time_dom_processing>0.9980</min_time_dom_processing>
+				<max_time_dom_processing>1.4990</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>4</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.396</min_time_dom_completion>
-				<max_time_dom_completion>0.712</max_time_dom_completion>
+				<min_time_dom_completion>0.1980</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>4</nb_hits_with_time_on_load>
-				<min_time_on_load>0.538</min_time_on_load>
-				<max_time_on_load>0.598</max_time_on_load>
+				<min_time_on_load>0.2690</min_time_on_load>
+				<max_time_on_load>0.2990</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -385,23 +385,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0.021</min_time_network>
-				<max_time_network>0.033</max_time_network>
+				<min_time_network>0.0210</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.144</min_time_server>
-				<max_time_server>0.344</max_time_server>
+				<min_time_server>0.1440</min_time_server>
+				<max_time_server>0.3440</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.299</min_time_transfer>
-				<max_time_transfer>0.318</max_time_transfer>
+				<min_time_transfer>0.2990</min_time_transfer>
+				<max_time_transfer>0.3180</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.245</min_time_dom_processing>
-				<max_time_dom_processing>0.289</max_time_dom_processing>
+				<min_time_dom_processing>0.2450</min_time_dom_processing>
+				<max_time_dom_processing>0.2890</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.035</min_time_dom_completion>
-				<max_time_dom_completion>0.189</max_time_dom_completion>
+				<min_time_dom_completion>0.0350</min_time_dom_completion>
+				<max_time_dom_completion>0.1890</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.05</min_time_on_load>
-				<max_time_on_load>0.35</max_time_on_load>
+				<min_time_on_load>0.0500</min_time_on_load>
+				<max_time_on_load>0.3500</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -434,23 +434,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.258</min_time_server>
-				<max_time_server>0.258</max_time_server>
+				<min_time_server>0.2580</min_time_server>
+				<max_time_server>0.2580</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.444</min_time_transfer>
-				<max_time_transfer>0.444</max_time_transfer>
+				<min_time_transfer>0.4440</min_time_transfer>
+				<max_time_transfer>0.4440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.325</min_time_dom_processing>
-				<max_time_dom_processing>0.325</max_time_dom_processing>
+				<min_time_dom_processing>0.3250</min_time_dom_processing>
+				<max_time_dom_processing>0.3250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.999</min_time_dom_completion>
-				<max_time_dom_completion>0.999</max_time_dom_completion>
+				<min_time_dom_completion>0.9990</min_time_dom_completion>
+				<max_time_dom_completion>0.9990</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.12</min_time_on_load>
-				<max_time_on_load>0.12</max_time_on_load>
+				<min_time_on_load>0.1200</min_time_on_load>
+				<max_time_on_load>0.1200</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_year.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_year.xml
@@ -8,23 +8,23 @@
 				<nb_hits>9</nb_hits>
 				<sum_time_spent>2880</sum_time_spent>
 				<nb_hits_with_time_network>9</nb_hits_with_time_network>
-				<min_time_network>0.252</min_time_network>
-				<max_time_network>0.252</max_time_network>
+				<min_time_network>0.0270</min_time_network>
+				<max_time_network>0.0360</max_time_network>
 				<nb_hits_with_time_server>9</nb_hits_with_time_server>
-				<min_time_server>2.372</min_time_server>
-				<max_time_server>2.372</max_time_server>
+				<min_time_server>0.2280</min_time_server>
+				<max_time_server>0.2680</max_time_server>
 				<nb_hits_with_time_transfer>9</nb_hits_with_time_transfer>
-				<min_time_transfer>3.183</min_time_transfer>
-				<max_time_transfer>3.183</max_time_transfer>
+				<min_time_transfer>0.3350</min_time_transfer>
+				<max_time_transfer>0.3560</max_time_transfer>
 				<nb_hits_with_time_dom_processing>9</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>9.215</min_time_dom_processing>
-				<max_time_dom_processing>9.215</max_time_dom_processing>
+				<min_time_dom_processing>1.0150</min_time_dom_processing>
+				<max_time_dom_processing>1.0250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>9</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>2.577</min_time_dom_completion>
-				<max_time_dom_completion>2.577</max_time_dom_completion>
+				<min_time_dom_completion>0.2090</min_time_dom_completion>
+				<max_time_dom_completion>0.2960</max_time_dom_completion>
 				<nb_hits_with_time_on_load>9</nb_hits_with_time_on_load>
-				<min_time_on_load>2.981</min_time_on_load>
-				<max_time_on_load>2.981</max_time_on_load>
+				<min_time_on_load>0.3010</min_time_on_load>
+				<max_time_on_load>0.3350</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -99,23 +99,23 @@
 				<nb_hits>16</nb_hits>
 				<sum_time_spent>4320</sum_time_spent>
 				<nb_hits_with_time_network>16</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0.264</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>16</nb_hits_with_time_server>
-				<min_time_server>1.592</min_time_server>
-				<max_time_server>2.848</max_time_server>
+				<min_time_server>0.1990</min_time_server>
+				<max_time_server>0.3560</max_time_server>
 				<nb_hits_with_time_transfer>16</nb_hits_with_time_transfer>
-				<min_time_transfer>2.312</min_time_transfer>
-				<max_time_transfer>3.616</max_time_transfer>
+				<min_time_transfer>0.2890</min_time_transfer>
+				<max_time_transfer>0.4520</max_time_transfer>
 				<nb_hits_with_time_dom_processing>16</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>7.984</min_time_dom_processing>
-				<max_time_dom_processing>11.992</max_time_dom_processing>
+				<min_time_dom_processing>0.9980</min_time_dom_processing>
+				<max_time_dom_processing>1.4990</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>16</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>1.584</min_time_dom_completion>
-				<max_time_dom_completion>2.848</max_time_dom_completion>
+				<min_time_dom_completion>0.1980</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>16</nb_hits_with_time_on_load>
-				<min_time_on_load>2.152</min_time_on_load>
-				<max_time_on_load>2.392</max_time_on_load>
+				<min_time_on_load>0.2690</min_time_on_load>
+				<max_time_on_load>0.2990</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -143,23 +143,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0.062</min_time_network>
-				<max_time_network>0.062</max_time_network>
+				<min_time_network>0.0620</min_time_network>
+				<max_time_network>0.0620</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.305</min_time_server>
-				<max_time_server>0.305</max_time_server>
+				<min_time_server>0.3050</min_time_server>
+				<max_time_server>0.3050</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.44</min_time_transfer>
-				<max_time_transfer>0.44</max_time_transfer>
+				<min_time_transfer>0.4400</min_time_transfer>
+				<max_time_transfer>0.4400</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>1.159</min_time_dom_processing>
-				<max_time_dom_processing>1.159</max_time_dom_processing>
+				<min_time_dom_processing>1.1590</min_time_dom_processing>
+				<max_time_dom_processing>1.1590</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.356</min_time_dom_completion>
-				<max_time_dom_completion>0.356</max_time_dom_completion>
+				<min_time_dom_completion>0.3560</min_time_dom_completion>
+				<max_time_dom_completion>0.3560</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.44</min_time_on_load>
-				<max_time_on_load>0.44</max_time_on_load>
+				<min_time_on_load>0.4400</min_time_on_load>
+				<max_time_on_load>0.4400</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -202,23 +202,23 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>2</nb_hits_with_time_network>
-				<min_time_network>0.021</min_time_network>
-				<max_time_network>0.033</max_time_network>
+				<min_time_network>0.0210</min_time_network>
+				<max_time_network>0.0330</max_time_network>
 				<nb_hits_with_time_server>2</nb_hits_with_time_server>
-				<min_time_server>0.144</min_time_server>
-				<max_time_server>0.344</max_time_server>
+				<min_time_server>0.1440</min_time_server>
+				<max_time_server>0.3440</max_time_server>
 				<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-				<min_time_transfer>0.299</min_time_transfer>
-				<max_time_transfer>0.318</max_time_transfer>
+				<min_time_transfer>0.2990</min_time_transfer>
+				<max_time_transfer>0.3180</max_time_transfer>
 				<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.245</min_time_dom_processing>
-				<max_time_dom_processing>0.289</max_time_dom_processing>
+				<min_time_dom_processing>0.2450</min_time_dom_processing>
+				<max_time_dom_processing>0.2890</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.035</min_time_dom_completion>
-				<max_time_dom_completion>0.189</max_time_dom_completion>
+				<min_time_dom_completion>0.0350</min_time_dom_completion>
+				<max_time_dom_completion>0.1890</max_time_dom_completion>
 				<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-				<min_time_on_load>0.05</min_time_on_load>
-				<max_time_on_load>0.35</max_time_on_load>
+				<min_time_on_load>0.0500</min_time_on_load>
+				<max_time_on_load>0.3500</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />
@@ -251,23 +251,23 @@
 				<nb_hits>1</nb_hits>
 				<sum_time_spent>0</sum_time_spent>
 				<nb_hits_with_time_network>1</nb_hits_with_time_network>
-				<min_time_network>0</min_time_network>
-				<max_time_network>0</max_time_network>
+				<min_time_network>0.0000</min_time_network>
+				<max_time_network>0.0000</max_time_network>
 				<nb_hits_with_time_server>1</nb_hits_with_time_server>
-				<min_time_server>0.258</min_time_server>
-				<max_time_server>0.258</max_time_server>
+				<min_time_server>0.2580</min_time_server>
+				<max_time_server>0.2580</max_time_server>
 				<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-				<min_time_transfer>0.444</min_time_transfer>
-				<max_time_transfer>0.444</max_time_transfer>
+				<min_time_transfer>0.4440</min_time_transfer>
+				<max_time_transfer>0.4440</max_time_transfer>
 				<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-				<min_time_dom_processing>0.325</min_time_dom_processing>
-				<max_time_dom_processing>0.325</max_time_dom_processing>
+				<min_time_dom_processing>0.3250</min_time_dom_processing>
+				<max_time_dom_processing>0.3250</max_time_dom_processing>
 				<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-				<min_time_dom_completion>0.999</min_time_dom_completion>
-				<max_time_dom_completion>0.999</max_time_dom_completion>
+				<min_time_dom_completion>0.9990</min_time_dom_completion>
+				<max_time_dom_completion>0.9990</max_time_dom_completion>
 				<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-				<min_time_on_load>0.12</min_time_on_load>
-				<max_time_on_load>0.12</max_time_on_load>
+				<min_time_on_load>0.1200</min_time_on_load>
+				<max_time_on_load>0.1200</max_time_on_load>
 				<sum_bandwidth>0</sum_bandwidth>
 				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 				<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_month.xml
@@ -7,23 +7,23 @@
 			<nb_hits>8</nb_hits>
 			<sum_time_spent>0</sum_time_spent>
 			<nb_hits_with_time_network>8</nb_hits_with_time_network>
-			<min_time_network>0.264</min_time_network>
-			<max_time_network>0.264</max_time_network>
+			<min_time_network>0.0330</min_time_network>
+			<max_time_network>0.0330</max_time_network>
 			<nb_hits_with_time_server>8</nb_hits_with_time_server>
-			<min_time_server>2.848</min_time_server>
-			<max_time_server>2.848</max_time_server>
+			<min_time_server>0.3560</min_time_server>
+			<max_time_server>0.3560</max_time_server>
 			<nb_hits_with_time_transfer>8</nb_hits_with_time_transfer>
-			<min_time_transfer>3.616</min_time_transfer>
-			<max_time_transfer>3.616</max_time_transfer>
+			<min_time_transfer>0.4520</min_time_transfer>
+			<max_time_transfer>0.4520</max_time_transfer>
 			<nb_hits_with_time_dom_processing>8</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>11.992</min_time_dom_processing>
-			<max_time_dom_processing>11.992</max_time_dom_processing>
+			<min_time_dom_processing>1.4990</min_time_dom_processing>
+			<max_time_dom_processing>1.4990</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>8</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>2.848</min_time_dom_completion>
-			<max_time_dom_completion>2.848</max_time_dom_completion>
+			<min_time_dom_completion>0.3560</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>8</nb_hits_with_time_on_load>
-			<min_time_on_load>2.152</min_time_on_load>
-			<max_time_on_load>2.152</max_time_on_load>
+			<min_time_on_load>0.2690</min_time_on_load>
+			<max_time_on_load>0.2690</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -50,23 +50,23 @@
 			<nb_hits>8</nb_hits>
 			<sum_time_spent>2880</sum_time_spent>
 			<nb_hits_with_time_network>8</nb_hits_with_time_network>
-			<min_time_network>0.216</min_time_network>
-			<max_time_network>0.216</max_time_network>
+			<min_time_network>0.0270</min_time_network>
+			<max_time_network>0.0270</max_time_network>
 			<nb_hits_with_time_server>8</nb_hits_with_time_server>
-			<min_time_server>2.144</min_time_server>
-			<max_time_server>2.144</max_time_server>
+			<min_time_server>0.2680</min_time_server>
+			<max_time_server>0.2680</max_time_server>
 			<nb_hits_with_time_transfer>8</nb_hits_with_time_transfer>
-			<min_time_transfer>2.848</min_time_transfer>
-			<max_time_transfer>2.848</max_time_transfer>
+			<min_time_transfer>0.3560</min_time_transfer>
+			<max_time_transfer>0.3560</max_time_transfer>
 			<nb_hits_with_time_dom_processing>8</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>8.2</min_time_dom_processing>
-			<max_time_dom_processing>8.2</max_time_dom_processing>
+			<min_time_dom_processing>1.0250</min_time_dom_processing>
+			<max_time_dom_processing>1.0250</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>8</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>2.368</min_time_dom_completion>
-			<max_time_dom_completion>2.368</max_time_dom_completion>
+			<min_time_dom_completion>0.2960</min_time_dom_completion>
+			<max_time_dom_completion>0.2960</max_time_dom_completion>
 			<nb_hits_with_time_on_load>8</nb_hits_with_time_on_load>
-			<min_time_on_load>2.68</min_time_on_load>
-			<max_time_on_load>2.68</max_time_on_load>
+			<min_time_on_load>0.3350</min_time_on_load>
+			<max_time_on_load>0.3350</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -96,23 +96,23 @@
 			<nb_hits>8</nb_hits>
 			<sum_time_spent>4320</sum_time_spent>
 			<nb_hits_with_time_network>8</nb_hits_with_time_network>
-			<min_time_network>0</min_time_network>
-			<max_time_network>0</max_time_network>
+			<min_time_network>0.0000</min_time_network>
+			<max_time_network>0.0000</max_time_network>
 			<nb_hits_with_time_server>8</nb_hits_with_time_server>
-			<min_time_server>1.592</min_time_server>
-			<max_time_server>1.592</max_time_server>
+			<min_time_server>0.1990</min_time_server>
+			<max_time_server>0.1990</max_time_server>
 			<nb_hits_with_time_transfer>8</nb_hits_with_time_transfer>
-			<min_time_transfer>2.312</min_time_transfer>
-			<max_time_transfer>2.312</max_time_transfer>
+			<min_time_transfer>0.2890</min_time_transfer>
+			<max_time_transfer>0.2890</max_time_transfer>
 			<nb_hits_with_time_dom_processing>8</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>7.984</min_time_dom_processing>
-			<max_time_dom_processing>7.984</max_time_dom_processing>
+			<min_time_dom_processing>0.9980</min_time_dom_processing>
+			<max_time_dom_processing>0.9980</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>8</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>1.584</min_time_dom_completion>
-			<max_time_dom_completion>1.584</max_time_dom_completion>
+			<min_time_dom_completion>0.1980</min_time_dom_completion>
+			<max_time_dom_completion>0.1980</max_time_dom_completion>
 			<nb_hits_with_time_on_load>8</nb_hits_with_time_on_load>
-			<min_time_on_load>2.392</min_time_on_load>
-			<max_time_on_load>2.392</max_time_on_load>
+			<min_time_on_load>0.2990</min_time_on_load>
+			<max_time_on_load>0.2990</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -137,23 +137,23 @@
 			<nb_hits>2</nb_hits>
 			<sum_time_spent>0</sum_time_spent>
 			<nb_hits_with_time_network>2</nb_hits_with_time_network>
-			<min_time_network>0.036</min_time_network>
-			<max_time_network>0.062</max_time_network>
+			<min_time_network>0.0360</min_time_network>
+			<max_time_network>0.0620</max_time_network>
 			<nb_hits_with_time_server>2</nb_hits_with_time_server>
-			<min_time_server>0.228</min_time_server>
-			<max_time_server>0.305</max_time_server>
+			<min_time_server>0.2280</min_time_server>
+			<max_time_server>0.3050</max_time_server>
 			<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-			<min_time_transfer>0.335</min_time_transfer>
-			<max_time_transfer>0.44</max_time_transfer>
+			<min_time_transfer>0.3350</min_time_transfer>
+			<max_time_transfer>0.4400</max_time_transfer>
 			<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>1.015</min_time_dom_processing>
-			<max_time_dom_processing>1.159</max_time_dom_processing>
+			<min_time_dom_processing>1.0150</min_time_dom_processing>
+			<max_time_dom_processing>1.1590</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.209</min_time_dom_completion>
-			<max_time_dom_completion>0.356</max_time_dom_completion>
+			<min_time_dom_completion>0.2090</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-			<min_time_on_load>0.301</min_time_on_load>
-			<max_time_on_load>0.44</max_time_on_load>
+			<min_time_on_load>0.3010</min_time_on_load>
+			<max_time_on_load>0.4400</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_week.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_week.xml
@@ -7,23 +7,23 @@
 			<nb_hits>2</nb_hits>
 			<sum_time_spent>0</sum_time_spent>
 			<nb_hits_with_time_network>2</nb_hits_with_time_network>
-			<min_time_network>0.036</min_time_network>
-			<max_time_network>0.062</max_time_network>
+			<min_time_network>0.0360</min_time_network>
+			<max_time_network>0.0620</max_time_network>
 			<nb_hits_with_time_server>2</nb_hits_with_time_server>
-			<min_time_server>0.228</min_time_server>
-			<max_time_server>0.305</max_time_server>
+			<min_time_server>0.2280</min_time_server>
+			<max_time_server>0.3050</max_time_server>
 			<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-			<min_time_transfer>0.335</min_time_transfer>
-			<max_time_transfer>0.44</max_time_transfer>
+			<min_time_transfer>0.3350</min_time_transfer>
+			<max_time_transfer>0.4400</max_time_transfer>
 			<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>1.015</min_time_dom_processing>
-			<max_time_dom_processing>1.159</max_time_dom_processing>
+			<min_time_dom_processing>1.0150</min_time_dom_processing>
+			<max_time_dom_processing>1.1590</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.209</min_time_dom_completion>
-			<max_time_dom_completion>0.356</max_time_dom_completion>
+			<min_time_dom_completion>0.2090</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-			<min_time_on_load>0.301</min_time_on_load>
-			<max_time_on_load>0.44</max_time_on_load>
+			<min_time_on_load>0.3010</min_time_on_load>
+			<max_time_on_load>0.4400</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -57,23 +57,23 @@
 			<nb_hits>6</nb_hits>
 			<sum_time_spent>0</sum_time_spent>
 			<nb_hits_with_time_network>6</nb_hits_with_time_network>
-			<min_time_network>0.198</min_time_network>
-			<max_time_network>0.198</max_time_network>
+			<min_time_network>0.0330</min_time_network>
+			<max_time_network>0.0330</max_time_network>
 			<nb_hits_with_time_server>6</nb_hits_with_time_server>
-			<min_time_server>2.136</min_time_server>
-			<max_time_server>2.136</max_time_server>
+			<min_time_server>0.3560</min_time_server>
+			<max_time_server>0.3560</max_time_server>
 			<nb_hits_with_time_transfer>6</nb_hits_with_time_transfer>
-			<min_time_transfer>2.712</min_time_transfer>
-			<max_time_transfer>2.712</max_time_transfer>
+			<min_time_transfer>0.4520</min_time_transfer>
+			<max_time_transfer>0.4520</max_time_transfer>
 			<nb_hits_with_time_dom_processing>6</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>8.994</min_time_dom_processing>
-			<max_time_dom_processing>8.994</max_time_dom_processing>
+			<min_time_dom_processing>1.4990</min_time_dom_processing>
+			<max_time_dom_processing>1.4990</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>6</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>2.136</min_time_dom_completion>
-			<max_time_dom_completion>2.136</max_time_dom_completion>
+			<min_time_dom_completion>0.3560</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>6</nb_hits_with_time_on_load>
-			<min_time_on_load>1.614</min_time_on_load>
-			<max_time_on_load>1.614</max_time_on_load>
+			<min_time_on_load>0.2690</min_time_on_load>
+			<max_time_on_load>0.2690</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -100,23 +100,23 @@
 			<nb_hits>6</nb_hits>
 			<sum_time_spent>2160</sum_time_spent>
 			<nb_hits_with_time_network>6</nb_hits_with_time_network>
-			<min_time_network>0.162</min_time_network>
-			<max_time_network>0.162</max_time_network>
+			<min_time_network>0.0270</min_time_network>
+			<max_time_network>0.0270</max_time_network>
 			<nb_hits_with_time_server>6</nb_hits_with_time_server>
-			<min_time_server>1.608</min_time_server>
-			<max_time_server>1.608</max_time_server>
+			<min_time_server>0.2680</min_time_server>
+			<max_time_server>0.2680</max_time_server>
 			<nb_hits_with_time_transfer>6</nb_hits_with_time_transfer>
-			<min_time_transfer>2.136</min_time_transfer>
-			<max_time_transfer>2.136</max_time_transfer>
+			<min_time_transfer>0.3560</min_time_transfer>
+			<max_time_transfer>0.3560</max_time_transfer>
 			<nb_hits_with_time_dom_processing>6</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>6.15</min_time_dom_processing>
-			<max_time_dom_processing>6.15</max_time_dom_processing>
+			<min_time_dom_processing>1.0250</min_time_dom_processing>
+			<max_time_dom_processing>1.0250</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>6</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>1.776</min_time_dom_completion>
-			<max_time_dom_completion>1.776</max_time_dom_completion>
+			<min_time_dom_completion>0.2960</min_time_dom_completion>
+			<max_time_dom_completion>0.2960</max_time_dom_completion>
 			<nb_hits_with_time_on_load>6</nb_hits_with_time_on_load>
-			<min_time_on_load>2.01</min_time_on_load>
-			<max_time_on_load>2.01</max_time_on_load>
+			<min_time_on_load>0.3350</min_time_on_load>
+			<max_time_on_load>0.3350</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -146,23 +146,23 @@
 			<nb_hits>6</nb_hits>
 			<sum_time_spent>3240</sum_time_spent>
 			<nb_hits_with_time_network>6</nb_hits_with_time_network>
-			<min_time_network>0</min_time_network>
-			<max_time_network>0</max_time_network>
+			<min_time_network>0.0000</min_time_network>
+			<max_time_network>0.0000</max_time_network>
 			<nb_hits_with_time_server>6</nb_hits_with_time_server>
-			<min_time_server>1.194</min_time_server>
-			<max_time_server>1.194</max_time_server>
+			<min_time_server>0.1990</min_time_server>
+			<max_time_server>0.1990</max_time_server>
 			<nb_hits_with_time_transfer>6</nb_hits_with_time_transfer>
-			<min_time_transfer>1.734</min_time_transfer>
-			<max_time_transfer>1.734</max_time_transfer>
+			<min_time_transfer>0.2890</min_time_transfer>
+			<max_time_transfer>0.2890</max_time_transfer>
 			<nb_hits_with_time_dom_processing>6</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>5.988</min_time_dom_processing>
-			<max_time_dom_processing>5.988</max_time_dom_processing>
+			<min_time_dom_processing>0.9980</min_time_dom_processing>
+			<max_time_dom_processing>0.9980</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>6</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>1.188</min_time_dom_completion>
-			<max_time_dom_completion>1.188</max_time_dom_completion>
+			<min_time_dom_completion>0.1980</min_time_dom_completion>
+			<max_time_dom_completion>0.1980</max_time_dom_completion>
 			<nb_hits_with_time_on_load>6</nb_hits_with_time_on_load>
-			<min_time_on_load>1.794</min_time_on_load>
-			<max_time_on_load>1.794</max_time_on_load>
+			<min_time_on_load>0.2990</min_time_on_load>
+			<max_time_on_load>0.2990</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -230,23 +230,23 @@
 			<nb_hits>2</nb_hits>
 			<sum_time_spent>0</sum_time_spent>
 			<nb_hits_with_time_network>2</nb_hits_with_time_network>
-			<min_time_network>0.066</min_time_network>
-			<max_time_network>0.066</max_time_network>
+			<min_time_network>0.0330</min_time_network>
+			<max_time_network>0.0330</max_time_network>
 			<nb_hits_with_time_server>2</nb_hits_with_time_server>
-			<min_time_server>0.712</min_time_server>
-			<max_time_server>0.712</max_time_server>
+			<min_time_server>0.3560</min_time_server>
+			<max_time_server>0.3560</max_time_server>
 			<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-			<min_time_transfer>0.904</min_time_transfer>
-			<max_time_transfer>0.904</max_time_transfer>
+			<min_time_transfer>0.4520</min_time_transfer>
+			<max_time_transfer>0.4520</max_time_transfer>
 			<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>2.998</min_time_dom_processing>
-			<max_time_dom_processing>2.998</max_time_dom_processing>
+			<min_time_dom_processing>1.4990</min_time_dom_processing>
+			<max_time_dom_processing>1.4990</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.712</min_time_dom_completion>
-			<max_time_dom_completion>0.712</max_time_dom_completion>
+			<min_time_dom_completion>0.3560</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-			<min_time_on_load>0.538</min_time_on_load>
-			<max_time_on_load>0.538</max_time_on_load>
+			<min_time_on_load>0.2690</min_time_on_load>
+			<max_time_on_load>0.2690</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -273,23 +273,23 @@
 			<nb_hits>2</nb_hits>
 			<sum_time_spent>720</sum_time_spent>
 			<nb_hits_with_time_network>2</nb_hits_with_time_network>
-			<min_time_network>0.054</min_time_network>
-			<max_time_network>0.054</max_time_network>
+			<min_time_network>0.0270</min_time_network>
+			<max_time_network>0.0270</max_time_network>
 			<nb_hits_with_time_server>2</nb_hits_with_time_server>
-			<min_time_server>0.536</min_time_server>
-			<max_time_server>0.536</max_time_server>
+			<min_time_server>0.2680</min_time_server>
+			<max_time_server>0.2680</max_time_server>
 			<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-			<min_time_transfer>0.712</min_time_transfer>
-			<max_time_transfer>0.712</max_time_transfer>
+			<min_time_transfer>0.3560</min_time_transfer>
+			<max_time_transfer>0.3560</max_time_transfer>
 			<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>2.05</min_time_dom_processing>
-			<max_time_dom_processing>2.05</max_time_dom_processing>
+			<min_time_dom_processing>1.0250</min_time_dom_processing>
+			<max_time_dom_processing>1.0250</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.592</min_time_dom_completion>
-			<max_time_dom_completion>0.592</max_time_dom_completion>
+			<min_time_dom_completion>0.2960</min_time_dom_completion>
+			<max_time_dom_completion>0.2960</max_time_dom_completion>
 			<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-			<min_time_on_load>0.67</min_time_on_load>
-			<max_time_on_load>0.67</max_time_on_load>
+			<min_time_on_load>0.3350</min_time_on_load>
+			<max_time_on_load>0.3350</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -319,23 +319,23 @@
 			<nb_hits>2</nb_hits>
 			<sum_time_spent>1080</sum_time_spent>
 			<nb_hits_with_time_network>2</nb_hits_with_time_network>
-			<min_time_network>0</min_time_network>
-			<max_time_network>0</max_time_network>
+			<min_time_network>0.0000</min_time_network>
+			<max_time_network>0.0000</max_time_network>
 			<nb_hits_with_time_server>2</nb_hits_with_time_server>
-			<min_time_server>0.398</min_time_server>
-			<max_time_server>0.398</max_time_server>
+			<min_time_server>0.1990</min_time_server>
+			<max_time_server>0.1990</max_time_server>
 			<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-			<min_time_transfer>0.578</min_time_transfer>
-			<max_time_transfer>0.578</max_time_transfer>
+			<min_time_transfer>0.2890</min_time_transfer>
+			<max_time_transfer>0.2890</max_time_transfer>
 			<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>1.996</min_time_dom_processing>
-			<max_time_dom_processing>1.996</max_time_dom_processing>
+			<min_time_dom_processing>0.9980</min_time_dom_processing>
+			<max_time_dom_processing>0.9980</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.396</min_time_dom_completion>
-			<max_time_dom_completion>0.396</max_time_dom_completion>
+			<min_time_dom_completion>0.1980</min_time_dom_completion>
+			<max_time_dom_completion>0.1980</max_time_dom_completion>
 			<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-			<min_time_on_load>0.598</min_time_on_load>
-			<max_time_on_load>0.598</max_time_on_load>
+			<min_time_on_load>0.2990</min_time_on_load>
+			<max_time_on_load>0.2990</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_year.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_year.xml
@@ -7,23 +7,23 @@
 			<nb_hits>8</nb_hits>
 			<sum_time_spent>0</sum_time_spent>
 			<nb_hits_with_time_network>8</nb_hits_with_time_network>
-			<min_time_network>0.264</min_time_network>
-			<max_time_network>0.264</max_time_network>
+			<min_time_network>0.0330</min_time_network>
+			<max_time_network>0.0330</max_time_network>
 			<nb_hits_with_time_server>8</nb_hits_with_time_server>
-			<min_time_server>2.848</min_time_server>
-			<max_time_server>2.848</max_time_server>
+			<min_time_server>0.3560</min_time_server>
+			<max_time_server>0.3560</max_time_server>
 			<nb_hits_with_time_transfer>8</nb_hits_with_time_transfer>
-			<min_time_transfer>3.616</min_time_transfer>
-			<max_time_transfer>3.616</max_time_transfer>
+			<min_time_transfer>0.4520</min_time_transfer>
+			<max_time_transfer>0.4520</max_time_transfer>
 			<nb_hits_with_time_dom_processing>8</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>11.992</min_time_dom_processing>
-			<max_time_dom_processing>11.992</max_time_dom_processing>
+			<min_time_dom_processing>1.4990</min_time_dom_processing>
+			<max_time_dom_processing>1.4990</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>8</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>2.848</min_time_dom_completion>
-			<max_time_dom_completion>2.848</max_time_dom_completion>
+			<min_time_dom_completion>0.3560</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>8</nb_hits_with_time_on_load>
-			<min_time_on_load>2.152</min_time_on_load>
-			<max_time_on_load>2.152</max_time_on_load>
+			<min_time_on_load>0.2690</min_time_on_load>
+			<max_time_on_load>0.2690</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -50,23 +50,23 @@
 			<nb_hits>8</nb_hits>
 			<sum_time_spent>2880</sum_time_spent>
 			<nb_hits_with_time_network>8</nb_hits_with_time_network>
-			<min_time_network>0.216</min_time_network>
-			<max_time_network>0.216</max_time_network>
+			<min_time_network>0.0270</min_time_network>
+			<max_time_network>0.0270</max_time_network>
 			<nb_hits_with_time_server>8</nb_hits_with_time_server>
-			<min_time_server>2.144</min_time_server>
-			<max_time_server>2.144</max_time_server>
+			<min_time_server>0.2680</min_time_server>
+			<max_time_server>0.2680</max_time_server>
 			<nb_hits_with_time_transfer>8</nb_hits_with_time_transfer>
-			<min_time_transfer>2.848</min_time_transfer>
-			<max_time_transfer>2.848</max_time_transfer>
+			<min_time_transfer>0.3560</min_time_transfer>
+			<max_time_transfer>0.3560</max_time_transfer>
 			<nb_hits_with_time_dom_processing>8</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>8.2</min_time_dom_processing>
-			<max_time_dom_processing>8.2</max_time_dom_processing>
+			<min_time_dom_processing>1.0250</min_time_dom_processing>
+			<max_time_dom_processing>1.0250</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>8</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>2.368</min_time_dom_completion>
-			<max_time_dom_completion>2.368</max_time_dom_completion>
+			<min_time_dom_completion>0.2960</min_time_dom_completion>
+			<max_time_dom_completion>0.2960</max_time_dom_completion>
 			<nb_hits_with_time_on_load>8</nb_hits_with_time_on_load>
-			<min_time_on_load>2.68</min_time_on_load>
-			<max_time_on_load>2.68</max_time_on_load>
+			<min_time_on_load>0.3350</min_time_on_load>
+			<max_time_on_load>0.3350</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -96,23 +96,23 @@
 			<nb_hits>8</nb_hits>
 			<sum_time_spent>4320</sum_time_spent>
 			<nb_hits_with_time_network>8</nb_hits_with_time_network>
-			<min_time_network>0</min_time_network>
-			<max_time_network>0</max_time_network>
+			<min_time_network>0.0000</min_time_network>
+			<max_time_network>0.0000</max_time_network>
 			<nb_hits_with_time_server>8</nb_hits_with_time_server>
-			<min_time_server>1.592</min_time_server>
-			<max_time_server>1.592</max_time_server>
+			<min_time_server>0.1990</min_time_server>
+			<max_time_server>0.1990</max_time_server>
 			<nb_hits_with_time_transfer>8</nb_hits_with_time_transfer>
-			<min_time_transfer>2.312</min_time_transfer>
-			<max_time_transfer>2.312</max_time_transfer>
+			<min_time_transfer>0.2890</min_time_transfer>
+			<max_time_transfer>0.2890</max_time_transfer>
 			<nb_hits_with_time_dom_processing>8</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>7.984</min_time_dom_processing>
-			<max_time_dom_processing>7.984</max_time_dom_processing>
+			<min_time_dom_processing>0.9980</min_time_dom_processing>
+			<max_time_dom_processing>0.9980</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>8</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>1.584</min_time_dom_completion>
-			<max_time_dom_completion>1.584</max_time_dom_completion>
+			<min_time_dom_completion>0.1980</min_time_dom_completion>
+			<max_time_dom_completion>0.1980</max_time_dom_completion>
 			<nb_hits_with_time_on_load>8</nb_hits_with_time_on_load>
-			<min_time_on_load>2.392</min_time_on_load>
-			<max_time_on_load>2.392</max_time_on_load>
+			<min_time_on_load>0.2990</min_time_on_load>
+			<max_time_on_load>0.2990</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -137,23 +137,23 @@
 			<nb_hits>2</nb_hits>
 			<sum_time_spent>0</sum_time_spent>
 			<nb_hits_with_time_network>2</nb_hits_with_time_network>
-			<min_time_network>0.036</min_time_network>
-			<max_time_network>0.062</max_time_network>
+			<min_time_network>0.0360</min_time_network>
+			<max_time_network>0.0620</max_time_network>
 			<nb_hits_with_time_server>2</nb_hits_with_time_server>
-			<min_time_server>0.228</min_time_server>
-			<max_time_server>0.305</max_time_server>
+			<min_time_server>0.2280</min_time_server>
+			<max_time_server>0.3050</max_time_server>
 			<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-			<min_time_transfer>0.335</min_time_transfer>
-			<max_time_transfer>0.44</max_time_transfer>
+			<min_time_transfer>0.3350</min_time_transfer>
+			<max_time_transfer>0.4400</max_time_transfer>
 			<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>1.015</min_time_dom_processing>
-			<max_time_dom_processing>1.159</max_time_dom_processing>
+			<min_time_dom_processing>1.0150</min_time_dom_processing>
+			<max_time_dom_processing>1.1590</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.209</min_time_dom_completion>
-			<max_time_dom_completion>0.356</max_time_dom_completion>
+			<min_time_dom_completion>0.2090</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-			<min_time_on_load>0.301</min_time_on_load>
-			<max_time_on_load>0.44</max_time_on_load>
+			<min_time_on_load>0.3010</min_time_on_load>
+			<max_time_on_load>0.4400</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_month.xml
@@ -7,23 +7,23 @@
 			<nb_hits>9</nb_hits>
 			<sum_time_spent>2880</sum_time_spent>
 			<nb_hits_with_time_network>9</nb_hits_with_time_network>
-			<min_time_network>0.252</min_time_network>
-			<max_time_network>0.252</max_time_network>
+			<min_time_network>0.0270</min_time_network>
+			<max_time_network>0.0360</max_time_network>
 			<nb_hits_with_time_server>9</nb_hits_with_time_server>
-			<min_time_server>2.372</min_time_server>
-			<max_time_server>2.372</max_time_server>
+			<min_time_server>0.2280</min_time_server>
+			<max_time_server>0.2680</max_time_server>
 			<nb_hits_with_time_transfer>9</nb_hits_with_time_transfer>
-			<min_time_transfer>3.183</min_time_transfer>
-			<max_time_transfer>3.183</max_time_transfer>
+			<min_time_transfer>0.3350</min_time_transfer>
+			<max_time_transfer>0.3560</max_time_transfer>
 			<nb_hits_with_time_dom_processing>9</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>9.215</min_time_dom_processing>
-			<max_time_dom_processing>9.215</max_time_dom_processing>
+			<min_time_dom_processing>1.0150</min_time_dom_processing>
+			<max_time_dom_processing>1.0250</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>9</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>2.577</min_time_dom_completion>
-			<max_time_dom_completion>2.577</max_time_dom_completion>
+			<min_time_dom_completion>0.2090</min_time_dom_completion>
+			<max_time_dom_completion>0.2960</max_time_dom_completion>
 			<nb_hits_with_time_on_load>9</nb_hits_with_time_on_load>
-			<min_time_on_load>2.981</min_time_on_load>
-			<max_time_on_load>2.981</max_time_on_load>
+			<min_time_on_load>0.3010</min_time_on_load>
+			<max_time_on_load>0.3350</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -98,23 +98,23 @@
 			<nb_hits>16</nb_hits>
 			<sum_time_spent>4320</sum_time_spent>
 			<nb_hits_with_time_network>16</nb_hits_with_time_network>
-			<min_time_network>0</min_time_network>
-			<max_time_network>0.264</max_time_network>
+			<min_time_network>0.0000</min_time_network>
+			<max_time_network>0.0330</max_time_network>
 			<nb_hits_with_time_server>16</nb_hits_with_time_server>
-			<min_time_server>1.592</min_time_server>
-			<max_time_server>2.848</max_time_server>
+			<min_time_server>0.1990</min_time_server>
+			<max_time_server>0.3560</max_time_server>
 			<nb_hits_with_time_transfer>16</nb_hits_with_time_transfer>
-			<min_time_transfer>2.312</min_time_transfer>
-			<max_time_transfer>3.616</max_time_transfer>
+			<min_time_transfer>0.2890</min_time_transfer>
+			<max_time_transfer>0.4520</max_time_transfer>
 			<nb_hits_with_time_dom_processing>16</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>7.984</min_time_dom_processing>
-			<max_time_dom_processing>11.992</max_time_dom_processing>
+			<min_time_dom_processing>0.9980</min_time_dom_processing>
+			<max_time_dom_processing>1.4990</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>16</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>1.584</min_time_dom_completion>
-			<max_time_dom_completion>2.848</max_time_dom_completion>
+			<min_time_dom_completion>0.1980</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>16</nb_hits_with_time_on_load>
-			<min_time_on_load>2.152</min_time_on_load>
-			<max_time_on_load>2.392</max_time_on_load>
+			<min_time_on_load>0.2690</min_time_on_load>
+			<max_time_on_load>0.2990</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -142,23 +142,23 @@
 			<nb_hits>1</nb_hits>
 			<sum_time_spent>0</sum_time_spent>
 			<nb_hits_with_time_network>1</nb_hits_with_time_network>
-			<min_time_network>0.062</min_time_network>
-			<max_time_network>0.062</max_time_network>
+			<min_time_network>0.0620</min_time_network>
+			<max_time_network>0.0620</max_time_network>
 			<nb_hits_with_time_server>1</nb_hits_with_time_server>
-			<min_time_server>0.305</min_time_server>
-			<max_time_server>0.305</max_time_server>
+			<min_time_server>0.3050</min_time_server>
+			<max_time_server>0.3050</max_time_server>
 			<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-			<min_time_transfer>0.44</min_time_transfer>
-			<max_time_transfer>0.44</max_time_transfer>
+			<min_time_transfer>0.4400</min_time_transfer>
+			<max_time_transfer>0.4400</max_time_transfer>
 			<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>1.159</min_time_dom_processing>
-			<max_time_dom_processing>1.159</max_time_dom_processing>
+			<min_time_dom_processing>1.1590</min_time_dom_processing>
+			<max_time_dom_processing>1.1590</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.356</min_time_dom_completion>
-			<max_time_dom_completion>0.356</max_time_dom_completion>
+			<min_time_dom_completion>0.3560</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-			<min_time_on_load>0.44</min_time_on_load>
-			<max_time_on_load>0.44</max_time_on_load>
+			<min_time_on_load>0.4400</min_time_on_load>
+			<max_time_on_load>0.4400</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_week.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_week.xml
@@ -7,23 +7,23 @@
 			<nb_hits>1</nb_hits>
 			<sum_time_spent>0</sum_time_spent>
 			<nb_hits_with_time_network>1</nb_hits_with_time_network>
-			<min_time_network>0.036</min_time_network>
-			<max_time_network>0.036</max_time_network>
+			<min_time_network>0.0360</min_time_network>
+			<max_time_network>0.0360</max_time_network>
 			<nb_hits_with_time_server>1</nb_hits_with_time_server>
-			<min_time_server>0.228</min_time_server>
-			<max_time_server>0.228</max_time_server>
+			<min_time_server>0.2280</min_time_server>
+			<max_time_server>0.2280</max_time_server>
 			<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-			<min_time_transfer>0.335</min_time_transfer>
-			<max_time_transfer>0.335</max_time_transfer>
+			<min_time_transfer>0.3350</min_time_transfer>
+			<max_time_transfer>0.3350</max_time_transfer>
 			<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>1.015</min_time_dom_processing>
-			<max_time_dom_processing>1.015</max_time_dom_processing>
+			<min_time_dom_processing>1.0150</min_time_dom_processing>
+			<max_time_dom_processing>1.0150</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.209</min_time_dom_completion>
-			<max_time_dom_completion>0.209</max_time_dom_completion>
+			<min_time_dom_completion>0.2090</min_time_dom_completion>
+			<max_time_dom_completion>0.2090</max_time_dom_completion>
 			<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-			<min_time_on_load>0.301</min_time_on_load>
-			<max_time_on_load>0.301</max_time_on_load>
+			<min_time_on_load>0.3010</min_time_on_load>
+			<max_time_on_load>0.3010</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -56,23 +56,23 @@
 			<nb_hits>1</nb_hits>
 			<sum_time_spent>0</sum_time_spent>
 			<nb_hits_with_time_network>1</nb_hits_with_time_network>
-			<min_time_network>0.062</min_time_network>
-			<max_time_network>0.062</max_time_network>
+			<min_time_network>0.0620</min_time_network>
+			<max_time_network>0.0620</max_time_network>
 			<nb_hits_with_time_server>1</nb_hits_with_time_server>
-			<min_time_server>0.305</min_time_server>
-			<max_time_server>0.305</max_time_server>
+			<min_time_server>0.3050</min_time_server>
+			<max_time_server>0.3050</max_time_server>
 			<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-			<min_time_transfer>0.44</min_time_transfer>
-			<max_time_transfer>0.44</max_time_transfer>
+			<min_time_transfer>0.4400</min_time_transfer>
+			<max_time_transfer>0.4400</max_time_transfer>
 			<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>1.159</min_time_dom_processing>
-			<max_time_dom_processing>1.159</max_time_dom_processing>
+			<min_time_dom_processing>1.1590</min_time_dom_processing>
+			<max_time_dom_processing>1.1590</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.356</min_time_dom_completion>
-			<max_time_dom_completion>0.356</max_time_dom_completion>
+			<min_time_dom_completion>0.3560</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-			<min_time_on_load>0.44</min_time_on_load>
-			<max_time_on_load>0.44</max_time_on_load>
+			<min_time_on_load>0.4400</min_time_on_load>
+			<max_time_on_load>0.4400</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -149,23 +149,23 @@
 			<nb_hits>6</nb_hits>
 			<sum_time_spent>2160</sum_time_spent>
 			<nb_hits_with_time_network>6</nb_hits_with_time_network>
-			<min_time_network>0.162</min_time_network>
-			<max_time_network>0.162</max_time_network>
+			<min_time_network>0.0270</min_time_network>
+			<max_time_network>0.0270</max_time_network>
 			<nb_hits_with_time_server>6</nb_hits_with_time_server>
-			<min_time_server>1.608</min_time_server>
-			<max_time_server>1.608</max_time_server>
+			<min_time_server>0.2680</min_time_server>
+			<max_time_server>0.2680</max_time_server>
 			<nb_hits_with_time_transfer>6</nb_hits_with_time_transfer>
-			<min_time_transfer>2.136</min_time_transfer>
-			<max_time_transfer>2.136</max_time_transfer>
+			<min_time_transfer>0.3560</min_time_transfer>
+			<max_time_transfer>0.3560</max_time_transfer>
 			<nb_hits_with_time_dom_processing>6</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>6.15</min_time_dom_processing>
-			<max_time_dom_processing>6.15</max_time_dom_processing>
+			<min_time_dom_processing>1.0250</min_time_dom_processing>
+			<max_time_dom_processing>1.0250</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>6</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>1.776</min_time_dom_completion>
-			<max_time_dom_completion>1.776</max_time_dom_completion>
+			<min_time_dom_completion>0.2960</min_time_dom_completion>
+			<max_time_dom_completion>0.2960</max_time_dom_completion>
 			<nb_hits_with_time_on_load>6</nb_hits_with_time_on_load>
-			<min_time_on_load>2.01</min_time_on_load>
-			<max_time_on_load>2.01</max_time_on_load>
+			<min_time_on_load>0.3350</min_time_on_load>
+			<max_time_on_load>0.3350</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -196,23 +196,23 @@
 			<nb_hits>12</nb_hits>
 			<sum_time_spent>3240</sum_time_spent>
 			<nb_hits_with_time_network>12</nb_hits_with_time_network>
-			<min_time_network>0</min_time_network>
-			<max_time_network>0.198</max_time_network>
+			<min_time_network>0.0000</min_time_network>
+			<max_time_network>0.0330</max_time_network>
 			<nb_hits_with_time_server>12</nb_hits_with_time_server>
-			<min_time_server>1.194</min_time_server>
-			<max_time_server>2.136</max_time_server>
+			<min_time_server>0.1990</min_time_server>
+			<max_time_server>0.3560</max_time_server>
 			<nb_hits_with_time_transfer>12</nb_hits_with_time_transfer>
-			<min_time_transfer>1.734</min_time_transfer>
-			<max_time_transfer>2.712</max_time_transfer>
+			<min_time_transfer>0.2890</min_time_transfer>
+			<max_time_transfer>0.4520</max_time_transfer>
 			<nb_hits_with_time_dom_processing>12</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>5.988</min_time_dom_processing>
-			<max_time_dom_processing>8.994</max_time_dom_processing>
+			<min_time_dom_processing>0.9980</min_time_dom_processing>
+			<max_time_dom_processing>1.4990</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>12</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>1.188</min_time_dom_completion>
-			<max_time_dom_completion>2.136</max_time_dom_completion>
+			<min_time_dom_completion>0.1980</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>12</nb_hits_with_time_on_load>
-			<min_time_on_load>1.614</min_time_on_load>
-			<max_time_on_load>1.794</max_time_on_load>
+			<min_time_on_load>0.2690</min_time_on_load>
+			<max_time_on_load>0.2990</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -242,23 +242,23 @@
 			<nb_hits>2</nb_hits>
 			<sum_time_spent>720</sum_time_spent>
 			<nb_hits_with_time_network>2</nb_hits_with_time_network>
-			<min_time_network>0.054</min_time_network>
-			<max_time_network>0.054</max_time_network>
+			<min_time_network>0.0270</min_time_network>
+			<max_time_network>0.0270</max_time_network>
 			<nb_hits_with_time_server>2</nb_hits_with_time_server>
-			<min_time_server>0.536</min_time_server>
-			<max_time_server>0.536</max_time_server>
+			<min_time_server>0.2680</min_time_server>
+			<max_time_server>0.2680</max_time_server>
 			<nb_hits_with_time_transfer>2</nb_hits_with_time_transfer>
-			<min_time_transfer>0.712</min_time_transfer>
-			<max_time_transfer>0.712</max_time_transfer>
+			<min_time_transfer>0.3560</min_time_transfer>
+			<max_time_transfer>0.3560</max_time_transfer>
 			<nb_hits_with_time_dom_processing>2</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>2.05</min_time_dom_processing>
-			<max_time_dom_processing>2.05</max_time_dom_processing>
+			<min_time_dom_processing>1.0250</min_time_dom_processing>
+			<max_time_dom_processing>1.0250</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>2</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.592</min_time_dom_completion>
-			<max_time_dom_completion>0.592</max_time_dom_completion>
+			<min_time_dom_completion>0.2960</min_time_dom_completion>
+			<max_time_dom_completion>0.2960</max_time_dom_completion>
 			<nb_hits_with_time_on_load>2</nb_hits_with_time_on_load>
-			<min_time_on_load>0.67</min_time_on_load>
-			<max_time_on_load>0.67</max_time_on_load>
+			<min_time_on_load>0.3350</min_time_on_load>
+			<max_time_on_load>0.3350</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -289,23 +289,23 @@
 			<nb_hits>4</nb_hits>
 			<sum_time_spent>1080</sum_time_spent>
 			<nb_hits_with_time_network>4</nb_hits_with_time_network>
-			<min_time_network>0</min_time_network>
-			<max_time_network>0.066</max_time_network>
+			<min_time_network>0.0000</min_time_network>
+			<max_time_network>0.0330</max_time_network>
 			<nb_hits_with_time_server>4</nb_hits_with_time_server>
-			<min_time_server>0.398</min_time_server>
-			<max_time_server>0.712</max_time_server>
+			<min_time_server>0.1990</min_time_server>
+			<max_time_server>0.3560</max_time_server>
 			<nb_hits_with_time_transfer>4</nb_hits_with_time_transfer>
-			<min_time_transfer>0.578</min_time_transfer>
-			<max_time_transfer>0.904</max_time_transfer>
+			<min_time_transfer>0.2890</min_time_transfer>
+			<max_time_transfer>0.4520</max_time_transfer>
 			<nb_hits_with_time_dom_processing>4</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>1.996</min_time_dom_processing>
-			<max_time_dom_processing>2.998</max_time_dom_processing>
+			<min_time_dom_processing>0.9980</min_time_dom_processing>
+			<max_time_dom_processing>1.4990</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>4</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.396</min_time_dom_completion>
-			<max_time_dom_completion>0.712</max_time_dom_completion>
+			<min_time_dom_completion>0.1980</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>4</nb_hits_with_time_on_load>
-			<min_time_on_load>0.538</min_time_on_load>
-			<max_time_on_load>0.598</max_time_on_load>
+			<min_time_on_load>0.2690</min_time_on_load>
+			<max_time_on_load>0.2990</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_year.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_year.xml
@@ -7,23 +7,23 @@
 			<nb_hits>9</nb_hits>
 			<sum_time_spent>2880</sum_time_spent>
 			<nb_hits_with_time_network>9</nb_hits_with_time_network>
-			<min_time_network>0.252</min_time_network>
-			<max_time_network>0.252</max_time_network>
+			<min_time_network>0.0270</min_time_network>
+			<max_time_network>0.0360</max_time_network>
 			<nb_hits_with_time_server>9</nb_hits_with_time_server>
-			<min_time_server>2.372</min_time_server>
-			<max_time_server>2.372</max_time_server>
+			<min_time_server>0.2280</min_time_server>
+			<max_time_server>0.2680</max_time_server>
 			<nb_hits_with_time_transfer>9</nb_hits_with_time_transfer>
-			<min_time_transfer>3.183</min_time_transfer>
-			<max_time_transfer>3.183</max_time_transfer>
+			<min_time_transfer>0.3350</min_time_transfer>
+			<max_time_transfer>0.3560</max_time_transfer>
 			<nb_hits_with_time_dom_processing>9</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>9.215</min_time_dom_processing>
-			<max_time_dom_processing>9.215</max_time_dom_processing>
+			<min_time_dom_processing>1.0150</min_time_dom_processing>
+			<max_time_dom_processing>1.0250</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>9</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>2.577</min_time_dom_completion>
-			<max_time_dom_completion>2.577</max_time_dom_completion>
+			<min_time_dom_completion>0.2090</min_time_dom_completion>
+			<max_time_dom_completion>0.2960</max_time_dom_completion>
 			<nb_hits_with_time_on_load>9</nb_hits_with_time_on_load>
-			<min_time_on_load>2.981</min_time_on_load>
-			<max_time_on_load>2.981</max_time_on_load>
+			<min_time_on_load>0.3010</min_time_on_load>
+			<max_time_on_load>0.3350</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -98,23 +98,23 @@
 			<nb_hits>16</nb_hits>
 			<sum_time_spent>4320</sum_time_spent>
 			<nb_hits_with_time_network>16</nb_hits_with_time_network>
-			<min_time_network>0</min_time_network>
-			<max_time_network>0.264</max_time_network>
+			<min_time_network>0.0000</min_time_network>
+			<max_time_network>0.0330</max_time_network>
 			<nb_hits_with_time_server>16</nb_hits_with_time_server>
-			<min_time_server>1.592</min_time_server>
-			<max_time_server>2.848</max_time_server>
+			<min_time_server>0.1990</min_time_server>
+			<max_time_server>0.3560</max_time_server>
 			<nb_hits_with_time_transfer>16</nb_hits_with_time_transfer>
-			<min_time_transfer>2.312</min_time_transfer>
-			<max_time_transfer>3.616</max_time_transfer>
+			<min_time_transfer>0.2890</min_time_transfer>
+			<max_time_transfer>0.4520</max_time_transfer>
 			<nb_hits_with_time_dom_processing>16</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>7.984</min_time_dom_processing>
-			<max_time_dom_processing>11.992</max_time_dom_processing>
+			<min_time_dom_processing>0.9980</min_time_dom_processing>
+			<max_time_dom_processing>1.4990</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>16</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>1.584</min_time_dom_completion>
-			<max_time_dom_completion>2.848</max_time_dom_completion>
+			<min_time_dom_completion>0.1980</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>16</nb_hits_with_time_on_load>
-			<min_time_on_load>2.152</min_time_on_load>
-			<max_time_on_load>2.392</max_time_on_load>
+			<min_time_on_load>0.2690</min_time_on_load>
+			<max_time_on_load>0.2990</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />
@@ -142,23 +142,23 @@
 			<nb_hits>1</nb_hits>
 			<sum_time_spent>0</sum_time_spent>
 			<nb_hits_with_time_network>1</nb_hits_with_time_network>
-			<min_time_network>0.062</min_time_network>
-			<max_time_network>0.062</max_time_network>
+			<min_time_network>0.0620</min_time_network>
+			<max_time_network>0.0620</max_time_network>
 			<nb_hits_with_time_server>1</nb_hits_with_time_server>
-			<min_time_server>0.305</min_time_server>
-			<max_time_server>0.305</max_time_server>
+			<min_time_server>0.3050</min_time_server>
+			<max_time_server>0.3050</max_time_server>
 			<nb_hits_with_time_transfer>1</nb_hits_with_time_transfer>
-			<min_time_transfer>0.44</min_time_transfer>
-			<max_time_transfer>0.44</max_time_transfer>
+			<min_time_transfer>0.4400</min_time_transfer>
+			<max_time_transfer>0.4400</max_time_transfer>
 			<nb_hits_with_time_dom_processing>1</nb_hits_with_time_dom_processing>
-			<min_time_dom_processing>1.159</min_time_dom_processing>
-			<max_time_dom_processing>1.159</max_time_dom_processing>
+			<min_time_dom_processing>1.1590</min_time_dom_processing>
+			<max_time_dom_processing>1.1590</max_time_dom_processing>
 			<nb_hits_with_time_dom_completion>1</nb_hits_with_time_dom_completion>
-			<min_time_dom_completion>0.356</min_time_dom_completion>
-			<max_time_dom_completion>0.356</max_time_dom_completion>
+			<min_time_dom_completion>0.3560</min_time_dom_completion>
+			<max_time_dom_completion>0.3560</max_time_dom_completion>
 			<nb_hits_with_time_on_load>1</nb_hits_with_time_on_load>
-			<min_time_on_load>0.44</min_time_on_load>
-			<max_time_on_load>0.44</max_time_on_load>
+			<min_time_on_load>0.4400</min_time_on_load>
+			<max_time_on_load>0.4400</max_time_on_load>
 			<sum_bandwidth>0</sum_bandwidth>
 			<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 			<min_bandwidth />

--- a/tests/PHPUnit/System/expected/test_reportLimiting__Events.getAction_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting__Events.getAction_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==event+action+1</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==event+action+2</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting__Events.getAction_month.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting__Events.getAction_month.xml
@@ -6,8 +6,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==event+action+1</segment>
@@ -18,8 +18,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -29,8 +29,8 @@
 				<nb_events>10</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -42,8 +42,8 @@
 		<nb_events>10</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==event+action+0</segment>
@@ -54,8 +54,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -65,8 +65,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -78,8 +78,8 @@
 		<nb_events>50</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 	</row>

--- a/tests/PHPUnit/System/expected/test_reportLimiting__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting__Events.getCategory_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventCategory==event+category+0</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventCategory==event+category+1</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting__Events.getCategory_month.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting__Events.getCategory_month.xml
@@ -6,8 +6,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventCategory==event+category+1</segment>
@@ -18,8 +18,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -29,8 +29,8 @@
 				<nb_events>10</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -42,8 +42,8 @@
 		<nb_events>10</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventCategory==event+category+0</segment>
@@ -54,8 +54,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -65,8 +65,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -78,8 +78,8 @@
 		<nb_events>50</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 	</row>

--- a/tests/PHPUnit/System/expected/test_reportLimiting__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting__Events.getName_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==event+name0</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==event+name1</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting__Events.getName_month.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting__Events.getName_month.xml
@@ -6,8 +6,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==event+name0</segment>
@@ -18,8 +18,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -29,8 +29,8 @@
 				<nb_events>10</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -42,8 +42,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==event+name1</segment>
@@ -54,8 +54,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -65,8 +65,8 @@
 				<nb_events>10</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>0</avg_event_value>
 			</row>
@@ -78,8 +78,8 @@
 		<nb_events>45</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<sum_daily_nb_uniq_visitors>9</sum_daily_nb_uniq_visitors>
 		<avg_event_value>0</avg_event_value>
 	</row>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flattened__Events.getAction_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flattened__Events.getAction_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<is_summary>1</is_summary>
 		<Events_EventAction>Others</Events_EventAction>
@@ -20,8 +20,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<Events_EventAction>event action 1</Events_EventAction>
 		<Events_EventName>event name0</Events_EventName>
@@ -33,8 +33,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<Events_EventAction>event action 2</Events_EventAction>
 		<Events_EventName>event name1</Events_EventName>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flattened__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flattened__Events.getCategory_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<is_summary>1</is_summary>
 		<Events_EventCategory>Others</Events_EventCategory>
@@ -20,8 +20,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<Events_EventCategory>event category 0</Events_EventCategory>
 		<Events_EventAction>event action 4</Events_EventAction>
@@ -33,8 +33,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<Events_EventCategory>event category 1</Events_EventCategory>
 		<Events_EventAction>event action 5</Events_EventAction>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flattened__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flattened__Events.getName_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<is_summary>1</is_summary>
 		<Events_EventName>Others</Events_EventName>
@@ -20,8 +20,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<Events_EventName>event name0</Events_EventName>
 		<Events_EventAction>event action 1</Events_EventAction>
@@ -33,8 +33,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<Events_EventName>event name1</Events_EventName>
 		<Events_EventAction>event action 2</Events_EventAction>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_rankingQuery__Events.getAction_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_rankingQuery__Events.getAction_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==event+action+1</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==event+action+2</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_rankingQuery__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_rankingQuery__Events.getCategory_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventCategory==event+category+0</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventCategory==event+category+3</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_rankingQuery__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_rankingQuery__Events.getName_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==event+name0</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>5</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==event+name1</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>5</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>15</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel___Events.getAction_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel___Events.getAction_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==-1</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==event+action+0</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>19</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel___Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel___Events.getCategory_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventCategory==-1</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventCategory==event+category+0</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>19</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel___Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel___Events.getName_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==-1</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==event+name+0</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>19</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel__flattened__Events.getAction_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel__flattened__Events.getAction_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>19</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<is_summary>1</is_summary>
 		<Events_EventAction>Others</Events_EventAction>
@@ -20,8 +20,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<Events_EventAction>-1</Events_EventAction>
 		<Events_EventName>-1</Events_EventName>
@@ -33,8 +33,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<Events_EventAction>event action 0</Events_EventAction>
 		<Events_EventName>event name 0</Events_EventName>

--- a/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel__flattened__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel__flattened__Events.getCategory_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>19</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<is_summary>1</is_summary>
 		<Events_EventCategory>Others</Events_EventCategory>
@@ -20,8 +20,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<Events_EventCategory>-1</Events_EventCategory>
 		<Events_EventAction>-1</Events_EventAction>
@@ -33,8 +33,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<Events_EventCategory>event category 0</Events_EventCategory>
 		<Events_EventAction>event action 0</Events_EventAction>

--- a/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel__flattened__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel__flattened__Events.getName_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>19</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<is_summary>1</is_summary>
 		<Events_EventName>Others</Events_EventName>
@@ -20,8 +20,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<Events_EventName>-1</Events_EventName>
 		<Events_EventAction>-1</Events_EventAction>
@@ -33,8 +33,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<Events_EventName>event name 0</Events_EventName>
 		<Events_EventAction>event action 0</Events_EventAction>

--- a/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel__rankingQuery__Events.getAction_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel__rankingQuery__Events.getAction_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==-1</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventAction==event+action+0</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>19</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel__rankingQuery__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel__rankingQuery__Events.getCategory_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventCategory==-1</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventCategory==event+category+0</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>19</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel__rankingQuery__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimitingwithNegOneLabel__rankingQuery__Events.getName_day.xml
@@ -7,8 +7,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==-1</segment>
 		<subtable>
@@ -19,8 +19,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -32,8 +32,8 @@
 		<nb_events>1</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 		<segment>eventName==event+name+0</segment>
 		<subtable>
@@ -44,8 +44,8 @@
 				<nb_events>1</nb_events>
 				<nb_events_with_value>0</nb_events_with_value>
 				<sum_event_value>0</sum_event_value>
-				<min_event_value>0</min_event_value>
-				<max_event_value>0</max_event_value>
+				<min_event_value />
+				<max_event_value />
 				<avg_event_value>0</avg_event_value>
 			</row>
 		</subtable>
@@ -57,8 +57,8 @@
 		<nb_events>19</nb_events>
 		<nb_events_with_value>0</nb_events_with_value>
 		<sum_event_value>0</sum_event_value>
-		<min_event_value>0</min_event_value>
-		<max_event_value>0</max_event_value>
+		<min_event_value />
+		<max_event_value />
 		<avg_event_value>0</avg_event_value>
 	</row>
 </result>


### PR DESCRIPTION
### Description:

Some plugins like PagePerformance or Bandwidth are adding additional metrics to the action reports. Some of those metrics need to be aggregated using min, max or avg aggregation.

As those column aggregation where not correctly set for the datatables, they were by default aggregated by summing the values up. This resulted in incorrect values.

fixes #22350 

(Ref DEV-18236)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
