### PR TITLE
Disable login for non-whitelisted IPs

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -519,6 +519,18 @@ login_password_recovery_replyto_email_name = "No-reply"
 ; Set this setting to "0" to allow HTTP Reporting API requests from any IP address.
 login_allowlist_apply_to_reporting_api_requests = 1
 
+; By default, if an allowlisted IP address is specified via "login_allowlist_ip[]", the authentication process
+; will only work for these allowlisted IPs.
+; Set the setting to "0" to allow authentication from any IP address.
+login_allowlist_apply_to_authentication = 1
+
+; By default, if an allowlisted IP address is specified via "login_allowlist_ip[]", the login process
+; will only work for these allowlisted IPs.
+; Set the setting to "0" to allow login from any IP address.
+login_allowlist_apply_to_login = 1
+; Additionally to setting it to "1" a customized message can be displayed on the login page to indicate it is not allowed.
+login_disabled_message = ""
+
 ; By default when user logs out they are redirected to Matomo "homepage" usually the Login form.
 ; Uncomment the next line to set a URL to redirect the user to after they log out of Matomo.
 ; login_logout_url = http://...

--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -92,7 +92,7 @@ class CoreHome extends \Piwik\Plugin
         }
 
         $list = new LoginAllowlist();
-        if ($list->shouldCheckAllowlist()) {
+        if ($list->shouldCheckAllowlist() && $list->shouldAllowlistApplyToAuthentication()) {
             $ip = IP::getIpFromHeader();
             $list->checkIsAllowed($ip);
         }

--- a/plugins/CoreHome/LoginAllowlist.php
+++ b/plugins/CoreHome/LoginAllowlist.php
@@ -29,6 +29,16 @@ class LoginAllowlist
         return !empty($general['login_allowlist_apply_to_reporting_api_requests']) || !empty($general['login_whitelist_apply_to_reporting_api_requests']);
     }
 
+    public function shouldAllowlistApplyToAuthentication()
+    {
+        return !empty($this->getGeneralConfig()['login_allowlist_apply_to_authentication']);
+    }
+
+    public function shouldAllowlistApplyToLogin()
+    {
+        return !empty($this->getGeneralConfig()['login_allowlist_apply_to_login']);
+    }
+
     public function shouldCheckAllowlist()
     {
         if (Common::isPhpCliMode()) {

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -152,25 +152,26 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             $ip = IP::getIpFromHeader();
             try {
                 $list->checkIsAllowed($ip);
-            } catch (\Exception $e) {
+            }
+            catch (\Exception $e) {
                 $messageNoAccess = Config::getInstance()->General['login_disabled_message'] ?? ' ';
             }
-        } else {
-            if ($form->validate()) {
-                $nonce = $form->getSubmitValue('form_nonce');
-                $messageNoAccess = Nonce::verifyNonceWithErrorMessage('Login.login', $nonce, null);
+        }
 
-                // validate if there is error message
-                if ($messageNoAccess === "") {
-                    $loginOrEmail = $form->getSubmitValue('form_login');
-                    $login = $this->getLoginFromLoginOrEmail($loginOrEmail);
+        if (empty($messageNoAccess) && $form->validate()) {
+            $nonce = $form->getSubmitValue('form_nonce');
+            $messageNoAccess = Nonce::verifyNonceWithErrorMessage('Login.login', $nonce, null);
 
-                    $password = $form->getSubmitValue('form_password');
-                    try {
-                        $this->authenticateAndRedirect($login, $password);
-                    } catch (Exception $e) {
-                        $messageNoAccess = $e->getMessage();
-                    }
+            // validate if there is error message
+            if ($messageNoAccess === "") {
+                $loginOrEmail = $form->getSubmitValue('form_login');
+                $login = $this->getLoginFromLoginOrEmail($loginOrEmail);
+
+                $password = $form->getSubmitValue('form_password');
+                try {
+                    $this->authenticateAndRedirect($login, $password);
+                } catch (Exception $e) {
+                    $messageNoAccess = $e->getMessage();
                 }
             }
         }

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -153,7 +153,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             try {
                 $list->checkIsAllowed($ip);
             } catch (\Exception $e) {
-                $messageNoAccess = Config::getInstance()->general['login_disabled_message'] ?? ' ';
+                $messageNoAccess = Config::getInstance()->General['login_disabled_message'] ?? ' ';
             }
         } else {
             if ($form->validate()) {

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -150,8 +150,11 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $list = new LoginAllowlist();
         if ($list->shouldCheckAllowlist() && $list->shouldAllowlistApplyToLogin()) {
             $ip = IP::getIpFromHeader();
-            try { $list->checkIsAllowed($ip); }
-            catch (\Exception $e) { $messageNoAccess = Config::getInstance()->general['login_disabled_message'] ?? ' '; }
+            try {
+                $list->checkIsAllowed($ip);
+            } catch (\Exception $e) {
+                $messageNoAccess = Config::getInstance()->general['login_disabled_message'] ?? ' ';
+            }
         } else {
             if ($form->validate()) {
                 $nonce = $form->getSubmitValue('form_nonce');


### PR DESCRIPTION
### Description:

This allows to disable login to non-whitelisted IPs and add some flexibility into the whitelist scope (i.e. for authentication & login).
A customized error message can be set to be displayed on the login page in order to inform about the reason for disabling login.

There are 3 new setting to play with:
- login_allowlist_apply_to_authentication
- login_allowlist_apply_to_login
- login_disabled_message

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [x] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [x] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [x] Existing documentation updated if needed
