### PR TITLE
Log a proper warning when an unexected translation key is added to client side translations

### DIFF
--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -10,6 +10,8 @@
 namespace Piwik\Translation;
 
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
+use Piwik\Log\LoggerInterface;
 use Piwik\Piwik;
 use Piwik\Translation\Loader\LoaderInterface;
 
@@ -199,6 +201,13 @@ class Translator
     {
         $clientSideTranslations = array();
         foreach ($this->getClientSideTranslationKeys() as $id) {
+            if (strpos($id, '_') === false) {
+                StaticContainer::get(LoggerInterface::class)->warning(
+                    'Unexpected translation key found in client side translations: {translation_key}',
+                    ['translation_key' => $id]
+                );
+                continue;
+            }
             [$plugin, $key] = explode('_', $id, 2);
             $clientSideTranslations[$id] = $this->decodeEntitiesSafeForHTML($this->getTranslation($id, $this->currentLanguage, $plugin, $key));
         }


### PR DESCRIPTION
### Description:

In case a translation key is added to the client side translations that does not contain a `_` a warning is currently triggered:

```
WARNING CoreHome[2024-12-13 12:02:09 UTC] [12316] /var/www/html/core/Translation/Translator.php(202): Warning - Undefined array key 1 - Matomo 5.2.0 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already) #0/core/Translation/Translator.php(202),#1/core/AssetManager.php(147),#2/core/Twig.php(231),#3/tmp/templates_c/9b/9bcdbc324b7372161ba12b6ad9eb6285.php(43),#4/vendor/twig/twig/src/Template.php(360),#5/tmp/templates_c/b3/b35accd563c963c7f8a6fbee91f567bb.php(137),#6/vendor/twig/twig/src/Template.php(430),#7/vendor/twig/twig/src/Template.php(492),#8/tmp/templates_c/f9/f91be83f44d125f542a7d6c7c5b11fc0.php(68),#9/vendor/twig/twig/src/Template.php(430)
```

That does not really help a plugin developer to see where the problem is. This PR will discard such unexpected translations key and trigger a helpful warning instead.

refs #22853

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
