### PR TITLE
Improve performance of archive state detection

### DIFF
--- a/core/Archive/ArchiveState.php
+++ b/core/Archive/ArchiveState.php
@@ -123,7 +123,7 @@ class ArchiveState
         $datePeriodEnd = Date::factory($periodEndDay . ' 23:59:59')->setTimezone($siteTimezone);
         $dateArchived = Date::factory($tsArchived);
 
-        if ($dateArchived->isEarlier($datePeriodEnd)) {
+        if (!$datePeriodEnd->isEarlier($dateArchived)) {
             return self::INCOMPLETE;
         }
 

--- a/tests/PHPUnit/Unit/Archive/ArchiveStateTest.php
+++ b/tests/PHPUnit/Unit/Archive/ArchiveStateTest.php
@@ -72,6 +72,30 @@ class ArchiveStateTest extends TestCase
             ArchiveWriter::DONE_INVALIDATED,
             ArchiveState::INVALIDATED
         ];
+
+        yield 'archive date matching date end exactly' => [
+            '2020-01-31',
+            '2020-01-31',
+            '2020-01-31 23:59:59',
+            ArchiveWriter::DONE_OK,
+            ArchiveState::INCOMPLETE
+        ];
+
+        yield 'archive date one second before date end' => [
+            '2020-01-31',
+            '2020-01-31',
+            '2020-01-31 23:59:58',
+            ArchiveWriter::DONE_OK,
+            ArchiveState::INCOMPLETE
+        ];
+
+        yield 'archive date one second past date end' => [
+            '2020-01-31',
+            '2020-01-31',
+            '2020-02-01 00:00:00',
+            ArchiveWriter::DONE_OK,
+            ArchiveState::COMPLETE
+        ];
     }
 
     /**
@@ -105,28 +129,28 @@ class ArchiveStateTest extends TestCase
         yield 'UTC+14, complete' => [
             'UTC+14',
             '2020-10-10',
-            '2020-10-10 12:00:00',
+            '2020-10-10 10:00:00',
             ArchiveState::COMPLETE,
         ];
 
         yield 'UTC+14, incomplete' => [
             'UTC+14',
             '2020-10-10',
-            '2020-10-10 02:00:00',
+            '2020-10-10 09:59:59',
             ArchiveState::INCOMPLETE,
         ];
 
         yield 'UTC-12, complete' => [
             'UTC-12',
             '2020-10-10',
-            '2020-10-11 16:00:00',
+            '2020-10-11 12:00:00',
             ArchiveState::COMPLETE,
         ];
 
         yield 'UTC-12, incomplete' => [
             'UTC-12',
             '2020-10-10',
-            '2020-10-11 02:00:00',
+            '2020-10-11 11:59:59',
             ArchiveState::INCOMPLETE,
         ];
     }


### PR DESCRIPTION
### Description:

Checking for complete/incomplete archives is more computationally expensive than it needs to be. This PR aims to lower the overhead by e.g. not using full `Site` objects (that are itself dispatching an event in the constructor).

Refs DEV-18679

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
