### PR TITLE
Adds code to update idvisitor if changed in visits_log table, #DEV-18502

### DIFF
--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -642,6 +642,26 @@ class Model
     }
 
     /**
+     * Update an existing visit in the DB
+     *
+     * @param int $idvisit
+     * @param string $idVisitor
+     *
+     * @throws Db\DbException
+     */
+    public function updateVisitorIDForConversion($idvisit, $idVisitor): void
+    {
+        $table = Common::prefixTable('log_conversion');
+        $sqlQuery = "UPDATE $table SET idvisitor = ? WHERE idvisit = ?";
+
+        $sqlBind = [];
+        $sqlBind[] = $idVisitor;
+        $sqlBind[] = $idvisit;
+
+        $this->getDb()->query($sqlQuery, $sqlBind);
+    }
+
+    /**
      * Build an array of fields and bind values
      *
      * @param array $valuesToUpdate

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -16,6 +16,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Matomo\Network\IPUtils;
+use Piwik\Piwik;
 use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugins\Actions\Tracker\ActionsRequestProcessor;
 use Piwik\Plugins\UserCountry\Columns\Base;
@@ -429,17 +430,20 @@ class Visit implements VisitInterface
 
         $idSite = $this->request->getIdSite();
         $idVisit = $this->visitProperties->getProperty('idvisit');
+        $model = $this->getModel();
 
-        $wasInserted = $this->getModel()->updateVisit($idSite, $idVisit, $valuesToUpdate);
+        $wasInserted = $model->updateVisit($idSite, $idVisit, $valuesToUpdate);
 
         // Debug output
         if (isset($valuesToUpdate['idvisitor'])) {
+            $model->updateVisitorIDForConversion($idVisit, $valuesToUpdate['idvisitor']);
+            Piwik::postEvent('Visit.updateIDVisitor', [$idVisit, $valuesToUpdate['idvisitor']]);
             $valuesToUpdate['idvisitor'] = bin2hex($valuesToUpdate['idvisitor']);
         }
 
         if ($wasInserted) {
             Common::printDebug('Updated existing visit: ' . var_export($valuesToUpdate, true));
-        } elseif (!$this->getModel()->hasVisit($idSite, $idVisit)) {
+        } elseif (!$model->hasVisit($idSite, $idVisit)) {
             // mostly for WordPress. see https://github.com/matomo-org/matomo/pull/15587
             // as WP doesn't set `MYSQLI_CLIENT_FOUND_ROWS` and therefore when the update succeeded but no value changed
             // it would still return 0 vs OnPremise would return 1 or 2.


### PR DESCRIPTION
### Description:

Adds code to update idvisitor if changed in visits_log table
Fixes: #DEV-18502, #22857

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
