### PR TITLE
Allow to pass a single string to write as a console message

### DIFF
--- a/core/Plugin/ConsoleCommand.php
+++ b/core/Plugin/ConsoleCommand.php
@@ -46,13 +46,17 @@ class ConsoleCommand extends SymfonyCommand
     private $input = null;
 
     /**
-     * Sends the given messages as success message to the output interface (surrounded by empty lines)
+     * Sends the given message(s) as success message(s) to the output interface (surrounded by empty lines)
      *
-     * @param string[] $messages
+     * @param string|string[] $messages
      * @return void
      */
-    public function writeSuccessMessage(array $messages): void
+    public function writeSuccessMessage(string|array $messages): void
     {
+        if (is_string($messages)) {
+            $messages = [$messages];
+        }
+
         $this->getOutput()->writeln('');
 
         foreach ($messages as $message) {

--- a/core/Plugin/ConsoleCommand.php
+++ b/core/Plugin/ConsoleCommand.php
@@ -51,7 +51,7 @@ class ConsoleCommand extends SymfonyCommand
      * @param string|string[] $messages
      * @return void
      */
-    public function writeSuccessMessage(string|array $messages): void
+    public function writeSuccessMessage($messages): void
     {
         if (is_string($messages)) {
             $messages = [$messages];

--- a/plugins/CoreAdminHome/Commands/DeleteLogsData.php
+++ b/plugins/CoreAdminHome/Commands/DeleteLogsData.php
@@ -100,8 +100,7 @@ class DeleteLogsData extends ConsoleCommand
             throw $ex;
         }
 
-        $this->writeSuccessMessage(array(
-            "Successfully deleted $logsDeleted visits. <comment>" . $timer . "</comment>"));
+        $this->writeSuccessMessage("Successfully deleted {$logsDeleted} visits. <comment>{$timer}</comment>");
 
         if ($input->getOption('optimize-tables')) {
             $this->optimizeTables();
@@ -203,6 +202,6 @@ class DeleteLogsData extends ConsoleCommand
             }
         }
 
-        $this->writeSuccessMessage(['Table optimization finished.']);
+        $this->writeSuccessMessage('Table optimization finished.');
     }
 }

--- a/plugins/CoreAdminHome/Commands/RunScheduledTasks.php
+++ b/plugins/CoreAdminHome/Commands/RunScheduledTasks.php
@@ -48,7 +48,7 @@ class RunScheduledTasks extends ConsoleCommand
             $scheduler->run();
         }
 
-        $this->writeSuccessMessage(array('Scheduled Tasks executed'));
+        $this->writeSuccessMessage('Scheduled Tasks executed');
 
         return self::SUCCESS;
     }

--- a/plugins/CoreConsole/Commands/ClearCaches.php
+++ b/plugins/CoreConsole/Commands/ClearCaches.php
@@ -31,7 +31,7 @@ class ClearCaches extends ConsoleCommand
         // Note: the logic for this command must be refactored in this helper function below.
         Filesystem::deleteAllCacheOnUpdate();
 
-        $this->writeSuccessMessage(array('Caches cleared'));
+        $this->writeSuccessMessage('Caches cleared');
 
         return self::SUCCESS;
     }

--- a/plugins/CoreConsole/Commands/DevelopmentEnable.php
+++ b/plugins/CoreConsole/Commands/DevelopmentEnable.php
@@ -48,7 +48,7 @@ class DevelopmentEnable extends ConsoleCommand
 
         Filesystem::deleteAllCacheOnUpdate();
 
-        $this->writeSuccessMessage(array($message));
+        $this->writeSuccessMessage($message);
 
         if ($enable && !SettingsPiwik::isGitDeployment()) {
             $comment = 'Development mode should be only enabled when installed through git. Not every development feature will be available.';

--- a/plugins/CoreConsole/Commands/GenerateCommand.php
+++ b/plugins/CoreConsole/Commands/GenerateCommand.php
@@ -44,9 +44,7 @@ class GenerateCommand extends GeneratePluginBase
 
         $this->copyTemplateToPlugin($exampleFolder, $pluginName, $replace, $whitelistFiles);
 
-        $this->writeSuccessMessage(array(
-            sprintf('Command %s for plugin %s generated', $commandName, $pluginName)
-        ));
+        $this->writeSuccessMessage(sprintf('Command %s for plugin %s generated', $commandName, $pluginName));
 
         return self::SUCCESS;
     }

--- a/plugins/CoreUpdater/Commands/ConvertToUtf8mb4.php
+++ b/plugins/CoreUpdater/Commands/ConvertToUtf8mb4.php
@@ -60,7 +60,7 @@ class ConvertToUtf8mb4 extends ConsoleCommand
         $output->writeln("This command will convert all Matomo database tables to utf8mb4.\n");
 
         if (DbHelper::getDefaultCharset() !== 'utf8mb4') {
-            $this->writeSuccessMessage(array('Your database does not support utf8mb4'));
+            $this->writeSuccessMessage('Your database does not support utf8mb4');
             return self::FAILURE;
         }
 
@@ -102,9 +102,9 @@ class ConvertToUtf8mb4 extends ConsoleCommand
                 $config->forceSave();
             }
 
-            $this->writeSuccessMessage(array('Conversion to utf8mb4 successful.'));
+            $this->writeSuccessMessage('Conversion to utf8mb4 successful.');
         } else {
-            $this->writeSuccessMessage(array('Database conversion skipped.'));
+            $this->writeSuccessMessage('Database conversion skipped.');
         }
 
         return self::SUCCESS;

--- a/plugins/CoreUpdater/Commands/Update.php
+++ b/plugins/CoreUpdater/Commands/Update.php
@@ -75,15 +75,15 @@ class Update extends ConsoleCommand
 
                     $this->makeUpdate(false);
 
-                    $this->writeSuccessMessage(array(Piwik::translate('CoreUpdater_PiwikHasBeenSuccessfullyUpgraded')));
+                    $this->writeSuccessMessage(Piwik::translate('CoreUpdater_PiwikHasBeenSuccessfullyUpgraded'));
                 } else {
-                    $this->writeSuccessMessage(array(Piwik::translate('CoreUpdater_DbUpgradeNotExecuted')));
+                    $this->writeSuccessMessage(Piwik::translate('CoreUpdater_DbUpgradeNotExecuted'));
                 }
 
                 $this->writeAlertMessageWhenCommandExecutedWithUnexpectedUser();
             } catch (NoUpdatesFoundException $e) {
                 // Do not fail if no updates were found
-                $this->writeSuccessMessage(array($e->getMessage()));
+                $this->writeSuccessMessage($e->getMessage());
             }
         } finally {
             Filesystem::$skipCacheClearOnUpdate = false;

--- a/plugins/CustomDimensions/Commands/AddCustomDimension.php
+++ b/plugins/CustomDimensions/Commands/AddCustomDimension.php
@@ -63,9 +63,9 @@ class AddCustomDimension extends ConsoleCommand
 
         $numDimensionsAvailable = $tracking->getNumInstalledIndexes();
 
-        $this->writeSuccessMessage([
+        $this->writeSuccessMessage(
             sprintf('Your Matomo is now configured for up to %d Custom Dimensions in scope %s.', $numDimensionsAvailable, $scope)
-        ]);
+        );
 
         return self::SUCCESS;
     }

--- a/plugins/CustomDimensions/Commands/RemoveCustomDimension.php
+++ b/plugins/CustomDimensions/Commands/RemoveCustomDimension.php
@@ -87,9 +87,9 @@ class RemoveCustomDimension extends ConsoleCommand
 
         $numDimensionsAvailable = $tracking->getNumInstalledIndexes();
 
-        $this->writeSuccessMessage([
+        $this->writeSuccessMessage(
             sprintf('Your Matomo is now configured for up to %d Custom Dimensions in scope %s.', $numDimensionsAvailable, $scope)
-        ]);
+        );
 
         return self::SUCCESS;
     }

--- a/plugins/Goals/Commands/CalculateConversionPages.php
+++ b/plugins/Goals/Commands/CalculateConversionPages.php
@@ -97,7 +97,7 @@ class CalculateConversionPages extends ConsoleCommand
             $output->write(".");
         }
 
-        $this->writeSuccessMessage(["Successfully calculated the pages before metric for $totalCalculated conversions. <comment>" . $timer . "</comment>"]);
+        $this->writeSuccessMessage("Successfully calculated the pages before metric for $totalCalculated conversions. <comment>{$timer}</comment>");
 
         return self::SUCCESS;
     }

--- a/plugins/TestRunner/Commands/TestsSetupFixture.php
+++ b/plugins/TestRunner/Commands/TestsSetupFixture.php
@@ -189,7 +189,7 @@ class TestsSetupFixture extends ConsoleCommand
             $fixture->performSetUp();
         }
 
-        $this->writeSuccessMessage(array("Fixture successfully setup!"));
+        $this->writeSuccessMessage("Fixture successfully set up!");
 
         $sqlDumpPath = $input->getOption('sqldump');
         if ($sqlDumpPath) {
@@ -236,7 +236,7 @@ class TestsSetupFixture extends ConsoleCommand
         $output->writeln("<info>Executing $command...</info>");
         passthru($command);
 
-        $this->writeSuccessMessage(array("SQL dump created!"));
+        $this->writeSuccessMessage("SQL dump created!");
     }
 
     private function setupDatabaseOverrides(Fixture $fixture)


### PR DESCRIPTION
### Description:

A small quality of life improvement that I came across when working on https://github.com/matomo-org/matomo/issues/22634.

The method indicates that it would write a single message but an array was required to wrap even a single string. This change allows to pass in both a single string or an array of strings.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
