### PR TITLE
Add postEvent for update site start and end

### DIFF
--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -1488,6 +1488,13 @@ class API extends \Piwik\Plugin\API
             throw new Exception("website id = $idSite not found");
         }
 
+        /**
+         * Triggered before a site has been updated.
+         *
+         * @param int $idSite The ID of the site that was updated.
+         */
+        Piwik::postEvent('SitesManager.updateSite.start', [$idSite]);
+
         // Build the SQL UPDATE based on specified updates to perform
         $bind = [];
 
@@ -1563,6 +1570,12 @@ class API extends \Piwik\Plugin\API
         }
 
         $this->postUpdateWebsite($idSite);
+        /**
+         * Triggered after a site has been updated.
+         *
+         * @param int $idSite The ID of the site that was updated.
+         */
+        Piwik::postEvent('SitesManager.updateSite.end', [$idSite]);
     }
 
     /**


### PR DESCRIPTION
### Description:

Sitesmanager is missing start and end hook for updating site. This pull requests add these.

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
