### PR TITLE
Add supported read isolation level to schema interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 
 ## Deprecations
 
-The methods `Db::isOptimizeInnoDBSupported` and `Db::optimizeTables` have been deprecated. Use `Db\Schema::getInstance()->isOptimizeInnoDBSupported` and `Db\Schema::getInstance()->optimizeTables` instead
+* The methods `Db::isOptimizeInnoDBSupported`, `Db::optimizeTables` have been deprecated. Use `Db\Schema::getInstance()->isOptimizeInnoDBSupported` and `Db\Schema::getInstance()->optimizeTables` instead
+* The method `TransactionLevel::setUncommitted` has been deprecated. Use `TransactionLevel::setTransactionLevelForNonLockingReads` instead
 
 ## Matomo 5.1.0
 

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -307,7 +307,7 @@ class LogAggregator
             // set uncommitted is easily noticeable in the code as it could be missed quite easily otherwise
             // we set uncommitted so we don't make the INSERT INTO... SELECT... locking ... we do not want to lock
             // eg the visits table
-            if (!$transactionLevel->setUncommitted()) {
+            if (!$transactionLevel->setTransactionLevelForNonLockingReads()) {
                 $canSetTransactionLevel = false;
             }
         }

--- a/core/Db/Schema.php
+++ b/core/Db/Schema.php
@@ -290,4 +290,17 @@ class Schema extends Singleton
     {
         return $this->getSchema()->supportsSortingInSubquery();
     }
+
+    /**
+     * Returns the supported read isolation transaction level
+     *
+     * For example:
+     *      READ COMMITTED
+     *      or
+     *      READ UNCOMMITTED
+     */
+    public function getSupportedReadIsolationTransactionLevel(): string
+    {
+        return $this->getSchema()->getSupportedReadIsolationTransactionLevel();
+    }
 }

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -757,6 +757,11 @@ class Mysql implements SchemaInterface
         return true;
     }
 
+    public function getSupportedReadIsolationTransactionLevel(): string
+    {
+        return 'READ UNCOMMITTED';
+    }
+
     protected function getDatabaseCreateOptions(): string
     {
         $charset = DbHelper::getDefaultCharset();

--- a/core/Db/Schema/Tidb.php
+++ b/core/Db/Schema/Tidb.php
@@ -68,6 +68,12 @@ class Tidb extends Mysql
         return false;
     }
 
+    public function getSupportedReadIsolationTransactionLevel(): string
+    {
+        // TiDB doesn't support READ UNCOMMITTED
+        return 'READ COMMITTED';
+    }
+
     protected function getDatabaseCreateOptions(): string
     {
         $charset = DbHelper::getDefaultCharset();

--- a/core/Db/SchemaInterface.php
+++ b/core/Db/SchemaInterface.php
@@ -70,6 +70,16 @@ interface SchemaInterface
     public function getInstallVersion();
 
     /**
+     * Returns the supported read isolation transaction level
+     *
+     * For example:
+     *      READ COMMITTED
+     *      or
+     *      READ UNCOMMITTED
+     */
+    public function getSupportedReadIsolationTransactionLevel(): string;
+
+    /**
      * Truncate all tables
      */
     public function truncateAllTables();

--- a/core/Db/TransactionLevel.php
+++ b/core/Db/TransactionLevel.php
@@ -57,7 +57,8 @@ class TransactionLevel
         }
 
         try {
-            $this->db->query('SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED');
+            $this->db->query('SET SESSION TRANSACTION ISOLATION LEVEL ' . Schema::getInstance()->getSupportedReadIsolationTransactionLevel());
+
             $this->statusBackup = $backup;
 
             if ($this->db->supportsUncommitted === null) {

--- a/core/Db/TransactionLevel.php
+++ b/core/Db/TransactionLevel.php
@@ -39,14 +39,14 @@ class TransactionLevel
     }
 
     /**
-     * @deprecated Use `setReadIsolationLevel`
+     * @deprecated Use `setTransactionLevelForNonLockingReads`
      */
     public function setUncommitted()
     {
-        return $this->setReadIsolationLevel();
+        return $this->setTransactionLevelForNonLockingReads();
     }
 
-    public function setReadIsolationLevel(): bool
+    public function setTransactionLevelForNonLockingReads(): bool
     {
         if ($this->db->supportsUncommitted === false) {
             // we know "Uncommitted" transaction level is not supported, we don't need to do anything as it won't work to set the status

--- a/core/Db/TransactionLevel.php
+++ b/core/Db/TransactionLevel.php
@@ -38,7 +38,15 @@ class TransactionLevel
         return strtolower($dbSettings->getEngine()) === 'innodb';
     }
 
+    /**
+     * @deprecated Use `setReadIsolationLevel`
+     */
     public function setUncommitted()
+    {
+        return $this->setReadIsolationLevel();
+    }
+
+    public function setReadIsolationLevel(): bool
     {
         if ($this->db->supportsUncommitted === false) {
             // we know "Uncommitted" transaction level is not supported, we don't need to do anything as it won't work to set the status

--- a/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
@@ -181,7 +181,7 @@ class DatabaseAbilitiesCheck implements Diagnostic
         $comment = 'Changing transaction isolation level';
 
         $level = new Db\TransactionLevel(Db::getReader());
-        if (!$level->setUncommitted()) {
+        if (!$level->setTransactionLevelForNonLockingReads()) {
             $status = DiagnosticResult::STATUS_WARNING;
             $comment .= '<br/>' . $this->translator->translate('Diagnostics_MysqlTransactionLevel');
         } else {

--- a/plugins/PrivacyManager/LogDataPurger.php
+++ b/plugins/PrivacyManager/LogDataPurger.php
@@ -70,7 +70,7 @@ class LogDataPurger
         $dateUpperLimit = Date::factory("today")->subDay($deleteLogsOlderThan);
 
         $transactionLevel = new TransactionLevel(Db::get());
-        $transactionLevel->setUncommitted();
+        $transactionLevel->setTransactionLevelForNonLockingReads();
 
         $this->logDeleter->deleteVisitsFor($start = null, $dateUpperLimit->getDatetime());
 

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -425,6 +425,8 @@ class LogAggregatorTest extends IntegrationTestCase
 
         $this->logAggregator->generateQuery('test, test2', 'log_visit', '1=1', false, '5');
 
+        $this->setSqlRequirePrimaryKeySetting(0);
+
         $this->assertTrue($db->supportsUncommitted);
     }
 

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -15,6 +15,7 @@ use Piwik\Config\DatabaseConfig;
 use Piwik\Common;
 use Piwik\DataAccess\LogAggregator;
 use Piwik\Date;
+use Piwik\Db;
 use Piwik\Db\Schema;
 use Piwik\Period;
 use Piwik\Segment;
@@ -406,6 +407,25 @@ class LogAggregatorTest extends IntegrationTestCase
             )
         );
         $this->assertSame($expected, $query);
+    }
+
+    public function testGenerateQuerySwitchesSupportsUncommittedToTrueWhenSupports()
+    {
+        $segment = new Segment('userId==1111', array($this->site->getId()));
+
+        $params = new Parameters($this->site, $this->period, $segment);
+        $this->logAggregator = new LogAggregator($params);
+        $this->logAggregator->allowUsageSegmentCache();
+
+        $this->setSqlRequirePrimaryKeySetting(1);
+
+        $db = Db::get();
+
+        $db->supportsUncommitted = null;
+
+        $this->logAggregator->generateQuery('test, test2', 'log_visit', '1=1', false, '5');
+
+        $this->assertTrue($db->supportsUncommitted);
     }
 
     public function testGetSegmentTmpTableName()

--- a/tests/PHPUnit/Integration/Db/TransactionLevelTest.php
+++ b/tests/PHPUnit/Integration/Db/TransactionLevelTest.php
@@ -43,7 +43,7 @@ class TransactionLevelTest extends IntegrationTestCase
         $this->assertTrue($this->level->canLikelySetTransactionLevel());
     }
 
-    public function testSetReadIsolationLevelRestorePreviousStatus()
+    public function testSetTransactionLevelForNonLockingReadsRestorePreviousStatus()
     {
         // mysql 8.0 using transaction_isolation
         $isolation = $this->db->fetchOne("SHOW GLOBAL VARIABLES LIKE 't%_isolation'");
@@ -52,7 +52,7 @@ class TransactionLevelTest extends IntegrationTestCase
         $value = $this->db->fetchOne('SELECT ' . $isolation);
         $this->assertSame('REPEATABLE-READ', $value);
 
-        $this->level->setReadIsolationLevel();
+        $this->level->setTransactionLevelForNonLockingReads();
         $value = $this->db->fetchOne('SELECT ' . $isolation);
 
         $expectedIsolation = str_replace(' ', '-', Schema::getInstance()->getSupportedReadIsolationTransactionLevel());

--- a/tests/PHPUnit/Integration/Db/TransactionLevelTest.php
+++ b/tests/PHPUnit/Integration/Db/TransactionLevelTest.php
@@ -43,7 +43,7 @@ class TransactionLevelTest extends IntegrationTestCase
         $this->assertTrue($this->level->canLikelySetTransactionLevel());
     }
 
-    public function testSetUncommittedRestorePreviousStatus()
+    public function testSetReadIsolationLevelRestorePreviousStatus()
     {
         // mysql 8.0 using transaction_isolation
         $isolation = $this->db->fetchOne("SHOW GLOBAL VARIABLES LIKE 't%_isolation'");
@@ -52,7 +52,7 @@ class TransactionLevelTest extends IntegrationTestCase
         $value = $this->db->fetchOne('SELECT ' . $isolation);
         $this->assertSame('REPEATABLE-READ', $value);
 
-        $this->level->setUncommitted();
+        $this->level->setReadIsolationLevel();
         $value = $this->db->fetchOne('SELECT ' . $isolation);
 
         $expectedIsolation = str_replace(' ', '-', Schema::getInstance()->getSupportedReadIsolationTransactionLevel());

--- a/tests/PHPUnit/Integration/Db/TransactionLevelTest.php
+++ b/tests/PHPUnit/Integration/Db/TransactionLevelTest.php
@@ -10,6 +10,7 @@
 namespace Piwik\Tests\Integration\Db;
 
 use Piwik\Db;
+use Piwik\Db\Schema;
 use Piwik\Db\TransactionLevel;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -54,7 +55,8 @@ class TransactionLevelTest extends IntegrationTestCase
         $this->level->setUncommitted();
         $value = $this->db->fetchOne('SELECT ' . $isolation);
 
-        $this->assertSame('READ-UNCOMMITTED', $value);
+        $expectedIsolation = str_replace(' ', '-', Schema::getInstance()->getSupportedReadIsolationTransactionLevel());
+        $this->assertSame($expectedIsolation, $value);
         $this->level->restorePreviousStatus();
 
         $value = $this->db->fetchOne('SELECT ' . $isolation);

--- a/tests/PHPUnit/Unit/DeprecatedMethodsTest.php
+++ b/tests/PHPUnit/Unit/DeprecatedMethodsTest.php
@@ -91,6 +91,7 @@ class DeprecatedMethodsTest extends \PHPUnit\Framework\TestCase
         $this->assertDeprecatedMethodIsRemovedInMatomo6('Piwik\Plugins\Overlay\API', 'getExcludedQueryParameters');
         $this->assertDeprecatedMethodIsRemovedInMatomo6('Piwik\Db', 'isOptimizeInnoDBSupported');
         $this->assertDeprecatedMethodIsRemovedInMatomo6('Piwik\Db', 'optimizeTables');
+        $this->assertDeprecatedMethodIsRemovedInMatomo6('Piwik\Db\TransactionLevel', 'setUncommitted');
     }
 
 


### PR DESCRIPTION
### Description:

TiDB doesn't support `READ_UNCOMMITTED`, I've added this variance to the schema.

To make sure it works, a test has been added to the LogAggregator making sure the `supportsUncommitted` doesn't switch to `false` but instead `true`

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
