### PR TITLE
Improve style for AdBlock warning

### DIFF
--- a/plugins/CoreHome/templates/_adblockDetect.twig
+++ b/plugins/CoreHome/templates/_adblockDetect.twig
@@ -27,15 +27,31 @@
                     var warning = document.createElement('p');
                     warning.innerText = '{{ 'CoreHome_AdblockIsMaybeUsed'|translate|e('js') }}';
 
+                    var warningBox = document.createElement('div');
+                    warningBox.style.border = '3px solid red';
+                    warningBox.style.padding = '10px';
+                    warningBox.style.margin = '10px 20px'; 
+                    warningBox.style.textAlign = 'center';
+                    warningBox.style.display = 'flex';
+                    warningBox.style.justifyContent = 'center';
+                    warningBox.style.alignItems = 'center';
+                    warningBox.style.position = 'fixed';
+                    warningBox.style.top = '0';
+                    warningBox.style.left = '0';
+                    warningBox.style.right = '0'; 
+                    warningBox.style.backgroundColor = 'white';
+                    warningBox.style.zIndex = '1000';
+
+                    warning.style.color = 'red';
+                    warning.style.fontWeight = 'bold';
+                    warning.style.fontSize = '20px';
+
+                    warningBox.appendChild(warning);
+
                     if (shouldGetHiddenElement) {
-                        shouldGetHiddenElement.appendChild(warning);
+                        shouldGetHiddenElement.appendChild(warningBox);
                     } else {
-                        body[0].insertBefore(warning, body[0].firstChild);
-                        warning.style.color = 'red';
-                        warning.style.fontWeight = 'bold';
-                        warning.style.marginLeft = '16px';
-                        warning.style.marginBottom = '16px';
-                        warning.style.fontSize = '20px';
+                        body[0].insertBefore(warningBox, body[0].firstChild);
                     }
                 }
             })();


### PR DESCRIPTION
### Description:

This PR updates the adblock detection script to display the warning message at the top of the page, styled to ensure it is clearly visible and centered inside the box.

> Fixes #17784

(Ref DEV-14222)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
