### PR TITLE
Fixes MarketingCampaignsReporting counting visit as new visit due to campaign_name keys mismatch

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -1029,6 +1029,18 @@ class Common
             Config::getInstance()->Tracker['campaign_keyword_var_name'],
         );
 
+        try {
+            // If MarketingCampaignsReporting is active, it can override this params and if we don't account the changes here, the referer_name and referer_keyword keys would differ and lead to count as a new visit
+            $marketingCampaignReportingKeys = array('campaign_name', 'campaign_keyword');
+            foreach ($marketingCampaignReportingKeys as $index => $marketingCampaignReportingKey) {
+                $campaignFields = StaticContainer::get('advanced_campaign_reporting.uri_parameters.' . $marketingCampaignReportingKey);
+                if (!empty($campaignFields[$marketingCampaignReportingKey])) {
+                    $return[$index] = implode(',', $campaignFields[$marketingCampaignReportingKey]);
+                }
+            }
+        } catch (\Exception $e) {
+        }
+
         foreach ($return as &$list) {
             if (strpos($list, ',') !== false) {
                 $list = explode(',', $list);


### PR DESCRIPTION
### Description:

Fixes MarketingCampaignsReporting counting visit as new visit due to campaign_name keys mismatch
Fixes: #PG-3672,https://github.com/matomo-org/plugin-MarketingCampaignsReporting/issues/157

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
