### PR TITLE
Escape control characters in log messages

### DIFF
--- a/plugins/Monolog/Formatter/LineMessageFormatter.php
+++ b/plugins/Monolog/Formatter/LineMessageFormatter.php
@@ -53,6 +53,8 @@ class LineMessageFormatter implements FormatterInterface
         $total = '';
 
         foreach ($messages as $message) {
+            // escape control characters
+            $message = addcslashes($message, "\x00..\x09\x0B..\x1F\x7F");
             $message = $this->prefixMessageWithRequestId($record, $message);
             $total  .= $this->formatMessage($class, $message, $date, $record);
         }

--- a/plugins/Monolog/tests/Unit/Formatter/LineMessageFormatterTest.php
+++ b/plugins/Monolog/tests/Unit/Formatter/LineMessageFormatterTest.php
@@ -59,7 +59,7 @@ class LineMessageFormatterTest extends \PHPUnit\Framework\TestCase
         $formatter = new LineMessageFormatter('%level% %message%');
 
         $record = array(
-            'message'    => "Hello world\ntest\ntest",
+            'message'    => "Hello world\ntest\x0Atest",
             'datetime'   => DateTime::createFromFormat('U', 0),
             'level_name' => 'ERROR',
         );
@@ -89,6 +89,25 @@ LOG;
 ERROR [1234] Hello world
 ERROR [1234] test
 ERROR [1234] test
+
+LOG;
+
+        $this->assertEquals($formatted, $formatter->format($record));
+    }
+
+    public function testItShouldEscapeControlCharacters()
+    {
+        $formatter = new LineMessageFormatter('%level% %message%', $allowInlineLineBreaks = false);
+
+        $record = array(
+            'message'    => "Hello world\x1Btest\ntesttest",
+            'datetime'   => DateTime::createFromFormat('U', 0),
+            'level_name' => 'ERROR',
+        );
+
+        $formatted = <<<LOG
+ERROR Hello world\\033test
+ERROR test\\033test
 
 LOG;
 


### PR DESCRIPTION
### Description:

Backport of #22937

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
