### PR TITLE
Allow invalidation of All Visits only

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -259,14 +259,14 @@ class ArchiveInvalidator
     }
 
     /**
-     * @param $idSites int[]
-     * @param $dates Date[]|string[]
-     * @param $period string
-     * @param $segment Segment
+     * @param int[] $idSites
+     * @param Date[]|string[] $dates
+     * @param string $period
+     * @param null|Segment $segment
      * @param bool $cascadeDown
      * @param bool $forceInvalidateNonexistentRanges set true to force inserting rows for ranges in archive_invalidations
-     * @param string $name null to make sure every plugin is archived when this invalidation is processed by core:archive,
-     *                     or a plugin name to only archive the specific plugin.
+     * @param null|string $name null to make sure every plugin is archived when this invalidation is processed by core:archive,
+     *                          or a plugin name to only archive the specific plugin.
      * @param bool $ignorePurgeLogDataDate
      * @param bool $doNotCreateInvalidations If true, archives will only be marked as invalid, but no archive_invalidation record will be created
      * @return InvalidationResult
@@ -317,7 +317,7 @@ class ArchiveInvalidator
          * @param array &$idSites An array containing a list of site IDs which are requested to be invalidated.
          * @param array $dates An array containing the dates to invalidate.
          * @param string $period A string containing the period to be invalidated.
-         * @param Segment $segment A Segment Object containing segment to invalidate.
+         * @param null|Segment $segment A Segment Object containing segment to invalidate.
          * @param string $name A string containing the name of the archive to be invalidated.
          * @param bool $isPrivacyDeleteData A boolean value if event is triggered via Privacy delete visit action.
          */

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -451,15 +451,9 @@ class ArchiveInvalidator
             $ranges[] = Period\Factory::build('range', $dateRange[0] . ',' . $dateRange[1]);
         }
 
-        $invalidatedMonths = array();
         $archiveNumericTables = ArchiveTableCreator::getTablesArchivesInstalled($type = ArchiveTableCreator::NUMERIC_TABLE);
         foreach ($archiveNumericTables as $table) {
-            $tableDate = ArchiveTableCreator::getDateFromTableName($table);
-
-            $rowsAffected = $this->model->updateArchiveAsInvalidated($table, $idSites, $ranges, $segment, false, $name);
-            if ($rowsAffected > 0) {
-                $invalidatedMonths[] = $tableDate;
-            }
+            $this->model->updateArchiveAsInvalidated($table, $idSites, $ranges, $segment, false, $name);
         }
 
         foreach ($idSites as $idSite) {

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -434,15 +434,15 @@ class ArchiveInvalidator
     }
 
     /**
-     * @param $idSites int[]
-     * @param $dates Date[]
-     * @param $period string
-     * @param $segment Segment
-     * @param bool $cascadeDown
+     * @param int[] $idSites
+     * @param Date[] $dates
+     * @param Segment $segment
+     * @param null|string $name null to make sure every plugin is archived when this invalidation is processed by core:archive,
+     * *                          or a plugin name to only archive the specific plugin.
      * @return InvalidationResult
      * @throws \Exception
      */
-    public function markArchivesOverlappingRangeAsInvalidated(array $idSites, array $dates, ?Segment $segment = null)
+    public function markArchivesOverlappingRangeAsInvalidated(array $idSites, array $dates, ?Segment $segment = null, ?string $name = null)
     {
         $invalidationInfo = new InvalidationResult();
 
@@ -456,7 +456,7 @@ class ArchiveInvalidator
         foreach ($archiveNumericTables as $table) {
             $tableDate = ArchiveTableCreator::getDateFromTableName($table);
 
-            $rowsAffected = $this->model->updateArchiveAsInvalidated($table, $idSites, $ranges, $segment);
+            $rowsAffected = $this->model->updateArchiveAsInvalidated($table, $idSites, $ranges, $segment, false, $name);
             if ($rowsAffected > 0) {
                 $invalidatedMonths[] = $tableDate;
             }

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -163,13 +163,22 @@ class Model
             }
         }
 
+        $doneFlag = Rules::getDoneFlagArchiveContainsAllPlugins($segment ?: new Segment('', []));
+
         if (empty($plugin)) {
-            $doneFlag = Rules::getDoneFlagArchiveContainsAllPlugins($segment ?: new Segment('', []));
+            if (null === $segment) {
+                $nameCondition = "name LIKE '$doneFlag%'"; // invalidate all segments
+            } else {
+                $nameCondition = "(name = '$doneFlag' OR name LIKE '$doneFlag.%')"; // invalidate specific segment only
+            }
         } else {
-            $doneFlag = Rules::getDoneFlagArchiveContainsOnePlugin($segment ?: new Segment('', []), $plugin);
+            if (null === $segment) {
+                $nameCondition = "name LIKE '$doneFlag%.$plugin'"; // invalidate all segments
+            } else {
+                $nameCondition = "name = '$doneFlag.$plugin'"; // invalidate specific segment only
+            }
         }
 
-        $nameCondition = "name LIKE '$doneFlag%'";
 
         $sql .= " AND $nameCondition";
 
@@ -218,6 +227,13 @@ class Model
         $hashesOfAllSegmentsToArchiveInCoreArchive = array_map(function ($definition) {
             return Segment::getSegmentHash($definition);
         }, $hashesOfAllSegmentsToArchiveInCoreArchive);
+
+
+        if (empty($plugin)) {
+            $doneFlag = Rules::getDoneFlagArchiveContainsAllPlugins($segment ?: new Segment('', []));
+        } else {
+            $doneFlag = Rules::getDoneFlagArchiveContainsOnePlugin($segment ?: new Segment('', []), $plugin);
+        }
 
         $dummyArchives = [];
         foreach ($idSites as $idSite) {

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -173,9 +173,9 @@ class Model
             }
         } else {
             if (null === $segment) {
-                $nameCondition = "name LIKE '$doneFlag%.$plugin'"; // invalidate all segments
+                $nameCondition = "name LIKE '$doneFlag%.$plugin'"; // invalidate all segments for specific plugin
             } else {
-                $nameCondition = "name = '$doneFlag.$plugin'"; // invalidate specific segment only
+                $nameCondition = "name = '$doneFlag.$plugin'"; // invalidate specific segment for specific plugin only
             }
         }
 
@@ -208,7 +208,7 @@ class Model
             }
         }
 
-        if (true === $doNotCreateInvalidations) {
+        if ($doNotCreateInvalidations) {
             return count($idArchives);
         }
 

--- a/plugins/CoreAdminHome/Commands/InvalidateReportData.php
+++ b/plugins/CoreAdminHome/Commands/InvalidateReportData.php
@@ -9,6 +9,8 @@
 
 namespace Piwik\Plugins\CoreAdminHome\Commands;
 
+use Exception;
+use Piwik\ArchiveProcessor\Rules;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Period;
@@ -110,20 +112,52 @@ class InvalidateReportData extends ConsoleCommand
 
         $logger = StaticContainer::get(LoggerInterface::class);
 
+        // check availability of provided segments for all sites
+        foreach ($segments as $segmentStr) {
+            // determine sites where current segment is available for
+            $sitesToProcess = $this->getSitesForSegment($segmentStr, $sites);
+            $segment = new Segment($segmentStr, $sitesToProcess);
+
+            if (empty($sitesToProcess)) {
+                // segment not available for any site
+                $logger->info("Segment [$segmentStr] not available for any site, skipping it...");
+                continue;
+            }
+
+            $sitesDiff = array_diff($sites, $sitesToProcess);
+
+            if (count($sitesDiff)) {
+                $logger->info(
+                    "Segment [$segmentStr] not available for all sites, skipping this segment for sites [ " . implode(
+                        ', ',
+                        $sitesDiff
+                    ) . " ]."
+                );
+            }
+        }
+
+
         foreach ($periodTypes as $periodType) {
             if ($periodType === 'range') {
                 continue; // special handling for range below
             }
             foreach ($dateRanges as $dateRange) {
-                foreach ($segments as $segment) {
-                    $segmentStr = $segment ? $segment->getString() : 'all segments';
+                foreach ($segments as $segmentStr) {
+                    // determine sites where current segment is available for
+                    $sitesToProcess = $this->getSitesForSegment($segmentStr, $sites);
+                    $segment = new Segment($segmentStr, $sitesToProcess);
 
-                    $logger->info("Invalidating $periodType periods in $dateRange [segment = $segmentStr]...");
+                    if (empty($sitesToProcess)) {
+                        continue;
+                    }
+
+                    $logger->info("Invalidating $periodType periods in $dateRange for site = [ "
+                        . implode(', ', $sitesToProcess) . " ], segment = [ $segmentStr ]...");
 
                     $dates = $this->getPeriodDates($periodType, $dateRange);
 
                     if ($dryRun) {
-                        $message = "[Dry-run] invalidating archives for site = [ " . implode(', ', $sites)
+                        $message = "[Dry-run] invalidating archives for site = [ " . implode(', ', $sitesToProcess)
                             . " ], dates = [ " . implode(', ', $dates) . " ], period = [ $periodType ], segment = [ "
                             . "$segmentStr ], cascade = [ " . (int)$cascade . " ]";
                         if (!empty($plugin)) {
@@ -132,7 +166,7 @@ class InvalidateReportData extends ConsoleCommand
                         $logger->info($message);
                     } else {
                         $invalidationResult = $invalidator->markArchivesAsInvalidated(
-                            $sites,
+                            $sitesToProcess,
                             $dates,
                             $periodType,
                             $segment,
@@ -167,19 +201,46 @@ class InvalidateReportData extends ConsoleCommand
                 $rangeDates[] = $this->getPeriodDates('range', $dateRange);
             }
             if (!empty($rangeDates)) {
-                foreach ($segments as $segment) {
-                    $segmentStr = $segment ? $segment->getString() : 'all segments';
+                foreach ($segments as $segmentStr) {
+                    $sitesToProcess = $this->getSitesForSegment($segmentStr, $sites);
+                    $segment = new Segment($segmentStr, $sitesToProcess);
+
                     if ($dryRun) {
                         $dateRangeStr = implode(';', $dateRanges);
-                        $logger->info("Invalidating range periods overlapping $dateRangeStr [segment = $segmentStr]...");
+                        $logger->info("Invalidating range periods overlapping $dateRangeStr for "
+                            . "site = [ " . implode(', ', $sitesToProcess) . " ], segment = [ $segmentStr ]...");
                     } else {
-                        $invalidator->markArchivesOverlappingRangeAsInvalidated($sites, $rangeDates, $segment, $plugin);
+                        $invalidator->markArchivesOverlappingRangeAsInvalidated($sitesToProcess, $rangeDates, $segment, $plugin);
                     }
                 }
             }
         }
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Returns all sites where the given segment is available for
+     *
+     * @param string $segmentStr
+     * @param array $idSites
+     * @return array
+     * @throws \Exception
+     */
+    private function getSitesForSegment(string $segmentStr, array $idSites)
+    {
+        $sitesToProcess = [];
+
+        foreach ($idSites as $idSite) {
+            try {
+                $segment = new Segment($segmentStr, $idSite);
+                $sitesToProcess[] = $idSite;
+            } catch (Exception $e) {
+                continue;
+            }
+        }
+
+        return $sitesToProcess;
     }
 
     private function getSitesToInvalidateFor()
@@ -235,7 +296,7 @@ class InvalidateReportData extends ConsoleCommand
             throw new \InvalidArgumentException("The --dates option is required.");
         }
 
-        return $dateRanges;
+        return is_array($dateRanges) ? $dateRanges : [$dateRanges];
     }
 
     private function getPeriodDates($periodType, $dateRange)
@@ -267,7 +328,7 @@ class InvalidateReportData extends ConsoleCommand
     /**
      * @param array<int> $idSites
      *
-     * @return array<Segment>
+     * @return array<string>
      */
     private function getSegmentsToInvalidateFor(array $idSites): array
     {
@@ -277,14 +338,16 @@ class InvalidateReportData extends ConsoleCommand
         $segments = array_unique($segments);
 
         if (empty($segments)) {
-            return [null];
+            $segments = Rules::getSegmentsToProcess($idSites);
+            array_unshift($segments, "");
+            return $segments;
         }
 
         $result = [];
 
         foreach ($segments as $segmentOptionValue) {
             if ($segmentOptionValue === "") {
-                $result[] = new Segment("", $idSites);
+                $result[] = "";
                 continue;
             }
 
@@ -294,7 +357,7 @@ class InvalidateReportData extends ConsoleCommand
                 continue;
             }
 
-            $result[] = new Segment($segmentDefinition, $idSites);
+            $result[] = $segmentDefinition;
         }
 
         return $result;

--- a/plugins/CoreAdminHome/Commands/InvalidateReportData.php
+++ b/plugins/CoreAdminHome/Commands/InvalidateReportData.php
@@ -10,9 +10,9 @@
 namespace Piwik\Plugins\CoreAdminHome\Commands;
 
 use Exception;
+use Piwik\Archive\ArchiveInvalidator;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\Container\StaticContainer;
-use Piwik\Date;
 use Piwik\Period;
 use Piwik\Period\Range;
 use Piwik\Piwik;
@@ -36,6 +36,24 @@ class InvalidateReportData extends ConsoleCommand
      */
     private $allSegments = null;
 
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var ArchiveInvalidator
+     */
+    private $invalidator;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->logger = StaticContainer::get(LoggerInterface::class);
+        $this->invalidator = StaticContainer::get(ArchiveInvalidator::class);
+    }
+
     protected function configure()
     {
         $this->setName('core:invalidate-report-data');
@@ -57,14 +75,15 @@ class InvalidateReportData extends ConsoleCommand
             'periods',
             null,
             'List of period types to invalidate report data for. Can be one or more of the following values: day, '
-            . 'week, month, year or "all" for all of them.',
+            . 'week, month, year, range or "all" for all of them.',
             self::ALL_OPTION_VALUE
         );
         $this->addRequiredValueOption(
             'segment',
             null,
             'List of segments to invalidate report data for. This can be the segment string itself, the segment name from the UI or the ID of the segment.'
-            . ' If specifying the segment definition, make sure it is encoded properly (it should be the same as the segment parameter in the URL.',
+            . ' If specifying the segment definition, make sure it is encoded properly (it should be the same as the segment parameter in the URL).'
+            . ' If no segment is provided, all segments (including all visits) will be invalidated. To specifically invalidate all visits --segment="" can be provided.',
             null,
             true
         );
@@ -95,139 +114,157 @@ class InvalidateReportData extends ConsoleCommand
 
     protected function doExecute(): int
     {
-        $input = $this->getInput();
-        $output = $this->getOutput();
-
-        $invalidator = StaticContainer::get('Piwik\Archive\ArchiveInvalidator');
-
-        $cascade = $input->getOption('cascade');
-        $dryRun = $input->getOption('dry-run');
-        $plugin = $input->getOption('plugin');
-        $ignoreLogDeletionLimit = $input->getOption('ignore-log-deletion-limit');
-
         $sites = $this->getSitesToInvalidateFor();
         $periodTypes = $this->getPeriodTypesToInvalidateFor();
         $dateRanges = $this->getDateRangesToInvalidateFor();
         $segments = $this->getSegmentsToInvalidateFor($sites);
 
-        $logger = StaticContainer::get(LoggerInterface::class);
-
-        // check availability of provided segments for all sites
-        foreach ($segments as $segmentStr) {
-            // determine sites where current segment is available for
-            $sitesToProcess = $this->getSitesForSegment($segmentStr, $sites);
-            $segment = new Segment($segmentStr, $sitesToProcess);
-
-            if (empty($sitesToProcess)) {
-                // segment not available for any site
-                $logger->info("Segment [$segmentStr] not available for any site, skipping it...");
-                continue;
-            }
-
-            $sitesDiff = array_diff($sites, $sitesToProcess);
-
-            if (count($sitesDiff)) {
-                $logger->info(
-                    "Segment [$segmentStr] not available for all sites, skipping this segment for sites [ " . implode(
-                        ', ',
-                        $sitesDiff
-                    ) . " ]."
-                );
-            }
-        }
-
+        $this->logUnavailableSegmentsInfo($segments, $sites);
 
         foreach ($periodTypes as $periodType) {
             if ($periodType === 'range') {
-                continue; // special handling for range below
-            }
-            foreach ($dateRanges as $dateRange) {
-                foreach ($segments as $segmentStr) {
-                    // determine sites where current segment is available for
-                    $sitesToProcess = $this->getSitesForSegment($segmentStr, $sites);
-                    $segment = new Segment($segmentStr, $sitesToProcess);
-
-                    if (empty($sitesToProcess)) {
-                        continue;
-                    }
-
-                    $logger->info("Invalidating $periodType periods in $dateRange for site = [ "
-                        . implode(', ', $sitesToProcess) . " ], segment = [ $segmentStr ]...");
-
-                    $dates = $this->getPeriodDates($periodType, $dateRange);
-
-                    if ($dryRun) {
-                        $message = "[Dry-run] invalidating archives for site = [ " . implode(', ', $sitesToProcess)
-                            . " ], dates = [ " . implode(', ', $dates) . " ], period = [ $periodType ], segment = [ "
-                            . "$segmentStr ], cascade = [ " . (int)$cascade . " ]";
-                        if (!empty($plugin)) {
-                            $message .= ", plugin = [ $plugin ]";
-                        }
-                        $logger->info($message);
-                    } else {
-                        $invalidationResult = $invalidator->markArchivesAsInvalidated(
-                            $sitesToProcess,
-                            $dates,
-                            $periodType,
-                            $segment,
-                            $cascade,
-                            false,
-                            $plugin,
-                            $ignoreLogDeletionLimit
-                        );
-
-                        if ($output->getVerbosity() > $output::VERBOSITY_NORMAL) {
-                            foreach ($invalidationResult->makeOutputLogs() as $outputLog) {
-                                $logger->info($outputLog);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        $periods = trim($input->getOption('periods'));
-        $isUsingAllOption = $periods === self::ALL_OPTION_VALUE;
-        if ($isUsingAllOption || in_array('range', $periodTypes)) {
-            $rangeDates = array();
-            foreach ($dateRanges as $dateRange) {
-                if (
-                    $isUsingAllOption
-                    && !Period::isMultiplePeriod($dateRange, 'day')
-                ) {
-                    continue; // not a range, nothing to do... only when "all" option is used
-                }
-
-                $rangeDates[] = $this->getPeriodDates('range', $dateRange);
-            }
-            if (!empty($rangeDates)) {
-                foreach ($segments as $segmentStr) {
-                    $sitesToProcess = $this->getSitesForSegment($segmentStr, $sites);
-                    $segment = new Segment($segmentStr, $sitesToProcess);
-
-                    if ($dryRun) {
-                        $dateRangeStr = implode(';', $dateRanges);
-                        $logger->info("Invalidating range periods overlapping $dateRangeStr for "
-                            . "site = [ " . implode(', ', $sitesToProcess) . " ], segment = [ $segmentStr ]...");
-                    } else {
-                        $invalidator->markArchivesOverlappingRangeAsInvalidated($sitesToProcess, $rangeDates, $segment, $plugin);
-                    }
-                }
+                $this->invalidateRangePeriods($dateRanges, $segments, $sites);
+            } else {
+                $this->invalidateNonRangePeriods($periodType, $dateRanges, $segments, $sites);
             }
         }
 
         return self::SUCCESS;
     }
 
+    private function logUnavailableSegmentsInfo(array $segments, array $sites): void
+    {
+        // check availability of provided segments for all sites
+        foreach ($segments as $segmentStr) {
+            // determine sites where current segment is available for
+            $sitesToProcess = $this->getSitesForSegment($segmentStr, $sites);
+
+            try {
+                $segment = new Segment($segmentStr, $sitesToProcess);
+            } catch (\Exception $e) {
+                $this->logger->info("Segment [$segmentStr] is not supported, skipping it...");
+                // segment definition might be invalid, so skip it here.
+                continue;
+            }
+
+            if (empty($sitesToProcess)) {
+                // segment not available for any site
+                $this->logger->info("Segment [$segmentStr] not available for any site, skipping it...");
+                continue;
+            }
+
+            $sitesDiff = array_diff($sites, $sitesToProcess);
+
+            if (count($sitesDiff)) {
+                $this->logger->info(
+                    "Segment [$segmentStr] not available for all sites, skipping this segment for sites [ "
+                    . implode(', ', $sitesDiff) . " ]."
+                );
+            }
+        }
+    }
+
+    private function invalidateNonRangePeriods(
+        string $periodType,
+        array $dateRangesToInvalidate,
+        array $segments,
+        array $sites
+    ): void {
+        $ignoreLogDeletionLimit = $this->getInput()->getOption('ignore-log-deletion-limit');
+        $cascade = $this->getInput()->getOption('cascade');
+        $dryRun = $this->getInput()->getOption('dry-run');
+        $plugin = $this->getInput()->getOption('plugin');
+
+        foreach ($dateRangesToInvalidate as $dateRange) {
+            foreach ($segments as $segmentStr) {
+                // determine sites where current segment is available for
+                $sitesToProcess = $this->getSitesForSegment($segmentStr, $sites);
+
+                if (empty($sitesToProcess)) {
+                    continue;
+                }
+
+                $segment = new Segment($segmentStr, $sitesToProcess);
+
+                $this->logger->info("Invalidating $periodType periods in $dateRange for site = [ "
+                    . implode(', ', $sitesToProcess) . " ], segment = [ $segmentStr ]...");
+
+                $dates = $this->getPeriodDates($periodType, $dateRange);
+
+                if ($dryRun) {
+                    $message = "[Dry-run] invalidating archives for site = [ " . implode(', ', $sitesToProcess)
+                        . " ], dates = [ " . implode(', ', $dates) . " ], period = [ $periodType ], segment = [ "
+                        . "$segmentStr ], cascade = [ " . (int)$cascade . " ]";
+                    if (!empty($plugin)) {
+                        $message .= ", plugin = [ $plugin ]";
+                    }
+                    $this->logger->info($message);
+                } else {
+                    $invalidationResult = $this->invalidator->markArchivesAsInvalidated(
+                        $sitesToProcess,
+                        $dates,
+                        $periodType,
+                        $segment,
+                        $cascade,
+                        false,
+                        $plugin,
+                        $ignoreLogDeletionLimit
+                    );
+
+                    if ($this->getOutput()->getVerbosity() > $this->getOutput()::VERBOSITY_NORMAL) {
+                        foreach ($invalidationResult->makeOutputLogs() as $outputLog) {
+                            $this->logger->info($outputLog);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private function invalidateRangePeriods(array $dateRangesToInvalidate, array $segments, array $sites): void
+    {
+        $dryRun = $this->getInput()->getOption('dry-run');
+        $plugin = $this->getInput()->getOption('plugin');
+        $periods = trim($this->getInput()->getOption('periods'));
+        $isUsingAllOption = $periods === self::ALL_OPTION_VALUE;
+        $rangeDates = [];
+
+        foreach ($dateRangesToInvalidate as $dateRange) {
+            if (
+                $isUsingAllOption
+                && !Period::isMultiplePeriod($dateRange, 'day')
+            ) {
+                continue; // not a range, nothing to do... only when "all" option is used
+            }
+
+            $rangeDates[] = $this->getPeriodDates('range', $dateRange);
+        }
+
+        if (!empty($rangeDates)) {
+            foreach ($segments as $segmentStr) {
+                $sitesToProcess = $this->getSitesForSegment($segmentStr, $sites);
+
+                if (empty($sitesToProcess)) {
+                    continue;
+                }
+
+                $segment = new Segment($segmentStr, $sitesToProcess);
+
+                if ($dryRun) {
+                    $dateRangeStr = implode(';', $dateRangesToInvalidate);
+                    $this->logger->info("Invalidating range periods overlapping $dateRangeStr for "
+                        . "site = [ " . implode(', ', $sitesToProcess) . " ], segment = [ $segmentStr ]...");
+                } else {
+                    $this->invalidator->markArchivesOverlappingRangeAsInvalidated($sitesToProcess, $rangeDates, $segment, $plugin);
+                }
+            }
+        }
+    }
+
     /**
      * Returns all sites where the given segment is available for
-     *
-     * @param string $segmentStr
-     * @param array $idSites
-     * @return array
-     * @throws \Exception
      */
-    private function getSitesForSegment(string $segmentStr, array $idSites)
+    private function getSitesForSegment(string $segmentStr, array $idSites): array
     {
         $sitesToProcess = [];
 
@@ -243,7 +280,10 @@ class InvalidateReportData extends ConsoleCommand
         return $sitesToProcess;
     }
 
-    private function getSitesToInvalidateFor()
+    /**
+     * Parses, validates and returns the provided list of site ids
+     */
+    private function getSitesToInvalidateFor(): array
     {
         $sites = $this->getInput()->getOption('sites');
 
@@ -262,7 +302,11 @@ class InvalidateReportData extends ConsoleCommand
         return $siteIds;
     }
 
-    private function getPeriodTypesToInvalidateFor()
+    /**
+     * Parses, validates and returns the provided list of period types
+     * If 'all' is provided, this will be converted to a list of all period types
+     */
+    private function getPeriodTypesToInvalidateFor(): array
     {
         $periods = $this->getInput()->getOption('periods');
         if (empty($periods)) {
@@ -287,9 +331,9 @@ class InvalidateReportData extends ConsoleCommand
     }
 
     /**
-     * @return Date[][]
+     * Returns the list of provided dates / date ranges
      */
-    private function getDateRangesToInvalidateFor()
+    private function getDateRangesToInvalidateFor(): array
     {
         $dateRanges = $this->getInput()->getOption('dates');
         if (empty($dateRanges)) {
@@ -311,7 +355,7 @@ class InvalidateReportData extends ConsoleCommand
             throw new \InvalidArgumentException("Invalid date or date range specifier '$dateRange'", $code = 0, $ex);
         }
 
-        $result = array();
+        $result = [];
         if ($periodType === 'range') {
             $result[] = $period->getDateStart();
             $result[] = $period->getDateEnd();
@@ -326,6 +370,9 @@ class InvalidateReportData extends ConsoleCommand
     }
 
     /**
+     * Parses, validates and returns the list of segments that can be invalidated for the provided sites
+     * If no segment is provided, a list of all segments available for the provided sites will be returned (including all visits segment)
+     *
      * @param array<int> $idSites
      *
      * @return array<string>
@@ -338,6 +385,7 @@ class InvalidateReportData extends ConsoleCommand
         $segments = array_unique($segments);
 
         if (empty($segments)) {
+            $this->logger->debug("No segment provided. Invalidating all stored segments.");
             $segments = Rules::getSegmentsToProcess($idSites);
             array_unshift($segments, "");
             return $segments;
@@ -368,7 +416,6 @@ class InvalidateReportData extends ConsoleCommand
      */
     private function findSegment(string $segmentOptionValue, array $idSites)
     {
-        $logger = StaticContainer::get(LoggerInterface::class);
         $allSegments = $this->getAllSegments($idSites);
 
         foreach ($allSegments as $segment) {
@@ -380,12 +427,12 @@ class InvalidateReportData extends ConsoleCommand
             }
 
             if ($segmentOptionValue == $segment['idsegment']) {
-                $logger->debug("Matching '$segmentOptionValue' by idsegment with segment {segment}.", ['segment' => json_encode($segment)]);
+                $this->logger->debug("Matching '$segmentOptionValue' by idsegment with segment {segment}.", ['segment' => json_encode($segment)]);
                 return $segment['definition'];
             }
 
             if (strtolower($segmentOptionValue) == strtolower($segment['name'])) {
-                $logger->debug("Matching '$segmentOptionValue' by name with segment {segment}.", ['segment' => json_encode($segment)]);
+                $this->logger->debug("Matching '$segmentOptionValue' by name with segment {segment}.", ['segment' => json_encode($segment)]);
                 return $segment['definition'];
             }
 
@@ -393,12 +440,12 @@ class InvalidateReportData extends ConsoleCommand
                 $segment['definition'] == $segmentOptionValue
                 || $segment['definition'] == urldecode($segmentOptionValue)
             ) {
-                $logger->debug("Matching '{value}' by definition with segment {segment}.", ['value' => $segmentOptionValue, 'segment' => json_encode($segment)]);
+                $this->logger->debug("Matching '{value}' by definition with segment {segment}.", ['value' => $segmentOptionValue, 'segment' => json_encode($segment)]);
                 return $segment['definition'];
             }
         }
 
-        $logger->warning("'$segmentOptionValue' did not match any stored segment, but invalidating it anyway.");
+        $this->logger->warning("'$segmentOptionValue' did not match any stored segment, but invalidating it anyway.");
         return $segmentOptionValue;
     }
 

--- a/plugins/CoreAdminHome/Commands/InvalidateReportData.php
+++ b/plugins/CoreAdminHome/Commands/InvalidateReportData.php
@@ -173,7 +173,7 @@ class InvalidateReportData extends ConsoleCommand
                         $dateRangeStr = implode(';', $dateRanges);
                         $logger->info("Invalidating range periods overlapping $dateRangeStr [segment = $segmentStr]...");
                     } else {
-                        $invalidator->markArchivesOverlappingRangeAsInvalidated($sites, $rangeDates, $segment);
+                        $invalidator->markArchivesOverlappingRangeAsInvalidated($sites, $rangeDates, $segment, $plugin);
                     }
                 }
             }

--- a/plugins/CoreAdminHome/Commands/InvalidateReportData.php
+++ b/plugins/CoreAdminHome/Commands/InvalidateReportData.php
@@ -116,7 +116,7 @@ class InvalidateReportData extends ConsoleCommand
             }
             foreach ($dateRanges as $dateRange) {
                 foreach ($segments as $segment) {
-                    $segmentStr = $segment ? $segment->getString() : '';
+                    $segmentStr = $segment ? $segment->getString() : 'all segments';
 
                     $logger->info("Invalidating $periodType periods in $dateRange [segment = $segmentStr]...");
 
@@ -168,7 +168,7 @@ class InvalidateReportData extends ConsoleCommand
             }
             if (!empty($rangeDates)) {
                 foreach ($segments as $segment) {
-                    $segmentStr = $segment ? $segment->getString() : '';
+                    $segmentStr = $segment ? $segment->getString() : 'all segments';
                     if ($dryRun) {
                         $dateRangeStr = implode(';', $dateRanges);
                         $logger->info("Invalidating range periods overlapping $dateRangeStr [segment = $segmentStr]...");
@@ -283,6 +283,11 @@ class InvalidateReportData extends ConsoleCommand
         $result = [];
 
         foreach ($segments as $segmentOptionValue) {
+            if ($segmentOptionValue === "") {
+                $result[] = new Segment("", $idSites);
+                continue;
+            }
+
             $segmentDefinition = $this->findSegment($segmentOptionValue, $idSites);
 
             if (empty($segmentDefinition)) {

--- a/plugins/CoreAdminHome/Commands/InvalidateReportData.php
+++ b/plugins/CoreAdminHome/Commands/InvalidateReportData.php
@@ -119,8 +119,6 @@ class InvalidateReportData extends ConsoleCommand
         $dateRanges = $this->getDateRangesToInvalidateFor();
         $segments = $this->getSegmentsToInvalidateFor($sites);
 
-        $this->logUnavailableSegmentsInfo($segments, $sites);
-
         foreach ($periodTypes as $periodType) {
             if ($periodType === 'range') {
                 $this->invalidateRangePeriods($dateRanges, $segments, $sites);
@@ -132,8 +130,13 @@ class InvalidateReportData extends ConsoleCommand
         return self::SUCCESS;
     }
 
-    private function logUnavailableSegmentsInfo(array $segments, array $sites): void
-    {
+    private function getSegmentsWithSitesToProcess(
+        array $segments,
+        array $sites,
+        bool $ignoreInvalidSegments = false
+    ): array {
+        $segmentDetails = [];
+
         // check availability of provided segments for all sites
         foreach ($segments as $segmentStr) {
             // determine sites where current segment is available for
@@ -141,10 +144,10 @@ class InvalidateReportData extends ConsoleCommand
 
             try {
                 $segment = new Segment($segmentStr, $sitesToProcess);
-            } catch (\Exception $e) {
-                $this->logger->info("Segment [$segmentStr] is not supported, skipping it...");
-                // segment definition might be invalid, so skip it here.
-                continue;
+            } catch (Exception $e) {
+                if (!$ignoreInvalidSegments) {
+                    throw $e;
+                }
             }
 
             if (empty($sitesToProcess)) {
@@ -161,7 +164,14 @@ class InvalidateReportData extends ConsoleCommand
                     . implode(', ', $sitesDiff) . " ]."
                 );
             }
+
+            $segmentDetails[$segmentStr] = [
+                'segment' => $segment,
+                'sites' => $sitesToProcess,
+            ];
         }
+
+        return $segmentDetails;
     }
 
     private function invalidateNonRangePeriods(
@@ -176,15 +186,9 @@ class InvalidateReportData extends ConsoleCommand
         $plugin = $this->getInput()->getOption('plugin');
 
         foreach ($dateRangesToInvalidate as $dateRange) {
-            foreach ($segments as $segmentStr) {
-                // determine sites where current segment is available for
-                $sitesToProcess = $this->getSitesForSegment($segmentStr, $sites);
-
-                if (empty($sitesToProcess)) {
-                    continue;
-                }
-
-                $segment = new Segment($segmentStr, $sitesToProcess);
+            foreach ($segments as $segmentStr => $segmentData) {
+                $sitesToProcess = $segmentData['sites'];
+                $segment = $segmentData['segment'];
 
                 $this->logger->info("Invalidating $periodType periods in $dateRange for site = [ "
                     . implode(', ', $sitesToProcess) . " ], segment = [ $segmentStr ]...");
@@ -241,14 +245,9 @@ class InvalidateReportData extends ConsoleCommand
         }
 
         if (!empty($rangeDates)) {
-            foreach ($segments as $segmentStr) {
-                $sitesToProcess = $this->getSitesForSegment($segmentStr, $sites);
-
-                if (empty($sitesToProcess)) {
-                    continue;
-                }
-
-                $segment = new Segment($segmentStr, $sitesToProcess);
+            foreach ($segments as $segmentStr => $segmentData) {
+                $sitesToProcess = $segmentData['sites'];
+                $segment = $segmentData['segment'];
 
                 if ($dryRun) {
                     $dateRangeStr = implode(';', $dateRangesToInvalidate);
@@ -388,7 +387,7 @@ class InvalidateReportData extends ConsoleCommand
             $this->logger->debug("No segment provided. Invalidating all stored segments.");
             $segments = Rules::getSegmentsToProcess($idSites);
             array_unshift($segments, "");
-            return $segments;
+            return $this->getSegmentsWithSitesToProcess($segments, $idSites, true);
         }
 
         $result = [];
@@ -408,7 +407,7 @@ class InvalidateReportData extends ConsoleCommand
             $result[] = $segmentDefinition;
         }
 
-        return $result;
+        return $this->getSegmentsWithSitesToProcess($result, $idSites);
     }
 
     /**

--- a/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php
@@ -10,6 +10,9 @@
 namespace Piwik\Plugins\CoreAdminHome\tests\Integration\Commands;
 
 use Monolog\Handler\AbstractProcessingHandler;
+use Piwik\ArchiveProcessor\Rules;
+use Piwik\Common;
+use Piwik\Db;
 use Piwik\Plugins\CustomDimensions\CustomDimensions;
 use Piwik\Plugins\CustomDimensions\API as CustomDimensionsAPI;
 use Piwik\Plugins\SegmentEditor\API as SegmentEditorAPI;
@@ -28,8 +31,8 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
     {
         parent::setUpBeforeClass();
 
-        $idSite = Fixture::createWebsite('2012-01-01 00:00:00');
-        Fixture::createWebsite('2012-01-01 00:00:00');
+        $idSite = Fixture::createWebsite('2011-01-01 00:00:00');
+        Fixture::createWebsite('2012-01-02 00:00:00');
         Fixture::createWebsite('2012-01-01 00:00:00');
 
         CustomDimensionsAPI::getInstance()->configureNewCustomDimension(
@@ -39,14 +42,17 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             true
         );
 
-        SegmentEditorAPI::getInstance()->add('test segment', 'browserCode==IE', $idSite);
-        SegmentEditorAPI::getInstance()->add('custom dimension', 'dimension1==test', $idSite);
+        Rules::setBrowserTriggerArchiving(false);
+        SegmentEditorAPI::getInstance()->add('test segment', 'browserCode==IE', false, true);
+        SegmentEditorAPI::getInstance()->add('custom dimension', 'dimension1==test', $idSite, true);
+        SegmentEditorAPI::getInstance()->add('browser segment', 'browserCode==FF', false, false);
     }
 
     public function setUp(): void
     {
         parent::setUp();
         self::$captureHandler->messages = [];
+        Db::query('TRUNCATE table ' . Common::prefixTable('archive_invalidations'));
     }
 
     protected function tearDown(): void
@@ -56,137 +62,162 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
     }
 
     /**
-     * @dataProvider getInvalidDateRanges
+     * @dataProvider getInvalidCommandOptions
      */
-    public function testCommandFailsWhenAnInvalidDateRangeIsUsed($invalidDateRange)
+    public function testCommandFailsWithInvalidOptions(array $commandOptions, array $expectedOutputs)
     {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => [$invalidDateRange],
-            '--periods' => 'day',
-            '--sites' => '1',
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
+        $commandOptions = array_merge(['command' => 'core:invalidate-report-data'], $commandOptions);
 
-        $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalid date or date range specifier", $this->getLogOutput());
+        $code = $this->applicationTester->run($commandOptions);
+        self::assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+
+        foreach ($expectedOutputs as $expectedOutput) {
+            self::assertStringContainsString($expectedOutput, $this->getLogOutput());
+        }
     }
 
-    public function getInvalidDateRanges()
+    public function getInvalidCommandOptions(): iterable
     {
-        return [
-            ['garbage'],
-            ['2012-01-03 2013-02-01'],
+        yield 'invalid dates parameter' => [
+            [
+                '--dates' => ['garbage'],
+                '--periods' => 'day',
+                '--sites' => '1',
+                '--dry-run' => true,
+                '-vvv' => true,
+            ],
+            [
+                'Invalid date or date range specifier'
+            ]
+        ];
+
+        yield 'invalid dates parameter format' => [
+            [
+                '--dates' => ['2012-01-03 2013-02-01'],
+                '--periods' => 'day',
+                '--sites' => '1',
+                '--dry-run' => true,
+                '-vvv' => true,
+            ],
+            [
+                'Invalid date or date range specifier'
+            ]
+        ];
+
+        yield 'dates parameter with too many dates in range' => [
+            [
+                '--dates' => ['2019-01-01,2019-01-09,2019-01-12,2019-01-15'],
+                '--periods' => 'range',
+                '--sites' => '1',
+                '--dry-run' => true,
+                '-vvv' => true,
+            ],
+            [
+                "The date '2019-01-01,2019-01-09,2019-01-12,2019-01-15' is not a correct date range"
+            ]
+        ];
+
+        yield 'invalid period parameter' => [
+            [
+                '--dates' => ['2012-01-03'],
+                '--periods' => 'cranberries',
+                '--sites' => '1',
+                '--dry-run' => true,
+                '-vvv' => true,
+            ],
+            [
+                'Invalid period type'
+            ]
+        ];
+
+        yield 'non numeric sites parameter' => [
+            [
+                '--dates' => ['2012-01-03'],
+                '--periods' => 'day',
+                '--sites' => 'wolfalice',
+                '--dry-run' => true,
+                '-vvv' => true,
+            ],
+            [
+                'Invalid --sites value'
+            ]
+        ];
+
+        yield 'idSite list without values' => [
+            [
+                '--dates' => ['2012-01-03'],
+                '--periods' => 'day',
+                '--sites' => ',',
+                '--dry-run' => true,
+                '-vvv' => true,
+            ],
+            [
+                'Invalid --sites value'
+            ]
+        ];
+
+        yield 'not existing idSite included in list' => [
+            [
+                '--dates' => ['2012-01-03'],
+                '--periods' => 'day',
+                '--sites' => '1,500',
+                '--dry-run' => true,
+                '-vvv' => true,
+            ],
+            [
+                'Invalid --sites value'
+            ]
+        ];
+
+        yield 'invalid segment provided' => [
+            [
+                '--dates' => ['2012-01-03'],
+                '--periods' => 'day',
+                '--sites' => '1',
+                '--segment' => ['ablksdjfdslkjf'],
+                '--dry-run' => true,
+                '-vvv' => true,
+            ],
+            [
+                "The segment condition 'ablksdjfdslkjf' is not valid"
+            ]
+        ];
+
+        yield 'segment name provided that does not exist for given site' => [
+            [
+                '--dates' => ['2012-01-03'],
+                '--periods' => 'day',
+                '--sites' => '2,3',
+                '--segment' => ['custom dimension'],
+                '--dry-run' => true,
+                '-vvv' => true,
+            ],
+            [
+                "'custom dimension' did not match any stored segment, but invalidating it anyway.",
+                "The segment condition 'custom dimension' is not valid.",
+            ]
+        ];
+
+        yield 'segment provided that does not exist for given site' => [
+            [
+                '--dates' => ['2012-01-03'],
+                '--periods' => 'day',
+                '--sites' => '2',
+                '--segment' => ['dimension1==test'],
+                '--dry-run' => true,
+                '-vvv' => true,
+            ],
+            [
+                "'dimension1==test' did not match any stored segment, but invalidating it anyway.",
+                "Segment 'dimension1' is not a supported segment."
+            ]
         ];
     }
 
-    /**
-     * @dataProvider getInvalidPeriodTypes
-     */
-    public function testCommandFailsWhenAnInvalidPeriodTypeIsUsed($invalidPeriodType)
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => '2012-01-01',
-            '--periods' => $invalidPeriodType,
-            '--sites' => '1',
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalid period type", $this->getLogOutput());
-    }
-
-    public function getInvalidPeriodTypes()
-    {
-        return [
-            ['cranberries'],
-        ];
-    }
-
-    /**
-     * @dataProvider getInvalidSiteLists
-     */
-    public function testCommandFailsWhenAnInvalidSiteListIsUsed($invalidSites)
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => '2012-01-01',
-            '--periods' => 'day',
-            '--sites' => $invalidSites,
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalid --sites value", $this->getLogOutput());
-    }
-
-    public function getInvalidSiteLists()
-    {
-        return [
-            ['wolfalice'],
-            [','],
-            ['1,500'],
-        ];
-    }
-
-    public function testCommandFailsWhenAnInvalidSegmentIsUsed()
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => '2012-01-01',
-            '--periods' => 'day',
-            '--sites' => '1',
-            '--segment' => ['ablksdjfdslkjf'],
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("The segment condition 'ablksdjfdslkjf' is not valid", $this->getLogOutput());
-    }
-
-    public function testCommandFailsWhenACustomDimensionSegmentIsNotSupportedByAllSites()
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => '2012-01-01',
-            '--periods' => 'day',
-            '--sites' => '1,2',
-            '--segment' => ['custom dimension'],
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Segment 'dimension1' is not a supported segment", $this->getLogOutput());
-    }
-
-
-    public function testCommandFailsWhenACustomDimensionSegmentIsNotValidForAnySite()
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => '2012-01-01',
-            '--periods' => 'day',
-            '--sites' => '2,3',
-            '--segment' => ['custom dimension'],
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("'custom dimension' did not match any stored segment, but invalidating it anyway", $this->getLogOutput());
-        self::assertStringContainsString("The segment condition 'custom dimension' is not valid", $this->getLogOutput());
-    }
-
-    /**
+     /**
      * @dataProvider getTestDataForSuccessTests
      */
-    public function testCommandInvalidatesCorrectSitesAndDates($dates, $periods, $sites, $cascade, $segments, $plugin, $expectedOutputs)
+    public function testCommandOutputSuccess($dates, $periods, $sites, $cascade, $segments, $plugin, $expectedOutputs)
     {
         $options = [
             'command' => 'core:invalidate-report-data',
@@ -212,131 +243,6 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         }
     }
 
-    public function testCommandInvalidateDateRange()
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => ['2019-01-01,2019-01-09'],
-            '--periods' => 'range',
-            '--sites' => '1',
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = all segments]", $this->getLogOutput());
-    }
-
-    public function testCommandInvalidateDateRangeInvalidDate()
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => ['2019-01-01,2019-01--09'],
-            '--periods' => 'range',
-            '--sites' => '1',
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("The date '2019-01-01,2019-01--09' is not a correct date range", $this->getLogOutput());
-    }
-
-    public function testCommandInvalidateDateRangeOnlyOneDate()
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => ['2019-01-01'],
-            '--periods' => 'range',
-            '--sites' => '1',
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("The date '2019-01-01' is not a correct date range", $this->getLogOutput());
-    }
-
-    public function testCommandInvalidateDateRangeTooManyDatesInRange()
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => ['2019-01-01,2019-01-09,2019-01-12,2019-01-15'],
-            '--periods' => 'range',
-            '--sites' => '1',
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("The date '2019-01-01,2019-01-09,2019-01-12,2019-01-15' is not a correct date range", $this->getLogOutput());
-    }
-
-    public function testCommandInvalidateDateRangeMultipleDateRanges()
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => ['2019-01-01,2019-01-09', '2019-01-12,2019-01-15'],
-            '--periods' => 'range',
-            '--sites' => '1',
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-15", $this->getLogOutput());
-    }
-
-    public function testCommandInvalidateDateRangeInvalidateAllPeriodTypesSkipsRangeWhenNotRangeDAte()
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => ['2019-01-01'],
-            '--periods' => 'all',
-            '--sites' => '1',
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringNotContainsString("range", $this->getLogOutput());
-        self::assertStringNotContainsString("Range", $this->getLogOutput());
-    }
-
-    public function testCommandInvalidateDateRangeInvalidateAllPeriodTypes()
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => ['2019-01-01,2019-01-09'],
-            '--periods' => 'all',
-            '--sites' => '1',
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalidating day periods in 2019-01-01,2019-01-09 [segment = all segments]", $this->getLogOutput());
-        self::assertStringContainsString("Invalidating week periods in 2019-01-01,2019-01-09 [segment = all segments]", $this->getLogOutput());
-        self::assertStringContainsString("Invalidating month periods in 2019-01-01,2019-01-09 [segment = all segments]", $this->getLogOutput());
-        self::assertStringContainsString("Invalidating year periods in 2019-01-01,2019-01-09 [segment = all segments]", $this->getLogOutput());
-        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = all segments]", $this->getLogOutput());
-    }
-
-    public function testCommandInvalidateAllMultipleDateRanges()
-    {
-        $code = $this->applicationTester->run([
-            'command' => 'core:invalidate-report-data',
-            '--dates' => ['2019-01-01,2019-01-09', '2019-01-12,2019-01-13'],
-            '--periods' => 'all',
-            '--sites' => '1',
-            '--dry-run' => true,
-            '-vvv' => true,
-        ]);
-
-        $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-13 [segment = all segments]", $this->getLogOutput());
-    }
-
     /**
      * @return iterable<string, array<mixed>>
      */
@@ -350,7 +256,9 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             null,
             [
-                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [ all segments ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [  ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [ browserCode==IE ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [ dimension1==test ]',
             ],
         ];
 
@@ -362,7 +270,9 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             null,
             [
-                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [ all segments ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [  ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [ browserCode==IE ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [ dimension1==test ]',
             ],
         ];
 
@@ -374,7 +284,9 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             null,
             [
-                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2011-12-26 ], period = [ week ], segment = [ all segments ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2011-12-26 ], period = [ week ], segment = [  ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2011-12-26 ], period = [ week ], segment = [ browserCode==IE ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2011-12-26 ], period = [ week ], segment = [ dimension1==test ]',
             ],
         ];
 
@@ -386,12 +298,25 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             null,
             [
-                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01, 2012-02-01 ], period = [ month ], segment = [ all segments ], cascade = [ 0 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01 ], period = [ month ], segment = [ all segments ], cascade = [ 0 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-01 ], period = [ month ], segment = [ all segments ], cascade = [ 0 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2011-12-26, 2012-01-02, 2012-01-09, 2012-01-16, 2012-01-23, 2012-01-30 ], period = [ week ], segment = [ all segments ], cascade = [ 0 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-23 ], period = [ week ], segment = [ all segments ], cascade = [ 0 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-18 ], period = [ week ], segment = [ all segments ], cascade = [ 0 ]',
+                'Segment [dimension1==test] not available for all sites, skipping this segment for sites [ 3 ].',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01, 2012-02-01 ], period = [ month ], segment = [  ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01, 2012-02-01 ], period = [ month ], segment = [ browserCode==IE ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01, 2012-02-01 ], period = [ month ], segment = [ dimension1==test ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01 ], period = [ month ], segment = [  ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01 ], period = [ month ], segment = [ browserCode==IE ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ month ], segment = [ dimension1==test ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-01 ], period = [ month ], segment = [  ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-01 ], period = [ month ], segment = [ browserCode==IE ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2013-03-01 ], period = [ month ], segment = [ dimension1==test ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2011-12-26, 2012-01-02, 2012-01-09, 2012-01-16, 2012-01-23, 2012-01-30 ], period = [ week ], segment = [  ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2011-12-26, 2012-01-02, 2012-01-09, 2012-01-16, 2012-01-23, 2012-01-30 ], period = [ week ], segment = [ browserCode==IE ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2011-12-26, 2012-01-02, 2012-01-09, 2012-01-16, 2012-01-23, 2012-01-30 ], period = [ week ], segment = [ dimension1==test ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-23 ], period = [ week ], segment = [  ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-23 ], period = [ week ], segment = [ browserCode==IE ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-23 ], period = [ week ], segment = [ dimension1==test ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-18 ], period = [ week ], segment = [  ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-18 ], period = [ week ], segment = [ browserCode==IE ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2013-03-18 ], period = [ week ], segment = [ dimension1==test ], cascade = [ 0 ]',
             ],
         ];
 
@@ -403,7 +328,8 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             null,
             [
-                '[Dry-run] invalidating archives for site = [ 2 ], dates = [ 2012-01-30, 2012-02-06 ], period = [ week ], segment = [ all segments ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 2 ], dates = [ 2012-01-30, 2012-02-06 ], period = [ week ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 2 ], dates = [ 2012-01-30, 2012-02-06 ], period = [ week ], segment = [ browserCode==IE ], cascade = [ 1 ]',
             ],
         ];
 
@@ -415,12 +341,25 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             null,
             [
-                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-01 ], period = [ month ], segment = [ all segments ], cascade = [ 1 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-01 ], period = [ month ], segment = [ all segments ], cascade = [ 1 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-01-30 ], period = [ week ], segment = [ all segments ], cascade = [ 1 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-12 ], period = [ week ], segment = [ all segments ], cascade = [ 1 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-03, 2012-02-04 ], period = [ day ], segment = [ all segments ], cascade = [ 1 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-15 ], period = [ day ], segment = [ all segments ], cascade = [ 1 ]',
+                'Segment [dimension1==test] not available for all sites, skipping this segment for sites [ 2, 3 ].',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-01 ], period = [ month ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-01 ], period = [ month ], segment = [ browserCode==IE ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-01 ], period = [ month ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-01 ], period = [ month ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-01 ], period = [ month ], segment = [ browserCode==IE ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-03-01 ], period = [ month ], segment = [ dimension1==test ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-01-30 ], period = [ week ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-01-30 ], period = [ week ], segment = [ browserCode==IE ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-30 ], period = [ week ], segment = [ dimension1==test ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-12 ], period = [ week ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-12 ], period = [ week ], segment = [ browserCode==IE ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-03-12 ], period = [ week ], segment = [ dimension1==test ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-03, 2012-02-04 ], period = [ day ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-03, 2012-02-04 ], period = [ day ], segment = [ browserCode==IE ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-02-03, 2012-02-04 ], period = [ day ], segment = [ dimension1==test ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-15 ], period = [ day ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-15 ], period = [ day ], segment = [ browserCode==IE ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-03-15 ], period = [ day ], segment = [ dimension1==test ], cascade = [ 1 ]',
             ],
         ];
 
@@ -444,7 +383,9 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             'ExamplePlugin',
             [
-                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [ all segments ], cascade = [ 0 ], plugin = [ ExamplePlugin ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [  ], cascade = [ 0 ], plugin = [ ExamplePlugin ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [ browserCode==IE ], cascade = [ 0 ], plugin = [ ExamplePlugin ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [ dimension1==test ], cascade = [ 0 ], plugin = [ ExamplePlugin ]',
             ],
         ];
 
@@ -507,6 +448,599 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
                 '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [  ], cascade = [ 0 ]',
             ],
         ];
+
+        yield 'segment only invalidated for supported sites, whileignoring others' => [
+            ['2012-01-01'],
+            'day',
+            '1,2',
+            false,
+            ['custom dimension'],
+            null,
+            [
+                'Segment [dimension1==test] not available for all sites, skipping this segment for sites [ 2 ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [ dimension1==test ]',
+            ],
+        ];
+
+        yield 'invalidating multiple date ranges' => [
+            ['2019-01-01,2019-01-09', '2019-01-12,2019-01-15'],
+            'range',
+            '1',
+            false,
+            null,
+            null,
+            [
+                "Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-15 for site = [ 1 ], segment = [  ]",
+                "Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-15 for site = [ 1 ], segment = [ browserCode==IE ]",
+                "Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-15 for site = [ 1 ], segment = [ dimension1==test ]",
+            ],
+        ];
+
+        yield 'invalidating period type all for range invalidates all period types' => [
+            ['2019-01-01,2019-01-09'],
+            'all',
+            '1',
+            false,
+            null,
+            null,
+            [
+                "Invalidating day periods in 2019-01-01,2019-01-09 for site = [ 1 ], segment = [  ]",
+                "Invalidating day periods in 2019-01-01,2019-01-09 for site = [ 1 ], segment = [ browserCode==IE ]",
+                "Invalidating day periods in 2019-01-01,2019-01-09 for site = [ 1 ], segment = [ dimension1==test ]",
+                "Invalidating week periods in 2019-01-01,2019-01-09 for site = [ 1 ], segment = [  ]",
+                "Invalidating week periods in 2019-01-01,2019-01-09 for site = [ 1 ], segment = [ browserCode==IE ]",
+                "Invalidating week periods in 2019-01-01,2019-01-09 for site = [ 1 ], segment = [ dimension1==test ]",
+                "Invalidating month periods in 2019-01-01,2019-01-09 for site = [ 1 ], segment = [  ]",
+                "Invalidating month periods in 2019-01-01,2019-01-09 for site = [ 1 ], segment = [ browserCode==IE ]",
+                "Invalidating month periods in 2019-01-01,2019-01-09 for site = [ 1 ], segment = [ dimension1==test ]",
+                "Invalidating year periods in 2019-01-01,2019-01-09 for site = [ 1 ], segment = [  ]",
+                "Invalidating year periods in 2019-01-01,2019-01-09 for site = [ 1 ], segment = [ browserCode==IE ]",
+                "Invalidating year periods in 2019-01-01,2019-01-09 for site = [ 1 ], segment = [ dimension1==test ]",
+                "Invalidating range periods overlapping 2019-01-01,2019-01-09 for site = [ 1 ], segment = [  ]",
+                "Invalidating range periods overlapping 2019-01-01,2019-01-09 for site = [ 1 ], segment = [ browserCode==IE ]",
+                "Invalidating range periods overlapping 2019-01-01,2019-01-09 for site = [ 1 ], segment = [ dimension1==test ]",
+            ],
+        ];
+    }
+
+
+    /**
+     * @dataProvider getInvalidationTestData
+     */
+    public function testCommandCreatesExpectedInvalidations(array $commandOptions, array $expectedInvalidations)
+    {
+        Db::query('TRUNCATE table ' . Common::prefixTable('archive_invalidations'));
+
+        $commandOptions = array_merge(['command' => 'core:invalidate-report-data'], $commandOptions);
+
+        $code = $this->applicationTester->run($commandOptions);
+
+        self::assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+
+        self::assertInvalidationsPresent($expectedInvalidations);
+    }
+
+    public function getInvalidationTestData(): iterable
+    {
+        yield "Invalidating a single day works for all segments, one website" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1',
+            ],
+            [
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a single day works for all visits segment only, one website" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1',
+                '--segment' => [''],
+            ],
+            [
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a single day works for specific segment only, one website" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1',
+                '--segment' => ['browserCode==IE'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a single day works for multiple segments, one website" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1',
+                '--segment' => ['browserCode==IE', 'dimension1==test'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating plugin for a single day works for all visits segment only, one website" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1',
+                '--segment' => [''],
+                '--plugin' => 'Actions'
+            ],
+            [
+                ['name' => 'done.Actions', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done.Actions', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done.Actions', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done.Actions', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating plugin for a single day works for all segments, one website" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1',
+                '--plugin' => 'Actions'
+            ],
+            [
+                ['name' => 'done.Actions', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done.Actions', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done.Actions', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done.Actions', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc.Actions', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc.Actions', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc.Actions', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc.Actions', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279.Actions', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279.Actions', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279.Actions', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279.Actions', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a single day as period works for segment, one website" => [
+            [
+                '--dates' => ['2012-01-01,2012-01-01'],
+                '--sites' => '1',
+                '--segment' => ['browserCode==IE'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a period works for all segments, one website" => [
+            [
+                '--dates' => ['2012-01-01,2012-01-12'],
+                '--sites' => '1',
+            ],
+            [
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-02', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-03', 'date2' => '2012-01-03', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-04', 'date2' => '2012-01-04', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-05', 'date2' => '2012-01-05', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-06', 'date2' => '2012-01-06', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-07', 'date2' => '2012-01-07', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-08', 'date2' => '2012-01-08', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-09', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-10', 'date2' => '2012-01-10', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-11', 'date2' => '2012-01-11', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-12', 'date2' => '2012-01-12', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-15', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-02', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-03', 'date2' => '2012-01-03', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-04', 'date2' => '2012-01-04', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-05', 'date2' => '2012-01-05', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-06', 'date2' => '2012-01-06', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-07', 'date2' => '2012-01-07', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-08', 'date2' => '2012-01-08', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-09', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-10', 'date2' => '2012-01-10', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-11', 'date2' => '2012-01-11', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-12', 'date2' => '2012-01-12', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-15', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-02', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-03', 'date2' => '2012-01-03', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-04', 'date2' => '2012-01-04', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-05', 'date2' => '2012-01-05', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-06', 'date2' => '2012-01-06', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-07', 'date2' => '2012-01-07', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-08', 'date2' => '2012-01-08', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-09', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-10', 'date2' => '2012-01-10', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-11', 'date2' => '2012-01-11', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-12', 'date2' => '2012-01-12', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-15', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a multiple dates works for all segments, one website" => [
+            [
+                '--dates' => ['2012-01-01', '2012-01-06', '2012-01-12'],
+                '--sites' => '1',
+            ],
+            [
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-06', 'date2' => '2012-01-06', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-12', 'date2' => '2012-01-12', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-15', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-06', 'date2' => '2012-01-06', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-12', 'date2' => '2012-01-12', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-15', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-06', 'date2' => '2012-01-06', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-12', 'date2' => '2012-01-12', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-15', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating multiple periods works for all segments, one website" => [
+            [
+                '--dates' => ['2012-01-01,2012-01-03', '2012-01-06,2012-01-07', '2012-01-10,2012-01-12'],
+                '--sites' => '1',
+            ],
+            [
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-02', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-03', 'date2' => '2012-01-03', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-06', 'date2' => '2012-01-06', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-07', 'date2' => '2012-01-07', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-10', 'date2' => '2012-01-10', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-11', 'date2' => '2012-01-11', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-12', 'date2' => '2012-01-12', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-15', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-02', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-03', 'date2' => '2012-01-03', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-06', 'date2' => '2012-01-06', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-07', 'date2' => '2012-01-07', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-10', 'date2' => '2012-01-10', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-11', 'date2' => '2012-01-11', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-12', 'date2' => '2012-01-12', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-15', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-02', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-03', 'date2' => '2012-01-03', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-06', 'date2' => '2012-01-06', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-07', 'date2' => '2012-01-07', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-10', 'date2' => '2012-01-10', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-11', 'date2' => '2012-01-11', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-12', 'date2' => '2012-01-12', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-15', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a single day works for all segments, multiple websites" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1,2',
+            ],
+            [
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done', 'idsite' => 2, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done', 'idsite' => 2, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done', 'idsite' => 2, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done', 'idsite' => 2, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 2, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 2, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 2, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 2, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                // second segment is only valid for idsite 1, so missing here
+            ]
+        ];
+
+        yield "Invalidating a week period works for specific segment only, one website" => [
+            [
+                '--dates' => ['2012-01-08'],
+                '--sites' => '1',
+                '--periods' => 'week',
+                '--segment' => ['browserCode==IE'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a week period accross years should not cascade up, one website" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1',
+                '--periods' => 'week',
+                '--segment' => ['browserCode==IE'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a week period accross months should not cascade up, one website" => [
+            [
+                '--dates' => ['2012-01-31'],
+                '--sites' => '1',
+                '--periods' => 'week',
+                '--segment' => ['browserCode==IE'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-30', 'date2' => '2012-02-05', 'period' => 2, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a month period works for specific segment only, one website" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1',
+                '--periods' => 'month',
+                '--segment' => ['browserCode==IE'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a year period works for specific segment only, one website" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1',
+                '--periods' => 'year',
+                '--segment' => ['browserCode==IE'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a month period works for specific segment only, one website, cascade down" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1',
+                '--periods' => 'month',
+                '--cascade' => true,
+                '--segment' => ['browserCode==IE'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-02', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-03', 'date2' => '2012-01-03', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-04', 'date2' => '2012-01-04', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-05', 'date2' => '2012-01-05', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-06', 'date2' => '2012-01-06', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-07', 'date2' => '2012-01-07', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-08', 'date2' => '2012-01-08', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-09', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-10', 'date2' => '2012-01-10', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-11', 'date2' => '2012-01-11', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-12', 'date2' => '2012-01-12', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-13', 'date2' => '2012-01-13', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-14', 'date2' => '2012-01-14', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-15', 'date2' => '2012-01-15', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-16', 'date2' => '2012-01-16', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-17', 'date2' => '2012-01-17', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-18', 'date2' => '2012-01-18', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-19', 'date2' => '2012-01-19', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-20', 'date2' => '2012-01-20', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-21', 'date2' => '2012-01-21', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-22', 'date2' => '2012-01-22', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-23', 'date2' => '2012-01-23', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-24', 'date2' => '2012-01-24', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-25', 'date2' => '2012-01-25', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-26', 'date2' => '2012-01-26', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-27', 'date2' => '2012-01-27', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-28', 'date2' => '2012-01-28', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-29', 'date2' => '2012-01-29', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-30', 'date2' => '2012-01-30', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-31', 'date2' => '2012-01-31', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-09', 'date2' => '2012-01-15', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-16', 'date2' => '2012-01-22', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-23', 'date2' => '2012-01-29', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-30', 'date2' => '2012-02-05', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a week period accross years should not cascade up, one website, cascade down" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1',
+                '--periods' => 'week',
+                '--cascade' => true,
+                '--segment' => ['browserCode==IE'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2011-12-26', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-27', 'date2' => '2011-12-27', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-28', 'date2' => '2011-12-28', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-29', 'date2' => '2011-12-29', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-30', 'date2' => '2011-12-30', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-31', 'date2' => '2011-12-31', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-01', 'date2' => '2011-12-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-01-01', 'date2' => '2011-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a week period accross years should not invalidate dates before website creation, one website, cascade down" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '2',
+                '--periods' => 'week',
+                '--cascade' => true,
+                '--segment' => ['browserCode==IE'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 2, 'date1' => '2012-01-01', 'date2' => '2012-01-01', 'period' => 1, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 2, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 2, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 2, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating a multiple periods works for specific segment only, one website, no cascade" => [
+            [
+                '--dates' => ['2012-01-01'],
+                '--sites' => '1',
+                '--periods' => 'week,year',
+                '--cascade' => false,
+                '--segment' => ['browserCode==IE'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+    }
+
+    public function testCommandInvalidateDateRange()
+    {
+        $code = $this->applicationTester->run([
+            'command' => 'core:invalidate-report-data',
+            '--dates' => ['2019-01-01,2019-01-09'],
+            '--periods' => 'range',
+            '--sites' => '1',
+            '--dry-run' => true,
+            '-vvv' => true,
+        ]);
+
+        $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 for site = [ 1 ], segment = [  ]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 for site = [ 1 ], segment = [ browserCode==IE ]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 for site = [ 1 ], segment = [ dimension1==test ]", $this->getLogOutput());
+    }
+
+    public function testCommandInvalidateDateRangeInvalidDate()
+    {
+        $code = $this->applicationTester->run([
+            'command' => 'core:invalidate-report-data',
+            '--dates' => ['2019-01-01,2019-01--09'],
+            '--periods' => 'range',
+            '--sites' => '1',
+            '--dry-run' => true,
+            '-vvv' => true,
+        ]);
+
+        $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+        self::assertStringContainsString("The date '2019-01-01,2019-01--09' is not a correct date range", $this->getLogOutput());
+    }
+
+    public function testCommandInvalidateDateRangeOnlyOneDate()
+    {
+        $code = $this->applicationTester->run([
+            'command' => 'core:invalidate-report-data',
+            '--dates' => ['2019-01-01'],
+            '--periods' => 'range',
+            '--sites' => '1',
+            '--dry-run' => true,
+            '-vvv' => true,
+        ]);
+
+        $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+        self::assertStringContainsString("The date '2019-01-01' is not a correct date range", $this->getLogOutput());
+    }
+
+    public function testCommandInvalidateDateRangeInvalidateAllPeriodTypesSkipsRangeWhenNotRangeDAte()
+    {
+        $code = $this->applicationTester->run([
+            'command' => 'core:invalidate-report-data',
+            '--dates' => ['2019-01-01'],
+            '--periods' => 'all',
+            '--sites' => '1',
+            '--dry-run' => true,
+            '-vvv' => true,
+        ]);
+
+        $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+        self::assertStringNotContainsString("range", $this->getLogOutput());
+        self::assertStringNotContainsString("Range", $this->getLogOutput());
     }
 
     /**
@@ -535,5 +1069,12 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
     private function getLogOutput(): string
     {
         return implode("\n", self::$captureHandler->messages);
+    }
+
+    private static function assertInvalidationsPresent(array $expectedInvalidations): void
+    {
+        $existingInvalidations = Db::fetchAll('SELECT name, idsite, date1, date2, period, report from ' . Common::prefixTable('archive_invalidations') . ' ORDER BY idsite, name, period, date1');
+
+        self::assertEquals($expectedInvalidations, $existingInvalidations);
     }
 }

--- a/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php
@@ -700,7 +700,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             ]
         ];
 
-        yield "Invalidating a multiple dates works for all segments, one website" => [
+        yield "Invalidating multiple dates works for all segments, one website" => [
             [
                 '--dates' => ['2012-01-01', '2012-01-06', '2012-01-12'],
                 '--sites' => '1',
@@ -949,7 +949,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             ]
         ];
 
-        yield "Invalidating a week period accross years should not invalidate dates before website creation, one website, cascade down" => [
+        yield "Invalidating a week period should not invalidate dates before website creation, one website, cascade down" => [
             [
                 '--dates' => ['2012-01-01'],
                 '--sites' => '2',
@@ -965,17 +965,39 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             ]
         ];
 
-        yield "Invalidating a multiple periods works for specific segment only, one website, no cascade" => [
+        yield "Invalidating multiple periods works for specific segment only, one website, no cascade" => [
             [
                 '--dates' => ['2012-01-01'],
                 '--sites' => '1',
                 '--periods' => 'week,year',
-                '--cascade' => false,
                 '--segment' => ['browserCode==IE'],
             ],
             [
                 ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
                 ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+            ]
+        ];
+
+        yield "Invalidating plugin for multiple periods works for specific multiple segments, multiple websites, no cascade" => [
+            [
+                '--dates' => ['2012-01-01', '2012-01-06,2012-01-07'],
+                '--sites' => '1,2',
+                '--periods' => 'week,year',
+                '--segment' => ['browserCode==IE', 'dimension1==test'],
+            ],
+            [
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done9aedf9b6022140586347897209404279', 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 2, 'date1' => '2011-12-26', 'date2' => '2012-01-01', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 2, 'date1' => '2012-01-02', 'date2' => '2012-01-08', 'period' => 2, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 2, 'date1' => '2012-01-01', 'date2' => '2012-01-31', 'period' => 3, 'report' => null],
+                ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 2, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'report' => null],
             ]
         ];
     }

--- a/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php
@@ -224,7 +224,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ]);
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = all segments]", $this->getLogOutput());
     }
 
     public function testCommandInvalidateDateRangeInvalidDate()
@@ -315,11 +315,11 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ]);
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalidating day periods in 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
-        self::assertStringContainsString("Invalidating week periods in 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
-        self::assertStringContainsString("Invalidating month periods in 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
-        self::assertStringContainsString("Invalidating year periods in 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
-        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating day periods in 2019-01-01,2019-01-09 [segment = all segments]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating week periods in 2019-01-01,2019-01-09 [segment = all segments]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating month periods in 2019-01-01,2019-01-09 [segment = all segments]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating year periods in 2019-01-01,2019-01-09 [segment = all segments]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = all segments]", $this->getLogOutput());
     }
 
     public function testCommandInvalidateAllMultipleDateRanges()
@@ -334,7 +334,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ]);
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-13 [segment = ]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-13 [segment = all segments]", $this->getLogOutput());
     }
 
     /**
@@ -350,7 +350,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             null,
             [
-                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [  ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [ all segments ]',
             ],
         ];
 
@@ -362,7 +362,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             null,
             [
-                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [  ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2012-01-01 ], period = [ day ], segment = [ all segments ]',
             ],
         ];
 
@@ -374,7 +374,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             null,
             [
-                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2011-12-26 ], period = [ week ], segment = [  ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2011-12-26 ], period = [ week ], segment = [ all segments ]',
             ],
         ];
 
@@ -386,12 +386,12 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             null,
             [
-                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01, 2012-02-01 ], period = [ month ], segment = [  ], cascade = [ 0 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01 ], period = [ month ], segment = [  ], cascade = [ 0 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-01 ], period = [ month ], segment = [  ], cascade = [ 0 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2011-12-26, 2012-01-02, 2012-01-09, 2012-01-16, 2012-01-23, 2012-01-30 ], period = [ week ], segment = [  ], cascade = [ 0 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-23 ], period = [ week ], segment = [  ], cascade = [ 0 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-18 ], period = [ week ], segment = [  ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01, 2012-02-01 ], period = [ month ], segment = [ all segments ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-01 ], period = [ month ], segment = [ all segments ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-01 ], period = [ month ], segment = [ all segments ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2011-12-26, 2012-01-02, 2012-01-09, 2012-01-16, 2012-01-23, 2012-01-30 ], period = [ week ], segment = [ all segments ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2012-01-23 ], period = [ week ], segment = [ all segments ], cascade = [ 0 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 3 ], dates = [ 2013-03-18 ], period = [ week ], segment = [ all segments ], cascade = [ 0 ]',
             ],
         ];
 
@@ -403,7 +403,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             null,
             [
-                '[Dry-run] invalidating archives for site = [ 2 ], dates = [ 2012-01-30, 2012-02-06 ], period = [ week ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 2 ], dates = [ 2012-01-30, 2012-02-06 ], period = [ week ], segment = [ all segments ], cascade = [ 1 ]',
             ],
         ];
 
@@ -415,12 +415,12 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             null,
             [
-                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-01 ], period = [ month ], segment = [  ], cascade = [ 1 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-01 ], period = [ month ], segment = [  ], cascade = [ 1 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-01-30 ], period = [ week ], segment = [  ], cascade = [ 1 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-12 ], period = [ week ], segment = [  ], cascade = [ 1 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-03, 2012-02-04 ], period = [ day ], segment = [  ], cascade = [ 1 ]',
-                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-15 ], period = [ day ], segment = [  ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-01 ], period = [ month ], segment = [ all segments ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-01 ], period = [ month ], segment = [ all segments ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-01-30 ], period = [ week ], segment = [ all segments ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-12 ], period = [ week ], segment = [ all segments ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-02-03, 2012-02-04 ], period = [ day ], segment = [ all segments ], cascade = [ 1 ]',
+                '[Dry-run] invalidating archives for site = [ 1, 2, 3 ], dates = [ 2012-03-15 ], period = [ day ], segment = [ all segments ], cascade = [ 1 ]',
             ],
         ];
 
@@ -444,7 +444,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             'ExamplePlugin',
             [
-                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [  ], cascade = [ 0 ], plugin = [ ExamplePlugin ]',
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [ all segments ], cascade = [ 0 ], plugin = [ ExamplePlugin ]',
             ],
         ];
 
@@ -493,6 +493,18 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
             null,
             [
                 '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [ dimension1==test ], cascade = [ 0 ]',
+            ],
+        ];
+
+        yield 'all visits segment only' => [
+            ['2015-05-04'],
+            'day',
+            '1',
+            false,
+            [''],
+            null,
+            [
+                '[Dry-run] invalidating archives for site = [ 1 ], dates = [ 2015-05-04 ], period = [ day ], segment = [  ], cascade = [ 0 ]',
             ],
         ];
     }

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
@@ -1001,7 +1001,7 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
             API::getInstance()->add('test segment 2', self::TEST_SEGMENT_2, false, true);
         }
 
-        if (!empty($segment)) {
+        if (null !== $segment) {
             $segment = new Segment($segment, $idSites);
         }
 
@@ -1028,708 +1028,484 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
         $this->assertTrue(count($uniqueArchives) == count($invalidatedIdArchives), "duplicates inserted");
     }
 
-    public function getTestDataForMarkArchivesAsInvalidated()
+    public function getTestDataForMarkArchivesAsInvalidated(): iterable
     {
-        // $idSites, $dates, $period, $segment, $cascadeDown, $expectedIdArchives
-        return array(
-            // day period, multiple sites, multiple dates across tables, cascade = true
-            array(
-                array(1, 2),
-                array('2015-01-01', '2015-02-05', '2015-04-30'),
-                'day',
-                null,
-                true,
-                array(
-                    '2015_04' => array(
-                        '1.2015-04-30.2015-04-30.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '2.2015-04-30.2015-04-30.1.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-04-27.2015-05-03.2.done',
-                        '2.2015-04-27.2015-05-03.2.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-04-01.2015-04-30.3.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '2.2015-04-01.2015-04-30.3.done5447835b0a861475918e79e932abdfd8',
-                    ),
-                    '2015_01' => array(
-                        '1.2015-01-01.2015-01-01.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '2.2015-01-01.2015-01-01.1.done.VisitsSummary',
-                        '1.2015-01-01.2015-01-31.3.done3736b708e4d20cfc10610e816a1b2341',
-                        '2.2015-01-01.2015-01-31.3.done.VisitsSummary',
-                        '1.2015-01-01.2015-12-31.4.done5447835b0a861475918e79e932abdfd8',
-                        '2.2015-01-01.2015-12-31.4.done',
-                        '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
-                    ),
-                    '2015_02' => array(
-                        '1.2015-02-05.2015-02-05.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '2.2015-02-05.2015-02-05.1.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-02-02.2015-02-08.2.done',
-                        '2.2015-02-02.2015-02-08.2.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-02-01.2015-02-28.3.done.VisitsSummary',
-                        '2.2015-02-01.2015-02-28.3.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                    ),
-                    '2014_12' => [
-                        '1.2014-12-29.2015-01-04.2.done3736b708e4d20cfc10610e816a1b2341',
-                        '2.2014-12-29.2015-01-04.2.done.VisitsSummary',
-                    ],
-                ),
-                [
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-02-01', 'date2' => '2015-02-28', 'period' => '3', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '85', 'idsite' => '1', 'date1' => '2015-02-02', 'date2' => '2015-02-08', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-02-05', 'date2' => '2015-02-05', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-04-01', 'date2' => '2015-04-30', 'period' => '3', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '100', 'idsite' => '1', 'date1' => '2015-04-27', 'date2' => '2015-05-03', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-04-30', 'date2' => '2015-04-30', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '2', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '110', 'idsite' => '2', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-02-01', 'date2' => '2015-02-28', 'period' => '3', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-02-02', 'date2' => '2015-02-08', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-02-05', 'date2' => '2015-02-05', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-04-01', 'date2' => '2015-04-30', 'period' => '3', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-04-27', 'date2' => '2015-05-03', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-04-30', 'date2' => '2015-04-30', 'period' => '1', 'name' => 'done', 'report' => null],
-                ],
-            ),
-
-            // month period, one site, one date, cascade = false
-            array(
-                array(1),
-                array('2015-01-01'),
-                'month',
-                null,
-                false,
-                array(
-                    '2015_01' => array(
-                        '1.2015-01-01.2015-01-31.3.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-01.2015-12-31.4.done5447835b0a861475918e79e932abdfd8',
-                    ),
-                ),
-                [
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
-                ],
-            ),
-
-            // month period, one site, one date, cascade = true
-            array(
-                array(1),
-                array('2015-01-15'),
-                'month',
-                null,
-                true,
-                array(
-                    '2014_12' => array(
-                        '1.2014-12-29.2015-01-04.2.done3736b708e4d20cfc10610e816a1b2341',
-                    ),
-                    '2015_01' => array(
-                        '1.2015-01-01.2015-01-01.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-02.2015-01-02.1.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-01-03.2015-01-03.1.done.VisitsSummary',
-                        '1.2015-01-04.2015-01-04.1.done',
-                        '1.2015-01-05.2015-01-05.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-06.2015-01-06.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-07.2015-01-07.1.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-01-08.2015-01-08.1.done.VisitsSummary',
-                        '1.2015-01-09.2015-01-09.1.done',
-                        '1.2015-01-10.2015-01-10.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-11.2015-01-11.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-12.2015-01-12.1.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-01-13.2015-01-13.1.done.VisitsSummary',
-                        '1.2015-01-14.2015-01-14.1.done',
-                        '1.2015-01-15.2015-01-15.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-16.2015-01-16.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-17.2015-01-17.1.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-01-18.2015-01-18.1.done.VisitsSummary',
-                        '1.2015-01-19.2015-01-19.1.done',
-                        '1.2015-01-20.2015-01-20.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-21.2015-01-21.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-22.2015-01-22.1.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-01-23.2015-01-23.1.done.VisitsSummary',
-                        '1.2015-01-24.2015-01-24.1.done',
-                        '1.2015-01-25.2015-01-25.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-26.2015-01-26.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-27.2015-01-27.1.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-01-28.2015-01-28.1.done.VisitsSummary',
-                        '1.2015-01-29.2015-01-29.1.done',
-                        '1.2015-01-30.2015-01-30.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-31.2015-01-31.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-05.2015-01-11.2.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-01-12.2015-01-18.2.done.VisitsSummary',
-                        '1.2015-01-19.2015-01-25.2.done',
-                        '1.2015-01-26.2015-02-01.2.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-01.2015-01-31.3.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-01.2015-12-31.4.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
-                    ),
-                ),
-                [
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-02', 'date2' => '2015-01-02', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-03', 'date2' => '2015-01-03', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '10', 'idsite' => '1', 'date1' => '2015-01-04', 'date2' => '2015-01-04', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-05', 'date2' => '2015-01-05', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-05', 'date2' => '2015-01-11', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-06', 'date2' => '2015-01-06', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-07', 'date2' => '2015-01-07', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-08', 'date2' => '2015-01-08', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '25', 'idsite' => '1', 'date1' => '2015-01-09', 'date2' => '2015-01-09', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-10', 'date2' => '2015-01-10', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-11', 'date2' => '2015-01-11', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-12', 'date2' => '2015-01-12', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-12', 'date2' => '2015-01-18', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-13', 'date2' => '2015-01-13', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '40', 'idsite' => '1', 'date1' => '2015-01-14', 'date2' => '2015-01-14', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-15', 'date2' => '2015-01-15', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-16', 'date2' => '2015-01-16', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-17', 'date2' => '2015-01-17', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-18', 'date2' => '2015-01-18', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '55', 'idsite' => '1', 'date1' => '2015-01-19', 'date2' => '2015-01-19', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '100', 'idsite' => '1', 'date1' => '2015-01-19', 'date2' => '2015-01-25', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-20', 'date2' => '2015-01-20', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-21', 'date2' => '2015-01-21', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-22', 'date2' => '2015-01-22', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-23', 'date2' => '2015-01-23', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '70', 'idsite' => '1', 'date1' => '2015-01-24', 'date2' => '2015-01-24', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-25', 'date2' => '2015-01-25', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-26', 'date2' => '2015-01-26', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-26', 'date2' => '2015-02-01', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-27', 'date2' => '2015-01-27', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-28', 'date2' => '2015-01-28', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '85', 'idsite' => '1', 'date1' => '2015-01-29', 'date2' => '2015-01-29', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-30', 'date2' => '2015-01-30', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-31', 'date2' => '2015-01-31', 'period' => '1', 'name' => 'done', 'report' => null],
-                ],
-            ),
-
-            // week period, one site, multiple dates w/ redundant dates & periods, cascade = true
-            array(
-                array(1),
-                array('2015-01-02', '2015-01-03', '2015-01-31'),
-                'week',
-                null,
-                true,
-                array(
-                    '2014_12' => array(
-                        '1.2014-12-29.2014-12-29.1.done',
-                        '1.2014-12-30.2014-12-30.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2014-12-31.2014-12-31.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2014-12-29.2015-01-04.2.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2014-12-01.2014-12-31.3.done5447835b0a861475918e79e932abdfd8',
-                        '1.2014-12-05.2015-01-01.5.done.VisitsSummary',
-                    ),
-                    '2015_01' => array(
-                        '1.2015-01-01.2015-01-01.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-02.2015-01-02.1.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-01-03.2015-01-03.1.done.VisitsSummary',
-                        '1.2015-01-04.2015-01-04.1.done',
-                        '1.2015-01-26.2015-01-26.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-27.2015-01-27.1.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-01-28.2015-01-28.1.done.VisitsSummary',
-                        '1.2015-01-29.2015-01-29.1.done',
-                        '1.2015-01-30.2015-01-30.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-31.2015-01-31.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-26.2015-02-01.2.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-01.2015-01-31.3.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-01.2015-12-31.4.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
-                    ),
-                    '2015_02' => array(
-                        '1.2015-02-01.2015-02-01.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-02-01.2015-02-28.3.done.VisitsSummary',
-                    ),
-                    '2014_01' => [
-                        '1.2014-01-01.2014-12-31.4.done3736b708e4d20cfc10610e816a1b2341',
-                    ],
-                ),
-                [
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-01-01', 'date2' => '2014-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-01', 'date2' => '2014-12-31', 'period' => '3', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '85', 'idsite' => '1', 'date1' => '2014-12-29', 'date2' => '2014-12-29', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-30', 'date2' => '2014-12-30', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-31', 'date2' => '2014-12-31', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-02', 'date2' => '2015-01-02', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-03', 'date2' => '2015-01-03', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '10', 'idsite' => '1', 'date1' => '2015-01-04', 'date2' => '2015-01-04', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-26', 'date2' => '2015-01-26', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-26', 'date2' => '2015-02-01', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-27', 'date2' => '2015-01-27', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-28', 'date2' => '2015-01-28', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => '85', 'idsite' => '1', 'date1' => '2015-01-29', 'date2' => '2015-01-29', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-30', 'date2' => '2015-01-30', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-31', 'date2' => '2015-01-31', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-02-01', 'date2' => '2015-02-01', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-02-01', 'date2' => '2015-02-28', 'period' => '3', 'name' => 'done', 'report' => null],
-                ],
-            ),
-
-            // range period, exact match, cascade = true
-            array(
-                array(1),
-                array('2015-01-01', '2015-01-10'),
-                'range',
-                null,
-                true,
-                array(
-                    '2015_01' => array(
-                        '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
-                    ),
-                ),
-                [
-                    // empty
-                ],
-            ),
-
-            // range period, overlapping a range in the DB
-            array(
-                array(1),
-                array('2015-01-02', '2015-03-05'),
-                'range',
-                null,
-                true,
-                array(
-                    '2015_01' => array(
-                        '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
-                    ),
-                    '2015_03' => [
-                        '1.2015-03-04.2015-03-05.5.done.VisitsSummary',
-                        '1.2015-03-05.2015-03-10.5.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                    ],
-                ),
-                [
-                    // empty
-                ],
-            ),
-
-            // week period, one site, cascade = true, segment
-            array(
-                array(1),
-                array('2015-01-05'),
-                'month',
-                self::TEST_SEGMENT_1,
-                true,
-                array(
-                    '2014_12' => array(
-                        '1.2014-12-29.2015-01-04.2.done3736b708e4d20cfc10610e816a1b2341',
-                    ),
-                    '2015_01' => array(
-                        '1.2015-01-01.2015-01-01.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-05.2015-01-05.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-06.2015-01-06.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-10.2015-01-10.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-11.2015-01-11.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-15.2015-01-15.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-16.2015-01-16.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-20.2015-01-20.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-21.2015-01-21.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-25.2015-01-25.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-26.2015-01-26.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-30.2015-01-30.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-31.2015-01-31.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-01-26.2015-02-01.2.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-01-01.2015-01-31.3.done3736b708e4d20cfc10610e816a1b2341',
-                    ),
-                ),
-                [
-                    ['idarchive' => '106', 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => '1', 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-02', 'date2' => '2015-01-02', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-03', 'date2' => '2015-01-03', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-04', 'date2' => '2015-01-04', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-05', 'date2' => '2015-01-11', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-05', 'date2' => '2015-01-05', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => '16', 'idsite' => '1', 'date1' => '2015-01-06', 'date2' => '2015-01-06', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-07', 'date2' => '2015-01-07', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-08', 'date2' => '2015-01-08', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-09', 'date2' => '2015-01-09', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-10', 'date2' => '2015-01-10', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => '31', 'idsite' => '1', 'date1' => '2015-01-11', 'date2' => '2015-01-11', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-12', 'date2' => '2015-01-18', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-12', 'date2' => '2015-01-12', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-13', 'date2' => '2015-01-13', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-14', 'date2' => '2015-01-14', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-15', 'date2' => '2015-01-15', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => '46', 'idsite' => '1', 'date1' => '2015-01-16', 'date2' => '2015-01-16', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-17', 'date2' => '2015-01-17', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-18', 'date2' => '2015-01-18', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-19', 'date2' => '2015-01-25', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-19', 'date2' => '2015-01-19', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-20', 'date2' => '2015-01-20', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => '61', 'idsite' => '1', 'date1' => '2015-01-21', 'date2' => '2015-01-21', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-22', 'date2' => '2015-01-22', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-23', 'date2' => '2015-01-23', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-24', 'date2' => '2015-01-24', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-25', 'date2' => '2015-01-25', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => '76', 'idsite' => '1', 'date1' => '2015-01-26', 'date2' => '2015-01-26', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-26', 'date2' => '2015-02-01', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-27', 'date2' => '2015-01-27', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-28', 'date2' => '2015-01-28', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-29', 'date2' => '2015-01-29', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-30', 'date2' => '2015-01-30', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    // archive id 106 occurs a second time as it comes from a different archive table
-                    ['idarchive' => '106', 'idsite' => '1', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                    ['idarchive' => '91', 'idsite' => '1', 'date1' => '2015-01-31', 'date2' => '2015-01-31', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
-                ],
-            ),
-
-            // removing all periods
-            array(
-                array(1),
-                array('2015-05-05'),
-                '',
-                null,
-                false,
-                array(
-                    '2015_01' => array(
-                        '1.2015-01-01.2015-12-31.4.done5447835b0a861475918e79e932abdfd8',
-                    ),
-                    '2015_05' => array(
-                        '1.2015-05-05.2015-05-05.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '1.2015-05-04.2015-05-10.2.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-05-01.2015-05-31.3.done3736b708e4d20cfc10610e816a1b2341',
-                    ),
-                ),
-                [
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-05-05', 'date2' => '2015-05-05', 'period' => '1', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-05-04', 'date2' => '2015-05-10', 'period' => '2', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-05-01', 'date2' => '2015-05-31', 'period' => '3', 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
-                ],
-            ),
-
-            // period before site creation date
+        yield 'day period, multiple sites, multiple dates across tables, cascade = true' => [
+            [1, 2],
+            ['2015-01-01', '2015-02-05', '2015-04-30'],
+            'day',
+            null,
+            true,
             [
-                [1],
-                ['2012-03-02'],
-                '',
-                null,
-                false,
-                [
-                    // empty
+                '2015_04' => [
+                    '1.2015-04-30.2015-04-30.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '2.2015-04-30.2015-04-30.1.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-04-27.2015-05-03.2.done',
+                    '2.2015-04-27.2015-05-03.2.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-04-01.2015-04-30.3.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '2.2015-04-01.2015-04-30.3.done5447835b0a861475918e79e932abdfd8',
                 ],
-                [
-                    // month week and year exist, but not day since it is before the site was created
-                    ['idarchive' => null, 'idsite' => 1, 'date1' => '2012-03-01', 'date2' => '2012-03-31', 'period' => 3, 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => 1, 'date1' => '2012-02-27', 'date2' => '2012-03-04', 'period' => 2, 'name' => 'done', 'report' => null],
-                    ['idarchive' => null, 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'name' => 'done', 'report' => null],
+                '2015_01' => [
+                    '1.2015-01-01.2015-01-01.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '2.2015-01-01.2015-01-01.1.done.VisitsSummary',
+                    '1.2015-01-01.2015-01-31.3.done3736b708e4d20cfc10610e816a1b2341',
+                    '2.2015-01-01.2015-01-31.3.done.VisitsSummary',
+                    '1.2015-01-01.2015-12-31.4.done5447835b0a861475918e79e932abdfd8',
+                    '2.2015-01-01.2015-12-31.4.done',
+                    '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
+                ],
+                '2015_02' => [
+                    '1.2015-02-05.2015-02-05.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '2.2015-02-05.2015-02-05.1.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-02-02.2015-02-08.2.done',
+                    '2.2015-02-02.2015-02-08.2.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-02-01.2015-02-28.3.done.VisitsSummary',
+                    '2.2015-02-01.2015-02-28.3.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                ],
+                '2014_12' => [
+                    '1.2014-12-29.2015-01-04.2.done3736b708e4d20cfc10610e816a1b2341',
+                    '2.2014-12-29.2015-01-04.2.done.VisitsSummary',
                 ],
             ],
+            [
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-02-01', 'date2' => '2015-02-28', 'period' => '3', 'name' => 'done', 'report' => null],
+                ['idarchive' => '85', 'idsite' => '1', 'date1' => '2015-02-02', 'date2' => '2015-02-08', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-02-05', 'date2' => '2015-02-05', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-04-01', 'date2' => '2015-04-30', 'period' => '3', 'name' => 'done', 'report' => null],
+                ['idarchive' => '100', 'idsite' => '1', 'date1' => '2015-04-27', 'date2' => '2015-05-03', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-04-30', 'date2' => '2015-04-30', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done', 'report' => null],
+                ['idarchive' => '110', 'idsite' => '2', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-02-01', 'date2' => '2015-02-28', 'period' => '3', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-02-02', 'date2' => '2015-02-08', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-02-05', 'date2' => '2015-02-05', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-04-01', 'date2' => '2015-04-30', 'period' => '3', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-04-27', 'date2' => '2015-05-03', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-04-30', 'date2' => '2015-04-30', 'period' => '1', 'name' => 'done', 'report' => null],
+            ],
+        ];
 
-            // day period, multiple sites, multiple dates across tables, stored segments added
-            array(
-                array(1, 2),
-                array('2015-01-01', '2015-02-05', '2015-04-30'),
-                'day',
-                null,
-                false,
-                array(
-                    '2015_04' => array(
-                        '1.2015-04-30.2015-04-30.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '2.2015-04-30.2015-04-30.1.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-04-27.2015-05-03.2.done',
-                        '2.2015-04-27.2015-05-03.2.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-04-01.2015-04-30.3.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '2.2015-04-01.2015-04-30.3.done5447835b0a861475918e79e932abdfd8',
-                    ),
-                    '2015_01' => array(
-                        '1.2015-01-01.2015-01-01.1.done3736b708e4d20cfc10610e816a1b2341',
-                        '2.2015-01-01.2015-01-01.1.done.VisitsSummary',
-                        '1.2015-01-01.2015-01-31.3.done3736b708e4d20cfc10610e816a1b2341',
-                        '2.2015-01-01.2015-01-31.3.done.VisitsSummary',
-                        '1.2015-01-01.2015-12-31.4.done5447835b0a861475918e79e932abdfd8',
-                        '2.2015-01-01.2015-12-31.4.done',
-                        '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
-                    ),
-                    '2015_02' => array(
-                        '1.2015-02-05.2015-02-05.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                        '2.2015-02-05.2015-02-05.1.done5447835b0a861475918e79e932abdfd8',
-                        '1.2015-02-02.2015-02-08.2.done',
-                        '2.2015-02-02.2015-02-08.2.done3736b708e4d20cfc10610e816a1b2341',
-                        '1.2015-02-01.2015-02-28.3.done.VisitsSummary',
-                        '2.2015-02-01.2015-02-28.3.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                    ),
-                    '2014_12' => [
-                        '1.2014-12-29.2015-01-04.2.done3736b708e4d20cfc10610e816a1b2341',
-                        '2.2014-12-29.2015-01-04.2.done.VisitsSummary',
-                    ],
-                ),
-                array (
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '1',
-                        'date1' => '2015-01-01',
-                        'date2' => '2015-01-01',
-                        'period' => '1',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => '1',
-                        'idsite' => '1',
-                        'date1' => '2015-01-01',
-                        'date2' => '2015-01-01',
-                        'period' => '1',
-                        'name' => 'done3736b708e4d20cfc10610e816a1b2341',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '1',
-                        'date1' => '2015-01-01',
-                        'date2' => '2015-01-31',
-                        'period' => '3',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => '106',
-                        'idsite' => '1',
-                        'date1' => '2015-01-01',
-                        'date2' => '2015-01-31',
-                        'period' => '3',
-                        'name' => 'done3736b708e4d20cfc10610e816a1b2341',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '1',
-                        'date1' => '2015-01-01',
-                        'date2' => '2015-12-31',
-                        'period' => '4',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => '109',
-                        'idsite' => '1',
-                        'date1' => '2015-01-01',
-                        'date2' => '2015-12-31',
-                        'period' => '4',
-                        'name' => 'done5447835b0a861475918e79e932abdfd8',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '2',
-                        'date1' => '2015-01-01',
-                        'date2' => '2015-01-01',
-                        'period' => '1',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '2',
-                        'date1' => '2015-01-01',
-                        'date2' => '2015-01-31',
-                        'period' => '3',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => '110',
-                        'idsite' => '2',
-                        'date1' => '2015-01-01',
-                        'date2' => '2015-12-31',
-                        'period' => '4',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '1',
-                        'date1' => '2014-12-29',
-                        'date2' => '2015-01-04',
-                        'period' => '2',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => '106',
-                        'idsite' => '1',
-                        'date1' => '2014-12-29',
-                        'date2' => '2015-01-04',
-                        'period' => '2',
-                        'name' => 'done3736b708e4d20cfc10610e816a1b2341',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '2',
-                        'date1' => '2014-12-29',
-                        'date2' => '2015-01-04',
-                        'period' => '2',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '1',
-                        'date1' => '2015-02-05',
-                        'date2' => '2015-02-05',
-                        'period' => '1',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => '85',
-                        'idsite' => '1',
-                        'date1' => '2015-02-02',
-                        'date2' => '2015-02-08',
-                        'period' => '2',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '1',
-                        'date1' => '2015-02-01',
-                        'date2' => '2015-02-28',
-                        'period' => '3',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '2',
-                        'date1' => '2015-02-05',
-                        'date2' => '2015-02-05',
-                        'period' => '1',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => '14',
-                        'idsite' => '2',
-                        'date1' => '2015-02-05',
-                        'date2' => '2015-02-05',
-                        'period' => '1',
-                        'name' => 'done5447835b0a861475918e79e932abdfd8',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '2',
-                        'date1' => '2015-02-02',
-                        'date2' => '2015-02-08',
-                        'period' => '2',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => '86',
-                        'idsite' => '2',
-                        'date1' => '2015-02-02',
-                        'date2' => '2015-02-08',
-                        'period' => '2',
-                        'name' => 'done3736b708e4d20cfc10610e816a1b2341',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '2',
-                        'date1' => '2015-02-01',
-                        'date2' => '2015-02-28',
-                        'period' => '3',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '1',
-                        'date1' => '2015-04-30',
-                        'date2' => '2015-04-30',
-                        'period' => '1',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => '100',
-                        'idsite' => '1',
-                        'date1' => '2015-04-27',
-                        'date2' => '2015-05-03',
-                        'period' => '2',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '1',
-                        'date1' => '2015-04-01',
-                        'date2' => '2015-04-30',
-                        'period' => '3',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '2',
-                        'date1' => '2015-04-30',
-                        'date2' => '2015-04-30',
-                        'period' => '1',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => '89',
-                        'idsite' => '2',
-                        'date1' => '2015-04-30',
-                        'date2' => '2015-04-30',
-                        'period' => '1',
-                        'name' => 'done5447835b0a861475918e79e932abdfd8',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '2',
-                        'date1' => '2015-04-27',
-                        'date2' => '2015-05-03',
-                        'period' => '2',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => '101',
-                        'idsite' => '2',
-                        'date1' => '2015-04-27',
-                        'date2' => '2015-05-03',
-                        'period' => '2',
-                        'name' => 'done3736b708e4d20cfc10610e816a1b2341',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => null,
-                        'idsite' => '2',
-                        'date1' => '2015-04-01',
-                        'date2' => '2015-04-30',
-                        'period' => '3',
-                        'name' => 'done',
-                        'report' => null,
-                    ),
-                    array (
-                        'idarchive' => '104',
-                        'idsite' => '2',
-                        'date1' => '2015-04-01',
-                        'date2' => '2015-04-30',
-                        'period' => '3',
-                        'name' => 'done5447835b0a861475918e79e932abdfd8',
-                        'report' => null,
-                    ),
-                ),
-                null, // report name
-                true, // add stored segments
-            ),
-        );
+        yield 'month period, one site, one date, cascade = false' => [
+            [1],
+            ['2015-01-01'],
+            'month',
+            null,
+            false,
+            [
+                '2015_01' => [
+                    '1.2015-01-01.2015-01-31.3.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-01.2015-12-31.4.done5447835b0a861475918e79e932abdfd8',
+                ],
+            ],
+            [
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
+            ],
+        ];
+
+        yield 'month period, one site, one date, cascade = true' => [
+            [1],
+            ['2015-01-15'],
+            'month',
+            null,
+            true,
+            [
+                '2014_12' => [
+                    '1.2014-12-29.2015-01-04.2.done3736b708e4d20cfc10610e816a1b2341',
+                ],
+                '2015_01' => [
+                    '1.2015-01-01.2015-01-01.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-02.2015-01-02.1.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-01-03.2015-01-03.1.done.VisitsSummary',
+                    '1.2015-01-04.2015-01-04.1.done',
+                    '1.2015-01-05.2015-01-05.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-06.2015-01-06.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-07.2015-01-07.1.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-01-08.2015-01-08.1.done.VisitsSummary',
+                    '1.2015-01-09.2015-01-09.1.done',
+                    '1.2015-01-10.2015-01-10.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-11.2015-01-11.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-12.2015-01-12.1.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-01-13.2015-01-13.1.done.VisitsSummary',
+                    '1.2015-01-14.2015-01-14.1.done',
+                    '1.2015-01-15.2015-01-15.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-16.2015-01-16.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-17.2015-01-17.1.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-01-18.2015-01-18.1.done.VisitsSummary',
+                    '1.2015-01-19.2015-01-19.1.done',
+                    '1.2015-01-20.2015-01-20.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-21.2015-01-21.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-22.2015-01-22.1.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-01-23.2015-01-23.1.done.VisitsSummary',
+                    '1.2015-01-24.2015-01-24.1.done',
+                    '1.2015-01-25.2015-01-25.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-26.2015-01-26.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-27.2015-01-27.1.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-01-28.2015-01-28.1.done.VisitsSummary',
+                    '1.2015-01-29.2015-01-29.1.done',
+                    '1.2015-01-30.2015-01-30.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-31.2015-01-31.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-05.2015-01-11.2.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-01-12.2015-01-18.2.done.VisitsSummary',
+                    '1.2015-01-19.2015-01-25.2.done',
+                    '1.2015-01-26.2015-02-01.2.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-01.2015-01-31.3.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-01.2015-12-31.4.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
+                ],
+            ],
+            [
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-02', 'date2' => '2015-01-02', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-03', 'date2' => '2015-01-03', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => '10', 'idsite' => '1', 'date1' => '2015-01-04', 'date2' => '2015-01-04', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-05', 'date2' => '2015-01-05', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-05', 'date2' => '2015-01-11', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-06', 'date2' => '2015-01-06', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-07', 'date2' => '2015-01-07', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-08', 'date2' => '2015-01-08', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => '25', 'idsite' => '1', 'date1' => '2015-01-09', 'date2' => '2015-01-09', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-10', 'date2' => '2015-01-10', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-11', 'date2' => '2015-01-11', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-12', 'date2' => '2015-01-12', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-12', 'date2' => '2015-01-18', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-13', 'date2' => '2015-01-13', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => '40', 'idsite' => '1', 'date1' => '2015-01-14', 'date2' => '2015-01-14', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-15', 'date2' => '2015-01-15', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-16', 'date2' => '2015-01-16', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-17', 'date2' => '2015-01-17', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-18', 'date2' => '2015-01-18', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => '55', 'idsite' => '1', 'date1' => '2015-01-19', 'date2' => '2015-01-19', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => '100', 'idsite' => '1', 'date1' => '2015-01-19', 'date2' => '2015-01-25', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-20', 'date2' => '2015-01-20', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-21', 'date2' => '2015-01-21', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-22', 'date2' => '2015-01-22', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-23', 'date2' => '2015-01-23', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => '70', 'idsite' => '1', 'date1' => '2015-01-24', 'date2' => '2015-01-24', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-25', 'date2' => '2015-01-25', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-26', 'date2' => '2015-01-26', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-26', 'date2' => '2015-02-01', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-27', 'date2' => '2015-01-27', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-28', 'date2' => '2015-01-28', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => '85', 'idsite' => '1', 'date1' => '2015-01-29', 'date2' => '2015-01-29', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-30', 'date2' => '2015-01-30', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-31', 'date2' => '2015-01-31', 'period' => '1', 'name' => 'done', 'report' => null],
+            ],
+        ];
+
+        yield 'week period, one site, multiple dates w/ redundant dates & periods, cascade = true' => [
+            [1],
+            ['2015-01-02', '2015-01-03', '2015-01-31'],
+            'week',
+            null,
+            true,
+            [
+                '2014_12' => [
+                    '1.2014-12-29.2014-12-29.1.done',
+                    '1.2014-12-30.2014-12-30.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2014-12-31.2014-12-31.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2014-12-29.2015-01-04.2.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2014-12-01.2014-12-31.3.done5447835b0a861475918e79e932abdfd8',
+                    '1.2014-12-05.2015-01-01.5.done.VisitsSummary',
+                ],
+                '2015_01' => [
+                    '1.2015-01-01.2015-01-01.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-02.2015-01-02.1.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-01-03.2015-01-03.1.done.VisitsSummary',
+                    '1.2015-01-04.2015-01-04.1.done',
+                    '1.2015-01-26.2015-01-26.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-27.2015-01-27.1.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-01-28.2015-01-28.1.done.VisitsSummary',
+                    '1.2015-01-29.2015-01-29.1.done',
+                    '1.2015-01-30.2015-01-30.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-31.2015-01-31.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-26.2015-02-01.2.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-01.2015-01-31.3.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-01.2015-12-31.4.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
+                ],
+                '2015_02' => [
+                    '1.2015-02-01.2015-02-01.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-02-01.2015-02-28.3.done.VisitsSummary',
+                ],
+                '2014_01' => [
+                    '1.2014-01-01.2014-12-31.4.done3736b708e4d20cfc10610e816a1b2341',
+                ],
+            ],
+            [
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-01-01', 'date2' => '2014-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-01', 'date2' => '2014-12-31', 'period' => '3', 'name' => 'done', 'report' => null],
+                ['idarchive' => '85', 'idsite' => '1', 'date1' => '2014-12-29', 'date2' => '2014-12-29', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-30', 'date2' => '2014-12-30', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-31', 'date2' => '2014-12-31', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-02', 'date2' => '2015-01-02', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-03', 'date2' => '2015-01-03', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => '10', 'idsite' => '1', 'date1' => '2015-01-04', 'date2' => '2015-01-04', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-26', 'date2' => '2015-01-26', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-26', 'date2' => '2015-02-01', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-27', 'date2' => '2015-01-27', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-28', 'date2' => '2015-01-28', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => '85', 'idsite' => '1', 'date1' => '2015-01-29', 'date2' => '2015-01-29', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-30', 'date2' => '2015-01-30', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-31', 'date2' => '2015-01-31', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-02-01', 'date2' => '2015-02-01', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-02-01', 'date2' => '2015-02-28', 'period' => '3', 'name' => 'done', 'report' => null],
+            ],
+        ];
+
+        yield 'range period, exact match, cascade = true' => [
+            [1],
+            ['2015-01-01', '2015-01-10'],
+            'range',
+            null,
+            true,
+            [
+                '2015_01' => [
+                    '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
+                ],
+            ],
+            [
+                // empty
+            ],
+        ];
+
+        yield 'range period, overlapping a range in the DB' => [
+            [1],
+            ['2015-01-02', '2015-03-05'],
+            'range',
+            null,
+            true,
+            [
+                '2015_01' => [
+                    '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
+                ],
+                '2015_03' => [
+                    '1.2015-03-04.2015-03-05.5.done.VisitsSummary',
+                    '1.2015-03-05.2015-03-10.5.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                ],
+            ],
+            [
+                // empty
+            ],
+        ];
+
+        yield 'week period, one site, cascade = true, segment' => [
+            [1],
+            ['2015-01-05'],
+            'month',
+            self::TEST_SEGMENT_1,
+            true,
+            [
+                '2014_12' => [
+                    '1.2014-12-29.2015-01-04.2.done3736b708e4d20cfc10610e816a1b2341',
+                ],
+                '2015_01' => [
+                    '1.2015-01-01.2015-01-01.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-05.2015-01-05.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-06.2015-01-06.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-10.2015-01-10.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-11.2015-01-11.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-15.2015-01-15.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-16.2015-01-16.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-20.2015-01-20.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-21.2015-01-21.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-25.2015-01-25.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-26.2015-01-26.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-30.2015-01-30.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-31.2015-01-31.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-01-26.2015-02-01.2.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-01-01.2015-01-31.3.done3736b708e4d20cfc10610e816a1b2341',
+                ],
+            ],
+            [
+                ['idarchive' => '106', 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => '1', 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-02', 'date2' => '2015-01-02', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-03', 'date2' => '2015-01-03', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-04', 'date2' => '2015-01-04', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-05', 'date2' => '2015-01-11', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-05', 'date2' => '2015-01-05', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => '16', 'idsite' => '1', 'date1' => '2015-01-06', 'date2' => '2015-01-06', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-07', 'date2' => '2015-01-07', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-08', 'date2' => '2015-01-08', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-09', 'date2' => '2015-01-09', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-10', 'date2' => '2015-01-10', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => '31', 'idsite' => '1', 'date1' => '2015-01-11', 'date2' => '2015-01-11', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-12', 'date2' => '2015-01-18', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-12', 'date2' => '2015-01-12', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-13', 'date2' => '2015-01-13', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-14', 'date2' => '2015-01-14', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-15', 'date2' => '2015-01-15', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => '46', 'idsite' => '1', 'date1' => '2015-01-16', 'date2' => '2015-01-16', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-17', 'date2' => '2015-01-17', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-18', 'date2' => '2015-01-18', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-19', 'date2' => '2015-01-25', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-19', 'date2' => '2015-01-19', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-20', 'date2' => '2015-01-20', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => '61', 'idsite' => '1', 'date1' => '2015-01-21', 'date2' => '2015-01-21', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-22', 'date2' => '2015-01-22', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-23', 'date2' => '2015-01-23', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-24', 'date2' => '2015-01-24', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-25', 'date2' => '2015-01-25', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => '76', 'idsite' => '1', 'date1' => '2015-01-26', 'date2' => '2015-01-26', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-26', 'date2' => '2015-02-01', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-27', 'date2' => '2015-01-27', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-28', 'date2' => '2015-01-28', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-29', 'date2' => '2015-01-29', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-30', 'date2' => '2015-01-30', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                // archive id 106 occurs a second time as it comes from a different archive table
+                ['idarchive' => '106', 'idsite' => '1', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+                ['idarchive' => '91', 'idsite' => '1', 'date1' => '2015-01-31', 'date2' => '2015-01-31', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null],
+            ],
+        ];
+
+        yield 'removing all periods' => [
+            [1],
+            ['2015-05-05'],
+            null,
+            null,
+            false,
+            [
+                '2015_01' => [
+                    '1.2015-01-01.2015-12-31.4.done5447835b0a861475918e79e932abdfd8',
+                ],
+                '2015_05' => [
+                    '1.2015-05-05.2015-05-05.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '1.2015-05-04.2015-05-10.2.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-05-01.2015-05-31.3.done3736b708e4d20cfc10610e816a1b2341',
+                ],
+            ],
+            [
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-05-05', 'date2' => '2015-05-05', 'period' => '1', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-05-04', 'date2' => '2015-05-10', 'period' => '2', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-05-01', 'date2' => '2015-05-31', 'period' => '3', 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null],
+            ],
+        ];
+
+        yield 'removing all periods, all visits only' => [
+            [1],
+            ['2015-02-04'],
+            null,
+            '',
+            false,
+            [
+                '2015_02' => [
+                    '1.2015-02-04.2015-02-04.1.done',
+                    '1.2015-02-02.2015-02-08.2.done',
+                    '1.2015-02-01.2015-02-28.3.done.VisitsSummary'
+                ],
+            ],
+            [
+                ['idarchive' => 10, 'idsite' => 1, 'date1' => '2015-02-04', 'date2' => '2015-02-04', 'period' => 1, 'name' => 'done', 'report' => null,],
+                ['idarchive' => 85, 'idsite' => 1, 'date1' => '2015-02-02', 'date2' => '2015-02-08', 'period' => 2, 'name' => 'done', 'report' => null,],
+                ['idarchive' => null, 'idsite' => 1, 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => 4, 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => 1, 'date1' => '2015-02-01', 'date2' => '2015-02-28', 'period' => 3, 'name' => 'done', 'report' => null,],
+            ],
+        ];
+
+        yield 'period before site creation date' => [
+            [1],
+            ['2012-03-02'],
+            '',
+            null,
+            false,
+            [
+                // empty
+            ],
+            [
+                // month week and year exist, but not day since it is before the site was created
+                ['idarchive' => null, 'idsite' => 1, 'date1' => '2012-03-01', 'date2' => '2012-03-31', 'period' => 3, 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => 1, 'date1' => '2012-02-27', 'date2' => '2012-03-04', 'period' => 2, 'name' => 'done', 'report' => null],
+                ['idarchive' => null, 'idsite' => 1, 'date1' => '2012-01-01', 'date2' => '2012-12-31', 'period' => 4, 'name' => 'done', 'report' => null],
+            ],
+        ];
+
+        yield 'day period, multiple sites, multiple dates across tables, stored segments added' => [
+            [1, 2],
+            ['2015-01-01', '2015-02-05', '2015-04-30'],
+            'day',
+            null,
+            false,
+            [
+                '2015_04' => [
+                    '1.2015-04-30.2015-04-30.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '2.2015-04-30.2015-04-30.1.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-04-27.2015-05-03.2.done',
+                    '2.2015-04-27.2015-05-03.2.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-04-01.2015-04-30.3.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '2.2015-04-01.2015-04-30.3.done5447835b0a861475918e79e932abdfd8',
+                ],
+                '2015_01' => [
+                    '1.2015-01-01.2015-01-01.1.done3736b708e4d20cfc10610e816a1b2341',
+                    '2.2015-01-01.2015-01-01.1.done.VisitsSummary',
+                    '1.2015-01-01.2015-01-31.3.done3736b708e4d20cfc10610e816a1b2341',
+                    '2.2015-01-01.2015-01-31.3.done.VisitsSummary',
+                    '1.2015-01-01.2015-12-31.4.done5447835b0a861475918e79e932abdfd8',
+                    '2.2015-01-01.2015-12-31.4.done',
+                    '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
+                ],
+                '2015_02' => [
+                    '1.2015-02-05.2015-02-05.1.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                    '2.2015-02-05.2015-02-05.1.done5447835b0a861475918e79e932abdfd8',
+                    '1.2015-02-02.2015-02-08.2.done',
+                    '2.2015-02-02.2015-02-08.2.done3736b708e4d20cfc10610e816a1b2341',
+                    '1.2015-02-01.2015-02-28.3.done.VisitsSummary',
+                    '2.2015-02-01.2015-02-28.3.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                ],
+                '2014_12' => [
+                    '1.2014-12-29.2015-01-04.2.done3736b708e4d20cfc10610e816a1b2341',
+                    '2.2014-12-29.2015-01-04.2.done.VisitsSummary',
+                ],
+            ],
+            [
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done', 'report' => null,],
+                ['idarchive' => '1', 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done', 'report' => null,],
+                ['idarchive' => '106', 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null,],
+                ['idarchive' => '109', 'idsite' => '1', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done5447835b0a861475918e79e932abdfd8', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-01-01', 'date2' => '2015-01-01', 'period' => '1', 'name' => 'done', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-01-01', 'date2' => '2015-01-31', 'period' => '3', 'name' => 'done', 'report' => null,],
+                ['idarchive' => '110', 'idsite' => '2', 'date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => '4', 'name' => 'done', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done', 'report' => null,],
+                ['idarchive' => '106', 'idsite' => '1', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2014-12-29', 'date2' => '2015-01-04', 'period' => '2', 'name' => 'done', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-02-05', 'date2' => '2015-02-05', 'period' => '1', 'name' => 'done', 'report' => null,],
+                ['idarchive' => '85', 'idsite' => '1', 'date1' => '2015-02-02', 'date2' => '2015-02-08', 'period' => '2', 'name' => 'done', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-02-01', 'date2' => '2015-02-28', 'period' => '3', 'name' => 'done', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-02-05', 'date2' => '2015-02-05', 'period' => '1', 'name' => 'done', 'report' => null,],
+                ['idarchive' => '14', 'idsite' => '2', 'date1' => '2015-02-05', 'date2' => '2015-02-05', 'period' => '1', 'name' => 'done5447835b0a861475918e79e932abdfd8', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-02-02', 'date2' => '2015-02-08', 'period' => '2', 'name' => 'done', 'report' => null,],
+                ['idarchive' => '86', 'idsite' => '2', 'date1' => '2015-02-02', 'date2' => '2015-02-08', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-02-01', 'date2' => '2015-02-28', 'period' => '3', 'name' => 'done', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-04-30', 'date2' => '2015-04-30', 'period' => '1', 'name' => 'done', 'report' => null,],
+                ['idarchive' => '100', 'idsite' => '1', 'date1' => '2015-04-27', 'date2' => '2015-05-03', 'period' => '2', 'name' => 'done', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '1', 'date1' => '2015-04-01', 'date2' => '2015-04-30', 'period' => '3', 'name' => 'done', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-04-30', 'date2' => '2015-04-30', 'period' => '1', 'name' => 'done', 'report' => null,],
+                ['idarchive' => '89', 'idsite' => '2', 'date1' => '2015-04-30', 'date2' => '2015-04-30', 'period' => '1', 'name' => 'done5447835b0a861475918e79e932abdfd8', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-04-27', 'date2' => '2015-05-03', 'period' => '2', 'name' => 'done', 'report' => null,],
+                ['idarchive' => '101', 'idsite' => '2', 'date1' => '2015-04-27', 'date2' => '2015-05-03', 'period' => '2', 'name' => 'done3736b708e4d20cfc10610e816a1b2341', 'report' => null,],
+                ['idarchive' => null, 'idsite' => '2', 'date1' => '2015-04-01', 'date2' => '2015-04-30', 'period' => '3', 'name' => 'done', 'report' => null,],
+                ['idarchive' => '104', 'idsite' => '2', 'date1' => '2015-04-01', 'date2' => '2015-04-30', 'period' => '3', 'name' => 'done5447835b0a861475918e79e932abdfd8', 'report' => null,],
+            ],
+            null, // report name
+            true, // add stored segments
+        ];
     }
 
     /**
@@ -1762,118 +1538,108 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
 
     public function getTestDataForMarkArchiveRangesAsInvalidated()
     {
-        // $idSites, $dates, $segment, $expectedIdArchives
-        return array(
-            // range period, has an exact match, also a match where DB end date = reference start date
-            array(
-                array(1),
-                array('2015-01-01', '2015-01-10'),
-                null,
-                array(
-                    '2014_12' => array(
-                        '1.2014-12-05.2015-01-01.5.done.VisitsSummary',
-                    ),
-                    '2015_01' => array(
-                        '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
-                    ),
-                ),
-                [
-                    // empty
+        yield 'range period, has an exact match, also a match where DB end date = reference start date' => [
+            [1],
+            ['2015-01-01', '2015-01-10'],
+            null,
+            [
+                '2014_12' => [
+                    '1.2014-12-05.2015-01-01.5.done.VisitsSummary',
                 ],
-            ),
+                '2015_01' => [
+                    '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
+                ],
+            ],
+            [
+                // empty
+            ],
+        ];
 
-            // range period, overlapping range = a match
-            array(
-                array(1),
-                array('2015-01-02', '2015-03-05'),
-                null,
-                array(
-                    '2015_01' => array(
-                        '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
-                    ),
-                    '2015_03' => array(
-                        '1.2015-03-04.2015-03-05.5.done.VisitsSummary',
-                        '1.2015-03-05.2015-03-10.5.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                    ),
-                ),
-                [
-                    // empty
+        yield 'range period, overlapping range = a match' => [
+            [1],
+            ['2015-01-02', '2015-03-05'],
+            null,
+            [
+                '2015_01' => [
+                    '1.2015-01-01.2015-01-10.5.done.VisitsSummary',
                 ],
-            ),
+                '2015_03' => [
+                    '1.2015-03-04.2015-03-05.5.done.VisitsSummary',
+                    '1.2015-03-05.2015-03-10.5.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
+                ],
+            ],
+            [
+                // empty
+            ],
+        ];
 
-            // range period, small range within the 2014-12-05 to 2015-01-01 range should cause it to be invalidated
-            array(
-                array(1),
-                array('2014-12-18', '2014-12-20'),
-                null,
-                array(
-                    '2014_12' => array(
-                        '1.2014-12-05.2015-01-01.5.done.VisitsSummary',
-                    ),
-                ),
-                [
-                    // empty
+        yield 'range period, small range within the 2014-12-05 to 2015-01-01 range should cause it to be invalidated' => [
+            [1],
+            ['2014-12-18', '2014-12-20'],
+            null,
+            [
+                '2014_12' => [
+                    '1.2014-12-05.2015-01-01.5.done.VisitsSummary',
                 ],
-            ),
+            ],
+            [
+                // empty
+            ],
+        ];
 
-            // range period, range that overlaps start of archived range
-            array(
-                array(1),
-                array('2014-12-01', '2014-12-05'),
-                null,
-                array(
-                    '2014_12' => array(
-                        '1.2014-12-05.2015-01-01.5.done.VisitsSummary',
-                    ),
-                ),
-                [
-                    // empty
+        yield 'range period, range that overlaps start of archived range' => [
+            [1],
+            ['2014-12-01', '2014-12-05'],
+            null,
+            [
+                '2014_12' => [
+                    '1.2014-12-05.2015-01-01.5.done.VisitsSummary',
                 ],
-            ),
+            ],
+            [
+                // empty
+            ],
+        ];
 
-            // range period, large range that includes the smallest archived range (3 to 4 March)
-            array(
-                array(1),
-                array('2015-01-11', '2015-03-30'),
-                null,
-                array(
-                    '2015_03' => array(
-                        '1.2015-03-04.2015-03-05.5.done.VisitsSummary',
-                        '1.2015-03-05.2015-03-10.5.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
-                    ),
-                ),
-                [
-                    // empty
+        yield 'range period, large range that includes the smallest archived range (3 to 4 March)' => [
+            [1],
+            ['2015-01-11', '2015-03-30'],
+            null,
+            [
+                '2015_03' => [
+                    '1.2015-03-04.2015-03-05.5.done.VisitsSummary',
+                    '1.2015-03-05.2015-03-10.5.done3736b708e4d20cfc10610e816a1b2341.UserCountry',
                 ],
-            ),
+            ],
+            [
+                // empty
+            ],
+        ];
 
-            // range period, doesn't match any archived ranges
-            array(
-                array(1),
-                array('2014-12-01', '2014-12-04'),
-                null,
-                array(
-                ),
-                [
-                    // empty
-                ],
-            ),
+        yield 'range period, doesn\'t match any archived ranges' => [
+            [1],
+            ['2014-12-01', '2014-12-04'],
+            null,
+            [
+            ],
+            [
+                // empty
+            ],
+        ];
 
-            // three-month range period, there's a range archive for the middle month
-            array(
-                array(1),
-                array('2014-09-01', '2014-11-08'),
-                null,
-                array(
-                    '2014_10' => array(
-                        '1.2014-10-15.2014-10-20.5.done3736b708e4d20cfc10610e816a1b2341',
-                    ),
-                ),
-                [
-                    // empty
+        yield 'three-month range period, there\'s a range archive for the middle month' => [
+            [1],
+            ['2014-09-01', '2014-11-08'],
+            null,
+            [
+                '2014_10' => [
+                    '1.2014-10-15.2014-10-20.5.done3736b708e4d20cfc10610e816a1b2341',
                 ],
-            ),
-        );
+            ],
+            [
+                // empty
+            ],
+        ];
     }
 
     public function testMarkArchivesAsInvalidatedForceInvalidatesNonExistantRangesWhenRequired()


### PR DESCRIPTION
### Description:

This PR improves and fixes some parts of the `core:invalidate-report-data` command

* **Allow invalidating `All visits` segment only by providing `--segment=""`**
  This new option will only invalidate the all visits segment

* **Correctly invalidate all known segments when no segment is provided**
  Before only segments with existing archives were invalidated, causing other segments not to be re archived at all.

* **Fixed range invalidation of plugin archives**
  While "normal" periods were invalidated correctly when a plugin was provided, this was not correctly done for range archives. Instead the all visits archive was invalidated, causing more re archiving than requested.

* **Improved handling of provided segments**
  When segments were provided that did not exist for one of the provided sites, the command previously failed. Now it will invalidate the segment for all sites where it is available, while skipping it for other sites.

The code overall was a restructured and improved. A plenty of new tests for the command should ensure that the correct invalidations are created when command is executed with certain parameters.

Currently "excluded" from the testing for the command is the handling of existing archives. Those should be marked as invalidated and in certain cases also plugin and segment archives should get invalid, depending on the invalidation request.
But I didn't want to extend the scope of this change here too much, so we should consider writing some proper tests for `Model::updateArchiveAsInvalidated` method another time.

fixes #19947 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
