### PR TITLE
Prevent unusable location provider from breaking the login process

### DIFF
--- a/plugins/Login/Security/LoginFromDifferentCountryDetection.php
+++ b/plugins/Login/Security/LoginFromDifferentCountryDetection.php
@@ -29,11 +29,6 @@ class LoginFromDifferentCountryDetection
      */
     private $usersModel;
 
-    /**
-     * @var array|null
-     */
-    private $location = null;
-
     public function __construct(Model $model, UsersModel $usersModel)
     {
         $this->model = $model;

--- a/plugins/Login/Security/LoginFromDifferentCountryDetection.php
+++ b/plugins/Login/Security/LoginFromDifferentCountryDetection.php
@@ -45,7 +45,8 @@ class LoginFromDifferentCountryDetection
     {
         $provider = LocationProvider::getCurrentProvider();
 
-        return $provider->canBeUsedForLocationBasedSecurityChecks()
+        return null !== $provider
+            && $provider->canBeUsedForLocationBasedSecurityChecks()
             && $provider->isAvailable()
             && $provider->isWorking()
             && true === $provider->getSupportedLocationInfo()[LocationProvider::COUNTRY_CODE_KEY];

--- a/plugins/Login/Security/LoginFromDifferentCountryDetection.php
+++ b/plugins/Login/Security/LoginFromDifferentCountryDetection.php
@@ -49,7 +49,7 @@ class LoginFromDifferentCountryDetection
             && $provider->canBeUsedForLocationBasedSecurityChecks()
             && $provider->isAvailable()
             && $provider->isWorking()
-            && true === $provider->getSupportedLocationInfo()[LocationProvider::COUNTRY_CODE_KEY];
+            && ($provider->getSupportedLocationInfo()[LocationProvider::COUNTRY_CODE_KEY] ?? false);
     }
 
     private function getLocation(): array

--- a/plugins/Login/tests/Integration/Security/LoginFromAnotherCountryTest.php
+++ b/plugins/Login/tests/Integration/Security/LoginFromAnotherCountryTest.php
@@ -10,6 +10,7 @@
 namespace Integration\Security;
 
 use PHPMailer\PHPMailer\PHPMailer;
+use Piwik\Container\StaticContainer;
 use Piwik\DI;
 use Piwik\Piwik;
 use Piwik\Plugins\GeoIp2\LocationProvider\GeoIp2;
@@ -135,6 +136,21 @@ class LoginFromAnotherCountryTest extends IntegrationTestCase
     public function testEmailIsNotSentWhenUsingDefaultGeoIpProvider()
     {
         LocationProvider::setCurrentProvider(LocationProvider\DefaultProvider::ID);
+
+        // start in France
+        $_SERVER['REMOTE_ADDR'] = self::IP_FRANCE;
+        Piwik::postEvent('Login.authenticate.processSuccessfulSession.end', [self::LOGIN]);
+        $this->assertEmpty($this->loginCountry);
+
+        // continue in USA
+        $_SERVER['REMOTE_ADDR'] = self::IP_USA;
+        Piwik::postEvent('Login.authenticate.processSuccessfulSession.end', [self::LOGIN]);
+        $this->assertEmpty($this->loginCountry);
+    }
+
+    public function testEmailIsNotSentWhenUsingGeoIpProviderIsActivateButNotAvailable()
+    {
+        StaticContainer::getContainer()->set('path.geoip2', '/tmp/invalid/geoip2/path');
 
         // start in France
         $_SERVER['REMOTE_ADDR'] = self::IP_FRANCE;


### PR DESCRIPTION
### Description:

When testing #22718 in a different environment, my geolocation setup was incomplete. The provider was configured, but the database was missing.

This resulted in a broken login process because `LocationProvider::getCurrentProvider()` returned a `null`.

I also changed the check for supported location info to prevent a potential "Undefined index: country_code" warning. With the GeoIp2 provider this could happen if there is only an ISP database available, but no "regular" database.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
