### PR TITLE
Make the alert more stern for UninstallConfirm in en.json

### DIFF
--- a/plugins/CorePluginsAdmin/lang/en.json
+++ b/plugins/CorePluginsAdmin/lang/en.json
@@ -83,7 +83,7 @@
         "Themes": "Themes",
         "ThemesDescription": "Themes can change the appearance of Matomo user interface, and provide a completely new visual experience to enjoy your analytics reports.",
         "ThemesManagement": "Manage Themes",
-        "UninstallConfirm": ""UninstallConfirm": "You are about to uninstall a plugin %s. The plugin and all the data it has collected will be completely removed from your platform and it won't be recoverable. Are you sure you want to do this?"",
+        "UninstallConfirm": "You are about to uninstall a plugin %s. The plugin and all the data it has collected will be completely removed from your platform and it won't be recoverable. Are you sure you want to do this?",
         "Version": "Version",
         "ViewAllMarketplacePlugins": "View all Marketplace plugins",
         "WeCouldNotLoadThePluginAsItHasMissingDependencies": "The plugin %1$s could not be loaded as it has missing dependencies: %2$s",

--- a/plugins/CorePluginsAdmin/lang/en.json
+++ b/plugins/CorePluginsAdmin/lang/en.json
@@ -83,7 +83,7 @@
         "Themes": "Themes",
         "ThemesDescription": "Themes can change the appearance of Matomo user interface, and provide a completely new visual experience to enjoy your analytics reports.",
         "ThemesManagement": "Manage Themes",
-        "UninstallConfirm": "You are about to uninstall a plugin %s. The plugin will be completely removed from your platform and it won't be recoverable. Are you sure you want to do this?",
+        "UninstallConfirm": ""UninstallConfirm": "You are about to uninstall a plugin %s. The plugin and all the data it has collected will be completely removed from your platform and it won't be recoverable. Are you sure you want to do this?"",
         "Version": "Version",
         "ViewAllMarketplacePlugins": "View all Marketplace plugins",
         "WeCouldNotLoadThePluginAsItHasMissingDependencies": "The plugin %1$s could not be loaded as it has missing dependencies: %2$s",


### PR DESCRIPTION
(Doing this after a customer accidentally deleted their data.)

### Description:

In this minor edit, I added the words "and all the data it has collected..."

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
