### PR TITLE
Ensure process list isn't cut of when looking for running processes

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -25,7 +25,7 @@ use Piwik\SettingsServer;
  */
 class Process
 {
-    public const PS_COMMAND = 'ps x';
+    public const PS_COMMAND = 'ps wwx';
     public const AWK_COMMAND = 'awk \'! /defunct/ {print $1}\'';
 
     private $finished = null;


### PR DESCRIPTION
### Description:

The line length limit of `ps x` is system dependent and it might be cut off after a certain limit.
When looking for running archive jobs this can cause problems if the part we are looking for is cut off.
Using `ww` output modifier will ensure the lines aren't cut off.

fixes #22508
fixes #21985

(Ref DEV-17826)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
