### PR TITLE
Require Write access for adding annotations in UI

### DIFF
--- a/plugins/Annotations/API.php
+++ b/plugins/Annotations/API.php
@@ -311,7 +311,7 @@ class API extends \Piwik\Plugin\API
      */
     private static function checkUserCanAddNotesFor($idSite): void
     {
-        if (!AnnotationList::canUserAddNotesFor($idSite)) {
+        if (!Piwik::isUserHasViewAccess($idSite) || Piwik::isUserIsAnonymous()) {
             throw new Exception("The current user is not allowed to add notes for site #$idSite.");
         }
     }

--- a/plugins/Annotations/AnnotationList.php
+++ b/plugins/Annotations/AnnotationList.php
@@ -443,8 +443,7 @@ class AnnotationList
      */
     public static function canUserAddNotesFor($idSite)
     {
-        return Piwik::isUserHasViewAccess($idSite)
-        && !Piwik::isUserIsAnonymous();
+        return Piwik::isUserHasWriteAccess($idSite);
     }
 
     /**

--- a/tests/UI/specs/EvolutionGraph_spec.js
+++ b/tests/UI/specs/EvolutionGraph_spec.js
@@ -211,4 +211,19 @@ describe("EvolutionGraph", function () {
 
         expect(await page.screenshot({ fullPage: true })).to.matchImage('periods_selected');
     });
+
+    it("should not show add annotation form for user with view access", async function () {
+        testEnvironment.idSitesViewAccess = [1];
+        testEnvironment.testUseMockAuth = 1;
+        testEnvironment.save();
+
+        await page.goto(url);
+        await showDataTableFooter();
+        await page.click('.annotationView');
+        await page.waitForNetworkIdle();
+
+        // check that add annotation link is not shown
+        const element = await page.$('.add-annotation');
+        expect(element).to.be.not.ok;
+    });
 });


### PR DESCRIPTION
### Description:

The 'Write' permission has already been introduce a long time ago. Nevertheless we forgot to restrict writing Annotations.
This PR will in a first step adjust the UI, so it won't show the annotation form for users without 'Write' permission.

In a follow-up PR we will also adjust the API to reflect this change. As changing the API is considered a breaking change, this will be done with the next major release.

fixes https://github.com/matomo-org/matomo/issues/20716

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
