### PR TITLE
Fix diagnostics:analyze-archive-table table output

### DIFF
--- a/core/DataAccess/ArchiveTableDao.php
+++ b/core/DataAccess/ArchiveTableDao.php
@@ -36,14 +36,14 @@ class ArchiveTableDao
      */
     public function getArchiveTableAnalysis($tableDate)
     {
-        $numericQueryEmptyRow = array(
+        $numericQueryEmptyRow = [
             'count_archives' => '-',
             'count_invalidated_archives' => '-',
             'count_temporary_archives' => '-',
             'count_error_archives' => '-',
             'count_segment_archives' => '-',
             'count_numeric_rows' => '-',
-        );
+        ];
 
         $tableDate = str_replace("`", "", $tableDate); // for sanity
 
@@ -80,10 +80,17 @@ class ArchiveTableDao
 
         foreach (Db::fetchAll($sql) as $blobStatsRow) {
             $label = $blobStatsRow['label'];
+
             if (isset($result[$label])) {
                 $result[$label] = array_merge($result[$label], $blobStatsRow);
             } else {
-                $result[$label] = $blobStatsRow + $numericQueryEmptyRow;
+                // ensure rows without numeric entries have the
+                // same internal result array key order
+                $result[$label] = array_merge(
+                    ['label' => $label],
+                    $numericQueryEmptyRow,
+                    $blobStatsRow
+                );
             }
         }
 

--- a/plugins/Diagnostics/Commands/AnalyzeArchiveTable.php
+++ b/plugins/Diagnostics/Commands/AnalyzeArchiveTable.php
@@ -62,14 +62,16 @@ class AnalyzeArchiveTable extends ConsoleCommand
         $totalError = 0;
         $totalSegment = 0;
         $totalBlobLength = 0;
+
         foreach ($rows as $row) {
-            $totalArchives += $row['count_archives'];
-            $totalInvalidated += $row['count_invalidated_archives'];
-            $totalTemporary += $row['count_temporary_archives'];
-            $totalError += $row['count_error_archives'];
-            $totalSegment += $row['count_segment_archives'];
+            $totalArchives += (int) $row['count_archives'];
+            $totalInvalidated += (int) $row['count_invalidated_archives'];
+            $totalTemporary += (int) $row['count_temporary_archives'];
+            $totalError += (int) $row['count_error_archives'];
+            $totalSegment += (int) $row['count_segment_archives'];
+
             if (isset($row['sum_blob_length'])) {
-                $totalBlobLength += $row['sum_blob_length'];
+                $totalBlobLength += (int) $row['sum_blob_length'];
             }
         }
 

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveTableDaoTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveTableDaoTest.php
@@ -217,31 +217,41 @@ class ArchiveTableDaoTest extends IntegrationTestCase
             ),
             '1.2015-01-20.2015-01-20.1' => array(
                 'label' => '1.2015-01-20.2015-01-20.1',
-                'count_blob_rows' => '3',
                 'count_archives' => '-',
                 'count_invalidated_archives' => '-',
                 'count_temporary_archives' => '-',
                 'count_error_archives' => '-',
                 'count_segment_archives' => '-',
                 'count_numeric_rows' => '-',
+                'count_blob_rows' => '3',
                 'sum_blob_length' => '36',
             ),
             '2.2015-01-21.2015-01-21.1' => array(
                 'label' => '2.2015-01-21.2015-01-21.1',
-                'count_blob_rows' => '3',
                 'count_archives' => '-',
                 'count_invalidated_archives' => '-',
                 'count_temporary_archives' => '-',
                 'count_error_archives' => '-',
                 'count_segment_archives' => '-',
                 'count_numeric_rows' => '-',
+                'count_blob_rows' => '3',
                 'sum_blob_length' => '36',
             ),
         );
 
         $actualStats = $this->archiveTableDao->getArchiveTableAnalysis($tableMonth);
 
-        $this->assertEquals($expectedStats, $actualStats);
+        // the type of the "count_blob_rows" column depends on the used PHP
+        // version and database adapter, so we cast it to string first to
+        // have assertSame always give the result we expect
+        foreach ($actualStats as &$actualStat) {
+            $actualStat['count_blob_rows'] = (string) $actualStat['count_blob_rows'];
+        }
+
+        // assertSame ensure array keys have the same internal order,
+        // so the console table displaying this information is placing
+        // each value in the correct column
+        $this->assertSame($expectedStats, $actualStats);
     }
 
     private function insertArchive(


### PR DESCRIPTION
### Description:

The `diagnostics:analyze-archive-table` can produce unexpected output (and warnings), if your instance contains blob archives without an associated numeric archive:

```
+---------------------------------------------+------------+---------------+-------------+---------+-----------+----------------+-------------+-------------+
| Group                                       | # Archives | # Invalidated | # Temporary | # Error | # Segment | # Numeric Rows | # Blob Rows | # Blob Data |
+---------------------------------------------+------------+---------------+-------------+---------+-----------+----------------+-------------+-------------+
| day[2024-01-01 - 2024-01-01] idSite = 1     | 110        | 2663          | -           | -       | -         | -              | -           | -           |
+---------------------------------------------+------------+---------------+-------------+---------+-----------+----------------+-------------+-------------+

> Warning - A non-numeric value encountered - Matomo 5.2.0-alpha - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)
```

In above output we are not looking at 110 archives and 2263 invalidated archives, the values are actually 110 blob rows with a 2663 blob data size.

This happens because the associative array keys are out of order, and the console table is rendered using a regular `for ($x in $y)` loop, without matching the associative keys to the table columns.

Forcing the array to have a defined key order solves this problem (and a type cast prevents the warnings):

```
+---------------------------------------------+------------+---------------+-------------+---------+-----------+----------------+-------------+-------------+
| Group                                       | # Archives | # Invalidated | # Temporary | # Error | # Segment | # Numeric Rows | # Blob Rows | # Blob Data |
+---------------------------------------------+------------+---------------+-------------+---------+-----------+----------------+-------------+-------------+
| day[2024-01-01 - 2024-01-01] idSite = 1     | -          | -             | -           | -       | -         | -              | 110         | 2663        |
+---------------------------------------------+------------+---------------+-------------+---------+-----------+----------------+-------------+-------------+
```

refs #22438

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
