### PR TITLE
Skip invalidating segments for today if flag is provided

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -284,8 +284,7 @@ class Archive implements ArchiveQuery
     public static function shouldSkipArchiveIfSkippingSegmentArchiveForToday(Site $site, Period $period, Segment $segment)
     {
         $now = Date::factory('now', $site->getTimezone());
-        return $period->getLabel() === 'day'
-            && !$segment->isEmpty()
+        return !$segment->isEmpty()
             && $period->getDateStart()->toString() === $now->toString();
     }
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -922,12 +922,12 @@ class CronArchive
             'date' => $date->getDatetime(),
         ]);
 
-        $skipSegments = $this->archiveFilter->isSkipSegmentsForToday() && $isToday;
+        $onlyProcessSegmentsChangedRecently = $this->archiveFilter->isSkipSegmentsForToday() && $isToday;
 
         // if we are invalidating yesterday here, we are only interested in checking if there is no archive for yesterday, or the day has changed since
         // the last archive was archived (in which there may have been more visits before midnight). so we disable the ttl check, since any archive
         // will be good enough, if the date hasn't changed.
-        $this->invalidateWithSegments([$idSite], $date->toString(), 'day', false, $isYesterday, $isYesterday, $skipSegments);
+        $this->invalidateWithSegments([$idSite], $date->toString(), 'day', false, $isYesterday, $isYesterday, $onlyProcessSegmentsChangedRecently);
     }
 
     private function invalidateWithSegments(
@@ -937,7 +937,7 @@ class CronArchive
         $_forceInvalidateNonexistent = false,
         $doNotIncludeTtlInExistingArchiveCheck = false,
         bool $skipWhenAlreadyRunning = false,
-        bool $skipSegments = false
+        bool $onlyProcessSegmentsChangedRecently = false
     ) {
         if ($date instanceof Date) {
             $date = $date->toString();
@@ -988,7 +988,7 @@ class CronArchive
                     continue;
                 }
 
-                if ($skipSegments && !$this->wasSegmentChangedRecently($segmentDefinition, $allSegments)) {
+                if ($onlyProcessSegmentsChangedRecently && !$this->wasSegmentChangedRecently($segmentDefinition, $allSegments)) {
                     continue;
                 }
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -980,15 +980,18 @@ class CronArchive
                 );
             }
 
-            if ($skipSegments) {
-                continue;
-            }
+            $allSegments = $this->segmentArchiving->getAllSegments();
 
             foreach ($this->segmentArchiving->getAllSegmentsToArchive($idSite) as $segmentDefinition) {
                // check if the segment is available
                 if (!$this->isSegmentAvailable($segmentDefinition, [$idSite])) {
                     continue;
                 }
+
+                if ($skipSegments && !$this->wasSegmentChangedRecently($segmentDefinition, $allSegments)) {
+                    continue;
+                }
+
                 $segmentObj = new Segment(
                     $segmentDefinition,
                     [$idSite],

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -916,6 +916,7 @@ class CronArchive
         }
 
         $isYesterday = $dateStr === 'yesterday';
+        $isToday = $dateStr === 'today';
         if ($isYesterday) {
             // Skip invalidation for yesterday if archiving for yesterday was already started after midnight in site's timezone
             $invalidationsInProgress = $this->model->getInvalidationsInProgress($idSite);
@@ -938,13 +939,15 @@ class CronArchive
             'date' => $date->getDatetime(),
         ]);
 
+        $skipSegments = $this->archiveFilter->isSkipSegmentsForToday() && $isToday;
+
         // if we are invalidating yesterday here, we are only interested in checking if there is no archive for yesterday, or the day has changed since
         // the last archive was archived (in which there may have been more visits before midnight). so we disable the ttl check, since any archive
         // will be good enough, if the date hasn't changed.
-        $this->invalidateWithSegments([$idSite], $date->toString(), 'day', false, $doNotIncludeTtlInExistingArchiveCheck = $isYesterday);
+        $this->invalidateWithSegments([$idSite], $date->toString(), 'day', false, $doNotIncludeTtlInExistingArchiveCheck = $isYesterday, $skipSegments);
     }
 
-    private function invalidateWithSegments($idSites, $date, $period, $_forceInvalidateNonexistent = false, $doNotIncludeTtlInExistingArchiveCheck = false)
+    private function invalidateWithSegments($idSites, $date, $period, $_forceInvalidateNonexistent = false, $doNotIncludeTtlInExistingArchiveCheck = false, bool $skipSegments = false)
     {
         if ($date instanceof Date) {
             $date = $date->toString();
@@ -983,6 +986,10 @@ class CronArchive
                     $cascadeDown = false,
                     $_forceInvalidateNonexistent
                 );
+            }
+
+            if ($skipSegments) {
+                continue;
             }
 
             foreach ($this->segmentArchiving->getAllSegmentsToArchive($idSite) as $segmentDefinition) {

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -27,7 +27,6 @@ use Piwik\DataAccess\ArchiveSelector;
 use Piwik\DataAccess\Model;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Metrics\Formatter;
-use Piwik\Period\Day;
 use Piwik\Period\Factory as PeriodFactory;
 use Piwik\CronArchive\SegmentArchiving;
 use Piwik\Period\Range;
@@ -917,22 +916,6 @@ class CronArchive
 
         $isYesterday = $dateStr === 'yesterday';
         $isToday = $dateStr === 'today';
-        if ($isYesterday) {
-            // Skip invalidation for yesterday if archiving for yesterday was already started after midnight in site's timezone
-            $invalidationsInProgress = $this->model->getInvalidationsInProgress($idSite);
-            $today = Date::factoryInTimezone('today', $timezone);
-
-            foreach ($invalidationsInProgress as $invalidation) {
-                if (
-                    $invalidation['period'] == Day::PERIOD_ID
-                    && $date->toString() === $invalidation['date1']
-                    && Date::factory($invalidation['ts_started'], $timezone)->getTimestamp() >= $today->getTimestamp()
-                ) {
-                    $this->logger->debug("  " . ucfirst($dateStr) . " archive already in process for idSite = $idSite, skipping invalidation...");
-                    return;
-                }
-            }
-        }
 
         $this->logger->info("  Will invalidate archived reports for $dateStr in site ID = {idSite}'s timezone ({date}).", [
             'idSite' => $idSite,
@@ -944,11 +927,18 @@ class CronArchive
         // if we are invalidating yesterday here, we are only interested in checking if there is no archive for yesterday, or the day has changed since
         // the last archive was archived (in which there may have been more visits before midnight). so we disable the ttl check, since any archive
         // will be good enough, if the date hasn't changed.
-        $this->invalidateWithSegments([$idSite], $date->toString(), 'day', false, $doNotIncludeTtlInExistingArchiveCheck = $isYesterday, $skipSegments);
+        $this->invalidateWithSegments([$idSite], $date->toString(), 'day', false, $isYesterday, $isYesterday, $skipSegments);
     }
 
-    private function invalidateWithSegments($idSites, $date, $period, $_forceInvalidateNonexistent = false, $doNotIncludeTtlInExistingArchiveCheck = false, bool $skipSegments = false)
-    {
+    private function invalidateWithSegments(
+        $idSites,
+        $date,
+        $period,
+        $_forceInvalidateNonexistent = false,
+        $doNotIncludeTtlInExistingArchiveCheck = false,
+        bool $skipWhenAlreadyRunning = false,
+        bool $skipSegments = false
+    ) {
         if ($date instanceof Date) {
             $date = $date->toString();
         }
@@ -977,6 +967,8 @@ class CronArchive
             );
             if ($this->canWeSkipInvalidatingBecauseThereIsAUsablePeriod($params, $doNotIncludeTtlInExistingArchiveCheck)) {
                 $this->logger->debug('  Found usable archive for {archive}, skipping invalidation.', ['archive' => $params]);
+            } elseif ($skipWhenAlreadyRunning && $this->canWeSkipInvalidatingBecauseInvalidationAlreadyInProgress($site->getId(), $periodObj)) {
+                $this->logger->debug('  Invalidation for {archive} already in progress, skipping invalidation.', ['archive' => $params]);
             } else {
                 $this->getApiToInvalidateArchivedReport()->invalidateArchivedReports(
                     $idSite,
@@ -997,18 +989,21 @@ class CronArchive
                 if (!$this->isSegmentAvailable($segmentDefinition, [$idSite])) {
                     continue;
                 }
+                $segmentObj = new Segment(
+                    $segmentDefinition,
+                    [$idSite],
+                    $periodObj->getDateTimeStart()->setTimezone($site->getTimezone()),
+                    $periodObj->getDateTimeEnd()->setTimezone($site->getTimezone())
+                );
                 $params = new Parameters(
                     $site,
                     $periodObj,
-                    new Segment(
-                        $segmentDefinition,
-                        [$idSite],
-                        $periodObj->getDateTimeStart()->setTimezone($site->getTimezone()),
-                        $periodObj->getDateTimeEnd()->setTimezone($site->getTimezone())
-                    )
+                    $segmentObj
                 );
                 if ($this->canWeSkipInvalidatingBecauseThereIsAUsablePeriod($params, $doNotIncludeTtlInExistingArchiveCheck)) {
                     $this->logger->debug('  Found usable archive for {archive}, skipping invalidation.', ['archive' => $params]);
+                } elseif ($skipWhenAlreadyRunning && $this->canWeSkipInvalidatingBecauseInvalidationAlreadyInProgress($site->getId(), $periodObj, $segmentObj)) {
+                    $this->logger->debug('  Invalidation for {archive} already in progress, skipping invalidation.', ['archive' => $params]);
                 } else {
                     if (empty($this->segmentArchiving)) {
                         // might not be initialised if init is not called
@@ -1047,7 +1042,7 @@ class CronArchive
      * @param $idSites
      * @return bool
      */
-    protected function isSegmentAvailable($segmentDefinition, $idSites)
+    protected function isSegmentAvailable($segmentDefinition, $idSites): bool
     {
         try {
             new Segment($segmentDefinition, $idSites);
@@ -1056,6 +1051,28 @@ class CronArchive
             return false;
         }
         return true;
+    }
+
+    private function canWeSkipInvalidatingBecauseInvalidationAlreadyInProgress(int $idSite, Period $period, Segment $segment = null): bool
+    {
+        $invalidationsInProgress = $this->model->getInvalidationsInProgress($idSite);
+        $timezone = Site::getTimezoneFor($idSite);
+
+        $doneFlag = Rules::getDoneFlagArchiveContainsAllPlugins($segment ?? new Segment('', [$idSite]));
+        $endOfDayInTimezone = $period->getDateEnd()->getEndOfDay();
+
+        foreach ($invalidationsInProgress as $invalidation) {
+            if (
+                $invalidation['name'] === $doneFlag
+                && $invalidation['period'] == $period->getId()
+                && $period->getDateStart()->toString() === $invalidation['date1']
+                && Date::factory($invalidation['ts_started'], $timezone)->isLater($endOfDayInTimezone)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -865,7 +865,7 @@ class CronArchive
 
             try {
                 $this->logger->debug('  Will invalidate archived reports for ' . $date . ' for following websites ids: ' . $listSiteIds);
-                $this->invalidateWithSegments($siteIdsToInvalidate, $date, $period = 'day');
+                $this->invalidateWithSegments($siteIdsToInvalidate, $date, 'day');
             } catch (Exception $e) {
                 $message = ExceptionToTextProcessor::getMessageAndWholeBacktrace($e);
                 $this->logger->info('  Failed to invalidate archived reports: ' . $message);
@@ -873,11 +873,11 @@ class CronArchive
         }
 
         // invalidate today if needed for all websites
-        $this->invalidateRecentDate('today', $idSiteToInvalidate);
+        $this->invalidateRecentDate('today', (int) $idSiteToInvalidate);
 
         // invalidate yesterday archive if the time of the latest valid archive is earlier than today
         // (means the day has changed and there might be more visits that weren't processed)
-        $this->invalidateRecentDate('yesterday', $idSiteToInvalidate);
+        $this->invalidateRecentDate('yesterday', (int) $idSiteToInvalidate);
 
         // invalidate range archives
         $dates = $this->getCustomDateRangeToPreProcess($idSiteToInvalidate);
@@ -892,7 +892,7 @@ class CronArchive
 
             $this->logger->debug('  Invalidating custom date range ({date}) for site {idSite}', ['idSite' => $idSiteToInvalidate, 'date' => $date]);
 
-            $this->invalidateWithSegments($idSiteToInvalidate, $date, 'range', $_forceInvalidateNonexistent = true);
+            $this->invalidateWithSegments($idSiteToInvalidate, $date, 'range');
         }
 
         $this->setInvalidationTime();
@@ -900,7 +900,7 @@ class CronArchive
         $this->logger->debug("Done invalidating");
     }
 
-    public function invalidateRecentDate($dateStr, $idSite)
+    public function invalidateRecentDate(string $dateStr, int $idSite): void
     {
         $timezone = Site::getTimezoneFor($idSite);
         $date = Date::factoryInTimezone($dateStr, $timezone);
@@ -927,16 +927,20 @@ class CronArchive
         // if we are invalidating yesterday here, we are only interested in checking if there is no archive for yesterday, or the day has changed since
         // the last archive was archived (in which there may have been more visits before midnight). so we disable the ttl check, since any archive
         // will be good enough, if the date hasn't changed.
-        $this->invalidateWithSegments([$idSite], $date->toString(), 'day', false, $isYesterday, $isYesterday, $onlyProcessSegmentsChangedRecently);
+        $this->invalidateWithSegments(
+            [$idSite],
+            $date->toString(),
+            'day',
+            $isYesterday,
+            $onlyProcessSegmentsChangedRecently
+        );
     }
 
     private function invalidateWithSegments(
         $idSites,
         $date,
-        $period,
-        $_forceInvalidateNonexistent = false,
-        $doNotIncludeTtlInExistingArchiveCheck = false,
-        bool $skipWhenAlreadyRunning = false,
+        string $period,
+        bool $skipWhenRunningOrNewEnoughArchiveExists = false,
         bool $onlyProcessSegmentsChangedRecently = false
     ) {
         if ($date instanceof Date) {
@@ -965,9 +969,10 @@ class CronArchive
                     $periodObj->getDateTimeEnd()->setTimezone($site->getTimezone())
                 )
             );
-            if ($this->canWeSkipInvalidatingBecauseThereIsAUsablePeriod($params, $doNotIncludeTtlInExistingArchiveCheck)) {
+
+            if ($this->canWeSkipInvalidatingBecauseThereIsAUsablePeriod($params, $skipWhenRunningOrNewEnoughArchiveExists)) {
                 $this->logger->debug('  Found usable archive for {archive}, skipping invalidation.', ['archive' => $params]);
-            } elseif ($skipWhenAlreadyRunning && $this->canWeSkipInvalidatingBecauseInvalidationAlreadyInProgress($site->getId(), $periodObj)) {
+            } elseif ($skipWhenRunningOrNewEnoughArchiveExists && $this->canWeSkipInvalidatingBecauseInvalidationAlreadyInProgress($site->getId(), $periodObj)) {
                 $this->logger->debug('  Invalidation for {archive} already in progress, skipping invalidation.', ['archive' => $params]);
             } else {
                 $this->getApiToInvalidateArchivedReport()->invalidateArchivedReports(
@@ -976,14 +981,14 @@ class CronArchive
                     $period,
                     $segment = false,
                     $cascadeDown = false,
-                    $_forceInvalidateNonexistent
+                    $period === 'range'
                 );
             }
 
             $allSegments = $this->segmentArchiving->getAllSegments();
 
             foreach ($this->segmentArchiving->getAllSegmentsToArchive($idSite) as $segmentDefinition) {
-               // check if the segment is available
+                // check if the segment is available
                 if (!$this->isSegmentAvailable($segmentDefinition, [$idSite])) {
                     continue;
                 }
@@ -998,14 +1003,16 @@ class CronArchive
                     $periodObj->getDateTimeStart()->setTimezone($site->getTimezone()),
                     $periodObj->getDateTimeEnd()->setTimezone($site->getTimezone())
                 );
+
                 $params = new Parameters(
                     $site,
                     $periodObj,
                     $segmentObj
                 );
-                if ($this->canWeSkipInvalidatingBecauseThereIsAUsablePeriod($params, $doNotIncludeTtlInExistingArchiveCheck)) {
+
+                if ($this->canWeSkipInvalidatingBecauseThereIsAUsablePeriod($params, $skipWhenRunningOrNewEnoughArchiveExists)) {
                     $this->logger->debug('  Found usable archive for {archive}, skipping invalidation.', ['archive' => $params]);
-                } elseif ($skipWhenAlreadyRunning && $this->canWeSkipInvalidatingBecauseInvalidationAlreadyInProgress($site->getId(), $periodObj, $segmentObj)) {
+                } elseif ($skipWhenRunningOrNewEnoughArchiveExists && $this->canWeSkipInvalidatingBecauseInvalidationAlreadyInProgress($site->getId(), $periodObj, $segmentObj)) {
                     $this->logger->debug('  Invalidation for {archive} already in progress, skipping invalidation.', ['archive' => $params]);
                 } else {
                     if (empty($this->segmentArchiving)) {
@@ -1031,7 +1038,7 @@ class CronArchive
                         $period,
                         $segmentDefinition,
                         $cascadeDown = false,
-                        $_forceInvalidateNonexistent
+                        $period === 'range'
                     );
                 }
             }
@@ -1085,7 +1092,7 @@ class CronArchive
      *
      * @params Parameters $params The parameters for the archive we want to invalidate.
      */
-    public function canWeSkipInvalidatingBecauseThereIsAUsablePeriod(Parameters $params, $doNotIncludeTtlInExistingArchiveCheck = false): bool
+    private function canWeSkipInvalidatingBecauseThereIsAUsablePeriod(Parameters $params, $doNotIncludeTtlInExistingArchiveCheck = false): bool
     {
         $timezone = Site::getTimezoneFor($params->getSite()->getId());
         $today = Date::factoryInTimezone('today', $timezone);

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -846,8 +846,13 @@ class CronArchiveTest extends IntegrationTestCase
             1, 1, $period::PERIOD_ID, $period->getDateStart()->toString(), $period->getDateEnd()->toString(), 'done', $archiveStatus, $tsArchived
         ]);
 
-        // $doNotIncludeTtlInExistingArchiveCheck is set to true when running invalidateRecentDate('yesterday');
-        $actual = $archiver->canWeSkipInvalidatingBecauseThereIsAUsablePeriod($params, $dayToArchive === 'yesterday');
+        // $skipWhenRunningOrNewEnoughArchiveExists is set to true when running invalidateRecentDate('yesterday');
+
+        $class = new \ReflectionClass(CronArchive::class);
+        $method = $class->getMethod('canWeSkipInvalidatingBecauseThereIsAUsablePeriod');
+        $method->setAccessible(true);
+
+        $actual = $method->invoke($archiver, $params, $dayToArchive === 'yesterday');
         $this->assertSame($expected, $actual);
     }
 
@@ -1189,6 +1194,7 @@ class CronArchiveTest extends IntegrationTestCase
 
         self::assertStringContainsString('Will skip segments archiving for today unless they were created recently', $logger->output);
     }
+
     public function testInvalidatingYesterdayWillStillRequestSegmentInvalidationsWithSkipSegmentsToday()
     {
         Date::$now = strtotime('2020-08-05 09:00:00');


### PR DESCRIPTION
### Description:

The `core:archive` command provides a flag `--skip-segments-today`, which prevents segments data from being processed for today.

The currently implementation only prevents them from being processed. But invalidation done for today before archiving is started is currently done anyway. This causes also the higher periods (week, month, year) to be invalidated. But as only today is prevented from being archived for segments, those higher periods will be reprocessed anyway, even if there actually were no changes in lower periods. 

To prevent this unnecessary archiving of those higher periods, this PR changes the behavior of the initial invalidation. If `--skip-segments-today` is provided, we will no longer create invalidations for segments for today (and periods including this day).
This shouldn't cause any problems even if the flag is used always when archiving is triggered, as `yesterday` will still be invalidated for segments.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
