### PR TITLE
Fix Unique visitors and Users metric shown in Users report

### DIFF
--- a/plugins/UserId/Reports/GetUsers.php
+++ b/plugins/UserId/Reports/GetUsers.php
@@ -56,6 +56,7 @@ class GetUsers extends Base
          * Hide most of the table footer actions, leaving only export icons and pagination
          */
         $view->config->columns_to_display = $this->metrics;
+
         $view->config->show_all_views_icons = false;
         $view->config->show_related_reports = false;
         $view->config->show_insights = false;
@@ -69,6 +70,14 @@ class GetUsers extends Base
 
         if ($view->isViewDataTableId(HtmlTable::ID)) {
             $view->config->disable_row_evolution = false;
+        }
+
+        if ($view->isViewDataTableId(HtmlTable\AllColumns::ID)) {
+            $view->config->filters[] = function () use ($view) {
+                // unique visitors and user metrics doesn't make sense here as they would be always showing a value of 1
+                $columnsToRemove = ['nb_uniq_visitors', 'nb_users'];
+                $view->config->columns_to_display = array_diff($view->config->columns_to_display, $columnsToRemove);
+            };
         }
 
         // exclude users with less then 2 visits, when low population filter is active

--- a/plugins/UserId/tests/UI/UserId_spec.js
+++ b/plugins/UserId/tests/UI/UserId_spec.js
@@ -1,0 +1,28 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * Screenshot tests for UserId plugin
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+describe("UserId", function () {
+  this.fixture = "Piwik\\Plugins\\UserId\\tests\\Fixtures\\TrackFewVisitsAndCreateUsers";
+
+  it('should show user id report', async function () {
+    await page.goto('?module=CoreHome&action=index&idSite=1&period=day&date=2010-02-04#?idSite=1&period=day&date=2010-02-04&category=General_Visitors&subcategory=UserId_UserReportTitle');
+    await page.waitForNetworkIdle();
+    expect(await page.screenshotSelector('#widgetUserIdgetUsers')).to.matchImage('report');
+  });
+
+    it('should switch to table with engagement metrics', async function () {
+      await page.click('.activateVisualizationSelection > span');
+      await page.click('.tableIcon[data-footer-icon-id=tableAllColumns]');
+      await page.mouse.move(-10, -10);
+      await page.waitForNetworkIdle();
+      expect(await page.screenshotSelector('#widgetUserIdgetUsers')).to.matchImage('report_engagement');
+  });
+
+
+});

--- a/plugins/UserId/tests/UI/expected-screenshots/UserId_report.png
+++ b/plugins/UserId/tests/UI/expected-screenshots/UserId_report.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f54555d03b5fdc09e759f27f666234f05fd007f4f7c96e3944017ee4d7eec8d3
+size 14161

--- a/plugins/UserId/tests/UI/expected-screenshots/UserId_report_engagement.png
+++ b/plugins/UserId/tests/UI/expected-screenshots/UserId_report_engagement.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d70366a0210ca42b6cbab7b5c15f093c860636720348e7a901c363bf6228774c
+size 20526


### PR DESCRIPTION
### Description:

Fix https://github.com/matomo-org/matomo/issues/19850

Removes Users and Unique Visitors metrics from the Users report. Those metrics don't make sense considering they would be always "1" except for the others row.

I also thought about additionally removing it from the API response (see diff below) but wasn't sure if we consider this a breaking API change. Figured in the API response the output of those metrics doesn't hurt as much and we can keep it there. In the UI the unneeded metrics "hurt" more considering it's processed by humans and it causes distraction.

```diff
diff --git a/plugins/UserId/API.php b/plugins/UserId/API.php
index a213466346..13256f5666 100644
--- a/plugins/UserId/API.php
+++ b/plugins/UserId/API.php
@@ -40,6 +40,9 @@ class API extends \Piwik\Plugin\API
         $dataTable->queueFilter('ReplaceColumnNames');
         $dataTable->queueFilter('ReplaceSummaryRowLabel');
         $dataTable->queueFilter('AddSegmentByLabel', array('userId'));
+        // Removing columns queued to improve performance. We could have 100K users in the table but only
+        // display 50 of them. We only want to perform this action on the 50 users.
+        $dataTable->queueFilter('ColumnDelete', array(array('nb_users', 'nb_uniq_visitors')));
 
         return $dataTable;
     }
```

#### Steps to reproduce
* Go:
https://demo.matomo.cloud/index.php?module=CoreHome&action=index&idSite=1&period=day&date=yesterday#?period=day&date=2022-10-10&idSite=1&category=General_Visitors&subcategory=UserId_UserReportTitle
* Click on the Change Visualisation icon then Display a table with Visitor engagement metrics
* Then some unneeded metrics were displayed:
![image](https://github.com/user-attachments/assets/619fddde-121d-43f5-a040-6921ff17c722)
* With this patch they are no longer shown

(Ref DEV-13846)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
