### PR TITLE
Skip invalidating yesterday if a proper archive is already in progress

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -922,7 +922,7 @@ class CronArchive
 
             foreach ($invalidationsInProgress as $invalidation) {
                 if (
-                    $invalidation['period'] == '1'
+                    $invalidation['period'] == 1
                     && $date->toString() === $invalidation['date1']
                     && Date::factory($invalidation['ts_started'], $timezone)->getTimestamp() >= $today->getTimestamp()
                 ) {

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -27,6 +27,7 @@ use Piwik\DataAccess\ArchiveSelector;
 use Piwik\DataAccess\Model;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Metrics\Formatter;
+use Piwik\Period\Day;
 use Piwik\Period\Factory as PeriodFactory;
 use Piwik\CronArchive\SegmentArchiving;
 use Piwik\Period\Range;
@@ -922,7 +923,7 @@ class CronArchive
 
             foreach ($invalidationsInProgress as $invalidation) {
                 if (
-                    $invalidation['period'] == 1
+                    $invalidation['period'] == Day::PERIOD_ID
                     && $date->toString() === $invalidation['date1']
                     && Date::factory($invalidation['ts_started'], $timezone)->getTimestamp() >= $today->getTimestamp()
                 ) {

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -914,8 +914,9 @@ class CronArchive
             return;
         }
 
-        if ($dateStr === 'yesterday') {
-            // Skip invalidation for yesterday if an archiving for yesterday was already started after midnight in site's timezone
+        $isYesterday = $dateStr === 'yesterday';
+        if ($isYesterday) {
+            // Skip invalidation for yesterday if archiving for yesterday was already started after midnight in site's timezone
             $invalidationsInProgress = $this->model->getInvalidationsInProgress($idSite);
             $today = Date::factoryInTimezone('today', $timezone);
 
@@ -939,7 +940,6 @@ class CronArchive
         // if we are invalidating yesterday here, we are only interested in checking if there is no archive for yesterday, or the day has changed since
         // the last archive was archived (in which there may have been more visits before midnight). so we disable the ttl check, since any archive
         // will be good enough, if the date hasn't changed.
-        $isYesterday = $dateStr == 'yesterday';
         $this->invalidateWithSegments([$idSite], $date->toString(), 'day', false, $doNotIncludeTtlInExistingArchiveCheck = $isYesterday);
     }
 

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -466,7 +466,7 @@ class CronArchiveTest extends IntegrationTestCase
     /**
      * @dataProvider getInvalidateYesterdayTestData
      */
-    public function testInvalidateRecentDateForYesterdayisSkippedWhenAlreadyInProgress($timezone, $tsStarted, $expectedInvalidationCalls)
+    public function testInvalidateRecentDateForYesterdayIsSkippedWhenAlreadyInProgress($timezone, $tsStarted, $expectedInvalidationCalls)
     {
         $idSite = Fixture::createWebsite('2019-04-04 03:45:45', 0, false, false, 1, null, null, $timezone);
 


### PR DESCRIPTION
### Description:

Our archiving process in the beginning automatically invalidates all data for today and yesterday. This is done to ensure those archives are finally built with all data.

For invalidating yesterday there are already certain restrictions when this will be skipped. If there is already an archive available that was built after midnight, it will be skipped as there won't be any new data to include anyway.

This PR extends those checks to also skip the invalidation if another archiving process is already archiving yesterday and was started after midnight. This prevents that this currently built archive can be invalidated right away before it was even finished.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
