### PR TITLE
Extend CliMulti to support using symfony/process

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
         "symfony/monolog-bridge": "~5.4.0",
         "symfony/polyfill-iconv": "^1.20",
         "symfony/polyfill-mbstring": "^1.20",
+        "symfony/process": "~5.4.0",
         "szymach/c-pchart": "~3.0.13",
         "tecnickcom/tcpdf": "~6.0",
         "tedivm/jshrink": "~v1.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c2227527db4c5adbbbad7d19fe07903",
+    "content-hash": "48a6fdae53f1ce9d920dd673ae5eb2d1",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3015,6 +3015,68 @@
                 }
             ],
             "time": "2024-06-19T12:30:46+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.4.40",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "deedcb3bb4669cae2148bc920eafd2b16dc7c046"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/deedcb3bb4669cae2148bc920eafd2b16dc7c046",
+                "reference": "deedcb3bb4669cae2148bc920eafd2b16dc7c046",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.4.40"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T14:33:22+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -471,7 +471,14 @@ class CliMulti
         $hostname = Url::getHost($checkIfTrusted = false);
         $command = $this->buildCommand($hostname, $query, $output->getPathToFile());
 
-        $this->logger->debug("Running command: {command}", ['command' => $command]);
+        $this->logger->debug(
+            'Running command: {command} [method = {method}]',
+            [
+                'command' => $command,
+                'method' => 'asyncCli',
+            ]
+        );
+
         shell_exec($command);
     }
 
@@ -482,7 +489,13 @@ class CliMulti
         $hostname = Url::getHost($checkIfTrusted = false);
         $command = $this->buildCommand($hostname, $query, '', true);
 
-        $this->logger->debug("Running command: {command}", ['command' => $command]);
+        $this->logger->debug(
+            'Running command: {command} [method = {method}]',
+            [
+                'command' => $command,
+                'method' => 'asyncCliSymfony',
+            ]
+        );
 
         // Prepending "exec" is required to send signals to the process
         // Not using array notation because $command can contain complex parameters
@@ -505,7 +518,14 @@ class CliMulti
         $hostname = Url::getHost($checkIfTrusted = false);
         $command = $this->buildCommand($hostname, $query, '', true);
 
-        $this->logger->debug("Running command: {command}", ['command' => $command]);
+        $this->logger->debug(
+            'Running command: {command} [method = {method}]',
+            [
+                'command' => $command,
+                'method' => 'syncCli',
+            ]
+        );
+
         $result = shell_exec($command);
         if ($result) {
             $result = trim($result);

--- a/core/CliMulti/ProcessSymfony.php
+++ b/core/CliMulti/ProcessSymfony.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\CliMulti;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Wrapper for Symfony Process class
+ */
+class ProcessSymfony extends Process
+{
+    /**
+     * @var string|null
+     */
+    private $commandId;
+
+    public function getCommandId(): ?string
+    {
+        return $this->commandId;
+    }
+
+    public function setCommandId(string $commandId): void
+    {
+        $this->commandId = $commandId;
+    }
+}

--- a/core/CliMulti/ProcessSymfony.php
+++ b/core/CliMulti/ProcessSymfony.php
@@ -9,7 +9,7 @@
 
 namespace Piwik\CliMulti;
 
-use Symfony\Component\Process\Process;
+use Piwik\Process;
 
 /**
  * Wrapper for Symfony Process class

--- a/core/Process.php
+++ b/core/Process.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik;
+
+use Symfony\Component\Process\Process as SymfonyProcess;
+
+/**
+ * Wrapper for Symfony process class
+ */
+class Process extends SymfonyProcess
+{
+    //
+}

--- a/plugins/CoreConsole/FeatureFlags/CliMultiProcessSymfony.php
+++ b/plugins/CoreConsole/FeatureFlags/CliMultiProcessSymfony.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\CoreConsole\FeatureFlags;
+
+use Piwik\Plugins\FeatureFlags\FeatureFlagInterface;
+
+class CliMultiProcessSymfony implements FeatureFlagInterface
+{
+    public function getName(): string
+    {
+        return 'CliMultiProcessSymfony';
+    }
+}

--- a/tests/PHPUnit/Framework/Mock/TestLogger.php
+++ b/tests/PHPUnit/Framework/Mock/TestLogger.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Piwik\Tests\Framework\Mock;
+
+use Piwik\Log\LoggerInterface;
+use Psr\Log\Test\TestLogger as PsrTestLogger;
+
+class TestLogger extends PsrTestLogger implements LoggerInterface
+{
+    // provide PSR TestLogger as Piwik\LoggerInterface type
+}

--- a/tests/PHPUnit/System/CliMultiTest.php
+++ b/tests/PHPUnit/System/CliMultiTest.php
@@ -61,6 +61,10 @@ class CliMultiTest extends SystemTestCase
         );
 
         \Piwik\Common::$isCliMode = true;
+
+        // deactivate symfony process usage by default
+        // required as local instance could have activated the feature flag
+        $this->cliMulti->supportsAsyncSymfony = false;
     }
 
     public function testRequestShouldNotFailAndReturnNoResponseIfNoUrlsAreGiven()
@@ -200,6 +204,18 @@ class CliMultiTest extends SystemTestCase
         $urls = $this->buildUrls('getPiwikVersion', 'getAnswerToLife', 'getPiwikVersion');
 
         $this->assertRequestReturnsValidResponses($urls, array('getPiwikVersion', 'getAnswerToLife', 'getPiwikVersion'));
+    }
+
+    public function testShouldRunWithSymfonyProcessIfDetected(): void
+    {
+        $this->cliMulti->supportsAsyncSymfony = true;
+
+        $urls = $this->buildUrls('getPiwikVersion', 'getAnswerToLife', 'getPiwikVersion');
+
+        $this->assertRequestReturnsValidResponses(
+            $urls,
+            ['getPiwikVersion', 'getAnswerToLife', 'getPiwikVersion']
+        );
     }
 
     public function testCleanupNotRemovedFilesShouldOnlyRemoveFilesIfTheyAreOlderThanOneWeek()


### PR DESCRIPTION
#### Relevant references

With #22394 we plan to use a database based approach to not archive a segment/period more than once. This will introduce a problem with long running archiving processes and server restarts/deployments, because a forced stop of an archiving process can no longer be "rescued" by a higher period archiving process. The stopped invalidation will prevent any further archiving until it is detected as broken and retried (by default after 24 hours).

With #22487 we plan to introduce signal handling into the archiving process to prevent mentioned problems. The intent is to support "stop the current archive after receiving SIGINT" and "abort the current archive after receiving SIGTERM, reset that invalidation so it does not stall archiving".

### CliMulti and OS signal handling

The `CliMulti` implementation received a performance improvement in #18157, using a synchronous `shell_exec` instead of the concurrent background process implementation, if only a single request is done.

A single `shell_exec` can not be intercepted with the features `ext-pcntl` provides, and with archives being able to take hours to complete, we can not provide our planned `SIGTERM` handling without changes. Having a server wait for hours to allow a clean shutdown of the archiving run would match our planned `SIGINT` handling, but `SIGTERM` should allow for an immediate shutdown. Especially when using costly cloud provider instances.

One way to solve our problem would be to revert the #18157 improvement, it would work ([test implementation](https://github.com/matomo-org/matomo/commit/9a75dc0b02ca79976c6a448af6cf866e695a1cc2), [CI run](https://github.com/matomo-org/matomo/actions/runs/10377298266/)) for our use case.

#### Symfony/Process alternative

This PR provides the alternative route of integrating `symfony/process` to replace our custom `shell_exec` implementation. Symfony is using `proc_open` instead of `shell_exec`, and should have a lower footprint compared to the custom output pipe/file handling used by `CliMulti`.

Some noteworthy details on the PR implementation:

- The `VisitorGenerator` tests fail because `symfony/process` is already integrated there. Should be taken care of if we decide to go with the approach of this PR
- The UI OneClickUpdate tests have some issues ([example run](https://github.com/matomo-org/matomo/actions/runs/10373024309/job/28717156383#step:3:1143)) with the new package and the location it is used in. It could be a quirk in the UI test setup itself, but needs further investigation to prevent problems with an actual upgrade.
- The symfony package support detection in `CliMulti` is using a feature flag and is quite defensive. This should allow us to work around any problems in the update process, with the current implementation taking over gracefully.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
