### PR TITLE
Improve type checks in SitesManager API

### DIFF
--- a/plugins/SitesManager/tests/Fixtures/ManySites.php
+++ b/plugins/SitesManager/tests/Fixtures/ManySites.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\SitesManager\tests\Fixtures;
 
+use Piwik\Plugin\Manager;
 use Piwik\Plugins\MobileAppMeasurable;
 use Piwik\Tests\Framework\Fixture;
 
@@ -21,6 +22,9 @@ class ManySites extends Fixture
 
     public function setUp(): void
     {
+        // Ensure plugin is activated, otherwise adding a site with this type will fail
+        Manager::getInstance()->activatePlugin('MobileAppMeasurable');
+
         for ($idSite = 1; $idSite < 64; $idSite++) {
             if (!self::siteCreated($idSite)) {
                 if ($idSite < 35) {

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -251,7 +251,7 @@ class ApiTest extends IntegrationTestCase
         }
     }
 
-    public function testAddSiteShouldFailAndNotCreatedASiteIfTypeIsInvalid()
+    public function testAddSiteShouldFailAndNotCreateASiteIfTypeIsInvalid()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Invalid website type notexistingtype');

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -13,6 +13,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugin;
+use Piwik\Plugins\IntranetMeasurable\Type as IntranetType;
 use Piwik\Plugins\MobileAppMeasurable;
 use Piwik\Plugins\WebsiteMeasurable\Type as WebsiteType;
 use Piwik\Plugins\SitesManager\API;
@@ -84,14 +85,6 @@ class ApiTest extends IntegrationTestCase
     {
         $this->expectException(\Exception::class);
         API::getInstance()->addSite("name", $url);
-    }
-
-    /**
-     * Test with valid IPs
-     */
-    public function testAddSiteWithExcludedIpsAndTimezoneAndCurrencyAndExcludedQueryParametersSucceedsWhenParamsAreValid()
-    {
-        $this->addSiteTest($expectedWebsiteType = 'mobile-\'app');
     }
 
     /**
@@ -249,6 +242,23 @@ class ApiTest extends IntegrationTestCase
         try {
             $settings = ['WebsiteMeasurable' => [['name' => 'exclude_unknown_urls', 'value' => 'fooBar']]];
             $this->addSiteWithType($type, $settings);
+        } catch (Exception $e) {
+            // make sure no site created
+            $ids = API::getInstance()->getAllSitesId();
+            $this->assertEquals([], $ids);
+
+            throw $e;
+        }
+    }
+
+    public function testAddSiteShouldFailAndNotCreatedASiteIfTypeIsInvalid()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid website type notexistingtype');
+
+        try {
+            $settings = ['WebsiteMeasurable' => [['name' => 'exclude_unknown_urls', 'value' => 'fooBar']]];
+            $this->addSiteWithType('notexistingtype', $settings);
         } catch (Exception $e) {
             // make sure no site created
             $ids = API::getInstance()->getAllSitesId();
@@ -906,7 +916,7 @@ class ApiTest extends IntegrationTestCase
 
         // Updating the group to nothing
         $group = '';
-        $type = 'mobileAppTest';
+        $type = MobileAppMeasurable\Type::ID;
         API::getInstance()->updateSite($idsite, "test toto@{}", $newMainUrl, $ecommerce = 0, $ss = false, $ss_kwd = '', $ss_cat = null, $ips = null, $parametersExclude = null, $timezone = null, $currency = null, $group, $startDate = '2010-01-01', $excludedUserAgent = null, $keepUrlFragment = 1, $type);
         $websites = API::getInstance()->getSitesFromGroup($group);
         $this->assertEquals(1, count($websites));
@@ -1081,6 +1091,38 @@ class ApiTest extends IntegrationTestCase
         $this->assertEquals(1, $site['exclude_unknown_urls']);
     }
 
+    public function testUpdateSiteWithInvalidTypeFails()
+    {
+        $idSite = $this->addSiteWithType('website', []);
+
+        $site = API::getInstance()->getSiteFromId($idSite);
+        $this->assertEquals(0, $site['exclude_unknown_urls']);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid website type invalidtype');
+
+        API::getInstance()->updateSite(
+            $idSite,
+            $siteName = 'new site name',
+            $urls = null,
+            $ecommerce = true,
+            $siteSearch = false,
+            $searchKeywordParams = null,
+            $searchCategoryParams = null,
+            $excludedIps = null,
+            $excludedQueryParameters = null,
+            $timzeone = null,
+            $currency = 'NZD',
+            $group = null,
+            $startDate = null,
+            $excludedUserAgents = null,
+            $keepUrlFragments = null,
+            $type = 'invalidtype',
+            $settings = null,
+            $excludeUnknownUrls = true
+        );
+    }
+
     /**
      * @dataProvider getDifferentTypesDataProvider
      */
@@ -1123,9 +1165,9 @@ class ApiTest extends IntegrationTestCase
     public function getDifferentTypesDataProvider()
     {
         return [
-            ['website'],
-            ['mobileapp'],
-            ['notexistingtype'],
+            [WebsiteType::ID],
+            [MobileAppMeasurable\Type::ID],
+            [IntranetType::ID],
         ];
     }
 

--- a/plugins/SitesManager/tests/Integration/ModelTest.php
+++ b/plugins/SitesManager/tests/Integration/ModelTest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\SitesManager\tests\Integration;
 
+use Piwik\Plugin\Manager;
 use Piwik\Plugins\SitesManager\Model;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -28,6 +29,8 @@ class ModelTest extends IntegrationTestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        Manager::getInstance()->activatePlugin('MobileAppMeasurable');
 
         $this->model = new Model();
     }
@@ -50,11 +53,11 @@ class ModelTest extends IntegrationTestCase
     {
         for ($i = 0; $i < 9; $i++) {
             $this->createMeasurable('website');
-            $this->createMeasurable('universal');
+            $this->createMeasurable('intranet');
             $this->createMeasurable('mobileapp');
         }
 
-        $this->assertEqualsCanonicalizing(['website', 'universal', 'mobileapp'], $this->model->getUsedTypeIds());
+        $this->assertEqualsCanonicalizing(['website', 'intranet', 'mobileapp'], $this->model->getUsedTypeIds());
     }
 
     public function testGetAllKnownUrlsForAllSitesShouldReturnAllUrls()


### PR DESCRIPTION
### Description:

While working on another issue I came across the fact, that the SitesManager API currently does not check the type that is provided when creating or updating a measurable. 

This makes it possible to create measurables with an invalid type, or update an existing measurable with one.

This PR therefor introduces a check if the provided type exists.
When updating an existing site, the type will only be checked if it differs from the previous one.
This is done, to ensure that a measurable that already has an invalid type (e.g. due to a removed plugin), is still update-able. 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
