### PR TITLE
Limit the processing time of archiving jobs

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -177,6 +177,15 @@ class CronArchive
      */
     public $maxArchivesToProcess = null;
 
+    /**
+     * Time in seconds how long an archiving job is allowed to start new archiving processes.
+     * When time limit is reached, the archiving job will wrap after current processes are finished up instead of
+     * continuing with the next invalidation requests.
+     *
+     * @var int
+     */
+    public $stopProcessingAfter = -1;
+
     private $archivingStartingTime;
 
     private $formatter;
@@ -416,6 +425,11 @@ class CronArchive
             $numArchivesFinished += $successCount;
             if ($this->maxArchivesToProcess && $numArchivesFinished >= $this->maxArchivesToProcess) {
                 $this->logger->info("Maximum number of archives to process per execution has been reached.");
+                break;
+            }
+
+            if ($this->stopProcessingAfter > 0 && $this->stopProcessingAfter < $timer->getTime()) {
+                $this->logger->info("Maximum time limit per execution has been reached.");
                 break;
             }
         }

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -52,6 +52,7 @@ class CoreArchiver extends ConsoleCommand
         $archiver->shouldArchiveAllSites = $input->getOption('force-all-websites');
         $archiver->maxSitesToProcess = $input->getOption('max-websites-to-process');
         $archiver->maxArchivesToProcess = $input->getOption('max-archives-to-process');
+        $archiver->stopProcessingAfter = $input->getOption('stop-processing-after');
         $archiver->setUrlToPiwik($url);
 
         $archiveFilter = new CronArchive\ArchiveFilter();
@@ -161,6 +162,12 @@ class CoreArchiver extends ConsoleCommand
             'max-archives-to-process',
             null,
             "Maximum number of archives to process during a single execution of the archiver. Can be used to limit the process lifetime e.g. to avoid increasing memory usage."
+        );
+        $command->addOptionalValueOption(
+            'stop-processing-after',
+            null,
+            "Number of seconds how long a job is allowed to start new archiving processes. When limit is reached job will wrap up after finishing current processes.",
+            60 * 60 * 24 // 24 hours, to ensure archiving is started once a day
         );
         $command->addNoValueOption(
             'disable-scheduled-tasks',

--- a/plugins/CoreConsole/tests/System/ArchiveCronTest.php
+++ b/plugins/CoreConsole/tests/System/ArchiveCronTest.php
@@ -439,6 +439,27 @@ class ArchiveCronTest extends SystemTestCase
         self::assertStringNotContainsString("Starting Piwik reports archiving...", $output);
     }
 
+    public function testArchivePhpCronWithTimeLimit()
+    {
+        self::$fixture->getTestEnvironment()->overrideConfig('General', 'enable_browser_archiving_triggering', 0);
+        self::$fixture->getTestEnvironment()->overrideConfig('General', 'browser_archiving_disabled_enforce', 1);
+        self::$fixture->getTestEnvironment()->save();
+
+        Config::getInstance()->General['enable_browser_archiving_triggering'] = 0;
+        Config::getInstance()->General['browser_archiving_disabled_enforce'] = 1;
+
+        Rules::setBrowserTriggerArchiving(false);
+
+        // track a visit so archiving will go through
+        $tracker = Fixture::getTracker(1, '2005-09-04');
+        $tracker->setUrl('http://example.com/test/url2');
+        Fixture::checkResponse($tracker->doTrackPageView('jkl'));
+
+        $output = $this->runArchivePhpCron(['-vvv --stop-processing-after=1' => null]);
+
+        self::assertStringContainsString('Maximum time limit per execution has been reached.', $output);
+    }
+
     private function runArchivePhpCron($options = array(), $archivePhpScript = false)
     {
         $archivePhpScript = $archivePhpScript ?: PIWIK_INCLUDE_PATH . '/tests/PHPUnit/proxy/archive.php';

--- a/plugins/CoreConsole/tests/System/ArchiveCronTest.php
+++ b/plugins/CoreConsole/tests/System/ArchiveCronTest.php
@@ -458,6 +458,9 @@ class ArchiveCronTest extends SystemTestCase
         $output = $this->runArchivePhpCron(['-vvv --stop-processing-after=1' => null]);
 
         self::assertStringContainsString('Maximum time limit per execution has been reached.', $output);
+
+        // Ensure work has stopped and some invalidations are left over
+        self::assertNotEmpty($this->getInvalidatedArchiveTableEntries());
     }
 
     private function runArchivePhpCron($options = array(), $archivePhpScript = false)


### PR DESCRIPTION
### Description:

Archiving jobs are supposed to be started at least once a day to ensure that invalidations are correctly processed.

To ensure jobs are not stuck in long running invalidations, preventing the system from starting new jobs and creating invalidations this PR introduces a configurable time limit per job. 

The time limit can be set by using the parameter `--stop-processing-after=`

The default value for now is set to 24 hours. If for any reason longer running jobs are needed, a value of `-1` can be provided.

fixes #22973 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
