### PR TITLE
Set array to blank string when array is empty (FE)

### DIFF
--- a/plugins/CorePluginsAdmin/vue/src/PluginSettings/PluginSettings.vue
+++ b/plugins/CorePluginsAdmin/vue/src/PluginSettings/PluginSettings.vue
@@ -199,6 +199,10 @@ export default defineComponent({
           postValue = '1';
         }
 
+        if (Array.isArray(postValue) && postValue.length === 0) {
+          postValue = '';
+        }
+
         values[pluginName].push({
           name: settingName,
           value: postValue,


### PR DESCRIPTION
### Description:

This change ensures that jQuery's serialization sends a value to the backend even when an array is empty. By default, jQuery would omit empty arrays during serialization, which could cause issues on the backend.

Initially, I considered handling this on the backend by populating any setting with a name but no value as an empty array. However, this approach carried potential side effects for API consumers, so it was deemed too risky.

Instead, this solution is simple and low-risk. It ensures that a value is always sent to the backend, allowing settings to be processed and saved correctly without impacting existing API behavior.

## Downside

This then stores the setting as an empty string array so `[""]` while this might look odd, it is compatible and does work.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
