### PR TITLE
Removing getting started menu from MTM

### DIFF
--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -474,7 +474,7 @@ class Controller extends Plugin\ControllerAdmin
             if (!empty($redirectTo) && $redirectTo === 'marketplace') {
                 $this->redirectToIndex('Marketplace', 'overview');
             } elseif (!empty($redirectTo) && $redirectTo === 'tagmanager') {
-                $this->redirectToIndex('TagManager', 'gettingStarted');
+                $this->redirectToIndex('TagManager', 'manageContainers');
             } elseif (!empty($redirectTo) && $redirectTo === 'referrer') {
                 $this->redirectAfterModification($redirectAfter);
             } else {

--- a/plugins/CorePluginsAdmin/tests/UI/TagManagerTeaser_spec.js
+++ b/plugins/CorePluginsAdmin/tests/UI/TagManagerTeaser_spec.js
@@ -63,7 +63,7 @@ describe("TagManagerTeaser", function () {
         await page.type('#login_form_password', superUserPassword);
         await page.click('#login_form_submit');
 
-        await page.waitForSelector('.tagManagerGettingStarted');
+        await page.waitForSelector('.manageContainer');
         await page.waitForNetworkIdle();
         await page.waitForTimeout(250);
 

--- a/plugins/CorePluginsAdmin/tests/UI/expected-screenshots/TagManagerTeaser_super_user_activate_plugin.png
+++ b/plugins/CorePluginsAdmin/tests/UI/expected-screenshots/TagManagerTeaser_super_user_activate_plugin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ffac267901af2d688520fc0a93a89d40306b331c9db67d750eff29274cb2273f
-size 200573
+oid sha256:314ba7fbf008d7e047aae72f68deeb7fbda4aed79d8e6b8b1e5f0ae29c0544c9
+size 57471


### PR DESCRIPTION
### Description:

We are removing the Getting Started page from MTM, so this PR is removing any references to it.

Internal ticket: PG-3564

This is related to, but not dependent on, the following PR: https://github.com/matomo-org/tag-manager/pull/848

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
