### PR TITLE
Ensure not to disable limit control for evolution charts

### DIFF
--- a/plugins/DevicePlugins/Reports/GetPlugin.php
+++ b/plugins/DevicePlugins/Reports/GetPlugin.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\DevicePlugins\Reports;
 
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
+use Piwik\Plugins\CoreVisualizations\Visualizations\JqplotGraph\Evolution;
 use Piwik\Plugins\DevicePlugins\Columns\Plugin;
 use Piwik\Plugins\DevicePlugins\DevicePlugins;
 
@@ -41,12 +42,15 @@ class GetPlugin extends Base
 
         $view->config->show_offset_information = false;
         $view->config->show_pagination_control = false;
-        $view->config->show_limit_control      = false;
         $view->config->show_all_views_icons    = false;
         $view->config->show_table_all_columns  = false;
         $view->config->show_totals_row         = false;
         $view->config->columns_to_display  = array('label', 'nb_visits_percentage', 'nb_visits');
         $view->config->show_footer_message = Piwik::translate('DevicePlugins_PluginDetectionDoesNotWorkInIE');
+
+        if (!$view->isViewDataTableId(Evolution::ID)) {
+            $view->config->show_limit_control = false;
+        }
 
         $view->requestConfig->filter_sort_column = 'nb_visits_percentage';
         $view->requestConfig->filter_sort_order  = 'desc';

--- a/plugins/UserCountry/Reports/GetContinent.php
+++ b/plugins/UserCountry/Reports/GetContinent.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\UserCountry\Reports;
 
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
+use Piwik\Plugins\CoreVisualizations\Visualizations\JqplotGraph\Evolution;
 use Piwik\Plugins\UserCountry\Columns\Continent;
 use Piwik\Report\ReportWidgetFactory;
 use Piwik\Widget\WidgetsList;
@@ -46,7 +47,10 @@ class GetContinent extends Base
         $view->config->show_search = false;
         $view->config->show_offset_information = false;
         $view->config->show_pagination_control = false;
-        $view->config->show_limit_control = false;
         $view->config->documentation = $this->documentation;
+
+        if (!$view->isViewDataTableId(Evolution::ID)) {
+            $view->config->show_limit_control = false;
+        }
     }
 }

--- a/plugins/VisitTime/Reports/Base.php
+++ b/plugins/VisitTime/Reports/Base.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\VisitTime\Reports;
 
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\CoreVisualizations\Visualizations\JqplotGraph\Bar;
+use Piwik\Plugins\CoreVisualizations\Visualizations\JqplotGraph\Evolution;
 
 abstract class Base extends \Piwik\Plugin\Report
 {
@@ -33,9 +34,12 @@ abstract class Base extends \Piwik\Plugin\Report
         $view->requestConfig->filter_sort_order = 'asc';
         $view->requestConfig->addPropertiesThatShouldBeAvailableClientSide(array('filter_sort_column'));
         $view->config->show_search = false;
-        $view->config->show_limit_control = false;
         $view->config->show_exclude_low_population = false;
         $view->config->show_offset_information = false;
         $view->config->show_pagination_control = false;
+
+        if (!$view->isViewDataTableId(Evolution::ID)) {
+            $view->config->show_limit_control = false;
+        }
     }
 }

--- a/plugins/VisitorInterest/Reports/GetNumberOfVisitsByDaysSinceLast.php
+++ b/plugins/VisitorInterest/Reports/GetNumberOfVisitsByDaysSinceLast.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\VisitorInterest\Reports;
 
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
+use Piwik\Plugins\CoreVisualizations\Visualizations\JqplotGraph\Evolution;
 use Piwik\Plugins\VisitorInterest\Columns\VisitorDaysSinceLast;
 use Piwik\Report\ReportWidgetFactory;
 use Piwik\Widget\WidgetsList;
@@ -49,10 +50,13 @@ class GetNumberOfVisitsByDaysSinceLast extends Base
         $view->config->enable_sort = false;
         $view->config->show_offset_information = false;
         $view->config->show_pagination_control = false;
-        $view->config->show_limit_control      = false;
         $view->config->show_all_views_icons    = false;
         $view->config->show_table_all_columns  = false;
         $view->config->show_exclude_low_population = false;
         $view->config->addTranslation('label', Piwik::translate('General_DaysSinceLastVisit'));
+
+        if (!$view->isViewDataTableId(Evolution::ID)) {
+            $view->config->show_limit_control = false;
+        }
     }
 }

--- a/plugins/VisitorInterest/Reports/GetNumberOfVisitsByVisitCount.php
+++ b/plugins/VisitorInterest/Reports/GetNumberOfVisitsByVisitCount.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\VisitorInterest\Reports;
 use Piwik\Metrics;
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
+use Piwik\Plugins\CoreVisualizations\Visualizations\JqplotGraph\Evolution;
 use Piwik\Plugins\VisitorInterest\Columns\VisitsbyVisitNumber;
 use Piwik\Plugins\CoreHome\Columns\Metrics\VisitsPercent;
 
@@ -50,9 +51,12 @@ class GetNumberOfVisitsByVisitCount extends Base
         $view->config->enable_sort = false;
         $view->config->show_offset_information = false;
         $view->config->show_pagination_control = false;
-        $view->config->show_limit_control      = false;
         $view->config->show_search             = false;
         $view->config->show_table_all_columns  = false;
         $view->config->show_all_views_icons    = false;
+
+        if (!$view->isViewDataTableId(Evolution::ID)) {
+            $view->config->show_limit_control = false;
+        }
     }
 }

--- a/plugins/VisitorInterest/Reports/GetNumberOfVisitsPerPage.php
+++ b/plugins/VisitorInterest/Reports/GetNumberOfVisitsPerPage.php
@@ -13,6 +13,7 @@ use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\CoreVisualizations\Visualizations\Cloud;
 use Piwik\Plugins\CoreVisualizations\Visualizations\Graph;
+use Piwik\Plugins\CoreVisualizations\Visualizations\JqplotGraph\Evolution;
 use Piwik\Plugins\VisitorInterest\Columns\PagesPerVisit;
 use Piwik\Report\ReportWidgetFactory;
 use Piwik\Widget\WidgetsList;
@@ -56,10 +57,13 @@ class GetNumberOfVisitsPerPage extends Base
         $view->config->show_exclude_low_population = false;
         $view->config->show_offset_information = false;
         $view->config->show_pagination_control = false;
-        $view->config->show_limit_control      = false;
         $view->config->show_search             = false;
         $view->config->show_table_all_columns  = false;
         $view->config->columns_to_display      = array('label', 'nb_visits');
+
+        if (!$view->isViewDataTableId(Evolution::ID)) {
+            $view->config->show_limit_control = false;
+        }
 
         if ($view->isViewDataTableId(Graph::ID)) {
             $view->config->show_series_picker = false;

--- a/plugins/VisitorInterest/Reports/GetNumberOfVisitsPerVisitDuration.php
+++ b/plugins/VisitorInterest/Reports/GetNumberOfVisitsPerVisitDuration.php
@@ -13,6 +13,7 @@ use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\CoreVisualizations\Visualizations\Cloud;
 use Piwik\Plugins\CoreVisualizations\Visualizations\Graph;
+use Piwik\Plugins\CoreVisualizations\Visualizations\JqplotGraph\Evolution;
 use Piwik\Plugins\VisitorInterest\Columns\VisitDuration;
 use Piwik\Report\ReportWidgetFactory;
 use Piwik\Widget\WidgetsList;
@@ -55,10 +56,13 @@ class GetNumberOfVisitsPerVisitDuration extends Base
         $view->config->show_exclude_low_population = false;
         $view->config->show_offset_information = false;
         $view->config->show_pagination_control = false;
-        $view->config->show_limit_control      = false;
         $view->config->show_search             = false;
         $view->config->show_table_all_columns  = false;
         $view->config->columns_to_display      = array('label', 'nb_visits');
+
+        if (!$view->isViewDataTableId(Evolution::ID)) {
+            $view->config->show_limit_control = false;
+        }
 
         if ($view->isViewDataTableId(Graph::ID)) {
             $view->config->show_series_picker = false;


### PR DESCRIPTION
### Description:

Disabling the limit control for the whole report, also caused it to be disabled for the evolution chart.
As it should be shown in that case, I've added it as an exception for those reports.

fixes #23030

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
