### PR TITLE
Implements system signal handling for archiving interruption / termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 #### New APIs
 
 * The method `getNthLevelTableDimension` has been added to the `Report` class. This extends support for subtable reports for more than three levels.
+* Commands can subscribe to system signals by defining a `getSystemSignalsToHandle` function in the command implementation. This feature is gated behind the "ProcessSignals" feature flag, signal subscription will be silently disabled unless that feature flag is enabled.
 
 ## Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 #### New APIs
 
 * The method `getNthLevelTableDimension` has been added to the `Report` class. This extends support for subtable reports for more than three levels.
-* Commands can subscribe to system signals by defining a `getSystemSignalsToHandle` function in the command implementation. This feature is gated behind the "ProcessSignals" feature flag, signal subscription will be silently disabled unless that feature flag is enabled.
+* Commands can subscribe to system signals by defining a `getSystemSignalsToHandle` function in the command implementation. This feature is gated behind the "SystemSignals" feature flag, signal subscription will be silently disabled unless that feature flag is enabled.
 
 ## Deprecations
 

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -111,6 +111,21 @@ class CliMulti
     public function handleSignal(int $signal): void
     {
         $this->signal = $signal;
+
+        if (\SIGTERM !== $signal) {
+            return;
+        }
+
+        foreach ($this->processes as $process) {
+            if ($process instanceof ProcessSymfony) {
+                $this->logger->debug(
+                    'Aborting command: {command} [method = asyncCliSymfony]',
+                    ['command' => $process->getCommandLine()]
+                );
+
+                $process->stop(0);
+            }
+        }
     }
 
     /**

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -95,12 +95,22 @@ class CliMulti
      */
     private $logger;
 
+    /**
+     * @var int|null
+     */
+    private $signal = null;
+
     public function __construct(?LoggerInterface $logger = null)
     {
         $this->supportsAsync = $this->supportsAsync();
         $this->supportsAsyncSymfony = $this->supportsAsyncSymfony();
 
         $this->logger = $logger ?: new NullLogger();
+    }
+
+    public function handleSignal(int $signal): void
+    {
+        $this->signal = $signal;
     }
 
     /**
@@ -124,13 +134,21 @@ class CliMulti
             }
         }
 
-        $chunks = array($piwikUrls);
+        $chunks = [$piwikUrls];
+
         if ($this->concurrentProcessesLimit) {
             $chunks = array_chunk($piwikUrls, $this->concurrentProcessesLimit);
         }
 
-        $results = array();
+        $results = [];
+
         foreach ($chunks as $urlsChunk) {
+            if (null !== $this->signal) {
+                $this->logSkippedRequests($urlsChunk);
+
+                continue;
+            }
+
             $results = array_merge($results, $this->requestUrls($urlsChunk));
         }
 
@@ -614,6 +632,16 @@ class CliMulti
         self::cleanupNotRemovedFiles();
 
         return $results;
+    }
+
+    private function logSkippedRequests(array $urls): void
+    {
+        foreach ($urls as $url) {
+            $this->logger->debug(
+                'Skipped climulti:request after abort signal received: {url}',
+                ['url' => $url]
+            );
+        }
     }
 
     private static function getSuperUserTokenAuth()

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -35,6 +35,7 @@ use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
 use Piwik\Plugins\UsersManager\UserPreferences;
 use Piwik\Log\LoggerInterface;
+use Piwik\Scheduler\Scheduler;
 
 /**
  * ./console core:archive runs as a cron and is a useful tool for general maintenance,
@@ -234,6 +235,28 @@ class CronArchive
     private $supportsAsync;
 
     /**
+     * @var null|int
+     */
+    private $signal = null;
+
+    /**
+     * @var CliMulti|null
+     */
+    private $cliMultiHandler = null;
+
+    /**
+     * @var Scheduler|null
+     */
+    private $scheduler = null;
+
+    private $step = 0;
+
+    private const STEP_INIT = 1;
+    private const STEP_ARCHIVING = 2;
+    private const STEP_SCHEDULED_TASKS = 3;
+    private const STEP_FINISH = 4;
+
+    /**
      * Constructor.
      *
      * @param LoggerInterface|null $logger
@@ -277,14 +300,48 @@ class CronArchive
          */
         Access::doAsSuperUser(function () use ($self) {
             try {
+                $this->step = self::STEP_INIT;
                 $self->init();
+
+                $this->step = self::STEP_ARCHIVING;
                 $self->run();
+
+                $this->step = self::STEP_SCHEDULED_TASKS;
                 $self->runScheduledTasks();
+
+                $this->step = self::STEP_FINISH;
                 $self->end();
             } catch (StopArchiverException $e) {
                 $this->logger->info("Archiving stopped by stop archiver exception" . $e->getMessage());
             }
         });
+    }
+
+    public function handleSignal(int $signal): void
+    {
+        $this->logger->info('Received system signal to stop archiving: ' . $signal);
+
+        $this->signal = $signal;
+
+        // initialisation and finishing can be stopped directly.
+        if (in_array($this->step, [self::STEP_INIT, self::STEP_FINISH])) {
+            $this->logger->info('Archiving stopped');
+            exit;
+        }
+
+        // stop archiving
+        if (!empty($this->cliMultiHandler)) {
+            $this->logger->info('Trying to stop running cli processes...');
+            $this->cliMultiHandler->handleSignal($signal);
+        }
+
+        // stop scheduled tasks
+        if (!empty($this->scheduler)) {
+            $this->logger->info('Trying to stop running tasks...');
+            $this->scheduler->handleSignal($signal);
+        }
+
+        // Note: finishing the archiving process will be handled in `run()`
     }
 
     public function init()
@@ -390,6 +447,11 @@ class CronArchive
         $queueConsumer->setMaxSitesToProcess($this->maxSitesToProcess);
 
         while (true) {
+            if (null !== $this->signal) {
+                $this->logger->info("Archiving will stop now because signal to abort received");
+                return;
+            }
+
             if ($this->isMaintenanceModeEnabled()) {
                 $this->logger->info("Archiving will stop now because maintenance mode is enabled");
                 return;
@@ -507,18 +569,29 @@ class CronArchive
             return 0; // all URLs had no visits and were using the tracker
         }
 
-        $cliMulti = $this->makeCliMulti();
-        $cliMulti->timeRequests();
+        $this->cliMultiHandler = $this->makeCliMulti();
+        $this->cliMultiHandler->timeRequests();
 
-        $responses = $cliMulti->request($urls);
+        $responses = $this->cliMultiHandler->request($urls);
 
         $this->disconnectDb();
 
-        $timers = $cliMulti->getTimers();
+        $timers = $this->cliMultiHandler->getTimers();
         $successCount = 0;
 
         foreach ($urls as $index => $url) {
             $content = array_key_exists($index, $responses) ? $responses[$index] : null;
+
+            if (null !== $this->signal && empty($content)) {
+                // processes killed by system
+                $idinvalidation = $archivesBeingQueried[$index]['idinvalidation'];
+
+                $this->model->releaseInProgressInvalidations([$idinvalidation]);
+                $this->logger->info('Archiving process killed, reset invalidation with id ' . $idinvalidation);
+
+                continue;
+            }
+
             $checkInvalid = $this->checkResponse($content, $url);
 
             $stats = json_decode($content, $assoc = true);
@@ -536,7 +609,6 @@ class CronArchive
 
             $visitsForPeriod = $this->getVisitsFromApiResponse($stats);
 
-
             $this->logArchiveJobFinished(
                 $url,
                 $timers[$index],
@@ -545,7 +617,6 @@ class CronArchive
                 $archivesBeingQueried[$index]['report'],
                 !$checkInvalid
             );
-
 
             $this->deleteInvalidatedArchives($archivesBeingQueried[$index]);
 
@@ -627,6 +698,11 @@ class CronArchive
      */
     public function end()
     {
+        if (null !== $this->signal) {
+            // Skip if abort signal has been received
+            return;
+        }
+
         /**
          * This event is triggered after archiving.
          *
@@ -659,6 +735,11 @@ class CronArchive
 
     public function runScheduledTasks()
     {
+        if (null !== $this->signal) {
+            // Skip running scheduled task if abort signal has been received
+            return;
+        }
+
         $this->logSection("SCHEDULED TASKS");
 
         if ($this->disableScheduledTasks) {
@@ -682,7 +763,8 @@ class CronArchive
         //         enable/disable the task
         Rules::$disablePureOutdatedArchive = true;
 
-        CoreAdminHomeAPI::getInstance()->runScheduledTasks();
+        $this->scheduler = StaticContainer::get(Scheduler::class);
+        $this->scheduler->run();
 
         $this->logSection("");
     }

--- a/core/Plugin/ConsoleCommand.php
+++ b/core/Plugin/ConsoleCommand.php
@@ -10,6 +10,7 @@
 namespace Piwik\Plugin;
 
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -28,7 +29,7 @@ use Symfony\Component\Console\Question\Question;
  *
  * @api
  */
-class ConsoleCommand extends SymfonyCommand
+class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterface
 {
     /**
      * @var ProgressBar|null
@@ -151,6 +152,43 @@ class ConsoleCommand extends SymfonyCommand
         $this->input  = $input;
         $this->output = $output;
         return parent::run($input, $output);
+    }
+
+    /**
+     * Method is final to make it impossible to overwrite it in plugin commands
+     * use getSystemSignalsToHandle() instead.
+     *
+     * @return array<int>
+     */
+    final public function getSubscribedSignals(): array
+    {
+        return $this->getSystemSignalsToHandle();
+    }
+
+    /**
+     * Method is final to make it impossible to overwrite it in plugin commands
+     * use handleSystemSignal() instead.
+     */
+    final public function handleSignal(int $signal): void
+    {
+        $this->handleSystemSignal($signal);
+    }
+
+    /**
+     * Returns the list of system signals to subscribe.
+     *
+     * @return array<int>
+     */
+    public function getSystemSignalsToHandle(): array
+    {
+        return [];
+    }
+
+    /**
+     * The method will be called when the application is signaled.
+     */
+    public function handleSystemSignal(int $signal): void
+    {
     }
 
     /**

--- a/core/Plugin/ConsoleCommand.php
+++ b/core/Plugin/ConsoleCommand.php
@@ -9,6 +9,9 @@
 
 namespace Piwik\Plugin;
 
+use Piwik\Container\StaticContainer;
+use Piwik\Plugins\CoreConsole\FeatureFlags\SystemSignals;
+use Piwik\Plugins\FeatureFlags\FeatureFlagManager;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Console\Exception\LogicException;
@@ -23,6 +26,7 @@ use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
+use Throwable;
 
 /**
  * The base class for console commands.
@@ -158,16 +162,35 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
      * Method is final to make it impossible to overwrite it in plugin commands
      * use getSystemSignalsToHandle() instead.
      *
+     * Will only have an effect if the "SystemSignals" feature flag is enabled.
+     *
      * @return array<int>
      */
     final public function getSubscribedSignals(): array
     {
+        $canSubscribe = false;
+
+        // The required DI configuration may not be loaded during the update process.
+        // This can happen for an upgrade from a version that did not yet contain
+        // the feature flag plugin.
+        try {
+            $featureFlagManager = StaticContainer::get(FeatureFlagManager::class);
+            $canSubscribe       = $featureFlagManager->isFeatureActive(SystemSignals::class);
+        } catch (Throwable $e) {
+        }
+
+        if (!$canSubscribe) {
+            return [];
+        }
+
         return $this->getSystemSignalsToHandle();
     }
 
     /**
      * Method is final to make it impossible to overwrite it in plugin commands
      * use handleSystemSignal() instead.
+     *
+     * Will only have an effect if the "SystemSignals" feature flag is enabled.
      */
     final public function handleSignal(int $signal): void
     {

--- a/core/Scheduler/Scheduler.php
+++ b/core/Scheduler/Scheduler.php
@@ -81,12 +81,22 @@ class Scheduler
      */
     private $lock;
 
+    /**
+     * @var int|null
+     */
+    private $signal = null;
+
     public function __construct(TaskLoader $loader, LoggerInterface $logger, ScheduledTaskLock $lock)
     {
         $this->timetable = new Timetable();
         $this->loader = $loader;
         $this->logger = $logger;
         $this->lock = $lock;
+    }
+
+    public function handleSignal(int $signal): void
+    {
+        $this->signal = $signal;
     }
 
     /**
@@ -121,6 +131,11 @@ class Scheduler
 
             // loop through each task
             foreach ($tasks as $task) {
+                if (in_array($this->signal, [\SIGINT, \SIGTERM], true)) {
+                    $this->logger->info("Scheduler: Aborting due to received signal");
+                    return $executionResults;
+                }
+
                 // if the task does not have the current priority level, don't execute it yet
                 if ($task->getPriority() != $priority) {
                     continue;

--- a/plugins/CoreAdminHome/tests/Fixtures/CoreArchiverProcessSignal.php
+++ b/plugins/CoreAdminHome/tests/Fixtures/CoreArchiverProcessSignal.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Fixtures;
+
+use Closure;
+use Piwik\ArchiveProcessor\Rules;
+use Piwik\Config;
+use Piwik\Container\Container;
+use Piwik\Date;
+use Piwik\DI;
+use Piwik\Plugins\CoreAdminHome\tests\Fixtures\CoreArchiverProcessSignal\StepControl;
+use Piwik\Plugins\Monolog\Handler\EchoHandler;
+use Piwik\Plugins\SegmentEditor\API as APISegmentEditor;
+use Piwik\Request;
+use Piwik\Tests\Framework\Fixture;
+
+/**
+ * Fixture that adds one site and tracks one pageview for today.
+ *
+ * Provides container configuration and helpers to run process signal tests.
+ */
+class CoreArchiverProcessSignal extends Fixture
+{
+    public const ENV_TRIGGER = 'MATOMO_TEST_CORE_ARCHIVER_PROCESS_SIGNAL';
+
+    public const TEST_SEGMENT_CH = 'browserCode==CH';
+    public const TEST_SEGMENT_FF = 'browserCode==FF';
+
+    /**
+     * @var int
+     */
+    public $idSite = 1;
+
+    /**
+     * @var StepControl
+     */
+    public $stepControl;
+
+    /**
+     * @var string
+     */
+    public $today;
+
+    /**
+     * @var bool
+     */
+    private $inTestEnv;
+
+    /**
+     * @var bool
+     */
+    private $inTestRequest;
+
+    public function __construct()
+    {
+        $this->inTestEnv = (bool) getenv(self::ENV_TRIGGER);
+        $this->inTestRequest = Request::fromRequest()->getBoolParameter(self::ENV_TRIGGER, false);
+        $this->today = Date::today()->toString();
+
+        $this->stepControl = new StepControl();
+    }
+
+    public function setUp(): void
+    {
+        Rules::setBrowserTriggerArchiving(false);
+        Config::getInstance()->General['process_new_segments_from'] = 'segment_creation_time';
+        Fixture::createSuperUser();
+
+        $this->setUpWebsites();
+        $this->setUpSegments();
+        $this->trackVisits();
+    }
+
+    public function tearDown(): void
+    {
+        // empty
+    }
+
+    public function provideContainerConfig(): array
+    {
+        if (!$this->inTestEnv && !$this->inTestRequest) {
+            return [];
+        }
+
+        if ($this->inTestRequest) {
+            return [
+                'observers.global' => DI::add([
+                    [
+                        'API.CoreAdminHome.archiveReports',
+                        DI::value(Closure::fromCallable([$this->stepControl, 'handleAPIArchiveReports'])),
+                    ],
+                ]),
+            ];
+        }
+
+        return [
+            'ini.tests.enable_logging' => 1,
+            'log.handlers' => static function (Container $c) {
+                return [$c->get(EchoHandler::class)];
+            },
+            'observers.global' => DI::add([
+                [
+                    'CronArchive.alterArchivingRequestUrl',
+                    DI::value(static function (&$url) {
+                        $url .= '&' . self::ENV_TRIGGER . '=1';
+                    }),
+                ],
+                [
+                    'CronArchive.init.finish',
+                    DI::value(Closure::fromCallable([$this->stepControl, 'handleCronArchiveStart'])),
+                ],
+            ]),
+        ];
+    }
+
+    private function setUpSegments(): void
+    {
+        APISegmentEditor::getInstance()->add(
+            self::TEST_SEGMENT_CH,
+            self::TEST_SEGMENT_CH,
+            $this->idSite,
+            $autoArchive = true,
+            $enabledAllUsers = true
+        );
+
+        APISegmentEditor::getInstance()->add(
+            self::TEST_SEGMENT_FF,
+            self::TEST_SEGMENT_FF,
+            $this->idSite,
+            $autoArchive = true,
+            $enabledAllUsers = true
+        );
+    }
+
+    private function setUpWebsites(): void
+    {
+        if (!self::siteCreated($this->idSite)) {
+            self::createWebsite('2021-01-01');
+        }
+    }
+
+    private function trackVisits(): void
+    {
+        $t = self::getTracker($this->idSite, $this->today, $defaultInit = true);
+        $t->setUrl('http://example.org/index.htm');
+
+        self::checkResponse($t->doTrackPageView('0'));
+    }
+}

--- a/plugins/CoreAdminHome/tests/Fixtures/CoreArchiverProcessSignal.php
+++ b/plugins/CoreAdminHome/tests/Fixtures/CoreArchiverProcessSignal.php
@@ -118,6 +118,14 @@ class CoreArchiverProcessSignal extends Fixture
                     'CronArchive.init.finish',
                     DI::value(Closure::fromCallable([$this->stepControl, 'handleCronArchiveStart'])),
                 ],
+                [
+                    'ScheduledTasks.execute',
+                    DI::value(Closure::fromCallable([$this->stepControl, 'handleScheduledTasksExecute'])),
+                ],
+                [
+                    'ScheduledTasks.shouldExecuteTask',
+                    DI::value(Closure::fromCallable([$this->stepControl, 'handleScheduledTasksShouldExecute'])),
+                ]
             ]),
         ];
     }

--- a/plugins/CoreAdminHome/tests/Fixtures/CoreArchiverProcessSignal/StepControl.php
+++ b/plugins/CoreAdminHome/tests/Fixtures/CoreArchiverProcessSignal/StepControl.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Fixtures\CoreArchiverProcessSignal;
+
+use Piwik\Option;
+use RuntimeException;
+
+class StepControl
+{
+    public const OPTION_PREFIX = 'CoreArchiverProcessSignal.';
+
+    private const OPTION_ARCHIVE_REPORTS_BLOCKED = self::OPTION_PREFIX . 'ArchiveReportsBlocked';
+    private const OPTION_CRON_ARCHIVE_BLOCKED = self::OPTION_PREFIX . 'CronArchiveBlocked';
+
+    /**
+     * Block proceeding from the "API.CoreAdminHome.archiveReports" event.
+     *
+     * @param array{segment: string, period: string, date: string} $blockSpec
+     */
+    public function blockAPIArchiveReports(array $blockSpec): void
+    {
+        Option::set(self::OPTION_ARCHIVE_REPORTS_BLOCKED, json_encode($blockSpec));
+    }
+
+    /**
+     * Block proceeding from the "CronArchive.init.finish" event.
+     */
+    public function blockCronArchiveStart(): void
+    {
+        Option::set(self::OPTION_CRON_ARCHIVE_BLOCKED, true);
+    }
+
+    /**
+     * DI hook intercepting the "API.CoreAdminHome.archiveReports" event.
+     */
+    public function handleAPIArchiveReports($parameters): void
+    {
+        $continue = $this->waitForSuccess(static function () use ($parameters): bool {
+            // force reading from database
+            Option::clearCachedOption(self::OPTION_ARCHIVE_REPORTS_BLOCKED);
+
+            $option = Option::get(self::OPTION_ARCHIVE_REPORTS_BLOCKED) ?: '';
+            $block = json_decode($option, true);
+
+            if (!is_array($block)) {
+                return true;
+            }
+
+            return (
+                $block['segment'] !== urldecode($parameters['segment'] ?: '')
+                || $block['period'] !== $parameters['period']
+                || $block['date'] !== $parameters['date']
+            );
+        });
+
+        if (!$continue) {
+            throw new RuntimeException('Waiting for ArchiveReports option took too long!');
+        }
+    }
+
+    /**
+     * DI hook intercepting the "CronArchive.init.finish" event.
+     */
+    public function handleCronArchiveStart(): void
+    {
+        $continue = $this->waitForSuccess(static function (): bool {
+            // force reading from database
+            Option::clearCachedOption(self::OPTION_CRON_ARCHIVE_BLOCKED);
+
+            return false === Option::get(self::OPTION_CRON_ARCHIVE_BLOCKED);
+        });
+
+        if (!$continue) {
+            throw new RuntimeException('Waiting for CronArchive option took too long!');
+        }
+    }
+
+    /**
+     * Remove all internal blocks.
+     */
+    public function reset(): void
+    {
+        Option::deleteLike(self::OPTION_PREFIX . '%');
+    }
+
+    /**
+     * Allow proceeding past the "API.CoreAdminHome.archiveReports" event.
+     */
+    public function unblockAPIArchiveReports(): void
+    {
+        Option::delete(self::OPTION_ARCHIVE_REPORTS_BLOCKED);
+    }
+
+    /**
+     * Allow proceeding past the "CronArchive.init.start" event.
+     */
+    public function unblockCronArchiveStart(): void
+    {
+        Option::delete(self::OPTION_CRON_ARCHIVE_BLOCKED);
+    }
+
+    /**
+     * Wait until a callable returns true or a timeout is reached.
+     */
+    public function waitForSuccess(callable $check, int $timeoutInSeconds = 10): bool
+    {
+        $start = time();
+
+        do {
+            $now = time();
+
+            if ($check()) {
+                return true;
+            }
+
+            // 250 millisecond sleep
+            usleep(250 * 1000);
+        } while ($timeoutInSeconds > $now - $start);
+
+        return false;
+    }
+}

--- a/plugins/CoreAdminHome/tests/Fixtures/RunScheduledTasksProcessSignal.php
+++ b/plugins/CoreAdminHome/tests/Fixtures/RunScheduledTasksProcessSignal.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Fixtures;
+
+use Closure;
+use Piwik\Container\Container;
+use Piwik\DI;
+use Piwik\Plugins\CoreAdminHome\tests\Fixtures\RunScheduledTasksProcessSignal\StepControl;
+use Piwik\Plugins\Monolog\Handler\EchoHandler;
+use Piwik\Tests\Framework\Fixture;
+
+/**
+ * Provides container configuration and helpers to run process signal tests.
+ */
+class RunScheduledTasksProcessSignal extends Fixture
+{
+    public const ENV_TRIGGER = 'MATOMO_TEST_RUN_SCHEDULED_TASKS_PROCESS_SIGNAL';
+
+    /**
+     * @var int
+     */
+    public $idSite = 1;
+
+    /**
+     * @var StepControl
+     */
+    public $stepControl;
+
+    /**
+     * @var bool
+     */
+    private $inTestEnv;
+
+    public function __construct()
+    {
+        $this->inTestEnv = (bool) getenv(self::ENV_TRIGGER);
+
+        $this->stepControl = new StepControl();
+    }
+
+    public function setUp(): void
+    {
+        Fixture::createSuperUser();
+
+        if (!self::siteCreated($this->idSite)) {
+            self::createWebsite('2021-01-01');
+        }
+    }
+
+    public function tearDown(): void
+    {
+        // empty
+    }
+
+    public function provideContainerConfig(): array
+    {
+        if (!$this->inTestEnv) {
+            return [];
+        }
+
+        return [
+            'ini.tests.enable_logging' => 1,
+            'log.handlers' => static function (Container $c) {
+                return [$c->get(EchoHandler::class)];
+            },
+            'observers.global' => DI::add([
+                [
+                    'ScheduledTasks.execute',
+                    DI::value(Closure::fromCallable([$this->stepControl, 'handleScheduledTasksExecute'])),
+                ],
+            ]),
+        ];
+    }
+}

--- a/plugins/CoreAdminHome/tests/Fixtures/RunScheduledTasksProcessSignal/StepControl.php
+++ b/plugins/CoreAdminHome/tests/Fixtures/RunScheduledTasksProcessSignal/StepControl.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Fixtures\RunScheduledTasksProcessSignal;
+
+use Piwik\Option;
+use RuntimeException;
+
+class StepControl
+{
+    public const OPTION_PREFIX = 'RunScheduledTasksProcessSignal.';
+
+    private const OPTION_SCHEDULED_TASKS_BLOCKED = self::OPTION_PREFIX . 'ScheduledTasksBlocked';
+
+    /**
+     * Block proceeding from the "ScheduledTasks.execute" event.
+     */
+    public function blockScheduledTasks(): void
+    {
+        Option::set(self::OPTION_SCHEDULED_TASKS_BLOCKED, true);
+    }
+
+    /**
+     * DI hook intercepting the "ScheduledTasks.execute" event.
+     */
+    public function handleScheduledTasksExecute(): void
+    {
+        $continue = $this->waitForSuccess(static function (): bool {
+            // force reading from database
+            Option::clearCachedOption(self::OPTION_SCHEDULED_TASKS_BLOCKED);
+
+            return false === Option::get(self::OPTION_SCHEDULED_TASKS_BLOCKED);
+        });
+
+        if (!$continue) {
+            throw new RuntimeException('Waiting for ScheduledTask option took too long!');
+        }
+    }
+
+    /**
+     * Remove all internal blocks.
+     */
+    public function reset(): void
+    {
+        Option::deleteLike(self::OPTION_PREFIX . '%');
+    }
+
+    /**
+     * Allow proceeding past the "ScheduledTasks.execute" event.
+     */
+    public function unblockScheduledTasks(): void
+    {
+        Option::delete(self::OPTION_SCHEDULED_TASKS_BLOCKED);
+    }
+
+    /**
+     * Wait until a callable returns true or a timeout is reached.
+     */
+    public function waitForSuccess(callable $check, int $timeoutInSeconds = 10): bool
+    {
+        $start = time();
+
+        do {
+            $now = time();
+
+            if ($check()) {
+                return true;
+            }
+
+            // 250 millisecond sleep
+            usleep(250 * 1000);
+        } while ($timeoutInSeconds > $now - $start);
+
+        return false;
+    }
+}

--- a/plugins/CoreAdminHome/tests/Integration/Commands/CoreArchiverProcessSignalTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/CoreArchiverProcessSignalTest.php
@@ -28,7 +28,10 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class CoreArchiverProcessSignalTest extends IntegrationTestCase
 {
+    private const METHOD_ASYNC_CLI = 'asyncCli';
     private const METHOD_ASYNC_CLI_SYMFONY = 'asyncCliSymfony';
+    private const METHOD_CURL = 'curl';
+    private const METHOD_SYNC_CLI = 'syncCli';
 
     /**
      * @var CoreArchiverProcessSignalFixture
@@ -61,13 +64,13 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         $this->setUpArchivingMethod($method);
 
         // let archiving run completely
-        $process = $this->startCoreArchiver();
+        $process = $this->startCoreArchiver($method);
         $process->setTimeout(60);
         $process->wait();
 
         self::assertFalse($process->isRunning());
 
-        $this->assertArchiveInvalidationCount($inProgress = 0, $total = 0);
+        $this->assertArchiveInvalidationCount(['inProgress' => 0, 'total' => 0]);
 
         $processOutput = $process->getOutput();
 
@@ -78,45 +81,91 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         self::assertStringContainsString('Archived website id 1, period = year', $processOutput);
         self::assertStringContainsString('Done archiving!', $processOutput);
         self::assertStringContainsString('Starting Scheduled tasks...', $processOutput);
+
+        if (self::METHOD_CURL === $method) {
+            self::assertStringContainsString('Execute HTTP API request:', $processOutput);
+        } else {
+            self::assertRegExp('/Running command.*\[method = ' . $method . ']/', $processOutput);
+        }
     }
 
     public function getArchivingWithoutSignalData(): iterable
     {
         yield 'symfony process' => [self::METHOD_ASYNC_CLI_SYMFONY];
+        yield 'default process (single process)' => [self::METHOD_SYNC_CLI];
+        yield 'default process (multi process)' => [self::METHOD_ASYNC_CLI];
+        yield 'curl' => [self::METHOD_CURL];
     }
 
     /**
      * @dataProvider getSigintDuringArchivingData
      *
      * @param array{segment: string, period: string, date: string} $blockSpec
+     * @param array{inProgress: int, total: int} $invalidationCountIntermediate
+     * @param array{inProgress: int, total: int} $invalidationCountFinal
      */
-    public function testSigintDuringArchiving(string $method, array $blockSpec): void
-    {
+    public function testSigintDuringArchiving(
+        string $method,
+        array $blockSpec,
+        array $invalidationCountIntermediate,
+        array $invalidationCountFinal
+    ): void {
         self::$fixture->stepControl->blockCronArchiveStart();
         self::$fixture->stepControl->blockAPIArchiveReports($blockSpec);
 
         $this->setUpArchivingMethod($method);
 
-        $process = $this->startCoreArchiver();
+        $process = $this->startCoreArchiver($method);
 
         self::$fixture->stepControl->unblockCronArchiveStart();
 
-        $this->waitForArchivingToStart($process, $blockSpec);
-        $this->assertArchiveInvalidationCount($inProgress = 1, $total = 12);
-        $this->sendSignalToProcess($process, \SIGINT);
+        $this->waitForArchivingToStart($process, $method, $blockSpec);
+        $this->assertArchiveInvalidationCount($invalidationCountIntermediate);
+        $this->sendSignalToProcess($process, \SIGINT, $method);
 
         self::$fixture->stepControl->unblockAPIArchiveReports();
 
         $this->waitForProcessToStop($process);
         $this->assertArchivingOutput($process, $method, \SIGINT, $blockSpec);
-        $this->assertArchiveInvalidationCount($inProgress = 0, $total = 11);
+        $this->assertArchiveInvalidationCount($invalidationCountFinal);
     }
 
     public function getSigintDuringArchivingData(): iterable
     {
+        $specToday = ['segment' => '', 'period' => 'day', 'date' => self::$fixture->today];
+
         yield 'symfony process' => [
             'method' => self::METHOD_ASYNC_CLI_SYMFONY,
-            'blockSpec' => ['segment' => '', 'period' => 'day', 'date' => self::$fixture->today],
+            'blockSpec' => $specToday,
+            'invalidationCountIntermediate' => ['inProgress' => 1, 'total' => 12],
+            'invalidationCountFinal' => ['inProgress' => 0, 'total' => 11],
+        ];
+
+        yield 'default process (single process)' => [
+            'method' => self::METHOD_SYNC_CLI,
+            'blockSpec' => $specToday,
+            'invalidationCountIntermediate' => ['inProgress' => 1, 'total' => 12],
+            'invalidationCountFinal' => ['inProgress' => 0, 'total' => 11],
+        ];
+
+        // empty day segment will always run as a single process
+        // so we use a non-empty segment for testing asyncCli
+        yield 'default process (multi process)' => [
+            'method' => self::METHOD_ASYNC_CLI,
+            'blockSpec' => [
+                'segment' => CoreArchiverProcessSignalFixture::TEST_SEGMENT_CH,
+                'period' => 'day',
+                'date' => self::$fixture->today,
+            ],
+            'invalidationCountIntermediate' => ['inProgress' => 2, 'total' => 11],
+            'invalidationCountFinal' => ['inProgress' => 0, 'total' => 9],
+        ];
+
+        yield 'curl' => [
+            'method' => self::METHOD_CURL,
+            'blockSpec' => $specToday,
+            'invalidationCountIntermediate' => ['inProgress' => 1, 'total' => 12],
+            'invalidationCountFinal' => ['inProgress' => 0, 'total' => 11],
         ];
     }
 
@@ -132,17 +181,17 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
 
         $this->setUpArchivingMethod($method);
 
-        $process = $this->startCoreArchiver();
+        $process = $this->startCoreArchiver($method);
 
         self::$fixture->stepControl->unblockCronArchiveStart();
 
-        $this->waitForArchivingToStart($process, $blockSpec);
-        $this->assertArchiveInvalidationCount($inProgress = 1, $total = 12);
-        $this->sendSignalToProcess($process, \SIGTERM);
+        $this->waitForArchivingToStart($process, $method, $blockSpec);
+        $this->assertArchiveInvalidationCount(['inProgress' => 1, 'total' => 12]);
+        $this->sendSignalToProcess($process, \SIGTERM, $method);
 
         $this->waitForProcessToStop($process);
         $this->assertArchivingOutput($process, $method, \SIGTERM, $blockSpec);
-        $this->assertArchiveInvalidationCount($inProgress = 0, $total = 12);
+        $this->assertArchiveInvalidationCount(['inProgress' => 0, 'total' => 12]);
     }
 
     public function getSigtermDuringArchivingData(): iterable
@@ -153,18 +202,19 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         ];
     }
 
-    private function assertArchiveInvalidationCount(
-        int $expectedInProgress,
-        int $expectedTotal
-    ): void {
+    /**
+     * @param array{inProgress: int, total: int} $expectedCounts
+     */
+    private function assertArchiveInvalidationCount(array $expectedCounts): void
+    {
         $actualInProgress = $this->dataAccessModel->getInvalidationsInProgress([self::$fixture->idSite]);
         $actualTotal = (int) Db::fetchOne(
             'SELECT COUNT(*) FROM ' . Common::prefixTable('archive_invalidations') . ' WHERE idsite = ?',
             [self::$fixture->idSite]
         );
 
-        self::assertSame($expectedTotal, $actualTotal);
-        self::assertCount($expectedInProgress, $actualInProgress);
+        self::assertSame($expectedCounts['total'], $actualTotal);
+        self::assertCount($expectedCounts['inProgress'], $actualInProgress);
     }
 
     /**
@@ -179,11 +229,21 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         $idSite = self::$fixture->idSite;
         $processOutput = $process->getOutput();
 
-        self::assertRegExp('/Running command.*\[method = ' . $method . ']/', $processOutput);
+        if (self::METHOD_CURL === $method) {
+            self::assertStringContainsString('Execute HTTP API request:', $processOutput);
+        } else {
+            self::assertRegExp('/Running command.*\[method = ' . $method . ']/', $processOutput);
+        }
 
         self::assertStringContainsString('Starting archiving for', $processOutput);
-        self::assertStringContainsString('Trying to stop running cli processes...', $processOutput);
         self::assertStringContainsString('Archiving will stop now because signal to abort received', $processOutput);
+
+        if (self::METHOD_CURL !== $method) {
+            // curl handling does not acknowledge signals properly
+            // so only check this output was posted for all other methods
+            self::assertStringContainsString('Received system signal to stop archiving: ' . $signal, $processOutput);
+            self::assertStringContainsString('Trying to stop running cli processes...', $processOutput);
+        }
 
         if (\SIGINT === $signal) {
             self::assertStringContainsString(sprintf(
@@ -201,9 +261,19 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         }
     }
 
-    private function sendSignalToProcess(ProcessSymfony $process, int $signal): void
-    {
+    private function sendSignalToProcess(
+        ProcessSymfony $process,
+        int $signal,
+        string $method
+    ): void {
         $process->signal($signal);
+
+        if (in_array($method, [self::METHOD_CURL, self::METHOD_SYNC_CLI], true)) {
+            // not all methods are able to acknowledge the signal at this point
+            // wait for 250 milliseconds and rely on final result assertions
+            usleep(250 * 1000);
+            return;
+        }
 
         $result = self::$fixture->stepControl->waitForSuccess(
             static function () use ($process, $signal): bool {
@@ -219,27 +289,30 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
 
     private function setUpArchivingMethod(string $method): void
     {
+        $environment = self::$fixture->getTestEnvironment();
+
+        $featureFlag = new CliMultiProcessSymfony();
+        $featureFlagConfigName = $featureFlag->getName() . '_feature';
+
         if (self::METHOD_ASYNC_CLI_SYMFONY === $method) {
-            $featureFlag = new CliMultiProcessSymfony();
-
-            $environment = self::$fixture->getTestEnvironment();
-            $environment->overrideConfig(
-                'FeatureFlags',
-                $featureFlag->getName() . '_feature',
-                'enabled'
-            );
-
-            $environment->save();
+            $environment->overrideConfig('FeatureFlags', $featureFlagConfigName, 'enabled');
+        } else {
+            $environment->removeOverriddenConfig('FeatureFlags', $featureFlagConfigName);
         }
+
+        $environment->forceCliMultiViaCurl = (int) (self::METHOD_CURL === $method);
+
+        $environment->save();
     }
 
-    private function startCoreArchiver(): ProcessSymfony
+    private function startCoreArchiver(string $method): ProcessSymfony
     {
         // exec is mandatory to send signals to the process
         // not using array notation because "Fixture::getCliCommandBase" contains parameters
         $process = ProcessSymfony::fromShellCommandline(sprintf(
-            'exec %s core:archive -vvv',
-            Fixture::getCliCommandBase()
+            'exec %s core:archive -vvv %s',
+            Fixture::getCliCommandBase(),
+            self::METHOD_SYNC_CLI === $method ? '--concurrent-requests-per-website=1' : ''
         ));
 
         $process->setEnv([CoreArchiverProcessSignalFixture::ENV_TRIGGER => '1']);
@@ -255,8 +328,11 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
     /**
      * @param array{segment: string, period: string, date: string} $blockSpec
      */
-    private function waitForArchivingToStart(ProcessSymfony $process, array $blockSpec): void
-    {
+    private function waitForArchivingToStart(
+        ProcessSymfony $process,
+        string $method,
+        array $blockSpec
+    ): void {
         $segment = new Segment($blockSpec['segment'], [self::$fixture->idSite]);
         $doneFlag = Rules::getDoneFlagArchiveContainsAllPlugins($segment);
 
@@ -279,14 +355,19 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         self::assertTrue($result, 'Invalidation did not start for: ' . json_encode($blockSpec));
 
         $result = self::$fixture->stepControl->waitForSuccess(
-            static function () use ($process, $blockSpec): bool {
+            static function () use ($process, $method, $blockSpec): bool {
                 $processOutput = $process->getOutput();
 
                 $needles = [
-                    'Running command',
                     'date=' . $blockSpec['date'],
                     'period=' . $blockSpec['period']
                 ];
+
+                if (self::METHOD_CURL === $method) {
+                    $needles[] = 'Execute HTTP API request';
+                } else {
+                    $needles[] = 'Running command';
+                }
 
                 if ('' !== $blockSpec['segment']) {
                     $needles[] = 'segment=' . urlencode($blockSpec['segment']);

--- a/plugins/CoreAdminHome/tests/Integration/Commands/CoreArchiverProcessSignalTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/CoreArchiverProcessSignalTest.php
@@ -18,6 +18,7 @@ use Piwik\Piwik;
 use Piwik\Plugins\CoreAdminHome\Tasks;
 use Piwik\Plugins\CoreAdminHome\tests\Fixtures\CoreArchiverProcessSignal as CoreArchiverProcessSignalFixture;
 use Piwik\Plugins\CoreConsole\FeatureFlags\CliMultiProcessSymfony;
+use Piwik\Plugins\CoreConsole\FeatureFlags\SystemSignals;
 use Piwik\Scheduler\Task;
 use Piwik\Segment;
 use Piwik\Tests\Framework\Fixture;
@@ -428,6 +429,12 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         } else {
             $environment->removeOverriddenConfig('FeatureFlags', $featureFlagConfigName);
         }
+
+        $environment->overrideConfig(
+            'FeatureFlags',
+            (new SystemSignals())->getName() . '_feature',
+            'enabled'
+        );
 
         $environment->forceCliMultiViaCurl = (int) (self::METHOD_CURL === $method);
 

--- a/plugins/CoreAdminHome/tests/Integration/Commands/CoreArchiverProcessSignalTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/CoreArchiverProcessSignalTest.php
@@ -1,0 +1,319 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Integration\Commands;
+
+use Piwik\ArchiveProcessor\Rules;
+use Piwik\CliMulti\ProcessSymfony;
+use Piwik\Common;
+use Piwik\DataAccess\Model;
+use Piwik\Db;
+use Piwik\Piwik;
+use Piwik\Plugins\CoreAdminHome\tests\Fixtures\CoreArchiverProcessSignal as CoreArchiverProcessSignalFixture;
+use Piwik\Plugins\CoreConsole\FeatureFlags\CliMultiProcessSymfony;
+use Piwik\Segment;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Core
+ * @group CoreAdminHome
+ * @group CoreArchiverProcessSignal
+ */
+class CoreArchiverProcessSignalTest extends IntegrationTestCase
+{
+    private const METHOD_ASYNC_CLI_SYMFONY = 'asyncCliSymfony';
+
+    /**
+     * @var CoreArchiverProcessSignalFixture
+     */
+    public static $fixture;
+
+    /**
+     * @var Model
+     */
+    private $dataAccessModel;
+
+    public function setUp(): void
+    {
+        if (!extension_loaded('pcntl') || !function_exists('pcntl_signal')) {
+            $this->markTestSkipped('signal test cannot run without ext-pcntl');
+        }
+
+        parent::setUp();
+
+        self::$fixture->stepControl->reset();
+
+        $this->dataAccessModel = new Model();
+    }
+
+    /**
+     * @dataProvider getArchivingWithoutSignalData
+     */
+    public function testArchivingWithoutSignalWorks(string $method): void
+    {
+        $this->setUpArchivingMethod($method);
+
+        // let archiving run completely
+        $process = $this->startCoreArchiver();
+        $process->setTimeout(60);
+        $process->wait();
+
+        self::assertFalse($process->isRunning());
+
+        $this->assertArchiveInvalidationCount($inProgress = 0, $total = 0);
+
+        $processOutput = $process->getOutput();
+
+        self::assertStringContainsString('Starting archiving for', $processOutput);
+        self::assertStringContainsString('Archived website id 1, period = day', $processOutput);
+        self::assertStringContainsString('Archived website id 1, period = week', $processOutput);
+        self::assertStringContainsString('Archived website id 1, period = month', $processOutput);
+        self::assertStringContainsString('Archived website id 1, period = year', $processOutput);
+        self::assertStringContainsString('Done archiving!', $processOutput);
+        self::assertStringContainsString('Starting Scheduled tasks...', $processOutput);
+    }
+
+    public function getArchivingWithoutSignalData(): iterable
+    {
+        yield 'symfony process' => [self::METHOD_ASYNC_CLI_SYMFONY];
+    }
+
+    /**
+     * @dataProvider getSigintDuringArchivingData
+     *
+     * @param array{segment: string, period: string, date: string} $blockSpec
+     */
+    public function testSigintDuringArchiving(string $method, array $blockSpec): void
+    {
+        self::$fixture->stepControl->blockCronArchiveStart();
+        self::$fixture->stepControl->blockAPIArchiveReports($blockSpec);
+
+        $this->setUpArchivingMethod($method);
+
+        $process = $this->startCoreArchiver();
+
+        self::$fixture->stepControl->unblockCronArchiveStart();
+
+        $this->waitForArchivingToStart($process, $blockSpec);
+        $this->assertArchiveInvalidationCount($inProgress = 1, $total = 12);
+        $this->sendSignalToProcess($process, \SIGINT);
+
+        self::$fixture->stepControl->unblockAPIArchiveReports();
+
+        $this->waitForProcessToStop($process);
+        $this->assertArchivingOutput($process, $method, \SIGINT, $blockSpec);
+        $this->assertArchiveInvalidationCount($inProgress = 0, $total = 11);
+    }
+
+    public function getSigintDuringArchivingData(): iterable
+    {
+        yield 'symfony process' => [
+            'method' => self::METHOD_ASYNC_CLI_SYMFONY,
+            'blockSpec' => ['segment' => '', 'period' => 'day', 'date' => self::$fixture->today],
+        ];
+    }
+
+    /**
+     * @dataProvider getSigtermDuringArchivingData
+     *
+     * @param array{segment: string, period: string, date: string} $blockSpec
+     */
+    public function testSigtermDuringArchiving(string $method, array $blockSpec): void
+    {
+        self::$fixture->stepControl->blockCronArchiveStart();
+        self::$fixture->stepControl->blockAPIArchiveReports($blockSpec);
+
+        $this->setUpArchivingMethod($method);
+
+        $process = $this->startCoreArchiver();
+
+        self::$fixture->stepControl->unblockCronArchiveStart();
+
+        $this->waitForArchivingToStart($process, $blockSpec);
+        $this->assertArchiveInvalidationCount($inProgress = 1, $total = 12);
+        $this->sendSignalToProcess($process, \SIGTERM);
+
+        self::$fixture->stepControl->unblockAPIArchiveReports();
+
+        $this->waitForProcessToStop($process);
+        $this->assertArchivingOutput($process, $method, \SIGTERM, $blockSpec);
+
+        // SIGTERM currently behaves like SIGINT
+        // this should become a "4" when full handling is available
+        $this->assertArchiveInvalidationCount($inProgress = 0, $total = 11);
+    }
+
+    public function getSigtermDuringArchivingData(): iterable
+    {
+        yield 'symfony process' => [
+            'method' => self::METHOD_ASYNC_CLI_SYMFONY,
+            'blockSpec' => ['segment' => '', 'period' => 'day', 'date' => self::$fixture->today],
+        ];
+    }
+
+    private function assertArchiveInvalidationCount(
+        int $expectedInProgress,
+        int $expectedTotal
+    ): void {
+        $actualInProgress = $this->dataAccessModel->getInvalidationsInProgress([self::$fixture->idSite]);
+        $actualTotal = (int) Db::fetchOne(
+            'SELECT COUNT(*) FROM ' . Common::prefixTable('archive_invalidations') . ' WHERE idsite = ?',
+            [self::$fixture->idSite]
+        );
+
+        self::assertSame($expectedTotal, $actualTotal);
+        self::assertCount($expectedInProgress, $actualInProgress);
+    }
+
+    /**
+     * @param array{segment: string, period: string, date: string} $blockSpec
+     */
+    private function assertArchivingOutput(
+        ProcessSymfony $process,
+        string $method,
+        int $signal,
+        array $blockSpec
+    ): void {
+        $idSite = self::$fixture->idSite;
+        $processOutput = $process->getOutput();
+
+        self::assertRegExp('/Running command.*\[method = ' . $method . ']/', $processOutput);
+
+        self::assertStringContainsString('Starting archiving for', $processOutput);
+        self::assertStringContainsString('Trying to stop running cli processes...', $processOutput);
+        self::assertStringContainsString('Archiving will stop now because signal to abort received', $processOutput);
+
+        if (\SIGINT === $signal) {
+            self::assertStringContainsString(sprintf(
+                "Archived website id %u, period = %s, date = %s, segment = '%s'",
+                $idSite,
+                $blockSpec['period'],
+                $blockSpec['date'],
+                $blockSpec['segment']
+            ), $processOutput);
+        }
+    }
+
+    private function sendSignalToProcess(ProcessSymfony $process, int $signal): void
+    {
+        $process->signal($signal);
+
+        $result = self::$fixture->stepControl->waitForSuccess(
+            static function () use ($process, $signal): bool {
+                return false !== strpos(
+                    $process->getOutput(),
+                    'Received system signal to stop archiving: ' . $signal
+                );
+            }
+        );
+
+        self::assertTrue($result, 'Process did not acknowledge signal');
+    }
+
+    private function setUpArchivingMethod(string $method): void
+    {
+        if (self::METHOD_ASYNC_CLI_SYMFONY === $method) {
+            $featureFlag = new CliMultiProcessSymfony();
+
+            $environment = self::$fixture->getTestEnvironment();
+            $environment->overrideConfig(
+                'FeatureFlags',
+                $featureFlag->getName() . '_feature',
+                'enabled'
+            );
+
+            $environment->save();
+        }
+    }
+
+    private function startCoreArchiver(): ProcessSymfony
+    {
+        // exec is mandatory to send signals to the process
+        // not using array notation because "Fixture::getCliCommandBase" contains parameters
+        $process = ProcessSymfony::fromShellCommandline(sprintf(
+            'exec %s core:archive -vvv',
+            Fixture::getCliCommandBase()
+        ));
+
+        $process->setEnv([CoreArchiverProcessSignalFixture::ENV_TRIGGER => '1']);
+        $process->setTimeout(null);
+        $process->start();
+
+        self::assertTrue($process->isRunning());
+        self::assertNotNull($process->getPid());
+
+        return $process;
+    }
+
+    /**
+     * @param array{segment: string, period: string, date: string} $blockSpec
+     */
+    private function waitForArchivingToStart(ProcessSymfony $process, array $blockSpec): void
+    {
+        $segment = new Segment($blockSpec['segment'], [self::$fixture->idSite]);
+        $doneFlag = Rules::getDoneFlagArchiveContainsAllPlugins($segment);
+
+        $result = self::$fixture->stepControl->waitForSuccess(function () use ($doneFlag, $blockSpec): bool {
+            $invalidations = $this->dataAccessModel->getInvalidationsInProgress([self::$fixture->idSite]);
+
+            foreach ($invalidations as $invalidation) {
+                if (
+                    $invalidation['name'] === $doneFlag
+                    && $invalidation['period'] == Piwik::$idPeriods[$blockSpec['period']]
+                    && $invalidation['date1'] == $blockSpec['date']
+                ) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+
+        self::assertTrue($result, 'Invalidation did not start for: ' . json_encode($blockSpec));
+
+        $result = self::$fixture->stepControl->waitForSuccess(
+            static function () use ($process, $blockSpec): bool {
+                $processOutput = $process->getOutput();
+
+                $needles = [
+                    'Running command',
+                    'date=' . $blockSpec['date'],
+                    'period=' . $blockSpec['period']
+                ];
+
+                if ('' !== $blockSpec['segment']) {
+                    $needles[] = 'segment=' . urlencode($blockSpec['segment']);
+                }
+
+                foreach ($needles as $needle) {
+                    if (false === strpos($processOutput, $needle)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        );
+
+        self::assertTrue($result, 'Archiving did not start for: ' . json_encode($blockSpec));
+    }
+
+    private function waitForProcessToStop(ProcessSymfony $process): void
+    {
+        $result = self::$fixture->stepControl->waitForSuccess(static function () use ($process): bool {
+            return !$process->isRunning();
+        });
+
+        self::assertTrue($result, 'Archiving process did not stop');
+        self::assertSame(0, $process->getExitCode());
+    }
+}
+
+CoreArchiverProcessSignalTest::$fixture = new CoreArchiverProcessSignalFixture();

--- a/plugins/CoreAdminHome/tests/Integration/Commands/RunScheduledTasksProcessSignalTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/RunScheduledTasksProcessSignalTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Integration\Commands;
+
+use Piwik\CliMulti\ProcessSymfony;
+use Piwik\Plugins\CoreAdminHome\Tasks;
+use Piwik\Plugins\CoreAdminHome\tests\Fixtures\RunScheduledTasksProcessSignal as RunScheduledTasksProcessSignalFixture;
+use Piwik\Scheduler\Task;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Core
+ * @group CoreAdminHome
+ * @group RunScheduledTasksProcessSignal
+ */
+class RunScheduledTasksProcessSignalTest extends IntegrationTestCase
+{
+    /**
+     * @var RunScheduledTasksProcessSignalFixture
+     */
+    public static $fixture;
+
+    public function setUp(): void
+    {
+        if (!extension_loaded('pcntl') || !function_exists('pcntl_signal')) {
+            $this->markTestSkipped('signal test cannot run without ext-pcntl');
+        }
+
+        parent::setUp();
+
+        self::$fixture->stepControl->reset();
+    }
+
+    /**
+     * @dataProvider getScheduledTasksStoppedData
+     */
+    public function testScheduledTasksStopped(int $signal): void
+    {
+        self::$fixture->stepControl->blockScheduledTasks();
+
+        $process = $this->startScheduledTasks();
+
+        // wait until scheduled tasks are running
+        $result = self::$fixture->stepControl->waitForSuccess(static function () use ($process): bool {
+            return false !== strpos($process->getOutput(), 'Scheduler: executing task');
+        }, $timeoutInSeconds = 30);
+
+        self::assertTrue($result, 'Scheduled tasks did not start');
+
+        $this->sendSignalToProcess($process, $signal);
+
+        self::$fixture->stepControl->unblockScheduledTasks();
+
+        $this->waitForProcessToStop($process);
+
+        $processOutput = $process->getOutput();
+        $expectedExecutedTask = Task::getTaskName(Tasks::class, 'invalidateOutdatedArchives', null);
+        $expectedSkippedTask = Task::getTaskName(Tasks::class, 'purgeOutdatedArchives', null);
+
+        self::assertStringContainsString('executing task ' . $expectedExecutedTask, $processOutput);
+        self::assertStringNotContainsString('executing task ' . $expectedSkippedTask, $processOutput);
+
+        self::assertStringContainsString(
+            'Received system signal to stop scheduled tasks: ' . $signal,
+            $processOutput
+        );
+
+        self::assertStringContainsString('Scheduler: Aborting due to received signal', $processOutput);
+    }
+
+    public function getScheduledTasksStoppedData(): iterable
+    {
+        yield 'stop using sigint' => [\SIGINT];
+        yield 'stop using sigterm' => [\SIGTERM];
+    }
+
+    private function sendSignalToProcess(ProcessSymfony $process, int $signal): void
+    {
+        $process->signal($signal);
+
+        $result = self::$fixture->stepControl->waitForSuccess(
+            static function () use ($process, $signal): bool {
+                return false !== strpos(
+                    $process->getOutput(),
+                    'Received system signal to stop scheduled tasks: ' . $signal
+                );
+            }
+        );
+
+        self::assertTrue($result, 'Process did not acknowledge signal');
+    }
+
+    private function startScheduledTasks(): ProcessSymfony
+    {
+        // exec is mandatory to send signals to the process
+        // not using array notation because "Fixture::getCliCommandBase" contains parameters
+        $process = ProcessSymfony::fromShellCommandline(sprintf(
+            'exec %s scheduled-tasks:run -vvv --force',
+            Fixture::getCliCommandBase()
+        ));
+
+        $process->setEnv([RunScheduledTasksProcessSignalFixture::ENV_TRIGGER => '1']);
+        $process->setTimeout(null);
+        $process->start();
+
+        self::assertTrue($process->isRunning());
+        self::assertNotNull($process->getPid());
+
+        return $process;
+    }
+
+    private function waitForProcessToStop(ProcessSymfony $process): void
+    {
+        $result = self::$fixture->stepControl->waitForSuccess(static function () use ($process): bool {
+            return !$process->isRunning();
+        });
+
+        self::assertTrue($result, 'Archiving process did not stop');
+        self::assertSame(0, $process->getExitCode());
+    }
+}
+
+RunScheduledTasksProcessSignalTest::$fixture = new RunScheduledTasksProcessSignalFixture();

--- a/plugins/CoreAdminHome/tests/Integration/Commands/RunScheduledTasksProcessSignalTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/RunScheduledTasksProcessSignalTest.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\CoreAdminHome\tests\Integration\Commands;
 use Piwik\CliMulti\ProcessSymfony;
 use Piwik\Plugins\CoreAdminHome\Tasks;
 use Piwik\Plugins\CoreAdminHome\tests\Fixtures\RunScheduledTasksProcessSignal as RunScheduledTasksProcessSignalFixture;
+use Piwik\Plugins\CoreConsole\FeatureFlags\SystemSignals;
 use Piwik\Scheduler\Task;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -35,6 +36,14 @@ class RunScheduledTasksProcessSignalTest extends IntegrationTestCase
         }
 
         parent::setUp();
+
+        $environment = self::$fixture->getTestEnvironment();
+        $environment->overrideConfig(
+            'FeatureFlags',
+            (new SystemSignals())->getName() . '_feature',
+            'enabled'
+        );
+        $environment->save();
 
         self::$fixture->stepControl->reset();
     }

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -15,6 +15,26 @@ use Piwik\Site;
 
 class CoreArchiver extends ConsoleCommand
 {
+    /**
+     * @var CronArchive|null
+     */
+    private $archiver = null;
+
+    public function getSystemSignalsToHandle(): array
+    {
+        return [\SIGINT, \SIGTERM];
+    }
+
+    public function handleSystemSignal(int $signal): void
+    {
+        if (null === $this->archiver) {
+            // archiving has not yet started, stop immediately
+            exit;
+        }
+
+        $this->archiver->handleSignal($signal);
+    }
+
     protected function configure()
     {
         $this->configureArchiveCommand($this);
@@ -30,8 +50,8 @@ class CoreArchiver extends ConsoleCommand
             $output->writeln('<comment>' . $message . '</comment>');
         }
 
-        $archiver = $this->makeArchiver($input->getOption('url'));
-        $archiver->main();
+        $this->archiver = $this->makeArchiver($input->getOption('url'));
+        $this->archiver->main();
 
         return self::SUCCESS;
     }

--- a/plugins/CoreConsole/FeatureFlags/SystemSignals.php
+++ b/plugins/CoreConsole/FeatureFlags/SystemSignals.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\CoreConsole\FeatureFlags;
+
+use Piwik\Plugins\FeatureFlags\FeatureFlagInterface;
+
+class SystemSignals implements FeatureFlagInterface
+{
+    public function getName(): string
+    {
+        return 'SystemSignals';
+    }
+}


### PR DESCRIPTION
### Description

Provides handling of `SIGINT` and `SIGTERM` for both `core:archive` and `scheduled-tasks:run`.

#### SIGINT

When receiving `SIGINT`, the current step in the process (currently running archives, current scheduled task) should be completed and then the command should gracefully stop.

#### SIGTERM

When receiving `SIGTERM`, the archiving tries to stop immediately, based on the current step and system capabilities.

Due to the way the default `CliMulti` is implemented, archiving requests made with `curl` or `shell_exec` will still be awaited to completion. Archiving tasks run with `Symfony/Process` will be killed immediately and the invalidation of those are reset to be picked up in the next archiving run.

As scheduled tasks are stopped after the current task is finished, to avoid any timing problems with emails not being sent or being sent too often, or aborted downloads leaving the system in an unplanned state.

### Tests

The behaviour of both signals should have full test coverage, documenting and asserting the way invalidations are handled.

As those tests require interaction with background shell processes, they currently use `Symfony/Process`, though a switch to `proc_open` is possible.

Every step in the tests is safeguarded by timeouts, to not leave zombie processes running if a test fails. For local debugging, depending on where a breakpoint is set (should work through the all shell execution levels), the timeouts can be changed in the implemented `waitForSuccess` helper methods to allow for an indefinite wait. This may require a local process cleanup after the test finishes, as some background tasks (e.g. `CliMulti::executeAsyncCli`) are not stopped with the associated test or `core:archive` process.

Refs DEV-18318

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
