### PR TITLE
[PHP 8.4] Explicitly mark nullable parameters

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -100,7 +100,7 @@ class Access
     /**
      * Constructor
      */
-    public function __construct(RolesProvider $roleProvider = null, CapabilitiesProvider $capabilityProvider = null)
+    public function __construct(?RolesProvider $roleProvider = null, ?CapabilitiesProvider $capabilityProvider = null)
     {
         if (!isset($roleProvider)) {
             $roleProvider = StaticContainer::get('Piwik\Access\RolesProvider');
@@ -135,7 +135,7 @@ class Access
      * @param null|Auth $auth Auth adapter
      * @return bool  true on success, false if reloading access failed (when auth object wasn't specified and user is not enforced to be Super User)
      */
-    public function reloadAccess(Auth $auth = null)
+    public function reloadAccess(?Auth $auth = null)
     {
         $this->resetSites();
 

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -156,7 +156,7 @@ class ArchiveInvalidator
         return array_keys($this->getRememberedArchivedReportsThatShouldBeInvalidated($idSite));
     }
 
-    public function getRememberedArchivedReportsThatShouldBeInvalidated(int $idSite = null)
+    public function getRememberedArchivedReportsThatShouldBeInvalidated(?int $idSite = null)
     {
         if (null === $idSite) {
             $optionName = $this->rememberArchivedReportIdStart . '%';
@@ -276,7 +276,7 @@ class ArchiveInvalidator
         array $idSites,
         array $dates,
         $period,
-        Segment $segment = null,
+        ?Segment $segment = null,
         bool $cascadeDown = false,
         bool $forceInvalidateNonexistentRanges = false,
         ?string $name = null,
@@ -416,7 +416,7 @@ class ArchiveInvalidator
         }
     }
 
-    private function addParentPeriodsByYearMonth(&$result, Period $period, Date $originalDate = null)
+    private function addParentPeriodsByYearMonth(&$result, Period $period, ?Date $originalDate = null)
     {
         if (
             $period->getLabel() == 'year'
@@ -442,7 +442,7 @@ class ArchiveInvalidator
      * @return InvalidationResult
      * @throws \Exception
      */
-    public function markArchivesOverlappingRangeAsInvalidated(array $idSites, array $dates, Segment $segment = null)
+    public function markArchivesOverlappingRangeAsInvalidated(array $idSites, array $dates, ?Segment $segment = null)
     {
         $invalidationInfo = new InvalidationResult();
 
@@ -485,7 +485,7 @@ class ArchiveInvalidator
      * @throws \Exception
      * @api
      */
-    public function reArchiveReport($idSites, string $plugin = null, string $report = null, Date $startDate = null, Segment $segment = null)
+    public function reArchiveReport($idSites, ?string $plugin = null, ?string $report = null, ?Date $startDate = null, ?Segment $segment = null)
     {
         $date2 = Date::today();
 
@@ -571,10 +571,10 @@ class ArchiveInvalidator
      */
     public function scheduleReArchiving(
         $idSites,
-        string $pluginName = null,
+        ?string $pluginName = null,
         $report = null,
-        Date $startDate = null,
-        Segment $segment = null
+        ?Date $startDate = null,
+        ?Segment $segment = null
     ) {
         if (!empty($report)) {
             $this->removeInvalidationsSafely($idSites, $pluginName, $report);
@@ -709,7 +709,7 @@ class ArchiveInvalidator
     private function markArchivesInvalidated(
         $idSites,
         $dates,
-        Segment $segment = null,
+        ?Segment $segment = null,
         bool $removeRanges = false,
         bool $forceInvalidateNonexistentRanges = false,
         ?string $name = null,

--- a/core/Archive/ArchivePurger.php
+++ b/core/Archive/ArchivePurger.php
@@ -70,7 +70,7 @@ class ArchivePurger
      */
     private $logger;
 
-    public function __construct(Model $model = null, Date $purgeCustomRangesOlderThan = null, LoggerInterface $logger = null)
+    public function __construct(?Model $model = null, ?Date $purgeCustomRangesOlderThan = null, ?LoggerInterface $logger = null)
     {
         $this->model = $model ?: new Model();
 

--- a/core/Archive/DataCollection.php
+++ b/core/Archive/DataCollection.php
@@ -157,7 +157,7 @@ class DataCollection
      * @param string        $value  eg 5
      * @param array|null    $meta   Optional metadata to add to the row
      */
-    public function set($idSite, $period, $name, $value, array $meta = null)
+    public function set($idSite, $period, $name, $value, ?array $meta = null)
     {
         $row = & $this->get($idSite, $period);
         $row[$name] = $value;

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -66,7 +66,7 @@ class PluginsArchiver
      */
     private $archiveWriter;
 
-    public function __construct(Parameters $params, ArchiveWriter $archiveWriter = null)
+    public function __construct(Parameters $params, ?ArchiveWriter $archiveWriter = null)
     {
         $this->params = $params;
         $this->archiveWriter = $archiveWriter ?: new ArchiveWriter($this->params);

--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -253,7 +253,7 @@ class Rules
         return !self::isArchivingEnabledFor($idSites, $segment, $periodLabel);
     }
 
-    public static function isRequestAuthorizedToArchive(Parameters $params = null)
+    public static function isRequestAuthorizedToArchive(?Parameters $params = null)
     {
         $isRequestAuthorizedToArchive = Rules::isBrowserTriggerEnabled() || SettingsServer::isArchivePhpTriggered();
 
@@ -334,7 +334,7 @@ class Rules
      */
     public static function getSelectableDoneFlagValues(
         $includeInvalidated = true,
-        Parameters $params = null,
+        ?Parameters $params = null,
         $checkAuthorizedToArchive = true
     ) {
         $possibleValues = array(ArchiveWriter::DONE_OK, ArchiveWriter::DONE_OK_TEMPORARY);

--- a/core/CacheId.php
+++ b/core/CacheId.php
@@ -29,7 +29,7 @@ class CacheId
         return $cacheId;
     }
 
-    public static function siteAware($cacheId, array $idSites = null)
+    public static function siteAware($cacheId, ?array $idSites = null)
     {
         if ($idSites === null) {
             $idSites = self::getIdSiteList('idSite');

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -95,7 +95,7 @@ class CliMulti
      */
     private $logger;
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->supportsAsync = $this->supportsAsync();
         $this->supportsAsyncSymfony = $this->supportsAsyncSymfony();

--- a/core/Columns/DimensionMetricFactory.php
+++ b/core/Columns/DimensionMetricFactory.php
@@ -37,7 +37,7 @@ class DimensionMetricFactory
     /**
      * @return ArchivedMetric
      */
-    public function createCustomMetric($metricName, $readableName, $aggregation, $documentation = '', string $semanticType = null)
+    public function createCustomMetric($metricName, $readableName, $aggregation, $documentation = '', ?string $semanticType = null)
     {
         if (!$this->dimension->getDbTableName() || !$this->dimension->getColumnName()) {
             throw new \Exception(sprintf('Cannot make metric from dimension %s because DB table or column missing', $this->dimension->getId()));

--- a/core/Columns/DimensionSegmentFactory.php
+++ b/core/Columns/DimensionSegmentFactory.php
@@ -39,7 +39,7 @@ class DimensionSegmentFactory
      * @return Segment
      * @throws \Exception
      */
-    public function createSegment(Segment $segment = null)
+    public function createSegment(?Segment $segment = null)
     {
         $dimension = $this->dimension;
 

--- a/core/Columns/Updater.php
+++ b/core/Columns/Updater.php
@@ -48,7 +48,7 @@ class Updater extends \Piwik\Updates
      * @param ActionDimension[]|null $actionDimensions
      * @param ConversionDimension[]|null $conversionDimensions
      */
-    public function __construct(array $visitDimensions = null, array $actionDimensions = null, array $conversionDimensions = null)
+    public function __construct(?array $visitDimensions = null, ?array $actionDimensions = null, ?array $conversionDimensions = null)
     {
         $this->visitDimensions = $visitDimensions;
         $this->actionDimensions = $actionDimensions;

--- a/core/Concurrency/DistributedList.php
+++ b/core/Concurrency/DistributedList.php
@@ -41,7 +41,7 @@ class DistributedList
      *
      * @param string $optionName
      */
-    public function __construct($optionName, LoggerInterface $logger = null)
+    public function __construct($optionName, ?LoggerInterface $logger = null)
     {
         $this->optionName = $optionName;
         $this->logger = $logger ?: StaticContainer::get(LoggerInterface::class);

--- a/core/Console.php
+++ b/core/Console.php
@@ -31,7 +31,7 @@ class Console extends Application
      */
     private $environment;
 
-    public function __construct(Environment $environment = null)
+    public function __construct(?Environment $environment = null)
     {
         $this->setServerArgsIfPhpCgi();
 

--- a/core/Container/Container.php
+++ b/core/Container/Container.php
@@ -23,9 +23,9 @@ use Psr\Container\ContainerInterface;
 class Container extends DIContainer implements ContainerInterface
 {
     public function __construct(
-        MutableDefinitionSource $definitionSource = null,
-        ProxyFactory $proxyFactory = null,
-        ContainerInterface $wrapperContainer = null
+        ?MutableDefinitionSource $definitionSource = null,
+        ?ProxyFactory $proxyFactory = null,
+        ?ContainerInterface $wrapperContainer = null
     ) {
         parent::__construct($definitionSource, $proxyFactory, $wrapperContainer);
         // ensure this container class can be resolved

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -235,7 +235,7 @@ class CronArchive
      *
      * @param LoggerInterface|null $logger
      */
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: StaticContainer::get(LoggerInterface::class);
         $this->formatter = new Formatter();
@@ -1063,7 +1063,7 @@ class CronArchive
         return true;
     }
 
-    private function canWeSkipInvalidatingBecauseInvalidationAlreadyInProgress(int $idSite, Period $period, Segment $segment = null): bool
+    private function canWeSkipInvalidatingBecauseInvalidationAlreadyInProgress(int $idSite, Period $period, ?Segment $segment = null): bool
     {
         $invalidationsInProgress = $this->model->getInvalidationsInProgress($idSite);
         $timezone = Site::getTimezoneFor($idSite);

--- a/core/CronArchive/Performance/Logger.php
+++ b/core/CronArchive/Performance/Logger.php
@@ -33,7 +33,7 @@ class Logger
      */
     private $archivingRunId;
 
-    public function __construct(Config $config, LoggerInterface $logger = null)
+    public function __construct(Config $config, ?LoggerInterface $logger = null)
     {
         $this->isEnabled = $config->Debug['archiving_profile'] == 1;
         $this->logger = $logger;

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -119,7 +119,7 @@ class QueueConsumer
         SegmentArchiving $segmentArchiving,
         CronArchive $cronArchive,
         RequestParser $cliMultiRequestParser,
-        ArchiveFilter $archiveFilter = null
+        ?ArchiveFilter $archiveFilter = null
     ) {
         $this->logger = $logger;
         $this->websiteIdArchiveList = $websiteIdArchiveList;

--- a/core/CronArchive/ReArchiveList.php
+++ b/core/CronArchive/ReArchiveList.php
@@ -16,7 +16,7 @@ class ReArchiveList extends DistributedList
 {
     public const OPTION_NAME = 'ReArchiveList';
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         parent::__construct(self::OPTION_NAME, $logger);
     }

--- a/core/CronArchive/SegmentArchiving.php
+++ b/core/CronArchive/SegmentArchiving.php
@@ -70,10 +70,10 @@ class SegmentArchiving
 
     public function __construct(
         $beginningOfTimeLastNInYears = self::DEFAULT_BEGINNING_OF_TIME_LAST_N_YEARS,
-        Model $segmentEditorModel = null,
-        Cache $segmentListCache = null,
-        Date $now = null,
-        LoggerInterface $logger = null
+        ?Model $segmentEditorModel = null,
+        ?Cache $segmentListCache = null,
+        ?Date $now = null,
+        ?LoggerInterface $logger = null
     ) {
         $this->processNewSegmentsFrom = StaticContainer::get('ini.General.process_new_segments_from');
         $this->beginningOfTimeLastNInYears = $beginningOfTimeLastNInYears;

--- a/core/DI.php
+++ b/core/DI.php
@@ -32,7 +32,7 @@ class DI
      * @return \DI\Definition\Helper\CreateDefinitionHelper
      * @see PHPDI\create()
      */
-    public static function create(string $className = null)
+    public static function create(?string $className = null)
     {
         return PHPDI\create($className);
     }
@@ -42,7 +42,7 @@ class DI
      * @return \DI\Definition\Helper\AutowireDefinitionHelper
      * @see PHPDI\autowire()
      */
-    public static function autowire(string $className = null)
+    public static function autowire(?string $className = null)
     {
         return PHPDI\autowire($className);
     }

--- a/core/DataAccess/ArchivingDbAdapter.php
+++ b/core/DataAccess/ArchivingDbAdapter.php
@@ -32,7 +32,7 @@ class ArchivingDbAdapter
      */
     private $maxExecutionTime;
 
-    public function __construct($wrapped, LoggerInterface $logger = null)
+    public function __construct($wrapped, ?LoggerInterface $logger = null)
     {
         $this->wrapped = $wrapped;
         $this->logger = $logger;

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -173,7 +173,7 @@ class LogAggregator
      *
      * @param \Piwik\ArchiveProcessor\Parameters $params
      */
-    public function __construct(Parameters $params, LoggerInterface $logger = null)
+    public function __construct(Parameters $params, ?LoggerInterface $logger = null)
     {
         $this->dateStart = $params->getDateTimeStart();
         $this->dateEnd = $params->getDateTimeEnd();

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -36,7 +36,7 @@ class Model
      */
     private $logger;
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: StaticContainer::get(LoggerInterface::class);
     }
@@ -113,7 +113,7 @@ class Model
         $archiveTable,
         $idSites,
         $allPeriodsToInvalidate,
-        Segment $segment = null,
+        ?Segment $segment = null,
         bool $forceInvalidateNonexistentRanges = false,
         ?string $name = null,
         bool $doNotCreateInvalidations = false
@@ -324,7 +324,7 @@ class Model
      * @return \Zend_Db_Statement
      * @throws Exception
      */
-    public function updateRangeArchiveAsInvalidated($archiveTable, $idSites, $allPeriodsToInvalidate, Segment $segment = null)
+    public function updateRangeArchiveAsInvalidated($archiveTable, $idSites, $allPeriodsToInvalidate, ?Segment $segment = null)
     {
         if (empty($idSites)) {
             return;

--- a/core/DataAccess/RawLogDao.php
+++ b/core/DataAccess/RawLogDao.php
@@ -33,7 +33,7 @@ class RawLogDao
      */
     private $logTablesProvider;
 
-    public function __construct(DimensionMetadataProvider $provider = null, LogTablesProvider $logTablesProvider = null)
+    public function __construct(?DimensionMetadataProvider $provider = null, ?LogTablesProvider $logTablesProvider = null)
     {
         $this->dimensionMetadataProvider = $provider ?: StaticContainer::get('Piwik\Plugin\Dimension\DimensionMetadataProvider');
         $this->logTablesProvider = $logTablesProvider ?: StaticContainer::get('Piwik\Plugin\LogTablesProvider');

--- a/core/Db/TransactionalDatabaseDynamicTrait.php
+++ b/core/Db/TransactionalDatabaseDynamicTrait.php
@@ -25,7 +25,7 @@ trait TransactionalDatabaseDynamicTrait
         return $this->supportsTransactionLevelForNonLockingReads;
     }
 
-    public function setSupportsTransactionLevelForNonLockingReads(bool $supports = null): void
+    public function setSupportsTransactionLevelForNonLockingReads(?bool $supports = null): void
     {
         $this->supportsTransactionLevelForNonLockingReads = $supports;
     }

--- a/core/Db/TransactionalDatabaseInterface.php
+++ b/core/Db/TransactionalDatabaseInterface.php
@@ -7,5 +7,5 @@ interface TransactionalDatabaseInterface
     public function getCurrentTransactionIsolationLevelForSession(): string;
     public function setTransactionIsolationLevel(string $level): void;
     public function getSupportsTransactionLevelForNonLockingReads(): ?bool;
-    public function setSupportsTransactionLevelForNonLockingReads(bool $supports = null): void;
+    public function setSupportsTransactionLevelForNonLockingReads(?bool $supports = null): void;
 }

--- a/core/Db/TransactionalDatabaseStaticTrait.php
+++ b/core/Db/TransactionalDatabaseStaticTrait.php
@@ -20,7 +20,7 @@ trait TransactionalDatabaseStaticTrait
         }
     }
 
-    public function setSupportsTransactionLevelForNonLockingReads(bool $supports = null): void
+    public function setSupportsTransactionLevelForNonLockingReads(?bool $supports = null): void
     {
         $this->supportsTransactionLevelForNonLockingReads = $supports;
     }

--- a/core/Exception/NotYetInstalledException.php
+++ b/core/Exception/NotYetInstalledException.php
@@ -13,7 +13,7 @@ use Throwable;
 
 class NotYetInstalledException extends InvalidRequestParameterException
 {
-    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    public function __construct($message = "", $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -218,7 +218,7 @@ class Filesystem
      * @param \Closure|false $beforeUnlink An optional closure to execute on a file path before unlinking.
      * @api
      */
-    public static function unlinkRecursive($dir, $deleteRootToo, \Closure $beforeUnlink = null)
+    public static function unlinkRecursive($dir, $deleteRootToo, ?\Closure $beforeUnlink = null)
     {
         if (!$dh = @opendir($dir)) {
             return;

--- a/core/Metrics/Formatter.php
+++ b/core/Metrics/Formatter.php
@@ -174,7 +174,7 @@ class Formatter
      *                           This parameter is not currently supported and subject to change.
      * @api
      */
-    public function formatMetrics(DataTable $dataTable, Report $report = null, $metricsToFormat = null, $formatAll = false)
+    public function formatMetrics(DataTable $dataTable, ?Report $report = null, $metricsToFormat = null, $formatAll = false)
     {
         $metrics = $this->getMetricsToFormat($dataTable, $report);
         if (
@@ -285,7 +285,7 @@ class Formatter
      * @param Report $report
      * @return Metric[]
      */
-    private function getMetricsToFormat(DataTable $dataTable, Report $report = null)
+    private function getMetricsToFormat(DataTable $dataTable, ?Report $report = null)
     {
         return Report::getMetricsForTable($dataTable, $report, $baseType = 'Piwik\\Plugin\\Metric');
     }

--- a/core/Plugin/ConsoleCommand.php
+++ b/core/Plugin/ConsoleCommand.php
@@ -231,7 +231,7 @@ class ConsoleCommand extends SymfonyCommand
     public function addOption(
         string $name,
         $shortcut = null,
-        int $mode = null,
+        ?int $mode = null,
         string $description = '',
         $default = null
     ) {
@@ -281,7 +281,7 @@ class ConsoleCommand extends SymfonyCommand
      *
      * @see addOptionalArgument, addRequiredArgument
      */
-    public function addArgument(string $name, int $mode = null, string $description = '', $default = null)
+    public function addArgument(string $name, ?int $mode = null, string $description = '', $default = null)
     {
         throw new \LogicException('addArgument can not be used.');
     }
@@ -409,9 +409,9 @@ class ConsoleCommand extends SymfonyCommand
      */
     protected function askAndValidate(
         string $question,
-        callable $validator = null,
+        ?callable $validator = null,
         $default = null,
-        iterable $autocompleterValues = null
+        ?iterable $autocompleterValues = null
     ) {
         /** @var QuestionHelper $helper */
         $helper   = parent::getHelper('question');

--- a/core/Plugin/Dimension/VisitDimension.php
+++ b/core/Plugin/Dimension/VisitDimension.php
@@ -240,7 +240,7 @@ abstract class VisitDimension extends Dimension
      * @return bool Return true to force a visit, false if otherwise.
      * @api
      */
-    public function shouldForceNewVisit(Request $request, Visitor $visitor, Action $action = null)
+    public function shouldForceNewVisit(Request $request, Visitor $visitor, ?Action $action = null)
     {
         return false;
     }

--- a/core/Plugin/Report.php
+++ b/core/Plugin/Report.php
@@ -1072,7 +1072,7 @@ class Report
      * @return Metric[]
      * @api
      */
-    public static function getMetricsForTable(DataTable $dataTable, Report $report = null, $baseType = 'Piwik\\Plugin\\Metric')
+    public static function getMetricsForTable(DataTable $dataTable, ?Report $report = null, $baseType = 'Piwik\\Plugin\\Metric')
     {
         $metrics = $dataTable->getMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME) ?: array();
 
@@ -1104,7 +1104,7 @@ class Report
      * @return ProcessedMetric[]
      * @api
      */
-    public static function getProcessedMetricsForTable(DataTable $dataTable, Report $report = null)
+    public static function getProcessedMetricsForTable(DataTable $dataTable, ?Report $report = null)
     {
         /** @var ProcessedMetric[] $metrics */
         $metrics = self::getMetricsForTable($dataTable, $report, 'Piwik\\Plugin\\ProcessedMetric');

--- a/core/Plugin/Tasks.php
+++ b/core/Plugin/Tasks.php
@@ -64,7 +64,7 @@ class Tasks
      * @return Schedule
      * @api
      */
-    protected function hourly($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY, int $ttlInSeconds = null)
+    protected function hourly($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY, ?int $ttlInSeconds = null)
     {
         return $this->custom($this, $methodName, $methodParameter, 'hourly', $priority, $ttlInSeconds);
     }
@@ -75,7 +75,7 @@ class Tasks
      * See {@link hourly()}
      * @api
      */
-    protected function daily($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY, int $ttlInSeconds = null)
+    protected function daily($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY, ?int $ttlInSeconds = null)
     {
         return $this->custom($this, $methodName, $methodParameter, 'daily', $priority, $ttlInSeconds);
     }
@@ -86,7 +86,7 @@ class Tasks
      * See {@link hourly()}
      * @api
      */
-    protected function weekly($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY, int $ttlInSeconds = null)
+    protected function weekly($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY, ?int $ttlInSeconds = null)
     {
         return $this->custom($this, $methodName, $methodParameter, 'weekly', $priority, $ttlInSeconds);
     }
@@ -97,7 +97,7 @@ class Tasks
      * See {@link hourly()}
      * @api
      */
-    protected function monthly($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY, int $ttlInSeconds = null)
+    protected function monthly($methodName, $methodParameter = null, $priority = self::NORMAL_PRIORITY, ?int $ttlInSeconds = null)
     {
         return $this->custom($this, $methodName, $methodParameter, 'monthly', $priority, $ttlInSeconds);
     }
@@ -120,7 +120,7 @@ class Tasks
      *
      * @api
      */
-    protected function custom($objectOrClassName, $methodName, $methodParameter, $time, $priority = self::NORMAL_PRIORITY, int $ttlInSeconds = null)
+    protected function custom($objectOrClassName, $methodName, $methodParameter, $time, $priority = self::NORMAL_PRIORITY, ?int $ttlInSeconds = null)
     {
         $this->checkIsValidTask($objectOrClassName, $methodName);
 

--- a/core/Scheduler/Task.php
+++ b/core/Scheduler/Task.php
@@ -93,7 +93,7 @@ class Task
         $methodParameter,
         $scheduledTime,
         $priority = self::NORMAL_PRIORITY,
-        int $ttlInSeconds = null
+        ?int $ttlInSeconds = null
     ) {
         $this->className = $this->getClassNameFromInstance($objectInstance);
 

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -123,7 +123,7 @@ class Segment
      * @param Date|null $endDate end date used to limit subqueries
      * @throws
      */
-    public function __construct($segmentCondition, $idSites, Date $startDate = null, Date $endDate = null)
+    public function __construct($segmentCondition, $idSites, ?Date $startDate = null, ?Date $endDate = null)
     {
 
         $this->segmentQueryBuilder = StaticContainer::get('Piwik\DataAccess\LogQueryBuilder');

--- a/core/Session/SessionAuth.php
+++ b/core/Session/SessionAuth.php
@@ -46,7 +46,7 @@ class SessionAuth implements Auth
 
     private $tokenAuth;
 
-    public function __construct(UsersModel $userModel = null, $shouldDestroySession = true)
+    public function __construct(?UsersModel $userModel = null, $shouldDestroySession = true)
     {
         $this->userModel = $userModel ?: new UsersModel();
         $this->shouldDestroySession = $shouldDestroySession;

--- a/core/Tracker/Visitor.php
+++ b/core/Tracker/Visitor.php
@@ -25,14 +25,14 @@ class Visitor
      */
     public $previousVisitProperties;
 
-    public function __construct(VisitProperties $visitProperties, $isVisitorKnown = false, VisitProperties $previousVisitProperties = null)
+    public function __construct(VisitProperties $visitProperties, $isVisitorKnown = false, ?VisitProperties $previousVisitProperties = null)
     {
         $this->visitProperties = $visitProperties;
         $this->previousVisitProperties = $previousVisitProperties;
         $this->setIsVisitorKnown($isVisitorKnown);
     }
 
-    public static function makeFromVisitProperties(VisitProperties $visitProperties, Request $request, VisitProperties $previousVisitProperties = null)
+    public static function makeFromVisitProperties(VisitProperties $visitProperties, Request $request, ?VisitProperties $previousVisitProperties = null)
     {
         $isKnown = $request->getMetadata('CoreHome', 'isVisitorKnown');
         return new Visitor($visitProperties, $isKnown, $previousVisitProperties);

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -144,7 +144,7 @@ class VisitorRecognizer
         }
     }
 
-    public function removeUnchangedValues($visit, VisitProperties $originalVisit = null)
+    public function removeUnchangedValues($visit, ?VisitProperties $originalVisit = null)
     {
         if (empty($originalVisit)) {
             return $visit;

--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -52,7 +52,7 @@ class Translator
     private const LIST_TYPE_AND = 'And';
     private const LIST_TYPE_OR = 'Or';
 
-    public function __construct(LoaderInterface $loader, array $directories = null)
+    public function __construct(LoaderInterface $loader, ?array $directories = null)
     {
         $this->loader          = $loader;
         $this->currentLanguage = $this->getDefaultLanguage();
@@ -111,7 +111,7 @@ class Translator
      * @param string|null $language
      * @return string
      */
-    public function createAndListing(array $items, string $language = null): string
+    public function createAndListing(array $items, ?string $language = null): string
     {
         return $this->createListing(self::LIST_TYPE_AND, $items, $language);
     }
@@ -123,7 +123,7 @@ class Translator
      * @param string|null $language
      * @return string
      */
-    public function createOrListing(array $items, string $language = null): string
+    public function createOrListing(array $items, ?string $language = null): string
     {
         return $this->createListing(self::LIST_TYPE_OR, $items, $language);
     }
@@ -134,7 +134,7 @@ class Translator
      * @param string|null $language
      * @return string
      */
-    private function createListing(string $listType, array $items, string $language = null): string
+    private function createListing(string $listType, array $items, ?string $language = null): string
     {
         switch (count($items)) {
             case 0:

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -61,7 +61,7 @@ class Updater
      *                                           for the plugin name.
      * @param Columns\Updater|null $columnsUpdater The dimensions updater instance.
      */
-    public function __construct($pathUpdateFileCore = null, $pathUpdateFilePlugins = null, Columns\Updater $columnsUpdater = null)
+    public function __construct($pathUpdateFileCore = null, $pathUpdateFilePlugins = null, ?Columns\Updater $columnsUpdater = null)
     {
         $this->pathUpdateFileCore = $pathUpdateFileCore ?: PIWIK_INCLUDE_PATH . '/core/Updates/';
 

--- a/libs/HTML/QuickForm2.php
+++ b/libs/HTML/QuickForm2.php
@@ -123,7 +123,7 @@ class HTML_QuickForm2 extends HTML_QuickForm2_Container
         );
     }
 
-    protected function setContainer(HTML_QuickForm2_Container $container = null)
+    protected function setContainer(?HTML_QuickForm2_Container $container = null)
     {
         throw new HTML_QuickForm2_Exception('Form cannot be added to container');
     }

--- a/libs/HTML/QuickForm2/Container.php
+++ b/libs/HTML/QuickForm2/Container.php
@@ -324,7 +324,7 @@ abstract class HTML_QuickForm2_Container extends HTML_QuickForm2_Node
     * @param    HTML_QuickForm2_Node     Reference to insert before
     * @return   HTML_QuickForm2_Node     Inserted element
     */
-    public function insertBefore(HTML_QuickForm2_Node $element, HTML_QuickForm2_Node $reference = null)
+    public function insertBefore(HTML_QuickForm2_Node $element, ?HTML_QuickForm2_Node $reference = null)
     {
         if (null === $reference) {
             return $this->appendChild($element);

--- a/libs/HTML/QuickForm2/Container/Group.php
+++ b/libs/HTML/QuickForm2/Container/Group.php
@@ -268,7 +268,7 @@ class HTML_QuickForm2_Container_Group extends HTML_QuickForm2_Container
     * @param    HTML_QuickForm2_Node     Reference to insert before
     * @return   HTML_QuickForm2_Node     Inserted element
     */
-    public function insertBefore(HTML_QuickForm2_Node $element, HTML_QuickForm2_Node $reference = null)
+    public function insertBefore(HTML_QuickForm2_Node $element, ?HTML_QuickForm2_Node $reference = null)
     {
         if (null === $reference) {
             return $this->appendChild($element);

--- a/libs/HTML/QuickForm2/Controller.php
+++ b/libs/HTML/QuickForm2/Controller.php
@@ -388,7 +388,7 @@ class HTML_QuickForm2_Controller implements IteratorAggregate
     *                                           before (not including) that page
     * @return bool
     */
-    public function isValid(HTML_QuickForm2_Controller_Page $reference = null)
+    public function isValid(?HTML_QuickForm2_Controller_Page $reference = null)
     {
         $container = $this->getSessionContainer();
         foreach ($this->pages as $id => $page) {

--- a/libs/HTML/QuickForm2/Element/InputFile.php
+++ b/libs/HTML/QuickForm2/Element/InputFile.php
@@ -258,7 +258,7 @@ class HTML_QuickForm2_Element_InputFile extends HTML_QuickForm2_Element_Input
         return parent::validate();
     }
 
-    public function addFilter($callback, array $options = null, $recursive = true)
+    public function addFilter($callback, ?array $options = null, $recursive = true)
     {
         throw new HTML_QuickForm2_Exception(
             'InputFile elements do not support filters'

--- a/libs/HTML/QuickForm2/Node.php
+++ b/libs/HTML/QuickForm2/Node.php
@@ -429,7 +429,7 @@ abstract class HTML_QuickForm2_Node extends HTML_Common2
     * @throws   HTML_QuickForm2_InvalidArgumentException   If trying to set a
     *                               child of an element as its container
     */
-    protected function setContainer(HTML_QuickForm2_Container $container = null)
+    protected function setContainer(?HTML_QuickForm2_Container $container = null)
     {
         if (null !== $container) {
             $check = $container;
@@ -640,7 +640,7 @@ abstract class HTML_QuickForm2_Node extends HTML_Common2
     * @return   HTML_QuickForm2_Node    The element
     * @throws   HTML_QuickForm2_InvalidArgumentException    If callback is incorrect
     */
-    public function addFilter($callback, array $options = null, $recursive = true)
+    public function addFilter($callback, ?array $options = null, $recursive = true)
     {
         if (!is_callable($callback, false, $callbackName)) {
             throw new HTML_QuickForm2_InvalidArgumentException(

--- a/libs/HTML/QuickForm2/Renderer.php
+++ b/libs/HTML/QuickForm2/Renderer.php
@@ -302,7 +302,7 @@ abstract class HTML_QuickForm2_Renderer
     * @param    HTML_QuickForm2_JavascriptBuilder
     * @return   HTML_QuickForm2_Renderer
     */
-    public function setJavascriptBuilder(HTML_QuickForm2_JavascriptBuilder $builder = null)
+    public function setJavascriptBuilder(?HTML_QuickForm2_JavascriptBuilder $builder = null)
     {
         $this->jsBuilder = $builder;
         return $this;

--- a/libs/HTML/QuickForm2/Renderer/Proxy.php
+++ b/libs/HTML/QuickForm2/Renderer/Proxy.php
@@ -205,7 +205,7 @@ class HTML_QuickForm2_Renderer_Proxy extends HTML_QuickForm2_Renderer
         return $this->_renderer->getJavascriptBuilder();
     }
 
-    public function setJavascriptBuilder(HTML_QuickForm2_JavascriptBuilder $builder = null)
+    public function setJavascriptBuilder(?HTML_QuickForm2_JavascriptBuilder $builder = null)
     {
         $this->_renderer->setJavascriptBuilder($builder);
         return $this;

--- a/libs/Zend/Db/Adapter/Db2/Exception.php
+++ b/libs/Zend/Db/Adapter/Db2/Exception.php
@@ -38,7 +38,7 @@ class Zend_Db_Adapter_Db2_Exception extends Zend_Db_Adapter_Exception
    protected $code = '00000';
    protected $message = 'unknown exception';
 
-   function __construct($message = 'unknown exception', $code = '00000', Exception $e = null)
+   function __construct($message = 'unknown exception', $code = '00000', ?Exception $e = null)
    {
        parent::__construct($message, $code, $e);
    }

--- a/libs/Zend/Db/Adapter/Exception.php
+++ b/libs/Zend/Db/Adapter/Exception.php
@@ -36,7 +36,7 @@ class Zend_Db_Adapter_Exception extends Zend_Db_Exception
 {
     protected $_chainedException = null;
 
-    public function __construct($message = '', $code = 0, Exception $e = null)
+    public function __construct($message = '', $code = 0, ?Exception $e = null)
     {
         if ($e && (0 === $code)) {
             $code = $e->getCode();

--- a/libs/Zend/Db/Statement.php
+++ b/libs/Zend/Db/Statement.php
@@ -291,7 +291,7 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
      * @param array $params OPTIONAL Values to bind to parameter placeholders.
      * @return bool
      */
-    public function execute(array $params = null)
+    public function execute(?array $params = null)
     {
         /*
          * Simple case - no query profiler to manage.

--- a/libs/Zend/Db/Statement/Db2.php
+++ b/libs/Zend/Db/Statement/Db2.php
@@ -191,7 +191,7 @@ class Zend_Db_Statement_Db2 extends Zend_Db_Statement
      * @return bool
      * @throws Zend_Db_Statement_Db2_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute(?array $params = null)
     {
         if (!$this->_stmt) {
             return false;

--- a/libs/Zend/Db/Statement/Mysqli.php
+++ b/libs/Zend/Db/Statement/Mysqli.php
@@ -180,7 +180,7 @@ class Zend_Db_Statement_Mysqli extends Zend_Db_Statement
      * @return bool
      * @throws Zend_Db_Statement_Mysqli_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute(?array $params = null)
     {
         if (!$this->_stmt) {
             return false;

--- a/libs/Zend/Db/Statement/Oracle.php
+++ b/libs/Zend/Db/Statement/Oracle.php
@@ -226,7 +226,7 @@ class Zend_Db_Statement_Oracle extends Zend_Db_Statement
      * @return bool
      * @throws Zend_Db_Statement_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute(?array $params = null)
     {
         $connection = $this->_adapter->getConnection();
 

--- a/libs/Zend/Db/Statement/Pdo.php
+++ b/libs/Zend/Db/Statement/Pdo.php
@@ -221,7 +221,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
      * @return bool
      * @throws Zend_Db_Statement_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute(?array $params = null)
     {
         try {
             if ($params !== null) {

--- a/libs/Zend/Db/Statement/Sqlsrv.php
+++ b/libs/Zend/Db/Statement/Sqlsrv.php
@@ -174,7 +174,7 @@ class Zend_Db_Statement_Sqlsrv extends Zend_Db_Statement
      * @return bool
      * @throws Zend_Db_Statement_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute(?array $params = null)
     {
         $connection = $this->_adapter->getConnection();
         if (!$this->_stmt) {

--- a/libs/Zend/Db/Table/Row/Abstract.php
+++ b/libs/Zend/Db/Table/Row/Abstract.php
@@ -332,7 +332,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @return boolean
      * @throws Zend_Db_Table_Row_Exception
      */
-    public function setTable(Zend_Db_Table_Abstract $table = null)
+    public function setTable(?Zend_Db_Table_Abstract $table = null)
     {
         if ($table == null) {
             $this->_table = null;
@@ -864,7 +864,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @return Zend_Db_Table_Rowset_Abstract Query result from $dependentTable
      * @throws Zend_Db_Table_Row_Exception If $dependentTable is not a table or is not loadable.
      */
-    public function findDependentRowset($dependentTable, $ruleKey = null, Zend_Db_Table_Select $select = null)
+    public function findDependentRowset($dependentTable, $ruleKey = null, ?Zend_Db_Table_Select $select = null)
     {
         $db = $this->_getTable()->getAdapter();
 
@@ -988,7 +988,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @throws Zend_Db_Table_Row_Exception If $matchTable or $intersectionTable is not a table class or is not loadable.
      */
     public function findManyToManyRowset($matchTable, $intersectionTable, $callerRefRule = null,
-                                         $matchRefRule = null, Zend_Db_Table_Select $select = null)
+                                         $matchRefRule = null, ?Zend_Db_Table_Select $select = null)
     {
         $db = $this->_getTable()->getAdapter();
 

--- a/libs/Zend/Exception.php
+++ b/libs/Zend/Exception.php
@@ -40,7 +40,7 @@ class Zend_Exception extends Exception
      * @param  Exception $previous
      * @return void
      */
-    public function __construct($msg = '', $code = 0, Exception $previous = null)
+    public function __construct($msg = '', $code = 0, ?Exception $previous = null)
     {
         if (version_compare(PHP_VERSION, '5.3.0', '<')) {
             parent::__construct($msg, (int) $code);

--- a/plugins/API/Filter/DataComparisonFilter.php
+++ b/plugins/API/Filter/DataComparisonFilter.php
@@ -130,7 +130,7 @@ class DataComparisonFilter
      */
     private $invertCompareChangeCompute;
 
-    public function __construct($request, Report $report = null)
+    public function __construct($request, ?Report $report = null)
     {
         $this->request = new \Piwik\Request($request);
 
@@ -423,7 +423,7 @@ class DataComparisonFilter
         return '(' . implode(') (', $comparisonLabels) . ')';
     }
 
-    private function getSegmentNameFromReport(Report $report = null)
+    private function getSegmentNameFromReport(?Report $report = null)
     {
         if (empty($report)) {
             return null;

--- a/plugins/API/Filter/DataComparisonFilter/ComparisonRowGenerator.php
+++ b/plugins/API/Filter/DataComparisonFilter/ComparisonRowGenerator.php
@@ -40,7 +40,7 @@ class ComparisonRowGenerator
         $this->columnMappings = $columnMappings;
     }
 
-    public function compareTables($compareMetadata, DataTableInterface $tables, DataTableInterface $compareTables = null)
+    public function compareTables($compareMetadata, DataTableInterface $tables, ?DataTableInterface $compareTables = null)
     {
         if ($tables instanceof DataTable) {
             $this->compareTable($compareMetadata, $tables, $compareTables, $compareTables);
@@ -91,7 +91,7 @@ class ComparisonRowGenerator
         }
     }
 
-    private function compareTable($compareMetadata, DataTable $table, DataTable $rootCompareTable = null, DataTable $compareTable = null)
+    private function compareTable($compareMetadata, DataTable $table, ?DataTable $rootCompareTable = null, ?DataTable $compareTable = null)
     {
         // if there are no rows in the table because the metrics are 0, add one so we can still set comparison values
         if ($table->getRowsCount() == 0) {
@@ -132,7 +132,7 @@ class ComparisonRowGenerator
         }
     }
 
-    private function compareRow(DataTable $table, $compareMetadata, DataTable\Row $row, DataTable\Row $compareRow = null, DataTable $rootTable = null)
+    private function compareRow(DataTable $table, $compareMetadata, DataTable\Row $row, ?DataTable\Row $compareRow = null, ?DataTable $rootTable = null)
     {
         $comparisonDataTable = $row->getComparisons();
         if (empty($comparisonDataTable)) {
@@ -211,7 +211,7 @@ class ComparisonRowGenerator
         }
     }
 
-    private function addIndividualChildPrettifiedMetadata(array &$metadata, DataTable $parentTable = null)
+    private function addIndividualChildPrettifiedMetadata(array &$metadata, ?DataTable $parentTable = null)
     {
         if (
             $parentTable

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -463,7 +463,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         string $groupBy,
         $orderBy,
         string $sprintfField,
-        RankingQuery $rankingQuery = null,
+        ?RankingQuery $rankingQuery = null,
         array $metricsConfig = array()
     ): void {
         $select = sprintf($select, $sprintfField);

--- a/plugins/Contents/RecordBuilders/ContentRecords.php
+++ b/plugins/Contents/RecordBuilders/ContentRecords.php
@@ -171,7 +171,7 @@ class ContentRecords extends RecordBuilder
         string $where,
         string $groupBy,
         string $orderBy,
-        RankingQuery $rankingQuery = null
+        ?RankingQuery $rankingQuery = null
     ) {
         // get query with segmentation
         $query = $logAggregator->generateQuery($select, $from, $where, $groupBy, $orderBy);

--- a/plugins/CoreAdminHome/Commands/DeleteLogsData.php
+++ b/plugins/CoreAdminHome/Commands/DeleteLogsData.php
@@ -42,7 +42,7 @@ class DeleteLogsData extends ConsoleCommand
      */
     private $logDeleter;
 
-    public function __construct(LogDeleter $logDeleter = null, RawLogDao $rawLogDao = null)
+    public function __construct(?LogDeleter $logDeleter = null, ?RawLogDao $rawLogDao = null)
     {
         parent::__construct();
 

--- a/plugins/CoreAdminHome/Commands/FixDuplicateLogActions.php
+++ b/plugins/CoreAdminHome/Commands/FixDuplicateLogActions.php
@@ -70,10 +70,10 @@ class FixDuplicateLogActions extends ConsoleCommand
      * @param LoggerInterface $logger
      */
     public function __construct(
-        ArchiveInvalidator $invalidator = null,
-        DuplicateActionRemover $duplicateActionRemover = null,
-        Actions $actionsAccess = null,
-        LoggerInterface $logger = null
+        ?ArchiveInvalidator $invalidator = null,
+        ?DuplicateActionRemover $duplicateActionRemover = null,
+        ?Actions $actionsAccess = null,
+        ?LoggerInterface $logger = null
     ) {
         parent::__construct();
 

--- a/plugins/CoreAdminHome/Commands/PurgeOldArchiveData.php
+++ b/plugins/CoreAdminHome/Commands/PurgeOldArchiveData.php
@@ -37,7 +37,7 @@ class PurgeOldArchiveData extends ConsoleCommand
      */
     private $archivePurger;
 
-    public function __construct(ArchivePurger $archivePurger = null)
+    public function __construct(?ArchivePurger $archivePurger = null)
     {
         parent::__construct();
 

--- a/plugins/CoreAdminHome/Model/DuplicateActionRemover.php
+++ b/plugins/CoreAdminHome/Model/DuplicateActionRemover.php
@@ -58,7 +58,7 @@ class DuplicateActionRemover
      * @param TableMetadata $tableMetadataAccess
      * @param LoggerInterface $logger
      */
-    public function __construct(TableMetadata $tableMetadataAccess = null, LoggerInterface $logger = null)
+    public function __construct(?TableMetadata $tableMetadataAccess = null, ?LoggerInterface $logger = null)
     {
         $this->tableMetadataAccess = $tableMetadataAccess ?: new TableMetadata();
         $this->logger = $logger ?: StaticContainer::get(LoggerInterface::class);

--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -64,7 +64,7 @@ class OptOutManager
     /**
      * @param DoNotTrackHeaderChecker|null $doNotTrackHeaderChecker
      */
-    public function __construct(DoNotTrackHeaderChecker $doNotTrackHeaderChecker = null)
+    public function __construct(?DoNotTrackHeaderChecker $doNotTrackHeaderChecker = null)
     {
         $this->doNotTrackHeaderChecker = $doNotTrackHeaderChecker ?: new DoNotTrackHeaderChecker();
 
@@ -531,7 +531,7 @@ JS;
      *
      * @return array
      */
-    private function getTranslations(string $language = null): array
+    private function getTranslations(?string $language = null): array
     {
         return [
             'OptOutComplete'        => Piwik::translate('CoreAdminHome_OptOutComplete', [], $language),

--- a/plugins/CoreHome/Columns/Metrics/CallableProcessedMetric.php
+++ b/plugins/CoreHome/Columns/Metrics/CallableProcessedMetric.php
@@ -19,7 +19,7 @@ class CallableProcessedMetric extends ProcessedMetric
     private $dependentMetrics;
     private $semanticType;
 
-    public function __construct($name, $callback, $dependentMetrics = array(), string $semanticType = null)
+    public function __construct($name, $callback, $dependentMetrics = array(), ?string $semanticType = null)
     {
         $this->name = $name;
         $this->callback = $callback;

--- a/plugins/CoreHome/tests/Integration/Column/VisitLastActionTimeTest.php
+++ b/plugins/CoreHome/tests/Integration/Column/VisitLastActionTimeTest.php
@@ -92,7 +92,7 @@ class VisitLastActionTimeTest extends IntegrationTestCase
         $this->assertEquals(12, $hourConverted);
     }
 
-    private function getVisitor(VisitProperties $previousProperties = null)
+    private function getVisitor(?VisitProperties $previousProperties = null)
     {
         $visit = new VisitProperties();
         $visit->setProperty('idvisit', '321');

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -51,7 +51,7 @@ class Controller extends \Piwik\Plugin\Controller
      */
     private $marketplacePlugins;
 
-    public function __construct(Updater $updater, Plugins $marketplacePlugins = null)
+    public function __construct(Updater $updater, ?Plugins $marketplacePlugins = null)
     {
         $this->updater = $updater;
         $this->marketplacePlugins = $marketplacePlugins;

--- a/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator/Chart.php
@@ -37,7 +37,7 @@ class Chart
      */
     protected $logger;
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?? StaticContainer::get(LoggerInterface::class);
     }

--- a/plugins/Events/RecordBuilders/EventReports.php
+++ b/plugins/Events/RecordBuilders/EventReports.php
@@ -150,7 +150,7 @@ class EventReports extends RecordBuilder
         string $where,
         string $groupBy,
         string $orderBy,
-        RankingQuery $rankingQuery = null
+        ?RankingQuery $rankingQuery = null
     ): void {
         // get query with segmentation
         $query = $logAggregator->generateQuery($select, $from, $where, $groupBy, $orderBy);

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -349,7 +349,7 @@ class API extends \Piwik\Plugin\API
      * @return string
      * @throws Exception
      */
-    public function getMostRecentVisitsDateTime($idSite, string $period = null, string $date = null): string
+    public function getMostRecentVisitsDateTime($idSite, ?string $period = null, ?string $date = null): string
     {
         Piwik::checkUserHasViewAccess($idSite);
 

--- a/plugins/Referrers/API.php
+++ b/plugins/Referrers/API.php
@@ -790,7 +790,7 @@ class API extends \Piwik\Plugin\API
         return $result;
     }
 
-    private function mergeNumericArchives(DataTable\DataTableInterface $table, DataTable\DataTableInterface $numericArchives = null)
+    private function mergeNumericArchives(DataTable\DataTableInterface $table, ?DataTable\DataTableInterface $numericArchives = null)
     {
         if ($table instanceof DataTable) {
             /** @var DataTable $numericArchives */

--- a/plugins/Referrers/Columns/Campaign.php
+++ b/plugins/Referrers/Columns/Campaign.php
@@ -34,7 +34,7 @@ class Campaign extends Base
      * @param Action|null $action
      * @return bool
      */
-    public function shouldForceNewVisit(Request $request, Visitor $visitor, Action $action = null)
+    public function shouldForceNewVisit(Request $request, Visitor $visitor, ?Action $action = null)
     {
         if (TrackerConfig::getConfigValue('create_new_visit_when_campaign_changes', $request->getIdSiteIfExists()) != 1) {
             return false;

--- a/plugins/Referrers/Columns/Website.php
+++ b/plugins/Referrers/Columns/Website.php
@@ -20,7 +20,7 @@ class Website extends Base
     protected $type = self::TYPE_TEXT;
     protected $nameSingular = 'General_Website';
 
-    public function shouldForceNewVisit(Request $request, Visitor $visitor, Action $action = null)
+    public function shouldForceNewVisit(Request $request, Visitor $visitor, ?Action $action = null)
     {
         if (TrackerConfig::getConfigValue('create_new_visit_when_website_referrer_changes', $request->getIdSiteIfExists()) != 1) {
             return false;

--- a/plugins/SegmentEditor/UnprocessedSegmentException.php
+++ b/plugins/SegmentEditor/UnprocessedSegmentException.php
@@ -32,7 +32,7 @@ class UnprocessedSegmentException extends \Exception
     /**
      * @param $segment
      */
-    public function __construct(Segment $segment, $isSegmentToPreprocess, array $storedSegment = null)
+    public function __construct(Segment $segment, $isSegmentToPreprocess, ?array $storedSegment = null)
     {
         parent::__construct(self::getErrorMessage($segment, $isSegmentToPreprocess, $storedSegment));
 
@@ -57,7 +57,7 @@ class UnprocessedSegmentException extends \Exception
         return $this->storedSegment;
     }
 
-    private static function getErrorMessage(Segment $segment, $isSegmentToPreprocess, array $storedSegment = null)
+    private static function getErrorMessage(Segment $segment, $isSegmentToPreprocess, ?array $storedSegment = null)
     {
         if (empty($storedSegment)) {
             // the segment was not created through the segment editor

--- a/plugins/UserCountry/Commands/AttributeHistoricalDataWithLocations.php
+++ b/plugins/UserCountry/Commands/AttributeHistoricalDataWithLocations.php
@@ -60,7 +60,7 @@ class AttributeHistoricalDataWithLocations extends ConsoleCommand
      */
     private $processedPercent = 0;
 
-    public function __construct(RawLogDao $dao = null)
+    public function __construct(?RawLogDao $dao = null)
     {
         parent::__construct();
 

--- a/plugins/UserCountry/VisitorGeolocator.php
+++ b/plugins/UserCountry/VisitorGeolocator.php
@@ -83,11 +83,11 @@ class VisitorGeolocator
     protected $logger;
 
     public function __construct(
-        LocationProvider $provider = null,
-        LocationProvider $backupProvider = null,
-        Cache $locationCache = null,
-        RawLogDao $dao = null,
-        LoggerInterface $logger = null
+        ?LocationProvider $provider = null,
+        ?LocationProvider $backupProvider = null,
+        ?Cache $locationCache = null,
+        ?RawLogDao $dao = null,
+        ?LoggerInterface $logger = null
     ) {
         if ($provider === null) {
             // note: Common::getCurrentLocationProviderId() uses the tracker cache, which is why it's used here instead

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -106,10 +106,10 @@ class API extends \Piwik\Plugin\API
         Model $model,
         UserAccessFilter $filter,
         Password $password,
-        Access $access = null,
-        Access\RolesProvider $roleProvider = null,
-        Access\CapabilitiesProvider $capabilityProvider = null,
-        PasswordVerifier $passwordVerifier = null
+        ?Access $access = null,
+        ?Access\RolesProvider $roleProvider = null,
+        ?Access\CapabilitiesProvider $capabilityProvider = null,
+        ?PasswordVerifier $passwordVerifier = null
     ) {
         $this->model = $model;
         $this->userFilter = $filter;

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -460,7 +460,7 @@ class Fixture extends \PHPUnit\Framework\Assert
      * @param array $extraPluginsToLoad Ignoerd.
      */
     public static function loadAllPlugins(
-        TestingEnvironmentVariables $testEnvironment = null,
+        ?TestingEnvironmentVariables $testEnvironment = null,
         $testCaseClass = false,
         $extraPluginsToLoad = []
     ) {

--- a/tests/PHPUnit/Framework/Mock/FakeAccess.php
+++ b/tests/PHPUnit/Framework/Mock/FakeAccess.php
@@ -91,7 +91,7 @@ class FakeAccess extends Access
         self::$superUser = $bool;
     }
 
-    public function reloadAccess(Auth $auth = null)
+    public function reloadAccess(?Auth $auth = null)
     {
         return true;
     }

--- a/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
+++ b/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
@@ -742,8 +742,8 @@ class RecordBuilderTest extends TestCase
 
     public function getMockArchiveProcessor(
         string $period = 'day',
-        array $requestedReports = null,
-        array $foundRequestedReports = null,
+        ?array $requestedReports = null,
+        ?array $foundRequestedReports = null,
         bool $addSubtablesToAggregatedTables = false
     ): ArchiveProcessor {
         Site::setSiteFromArray(1, ['idsite' => 1, 'ecommerce' => 0, 'sitesearch' => 0, 'exclude_unknown_urls' => 0, 'keep_url_fragment' => 0]);


### PR DESCRIPTION
### Description:

With PHP 8.4 implicitly marking parameters as nullable by only setting null as default value is deprecated.
To get rid of all the deprecation notices caused by our code, this PR aims to change all occurrences to explicitly mark the parameters as nullable.

refs #22471

(Ref DEV-18385)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
