### PR TITLE
Throw date exception when a fictitious is provided by a URL parameter 

### DIFF
--- a/core/Date.php
+++ b/core/Date.php
@@ -141,6 +141,11 @@ class Date
             $date = self::lastMonth();
         } elseif (is_string($dateString) && preg_match('/last[ -]?year/i', urldecode($dateString))) {
             $date = self::lastYear();
+        } else if (preg_match('/(\d{4})-(\d{2})-(\d{2})/', urldecode($dateString))) {
+            if (!self::isDateStringValid($dateString)) {
+                throw self::getFictiousDateException($dateString);
+            }
+            $date = new Date(strtotime($dateString));
         } elseif (
             !is_int($dateString)
             && (
@@ -174,6 +179,23 @@ class Date
         $timestamp = self::adjustForTimezone($timestamp, $timezone);
         return Date::factory($timestamp);
     }
+
+    /**
+     * Returns if the date string is valid
+     *
+     * @param $dateString
+     * @return Boolean
+     * @ignore
+     */
+    public static function isDateStringValid($dateString)
+    {
+        $ret = date_parse($dateString);
+        if ($ret['warning_count'] || $ret['error_count']) {
+            return false;
+        }
+        return true;
+    }
+
 
     /**
      * Returns Date w/ UTC timestamp of time $dateString/$timezone.
@@ -1138,6 +1160,13 @@ class Date
     {
         return $secs / self::NUM_SECONDS_IN_DAY;
     }
+
+    private static function getFictiousDateException($dateString)
+    {
+        $message = Piwik::translate('General_ExceptionFictiousDate');
+        return new Exception($message . ": $dateString");
+    }
+
 
     private static function getInvalidDateFormatException($dateString)
     {

--- a/lang/en.json
+++ b/lang/en.json
@@ -199,6 +199,7 @@
         "ExceptionIncompatibleClientServerVersions": "Your %1$s client version is %2$s which is incompatible with server version %3$s.",
         "ExceptionInvalidAggregateReportsFormat": "Aggregate reports format '%1$s' not valid. Try any of the following instead: %2$s.",
         "ExceptionInvalidArchiveTimeToLive": "Today archive time to live must be a number of seconds greater than zero",
+        "ExceptionFictiousDate": "This date does not exist.",
         "ExceptionInvalidDateBeforeFirstWebsite": "The date '%1$s' is a date before first website was online. Try date that's after %2$s (timestamp %3$s).",
         "ExceptionInvalidDateFormat": "Date format must be: %1$s or any keyword supported by the %2$s function (see %3$s for more information)",
         "ExceptionInvalidDateRange": "The date '%1$s' is not a correct date range. It should have the following format: %2$s.",

--- a/tests/PHPUnit/Unit/DateTest.php
+++ b/tests/PHPUnit/Unit/DateTest.php
@@ -415,6 +415,14 @@ class DateTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    public function testIsDateStringValid()
+    {
+        $this->assertTrue(Date::isDateStringValid('2024-02-29'));
+        $this->assertFalse(Date::isDateStringValid('2025-02-29'));
+        $this->assertFalse(Date::isDateStringValid('2025-09-31'));
+        $this->assertTrue(Date::isDateStringValid('2025-03-31'));
+    }
+
 
     public function getLocalizedLongStrings()
     {


### PR DESCRIPTION
### Description:

Handles invalid dates being sent to the **All Websites** dashboard as a URL parameter.
resolves #22573

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
