### PR TITLE
Ensure UI tests use the correct charset / collation on TiDb

### DIFF
--- a/tests/PHPUnit/Fixtures/SqlDump.php
+++ b/tests/PHPUnit/Fixtures/SqlDump.php
@@ -72,7 +72,7 @@ class SqlDump extends Fixture
 
         if (DatabaseConfig::getConfigValue('schema') === 'Tidb') {
             // For TiDb we need to remove the default charset from the create table statements, otherwise it will use the default charset collation, which differs from database default collation
-            $cmd = "sed 's/ DEFAULT CHARSET=utf8mb4//g' \"" . $deflatedDumpPath . "\" | mysql --defaults-extra-file=\"$defaultsFile\" -h \"$host\" {$this->dbName}  2>&1";
+            $cmd = "sed 's/ DEFAULT CHARSET=utf8mb4//' \"$deflatedDumpPath\" | mysql --defaults-extra-file=\"$defaultsFile\" -h \"$host\" {$this->dbName} 2>&1";
         }
 
         exec($cmd, $output, $return);

--- a/tests/PHPUnit/Fixtures/SqlDump.php
+++ b/tests/PHPUnit/Fixtures/SqlDump.php
@@ -12,6 +12,7 @@ namespace Piwik\Tests\Fixtures;
 use Piwik\Access;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\Config;
+use Piwik\Config\DatabaseConfig;
 use Piwik\Db;
 use Piwik\Tests\Framework\Fixture;
 use Exception;
@@ -68,6 +69,12 @@ class SqlDump extends Fixture
         $defaultsFile = $this->makeMysqlDefaultsFile($user, $password);
 
         $cmd = "mysql --defaults-extra-file=\"$defaultsFile\" -h \"$host\" {$this->dbName} < \"" . $deflatedDumpPath . "\" 2>&1";
+
+        if (DatabaseConfig::getConfigValue('schema') === 'Tidb') {
+            // For TiDb we need to remove the default charset from the create table statements, otherwise it will use the default charset collation, which differs from database default collation
+            $cmd = "sed 's/ DEFAULT CHARSET=utf8mb4//g' \"" . $deflatedDumpPath . "\" | mysql --defaults-extra-file=\"$defaultsFile\" -h \"$host\" {$this->dbName}  2>&1";
+        }
+
         exec($cmd, $output, $return);
         if ($return !== 0) {
             throw new Exception("Failed to load sql dump: " . implode("\n", $output));


### PR DESCRIPTION
### Description:

UI tests are currently not working as expected on TiDb. This is caused by the collation used when setting up the test fixture. As the SQL dump only defines the Charset, the default collation for that charset will be used.
For TiDb this is `utf8mb4_bin`, which differs from MySQL. Removing the charset from create table statements will cause the database to use the default charset and collation defined for the database.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
