### PR TITLE
Update core:convert-to-utf8mb4 to write db collaction to config

### DIFF
--- a/core/DataAccess/ArchiveTableCreator.php
+++ b/core/DataAccess/ArchiveTableCreator.php
@@ -116,24 +116,11 @@ class ArchiveTableCreator
         }
 
         // sort tables so we have them in descending order of their date
-        rsort($archiveTables);
+        usort($archiveTables, function ($a, $b) {
+            return static::getDateFromTableName($b) <=> static::getDateFromTableName($a);
+        });
 
-        // if we have a type, we can rely on name ordering, otherwise we need to extract the year_month and compare
-        if ($type) {
-            return $archiveTables[0];
-        } else {
-            $latestDate = '0_00';
-            $latestTable = null;
-            foreach ($archiveTables as $archiveTable) {
-                $tableDate = static::getDateFromTableName($archiveTable);
-                if ($tableDate > $latestDate) {
-                    $latestDate = $tableDate;
-                    $latestTable = $archiveTable;
-                }
-            }
-
-            return $latestTable;
-        }
+        return $archiveTables[0];
     }
 
     public static function getDateFromTableName($tableName)

--- a/core/Plugin/ConsoleCommand.php
+++ b/core/Plugin/ConsoleCommand.php
@@ -67,13 +67,38 @@ class ConsoleCommand extends SymfonyCommand
     }
 
     /**
-     * Sends the given messages as comment message to the output interface (surrounded by empty lines)
+     * Sends the given message(s) as error message(s) to the output interface (surrounded by empty lines)
      *
-     * @param string[] $messages
+     * @param string|string[] $messages
      * @return void
      */
-    public function writeComment(array $messages): void
+    public function writeErrorMessage($messages): void
     {
+        if (is_string($messages)) {
+            $messages = [$messages];
+        }
+
+        $this->getOutput()->writeln('');
+
+        foreach ($messages as $message) {
+            $this->getOutput()->writeln(self::wrapInTag('error', $message));
+        }
+
+        $this->getOutput()->writeln('');
+    }
+
+    /**
+     * Sends the given messages as comment message to the output interface (surrounded by empty lines)
+     *
+     * @param string|string[] $messages
+     * @return void
+     */
+    public function writeComment($messages): void
+    {
+        if (is_string($messages)) {
+            $messages = [$messages];
+        }
+
         $this->getOutput()->writeln('');
 
         foreach ($messages as $message) {

--- a/core/Updates/5.2.0-b2.php
+++ b/core/Updates/5.2.0-b2.php
@@ -80,17 +80,8 @@ class Updates_5_2_0_b2 extends Updates
                 return $userTableCollation;
             }
 
-            $archiveTables = ArchiveTableCreator::getTablesArchivesInstalled(ArchiveTableCreator::NUMERIC_TABLE);
-
-            if (0 === count($archiveTables)) {
-                // skip if there is no archive table (yet)
-                return null;
-            }
-
-            // sort tables so we have them in order of their date
-            rsort($archiveTables);
-
-            $archiveTableStatus = $metadataProvider->getTableStatus(Common::unprefixTable($archiveTables[0]));
+            $archiveTable = ArchiveTableCreator::getLatestArchiveTableInstalled(ArchiveTableCreator::NUMERIC_TABLE);
+            $archiveTableStatus = $metadataProvider->getTableStatus(Common::unprefixTable($archiveTable));
 
             if (
                 !empty($archiveTableStatus['Collation'] ?? null)

--- a/core/Updates/5.2.0-b2.php
+++ b/core/Updates/5.2.0-b2.php
@@ -65,7 +65,7 @@ class Updates_5_2_0_b2 extends Updates
 
             $metadataProvider = StaticContainer::get('Piwik\Plugins\DBStats\MySQLMetadataProvider');
             $userTableStatus = $metadataProvider->getTableStatus('user');
-            if (empty($userTableStatus['Collation'])) {
+            if (empty($userTableStatus['Collation'] ?? null)) {
                 // if there is no user table, or no collation for it, abort detection
                 // this table should always exist and something must be wrong in this case
                 return null;
@@ -93,7 +93,7 @@ class Updates_5_2_0_b2 extends Updates
             $archiveTableStatus = $metadataProvider->getTableStatus(Common::unprefixTable($archiveTables[0]));
 
             if (
-                !empty($archiveTableStatus['Collation'])
+                !empty($archiveTableStatus['Collation'] ?? null)
                 && $archiveTableStatus['Collation'] === $userTableCollation
             ) {
                 // the most recent numeric archive table is matching the collation

--- a/core/Updates/5.2.0-b2.php
+++ b/core/Updates/5.2.0-b2.php
@@ -11,6 +11,7 @@ namespace Piwik\Updates;
 
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\Db;
 use Piwik\Updater;
@@ -61,9 +62,9 @@ class Updates_5_2_0_b2 extends Updates
     {
         try {
             $db = Db::get();
-            $userTable = Common::prefixTable('user');
-            $userTableStatus = $db->fetchRow('SHOW TABLE STATUS WHERE Name = ?', [$userTable]);
 
+            $metadataProvider = StaticContainer::get('Piwik\Plugins\DBStats\MySQLMetadataProvider');
+            $userTableStatus = $metadataProvider->getTableStatus('user');
             if (empty($userTableStatus['Collation'])) {
                 // if there is no user table, or no collation for it, abort detection
                 // this table should always exist and something must be wrong in this case
@@ -89,7 +90,7 @@ class Updates_5_2_0_b2 extends Updates
             // sort tables so we have them in order of their date
             rsort($archiveTables);
 
-            $archiveTableStatus = $db->fetchRow('SHOW TABLE STATUS WHERE Name = ?', [$archiveTables[0]]);
+            $archiveTableStatus = $metadataProvider->getTableStatus(Common::unprefixTable($archiveTables[0]));
 
             if (
                 !empty($archiveTableStatus['Collation'])

--- a/core/Updates/5.2.0-b2.php
+++ b/core/Updates/5.2.0-b2.php
@@ -81,10 +81,14 @@ class Updates_5_2_0_b2 extends Updates
             }
 
             $archiveTable = ArchiveTableCreator::getLatestArchiveTableInstalled(ArchiveTableCreator::NUMERIC_TABLE);
+            if (null === $archiveTable) {
+                return null;
+            }
+
             $archiveTableStatus = $metadataProvider->getTableStatus(Common::unprefixTable($archiveTable));
 
             if (
-                !empty($archiveTableStatus['Collation'] ?? null)
+                !empty($archiveTableStatus['Collation'])
                 && $archiveTableStatus['Collation'] === $userTableCollation
             ) {
                 // the most recent numeric archive table is matching the collation

--- a/plugins/CoreUpdater/Commands/ConvertToUtf8mb4.php
+++ b/plugins/CoreUpdater/Commands/ConvertToUtf8mb4.php
@@ -154,7 +154,7 @@ class ConvertToUtf8mb4 extends ConsoleCommand
         try {
             $metadataProvider = StaticContainer::get('Piwik\Plugins\DBStats\MySQLMetadataProvider');
             $userTableStatus = $metadataProvider->getTableStatus('user');
-            if (empty($userTableStatus['Collation'])) {
+            if (empty($userTableStatus['Collation'] ?? null)) {
                 // if there is no user table, or no collation for it, abort detection
                 // this table should always exist and something must be wrong in this case
                 return null;
@@ -165,7 +165,7 @@ class ConvertToUtf8mb4 extends ConsoleCommand
             $archiveTableStatus = $metadataProvider->getTableStatus(Common::unprefixTable($archiveTable));
 
             if (
-                !empty($archiveTableStatus['Collation'])
+                !empty($archiveTableStatus['Collation'] ?? null)
                 && $archiveTableStatus['Collation'] === $userTableCollation
             ) {
                 // the most recent numeric archive table is matching the collation

--- a/plugins/CoreUpdater/Commands/ConvertToUtf8mb4.php
+++ b/plugins/CoreUpdater/Commands/ConvertToUtf8mb4.php
@@ -162,10 +162,14 @@ class ConvertToUtf8mb4 extends ConsoleCommand
             $userTableCollation = $userTableStatus['Collation'];
 
             $archiveTable = ArchiveTableCreator::getLatestArchiveTableInstalled(ArchiveTableCreator::NUMERIC_TABLE);
+            if (null === $archiveTable) {
+                return null;
+            }
+
             $archiveTableStatus = $metadataProvider->getTableStatus(Common::unprefixTable($archiveTable));
 
             if (
-                !empty($archiveTableStatus['Collation'] ?? null)
+                !empty($archiveTableStatus['Collation'])
                 && $archiveTableStatus['Collation'] === $userTableCollation
             ) {
                 // the most recent numeric archive table is matching the collation

--- a/plugins/CoreUpdater/Commands/ConvertToUtf8mb4.php
+++ b/plugins/CoreUpdater/Commands/ConvertToUtf8mb4.php
@@ -54,13 +54,13 @@ class ConvertToUtf8mb4 extends ConsoleCommand
         $show = $input->getOption('show');
 
         if (DbHelper::getDefaultCharset() !== 'utf8mb4') {
-            $this->writeSuccessMessage('Your database does not support utf8mb4');
+            $this->writeErrorMessage('Your database does not support utf8mb4');
             return self::FAILURE;
         }
 
         $defaultCollation = DbHelper::getDefaultCollationForCharset('utf8mb4');
         if (empty($defaultCollation)) {
-            $this->writeSuccessMessage('Could not detect default collation for utf8mb4 charset');
+            $this->writeErrorMessage('Could not detect default collation for utf8mb4 charset');
             return self::FAILURE;
         }
 

--- a/tests/PHPUnit/Unit/DataAccess/ArchiveTableCreatorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/ArchiveTableCreatorTest.php
@@ -50,52 +50,75 @@ class ArchiveTableCreatorTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedTables, $tables);
     }
 
-    public function getTestDataForGetTablesArchivesInstalled()
+    public function getTestDataForGetTablesArchivesInstalled(): array
     {
-        return array(
-            array(
+        return [
+            [
                 ArchiveTableCreator::BLOB_TABLE,
-                array(
+                [
                     'archive_blob_2015_05',
                     'archive_blob_2015_01',
                     'archive_blob_2015_02',
-                ),
-            ),
+                ],
+            ],
 
-            array(
+            [
                 ArchiveTableCreator::NUMERIC_TABLE,
-                array(
+                [
                     'archive_numeric_2015_02',
                     'archive_numeric_2014_03',
-                ),
-            ),
+                ],
+            ],
 
-            array(
+            [
                 'qewroufsjdlf',
-                array(),
-            ),
+                [],
+            ],
 
-            array(
+            [
                 '',
-                array(
+                [
                     'archive_numeric_2015_02',
                     'archive_blob_2015_05',
                     'archive_numeric_2014_03',
                     'archive_blob_2015_01',
                     'archive_blob_2015_02',
-                ),
-            ),
+                ],
+            ],
 
-            array(
+            [
                 null,
-                array(
+                [
                     'archive_numeric_2015_02',
                     'archive_blob_2015_05',
                     'archive_numeric_2014_03',
                     'archive_blob_2015_01',
                     'archive_blob_2015_02',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getTestDataForGetLatestArchiveTableInstalled
+     */
+    public function testGetLatestArchiveTableInstalled($type, $expectedLatestTable)
+    {
+        ArchiveTableCreator::$tablesAlreadyInstalled = $this->tables;
+
+        $latestTable = ArchiveTableCreator::getLatestArchiveTableInstalled($type);
+
+        $this->assertEquals($expectedLatestTable, $latestTable);
+    }
+
+    public function getTestDataForGetLatestArchiveTableInstalled(): array
+    {
+        return [
+            [ArchiveTableCreator::BLOB_TABLE, 'archive_blob_2015_05'],
+            [ArchiveTableCreator::NUMERIC_TABLE, 'archive_numeric_2015_02'],
+            ['qewroufsjdlf', ''],
+            ['', 'archive_blob_2015_05'],
+            [null, 'archive_blob_2015_05'],
+        ];
     }
 }


### PR DESCRIPTION
### Description:

Updates the `core:convert-to-utf8mb4` command to also write the db collation to the config.

For the `--show` option, the command displays the likely collation to be used based on what the database returns as its default collation, however, when actually running the command, it may end up being a different collation based on the current db connection collation which will affect how the tables are converted.

When the tables are converted, another query is performed to get the collation of the user table and the newest archive table to try determine the collation that should be written to the config. If those collations differ for some reason, the default collation is used.

Ref. #22634


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
