### PR TITLE
Clean up export filenames for Excel compatibility

### DIFF
--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -13,6 +13,7 @@ use Piwik\Common;
 use Piwik\DataTable\Renderer;
 use Piwik\DataTable\Simple;
 use Piwik\DataTable;
+use Piwik\Filesystem;
 use Piwik\Period;
 use Piwik\Period\Range;
 use Piwik\Piwik;
@@ -318,6 +319,8 @@ class Csv extends Renderer
             $fileName .= ' _ ' . $name
                 . ' _ ' . $prettyDate . '.csv';
         }
+
+        $fileName = Filesystem::sanitizeFilename($fileName);
 
         // silent fail otherwise unit tests fail
         Common::sendHeader("Content-Disposition: attachment; filename*=UTF-8''" . rawurlencode($fileName), true);

--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -585,6 +585,30 @@ class Filesystem
     }
 
     /**
+     * Removes characters from filenames that could cause problems.
+     *
+     * This is not intended as a security measure per se, but to avoid
+     * some known problems, e.g. Excel not allowing to open an export
+     * file if some special whitespace/dash characters are present.
+     */
+    public static function sanitizeFilename(string $filename): string
+    {
+        $filename = trim($filename);
+
+        // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+        $filename = preg_replace('~[<>:"/\\\\|?*]~', '', $filename);
+        $filename = preg_replace('~\p{Cc}~u', '', $filename);
+
+        // normalize spaces
+        $filename = preg_replace('~\p{Zs}~u', ' ', $filename);
+
+        // normalize dashes
+        $filename = preg_replace('~\p{Pd}~u', '-', $filename);
+
+        return trim($filename);
+    }
+
+    /**
      * in tmp/ (sub-)folder(s) we create empty index.htm|php files
      *
      * @param $path

--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -595,14 +595,17 @@ class Filesystem
     {
         $filename = trim($filename);
 
+        // replace reserved characters
         // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
         $filename = preg_replace('~[<>:"/\\\\|?*]~', '', $filename);
+
+        // replace special characters
+        // https://www.php.net/manual/it/regexp.reference.unicode.php
+        // - Cc: Control characters
+        // - Zs: Space separators
+        // - Pd: Dash punctuation
         $filename = preg_replace('~\p{Cc}~u', '', $filename);
-
-        // normalize spaces
         $filename = preg_replace('~\p{Zs}~u', ' ', $filename);
-
-        // normalize dashes
         $filename = preg_replace('~\p{Pd}~u', '-', $filename);
 
         return trim($filename);

--- a/plugins/ScheduledReports/ReportEmailGenerator/AttachedFileReportEmailGenerator.php
+++ b/plugins/ScheduledReports/ReportEmailGenerator/AttachedFileReportEmailGenerator.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\ScheduledReports\ReportEmailGenerator;
 
+use Piwik\Filesystem;
 use Piwik\Mail;
 use Piwik\Plugins\ScheduledReports\API;
 use Piwik\Plugins\ScheduledReports\GeneratedReport;
@@ -46,10 +47,12 @@ class AttachedFileReportEmailGenerator extends ReportEmailGenerator
         $message = $this->getMessageBody($report);
         $mail->setBodyHtml($message);
 
+        $reportFilename = Filesystem::sanitizeFilename($report->getReportDescription());
+
         $mail->addAttachment(
             $report->getContents(),
             $this->attachedFileMimeType,
-            $report->getReportDescription() . $this->attachedFileExtension
+            $reportFilename . $this->attachedFileExtension
         );
     }
 

--- a/tests/PHPUnit/Unit/FilesystemTest.php
+++ b/tests/PHPUnit/Unit/FilesystemTest.php
@@ -444,6 +444,36 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
             ['  spaces are trimmed  ', 'spaces are trimmed'],
             ['unicode    spaces', 'unicode    spaces'],
             ['unicode‒–—dashes', 'unicode---dashes'],
+            [
+                // english (en) export for date range, replaced "thsp" + "endash"
+                'Export _ Main metrics _ December 31, 2024 – January 1, 2025.csv',
+                'Export _ Main metrics _ December 31, 2024 - January 1, 2025.csv',
+            ],
+            [
+                // bulgarian (bg) export for date range, replaced "nnbsp" + "endash"
+                'Запазване _ Главни метрики _ 31 декември 2024 г. – 1 януари 2025 г..csv',
+                'Запазване _ Главни метрики _ 31 декември 2024 г. - 1 януари 2025 г..csv',
+            ],
+            [
+                // basque (eu) export for date range, replaced "endash"
+                'Esportatu _ Metrika nagusiak _ 2025(e)ko urtarrila 1–2.csv',
+                'Esportatu _ Metrika nagusiak _ 2025(e)ko urtarrila 1-2.csv',
+            ],
+            [
+                // kurdish (ku) export for date range, replaced "thsp" + "endash"
+                'Export _ Main metrics _ 31ê berfanbara 2024an – 1ê rêbendana 2025an.csv',
+                'Export _ Main metrics _ 31ê berfanbara 2024an - 1ê rêbendana 2025an.csv',
+            ],
+            [
+                // japanese (ja) export for date range, unchanged
+                'エクスポート _ メインメトリクス _ 2024年12月31日～2025年01月1日.csv',
+                'エクスポート _ メインメトリクス _ 2024年12月31日～2025年01月1日.csv',
+            ],
+            [
+                // simplified chinese (zh-cn) export for date range, unchanged
+                '导出 _ 主要指标 _ 2025年01月1日至2日.csv',
+                '导出 _ 主要指标 _ 2025年01月1日至2日.csv',
+            ],
         ];
     }
 }

--- a/tests/PHPUnit/Unit/FilesystemTest.php
+++ b/tests/PHPUnit/Unit/FilesystemTest.php
@@ -424,4 +424,26 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
 
         $this->assertNull($size);
     }
+
+    /**
+     * @dataProvider getSanitizeFilenameTestData
+     */
+    public function testSanitizeFilename(string $filename, string $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            Filesystem::sanitizeFilename($filename)
+        );
+    }
+
+    public function getSanitizeFilenameTestData(): array
+    {
+        return [
+            ['reserved<>:"/\\|?*characters', 'reservedcharacters'],
+            ["control\x00\x09\x0A\x7Fcharacters", 'controlcharacters'],
+            ['  spaces are trimmed  ', 'spaces are trimmed'],
+            ['unicode    spaces', 'unicode    spaces'],
+            ['unicode‒–—dashes', 'unicode---dashes'],
+        ];
+    }
 }


### PR DESCRIPTION
### Description:

The current (CSV) exports can contain unicode characters like `&thsp;` ("thin space"), preventing them from being openend in some programs like Excel.

A replacement of "special dashes" and "special whitespace" with their ASCII representation should fix that problem. Additionaly some other reserved characters like `<>` are now being removed from both report exports and scheduled report email attachment filenames.

Refs DEV-18832

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
