### PR TITLE
Fix handling of ranking query for TiDb

### DIFF
--- a/core/Db/Schema.php
+++ b/core/Db/Schema.php
@@ -280,4 +280,14 @@ class Schema extends Singleton
     {
         return $this->getSchema()->optimizeTables($tables, $force);
     }
+
+    /**
+     * Returns if the database engine is able to use sorted subqueries
+     *
+     * @return bool
+     */
+    public function supportsSortingInSubquery(): bool
+    {
+        return $this->getSchema()->supportsSortingInSubquery();
+    }
 }

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -752,6 +752,11 @@ class Mysql implements SchemaInterface
         return version_compare($semanticVersion, '10.1.1', '>=');
     }
 
+    public function supportsSortingInSubquery(): bool
+    {
+        return true;
+    }
+
     protected function getDatabaseCreateOptions(): string
     {
         $charset = DbHelper::getDefaultCharset();

--- a/core/Db/Schema/Tidb.php
+++ b/core/Db/Schema/Tidb.php
@@ -62,6 +62,12 @@ class Tidb extends Mysql
         return false;
     }
 
+    public function supportsSortingInSubquery(): bool
+    {
+        // TiDb optimizer removes all sorting from subqueries
+        return false;
+    }
+
     protected function getDatabaseCreateOptions(): string
     {
         $charset = DbHelper::getDefaultCharset();

--- a/core/Db/SchemaInterface.php
+++ b/core/Db/SchemaInterface.php
@@ -158,4 +158,11 @@ interface SchemaInterface
      * @return bool
      */
     public function optimizeTables(array $tables, bool $force = false): bool;
+
+    /**
+     * Returns if the database engine is able to use sorted subqueries
+     *
+     * @return bool
+     */
+    public function supportsSortingInSubquery(): bool;
 }

--- a/tests/PHPUnit/Unit/RankingQueryTest.php
+++ b/tests/PHPUnit/Unit/RankingQueryTest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Tests\Unit;
 
+use Piwik\Db\Schema;
 use Piwik\RankingQuery;
 
 class RankingQueryTest extends \PHPUnit\Framework\TestCase
@@ -28,28 +29,55 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
         $innerQuery = "SELECT label, column, columnSum FROM myTable";
 
         $expected = "
-			SELECT
-				CASE
-					WHEN counter = 11 THEN 'Others'
-					ELSE `label`
-				END AS `label`,
-				`column`,
-				sum(`columnSum`) AS `columnSum`
-			FROM (
-				SELECT
-					`label`,
-					CASE
-						WHEN @counter = 11 THEN 11
-						ELSE @counter:=@counter+1
-					END AS counter,
-					`column`,
-					`columnSum`
-				FROM
-					( SELECT @counter:=0 ) initCounter,
-					( SELECT label, column, columnSum FROM myTable ) actualQuery
-			 ) AS withCounter
-			GROUP BY counter
-		";
+            SELECT
+                CASE
+                    WHEN counter = 11 THEN 'Others'
+                    ELSE `label`
+                END AS `label`,
+                `column`,
+                sum(`columnSum`) AS `columnSum`
+            FROM (
+                SELECT
+                    `label`,
+                    CASE
+                        WHEN @counter = 11 THEN 11
+                        ELSE @counter:=@counter+1
+                    END AS counter,
+                    `column`,
+                    `columnSum`
+                FROM
+                    ( SELECT @counter:=0 ) initCounter,
+                    ( SELECT label, column, columnSum FROM myTable ) actualQuery
+             ) AS withCounter
+            GROUP BY counter
+        ";
+
+        if (!Schema::getInstance()->supportsSortingInSubquery()) {
+            $expected = "
+                SELECT
+                    CASE
+                        WHEN counter = 11 THEN 'Others'
+                        ELSE `label`
+                    END AS `label`,
+                    `column`,
+                    sum(`columnSum`) AS `columnSum`
+                FROM (
+                    SELECT
+                        `label`,
+                        CASE
+                            WHEN @counter = 11 THEN 11
+                            ELSE @counter:=@counter+1
+                        END AS counter,
+                        `column`,
+                        `columnSum`
+                    FROM
+                        ( SELECT @counter:=0 ) initCounter,
+                        ( SELECT label, column, columnSum FROM myTable LIMIT 18446744073709551615 ) actualQuery
+                 ) AS withCounter
+                GROUP BY counter
+                ORDER BY counter
+            ";
+        }
 
         $this->checkQuery($query, $innerQuery, $expected);
     }
@@ -68,27 +96,53 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
         $innerQuery = "SELECT label, 1 AS exclude_marker FROM myTable";
 
         $expected = "
-			SELECT
-				CASE
-					WHEN counter = 21 THEN 'Others'
-					ELSE `label`
-				END AS `label`,
-				`exclude_marker`
-			FROM (
-				SELECT
-					`label`,
-					CASE
-						WHEN exclude_marker != 0 THEN -1 * exclude_marker
-						WHEN @counter = 21 THEN 21
-						ELSE @counter:=@counter+1
-					END AS counter,
-					`exclude_marker`
-				FROM
-					( SELECT @counter:=0 ) initCounter,
-					( SELECT label, 1 AS exclude_marker FROM myTable ) actualQuery
-			) AS withCounter
-			GROUP BY counter
-		";
+            SELECT
+                CASE
+                    WHEN counter = 21 THEN 'Others'
+                    ELSE `label`
+                END AS `label`,
+                `exclude_marker`
+            FROM (
+                SELECT
+                    `label`,
+                    CASE
+                        WHEN exclude_marker != 0 THEN -1 * exclude_marker
+                        WHEN @counter = 21 THEN 21
+                        ELSE @counter:=@counter+1
+                    END AS counter,
+                    `exclude_marker`
+                FROM
+                    ( SELECT @counter:=0 ) initCounter,
+                    ( SELECT label, 1 AS exclude_marker FROM myTable ) actualQuery
+            ) AS withCounter
+            GROUP BY counter
+        ";
+
+        if (!Schema::getInstance()->supportsSortingInSubquery()) {
+            $expected = "
+                SELECT
+                    CASE
+                        WHEN counter = 21 THEN 'Others'
+                        ELSE `label`
+                    END AS `label`,
+                    `exclude_marker`
+                FROM (
+                    SELECT
+                        `label`,
+                        CASE
+                            WHEN exclude_marker != 0 THEN -1 * exclude_marker
+                            WHEN @counter = 21 THEN 21
+                            ELSE @counter:=@counter+1
+                        END AS counter,
+                        `exclude_marker`
+                    FROM
+                        ( SELECT @counter:=0 ) initCounter,
+                        ( SELECT label, 1 AS exclude_marker FROM myTable LIMIT 18446744073709551615 ) actualQuery
+                ) AS withCounter
+                GROUP BY counter
+                ORDER BY counter
+            ";
+        }
 
         $this->checkQuery($query, $innerQuery, $expected);
 
@@ -112,33 +166,65 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
         $innerQuery = "SELECT label, partition FROM myTable";
 
         $expected = "
-			SELECT
-				CASE
-					WHEN counter = 1001 THEN 'Others'
-					ELSE `label`
-				END AS `label`,
-				`partition`
-			FROM (
-				SELECT
-					`label`,
-					CASE
-						WHEN `partition` = 1 AND @counter1 = 1001 THEN 1001
-						WHEN `partition` = 1 THEN @counter1:=@counter1+1
-						WHEN `partition` = 2 AND @counter2 = 1001 THEN 1001
-						WHEN `partition` = 2 THEN @counter2:=@counter2+1
-						WHEN `partition` = 3 AND @counter3 = 1001 THEN 1001
-						WHEN `partition` = 3 THEN @counter3:=@counter3+1
-						ELSE 0
-					END AS counter,
-					`partition`
-				FROM
-					( SELECT @counter1:=0 ) initCounter1,
-					( SELECT @counter2:=0 ) initCounter2,
-					( SELECT @counter3:=0 ) initCounter3,
-					( SELECT label, partition FROM myTable ) actualQuery
-			) AS withCounter
-			GROUP BY counter, `partition`
-		";
+            SELECT
+                CASE
+                    WHEN counter = 1001 THEN 'Others'
+                    ELSE `label`
+                END AS `label`,
+                `partition`
+            FROM (
+                SELECT
+                    `label`,
+                    CASE
+                        WHEN `partition` = 1 AND @counter1 = 1001 THEN 1001
+                        WHEN `partition` = 1 THEN @counter1:=@counter1+1
+                        WHEN `partition` = 2 AND @counter2 = 1001 THEN 1001
+                        WHEN `partition` = 2 THEN @counter2:=@counter2+1
+                        WHEN `partition` = 3 AND @counter3 = 1001 THEN 1001
+                        WHEN `partition` = 3 THEN @counter3:=@counter3+1
+                        ELSE 0
+                    END AS counter,
+                    `partition`
+                FROM
+                    ( SELECT @counter1:=0 ) initCounter1,
+                    ( SELECT @counter2:=0 ) initCounter2,
+                    ( SELECT @counter3:=0 ) initCounter3,
+                    ( SELECT label, partition FROM myTable ) actualQuery
+            ) AS withCounter
+            GROUP BY counter, `partition`
+        ";
+
+        if (!Schema::getInstance()->supportsSortingInSubquery()) {
+            $expected = "
+                SELECT
+                    CASE
+                        WHEN counter = 1001 THEN 'Others'
+                        ELSE `label`
+                    END AS `label`,
+                    `partition`
+                FROM (
+                    SELECT
+                        `label`,
+                        CASE
+                            WHEN `partition` = 1 AND @counter1 = 1001 THEN 1001
+                            WHEN `partition` = 1 THEN @counter1:=@counter1+1
+                            WHEN `partition` = 2 AND @counter2 = 1001 THEN 1001
+                            WHEN `partition` = 2 THEN @counter2:=@counter2+1
+                            WHEN `partition` = 3 AND @counter3 = 1001 THEN 1001
+                            WHEN `partition` = 3 THEN @counter3:=@counter3+1
+                            ELSE 0
+                        END AS counter,
+                        `partition`
+                    FROM
+                        ( SELECT @counter1:=0 ) initCounter1,
+                        ( SELECT @counter2:=0 ) initCounter2,
+                        ( SELECT @counter3:=0 ) initCounter3,
+                        ( SELECT label, partition FROM myTable LIMIT 18446744073709551615 ) actualQuery
+                ) AS withCounter
+                GROUP BY counter, `partition`
+                ORDER BY counter
+            ";
+        }
 
         $this->checkQuery($query, $innerQuery, $expected);
     }


### PR DESCRIPTION
### Description:

Matomo uses a so called ranking query to group records above a certain limit into a `Others` row.
This is done by moving the actual query into a subquery using SQL counters to count the records for grouping.

In transitions for example this is used to group all rows per type into an `Others` row that are above the limit of `6`.
In that case the final ranking query currently looks like this:

```sql
SELECT
	CASE WHEN counter = 6 THEN 'Others' ELSE `name` END AS `name`,
	CASE WHEN counter = 6 THEN 'Others' ELSE `url_prefix` END AS `url_prefix`,
	`type`,
	SUM(`3`) AS `3`
FROM
	(
		SELECT
			`name`,
			`url_prefix`,
			CASE WHEN `type` = 4
			AND @counter4 = 6 THEN 6 WHEN `type` = 4 THEN @counter4 := @counter4 + 1 WHEN `type` = 8
			AND @counter8 = 6 THEN 6 WHEN `type` = 8 THEN @counter8 := @counter8 + 1 WHEN `type` = 2
			AND @counter2 = 6 THEN 6 WHEN `type` = 2 THEN @counter2 := @counter2 + 1 WHEN `type` = 3
			AND @counter3 = 6 THEN 6 WHEN `type` = 3 THEN @counter3 := @counter3 + 1 ELSE 0 END AS counter,
			`type`,
			`3`
		FROM
			(
				SELECT
					@counter4 := 0
			) initCounter4,
			(
				SELECT
					@counter8 := 0
			) initCounter8,
			(
				SELECT
					@counter2 := 0
			) initCounter2,
			(
				SELECT
					@counter3 := 0
			) initCounter3,
			(
				SELECT

					/* sites 1 */

					/* 2012-01-01,2012-12-31 */
					CASE WHEN log_link_visit_action.idaction_url IS NULL THEN log_action2.idaction WHEN log_action1.type = 1 THEN log_action2.idaction ELSE log_action1.idaction END,
					COUNT(*) AS `3`,
					CASE WHEN log_link_visit_action.idaction_url IS NULL THEN log_action2.name WHEN log_action1.type = 1 THEN log_action2.name ELSE log_action1.name END AS `name`,
					CASE WHEN log_link_visit_action.idaction_url IS NULL THEN log_action2.type WHEN log_action1.type = 1 THEN log_action2.type ELSE log_action1.type END AS `type`,
					NULL AS `url_prefix`
				FROM
					log_link_visit_action AS log_link_visit_action
					LEFT JOIN log_action AS log_action1 ON log_action1.idaction = log_link_visit_action.idaction_url
					LEFT JOIN log_action AS log_action2 ON log_action2.idaction = log_link_visit_action.idaction_name
				WHERE
					log_link_visit_action.server_time >= '2012-01-01 00:00:00'
					AND log_link_visit_action.server_time <= '2012-12-31 23:59:59'
					AND log_link_visit_action.idsite IN (1)
					AND log_link_visit_action.idaction_name_ref = 0
					AND (
						log_link_visit_action.idaction_name IS NULL
						OR log_link_visit_action.idaction_name != 0
					)
				GROUP BY
					CASE WHEN log_link_visit_action.idaction_url IS NULL THEN log_action2.idaction WHEN log_action1.type = 1 THEN log_action2.idaction ELSE log_action1.idaction END
				ORDER BY
					`3` DESC,
					`name`
			) actualQuery

	) AS withCounter
GROUP BY
	counter,
	`type`
```

This query works nicely on MySQL as it can rely on a sorted result of the `actualQuery`. Unfortunately this is not the case for TiDb. TiDb's optimizer simply ignores the `ORDER BY`, causing all results to return in a random order. Due to this the `counter` mechanism doesn't work correctly anymore and the wrong records are group into the `Others` row.

This PR implements some sort of hack. By setting a `LIMIT` to the `actualQuery`, the optimizer is forced to use a temporary table (which MySQL does by default in that case), which causes the sorting to be applied. Therefor the counter works again. But to have the final result in correct order again we need to apply an addition sorting to the outer query. The changed query would though look like this:

```sql
SELECT
	CASE WHEN counter = 6 THEN 'Others' ELSE `name` END AS `name`,
	CASE WHEN counter = 6 THEN 'Others' ELSE `url_prefix` END AS `url_prefix`,
	`type`,
	SUM(`3`) AS `3`
FROM
	(
		SELECT
			`name`,
			`url_prefix`,
			CASE WHEN `type` = 4
			AND @counter4 = 6 THEN 6 WHEN `type` = 4 THEN @counter4 := @counter4 + 1 WHEN `type` = 8
			AND @counter8 = 6 THEN 6 WHEN `type` = 8 THEN @counter8 := @counter8 + 1 WHEN `type` = 2
			AND @counter2 = 6 THEN 6 WHEN `type` = 2 THEN @counter2 := @counter2 + 1 WHEN `type` = 3
			AND @counter3 = 6 THEN 6 WHEN `type` = 3 THEN @counter3 := @counter3 + 1 ELSE 0 END AS counter,
			`type`,
			`3`
		FROM
			(
				SELECT
					@counter4 := 0
			) initCounter4,
			(
				SELECT
					@counter8 := 0
			) initCounter8,
			(
				SELECT
					@counter2 := 0
			) initCounter2,
			(
				SELECT
					@counter3 := 0
			) initCounter3,
			(
				SELECT

					/* sites 1 */

					/* 2012-01-01,2012-12-31 */
					CASE WHEN log_link_visit_action.idaction_url IS NULL THEN log_action2.idaction WHEN log_action1.type = 1 THEN log_action2.idaction ELSE log_action1.idaction END,
					COUNT(*) AS `3`,
					CASE WHEN log_link_visit_action.idaction_url IS NULL THEN log_action2.name WHEN log_action1.type = 1 THEN log_action2.name ELSE log_action1.name END AS `name`,
					CASE WHEN log_link_visit_action.idaction_url IS NULL THEN log_action2.type WHEN log_action1.type = 1 THEN log_action2.type ELSE log_action1.type END AS `type`,
					NULL AS `url_prefix`
				FROM
					log_link_visit_action AS log_link_visit_action
					LEFT JOIN log_action AS log_action1 ON log_action1.idaction = log_link_visit_action.idaction_url
					LEFT JOIN log_action AS log_action2 ON log_action2.idaction = log_link_visit_action.idaction_name
				WHERE
					log_link_visit_action.server_time >= '2012-01-01 00:00:00'
					AND log_link_visit_action.server_time <= '2012-12-31 23:59:59'
					AND log_link_visit_action.idsite IN (1)
					AND log_link_visit_action.idaction_name_ref = 0
					AND (
						log_link_visit_action.idaction_name IS NULL
						OR log_link_visit_action.idaction_name != 0
					)
				GROUP BY
					CASE WHEN log_link_visit_action.idaction_url IS NULL THEN log_action2.idaction WHEN log_action1.type = 1 THEN log_action2.idaction ELSE log_action1.idaction END
				ORDER BY
					`3` DESC,
					`name`
				LIMIT 18446744073709551615
			) actualQuery

	) AS withCounter
GROUP BY
	counter,
	`type`
	
ORDER BY counter
```

Note: This will be a workaround until #19646 will be implemented.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
