### PR TITLE
Handle invalidation of currently processed archives correctly

### DIFF
--- a/core/DataAccess/ArchiveTableDao.php
+++ b/core/DataAccess/ArchiveTableDao.php
@@ -55,7 +55,7 @@ class ArchiveTableDao
                        SUM(CASE WHEN name LIKE 'done%' THEN 1 ELSE 0 END) AS count_archives,
                        SUM(CASE WHEN name LIKE 'done%' AND value = ? THEN 1 ELSE 0 END) AS count_invalidated_archives,
                        SUM(CASE WHEN name LIKE 'done%' AND value = ? THEN 1 ELSE 0 END) AS count_temporary_archives,
-                       SUM(CASE WHEN name LIKE 'done%' AND value = ? THEN 1 ELSE 0 END) AS count_error_archives,
+                       SUM(CASE WHEN name LIKE 'done%' AND value IN (?, ?) THEN 1 ELSE 0 END) AS count_error_archives,
                        SUM(CASE WHEN name LIKE 'done%' AND CHAR_LENGTH(name) > 32 THEN 1 ELSE 0 END) AS count_segment_archives,
                        SUM(CASE WHEN name NOT LIKE 'done%' THEN 1 ELSE 0 END) AS count_numeric_rows,
                        0 AS count_blob_rows
@@ -63,7 +63,7 @@ class ArchiveTableDao
               GROUP BY idsite, date1, date2, period";
 
         $rows = Db::fetchAll($sql, array(ArchiveWriter::DONE_INVALIDATED, ArchiveWriter::DONE_OK_TEMPORARY,
-            ArchiveWriter::DONE_ERROR));
+            ArchiveWriter::DONE_ERROR, ArchiveWriter::DONE_ERROR_INVALIDATED));
 
         // index result
         $result = array();

--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -67,6 +67,11 @@ class ArchiveWriter
      */
     public const DONE_PARTIAL = 5;
 
+    /**
+     * Flag indicates an archive that is currently been processed, but has already been invalidated again
+     */
+    public const DONE_ERROR_INVALIDATED = 6;
+
     protected $fields = ['idarchive',
         'idsite',
         'date1',
@@ -199,6 +204,13 @@ class ArchiveWriter
 
         $doneValue = $this->parameters->isPartialArchive() ? self::DONE_PARTIAL : self::DONE_OK;
         $this->checkDoneValueIsOnlyPartialForPluginArchives($doneValue); // check and log
+
+        $currentStatus = $this->getModel()->getArchiveStatus($numericTable, $idArchive, $this->doneFlag);
+
+        // If the current archive was already invalidated during runtime, directly update status to invalidated instead of done
+        if ($currentStatus == self::DONE_ERROR_INVALIDATED) {
+            $doneValue = self::DONE_INVALIDATED;
+        }
 
         $this->getModel()->updateArchiveStatus($numericTable, $idArchive, $this->doneFlag, $doneValue);
 

--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -68,7 +68,7 @@ class ArchiveWriter
     public const DONE_PARTIAL = 5;
 
     /**
-     * Flag indicates an archive that is currently been processed, but has already been invalidated again
+     * Flag indicates an archive that is currently being processed, but has already been invalidated again
      */
     public const DONE_ERROR_INVALIDATED = 6;
 
@@ -208,7 +208,7 @@ class ArchiveWriter
         $currentStatus = $this->getModel()->getArchiveStatus($numericTable, $idArchive, $this->doneFlag);
 
         // If the current archive was already invalidated during runtime, directly update status to invalidated instead of done
-        if ($currentStatus == self::DONE_ERROR_INVALIDATED) {
+        if (self::DONE_ERROR_INVALIDATED === $currentStatus) {
             $doneValue = self::DONE_INVALIDATED;
         }
 

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -552,11 +552,11 @@ class Model
         );
     }
 
-    public function getArchiveStatus($numericTable, $archiveId, $doneFlag)
+    public function getArchiveStatus($numericTable, $archiveId, $doneFlag): int
     {
-        return Db::fetchOne(
+        return (int) Db::fetchOne(
             "SELECT value FROM $numericTable WHERE idarchive = ? AND `name` = ?",
-            array($archiveId, $doneFlag)
+            [$archiveId, $doneFlag]
         );
     }
 

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -65,7 +65,7 @@ class Model
                        GROUP_CONCAT(idarchive, '.', value ORDER BY ts_archived DESC) as archives
                   FROM `$archiveTable`
                  WHERE name LIKE 'done%'
-                   AND `value` NOT IN (" . ArchiveWriter::DONE_ERROR . ")
+                   AND `value` NOT IN (" . ArchiveWriter::DONE_ERROR . ", " . ArchiveWriter::DONE_ERROR_INVALIDATED . ")
               GROUP BY idsite, date1, date2, period, name HAVING count(*) > 1";
 
         $archiveIds = array();
@@ -184,8 +184,15 @@ class Model
             if (!empty($idArchives)) {
                 $idArchives = array_map('intval', $idArchives);
 
+                // set status to DONE_INVALIDATED for finished archives
                 $sql = "UPDATE `$archiveTable` SET `value` = " . ArchiveWriter::DONE_INVALIDATED . " WHERE idarchive IN ("
-                    . implode(',', $idArchives) . ") AND $nameCondition";
+                    . implode(',', $idArchives) . ") AND value != " . ArchiveWriter::DONE_ERROR . " AND $nameCondition";
+
+                Db::query($sql);
+
+                // set status to DONE_ERROR_INVALIDATED for currently processed archives
+                $sql = "UPDATE `$archiveTable` SET `value` = " . ArchiveWriter::DONE_ERROR_INVALIDATED . " WHERE idarchive IN ("
+                    . implode(',', $idArchives) . ") AND value = " . ArchiveWriter::DONE_ERROR . " AND $nameCondition";
 
                 Db::query($sql);
             }
@@ -359,7 +366,7 @@ class Model
                   WHERE name LIKE 'done%'
                     AND ((  value = " . ArchiveWriter::DONE_OK_TEMPORARY . "
                             AND ts_archived < ?)
-                         OR value = " . ArchiveWriter::DONE_ERROR . ")";
+                         OR value IN (" . ArchiveWriter::DONE_ERROR . ", " . ArchiveWriter::DONE_ERROR_INVALIDATED . "))";
 
         return Db::fetchAll($query, array($purgeArchivesOlderThan));
     }
@@ -542,6 +549,14 @@ class Model
         Db::query(
             "UPDATE $numericTable SET `value` = ? WHERE idarchive = ? and `name` = ?",
             array($value, $archiveId, $doneFlag)
+        );
+    }
+
+    public function getArchiveStatus($numericTable, $archiveId, $doneFlag)
+    {
+        return Db::fetchOne(
+            "SELECT value FROM $numericTable WHERE idarchive = ? AND `name` = ?",
+            array($archiveId, $doneFlag)
         );
     }
 

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
@@ -193,6 +193,7 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
         $actualInvalidations = $this->getInvalidatedArchiveTableEntries();
         $this->assertEquals($expectedInvalidations, $actualInvalidations);
     }
+    
     public function testMarkArchivesAsInvalidatedDoesHandleInProgressArchivesCorrectly()
     {
         // Insert an archive/invalidation that is currently in progress
@@ -2532,7 +2533,7 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
 
     private function getAvailableArchives()
     {
-        $result = array();
+        $result = [];
         foreach (ArchiveTableCreator::getTablesArchivesInstalled(ArchiveTableCreator::NUMERIC_TABLE) as $table) {
             $date = ArchiveTableCreator::getDateFromTableName($table);
 

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
@@ -193,7 +193,7 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
         $actualInvalidations = $this->getInvalidatedArchiveTableEntries();
         $this->assertEquals($expectedInvalidations, $actualInvalidations);
     }
-    
+
     public function testMarkArchivesAsInvalidatedDoesHandleInProgressArchivesCorrectly()
     {
         // Insert an archive/invalidation that is currently in progress

--- a/tests/PHPUnit/Integration/DataAccess/ModelTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ModelTest.php
@@ -125,6 +125,27 @@ class ModelTest extends IntegrationTestCase
         $this->assertEquals($expectedId, $id);
     }
 
+    public function testGetAndUpdateArchiveStatus()
+    {
+        $this->insertArchiveData([
+            ['date1' => '2020-02-03', 'date2' => '2020-02-03', 'period' => 1, 'name' => 'done', 'value' => ArchiveWriter::DONE_ERROR],
+        ]);
+
+        $numericTable = ArchiveTableCreator::getNumericTable(Date::factory('2020-02-03'));
+
+        self::assertEquals(
+            ArchiveWriter::DONE_ERROR,
+            $this->model->getArchiveStatus($numericTable, '1', 'done')
+        );
+
+        $this->model->updateArchiveStatus($numericTable, '1', 'done', ArchiveWriter::DONE_ERROR_INVALIDATED);
+
+        self::assertEquals(
+            ArchiveWriter::DONE_ERROR_INVALIDATED,
+            $this->model->getArchiveStatus($numericTable, '1', 'done')
+        );
+    }
+
     /**
      * @dataProvider getTestDataForHasChildArchivesInPeriod
      */


### PR DESCRIPTION
### Description:

When a period is being invalidated for whatever reason, we currently update all existing archives to the state INVALIDATED. Invalidated archives may still be used for reporting until new archives were built.

Updating archives to invalidated currently is also done for archives that are still in progress. In progress archives aren't considered for the reporting. So updating them to invalidated while they are still processed currently has the effect, that unfinished archives might be used for reporting, causing report data to disappear, for reports that were not yet processed for this archive. Once the archiving is finished those archives are updated to OK, causing them to get final again, even if they had been marked as invalidated in between.

This PR fixes the behavior by introducing a new state to mark in progress archives invalidated. This new state won't be considered for reporting, but when the archiving finished, the status will be updated to INVALIDATED instead of OK.

Refs DEV-18289

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
