### PR TITLE
Skip transaction level test for TiDB

### DIFF
--- a/tests/PHPUnit/Integration/Db/TransactionLevelTest.php
+++ b/tests/PHPUnit/Integration/Db/TransactionLevelTest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Tests\Integration\Db;
 
+use Piwik\Config\DatabaseConfig;
 use Piwik\Db;
 use Piwik\Db\TransactionLevel;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -44,6 +45,10 @@ class TransactionLevelTest extends IntegrationTestCase
 
     public function testSetUncommittedRestorePreviousStatus()
     {
+        if (DatabaseConfig::getConfigValue('schema') === 'Tidb') {
+            $this->markTestSkipped('TiDB doesnt support uncommitted isolation');
+        }
+
         // mysql 8.0 using transaction_isolation
         $isolation = $this->db->fetchOne("SHOW GLOBAL VARIABLES LIKE 't%_isolation'");
         $isolation = "@@" . $isolation;


### PR DESCRIPTION
### Description:

This particular test fails for TiDB due to TiDB not supporting the `read uncommitted` isolation level.

https://docs.pingcap.com/tidbcloud/dev-guide-third-party-tools-compatibility#the-read-uncommitted-and-serializable-isolation-levels-are-not-supported

It might seem mad to just skip the test, however the implementation of `setUncommitted` fails gracefully and marks itself as 'supportsUncommitted' = false, allowing execution to continue as normal.

Ideally if someone knows a way to set `Db:::$supportsUncommitted` before even attempting then let me know.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
