### PR TITLE
Use terminal width independent "ps" command

### DIFF
--- a/core/CliMulti/RequestParser.php
+++ b/core/CliMulti/RequestParser.php
@@ -108,6 +108,6 @@ class RequestParser
             return ''; // skip check in tests as it might result in random failures
         }
 
-        return `ps aux`;
+        return `ps wwaux`;
     }
 }


### PR DESCRIPTION
### Description:

The current process list lookup is using a `ps` invocation that depends on the clients terminal width.

Until #22487 is merged, archiving can run on the same host multiple times with overlapping period, e.g. archive both a day and the matching week.

This PR provides the intermediate step of fixing the invocation until we can remove it, to lower the chance of having overlapping periods being archived on the same host.

See also #22515.
Refs L3-798

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
