### PR TITLE
CLOUD-2557 Ensure only strings are decoded by Twig filter

### DIFF
--- a/core/Twig.php
+++ b/core/Twig.php
@@ -365,7 +365,7 @@ class Twig
     protected function addFilterSafeDecodeRaw()
     {
         $rawSafeDecoded = new TwigFilter('rawSafeDecoded', function ($string) {
-
+            $string = is_scalar($string) ? strval($string) : null;
             if ($string === null) {
                 return '';
             }


### PR DESCRIPTION
### Description:

When rendering DataTables returned via the ProxySite plugin, it's possible that some columns contain arrays. The template calls the `addFilterSafeDecodeRaw()` method for each column within the result set and will trigger the following PHP exception if the column contains a non-scalar value:

> An exception has been thrown during the rendering of a template ("urldecode(): Argument #1 ($string) must be of type string, array given").


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
