### PR TITLE
Ensure time strings are parsed relative to now time

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -516,7 +516,7 @@ class Request
         }
 
         if (!is_numeric($cdt)) {
-            $cdt = strtotime($cdt);
+            $cdt = strtotime($cdt, $this->timestamp);
         }
 
         if (!empty($cdo)) {


### PR DESCRIPTION
### Description:

The test `RequestTest:testCdtShouldReturnTheCustomTimestampShouldUseStrToTimeIfItIsNotATime` started failing recently.
This is caused by the fact, that time strings were not parsed relative to the current "now" time stamp.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
