### PR TITLE
Run tests on PHP 8.4 instead of PHP 8.3

### DIFF
--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: ${{ inputs.is_preview == true }}
       matrix:
         type: [ 'UnitTests', 'SystemTestsPlugins', 'SystemTestsCore', 'IntegrationTestsCore', 'IntegrationTestsPlugins' ]
-        php: [ '7.2', '8.2', '8.3' ]
+        php: [ '7.2', '8.2', '8.4' ]
         engine: [ 'Mysql', 'Mariadb' ]
         adapter: [ 'PDO_MYSQL', 'MYSQLI' ]
         exclude:
@@ -55,13 +55,13 @@ jobs:
             engine: 'Mariadb'
           - php: '8.2'
             engine: 'Mysql'
-          - php: '8.3'
+          - php: '8.4'
             engine: 'Mariadb'
           - php: '7.2'
             adapter: 'MYSQLI'
           - php: '8.2'
             adapter: 'MYSQLI'
-          - php: '8.3'
+          - php: '8.4'
             adapter: 'PDO_MYSQL'
     steps:
       - uses: actions/checkout@v4
@@ -133,7 +133,6 @@ jobs:
       - name: running tests
         uses: matomo-org/github-action-tests@main
         with:
-          testomatio: ${{ secrets.TESTOMATIO }}
           ui-test-options: '--num-test-groups=4 --test-group=${{ matrix.parts }}'
           test-type: 'UI'
           php-version: '7.2'
@@ -141,3 +140,4 @@ jobs:
           redis-service: true
           artifacts-pass: ${{ secrets.ARTIFACTS_PASS }}
           upload-artifacts: true
+          testomatio: ${{ secrets.TESTOMATIO }}

--- a/core/ErrorHandler.php
+++ b/core/ErrorHandler.php
@@ -115,7 +115,9 @@ class ErrorHandler
                 return "User Warning";
             case E_USER_NOTICE:
                 return "User Notice";
-            case E_STRICT:
+            // E_STRICT is deprecated as of PHP 8.4
+            // @todo can be removed once only PHP 8 is supported
+            case @E_STRICT:
                 return "Strict Notice";
             case E_RECOVERABLE_ERROR:
                 return "Recoverable Error";
@@ -160,7 +162,9 @@ class ErrorHandler
             case E_NOTICE:
             case E_USER_WARNING:
             case E_USER_NOTICE:
-            case E_STRICT:
+            // E_STRICT is deprecated as of PHP 8.4
+            // @todo can be removed once only PHP 8 is supported
+            case @E_STRICT:
             case E_RECOVERABLE_ERROR:
             case E_DEPRECATED:
             case E_USER_DEPRECATED:

--- a/core/bootstrap.php
+++ b/core/bootstrap.php
@@ -15,7 +15,15 @@ if (!defined('PIWIK_USER_PATH')) {
     define('PIWIK_USER_PATH', PIWIK_DOCUMENT_ROOT);
 }
 
-error_reporting(E_ALL);
+$errorLevel = E_ALL;
+
+// We cannot enable deprecations for PHP 8.4 until we were able to update php-di/php-di to a version compatible
+// with PHP 8.4. Otherwise deprecation notices would be triggered at a point, where they break Matomo
+if (version_compare(PHP_VERSION, '8.4.0-dev', '>=')) {
+    $errorLevel = E_ALL & ~E_DEPRECATED;
+}
+
+error_reporting($errorLevel);
 @ini_set('display_errors', defined('PIWIK_DISPLAY_ERRORS') ? PIWIK_DISPLAY_ERRORS : @ini_get('display_errors'));
 @ini_set('xdebug.show_exception_trace', 0);
 

--- a/core/bootstrap.php
+++ b/core/bootstrap.php
@@ -17,8 +17,8 @@ if (!defined('PIWIK_USER_PATH')) {
 
 $errorLevel = E_ALL;
 
-// We cannot enable deprecations for PHP 8.4 until we were able to update php-di/php-di to a version compatible
-// with PHP 8.4. Otherwise deprecation notices would be triggered at a point, where they break Matomo
+// We cannot enable deprecations for PHP 8.4 until we are able to update php-di/php-di to a version compatible
+// with PHP 8.4. Otherwise deprecation notices would be triggered at a point where they break Matomo completely.
 if (version_compare(PHP_VERSION, '8.4.0-dev', '>=')) {
     $errorLevel = E_ALL & ~E_DEPRECATED;
 }

--- a/js/tracker.php
+++ b/js/tracker.php
@@ -26,6 +26,9 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST'
  */
 define('PIWIK_DOCUMENT_ROOT', '..');
 
+// ensure errors are not printed
+ini_set('display_errors', 0);
+
 if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
     require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
 }

--- a/tests/PHPUnit/Integration/DocumentationGeneratorTest.php
+++ b/tests/PHPUnit/Integration/DocumentationGeneratorTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Piwik\API\DocumentationGenerator;
 use Piwik\API\Proxy;
 use Piwik\EventDispatcher;
+use ReflectionClass;
 
 /**
  * @group Core
@@ -21,14 +22,9 @@ class DocumentationGeneratorTest extends TestCase
 {
     public function testCheckIfModuleContainsHideAnnotation()
     {
-        $annotation = '@hideExceptForSuperUser test test';
-        $mock = $this->getMockBuilder('ReflectionClass')
-            ->disableOriginalConstructor()
-            ->onlyMethods(array('getDocComment'))
-            ->getMock();
-        $mock->expects($this->once())->method('getDocComment')->willReturn($annotation);
+        $refelction = new ReflectionClass(DocumentationGenerator::class);
         $documentationGenerator = new DocumentationGenerator();
-        $this->assertTrue($documentationGenerator->checkIfClassCommentContainsHideAnnotation($mock));
+        $this->assertTrue($documentationGenerator->checkIfClassCommentContainsHideAnnotation($refelction));
     }
 
     public function testCheckDocumentation()

--- a/tests/PHPUnit/Integration/DocumentationGeneratorTest.php
+++ b/tests/PHPUnit/Integration/DocumentationGeneratorTest.php
@@ -22,9 +22,9 @@ class DocumentationGeneratorTest extends TestCase
 {
     public function testCheckIfModuleContainsHideAnnotation()
     {
-        $refelction = new ReflectionClass(DocumentationGenerator::class);
+        $reflection = new ReflectionClass(DocumentationGenerator::class);
         $documentationGenerator = new DocumentationGenerator();
-        $this->assertTrue($documentationGenerator->checkIfClassCommentContainsHideAnnotation($refelction));
+        $this->assertTrue($documentationGenerator->checkIfClassCommentContainsHideAnnotation($reflection));
     }
 
     public function testCheckDocumentation()

--- a/tests/PHPUnit/Integration/FrontControllerTest.php
+++ b/tests/PHPUnit/Integration/FrontControllerTest.php
@@ -52,6 +52,12 @@ FORMAT;
 test message on {includePath}/tests/resources/trigger-fatal-exception.php(23) #0 [internal function]: {closure}('CoreHome', 'index', Array) #1 {includePath}/core/EventDispatcher.php(141): call_user_func_array(Object(Closure), Array) #2 {includePath}/core/Piwik.php(845): Piwik\EventDispatcher-&gt;postEvent('Request.dispatc...', Array, false, Array) #3 {includePath}/core/FrontController.php(606): Piwik\Piwik::postEvent('Request.dispatc...', Array) #4 {includePath}/core/FrontController.php(168): Piwik\FrontController-&gt;doDispatch('CoreHome', 'index', Array) #5 {includePath}/tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('CoreHome', 'index') #6 {main}
 FORMAT;
 
+        if (version_compare(PHP_VERSION, '8.4.0-dev', '>=')) {
+            $expectedFormat = <<<FORMAT
+test message on {includePath}/tests/resources/trigger-fatal-exception.php(23) #0 [internal function]: {closure:{includePath}/tests/resources/trigger-fatal-exception.php:20}('...', '...', Array) #1 {includePath}/core/EventDispatcher.php(147): call_user_func_array(Object(Closure), Array) #2 {includePath}/core/Piwik.php(880): Piwik\EventDispatcher-&gt;postEvent('...', Array, false, Array) #3 {includePath}/core/FrontController.php(625): Piwik\Piwik::postEvent('...', Array) #4 {includePath}/core/FrontController.php(169): Piwik\FrontController-&gt;doDispatch('...', '...', Array) #5 {includePath}/tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('...', '...') #6 {main}
+FORMAT;
+        }
+
         //remove all the numbers
         $expectedFormat = preg_replace('/[0-9]+/', 'x', $expectedFormat);
         $expectedFormat = preg_replace('/".*?"|\'.*?\'/', 'xxx', $expectedFormat);

--- a/tests/PHPUnit/System/EnvironmentValidationTest.php
+++ b/tests/PHPUnit/System/EnvironmentValidationTest.php
@@ -124,7 +124,11 @@ class EnvironmentValidationTest extends SystemTestCase
 
     private function assertOutputContainsConfigFileMissingError($fileName, $output)
     {
-        $this->assertRegExp("/.*The configuration file \\{.*\\/" . preg_quote($fileName) . "\\} has not been found or could not be read\\..*/", $output, "Output did not contain the expected exception for $fileName --- Output was --- $output");
+        $this->assertRegExp(
+            "/.*The configuration file \\{.*\\/" . preg_quote($fileName) . "\\} has not been found or could not be read\\..*/",
+            (string) $output,
+            "Output did not contain the expected exception for $fileName --- Output was --- $output"
+        );
     }
 
     private function assertOutputContainsBadConfigFileError($output)


### PR DESCRIPTION
### Description:

This PR contains a couple of changes / fixes for PHP 8.4

* Deprecations will be removed from error_reporting for PHP 8.4+
  This is required, as we are using a couple of vendor libraries, that are not compatible with PHP 8.4. Updating them is not possible as long as we support PHP < 8
* Various changes to tests to ensure they also pass with PHP 8.4
* Suppress deprecation notices where `E_STRICT` is used
* Ensure javascript tracker proxy runs with `display_errors = 0`, to ensure no deprecation notices are printed within the javascript code

Last Test run with all test suites on PHP 8.4: https://github.com/matomo-org/matomo/actions/runs/11437068780?pr=22667

fixes #22471

(Ref DEV-18385)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
