### PR TITLE
Fix Flatten Report option is removed after search in UI reports

### DIFF
--- a/plugins/Actions/javascripts/actionsDataTable.js
+++ b/plugins/Actions/javascripts/actionsDataTable.js
@@ -53,11 +53,11 @@
             // we don't display the link on the row with subDataTable when we are already
             // printing all the subTables (case of recursive search when the content is
             // including recursively all the subtables
-            if (!self.param.filter_pattern_recursive) {
-                self.numberOfSubtables = rows.filter('.subDataTable').click(function () {
-                    self.onClickActionSubDataTable(this)
-                }).length;
-            }
+            self.numberOfSubtables = rows.filter('.subDataTable').click(function () {
+              if (!self.param.filter_pattern_recursive) {
+                  self.onClickActionSubDataTable(this);
+              }
+            }).length;
             self.applyCosmetics(domElem, rows);
             self.handleColumnHighlighting(domElem);
             self.handleRowActions(domElem, rows);

--- a/plugins/Actions/javascripts/actionsDataTable.js
+++ b/plugins/Actions/javascripts/actionsDataTable.js
@@ -50,13 +50,13 @@
                 rows = $('tr', domElem);
             }
 
-            // we don't display the link on the row with subDataTable when we are already
-            // printing all the subTables (case of recursive search when the content is
-            // including recursively all the subtables
             self.numberOfSubtables = rows.filter('.subDataTable').click(function () {
-              if (!self.param.filter_pattern_recursive) {
-                  self.onClickActionSubDataTable(this);
-              }
+                if (!self.param.filter_pattern_recursive) {
+                    // we don't display the link on the row with subDataTable when we are already
+                    // printing all the subTables (case of recursive search when the content is
+                    // including recursively all the subtables
+                    self.onClickActionSubDataTable(this);
+                }
             }).length;
             self.applyCosmetics(domElem, rows);
             self.handleColumnHighlighting(domElem);


### PR DESCRIPTION
### Description:

Fixes https://github.com/matomo-org/matomo/issues/22650

Problem was that Flatten option was only shown in [vue template](https://github.com/matomo-org/matomo/blob/5.2.0-b4/plugins/CoreHome/vue/src/ReportExport/ReportExportPopover.vue#L30) when it [has subtables](https://github.com/matomo-org/matomo/blob/5.2.0-b4/plugins/CoreHome/vue/src/ReportExport/ReportExport.ts#L52C9-L52C21). 

When someone searched, a filter pattern was defined and prevented the subtable count to function.

We falsely ignored the subtable count when we only wanted to ignore "onClickActionSubDataTable" part when a filter pattern is defined. Meaning when a search is done, we're ignoring the +/- Icons and we don't make them work because we show them all always expanded. This behaviour we could potentially improve in the future and still have those icons work. That's a different topic though.

### Reproduction steps:
* Go to https://demo.matomo.cloud/index.php?module=CoreHome&action=index&idSite=1&period=day&date=yesterday#?idSite=1&period=day&date=yesterday&category=General_Actions&subcategory=General_Pages
* Search in the table footer 
![image](https://github.com/user-attachments/assets/6581a6f0-6863-44ca-b1fc-0f6e80849f92)
* Click on export icon
![image](https://github.com/user-attachments/assets/591d8380-c788-49f9-a6ed-330b04872ee5)
* You will now see the flatten option appear and it works appropriately depending on if flatten option is enabled or disabled
![image](https://github.com/user-attachments/assets/4068c319-15bb-4e95-af3a-79200b9b5a6b)

Before this PR, the flatten option wasn't shown.

### Risks of this PR

Is limited because the change is contained in the ActionsDataTable (applied to Actions plugin reports mostly). Not in the dataTable used by all other reports.

Didn't add a UI test for it as it's rather edge case.

(Ref DEV-18579)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
