### PR TITLE
Sort email reports by description in API & UI

### DIFF
--- a/config/environment/ui-test-tidb.php
+++ b/config/environment/ui-test-tidb.php
@@ -1,0 +1,15 @@
+<?php
+
+use Piwik\DI;
+
+return [
+    'observers.global' => DI::add([
+        ['API.ScheduledReports.getReports.end', DI::value(function (&$result, $parameters) {
+            // TiDb uses a different collation, causing the report order to be slightly different.
+            // To have a consistent sorting, we manually sort here in PHP again.
+            usort($result, function ($a, $b) {
+                return strcmp($a['description'], $b['description']);
+            });
+        })],
+    ]),
+];

--- a/config/environment/ui-test.php
+++ b/config/environment/ui-test.php
@@ -138,16 +138,6 @@ return [
             }
         })],
 
-        ['API.ScheduledReports.getReports.end', Piwik\DI::value(function (&$result, $parameters) {
-            // TiDb uses a different collation, causing the report order to be slightly different.
-            // To have a consistent sorting, we manually sort here in PHP again.
-            if (\Piwik\Config\DatabaseConfig::getConfigValue('schema') === 'Tidb') {
-                usort($result, function ($a, $b) {
-                    return strcmp($a['description'], $b['description']);
-                });
-            }
-        })],
-
         \Piwik\Tests\Framework\XssTesting::getJavaScriptAddEvent(),
     ]),
 

--- a/config/environment/ui-test.php
+++ b/config/environment/ui-test.php
@@ -138,6 +138,16 @@ return [
             }
         })],
 
+        ['API.ScheduledReports.getReports.end', Piwik\DI::value(function (&$result, $parameters) {
+            // TiDb uses a different collation, causing the report order to be slightly different.
+            // To have a consistent sorting, we manually sort here in PHP again.
+            if (\Piwik\Config\DatabaseConfig::getConfigValue('schema') === 'Tidb') {
+                usort($result, function ($a, $b) {
+                    return strcmp($a['description'], $b['description']);
+                });
+            }
+        })],
+
         \Piwik\Tests\Framework\XssTesting::getJavaScriptAddEvent(),
     ]),
 

--- a/core/Container/ContainerFactory.php
+++ b/core/Container/ContainerFactory.php
@@ -119,6 +119,17 @@ class ContainerFactory
             $builder->addDefinitions($file);
         }
 
+        $file = sprintf(
+            '%s/config/environment/%s-%s.php',
+            PIWIK_USER_PATH,
+            $environment,
+            strtolower($this->getDatabaseSchema())
+        );
+
+        if (file_exists($file)) {
+            $builder->addDefinitions($file);
+        }
+
         // add plugin environment configs
         $plugins = $this->pluginList->getActivatedPlugins();
         $plugins = array_unique(array_merge($plugins, Manager::getAlwaysActivatedPlugins()));
@@ -179,5 +190,11 @@ class ContainerFactory
     {
         $section = $this->settings->getSection('Development');
         return (bool) @$section['enabled']; // TODO: code redundancy w/ Development. hopefully ok for now.
+    }
+
+    private function getDatabaseSchema(): string
+    {
+        $section = $this->settings->getSection('database');
+        return $section['schema'] ?? 'Mysql';
     }
 }

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -300,7 +300,7 @@ class API extends \Piwik\Plugin\API
 									JOIN " . Common::prefixTable('site') . "
 									USING (idsite)
 								WHERE deleted = 0
-									$sqlWhere", $bind);
+									$sqlWhere ORDER BY description", $bind);
         // When a specific report was requested and not found, throw an error
         if (
             $idReport !== false

--- a/plugins/ScheduledReports/Controller.php
+++ b/plugins/ScheduledReports/Controller.php
@@ -90,7 +90,11 @@ class Controller extends \Piwik\Plugin\Controller
         $reports = array();
         $reportsById = array();
         if (!Piwik::isUserIsAnonymous()) {
-            $reports = API::getInstance()->getReports($this->idSite, $period = false, $idReport = false, $ifSuperUserReturnOnlySuperUserReports = true);
+            $reports = Request::processRequest('ScheduledReports.getReports', array(
+                'idSite' => $this->idSite,
+                'ifSuperUserReturnOnlySuperUserReports' => true,
+                'filter_limit' => -1,
+            ), []);
             foreach ($reports as &$report) {
                 $report['evolutionPeriodFor'] = $report['evolution_graph_within_period'] ? 'each' : 'prev';
                 $report['evolutionPeriodN'] = (int) $report['evolution_graph_period_n'] ?: ImageGraph::getDefaultGraphEvolutionLastPeriods();

--- a/tests/UI/expected-screenshots/UIIntegrationTest_email_reports.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_email_reports.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:49f4e02b721aab4afe84c9e0df24acfba6e275e40c851847a9296bb2e0e7feb4
-size 111239
+oid sha256:39923205123eeb6d7f6223396984fa18681602487373e985596afbf0a6c485b9
+size 111266

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -775,7 +775,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
 
         it('should load the scheduled reports when Edit button is clicked', async function () {
             await page.goto("?" + generalParams + "&module=ScheduledReports&action=index");
-            await page.click('.entityTable tr:nth-child(4) button[title="Edit"]');
+            await page.click('.entityTable tr:nth-child(3) button[title="Edit"]');
 
             expect(await screenshotPageWrap()).to.matchImage('email_reports_editor');
         });


### PR DESCRIPTION
### Description:

Due to differences in sorting between MySQL and TiDb, this PR also includes the possibility to create database specific config files. This allows to manually sort the API response in tests again for TiDb, so the result matches the expectations (created with MySQL)

refs #11643

(Ref DEV-14881)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
