### PR TITLE
Fixes undefined variable error due to variable being placed in try block, but being used in finally section

### DIFF
--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -410,6 +410,7 @@ class API extends \Piwik\Plugin\API
 
         $originalShowEvolutionWithinSelectedPeriod = Config::getInstance()->General['graphs_show_evolution_within_selected_period'];
         $originalDefaultEvolutionGraphLastPeriodsAmount = Config::getInstance()->General['graphs_default_evolution_graph_last_days_amount'];
+        $initialFilterTruncate = Common::getRequestVar('filter_truncate', false);
         try {
             Config::setSetting('General', 'graphs_show_evolution_within_selected_period', (bool)$report['evolution_graph_within_period']);
             Config::setSetting('General', 'graphs_default_evolution_graph_last_days_amount', $report['evolution_graph_period_n']);
@@ -513,7 +514,6 @@ class API extends \Piwik\Plugin\API
             Config::setSetting('General', 'graphs_default_evolution_graph_last_days_amount', $originalDefaultEvolutionGraphLastPeriodsAmount);
 
             // restore filter truncate parameter value
-            $initialFilterTruncate = Common::getRequestVar('filter_truncate', false);
             if ($initialFilterTruncate !== false) {
                 $_GET['filter_truncate'] = $initialFilterTruncate;
             }

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -427,7 +427,6 @@ class API extends \Piwik\Plugin\API
 
             // the report will be rendered with the first 23 rows and will aggregate other rows in a summary row
             // 23 rows table fits in one portrait page
-            $initialFilterTruncate = Common::getRequestVar('filter_truncate', false);
             $_GET['filter_truncate'] = Config::getInstance()->General['scheduled_reports_truncate'];
 
             $prettyDate = null;
@@ -514,6 +513,7 @@ class API extends \Piwik\Plugin\API
             Config::setSetting('General', 'graphs_default_evolution_graph_last_days_amount', $originalDefaultEvolutionGraphLastPeriodsAmount);
 
             // restore filter truncate parameter value
+            $initialFilterTruncate = Common::getRequestVar('filter_truncate', false);
             if ($initialFilterTruncate !== false) {
                 $_GET['filter_truncate'] = $initialFilterTruncate;
             }


### PR DESCRIPTION
### Description:

Fixes undefined variable error due to variable being placed in try block, but being used in finally section.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
