### PR TITLE
Use automation user to commit built vue files to ensure other actions are triggered

### DIFF
--- a/.github/workflows/buildvue.yml
+++ b/.github/workflows/buildvue.yml
@@ -108,16 +108,16 @@ jobs:
         run: |
           cat <<- EOF > $HOME/.netrc
             machine github.com
-            login $GITHUB_ACTOR
-            password $GITHUB_TOKEN
+            login innocraft-automation
+            password $CUSTOM_ACCESS_TOKEN
             machine api.github.com
-            login $GITHUB_ACTOR
-            password $GITHUB_TOKEN
+            login innocraft-automation
+            password $CUSTOM_ACCESS_TOKEN
           EOF
           chmod 600 $HOME/.netrc
-          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git config --global user.name "$GITHUB_ACTOR"
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+          git config --global user.email "innocraft-automation@users.noreply.github.com"
+          git config --global user.name "innocraft-automation"
+          git remote set-url origin https://x-access-token:${{ secrets.CUSTOM_ACCESS_TOKEN }}@github.com/$GITHUB_REPOSITORY
           if [[ ${{ steps.vars.outputs.islocalbranch }} ]]
           then
             git fetch --depth=1 origin $BRANCH_NAME


### PR DESCRIPTION
### Description:

When vue files are commited our action automatically will built the files and commit them if necessary.
Currently this is done using the permissions of the action. Due to that, no other actions will be triggered by that commit.
This PR updates the action to use the automation user instead, to ensure tests will run for such commits.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
