### PR TITLE
Fix typo in displayed migration command

### DIFF
--- a/core/Updates/5.2.0-b6.php
+++ b/core/Updates/5.2.0-b6.php
@@ -31,7 +31,7 @@ class Updates_5_2_0_b6 extends Updates
 
     public function getMigrations(Updater $updater)
     {
-        $startOfCurrentYear = '01-01-' . Date::now()->toString('Y');
+        $startOfCurrentYear = Date::now()->toString('Y') . '-01-01';
 
         $commandToExecute = sprintf(
             './console core:invalidate-report-data --dates=%s,today --plugin=Actions.Actions_hits',


### PR DESCRIPTION
### Description:

The migration itself works, but copying the displayed command will result in a date parsing exception as `Range::parseDateRange` requires the `Y-m-d` format.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
