### PR TITLE
Remove prepared statements cache from PDO\MySQL adapter

### DIFF
--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -64,13 +64,6 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         parent::__construct($config);
     }
 
-    public function closeConnection()
-    {
-        $this->cachePreparedStatement = [];
-
-        parent::closeConnection();
-    }
-
     /**
      * Returns connection handle
      *
@@ -300,40 +293,6 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             // In case of the driver doesn't support getting attributes
         }
         return null;
-    }
-
-    /**
-     * @var \Zend_Db_Statement_Pdo[]
-     */
-    private $cachePreparedStatement = array();
-
-    /**
-     * Prepares and executes an SQL statement with bound data.
-     * Caches prepared statements to avoid preparing the same query more than once
-     *
-     * @param string|Zend_Db_Select $sql The SQL statement with placeholders.
-     * @param array $bind An array of data to bind to the placeholders.
-     * @return Zend_Db_Statement_Interface
-     */
-    public function query($sql, $bind = array())
-    {
-        if (!is_string($sql)) {
-            return parent::query($sql, $bind);
-        }
-
-        if (isset($this->cachePreparedStatement[$sql])) {
-            if (!is_array($bind)) {
-                $bind = array($bind);
-            }
-
-            $stmt = $this->cachePreparedStatement[$sql];
-            $stmt->execute($bind);
-            return $stmt;
-        }
-
-        $stmt = parent::query($sql, $bind);
-        $this->cachePreparedStatement[$sql] = $stmt;
-        return $stmt;
     }
 
     /**

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -18,8 +18,6 @@ use Piwik\Db\AdapterInterface;
 use Piwik\Piwik;
 use Zend_Config;
 use Zend_Db_Adapter_Pdo_Mysql;
-use Zend_Db_Select;
-use Zend_Db_Statement_Interface;
 
 /**
  */


### PR DESCRIPTION
### Description:

The cache was removed from MySQLi adapter long time ago (ref #766).

We've considered other options as making it configurable either in a config or based on the process or per query, but decided to go with a complete removal for now and we'll monitor the usage and how it behaves.

We are still considering whether this could be also released in 5.2.x patch as a fix for a long standing memory consumption issue where the cache could grow with a large number of queries on instances with lower PHP memory.

Ref. #22875 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
