### PR TITLE
Optimise dispatcher when list of plugins provided

### DIFF
--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -101,18 +101,22 @@ class EventDispatcher
 
         if (empty($plugins)) {
             $plugins = $manager->getPluginsLoadedAndActivated();
+        } else {
+            $pluginMap = [];
+            foreach ($plugins as $plugin) {
+                if (is_string($plugin)) {
+                    $plugin = $this->pluginManager->getLoadedPlugin($plugin);
+                }
+                $pluginMap[$plugin->getPluginName()] = $plugin;
+            }
+            $plugins = $pluginMap;
         }
 
         $callbacks = array();
 
         // collect all callbacks to execute
-        foreach ($plugins as $pluginName) {
-            if (!is_string($pluginName)) {
-                $pluginName = $pluginName->getPluginName();
-            }
-
+        foreach ($plugins as $pluginName => $plugin) {
             if (!isset($this->pluginHooks[$pluginName])) {
-                $plugin = $manager->getLoadedPlugin($pluginName);
                 $this->pluginHooks[$pluginName] = $plugin->registerEvents();
             }
 
@@ -122,8 +126,7 @@ class EventDispatcher
                 list($pluginFunction, $callbackGroup) = $this->getCallbackFunctionAndGroupNumber($hooks[$eventName]);
 
                 if (is_string($pluginFunction)) {
-                    $plugin = $manager->getLoadedPlugin($pluginName);
-                    $callbacks[$callbackGroup][] = array($plugin, $pluginFunction) ;
+                    $callbacks[$callbackGroup][] = [$plugin, $pluginFunction];
                 } else {
                     $callbacks[$callbackGroup][] = $pluginFunction;
                 }


### PR DESCRIPTION
### Description:

The event dispatcher is used in many places/processes in Matomo, there is an inefficiency here that will affect large instance with lots of sites and/or lots of visits, when there are many calls to `Piwik\EventDispatcher::postEvent`

This optimisation converts the provided array of plugins (which is mixed type of objects or strings), and converts them to a assoc array with the index being the plugin name.

This will reduce the calls to `getPluginName` and `getLoadedPlugin`

*All websites without fix*

![image](https://github.com/user-attachments/assets/ff0ecec5-b98c-4dec-9a84-70df2ed9b2c3)


*All websites with fix*

![image](https://github.com/user-attachments/assets/16e93f7b-d703-481f-9ca3-d91bae51051e)




### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
