### PR TITLE
Ensure grouping a dimension in ms doesn't fail if ranking query limit is reached

### DIFF
--- a/core/Columns/Dimension.php
+++ b/core/Columns/Dimension.php
@@ -419,6 +419,10 @@ abstract class Dimension
             case Dimension::TYPE_BOOL:
                 return !empty($value) ? '1' : '0';
             case Dimension::TYPE_DURATION_MS:
+                if (!is_numeric($value)) {
+                    // This might happen if ranking query has too many results and `__mtm_ranking_query_others__` is returned
+                    return $value;
+                }
                 return round($value / 1000, 2) * 1000; // because we divide we need to group them and cannot do this in formatting step
         }
         return $value;


### PR DESCRIPTION
### Description:

When grouping dimension values it might happen that a ranking query already limited the amount of records. In that case a row with value `__mtm_ranking_query_others__ ` will occur.

This currently fails for dimensions in milliseconds, as calculating with the `__mtm_ranking_query_others__ ` value doesn't work.

This PR ensures that only numeric values are taken into account for that calculation.

fixes #22579

(Ref DEV-18521)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
