### PR TITLE
Avoid strlen(null) call on undefined "idvisitor" property

### DIFF
--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -580,8 +580,9 @@ class Visit implements VisitInterface
      */
     private function setIdVisitorForExistingVisit($valuesToUpdate)
     {
-        if (strlen($this->visitProperties->getProperty('idvisitor') ?? '') == Tracker::LENGTH_BINARY_ID) {
-            $valuesToUpdate['idvisitor'] = $this->visitProperties->getProperty('idvisitor');
+        $idVisitor = $this->visitProperties->getProperty('idvisitor');
+        if (!empty($idVisitor) && Tracker::LENGTH_BINARY_ID == strlen($idVisitor)) {
+            $valuesToUpdate['idvisitor'] = $idVisitor;
         }
 
         $visitorId = $this->request->getVisitorId();

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -580,7 +580,7 @@ class Visit implements VisitInterface
      */
     private function setIdVisitorForExistingVisit($valuesToUpdate)
     {
-        if (strlen($this->visitProperties->getProperty('idvisitor')) == Tracker::LENGTH_BINARY_ID) {
+        if (strlen($this->visitProperties->getProperty('idvisitor') ?? '') == Tracker::LENGTH_BINARY_ID) {
             $valuesToUpdate['idvisitor'] = $this->visitProperties->getProperty('idvisitor');
         }
 


### PR DESCRIPTION
The "idvisitor" property can be undefined/null, this must be taken into account to avoid this error:

> strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /.../core/Tracker/Visit.php on line 583

### Description:

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
