### PR TITLE
Introduce new method to check if a segment is valid and available for a given site

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1003,7 +1003,8 @@ class CronArchive
 
             foreach ($this->segmentArchiving->getAllSegmentsToArchive($idSite) as $segmentDefinition) {
                 // check if the segment is available
-                if (!$this->isSegmentAvailable($segmentDefinition, [$idSite])) {
+                if (!Segment::isAvailable($segmentDefinition, [$idSite])) {
+                    $this->logger->info("Segment '" . $segmentDefinition . "' is not a supported segment");
                     continue;
                 }
 
@@ -1057,24 +1058,6 @@ class CronArchive
                 }
             }
         }
-    }
-
-
-    /**
-     * check if segments that contain dimensions that don't exist anymore
-     * @param $segmentDefinition
-     * @param $idSites
-     * @return bool
-     */
-    protected function isSegmentAvailable($segmentDefinition, $idSites): bool
-    {
-        try {
-            new Segment($segmentDefinition, $idSites);
-        } catch (\Exception $e) {
-            $this->logger->info("Segment '" . $segmentDefinition . "' is not a supported segment");
-            return false;
-        }
-        return true;
     }
 
     private function canWeSkipInvalidatingBecauseInvalidationAlreadyInProgress(int $idSite, Period $period, ?Segment $segment = null): bool

--- a/core/CronArchive/SegmentArchiving.php
+++ b/core/CronArchive/SegmentArchiving.php
@@ -94,12 +94,12 @@ class SegmentArchiving
                 continue;
             }
 
-            try {
-                $segmentObj = new Segment($segment['definition'], [$idSite]);
-            } catch (\Exception $ex) {
+            if (!Segment::isAvailable($segment['definition'], [$idSite])) {
                 $this->logger->debug("Could not process segment {$segment['definition']} for site {$idSite}. Segment should not exist for the site, but does.");
                 continue;
             }
+
+            $segmentObj = new Segment($segment['definition'], [$idSite]);
 
             if ($segmentObj->getHash() == $hash) {
                 return $segment;

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -609,7 +609,11 @@ class Segment
     public function getSelectQuery($select, $from, $where = false, $bind = array(), $orderBy = false, $groupBy = false, $limit = 0, $offset = 0, $forceGroupBy = false)
     {
         if (Development::isEnabled() && !empty($this->missingDatesException)) {
-            Log::warning("Avoiding segment subquery due to missing start date and/or an end date. Please ensure a start date and/or end date is set when initializing a segment if it's used to build a query. Stacktrace:\n" . $this->missingDatesException->getTraceAsString());
+            $e = new Exception();
+            Log::warning('Avoiding segment subquery due to missing start date and/or an end date. '
+                        . 'Please ensure a start date and/or end date is set when initializing segment: '
+                        . "\n\nCreation stacktrace:\n" . $this->missingDatesException->getTraceAsString()
+                        . "\n\nUsage stacktrace:\n" . $e->getTraceAsString());
         }
 
         $segmentExpression = $this->segmentExpression;

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -100,6 +100,11 @@ class Segment
     private $isSegmentEncoded;
 
     /**
+     * @var Exception|null
+     */
+    private $missingDatesException = null;
+
+    /**
      * Truncate the Segments to 8k
      */
     public const SEGMENT_TRUNCATE_LIMIT = 8192;
@@ -125,7 +130,6 @@ class Segment
      */
     public function __construct($segmentCondition, $idSites, ?Date $startDate = null, ?Date $endDate = null)
     {
-
         $this->segmentQueryBuilder = StaticContainer::get('Piwik\DataAccess\LogQueryBuilder');
 
         $segmentCondition = trim($segmentCondition ?: '');
@@ -175,6 +179,25 @@ class Segment
             $this->initializeSegment(urldecode($segmentCondition), $idSites);
             $this->isSegmentEncoded = true;
         }
+    }
+
+    /**
+     * Checks if the provided segmentCondition is valid and available for the given idSites
+     *
+     * @param string $segmentCondition
+     * @params array $idSites
+     * @return bool
+     * @api since Matomo 5.3.0
+     */
+    public static function isAvailable(string $segmentCondition, array $idSites): bool
+    {
+        try {
+            new self($segmentCondition, $idSites);
+        } catch (Exception $e) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -335,8 +358,7 @@ class Segment
 
         if ($requiresSubQuery && empty($this->startDate) && empty($this->endDate)) {
             if (Development::isEnabled()) {
-                $e = new Exception();
-                Log::warning("Avoiding segment subquery due to missing start date and/or an end date. Please ensure a start date and/or end date is set when initializing a segment if it's used to build a query. Stacktrace:\n" . $e->getTraceAsString());
+                $this->missingDatesException = new Exception();
             }
             return false;
         }
@@ -586,6 +608,10 @@ class Segment
      */
     public function getSelectQuery($select, $from, $where = false, $bind = array(), $orderBy = false, $groupBy = false, $limit = 0, $offset = 0, $forceGroupBy = false)
     {
+        if (Development::isEnabled() && !empty($this->missingDatesException)) {
+            Log::warning("Avoiding segment subquery due to missing start date and/or an end date. Please ensure a start date and/or end date is set when initializing a segment if it's used to build a query. Stacktrace:\n" . $this->missingDatesException->getTraceAsString());
+        }
+
         $segmentExpression = $this->segmentExpression;
 
         $limitAndOffset = null;

--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -416,9 +416,7 @@ class API extends \Piwik\Plugin\API
         $idSites = false === $idSite ? [] : [$idSite];
 
         foreach ($segments as $k => $segment) {
-            try {
-                new Segment($segment['definition'], $idSites);
-            } catch (Exception $e) {
+            if (!Segment::isAvailable($segment['definition'], $idSites)) {
                 unset($segments[$k]);
             }
         }


### PR DESCRIPTION
### Description:

This PR introduces a new static method to easily allow checking if a segment is actually valid and available.

In addition this PR changes the nasty warning, that is being logged in development mode when a certain segment is created without start and end date.

This warning was actually meant to ensure that start and end dates are set when the segment is used to create a sql query.

Therefor this PR ensures that the warning is now only logged when the object is used to generate a query, rather upon construction.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
