### PR TITLE
Added the ability to force the use of an index

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -22,6 +22,7 @@ use Piwik\Metrics;
 use Piwik\Plugin\LogTablesProvider;
 use Piwik\RankingQuery;
 use Piwik\Segment;
+use Piwik\SettingsPiwik;
 use Piwik\Tracker\Action;
 use Piwik\Tracker\GoalManager;
 use Piwik\Log\LoggerInterface;
@@ -1195,7 +1196,8 @@ class LogAggregator
 
         $select = $this->getSelectStatement($dimensions, $tableName, $additionalSelects, $availableMetrics);
 
-        $primaryFrom = !$forceSiteDateIndex ? [$tableName] : [['table' => $tableName, 'useIndex' => 'index_idsite_datetime']];
+        $isForceSiteDateIndexEnabled = SettingsPiwik::isForceSiteDateIndexEnabled();
+        $primaryFrom = (!$forceSiteDateIndex || !$isForceSiteDateIndexEnabled) ? [$tableName] : [['table' => $tableName, 'useIndex' => 'index_idsite_datetime']];
         $from    = array_merge($primaryFrom, $extraFrom);
         $where   = $this->getWhereStatement($tableName, self::CONVERSION_DATETIME_FIELD, $where);
         $groupBy = $this->getGroupByStatement($dimensions, $tableName);

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -1176,6 +1176,8 @@ class LogAggregator
      * @param RankingQuery|bool $rankingQuery
      * @param bool $rankingQueryGenerate if `true`, generates a SQL query / bind array pair and returns it. If false, the
      *                                   ranking query SQL will be immediately executed and the results returned.
+     * @param bool $forceSiteDateIndex Forces the resulting query to use the index_idsite_datetime index. For some
+     * reason, the engine doesn't always use that index automatically. This allows use to make sure that it uses it.
      * @return \Zend_Db_Statement|array
      */
     public function queryConversionsByDimension(
@@ -1184,7 +1186,8 @@ class LogAggregator
         $additionalSelects = array(),
         $extraFrom = [],
         $rankingQuery = false,
-        $rankingQueryGenerate = false
+        $rankingQueryGenerate = false,
+        $forceSiteDateIndex = false
     ) {
         $dimensions = array_merge(array(self::IDGOAL_FIELD), $dimensions);
         $tableName  = self::LOG_CONVERSION_TABLE;
@@ -1192,7 +1195,8 @@ class LogAggregator
 
         $select = $this->getSelectStatement($dimensions, $tableName, $additionalSelects, $availableMetrics);
 
-        $from    = array_merge([$tableName], $extraFrom);
+        $primaryFrom = !$forceSiteDateIndex ? [$tableName] : [['table' => $tableName, 'useIndex' => 'index_idsite_datetime']];
+        $from    = array_merge($primaryFrom, $extraFrom);
         $where   = $this->getWhereStatement($tableName, self::CONVERSION_DATETIME_FIELD, $where);
         $groupBy = $this->getGroupByStatement($dimensions, $tableName);
         $orderBy = false;

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -1198,8 +1198,7 @@ class LogAggregator
 
         $select = $this->getSelectStatement($dimensions, $tableName, $additionalSelects, $availableMetrics);
 
-        $isForceSiteDateIndexEnabled = SettingsPiwik::isForceSiteDateIndexEnabled();
-        $primaryFrom = (!$forceSiteDateIndex || !$isForceSiteDateIndexEnabled) ? [$tableName] : [['table' => $tableName, 'useIndex' => 'index_idsite_datetime']];
+        $primaryFrom = !$forceSiteDateIndex ? [$tableName] : [['table' => $tableName, 'useIndex' => 'index_idsite_datetime']];
         $from    = array_merge($primaryFrom, $extraFrom);
         $where   = $this->getWhereStatement($tableName, self::CONVERSION_DATETIME_FIELD, $where);
         $groupBy = $this->getGroupByStatement($dimensions, $tableName);

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -22,7 +22,6 @@ use Piwik\Metrics;
 use Piwik\Plugin\LogTablesProvider;
 use Piwik\RankingQuery;
 use Piwik\Segment;
-use Piwik\SettingsPiwik;
 use Piwik\Tracker\Action;
 use Piwik\Tracker\GoalManager;
 use Piwik\Log\LoggerInterface;

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -399,7 +399,9 @@ class LogAggregator
         if (is_array($query) && array_key_exists('sql', $query)) {
             $query['sql'] = DbHelper::addOriginHintToQuery($query['sql'], $this->queryOriginHint, $this->dateStart, $this->dateEnd, $this->sites, $this->segment);
             if (DatabaseConfig::getConfigValue('enable_first_table_join_prefix')) {
-                $query['sql'] = DbHelper::addJoinPrefixHintToQuery($query['sql'], (is_array($from) ? reset($from) : $from));
+                $fromTable = is_array($from) ? reset($from) : $from;
+                $fromTable = is_array($fromTable) ? $fromTable['table'] : $fromTable;
+                $query['sql'] = DbHelper::addJoinPrefixHintToQuery($query['sql'], $fromTable);
             }
         }
 

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -1177,7 +1177,7 @@ class LogAggregator
      * @param bool $rankingQueryGenerate if `true`, generates a SQL query / bind array pair and returns it. If false, the
      *                                   ranking query SQL will be immediately executed and the results returned.
      * @param bool $forceSiteDateIndex Forces the resulting query to use the index_idsite_datetime index. For some
-     * reason, the engine doesn't always use that index automatically. This allows use to make sure that it uses it.
+     * reason, the engine doesn't always use that index automatically. This allows us to make sure that it uses it.
      * @return \Zend_Db_Statement|array
      */
     public function queryConversionsByDimension(

--- a/core/DataAccess/LogQueryBuilder/JoinGenerator.php
+++ b/core/DataAccess/LogQueryBuilder/JoinGenerator.php
@@ -146,6 +146,12 @@ class JoinGenerator
         $this->tables->sort();
 
         foreach ($this->tables as $i => $table) {
+            $useIndex = '';
+            if ($i === 0 && is_array($table)) {
+                $useIndex = $table['useIndex'];
+                $table = $table['table'];
+            }
+
             if (is_array($table)) {
                 // join condition provided
                 $alias = isset($table['tableAlias']) ? $table['tableAlias'] : $table['table'];
@@ -180,6 +186,11 @@ class JoinGenerator
             if ($i == 0) {
                 // first table
                 $this->joinString .= $tableSql;
+
+                // Force the use of the index if an index was provided
+                if (!empty($useIndex)) {
+                    $this->joinString .= " USE INDEX ($useIndex)";
+                }
             } else {
                 $join = $this->findJoinCriteriasForTables($logTable, $availableLogTables);
 

--- a/core/DataAccess/LogQueryBuilder/JoinGenerator.php
+++ b/core/DataAccess/LogQueryBuilder/JoinGenerator.php
@@ -148,7 +148,7 @@ class JoinGenerator
         foreach ($this->tables as $i => $table) {
             $useIndex = '';
             if ($i === 0 && is_array($table)) {
-                $useIndex = $table['useIndex'];
+                $useIndex = $table['useIndex'] ?? '';
                 $table = $table['table'];
             }
 

--- a/core/DataAccess/LogQueryBuilder/JoinTables.php
+++ b/core/DataAccess/LogQueryBuilder/JoinTables.php
@@ -155,7 +155,7 @@ class JoinTables extends \ArrayObject
         $firstTable = array_shift($tables);
         $sorted = [$firstTable];
 
-        // Added the ability to specify which index to use, so the first table might be an array
+        // With the ability to specify which index to use, the $firstTable var may be an array
         if (is_array($firstTable) && !empty($firstTable['table'])) {
             $firstTable = $firstTable['table'];
         }

--- a/core/DataAccess/LogQueryBuilder/JoinTables.php
+++ b/core/DataAccess/LogQueryBuilder/JoinTables.php
@@ -155,6 +155,11 @@ class JoinTables extends \ArrayObject
         $firstTable = array_shift($tables);
         $sorted = [$firstTable];
 
+        // Added the ability to specify which index to use, so the first table might be an array
+        if (is_array($firstTable) && !empty($firstTable['table'])) {
+            $firstTable = $firstTable['table'];
+        }
+
         if (strpos($firstTable, LogAggregator::LOG_TABLE_SEGMENT_TEMPORARY_PREFIX) === 0) {
             // the first table might be a temporary segment table in which case we need to keep the next one as well
             $sorted[] = array_shift($tables);

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -526,4 +526,14 @@ class SettingsPiwik
     {
         return (bool)Config::getInstance()->Tracker['enable_fingerprinting_across_websites'];
     }
+
+    /**
+     * @return bool Whether the feature to force the idSite datetime index is enabled. This is currently limited to a
+     * few queries and only when the appropriate flag is provided when the query method is called.
+     */
+    public static function isForceSiteDateIndexEnabled(): bool
+    {
+        $general = Config::getInstance()->General;
+        return !empty($general['enable_force_site_date_index']);
+    }
 }

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -526,14 +526,4 @@ class SettingsPiwik
     {
         return (bool)Config::getInstance()->Tracker['enable_fingerprinting_across_websites'];
     }
-
-    /**
-     * @return bool Whether the feature to force the idSite datetime index is enabled. This is currently limited to a
-     * few queries and only when the appropriate flag is provided when the query method is called.
-     */
-    public static function isForceSiteDateIndexEnabled(): bool
-    {
-        $general = Config::getInstance()->General;
-        return !empty($general['enable_force_site_date_index']);
-    }
 }

--- a/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
@@ -30,8 +30,6 @@ class LogAggregatorTest extends \PHPUnit\Framework\TestCase
         $dbMock = $this->createMock(ArchivingDbAdapter::class);
         $dbMock->expects($this->once())->method('query')->with($this->stringContains($expectedSql), $this->equalTo([]));
 
-        Config::getInstance()->General['enable_force_site_date_index'] = 1;
-
         DatabaseConfig::setConfigValue('enable_first_table_join_prefix', 1);
 
         $segmentMock = $this->createMock(Segment::class);

--- a/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\DataAccess;
+
+use Piwik\DataAccess\ArchivingDbAdapter;
+use Piwik\DataAccess\LogAggregator;
+
+/**
+ * @group Core
+ */
+class LogAggregatorTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider getTestQueryConversionsByDimensionForcingIndexFlagTestData
+     *
+     * @param bool $forceIndex
+     * @return void
+     */
+    public function testQueryConversionsByDimensionForcingIndexFlag(bool $forceIndex)
+    {
+        $dimensions = ['custom_var_k1', 'custom_var_v1'];
+        $where = "%s.custom_var_k1 != ''";
+
+        $expectedSelect = "log_conversion.idgoal AS `idgoal`, 
+			log_conversion.custom_var_k1 AS `custom_var_k1`, 
+			log_conversion.custom_var_v1 AS `custom_var_v1`, 
+			count(*) AS `1`, 
+			count(distinct log_conversion.idvisit) AS `3`, 
+			ROUND(SUM(log_conversion.revenue),2) AS `2`, 
+			ROUND(SUM(log_conversion.revenue_subtotal),2) AS `4`, 
+			ROUND(SUM(log_conversion.revenue_tax),2) AS `5`, 
+			ROUND(SUM(log_conversion.revenue_shipping),2) AS `6`, 
+			ROUND(SUM(log_conversion.revenue_discount),2) AS `7`, 
+			SUM(log_conversion.items) AS `8`";
+        $expectedFrom = $forceIndex
+            ? [['table' => LogAggregator::LOG_CONVERSION_TABLE, 'useIndex' => 'index_idsite_datetime']]
+            : [LogAggregator::LOG_CONVERSION_TABLE];
+        $expectedWhere = "log_conversion.server_time >= ?
+				AND log_conversion.server_time <= ?
+				AND log_conversion.idsite IN (?) AND log_conversion.custom_var_k1 != ''";
+
+        $dbMock = $this->createMock(ArchivingDbAdapter::class);
+        $dbMock->expects($this->once())->method('query');
+
+        $aggregatorMock = $this->createPartialMock(LogAggregator::class, ['generateQuery', 'getDb']);
+        $aggregatorMock->expects($this->once())->method('generateQuery')->with($expectedSelect, $expectedFrom, $expectedWhere)->willReturn(['sql' => '', 'bind' => []]);
+        $aggregatorMock->expects($this->once())->method('getDb')->willReturn($dbMock);
+        $aggregatorMock->setSites([1]);
+        $aggregatorMock->queryConversionsByDimension($dimensions, $where, [], [], false, false, $forceIndex);
+    }
+
+    public function getTestQueryConversionsByDimensionForcingIndexFlagTestData(): array
+    {
+        return [
+            [false],
+            [true],
+        ];
+    }
+}

--- a/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
@@ -27,6 +27,12 @@ class LogAggregatorTest extends \PHPUnit\Framework\TestCase
     {
         $dimensions = ['custom_var_k1', 'custom_var_v1'];
         $where = "%s.custom_var_k1 != ''";
+        $extraFrom = [
+            [
+                'table' => 'log_visit',
+                'joinOn' => 'log_visit.idvisit = log_conversion.idvisit',
+            ],
+        ];
 
         $expectedSelect = "log_conversion.idgoal AS `idgoal`, 
 			log_conversion.custom_var_k1 AS `custom_var_k1`, 
@@ -42,6 +48,7 @@ class LogAggregatorTest extends \PHPUnit\Framework\TestCase
         $expectedFrom = $forceIndex
             ? [['table' => LogAggregator::LOG_CONVERSION_TABLE, 'useIndex' => 'index_idsite_datetime']]
             : [LogAggregator::LOG_CONVERSION_TABLE];
+        $expectedFrom = array_merge($expectedFrom, $extraFrom);
         $expectedWhere = "log_conversion.server_time >= ?
 				AND log_conversion.server_time <= ?
 				AND log_conversion.idsite IN (?) AND log_conversion.custom_var_k1 != ''";
@@ -53,7 +60,7 @@ class LogAggregatorTest extends \PHPUnit\Framework\TestCase
         $aggregatorMock->expects($this->once())->method('generateQuery')->with($expectedSelect, $expectedFrom, $expectedWhere)->willReturn(['sql' => '', 'bind' => []]);
         $aggregatorMock->expects($this->once())->method('getDb')->willReturn($dbMock);
         $aggregatorMock->setSites([1]);
-        $aggregatorMock->queryConversionsByDimension($dimensions, $where, [], [], false, false, $forceIndex);
+        $aggregatorMock->queryConversionsByDimension($dimensions, $where, [], $extraFrom, false, false, $forceIndex);
     }
 
     public function getTestQueryConversionsByDimensionForcingIndexFlagTestData(): array

--- a/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
@@ -51,7 +51,7 @@ class LogAggregatorTest extends \PHPUnit\Framework\TestCase
      * @param bool $forceIndex
      * @return void
      */
-    public function testQueryConversionsByDimensionForcingIndexFlag($configSettingValue, bool $forceIndex)
+    public function testQueryConversionsByDimensionForcingIndexFlag(bool $forceIndex)
     {
         $dimensions = ['custom_var_k1', 'custom_var_v1'];
         $where = "%s.custom_var_k1 != ''";
@@ -73,7 +73,7 @@ class LogAggregatorTest extends \PHPUnit\Framework\TestCase
 			ROUND(SUM(log_conversion.revenue_shipping),2) AS `6`, 
 			ROUND(SUM(log_conversion.revenue_discount),2) AS `7`, 
 			SUM(log_conversion.items) AS `8`";
-        $expectedFrom = $forceIndex && !empty($configSettingValue)
+        $expectedFrom = $forceIndex
             ? [['table' => LogAggregator::LOG_CONVERSION_TABLE, 'useIndex' => 'index_idsite_datetime']]
             : [LogAggregator::LOG_CONVERSION_TABLE];
         $expectedFrom = array_merge($expectedFrom, $extraFrom);
@@ -83,8 +83,6 @@ class LogAggregatorTest extends \PHPUnit\Framework\TestCase
 
         $dbMock = $this->createMock(ArchivingDbAdapter::class);
         $dbMock->expects($this->once())->method('query');
-
-        Config::getInstance()->General['enable_force_site_date_index'] = $configSettingValue;
 
         $aggregatorMock = $this->createPartialMock(LogAggregator::class, ['generateQuery', 'getDb']);
         $aggregatorMock->expects($this->once())->method('generateQuery')->with($expectedSelect, $expectedFrom, $expectedWhere)->willReturn(['sql' => '', 'bind' => []]);
@@ -96,16 +94,8 @@ class LogAggregatorTest extends \PHPUnit\Framework\TestCase
     public function getTestQueryConversionsByDimensionForcingIndexFlagTestData(): array
     {
         return [
-            [null, false],
-            [null, true],
-            [0, false],
-            [0, true],
-            [1, false],
-            [1, true],
-            ['0', false],
-            ['0', true],
-            ['1', false],
-            ['1', true],
+            [false],
+            [true],
         ];
     }
 }

--- a/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
@@ -10,7 +10,6 @@
 namespace Piwik\Tests\Unit\DataAccess;
 
 use Piwik\ArchiveProcessor\Parameters;
-use Piwik\Config;
 use Piwik\Config\DatabaseConfig;
 use Piwik\DataAccess\ArchivingDbAdapter;
 use Piwik\DataAccess\LogAggregator;

--- a/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
@@ -10,7 +10,6 @@
 namespace Piwik\Tests\Unit\DataAccess;
 
 use Piwik\Config;
-use Piwik\Container\StaticContainer;
 use Piwik\DataAccess\ArchivingDbAdapter;
 use Piwik\DataAccess\LogAggregator;
 

--- a/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
@@ -35,7 +35,9 @@ class LogAggregatorTest extends \PHPUnit\Framework\TestCase
         DatabaseConfig::setConfigValue('enable_first_table_join_prefix', 1);
 
         $segmentMock = $this->createMock(Segment::class);
-        $segmentMock->expects($this->once())->method('getSelectQuery')->willReturn(['sql' => 'SELECT * FROM log_visit', 'bind' => []]);
+        $segmentMock->expects($this->once())->method('getSelectQuery')
+            ->with($this->anything(), $this->equalTo([['table' => 'log_conversion', 'useIndex' => 'index_idsite_datetime']]))
+            ->willReturn(['sql' => 'SELECT * FROM log_visit', 'bind' => []]);
 
         $aggregatorMock = $this->createPartialMock(LogAggregator::class, ['getDb']);
         $aggregatorMock->expects($this->once())->method('getDb')->willReturn($dbMock);

--- a/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
@@ -58,13 +58,7 @@ class LogAggregatorTest extends \PHPUnit\Framework\TestCase
         $dbMock = $this->createMock(ArchivingDbAdapter::class);
         $dbMock->expects($this->once())->method('query');
 
-        $configMock = $this->createMock(Config::class);
-        $configMock->method('__get')
-            ->with('General')
-            ->willReturn([
-                'enable_force_site_date_index' => $configSettingValue,
-            ]);
-        StaticContainer::getContainer()->set(Config::class, $configMock);
+        Config::getInstance()->General['enable_force_site_date_index'] = $configSettingValue;
 
         $aggregatorMock = $this->createPartialMock(LogAggregator::class, ['generateQuery', 'getDb']);
         $aggregatorMock->expects($this->once())->method('generateQuery')->with($expectedSelect, $expectedFrom, $expectedWhere)->willReturn(['sql' => '', 'bind' => []]);

--- a/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinGeneratorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinGeneratorTest.php
@@ -212,6 +212,20 @@ class JoinGeneratorTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $generator->getJoinString());
     }
 
+    public function testGenerateGetJoinStringForceIndexUse()
+    {
+        $generator = $this->generate([
+            ['table' => 'log_visit', 'useIndex' => 'index_idsite_datetime'],
+            ['table' => 'log_link_visit_action', 'join' => 'RIGHT JOIN'],
+            'log_action'
+        ]);
+
+        $expected  = 'log_visit AS log_visit USE INDEX (index_idsite_datetime) ';
+        $expected  .= 'RIGHT JOIN log_link_visit_action AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit ';
+        $expected  .= 'LEFT JOIN log_action AS log_action ON log_link_visit_action.idaction_url = log_action.idaction';
+        $this->assertEquals($expected, $generator->getJoinString());
+    }
+
     public function testGenerateGetJoinStringManuallyJoinedAlreadyPlusCustomJoinAtEndButAlsoLeftNeedsKeepOrder()
     {
         $generator = $this->generate(array(

--- a/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinTablesTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinTablesTest.php
@@ -189,6 +189,34 @@ class JoinTablesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $tables->getTables());
     }
 
+    public function testSortTablesForJoinShouldSortTablesAsSpecifiedIncludingUseIndex()
+    {
+        $tables = [
+            ['table' => 'log_link_visit_action', 'useIndex' => 'index_idsite_servertime'],
+            'log_action',
+            ['table' => 'log_conversion', 'joinOn' => 'log_conversion.idvisit = log_visit.idvisit'],
+            'log_conversion_item',
+            'log_conversion',
+            'log_visit',
+            ['table' => 'log_foo_bar'],
+        ];
+
+        $tables = $this->makeTables($tables);
+        $tables->sort();
+
+        $expected = [
+            ['table' => 'log_link_visit_action', 'useIndex' => 'index_idsite_servertime'],
+            'log_visit',
+            ['table' => 'log_conversion', 'joinOn' => 'log_conversion.idvisit = log_visit.idvisit'],
+            'log_conversion_item',
+            'log_action',
+            'log_conversion',
+            ['table' => 'log_foo_bar'],
+        ];
+
+        $this->assertEquals($expected, $tables->getTables());
+    }
+
     public function testSortTablesForJoinAnotherTestMakingSureWorksOhPhp55()
     {
         $tables = array (


### PR DESCRIPTION
### Description:

Added the ability to force the use of an index when aggregating logs. This is to try and improve efficiency when the query engine doesn't always automatically select the correct index.

Internal ticket: PG-3720

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
