### PR TITLE
Sticky headers might break when resizing

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -119,13 +119,27 @@ $.extend(DataTable.prototype, UIControl.prototype, {
     },
 
     enableStickHead: function (domElem) {
-      // Bind to the resize event of the window object
-      $(window).on('resize', function () {
+      var resizeTimeout = null;
+      var resize = function(domElem) {
         var tableScrollerWidth = $(domElem).find('.dataTableScroller').width();
         var tableWidth = $(domElem).find('table').width();
         if (tableScrollerWidth < tableWidth) {
           $('.dataTableScroller').css('overflow-x', 'scroll');
+        } else {
+          $('.dataTableScroller').css('overflow-x', '');
         }
+      };
+      // Bind to the resize event of the window object
+      $(window).on('resize', function () {
+        resize(domElem);
+        // trigger another check after a certain delay as during fast resizing
+        // the width is sometimes reported incorrectly
+        if (resizeTimeout) {
+          window.clearTimeout(resizeTimeout);
+        }
+        resizeTimeout = window.setTimeout(function(){
+          resize(domElem);
+        }, 500);
         // Invoke the resize event immediately
       }).resize();
     },

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -346,6 +346,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         it('should load the actions > site search page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_Actions&subcategory=Actions_SubmenuSitesearch");
             await page.waitForNetworkIdle();
+            await page.waitForTimeout(150);
 
             expect(await screenshotPageWrap()).to.matchImage('actions_site_search');
         });


### PR DESCRIPTION
### Description:

During an investigation I came across the fact that often after manually resizing the window, the sticky headers of reports do not work correctly anymore.

The problem for this lays in the way how sticky headers work for our table reports.
For tables that would be wider than the available screen, Matomo set `overflow-x: scroll` for the element around the table.
This should ensure that the table element can be scrolled around.
But this detection is a bit lagy. It tries to compare the available width with the total width the table would have. This works perfectly in most cases. But when the resize event is triggered, it seems that those elements might not yet be fully re-renderd, causing an incorrect width to be returned.
This then causes the overflow to be set, which disables the sticky headers. As that mechanism only did set the overflow, but never removed it again - even if the width matched again, resizing easily killed the sticky headers.

This PR includes a this changes to fix that incorrect behavior:
* Remove `overflow-x: scroll` again, if the width matches
* Add another check 500ms after resize to revalidate if the width then matches again

refs DEV-18738

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
