### PR TITLE
Sort goals by id in API response

### DIFF
--- a/core/DataTable/Filter/ReplaceColumnNames.php
+++ b/core/DataTable/Filter/ReplaceColumnNames.php
@@ -162,6 +162,8 @@ class ReplaceColumnNames extends BaseFilter
     protected function flattenGoalColumns($columnValue)
     {
         $newSubColumns = array();
+        // sort by key (idgoal) to ensure a static result
+        ksort($columnValue);
         foreach ($columnValue as $idGoal => $goalValues) {
             $mapping = Metrics::$mappingFromIdToNameGoal;
             if ($idGoal == GoalManager::IDGOAL_CART) {

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_VisitTime.getVisitInformationPerServerTime__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_VisitTime.getVisitInformationPerServerTime__API.getProcessedReport_day.xml
@@ -419,11 +419,6 @@
 		<bounce_count>0</bounce_count>
 		<nb_visits_converted>2</nb_visits_converted>
 		<goals>
-			<row idgoal="1">
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>10</revenue>
-			</row>
 			<row idgoal="ecommerceAbandonedCart">
 				<nb_conversions>2</nb_conversions>
 				<nb_visits_converted>2</nb_visits_converted>
@@ -439,6 +434,11 @@
 				<revenue_shipping>100.11</revenue_shipping>
 				<revenue_discount>666</revenue_discount>
 				<items>10</items>
+			</row>
+			<row idgoal="1">
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>10</revenue>
 			</row>
 		</goals>
 		<nb_conversions>3</nb_conversions>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems__API.getProcessedReport_day.xml
@@ -111,11 +111,6 @@
 		<bounce_count>0</bounce_count>
 		<nb_visits_converted>2</nb_visits_converted>
 		<goals>
-			<row idgoal="1">
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>10</revenue>
-			</row>
 			<row idgoal="ecommerceAbandonedCart">
 				<nb_conversions>2</nb_conversions>
 				<nb_visits_converted>2</nb_visits_converted>
@@ -131,6 +126,11 @@
 				<revenue_shipping>100.11</revenue_shipping>
 				<revenue_discount>666</revenue_discount>
 				<items>10</items>
+			</row>
+			<row idgoal="1">
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>10</revenue>
 			</row>
 		</goals>
 		<nb_conversions>3</nb_conversions>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems__UserCountry.getContinent_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems__UserCountry.getContinent_day.xml
@@ -11,11 +11,6 @@
 		<bounce_count>0</bounce_count>
 		<nb_visits_converted>2</nb_visits_converted>
 		<goals>
-			<row idgoal='1'>
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>10</revenue>
-			</row>
 			<row idgoal='ecommerceAbandonedCart'>
 				<nb_conversions>2</nb_conversions>
 				<nb_visits_converted>2</nb_visits_converted>
@@ -31,6 +26,11 @@
 				<revenue_shipping>100.11</revenue_shipping>
 				<revenue_discount>666</revenue_discount>
 				<items>10</items>
+			</row>
+			<row idgoal='1'>
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>10</revenue>
 			</row>
 		</goals>
 		<nb_conversions>3</nb_conversions>

--- a/plugins/Goals/tests/System/expected/test_goals_ecommerceshowSalesByPages__Actions.getPageUrls_day.xml
+++ b/plugins/Goals/tests/System/expected/test_goals_ecommerceshowSalesByPages__Actions.getPageUrls_day.xml
@@ -18,19 +18,6 @@
 		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 		<exit_nb_visits>3</exit_nb_visits>
 		<goals>
-			<row idgoal='1'>
-				<nb_conversions>1</nb_conversions>
-				<revenue>10</revenue>
-				<nb_conv_pages_before>1</nb_conv_pages_before>
-				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>1</nb_conversions_page_rate>
-				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
-				<revenue_attrib>10</revenue_attrib>
-				<revenue_entry>10</revenue_entry>
-				<nb_conversions_entry_rate>0.333</nb_conversions_entry_rate>
-				<revenue_per_entry>3.333</revenue_per_entry>
-				<nb_conversions_entry>1</nb_conversions_entry>
-			</row>
 			<row idgoal='ecommerceAbandonedCart'>
 				<nb_conversions>9</nb_conversions>
 				<revenue>22590.99</revenue>
@@ -49,6 +36,19 @@
 				<nb_conversions_entry_rate>0.667</nb_conversions_entry_rate>
 				<revenue_per_entry>1037.037</revenue_per_entry>
 				<nb_conversions_entry>2</nb_conversions_entry>
+			</row>
+			<row idgoal='1'>
+				<nb_conversions>1</nb_conversions>
+				<revenue>10</revenue>
+				<nb_conv_pages_before>1</nb_conv_pages_before>
+				<nb_conversions_attrib>1</nb_conversions_attrib>
+				<nb_conversions_page_rate>1</nb_conversions_page_rate>
+				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
+				<revenue_attrib>10</revenue_attrib>
+				<revenue_entry>10</revenue_entry>
+				<nb_conversions_entry_rate>0.333</nb_conversions_entry_rate>
+				<revenue_per_entry>3.333</revenue_per_entry>
+				<nb_conversions_entry>1</nb_conversions_entry>
 			</row>
 		</goals>
 		<avg_bandwidth>0</avg_bandwidth>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
@@ -124,19 +124,6 @@
 		<entry_bounce_count>1</entry_bounce_count>
 		<exit_nb_visits>2</exit_nb_visits>
 		<goals>
-			<row idgoal="2">
-				<nb_conversions>1</nb_conversions>
-				<revenue>1</revenue>
-				<nb_conv_pages_before>1</nb_conv_pages_before>
-				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
-				<revenue_attrib>1</revenue_attrib>
-				<revenue_entry>1</revenue_entry>
-				<revenue_per_entry>1</revenue_per_entry>
-				<nb_conversions_entry>1</nb_conversions_entry>
-				<nb_conversions_page_rate>1</nb_conversions_page_rate>
-				<nb_conversions_entry_rate>1</nb_conversions_entry_rate>
-			</row>
 			<row idgoal="1">
 				<nb_conversions>2</nb_conversions>
 				<revenue>84</revenue>
@@ -148,6 +135,19 @@
 				<revenue_per_entry>42</revenue_per_entry>
 				<nb_conversions_entry>1</nb_conversions_entry>
 				<nb_conversions_page_rate>2</nb_conversions_page_rate>
+				<nb_conversions_entry_rate>1</nb_conversions_entry_rate>
+			</row>
+			<row idgoal="2">
+				<nb_conversions>1</nb_conversions>
+				<revenue>1</revenue>
+				<nb_conv_pages_before>1</nb_conv_pages_before>
+				<nb_conversions_attrib>1</nb_conversions_attrib>
+				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
+				<revenue_attrib>1</revenue_attrib>
+				<revenue_entry>1</revenue_entry>
+				<revenue_per_entry>1</revenue_per_entry>
+				<nb_conversions_entry>1</nb_conversions_entry>
+				<nb_conversions_page_rate>1</nb_conversions_page_rate>
 				<nb_conversions_entry_rate>1</nb_conversions_entry_rate>
 			</row>
 		</goals>


### PR DESCRIPTION
### Description:

Various reports contain goal metrics. Currently the order of the goals is a matter of how the database decides to return the goals in.

This PR adds a simply sorting by id, so the order will always be the same and independent from the database.

This will also help to fix certain tests failing for TiDb

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
