### PR TITLE
Allow newer version of php-di (v7)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "monolog/monolog": "~1.11",
         "mustangostang/spyc": "^0.6.0",
         "pear/pear_exception": "~1.0.0",
-        "php-di/php-di": "^6.0.0",
+        "php-di/php-di": "^6.0.0 || ^7.0.0",
         "phpmailer/phpmailer": "^6.1",
         "psr/log": "~1.0",
         "symfony/console": "~5.4.0",


### PR DESCRIPTION
### Description:

By reading: https://php-di.org/doc/migration/7.0.html The code uses `useAnnotations(false);`, that means no annotation needs to be changed.
And there is no use of `buildDevContainer`

No changes to the lock file are to be expected, since PHP 7 support is still needed.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
