### PR TITLE
Set table overflow only for the actual overflowing table

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -121,12 +121,13 @@ $.extend(DataTable.prototype, UIControl.prototype, {
     enableStickHead: function (domElem) {
       var resizeTimeout = null;
       var resize = function(domElem) {
-        var tableScrollerWidth = $(domElem).find('.dataTableScroller').width();
+        var tableScroller = $(domElem).find('.dataTableScroller');
+        var tableScrollerWidth = tableScroller.width();
         var tableWidth = $(domElem).find('table').width();
         if (tableScrollerWidth < tableWidth) {
-          $('.dataTableScroller').css('overflow-x', 'scroll');
+          tableScroller.css('overflow-x', 'scroll');
         } else {
-          $('.dataTableScroller').css('overflow-x', '');
+          tableScroller.css('overflow-x', '');
         }
       };
       // Bind to the resize event of the window object


### PR DESCRIPTION
### Description:

The fix to reset the data table overflow done in #22811 surfaced a different problem: if any table on the page overflowing, all tables on the page will be set to overflow.

Previously this was only breaking the sticky table headers, for example on the "Behaviour > Site Search" page. As the overflow is now being reset when possible, the wrong selector now can lead to some tables flowing out of their cards.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
