### PR TITLE
Skip invalidating segments for today if flag is provided

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -284,8 +284,7 @@ class Archive implements ArchiveQuery
     public static function shouldSkipArchiveIfSkippingSegmentArchiveForToday(Site $site, Period $period, Segment $segment)
     {
         $now = Date::factory('now', $site->getTimezone());
-        return $period->getLabel() === 'day'
-            && !$segment->isEmpty()
+        return !$segment->isEmpty()
             && $period->getDateStart()->toString() === $now->toString();
     }
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -972,15 +972,18 @@ class CronArchive
                 );
             }
 
-            if ($skipSegments) {
-                continue;
-            }
+            $allSegments = $this->segmentArchiving->getAllSegments();
 
             foreach ($this->segmentArchiving->getAllSegmentsToArchive($idSite) as $segmentDefinition) {
                // check if the segment is available
                 if (!$this->isSegmentAvailable($segmentDefinition, [$idSite])) {
                     continue;
                 }
+
+                if ($skipSegments && !$this->wasSegmentChangedRecently($segmentDefinition, $allSegments)) {
+                    continue;
+                }
+
                 $segmentObj = new Segment(
                     $segmentDefinition,
                     [$idSite],

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -914,12 +914,12 @@ class CronArchive
             'date' => $date->getDatetime(),
         ]);
 
-        $skipSegments = $this->archiveFilter->isSkipSegmentsForToday() && $isToday;
+        $onlyProcessSegmentsChangedRecently = $this->archiveFilter->isSkipSegmentsForToday() && $isToday;
 
         // if we are invalidating yesterday here, we are only interested in checking if there is no archive for yesterday, or the day has changed since
         // the last archive was archived (in which there may have been more visits before midnight). so we disable the ttl check, since any archive
         // will be good enough, if the date hasn't changed.
-        $this->invalidateWithSegments([$idSite], $date->toString(), 'day', false, $isYesterday, $isYesterday, $skipSegments);
+        $this->invalidateWithSegments([$idSite], $date->toString(), 'day', false, $isYesterday, $isYesterday, $onlyProcessSegmentsChangedRecently);
     }
 
     private function invalidateWithSegments(
@@ -929,7 +929,7 @@ class CronArchive
         $_forceInvalidateNonexistent = false,
         $doNotIncludeTtlInExistingArchiveCheck = false,
         bool $skipWhenAlreadyRunning = false,
-        bool $skipSegments = false
+        bool $onlyProcessSegmentsChangedRecently = false
     ) {
         if ($date instanceof Date) {
             $date = $date->toString();
@@ -980,7 +980,7 @@ class CronArchive
                     continue;
                 }
 
-                if ($skipSegments && !$this->wasSegmentChangedRecently($segmentDefinition, $allSegments)) {
+                if ($onlyProcessSegmentsChangedRecently && !$this->wasSegmentChangedRecently($segmentDefinition, $allSegments)) {
                     continue;
                 }
 

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -846,8 +846,13 @@ class CronArchiveTest extends IntegrationTestCase
             1, 1, $period::PERIOD_ID, $period->getDateStart()->toString(), $period->getDateEnd()->toString(), 'done', $archiveStatus, $tsArchived
         ]);
 
-        // $doNotIncludeTtlInExistingArchiveCheck is set to true when running invalidateRecentDate('yesterday');
-        $actual = $archiver->canWeSkipInvalidatingBecauseThereIsAUsablePeriod($params, $dayToArchive === 'yesterday');
+        // $skipWhenRunningOrNewEnoughArchiveExists is set to true when running invalidateRecentDate('yesterday');
+
+        $class = new \ReflectionClass(CronArchive::class);
+        $method = $class->getMethod('canWeSkipInvalidatingBecauseThereIsAUsablePeriod');
+        $method->setAccessible(true);
+
+        $actual = $method->invoke($archiver, $params, $dayToArchive === 'yesterday');
         $this->assertSame($expected, $actual);
     }
 
@@ -1189,6 +1194,7 @@ class CronArchiveTest extends IntegrationTestCase
 
         self::assertStringContainsString('Will skip segments archiving for today unless they were created recently', $logger->output);
     }
+
     public function testInvalidatingYesterdayWillStillRequestSegmentInvalidationsWithSkipSegmentsToday()
     {
         Date::$now = strtotime('2020-08-05 09:00:00');


### PR DESCRIPTION
### Description:

The `core:archive` command provides a flag `--skip-segments-today`, which prevents segments data from being processed for today.

The currently implementation only prevents them from being processed. But invalidation done for today before archiving is started is currently done anyway. This causes also the higher periods (week, month, year) to be invalidated. But as only today is prevented from being archived for segments, those higher periods will be reprocessed anyway, even if there actually were no changes in lower periods. 

To prevent this unnecessary archiving of those higher periods, this PR changes the behavior of the initial invalidation. If `--skip-segments-today` is provided, we will no longer create invalidations for segments for today (and periods including this day).
This shouldn't cause any problems even if the flag is used always when archiving is triggered, as `yesterday` will still be invalidated for segments.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
