### PR TITLE
Escape referrer url in visits log tooltip

### DIFF
--- a/plugins/Referrers/templates/_visitorDetails.twig
+++ b/plugins/Referrers/templates/_visitorDetails.twig
@@ -1,7 +1,7 @@
 <div class="visitorReferrer {{ visitInfo.getColumn('referrerType') }}">
     {% if visitInfo.getColumn('referrerType') == 'website' %}
         <span>{{ 'Referrers_ColumnWebsite'|translate }}:</span>
-        <a href="{{ visitInfo.getColumn('referrerUrl')|safelink|e('html_attr') }}" rel="noreferrer noopener" target="_blank" class="visitorLogTooltip" title="{{ visitInfo.getColumn('referrerUrl') }}"
+        <a href="{{ visitInfo.getColumn('referrerUrl')|safelink|e('html_attr') }}" rel="noreferrer noopener" target="_blank" class="visitorLogTooltip" title="{{ visitInfo.getColumn('referrerUrl')|e('html')|e('html') }}"
            style="text-decoration:underline;">
             {{ visitInfo.getColumn('referrerName') }}
         </a>
@@ -15,7 +15,7 @@
         {% if visitInfo.getColumn('referrerSearchEngineIcon') %}
             <img width="16" src="{{ visitInfo.getColumn('referrerSocialNetworkIcon') }}" alt="{{ visitInfo.getColumn('referrerName') }}"/>
         {% endif %}
-        <a href="{{ visitInfo.getColumn('referrerUrl')|safelink|e('html_attr') }}" rel="noreferrer" target="_blank" class="visitorLogTooltip" title="{{ visitInfo.getColumn('referrerUrl') }}"
+        <a href="{{ visitInfo.getColumn('referrerUrl')|safelink|e('html_attr') }}" rel="noreferrer" target="_blank" class="visitorLogTooltip" title="{{ visitInfo.getColumn('referrerUrl')|e('html')|e('html') }}"
            style="text-decoration:underline;">
             {{ visitInfo.getColumn('referrerName') }}
         </a>


### PR DESCRIPTION
### Description:

Note: A double escaping is needed there, as one level of escaping gets removed when reading the attribute content in javascript.

fixes DEV-18863

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
