### PR TITLE
Make set user access atomical using locks

### DIFF
--- a/core/Concurrency/Lock.php
+++ b/core/Concurrency/Lock.php
@@ -149,6 +149,25 @@ class Lock
     }
 
     /**
+     * Checks if a lock exists for a given ID.
+     *
+     * @param string $id
+     * @return bool
+     */
+    public function lockExists(string $id): bool
+    {
+        $lockKey = $this->namespace . $id;
+
+        if (mb_strlen($lockKey) > self::MAX_KEY_LEN) {
+            // Ensure the lock key isn't too long
+            $md5Len = 32;
+            $lockKey = mb_substr($lockKey, 0, self::MAX_KEY_LEN - $md5Len - 1) . md5($id);
+        }
+
+        return (bool) $this->backend->get($lockKey);
+    }
+
+    /**
      * Return if the acquired lock is currently locked
      *
      * @return bool

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -16,6 +16,8 @@ use Piwik\Access\CapabilitiesProvider;
 use Piwik\Access\RolesProvider;
 use Piwik\Auth\Password;
 use Piwik\Common;
+use Piwik\Concurrency\Lock;
+use Piwik\Concurrency\LockBackend;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
@@ -1132,12 +1134,38 @@ class API extends \Piwik\Plugin\API
         $this->checkUserExist($userLogin);
         $this->checkUsersHasNotSuperUserAccess($userLogin);
 
+        $lock = $this->getLockIfRevoking($userLogin, $role);
+
         $this->performModificationToAccess($userLogin, $idSites, $access, $role, $capabilities);
 
         $this->sendNotificationAboutAccessChangeIfApplicable($userLogin, $access, $idSites);
 
         // we reload the access list which doesn't yet take in consideration this new user access
         $this->reloadPermissions();
+
+        $lock->unlock();
+    }
+
+    /**
+     * @param string $userLogin
+     * @param string $role
+     * @return Lock
+     */
+    private function getLockIfRevoking(string $userLogin, string $role): Lock
+    {
+        $lock = new Lock(StaticContainer::get(LockBackend::class), 'UsersManager_SetUserAccess', 10);
+
+        if ($lock->lockExists($userLogin)) {
+            throw new Exception(Piwik::translate('UsersManager_ExceptionLocked'));
+        }
+
+        if ($role !== 'admin') {
+            $lockAcquired = $lock->acquireLock($userLogin);
+            if ($lockAcquired === false) {
+                throw new Exception(Piwik::translate('UsersManager_ExceptionLocked'));
+            }
+        }
+        return $lock;
     }
 
     /**

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1127,6 +1127,52 @@ class API extends \Piwik\Plugin\API
             ));
         }
 
+        list($role, $capabilities) = $this->extractRoleAndCapabilitiesFromAccess($access);
+
+        $this->checkUserExist($userLogin);
+        $this->checkUsersHasNotSuperUserAccess($userLogin);
+
+        $this->performModificationToAccess($userLogin, $idSites, $access, $role, $capabilities);
+
+        $this->sendNotificationAboutAccessChangeIfApplicable($userLogin, $access, $idSites);
+
+        // we reload the access list which doesn't yet take in consideration this new user access
+        $this->reloadPermissions();
+    }
+
+    /**
+     * @param string $userLogin
+     * @param array $idSites
+     * @param array|string $access
+     * @param string $role
+     * @param array $capabilities
+     * @return void
+     * @throws Exception
+     */
+    private function performModificationToAccess(string $userLogin, array $idSites, $access, string $role, array $capabilities): void
+    {
+        $this->model->deleteUserAccess($userLogin, $idSites);
+
+        if ($access === 'noaccess') {
+            // if the access is noaccess then we don't save it as this is the default value
+            // when no access are specified
+            Piwik::postEvent('UsersManager.removeSiteAccess', [$userLogin, $idSites]);
+        } else {
+            $this->model->addUserAccess($userLogin, $role, $idSites);
+        }
+
+        if (!empty($capabilities)) {
+            $this->addCapabilities($userLogin, $capabilities, $idSites);
+        }
+    }
+
+    /**
+     * @param array|string $access
+     * @return array
+     * @throws Exception
+     */
+    private function extractRoleAndCapabilitiesFromAccess($access): array
+    {
         $roles = [];
         $capabilities = [];
 
@@ -1150,25 +1196,21 @@ class API extends \Piwik\Plugin\API
                 $roles[] = $access;
             }
         }
+        return [array_shift($roles), $capabilities];
+    }
 
-        $this->checkUserExist($userLogin);
-        $this->checkUsersHasNotSuperUserAccess($userLogin);
-
-        $this->model->deleteUserAccess($userLogin, $idSites);
-
-        if ($access === 'noaccess') {
-            // if the access is noaccess then we don't save it as this is the default value
-            // when no access are specified
-            Piwik::postEvent('UsersManager.removeSiteAccess', [$userLogin, $idSites]);
-        } else {
-            $role = array_shift($roles);
-            $this->model->addUserAccess($userLogin, $role, $idSites);
-        }
-
-        if (!empty($capabilities)) {
-            $this->addCapabilities($userLogin, $capabilities, $idSites);
-        }
-
+    /**
+     * @param string $userLogin
+     * @param array|string $access
+     * @param array $idSites
+     * @return void
+     * @throws \DI\DependencyException
+     * @throws \DI\NotFoundException
+     * @throws \Piwik\Exception\DI\DependencyException
+     * @throws \Piwik\Exception\DI\NotFoundException
+     */
+    private function sendNotificationAboutAccessChangeIfApplicable(string $userLogin, $access, array $idSites): void
+    {
         // Send notification to all super users if anonymous access is set for a site
         if ($userLogin === 'anonymous' && $access === 'view') {
             $container = StaticContainer::getContainer();
@@ -1189,9 +1231,6 @@ class API extends \Piwik\Plugin\API
                 $email->safeSend();
             }
         }
-
-        // we reload the access list which doesn't yet take in consideration this new user access
-        $this->reloadPermissions();
     }
 
     /**

--- a/plugins/UsersManager/lang/en.json
+++ b/plugins/UsersManager/lang/en.json
@@ -236,6 +236,7 @@
         "AuthTokenSecureOnlyHelp": "Enable this option to only allow this token to be used in a secure way (e.g. POST requests), this is recommended as a best security practice. The token will then not be valid as a URL parameter in GET requests.",
         "AuthTokenSecureOnlyHelpForced": "The system administrator has configured Matomo to only allow tokens to be created for use in secure way (e.g. via POST requests), you cannot change this token option.",
         "OnlyAllowSecureRequests": "Only allow secure requests",
-        "SecureUseOnly": "Secure use only"
+        "SecureUseOnly": "Secure use only",
+        "ExceptionLocked": "This user is locked for modification"
     }
 }

--- a/tests/PHPUnit/Integration/Concurrency/LockTest.php
+++ b/tests/PHPUnit/Integration/Concurrency/LockTest.php
@@ -186,6 +186,25 @@ class LockTest extends IntegrationTestCase
         $this->assertNotEquals($expireTime, $newExpireTime);
     }
 
+    public function testLockExistsReturnsFalseIfLockDoesNotExist(): void
+    {
+        $this->assertFalse($this->lock->lockExists('unit_test'));
+    }
+
+    public function testLockExistsReturnsFalseIfLockExpired(): void
+    {
+        $this->lock->acquireLock('unit_test', 0.1);
+        sleep(1);
+        $this->assertFalse($this->lock->lockExists('unit_test'));
+    }
+
+    public function testLockExistsReturnsTrueIfLockExists(): void
+    {
+        $this->lock->acquireLock('unit_test');
+
+        $this->assertTrue($this->lock->lockExists('unit_test'));
+    }
+
     private function assertNumberOfLocksEquals($numExpectedLocks)
     {
         $this->assertSame($numExpectedLocks, $this->lock->getNumberOfAcquiredLocks());


### PR DESCRIPTION
### Description:

Alternative approach to : https://github.com/matomo-org/matomo/pull/22931

Using locks

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
