### PR TITLE
Always use utf8 for load data infile on tidb

### DIFF
--- a/core/Config/DatabaseConfig.php
+++ b/core/Config/DatabaseConfig.php
@@ -15,4 +15,9 @@ class DatabaseConfig extends SectionConfig
     {
         return 'database';
     }
+
+    public static function isTiDb(): bool
+    {
+        return self::getConfigValue('schema') === 'Tidb';
+    }
 }

--- a/core/Db/BatchInsert.php
+++ b/core/Db/BatchInsert.php
@@ -98,8 +98,8 @@ class BatchInsert
             }
             $filePath = $path . $tableName . '-' . $instanceId . Common::generateUniqId() . '.csv';
 
-            // always use utf8 for TiDb, as TiDb has problems fir latin1
-            if (DatabaseConfig::getConfigValue('schema') === 'Tidb') {
+            // always use utf8 for TiDb, as TiDb has problems with latin1
+            if (DatabaseConfig::isTiDb()) {
                 $charset = 'utf8';
             }
 

--- a/core/Db/BatchInsert.php
+++ b/core/Db/BatchInsert.php
@@ -12,6 +12,7 @@ namespace Piwik\Db;
 use Exception;
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Config\DatabaseConfig;
 use Piwik\Container\StaticContainer;
 use Piwik\Db;
 use Piwik\Log;
@@ -97,6 +98,10 @@ class BatchInsert
             }
             $filePath = $path . $tableName . '-' . $instanceId . Common::generateUniqId() . '.csv';
 
+            // always use utf8 for TiDb, as TiDb has problems fir latin1
+            if (DatabaseConfig::getConfigValue('schema') === 'Tidb') {
+                $charset = 'utf8';
+            }
 
             try {
                 $fileSpec = array(

--- a/tests/PHPUnit/Fixtures/SqlDump.php
+++ b/tests/PHPUnit/Fixtures/SqlDump.php
@@ -70,7 +70,7 @@ class SqlDump extends Fixture
 
         $cmd = "mysql --defaults-extra-file=\"$defaultsFile\" -h \"$host\" {$this->dbName} < \"" . $deflatedDumpPath . "\" 2>&1";
 
-        if (DatabaseConfig::getConfigValue('schema') === 'Tidb') {
+        if (DatabaseConfig::isTiDb()) {
             // For TiDb we need to remove the default charset from the create table statements, otherwise it will use the default charset collation, which differs from database default collation
             $cmd = "sed 's/ DEFAULT CHARSET=utf8mb4//' \"$deflatedDumpPath\" | mysql --defaults-extra-file=\"$defaultsFile\" -h \"$host\" {$this->dbName} 2>&1";
         }

--- a/tests/PHPUnit/Integration/Db/Schema/TidbTest.php
+++ b/tests/PHPUnit/Integration/Db/Schema/TidbTest.php
@@ -23,7 +23,7 @@ class TidbTest extends IntegrationTestCase
 
     public function testOptimize()
     {
-        if (DatabaseConfig::getConfigValue('schema') !== 'Tidb') {
+        if (!DatabaseConfig::isTiDb()) {
             self::markTestSkipped('Tidb is not available');
         }
 


### PR DESCRIPTION
### Description:

TiDb has problems with charset latin1, which we are using for some cases of load data infile.
Always using utf8 for TiDb should solve any issues around that.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
