### PR TITLE
Example code for setCustomRequestProcessing is not working anymore with encodedURI

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -5536,7 +5536,7 @@ if (typeof window.Matomo !== 'object') {
              *       pair = pair.split('=');
              *       result[pair[0]] = decodeURIComponent(pair[1] || '');
              *     });
-             *     return JSON.stringify(result);
+             *     return new URLSearchParams(result).toString();
              *   });
              *
              * @param {Function} customRequestContentProcessingLogic


### PR DESCRIPTION
### Description:

Example for `setCustomRequestProcessing` method (written 8 years ago) does not work as the URI components are not encoded properly.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
