### PR TITLE
Block installation if installation is older than 3 days

### DIFF
--- a/core/Application/Kernel/EnvironmentValidator.php
+++ b/core/Application/Kernel/EnvironmentValidator.php
@@ -71,16 +71,21 @@ class EnvironmentValidator
      */
     private function checkConfigFileExists($path, $startInstaller = false)
     {
-        if (is_readable($path)) {
+        if (is_readable($path) && !$startInstaller) {
             return;
         }
 
         $general = $this->settingsProvider->getSection('General');
 
         if (
-            isset($general['enable_installer'])
-            && !$general['enable_installer']
+            isset($general['installation_in_progress'])
+            && $general['installation_in_progress']
+            && $startInstaller
         ) {
+            return;
+        }
+
+        if (isset($general['enable_installer']) && !$general['enable_installer']) {
             throw new NotYetInstalledException('Matomo is not set up yet');
         }
 

--- a/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
@@ -13,6 +13,7 @@ use Piwik\Common;
 use Piwik\Config;
 use Piwik\Db;
 use Piwik\DbHelper;
+use Piwik\SettingsPiwik;
 use Piwik\Translation\Translator;
 use Piwik\Url;
 
@@ -33,10 +34,9 @@ class DatabaseAbilitiesCheck implements Diagnostic
 
     public function execute()
     {
-        $isPiwikInstalling = !Config::getInstance()->existsLocalConfig();
-        if ($isPiwikInstalling) {
-            // Skip the diagnostic if Piwik is being installed
-            return array();
+        if (!SettingsPiwik::isMatomoInstalled()) {
+            // Skip the diagnostic if Matomo is being installed
+            return [];
         }
 
         $result = new DiagnosticResult($this->translator->translate('Installation_DatabaseAbilities'));

--- a/plugins/Diagnostics/Diagnostic/DbReaderCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DbReaderCheck.php
@@ -9,9 +9,9 @@
 
 namespace Piwik\Plugins\Diagnostics\Diagnostic;
 
-use Piwik\Config;
 use Piwik\Db;
 use Piwik\Piwik;
+use Piwik\SettingsPiwik;
 use Piwik\Translation\Translator;
 
 /**
@@ -31,15 +31,14 @@ class DbReaderCheck implements Diagnostic
 
     public function execute()
     {
-        $isPiwikInstalling = !Config::getInstance()->existsLocalConfig();
-        if ($isPiwikInstalling) {
-            // Skip the diagnostic if Piwik is being installed
-            return array();
+        if (!SettingsPiwik::isMatomoInstalled()) {
+            // Skip the diagnostic if Matomo is being installed
+            return [];
         }
 
         if (!Db::hasReaderConfigured()) {
             // only show an entry when reader is actually configured
-            return array();
+            return [];
         }
 
         $label = $this->translator->translate('Diagnostics_DatabaseReaderConnection');

--- a/plugins/Diagnostics/Diagnostic/ForceSSLCheck.php
+++ b/plugins/Diagnostics/Diagnostic/ForceSSLCheck.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\Diagnostics\Diagnostic;
 
 use Piwik\Config;
 use Piwik\ProxyHttp;
+use Piwik\SettingsPiwik;
 use Piwik\Translation\Translator;
 use Piwik\Url;
 use Piwik\View;
@@ -35,8 +36,7 @@ class ForceSSLCheck implements Diagnostic
         $label = $this->translator->translate('General_ForcedSSL');
 
         // special handling during install
-        $isPiwikInstalling = !Config::getInstance()->existsLocalConfig();
-        if ($isPiwikInstalling) {
+        if (!SettingsPiwik::isMatomoInstalled()) {
             if (ProxyHttp::isHttps()) {
                 return [];
             }

--- a/plugins/Diagnostics/Diagnostic/NfsDiskCheck.php
+++ b/plugins/Diagnostics/Diagnostic/NfsDiskCheck.php
@@ -9,8 +9,8 @@
 
 namespace Piwik\Plugins\Diagnostics\Diagnostic;
 
-use Piwik\Config;
 use Piwik\Filesystem;
+use Piwik\SettingsPiwik;
 use Piwik\Translation\Translator;
 
 /**
@@ -39,8 +39,7 @@ class NfsDiskCheck implements Diagnostic
             return array(DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_OK));
         }
 
-        $isPiwikInstalling = !Config::getInstance()->existsLocalConfig();
-        if ($isPiwikInstalling) {
+        if (!SettingsPiwik::isMatomoInstalled()) {
             $help = 'Installation_NfsFilesystemWarningSuffixInstall';
         } else {
             $help = 'Installation_NfsFilesystemWarningSuffixAdmin';

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -796,7 +796,22 @@ class Controller extends ControllerAdmin
         $threeDaysAgo = Date::getNowTimestamp() - (3 * 24 * 60 * 60);
 
         if ($firstAccess < $threeDaysAgo) {
-            throw new Exception('This installation has expired, please delete installation_first_accessed from config.ini.php to reset');
+            Piwik::exitWithErrorMessage(
+                Piwik::translate('Installation_ErrorExpired1') .
+                "\n<br/>" .
+                Piwik::translate('Installation_ErrorExpired2') .
+                "\n<ul>" .
+                "\n<li>" . Piwik::translate('Installation_ErrorExpired3', ['<strong>', '</strong>']) . '</li>' .
+                "\n<li>" . Piwik::translate('Installation_ErrorExpired4', ['<strong>', '</strong>']) . '</li>' .
+                "\n<li>" . Piwik::translate('Installation_ErrorExpired5') . '</li>' .
+                "\n</ul>" .
+                Piwik::translate('Installation_ErrorExpired6') .
+                "\n<br/>" .
+                Piwik::translate('Installation_ErrorExpired7', [
+                    '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/guide/installation-maintenance/matomo-on-premise-self-hosted/') . '" rel="noreferrer noopener" target="_blank">',
+                    '</a>'
+                ])
+            );
         }
     }
 

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -808,7 +808,7 @@ class Controller extends ControllerAdmin
                 Piwik::translate('Installation_ErrorExpired6') .
                 "\n<br/>" .
                 Piwik::translate('Installation_ErrorExpired7', [
-                    '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/guide/installation-maintenance/matomo-on-premise-self-hosted/') . '" rel="noreferrer noopener" target="_blank">',
+                    '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to-install/manage-secure-access-to-the-matomo-installer/') . '" rel="noreferrer noopener" target="_blank">',
                     '</a>'
                 ])
             );

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -160,6 +160,13 @@
         "PerformanceSettingsDesc1": "Your Matomo is set up and ready to track and report on your website's traffic. Set up %1$sCLI archiving%2$s if you find it to be slow. This generates reports in the background, rather than on demand.",
         "PerformanceSettingsDesc2": "This requires adding a Matomo command to Cron which can't be done automatically by the installer. %1$sRead our FAQ to learn to set it up yourself.%2$s",
         "MatomoHttpRequestConfigInfo": "The option <code>force_matomo_http_request</code> in the general config is turned on, we highly recommend switching it off for security reasons. For more details please read %1$show to disable https for matomo.org requests%2$s",
-        "MatomoHttpsNotSupported": "Could not initialize HTTPS. Connections to matomo.org use HTTPS by default for security. Please make sure that HTTPS works on your environment or enable the option `force_matomo_http_request`. For more details please read %1$show to disable https for matomo.org requests%2$s"
+        "MatomoHttpsNotSupported": "Could not initialize HTTPS. Connections to matomo.org use HTTPS by default for security. Please make sure that HTTPS works on your environment or enable the option `force_matomo_http_request`. For more details please read %1$show to disable https for matomo.org requests%2$s",
+        "ErrorExpired1": "Your Matomo installation was started more than 3 days ago, but it has not been completed.",
+        "ErrorExpired2": "Please follow these steps to continue the installation:",
+        "ErrorExpired3": "Open the %1$sconfig/config.ini.php%2$s file in your Matomo installation directory.",
+        "ErrorExpired4": "Find and delete the line containing %1$sinstallation_first_accessed%2$s.",
+        "ErrorExpired5": "Save the file and refresh the page to continue the installation process.",
+        "ErrorExpired6": "Alternatively, you can also delete the configuration file instead of editing it.",
+        "ErrorExpired7": "If you need further assistance, check out the %1$sFAQ%2$s for more detailed help."
     }
 }

--- a/plugins/Installation/tests/UI/Installation_spec.js
+++ b/plugins/Installation/tests/UI/Installation_spec.js
@@ -9,10 +9,23 @@
 var fs = require('fs'),
     path = require('../../../../tests/lib/screenshot-testing/support/path');
 
-describe("Installation", function () {
+describe('Installation', function () {
     this.timeout(0);
+    this.fixture = 'Piwik\\Tests\\Fixtures\\EmptySite';
 
-    this.fixture = "Piwik\\Tests\\Fixtures\\EmptySite";
+    /** Timestamp when first website came online - Tue, 06 Aug 1991 00:00:00 GMT. */
+    const firstWebsiteTimestamp = 681436800;
+    const installationDbName = 'newdb';
+
+    let installationStarted;
+    let pageUrl;
+    let pageUrlDe;
+
+    function deleteLocalConfigFile() {
+        if (fs.existsSync(testEnvironment.configFileLocal)) {
+            fs.unlinkSync(testEnvironment.configFileLocal);
+        }
+    }
 
     before(function () {
         testEnvironment.testUseMockAuth = 0;
@@ -22,9 +35,7 @@ describe("Installation", function () {
         testEnvironment.tablesPrefix = 'piwik_';
         testEnvironment.save();
 
-        if (fs.existsSync(testEnvironment.configFileLocal)) {
-            fs.unlinkSync(testEnvironment.configFileLocal);
-        }
+        deleteLocalConfigFile();
     });
 
     after(function () {
@@ -50,8 +61,34 @@ describe("Installation", function () {
         expect(await page.screenshot({ fullPage: true })).to.matchImage('access_no_config');
     });
 
-    it("should start the installation process when the index is visited w/o a config.ini.php file", async function() {
+    it("should lock the installer when installation first accessed more than 3 days ago", async function() {
+        deleteLocalConfigFile();
+
+        // create a valid config file
         await page.goto("");
+
+        // overwrite access timestamp
+        testEnvironment.appendToLocalConfig(`
+[General]
+installation_first_accessed = ${firstWebsiteTimestamp}
+`);
+
+        await page.goto("");
+
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('expired');
+    });
+
+    it("should start the installation process when the index is visited w/o a config.ini.php file", async function() {
+        deleteLocalConfigFile();
+
+        await page.goto("");
+
+        const { firstAccessed, inProgress } = testEnvironment.readInstallationInfoFromLocalConfig();
+
+        expect(inProgress).to.be.false;
+        expect(firstAccessed).to.be.greaterThan(firstWebsiteTimestamp);
+
+        installationStarted = firstAccessed;
 
         expect(await page.screenshot({ fullPage: true })).to.matchImage('start');
     });
@@ -63,7 +100,6 @@ describe("Installation", function () {
         expect(await page.screenshot({ fullPage: true })).to.matchImage('system_check');
     });
 
-    let pageUrl;
     it("should have already created a tmp/sessions/index.htm file to prevent directory listing", async function() {
         pageUrl = page.url();
 
@@ -77,7 +113,7 @@ describe("Installation", function () {
     it("should display the database setup page when next is clicked on the system check page", async function() {
         await page.goto(pageUrl);
 
-        page.click('.next-step .btn');
+        await page.click('.next-step .btn');
         await page.waitForNetworkIdle();
 
         expect(await page.screenshot({ fullPage: true })).to.matchImage('db_setup');
@@ -91,20 +127,22 @@ describe("Installation", function () {
     });
 
     it("should display the tables created page when next is clicked on the db setup page w/ correct info entered in the form", async function() {
-        const dbInfo = testEnvironment.readDbInfoFromConfig();
-        const username = dbInfo.username;
-        const password = dbInfo.password;
+        const { username, password } = testEnvironment.readDbInfoFromConfig();
+
         await page.type('input[name="username"]', username);
-
-        if (password) {
-            await page.type('input[name="password"]', password);
-        }
-
-        await page.type('input[name="dbname"]', 'newdb');
+        await page.type('input[name="password"]', password);
+        await page.type('input[name="dbname"]', installationDbName);
         await page.click('.btn');
         await page.waitForNetworkIdle();
 
         expect(await page.screenshot({ fullPage: true })).to.matchImage('db_created');
+    });
+
+    it("should have set the installation to be 'in progress'", async function() {
+        const { firstAccessed, inProgress } = testEnvironment.readInstallationInfoFromLocalConfig();
+
+        expect(inProgress).to.be.true;
+        expect(firstAccessed).to.be.equal(installationStarted);
     });
 
     it("should display the superuser configuration page when next is clicked on the tables created page", async function() {
@@ -114,11 +152,10 @@ describe("Installation", function () {
         expect(await page.screenshot({ fullPage: true })).to.matchImage('superuser');
     });
 
-    let pageUrlDe;
-
     it("should un-select Professional Services newsletter checkbox when language is German", async function() {
         pageUrl = await page.url();
         pageUrlDe = pageUrl + '&language=de';
+
         await page.goto(pageUrlDe);
 
         expect(await page.screenshot({ fullPage: true })).to.matchImage('superuser_de');
@@ -178,7 +215,48 @@ describe("Installation", function () {
         await page.click('.next-step .btn');
         await page.waitForNetworkIdle();
 
+        // the installation is NOT finished at this point
+        // the user needs to click the submit button once more!
         expect(await page.screenshot({ fullPage: true })).to.matchImage('congrats');
+    });
+
+    it("should clear the configuration file when restarting the installation process", async function() {
+        // restart installation
+        await page.goto("");
+        await page.waitForSelector('#installation');
+
+        // go to system check
+        await page.click('.next-step .btn');
+        await page.waitForSelector('[vue-entry="Installation.SystemCheck"]');
+
+        // system check will delete existing configuration file
+        // but should keep "first_accessed" information
+        const { firstAccessed, inProgress } = testEnvironment.readInstallationInfoFromLocalConfig();
+
+        expect(inProgress).to.be.false;
+        expect(firstAccessed).to.be.equal(installationStarted);
+    });
+
+    it("should allow reusing an existing database from a previous installation", async function() {
+        // go to database setup
+        await page.click('.next-step .btn');
+        await page.waitForNetworkIdle();
+
+        // submit database credentials
+        const { username, password } = testEnvironment.readDbInfoFromConfig();
+
+        await page.type('input[name="username"]', username);
+        await page.type('input[name="password"]', password);
+        await page.type('input[name="dbname"]', installationDbName);
+        await page.click('.btn');
+        await page.waitForNetworkIdle();
+
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('db_existing');
+    });
+
+    it("should skip to the congrats page as installation was already completed up to that step", async function() {
+        await page.click('a[href*="reuseTables"]');
+        await page.waitForSelector('.installation-finished');
     });
 
     it("should continue to piwik after submitting on the privacy settings form in the congrats page", async function() {
@@ -187,5 +265,25 @@ describe("Installation", function () {
 
         // check login form is displayed
         await page.waitForSelector('.loginForm');
+
+        // check installation is no longer in progress
+        const { firstAccessed, inProgress } = testEnvironment.readInstallationInfoFromLocalConfig();
+
+        expect(inProgress).to.be.false;
+        expect(firstAccessed).to.be.null;
+    });
+
+    it("should display an error page if installation is accessed on an installed instance", async function() {
+        // go back to a previous installation step
+        await page.goto(pageUrl);
+        await page.waitForNetworkIdle();
+
+        // check no installation progress information was added
+        const { firstAccessed, inProgress } = testEnvironment.readInstallationInfoFromLocalConfig();
+
+        expect(inProgress).to.be.false;
+        expect(firstAccessed).to.be.null;
+
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('already_installed');
     });
 });

--- a/plugins/Installation/tests/UI/expected-screenshots/Installation_already_installed.png
+++ b/plugins/Installation/tests/UI/expected-screenshots/Installation_already_installed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae5f4db76202140f70a930ebdd72f400e2b0a65a9c1f512b52c06a7bde097b20
+size 14491

--- a/plugins/Installation/tests/UI/expected-screenshots/Installation_db_existing.png
+++ b/plugins/Installation/tests/UI/expected-screenshots/Installation_db_existing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:514a209b7eebfa8d6ccbfbd815d9669134a84e96d74c2a3ac87474cab8786535
+size 135507

--- a/plugins/Installation/tests/UI/expected-screenshots/Installation_expired.png
+++ b/plugins/Installation/tests/UI/expected-screenshots/Installation_expired.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe46db146e41abb57f69c52abaebc1fbe5bc873b090dc6566465f4c135256be5
+size 48655

--- a/plugins/UserCountry/Diagnostic/GeolocationDiagnostic.php
+++ b/plugins/UserCountry/Diagnostic/GeolocationDiagnostic.php
@@ -9,11 +9,11 @@
 
 namespace Piwik\Plugins\UserCountry\Diagnostic;
 
-use Piwik\Config;
 use Piwik\Piwik;
 use Piwik\Plugins\Diagnostics\Diagnostic\Diagnostic;
 use Piwik\Plugins\Diagnostics\Diagnostic\DiagnosticResult;
 use Piwik\Plugins\UserCountry\LocationProvider;
+use Piwik\SettingsPiwik;
 use Piwik\Translation\Translator;
 
 /**
@@ -33,10 +33,9 @@ class GeolocationDiagnostic implements Diagnostic
 
     public function execute()
     {
-        $isMatomoInstalling = !Config::getInstance()->existsLocalConfig();
-        if ($isMatomoInstalling) {
+        if (!SettingsPiwik::isMatomoInstalled()) {
             // Skip the diagnostic if Matomo is being installed
-            return array();
+            return [];
         }
 
         $label = $this->translator->translate('UserCountry_Geolocation');

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -477,6 +477,7 @@ PageRenderer.prototype._setupWebpageEvents = function () {
         --this.activeRequestCount;
 
         const response = request.response();
+
         if (VERBOSE || (response.status() >= 400 && this._isUrlThatWeCareAbout(request.url()))) {
             let bodyLength = 0;
             let bodyContent = '';
@@ -529,7 +530,5 @@ PageRenderer.prototype.getWholeCurrentUrl = function () {
 PageRenderer.prototype.allowClipboard = async function () {
     await this.browserContext.overridePermissions(await this.getWholeCurrentUrl(), ['clipboard-read', 'clipboard-write']);
 };
-
-
 
 exports.PageRenderer = PageRenderer;

--- a/tests/lib/screenshot-testing/support/test-environment.js
+++ b/tests/lib/screenshot-testing/support/test-environment.js
@@ -218,16 +218,16 @@ TestingEnvironment.prototype.setupFixture = function (fixtureClass, done) {
 };
 
 TestingEnvironment.prototype.readDbInfoFromConfig = function () {
+    let username = 'root';
+    let password = '';
 
-    var username = 'root';
-    var password = '';
-
-    var pathConfigIni = path.join(PIWIK_INCLUDE_PATH, "/config/config.ini.php");
-
-    var configFile = fs.readFileSync(pathConfigIni);
+    const pathConfigIni = path.join(PIWIK_INCLUDE_PATH, "/config/config.ini.php");
+    const configFile = fs.readFileSync(pathConfigIni);
 
     if (configFile) {
-        var match = ('' + configFile).match(/password\s?=\s?"(.*)"/);
+        let match;
+
+        match = ('' + configFile).match(/password\s?=\s?"(.*)"/);
 
         if (match && match.length) {
             password = match[1];
@@ -240,10 +240,39 @@ TestingEnvironment.prototype.readDbInfoFromConfig = function () {
         }
     }
 
-    return {
-        username: username,
-        password: password
+    return { username, password };
+};
+
+TestingEnvironment.prototype.readInstallationInfoFromLocalConfig = function () {
+    let inProgress = false;
+    let firstAccessed = null;
+
+    const pathConfigIni = path.join(testEnvironment.configFileLocal);
+    const configFile = fs.readFileSync(pathConfigIni);
+
+    if (configFile) {
+        let match;
+
+        match = ('' + configFile).match(/installation_first_accessed\s?=\s?(\d+)/);
+
+        if (match && match.length) {
+            firstAccessed = parseInt(match[1]);
+        }
+
+        match = ('' + configFile).match(/installation_in_progress\s?=\s?(\d+)/);
+
+        if (match && match.length) {
+            inProgress = !!match[1];
+        }
     }
+
+    return { firstAccessed, inProgress };
+};
+
+TestingEnvironment.prototype.appendToLocalConfig = function (content) {
+    const pathConfigIni = path.join(testEnvironment.configFileLocal);
+
+    fs.appendFileSync(pathConfigIni, content);
 };
 
 TestingEnvironment.prototype.teardownFixture = function (fixtureClass, done) {


### PR DESCRIPTION
### Description:

Sometimes people can put Matomo on their server and leave it sitting their for an extended period, possibly opening themselves up to bad actors.

This PR locks the install out 3 days after first access.

Refs DEV-18623.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
