### PR TITLE
Fix CoreHome global property typing

### DIFF
--- a/plugins/CoreVue/types/index.d.ts
+++ b/plugins/CoreVue/types/index.d.ts
@@ -273,10 +273,10 @@ declare module '@vue/runtime-core' {
     $sanitize: Window['vueSanitize'];
     externalLink: (url: string, ...values:string[]) => string;
     externalRawLink: (url: string, ...values:string[]) => string;
-    formatNumber: (val: string, maxFractionDigits?: number, minFractionDigits?: number) => string;
-    formatPercent: (val: string, maxFractionDigits?: number, minFractionDigits?: number) => string;
-    formatCurrency: (val: string, cur: string, maxFractionDigits?: number, minFractionDigits?: number) => string;
-    formatEvolution: (val: string, cur: string, maxFractionDigits?: number, minFractionDigits?: number, noSign?: boolean) => string;
-    calculateAndFormatEvolution: (valCur: string, valPast: string, noSign?: boolean) => string;
+    formatNumber: (val: string|number, maxFractionDigits?: number, minFractionDigits?: number) => string;
+    formatPercent: (val: string|number, maxFractionDigits?: number, minFractionDigits?: number) => string;
+    formatCurrency: (val: string|number, cur: string, maxFractionDigits?: number, minFractionDigits?: number) => string;
+    formatEvolution: (val: string|number, maxFractionDigits?: number, minFractionDigits?: number, noSign?: boolean) => string;
+    calculateAndFormatEvolution: (valCur: string|number, valPrev: string|number, noSign?: boolean) => string;
   }
 }


### PR DESCRIPTION
### Description:

While working on #22751 the types for the global formatting functions got messed up. This seems to be no problem with the current build, but the next update (#22707) would break:

> [tsl] ERROR in /home/runner/work/matomo/matomo/plugins/CoreHome/vue/src/createVueApp.ts(31,3)
      TS2322: Type '(val: string | number, maxFractionDigits?: number | undefined, minFractionDigits?: number | undefined, noSign?: boolean | undefined) => string' is not assignable to type '(val: string, cur: string, maxFractionDigits?: number | undefined, minFractionDigits?: number | undefined, noSign?: boolean | undefined) => string'.
  Types of parameters 'maxFractionDigits' and 'cur' are incompatible.
    Type 'string' is not assignable to type 'number | undefined'.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
