### PR TITLE
Added a common validation method to base API class

### DIFF
--- a/core/Plugin/API.php
+++ b/core/Plugin/API.php
@@ -163,7 +163,7 @@ abstract class API
      * @internal
      * @throws Exception If the provided values aren't valid
      */
-    public function checkLastNMinutes(int $maxMinutes, int $lastMinutes)
+    public function checkLastMinutes(int $maxMinutes, int $lastMinutes)
     {
         if ($maxMinutes <= 0) {
             throw new \Exception(Piwik::translate('Max minutes must be greater than 0'));

--- a/core/Plugin/API.php
+++ b/core/Plugin/API.php
@@ -152,4 +152,29 @@ abstract class API
     {
         return $this->autoSanitizeInputParams;
     }
+
+    /**
+     * Check whether the provided lastMinutes value is within the allowed range. If the value is too low or greater than
+     * the maxMinutes value, an exception is thrown.
+     *
+     * @param int $maxMinutes This should come from a config or constant. It is a system constraint to fight against DDOS
+     * @param int $lastMinutes The parameter value provided to the API
+     * @return void
+     * @internal
+     * @throws Exception If the provided values aren't valid
+     */
+    public function checkLastNMinutes(int $maxMinutes, int $lastMinutes)
+    {
+        if ($maxMinutes <= 0) {
+            throw new \Exception(Piwik::translate('Max minutes must be greater than 0'));
+        }
+
+        if ($lastMinutes <= 0) {
+            throw new \Exception(Piwik::translate('General_ValidatorErrorNumberTooLow', [$lastMinutes, 0]));
+        }
+
+        if ($lastMinutes > $maxMinutes) {
+            throw new \Exception(Piwik::translate('General_ValidatorErrorNumberTooHigh', [$lastMinutes, $maxMinutes]));
+        }
+    }
 }

--- a/plugins/CorePluginsAdmin/tests/Unit/ApiTest.php
+++ b/plugins/CorePluginsAdmin/tests/Unit/ApiTest.php
@@ -26,15 +26,6 @@ class ApiTest extends TestCase
     public function testCheckLastMinutes($maxMinutes, $lastNMinutes, $isMaxInvalid = false, $areMinutesTooLow = false, $areMinutesTooHigh = false)
     {
         $isExceptionExpected = false;
-        if (!is_numeric($maxMinutes)) {
-            $this->expectException(\TypeError::class);
-            $isExceptionExpected = true;
-        }
-
-        if (!is_numeric($lastNMinutes)) {
-            $this->expectException(\TypeError::class);
-            $isExceptionExpected = true;
-        }
 
         if ($isMaxInvalid || $areMinutesTooLow || $areMinutesTooHigh) {
             $this->expectException(\Exception::class);
@@ -61,9 +52,7 @@ class ApiTest extends TestCase
     {
         return [
             ['60', 60, false, false, false],
-            ['60a', 60, false, false, false],
             [60, '60', false, false, false],
-            [60, '60a', false, false, false],
             [-60, 60, true, false, false],
             [-1, 60, true, false, false],
             [0, 60, true, false, false],
@@ -72,6 +61,7 @@ class ApiTest extends TestCase
             [120, 120, false, false, false],
             [360, 360, false, false, false],
             [720, 720, false, false, false],
+            [3600, 3600, false, false, false],
             [60, -60, false, true, false],
             [60, -1, false, true, false],
             [60, 0, false, true, false],
@@ -85,6 +75,7 @@ class ApiTest extends TestCase
             [360, 361, false, false, true],
             [360, 720, false, false, true],
             [720, 721, false, false, true],
+            [3600, 3601, false, false, true],
         ];
     }
 }

--- a/plugins/CorePluginsAdmin/tests/Unit/ApiTest.php
+++ b/plugins/CorePluginsAdmin/tests/Unit/ApiTest.php
@@ -26,6 +26,21 @@ class ApiTest extends TestCase
     public function testCheckLastMinutes($maxMinutes, $lastNMinutes, $isMaxInvalid = false, $areMinutesTooLow = false, $areMinutesTooHigh = false)
     {
         $isExceptionExpected = false;
+        if (!is_numeric($maxMinutes)) {
+            if (version_compare(PHP_VERSION, '8.0', '<')) {
+                $this->markTestSkipped();
+            }
+            $this->expectException(\TypeError::class);
+            $isExceptionExpected = true;
+        }
+
+        if (!is_numeric($lastNMinutes)) {
+            if (version_compare(PHP_VERSION, '8.0', '<')) {
+                $this->markTestSkipped();
+            }
+            $this->expectException(\TypeError::class);
+            $isExceptionExpected = true;
+        }
 
         if ($isMaxInvalid || $areMinutesTooLow || $areMinutesTooHigh) {
             $this->expectException(\Exception::class);
@@ -52,7 +67,9 @@ class ApiTest extends TestCase
     {
         return [
             ['60', 60, false, false, false],
+            ['60a', 60, false, false, false],
             [60, '60', false, false, false],
+            [60, '60a', false, false, false],
             [-60, 60, true, false, false],
             [-1, 60, true, false, false],
             [0, 60, true, false, false],

--- a/plugins/CorePluginsAdmin/tests/Unit/ApiTest.php
+++ b/plugins/CorePluginsAdmin/tests/Unit/ApiTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CorePluginsAdmin\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class ApiTest extends TestCase
+{
+    /**
+     * @dataProvider getCheckLastNHoursTestData
+     * @param int $maxMinutes
+     * @param int $lastNMinutes
+     * @param bool $isMaxInvalid
+     * @param bool $areMinutesTooLow
+     * @param bool $areMinutesTooHigh
+     * @return void
+     * @throws \Exception
+     */
+    public function testCheckLastNMinutes($maxMinutes, $lastNMinutes, $isMaxInvalid = false, $areMinutesTooLow = false, $areMinutesTooHigh = false)
+    {
+        $isExceptionExpected = false;
+        if (!is_numeric($maxMinutes)) {
+            $this->expectException(\TypeError::class);
+            $isExceptionExpected = true;
+        }
+
+        if (!is_numeric($lastNMinutes)) {
+            $this->expectException(\TypeError::class);
+            $isExceptionExpected = true;
+        }
+
+        if ($isMaxInvalid || $areMinutesTooLow || $areMinutesTooHigh) {
+            $this->expectException(\Exception::class);
+            $isExceptionExpected = true;
+        }
+        if ($isMaxInvalid) {
+            $this->expectExceptionMessage('Max minutes must be greater than 0');
+        }
+        if ($areMinutesTooLow) {
+            $this->expectExceptionMessage('General_ValidatorErrorNumberTooLow');
+        }
+        if ($areMinutesTooHigh) {
+            $this->expectExceptionMessage('General_ValidatorErrorNumberTooHigh');
+        }
+
+        if (!$isExceptionExpected) {
+            $this->expectNotToPerformAssertions();
+        }
+
+        \Piwik\Plugins\CorePluginsAdmin\API::getInstance()->checkLastNMinutes($maxMinutes, $lastNMinutes);
+    }
+
+    public function getCheckLastNHoursTestData(): array
+    {
+        return [
+            ['60', 60, false, false, false],
+            ['60a', 60, false, false, false],
+            [60, '60', false, false, false],
+            [60, '60a', false, false, false],
+            [-60, 60, true, false, false],
+            [-1, 60, true, false, false],
+            [0, 60, true, false, false],
+            [1, 1, false, false, false],
+            [60, 60, false, false, false],
+            [120, 120, false, false, false],
+            [360, 360, false, false, false],
+            [720, 720, false, false, false],
+            [60, -60, false, true, false],
+            [60, -1, false, true, false],
+            [60, 0, false, true, false],
+            [1, 2, false, false, true],
+            [1, 60, false, false, true],
+            [60, 61, false, false, true],
+            [60, 120, false, false, true],
+            [120, 121, false, false, true],
+            [120, 360, false, false, true],
+            [120, 720, false, false, true],
+            [360, 361, false, false, true],
+            [360, 720, false, false, true],
+            [720, 721, false, false, true],
+        ];
+    }
+}

--- a/plugins/CorePluginsAdmin/tests/Unit/ApiTest.php
+++ b/plugins/CorePluginsAdmin/tests/Unit/ApiTest.php
@@ -23,7 +23,7 @@ class ApiTest extends TestCase
      * @return void
      * @throws \Exception
      */
-    public function testCheckLastNMinutes($maxMinutes, $lastNMinutes, $isMaxInvalid = false, $areMinutesTooLow = false, $areMinutesTooHigh = false)
+    public function testCheckLastMinutes($maxMinutes, $lastNMinutes, $isMaxInvalid = false, $areMinutesTooLow = false, $areMinutesTooHigh = false)
     {
         $isExceptionExpected = false;
         if (!is_numeric($maxMinutes)) {
@@ -54,7 +54,7 @@ class ApiTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        \Piwik\Plugins\CorePluginsAdmin\API::getInstance()->checkLastNMinutes($maxMinutes, $lastNMinutes);
+        \Piwik\Plugins\CorePluginsAdmin\API::getInstance()->checkLastMinutes($maxMinutes, $lastNMinutes);
     }
 
     public function getCheckLastNHoursTestData(): array


### PR DESCRIPTION
### Description:

There are multiple plugins that need the same validation method. Rather than duplicate code, we'd like to add it to the parent class.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
