### PR TITLE
Ensure a static sorting of referrers in transitions

### DIFF
--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -400,7 +400,14 @@ class API extends \Piwik\Plugin\API
         $metrics = array(Metrics::INDEX_NB_VISITS);
         $data = $logAggregator->queryVisitsByDimension($dimensions, $where, [], $metrics, $rankingQuery, false, Config::getInstance()->General['live_query_max_execution_time']);
 
-        $referrerData = array();
+        // array is prefilled with available keys and empty values are removed in the end to ensure the order is static
+        $referrerData = [
+            Common::REFERRER_TYPE_DIRECT_ENTRY => [],
+            Common::REFERRER_TYPE_SEARCH_ENGINE => [],
+            Common::REFERRER_TYPE_SOCIAL_NETWORK => [],
+            Common::REFERRER_TYPE_WEBSITE => [],
+            Common::REFERRER_TYPE_CAMPAIGN => [],
+        ];
         $referrerSubData = array();
 
         foreach ($data as $referrerType => &$subData) {
@@ -424,6 +431,9 @@ class API extends \Piwik\Plugin\API
                 }
             }
         }
+
+        // remove empty records
+        $referrerData = array_filter($referrerData);
 
         $array = new DataArray($referrerData, $referrerSubData);
         return $array->asDataTable();


### PR DESCRIPTION
### Description:

The order of the referrer types listed in the transitions API is currently dependent to the order the database returns the data in.

This PR ensures the order is independent from the database.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
