### PR TITLE
Change Do -> Select for Mysqli Tidb Compat

### DIFF
--- a/core/ArchiveProcessor/LoaderLock.php
+++ b/core/ArchiveProcessor/LoaderLock.php
@@ -42,7 +42,7 @@ class LoaderLock
 
     public function unLock()
     {
-        Db::query('DO RELEASE_LOCK(?)', array($this->id));
+        Db::query('SELECT RELEASE_LOCK(?)', array($this->id));
     }
 
     public function getId()


### PR DESCRIPTION
### Description:

For some reason when using:

TiDB + Mysqli adapter, this release lock only works on the second call.

@mneudert spotted that using `Select` rather than `Do` 'fixes' this

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
