### PR TITLE
Fix detection of current transaction isolation level

### DIFF
--- a/core/Db/TransactionalDatabaseDynamicTrait.php
+++ b/core/Db/TransactionalDatabaseDynamicTrait.php
@@ -10,7 +10,7 @@ trait TransactionalDatabaseDynamicTrait
     {
         try {
             return $this->fetchOne('SELECT @@TX_ISOLATION');
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $this->fetchOne('SELECT @@transaction_isolation');
         }
     }

--- a/core/Db/TransactionalDatabaseStaticTrait.php
+++ b/core/Db/TransactionalDatabaseStaticTrait.php
@@ -15,7 +15,7 @@ trait TransactionalDatabaseStaticTrait
     {
         try {
             return static::fetchOne('SELECT @@TX_ISOLATION');
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return static::fetchOne('SELECT @@transaction_isolation');
         }
     }


### PR DESCRIPTION
### Description:

The implementation of #22535 moved the detection of the current transaction level to traits.

During this migration a typo slipped through, breaking the fallback from `@@TX_ISOLATION` to `@@transaction_isolation` because PHP happily ignores any catch statement for classes that don't exist.

- `MySQL 5.7` and `MariaDB latest` (the database versions running in CI) both provide the `@@TX_ISOLATION` system variable, so tests were successful
- `MySQL 8.0` does NOT provide that variable, triggering the fallback that was then skipped due to a typo in the `catch` clause.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
