### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.4",
+            "version": "1.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "bc0593537a463e55cadf45fd938d23b75095b7e1"
+                "reference": "08c50d5ec4c6ced7d0271d2862dec8c1033283e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/bc0593537a463e55cadf45fd938d23b75095b7e1",
-                "reference": "bc0593537a463e55cadf45fd938d23b75095b7e1",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/08c50d5ec4c6ced7d0271d2862dec8c1033283e6",
+                "reference": "08c50d5ec4c6ced7d0271d2862dec8c1033283e6",
                 "shasum": ""
             },
             "require": {
@@ -64,7 +64,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.4"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.5"
             },
             "funding": [
                 {
@@ -80,7 +80,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-27T15:35:25+00:00"
+            "time": "2025-01-08T16:17:16+00:00"
         },
         {
             "name": "composer/semver",
@@ -714,12 +714,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/referrer-spam-list.git",
-                "reference": "9b5c253251697fd478fddeea6d58c3bf9639b7ef"
+                "reference": "6edbb4a2c2a964b3175265e4eb58dfc514132143"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/9b5c253251697fd478fddeea6d58c3bf9639b7ef",
-                "reference": "9b5c253251697fd478fddeea6d58c3bf9639b7ef",
+                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/6edbb4a2c2a964b3175265e4eb58dfc514132143",
+                "reference": "6edbb4a2c2a964b3175265e4eb58dfc514132143",
                 "shasum": ""
             },
             "replace": {
@@ -737,7 +737,7 @@
                 "issues": "https://github.com/matomo-org/referrer-spam-list/issues",
                 "source": "https://github.com/matomo-org/referrer-spam-list/tree/master"
             },
-            "time": "2024-11-25T22:14:44+00:00"
+            "time": "2025-01-08T02:25:37+00:00"
         },
         {
             "name": "matomo/searchengine-and-social-list",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
                                                      Updating dependencies
Lock file operations: 0 installs, 2 updates, 0 removals
  - Upgrading composer/ca-bundle (1.5.4 => 1.5.5)
  - Upgrading matomo/referrer-spam-list (dev-master 9b5c253 => dev-master 6edbb4a)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 2 updates, 0 removals
  - Downloading composer/ca-bundle (1.5.5)
  - Downloading matomo/referrer-spam-list (dev-master 6edbb4a)
  - Upgrading composer/ca-bundle (1.5.4 => 1.5.5): Extracting archive
  - Upgrading matomo/referrer-spam-list (dev-master 9b5c253 => dev-master 6edbb4a): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
52 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.
```
