### PR TITLE
Fix handling of color parameter

### DIFF
--- a/core/Visualization/Sparkline.php
+++ b/core/Visualization/Sparkline.php
@@ -182,7 +182,7 @@ class Sparkline implements ViewInterface
             'fillColor' => '#ffffff'
         );
 
-        if (empty($colors)) {
+        if (empty($colors) || !is_array($colors)) {
             $colors = $defaultColors; //set default color, if no color passed
         } else {
             $colors = array_merge($defaultColors, $colors); //set default color key, if no key set.


### PR DESCRIPTION
### Description:

A malformed request to `MultiSites`.`getEvolutionGraph` having an unexpected value for `colors` might currently end up in an error.

Discarding non array values should solve that.

Example request that fails: `index.php?module=MultiSites&action=getEvolutionGraph&period=day&date=2024-06-04%2C2024-07-03&evolutionBy=nb_visits&columns=nb_visits&idSite=3&idsite=3&viewDataTable=sparkline&colors="test"`

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
