### PR TITLE
Automatically remove duplicate invalidations upon reset

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -534,7 +534,7 @@ class CronArchive
                 $this->logger->info(var_export($content, true));
 
                 $idinvalidation = $archivesBeingQueried[$index]['idinvalidation'];
-                $this->model->releaseInProgressInvalidation($idinvalidation);
+                $this->model->releaseInProgressInvalidations([$idinvalidation]);
 
                 $queueConsumer->ignoreIdInvalidation($idinvalidation);
 
@@ -1065,7 +1065,7 @@ class CronArchive
 
     private function canWeSkipInvalidatingBecauseInvalidationAlreadyInProgress(int $idSite, Period $period, ?Segment $segment = null): bool
     {
-        $invalidationsInProgress = $this->model->getInvalidationsInProgress($idSite);
+        $invalidationsInProgress = $this->model->getInvalidationsInProgress([$idSite]);
         $timezone = Site::getTimezoneFor($idSite);
 
         $doneFlag = Rules::getDoneFlagArchiveContainsAllPlugins($segment ?? new Segment('', [$idSite]));

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -1025,7 +1025,7 @@ class Model
      *
      * To avoid duplicate invalidations in the database, the method is also meant to prevent having duplicates after a reset
      * Therefor below code will check if any of the invalidations to be reset should be removed instead
-     * An invalidation can be savely removed
+     * An invalidation can be safely removed
      *  - if there exists another queued invalidation with the same parameters
      *  - if there is another running invalidation, that had been started after the current one was invalidated
      * Otherwise the invalidation will be reset
@@ -1045,9 +1045,9 @@ class Model
 
         // Check invalidations one by one, to ensure we safely remove invalidations in cases where two identical ones are requested to reset
         foreach ($invalidations as $invalidation) {
-            // Look for other indentical invalidations that are either not started or started after the current one had been invalidated
+            // Look for other identical invalidations that are either not started or started after the current one had been invalidated
             $query = "SELECT COUNT(*) FROM $table WHERE name = ? AND idsite = ? AND date1 = ? AND date2 = ? AND period = ? AND "
-                   . "(status = ? OR (status = ? AND ts_started > ?)) AND idinvalidation != " . $invalidation['idinvalidation'];
+                   . "(status = ? OR (status = ? AND ts_started > ?)) AND idinvalidation != ?";
             $bind = [
                 $invalidation['name'],
                 $invalidation['idsite'],
@@ -1057,6 +1057,7 @@ class Model
                 ArchiveInvalidator::INVALIDATION_STATUS_QUEUED,
                 ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
                 $invalidation['ts_invalidated'],
+                $invalidation['idinvalidation'],
             ];
 
             if (empty($invalidation['report'])) {

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -784,19 +784,37 @@ class Model
         return !empty($result);
     }
 
-    public function getInvalidationsInProgress(?int $idSite = null): array
-    {
+    public function getInvalidationsInProgress(
+        array $idSites = [],
+        array $processingHosts = [],
+        ?Date $startTime = null,
+        ?Date $endTime = null
+    ): array {
         $table = Common::prefixTable('archive_invalidations');
 
         $bind = [ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS];
-        $idSiteCondition = '';
+        $whereConditions = '';
 
-        if (!empty($idSite)) {
-            $idSiteCondition = ' AND idsite = ?';
-            $bind[] = $idSite;
+        if (!empty($processingHosts)) {
+            $whereConditions .= sprintf(' AND `processing_host` IN (%1$s)', Common::getSqlStringFieldsArray($processingHosts));
+            $bind = array_merge($bind, $processingHosts);
         }
 
-        $sql = "SELECT idinvalidation, idsite, period, date1, date2, name, ts_started FROM `$table` WHERE `status` = ? $idSiteCondition AND ts_started IS NOT NULL ORDER BY ts_started ASC";
+        if (!empty($idSites)) {
+            $whereConditions .= sprintf(' AND `idsite` IN (' . implode(', ', $idSites) . ')');
+        }
+
+        if (!empty($startTime)) {
+            $whereConditions .= ' AND `ts_started` > ?';
+            $bind[] = $startTime->toString('Y-m-d H:i:s');
+        }
+
+        if (!empty($endTime)) {
+            $whereConditions .= ' AND `ts_started` < ?';
+            $bind[] = $endTime->toString('Y-m-d H:i:s');
+        }
+
+        $sql = "SELECT idinvalidation, idsite, period, date1, date2, name, report, ts_invalidated, ts_started, processing_host, process_id FROM `$table` WHERE `status` = ? $whereConditions AND ts_started IS NOT NULL ORDER BY ts_started ASC";
         return Db::fetchAll($sql, $bind);
     }
 
@@ -1002,11 +1020,84 @@ class Model
         return "idsite IN ($idSitesStr) AND";
     }
 
-    public function releaseInProgressInvalidation($idinvalidation)
+    /**
+     * Releases in progress invalidations for the given ids
+     *
+     * To avoid duplicate invalidations in the database, the method is also meant to prevent having duplicates after a reset
+     * Therefor below code will check if any of the invalidations to be reset should be removed instead
+     * An invalidation can be savely removed
+     *  - if there exists another queued invalidation with the same parameters
+     *  - if there is another running invalidation, that had been started after the current one was invalidated
+     * Otherwise the invalidation will be reset
+     *
+     * @param array $idinvalidations
+     * @return int
+     * @throws \Zend_Db_Statement_Exception
+     */
+    public function releaseInProgressInvalidations(array $idinvalidations): int
     {
+        $idinvalidations = array_map('intval', $idinvalidations);
         $table = Common::prefixTable('archive_invalidations');
-        $sql = "UPDATE $table SET status = " . ArchiveInvalidator::INVALIDATION_STATUS_QUEUED . ", ts_started = NULL, processing_host = NULL, process_id = NULL WHERE idinvalidation = ?";
-        Db::query($sql, [$idinvalidation]);
+        $changedCount = 0;
+
+        $sql = "SELECT * FROM $table WHERE idinvalidation IN (" . implode(',', $idinvalidations) . ")";
+        $invalidations = Db::fetchAll($sql);
+
+        // Check invalidations one by one, to ensure we safely remove invalidations in cases where two identical ones are requested to reset
+        foreach ($invalidations as $invalidation) {
+            // Look for other indentical invalidations that are either not started or started after the current one had been invalidated
+            $query = "SELECT COUNT(*) FROM $table WHERE name = ? AND idsite = ? AND date1 = ? AND date2 = ? AND period = ? AND "
+                   . "(status = ? OR (status = ? AND ts_started > ?)) AND idinvalidation != " . $invalidation['idinvalidation'];
+            $bind = [
+                $invalidation['name'],
+                $invalidation['idsite'],
+                $invalidation['date1'],
+                $invalidation['date2'],
+                $invalidation['period'],
+                ArchiveInvalidator::INVALIDATION_STATUS_QUEUED,
+                ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                $invalidation['ts_invalidated'],
+            ];
+
+            if (empty($invalidation['report'])) {
+                $query .= " AND (report IS NULL OR report = '')";
+            } else {
+                $query .= " AND report = ?";
+                $bind[] = $invalidation['report'];
+            }
+
+            $count = Db::fetchOne($query, $bind);
+
+            if ($count > 0) {
+                $this->logger->info(
+                    'Found duplicate invalidation for params (name = {name}, idsite = {idsite}, date1 = {date1}, date2 = {date2}, period = {period}, report = {report}). Removing invalidation {idinvalidation} instead of resetting it.',
+                    $invalidation
+                );
+
+                $sql = "DELETE FROM $table WHERE status = ? AND idinvalidation = ?";
+
+                $bind = [
+                    ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                    $invalidation['idinvalidation'],
+                ];
+
+                $query = Db::query($sql, $bind);
+                $changedCount += $query->rowCount();
+            } else {
+                $sql = "UPDATE $table SET status = ?, processing_host = NULL, process_id = NULL, ts_started = NULL WHERE status = ? AND idinvalidation = ?";
+
+                $bind = [
+                    ArchiveInvalidator::INVALIDATION_STATUS_QUEUED,
+                    ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                    $invalidation['idinvalidation'],
+                ];
+
+                $query = Db::query($sql, $bind);
+                $changedCount += $query->rowCount();
+            }
+        }
+
+        return $changedCount;
     }
 
     public function resetFailedArchivingJobs()
@@ -1026,16 +1117,7 @@ class Model
             return 0;
         }
 
-        $table = Common::prefixTable('archive_invalidations');
-        $sql = "UPDATE $table SET status = ? WHERE status = ? AND idinvalidation IN (" . implode(',', $idsToReset) . ")";
-
-        $bind = [
-            ArchiveInvalidator::INVALIDATION_STATUS_QUEUED,
-            ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS
-        ];
-
-        $query = Db::query($sql, $bind);
-        return $query->rowCount();
+        return $this->releaseInProgressInvalidations($idsToReset);
     }
 
     public function getRecordsContainedInArchives(Date $archiveStartDate, array $idArchives, $requestedRecords): array

--- a/plugins/CoreAdminHome/tests/Integration/Commands/ResetInvalidationsTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/ResetInvalidationsTest.php
@@ -274,8 +274,6 @@ class ResetInvalidationsTest extends ConsoleCommandTestCase
 
     public function testDuplicateInvalidationIsRemovedOnReset()
     {
-        Db::exec('TRUNCATE TABLE ' . Common::prefixTable('archive_invalidations'));
-
         $invalidationsToInsert = [
             [
                 'idarchive' => 7, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
@@ -289,13 +287,7 @@ class ResetInvalidationsTest extends ConsoleCommandTestCase
             ],
         ];
 
-        $sql = 'INSERT INTO ' . Common::prefixTable('archive_invalidations')
-            . ' (`idarchive`, `name`, `idsite`, `date1`, `date2`, `period`, `ts_invalidated`, `status`, `report`, `ts_started`, `processing_host`, `process_id`)'
-            . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
-
-        foreach ($invalidationsToInsert as $invalidation) {
-            Db::query($sql, $invalidation);
-        }
+        $this->insertInvalidations($invalidationsToInsert);
 
         $inProgressInvalidationCount = $this->getInProgressInvalidationCount();
 
@@ -339,8 +331,6 @@ class ResetInvalidationsTest extends ConsoleCommandTestCase
 
     public function testDuplicateInvalidationIsRemovedOnResetWhenOtherOneStartedAfterInvalidationDate()
     {
-        Db::exec('TRUNCATE TABLE ' . Common::prefixTable('archive_invalidations'));
-
         $invalidationsToInsert = [
             [
                 'idarchive' => 7, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
@@ -354,13 +344,7 @@ class ResetInvalidationsTest extends ConsoleCommandTestCase
             ],
         ];
 
-        $sql = 'INSERT INTO ' . Common::prefixTable('archive_invalidations')
-            . ' (`idarchive`, `name`, `idsite`, `date1`, `date2`, `period`, `ts_invalidated`, `status`, `report`, `ts_started`, `processing_host`, `process_id`)'
-            . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
-
-        foreach ($invalidationsToInsert as $invalidation) {
-            Db::query($sql, $invalidation);
-        }
+        $this->insertInvalidations($invalidationsToInsert);
 
         $inProgressInvalidationCount = $this->getInProgressInvalidationCount();
 
@@ -405,8 +389,6 @@ class ResetInvalidationsTest extends ConsoleCommandTestCase
 
     public function testDuplicateInvalidationIsOnlyResetWhenOtherOneStartedBeforeInvalidationDate()
     {
-        Db::exec('TRUNCATE TABLE ' . Common::prefixTable('archive_invalidations'));
-
         $invalidationsToInsert = [
             [
                 'idarchive' => 7, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
@@ -420,13 +402,7 @@ class ResetInvalidationsTest extends ConsoleCommandTestCase
             ],
         ];
 
-        $sql = 'INSERT INTO ' . Common::prefixTable('archive_invalidations')
-            . ' (`idarchive`, `name`, `idsite`, `date1`, `date2`, `period`, `ts_invalidated`, `status`, `report`, `ts_started`, `processing_host`, `process_id`)'
-            . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
-
-        foreach ($invalidationsToInsert as $invalidation) {
-            Db::query($sql, $invalidation);
-        }
+        $this->insertInvalidations($invalidationsToInsert);
 
         $inProgressInvalidationCount = $this->getInProgressInvalidationCount();
 
@@ -469,8 +445,6 @@ class ResetInvalidationsTest extends ConsoleCommandTestCase
 
     public function testDuplicateInvalidationIsRemovedWhenBothAreReset()
     {
-        Db::exec('TRUNCATE TABLE ' . Common::prefixTable('archive_invalidations'));
-
         $invalidationsToInsert = [
             [
                 'idarchive' => 7, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
@@ -484,13 +458,7 @@ class ResetInvalidationsTest extends ConsoleCommandTestCase
             ],
         ];
 
-        $sql = 'INSERT INTO ' . Common::prefixTable('archive_invalidations')
-            . ' (`idarchive`, `name`, `idsite`, `date1`, `date2`, `period`, `ts_invalidated`, `status`, `report`, `ts_started`, `processing_host`, `process_id`)'
-            . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
-
-        foreach ($invalidationsToInsert as $invalidation) {
-            Db::query($sql, $invalidation);
-        }
+        $this->insertInvalidations($invalidationsToInsert);
 
         $inProgressInvalidationCount = $this->getInProgressInvalidationCount();
 
@@ -565,50 +533,118 @@ class ResetInvalidationsTest extends ConsoleCommandTestCase
 
     private function prepareInvalidations(): void
     {
-        Db::exec('TRUNCATE TABLE ' . Common::prefixTable('archive_invalidations'));
-
         $invalidationsToInsert = [
             // invalidations idsite 1
             [
-                'idarchive' => 7, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
-                'period' => Day::PERIOD_ID, 'ts_invalidated' => '2025-01-01 16:00:00', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
-                'report' => null, 'ts_started' => '2025-02-05 11:30:00', 'processing_host' => 'host1', 'process_id' => 1256
+                'idarchive' => 7,
+                'name' => 'done',
+                'idsite' => 1,
+                'date1' => '2025-01-01',
+                'date2' => '2025-01-01',
+                'period' => Day::PERIOD_ID,
+                'ts_invalidated' => '2025-01-01 16:00:00',
+                'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                'report' => null,
+                'ts_started' => '2025-02-05 11:30:00',
+                'processing_host' => 'host1',
+                'process_id' => 1256
             ],
             [
-                'idarchive' => null, 'name' => 'done', 'idsite' => 1, 'date1' => '2024-12-30', 'date2' => '2025-01-05',
-                'period' => Week::PERIOD_ID, 'ts_invalidated' => '2025-01-01 16:00:01', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_QUEUED,
-                'report' => null, 'ts_started' => null, 'processing_host' => null, 'process_id' => null
+                'idarchive' => null,
+                'name' => 'done',
+                'idsite' => 1,
+                'date1' => '2024-12-30',
+                'date2' => '2025-01-05',
+                'period' => Week::PERIOD_ID,
+                'ts_invalidated' => '2025-01-01 16:00:01',
+                'status' => ArchiveInvalidator::INVALIDATION_STATUS_QUEUED,
+                'report' => null,
+                'ts_started' => null,
+                'processing_host' => null,
+                'process_id' => null
             ],
             [
-                'idarchive' => 66, 'name' => 'donec7445c35d0f9b340f5851df27a15c5ef.Actions', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-12-31',
-                'period' => Year::PERIOD_ID, 'ts_invalidated' => '2025-01-01 16:00:02', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
-                'report' => null, 'ts_started' => '2025-02-05 16:44:22', 'processing_host' => 'anotherhost', 'process_id' => 662
+                'idarchive' => 66,
+                'name' => 'donec7445c35d0f9b340f5851df27a15c5ef.Actions',
+                'idsite' => 1,
+                'date1' => '2025-01-01',
+                'date2' => '2025-12-31',
+                'period' => Year::PERIOD_ID,
+                'ts_invalidated' => '2025-01-01 16:00:02',
+                'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                'report' => null,
+                'ts_started' => '2025-02-05 16:44:22',
+                'processing_host' => 'anotherhost',
+                'process_id' => 662
             ],
 
             // invalidations idsite 2
             [
-                'idarchive' => 7, 'name' => 'done', 'idsite' => 2, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
-                'period' => Day::PERIOD_ID, 'ts_invalidated' => '2025-01-01 19:15:00', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_QUEUED,
-                'report' => null, 'ts_started' => null, 'processing_host' => null, 'process_id' => null
+                'idarchive' => 7,
+                'name' => 'done',
+                'idsite' => 2,
+                'date1' => '2025-01-01',
+                'date2' => '2025-01-01',
+                'period' => Day::PERIOD_ID,
+                'ts_invalidated' => '2025-01-01 19:15:00',
+                'status' => ArchiveInvalidator::INVALIDATION_STATUS_QUEUED,
+                'report' => null,
+                'ts_started' => null,
+                'processing_host' => null,
+                'process_id' => null
             ],
             [
-                'idarchive' => null, 'name' => 'done', 'idsite' => 2, 'date1' => '2024-12-30', 'date2' => '2025-01-05',
-                'period' => Week::PERIOD_ID, 'ts_invalidated' => '2025-01-01 19:15:01', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
-                'report' => null, 'ts_started' => '2025-02-05 09:11:00', 'processing_host' => 'host1', 'process_id' => 2333
+                'idarchive' => null,
+                'name' => 'done',
+                'idsite' => 2,
+                'date1' => '2024-12-30',
+                'date2' => '2025-01-05',
+                'period' => Week::PERIOD_ID,
+                'ts_invalidated' => '2025-01-01 19:15:01',
+                'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                'report' => null,
+                'ts_started' => '2025-02-05 09:11:00',
+                'processing_host' => 'host1',
+                'process_id' => 2333
             ],
             [
-                'idarchive' => 66, 'name' => 'donec7445c35d0f9b340f5851df27a15c5ef', 'idsite' => 2, 'date1' => '2025-01-01', 'date2' => '2025-12-31',
-                'period' => Year::PERIOD_ID, 'ts_invalidated' => '2025-01-01 19:15:02', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_QUEUED,
-                'report' => null, 'ts_started' => null, 'processing_host' => null, 'process_id' => null
+                'idarchive' => 66,
+                'name' => 'donec7445c35d0f9b340f5851df27a15c5ef',
+                'idsite' => 2,
+                'date1' => '2025-01-01',
+                'date2' => '2025-12-31',
+                'period' => Year::PERIOD_ID,
+                'ts_invalidated' => '2025-01-01 19:15:02',
+                'status' => ArchiveInvalidator::INVALIDATION_STATUS_QUEUED,
+                'report' => null,
+                'ts_started' => null,
+                'processing_host' => null,
+                'process_id' => null
             ],
 
             // invalidations idsite 3
             [
-                'idarchive' => null, 'name' => 'done.VisitsSummary', 'idsite' => 3, 'date1' => '2025-02-01', 'date2' => '2025-02-28',
-                'period' => Month::PERIOD_ID, 'ts_invalidated' => '2025-02-020 19:15:01', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
-                'report' => null, 'ts_started' => '2025-02-23 18:35:00', 'processing_host' => 'random', 'process_id' => 8558
+                'idarchive' => null,
+                'name' => 'done.VisitsSummary',
+                'idsite' => 3,
+                'date1' => '2025-02-01',
+                'date2' => '2025-02-28',
+                'period' => Month::PERIOD_ID,
+                'ts_invalidated' => '2025-02-020 19:15:01',
+                'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                'report' => null,
+                'ts_started' => '2025-02-23 18:35:00',
+                'processing_host' => 'random',
+                'process_id' => 8558
             ],
         ];
+
+        $this->insertInvalidations($invalidationsToInsert);
+    }
+
+    private function insertInvalidations(array $invalidationsToInsert): void
+    {
+        Db::exec('TRUNCATE TABLE ' . Common::prefixTable('archive_invalidations'));
 
         $sql = 'INSERT INTO ' . Common::prefixTable('archive_invalidations')
             . ' (`idarchive`, `name`, `idsite`, `date1`, `date2`, `period`, `ts_invalidated`, `status`, `report`, `ts_started`, `processing_host`, `process_id`)'

--- a/plugins/CoreAdminHome/tests/Integration/Commands/ResetInvalidationsTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/ResetInvalidationsTest.php
@@ -272,6 +272,264 @@ class ResetInvalidationsTest extends ConsoleCommandTestCase
         ];
     }
 
+    public function testDuplicateInvalidationIsRemovedOnReset()
+    {
+        Db::exec('TRUNCATE TABLE ' . Common::prefixTable('archive_invalidations'));
+
+        $invalidationsToInsert = [
+            [
+                'idarchive' => 7, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
+                'period' => Day::PERIOD_ID, 'ts_invalidated' => '2025-01-01 16:00:00', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                'report' => null, 'ts_started' => '2025-02-05 11:30:00', 'processing_host' => 'host1', 'process_id' => 1256
+            ],
+            [
+                'idarchive' => null, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
+                'period' => Day::PERIOD_ID, 'ts_invalidated' => '2025-01-03 02:55:55', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_QUEUED,
+                'report' => null, 'ts_started' => null, 'processing_host' => null, 'process_id' => null
+            ],
+        ];
+
+        $sql = 'INSERT INTO ' . Common::prefixTable('archive_invalidations')
+            . ' (`idarchive`, `name`, `idsite`, `date1`, `date2`, `period`, `ts_invalidated`, `status`, `report`, `ts_started`, `processing_host`, `process_id`)'
+            . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+
+        foreach ($invalidationsToInsert as $invalidation) {
+            Db::query($sql, $invalidation);
+        }
+
+        $inProgressInvalidationCount = $this->getInProgressInvalidationCount();
+
+        $code = $this->applicationTester->run([
+            'command' => 'core:reset-invalidations',
+            '--dry-run' => true,
+        ]);
+
+        $inProgressInvalidationCountAfterDryRun = $this->getInProgressInvalidationCount();
+
+        self::assertEquals($inProgressInvalidationCount, $inProgressInvalidationCountAfterDryRun);
+        self::assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+
+        $expectedOutput = '1 invalidations found:
++------+--------+--------+------------+------------+--------+---------------------+---------------------+-----------------+------------+
+| name | idsite | report | date1      | date2      | period | ts_invalidated      | ts_started          | processing_host | process_id |
++------+--------+--------+------------+------------+--------+---------------------+---------------------+-----------------+------------+
+| done | 1      |        | 2025-01-01 | 2025-01-01 | 1      | 2025-01-01 16:00:00 | 2025-02-05 11:30:00 | host1           | 1256       |
++------+--------+--------+------------+------------+--------+---------------------+---------------------+-----------------+------------+
+';
+
+        self::assertStringContainsString($expectedOutput, $this->applicationTester->getDisplay(true));
+
+        $code = $this->applicationTester->run([
+            'command' => 'core:reset-invalidations',
+            '-vvv' => true,
+        ]);
+
+        self::assertEquals(0, $this->getInProgressInvalidationCount());
+        self::assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+
+        $rows = Db::fetchAll('SELECT * FROM ' . Common::prefixTable('archive_invalidations'));
+
+        self::assertEquals(1, count($rows));
+        // expected invalidation date from second record, as first one should be removed instead of reset
+        self::assertEquals('2025-01-03 02:55:55', $rows[0]['ts_invalidated']);
+
+        self::assertStringContainsString('Found duplicate invalidation for params (name = done, idsite = 1, date1 = 2025-01-01, date2 = 2025-01-01, period = 1, report = ). Removing invalidation 1 instead of resetting it.', $this->getLogOutput());
+    }
+
+
+    public function testDuplicateInvalidationIsRemovedOnResetWhenOtherOneStartedAfterInvalidationDate()
+    {
+        Db::exec('TRUNCATE TABLE ' . Common::prefixTable('archive_invalidations'));
+
+        $invalidationsToInsert = [
+            [
+                'idarchive' => 7, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
+                'period' => Day::PERIOD_ID, 'ts_invalidated' => '2025-01-01 16:00:00', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                'report' => null, 'ts_started' => '2025-02-05 11:30:00', 'processing_host' => 'host1', 'process_id' => 1256
+            ],
+            [
+                'idarchive' => null, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
+                'period' => Day::PERIOD_ID, 'ts_invalidated' => '2025-01-03 02:55:55', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                'report' => null, 'ts_started' => '2025-01-02 08:00:00', 'processing_host' => 'host4', 'process_id' => 22555
+            ],
+        ];
+
+        $sql = 'INSERT INTO ' . Common::prefixTable('archive_invalidations')
+            . ' (`idarchive`, `name`, `idsite`, `date1`, `date2`, `period`, `ts_invalidated`, `status`, `report`, `ts_started`, `processing_host`, `process_id`)'
+            . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+
+        foreach ($invalidationsToInsert as $invalidation) {
+            Db::query($sql, $invalidation);
+        }
+
+        $inProgressInvalidationCount = $this->getInProgressInvalidationCount();
+
+        $code = $this->applicationTester->run([
+            'command' => 'core:reset-invalidations',
+            '--processing-host' => ['host1'],
+            '--dry-run' => true,
+        ]);
+
+        $inProgressInvalidationCountAfterDryRun = $this->getInProgressInvalidationCount();
+
+        self::assertEquals($inProgressInvalidationCount, $inProgressInvalidationCountAfterDryRun);
+        self::assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+
+        $expectedOutput = '1 invalidations found:
++------+--------+--------+------------+------------+--------+---------------------+---------------------+-----------------+------------+
+| name | idsite | report | date1      | date2      | period | ts_invalidated      | ts_started          | processing_host | process_id |
++------+--------+--------+------------+------------+--------+---------------------+---------------------+-----------------+------------+
+| done | 1      |        | 2025-01-01 | 2025-01-01 | 1      | 2025-01-01 16:00:00 | 2025-02-05 11:30:00 | host1           | 1256       |
++------+--------+--------+------------+------------+--------+---------------------+---------------------+-----------------+------------+
+';
+
+        self::assertStringContainsString($expectedOutput, $this->applicationTester->getDisplay(true));
+
+        $code = $this->applicationTester->run([
+            'command' => 'core:reset-invalidations',
+            '--processing-host' => ['host1'],
+            '-vvv' => true,
+        ]);
+
+        self::assertEquals(1, $this->getInProgressInvalidationCount());
+        self::assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+
+        $rows = Db::fetchAll('SELECT * FROM ' . Common::prefixTable('archive_invalidations'));
+
+        self::assertEquals(1, count($rows));
+        // expected invalidation date from second record, as first one should be removed instead of reset
+        self::assertEquals('2025-01-03 02:55:55', $rows[0]['ts_invalidated']);
+
+        self::assertStringContainsString('Found duplicate invalidation for params (name = done, idsite = 1, date1 = 2025-01-01, date2 = 2025-01-01, period = 1, report = ). Removing invalidation 1 instead of resetting it.', $this->getLogOutput());
+    }
+
+    public function testDuplicateInvalidationIsOnlyResetWhenOtherOneStartedBeforeInvalidationDate()
+    {
+        Db::exec('TRUNCATE TABLE ' . Common::prefixTable('archive_invalidations'));
+
+        $invalidationsToInsert = [
+            [
+                'idarchive' => 7, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
+                'period' => Day::PERIOD_ID, 'ts_invalidated' => '2025-01-01 16:00:00', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                'report' => null, 'ts_started' => '2025-02-05 11:30:00', 'processing_host' => 'host1', 'process_id' => 1256
+            ],
+            [
+                'idarchive' => null, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
+                'period' => Day::PERIOD_ID, 'ts_invalidated' => '2025-01-03 02:55:55', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                'report' => null, 'ts_started' => '2025-01-01 08:00:00', 'processing_host' => 'host4', 'process_id' => 22555
+            ],
+        ];
+
+        $sql = 'INSERT INTO ' . Common::prefixTable('archive_invalidations')
+            . ' (`idarchive`, `name`, `idsite`, `date1`, `date2`, `period`, `ts_invalidated`, `status`, `report`, `ts_started`, `processing_host`, `process_id`)'
+            . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+
+        foreach ($invalidationsToInsert as $invalidation) {
+            Db::query($sql, $invalidation);
+        }
+
+        $inProgressInvalidationCount = $this->getInProgressInvalidationCount();
+
+        $code = $this->applicationTester->run([
+            'command' => 'core:reset-invalidations',
+            '--processing-host' => ['host1'],
+            '--dry-run' => true,
+        ]);
+
+        $inProgressInvalidationCountAfterDryRun = $this->getInProgressInvalidationCount();
+
+        self::assertEquals($inProgressInvalidationCount, $inProgressInvalidationCountAfterDryRun);
+        self::assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+
+        $expectedOutput = '1 invalidations found:
++------+--------+--------+------------+------------+--------+---------------------+---------------------+-----------------+------------+
+| name | idsite | report | date1      | date2      | period | ts_invalidated      | ts_started          | processing_host | process_id |
++------+--------+--------+------------+------------+--------+---------------------+---------------------+-----------------+------------+
+| done | 1      |        | 2025-01-01 | 2025-01-01 | 1      | 2025-01-01 16:00:00 | 2025-02-05 11:30:00 | host1           | 1256       |
++------+--------+--------+------------+------------+--------+---------------------+---------------------+-----------------+------------+
+';
+
+        self::assertStringContainsString($expectedOutput, $this->applicationTester->getDisplay(true));
+
+        $code = $this->applicationTester->run([
+            'command' => 'core:reset-invalidations',
+            '--processing-host' => ['host1'],
+            '-vvv' => true,
+        ]);
+
+        self::assertEquals(1, $this->getInProgressInvalidationCount());
+        self::assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+
+        $rows = Db::fetchAll('SELECT * FROM ' . Common::prefixTable('archive_invalidations'));
+
+        self::assertEquals(2, count($rows));
+
+        self::assertStringNotContainsString('Found duplicate invalidation', $this->getLogOutput());
+    }
+
+    public function testDuplicateInvalidationIsRemovedWhenBothAreReset()
+    {
+        Db::exec('TRUNCATE TABLE ' . Common::prefixTable('archive_invalidations'));
+
+        $invalidationsToInsert = [
+            [
+                'idarchive' => 7, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
+                'period' => Day::PERIOD_ID, 'ts_invalidated' => '2025-01-01 16:00:00', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                'report' => null, 'ts_started' => '2025-02-05 11:30:00', 'processing_host' => 'host1', 'process_id' => 1256
+            ],
+            [
+                'idarchive' => null, 'name' => 'done', 'idsite' => 1, 'date1' => '2025-01-01', 'date2' => '2025-01-01',
+                'period' => Day::PERIOD_ID, 'ts_invalidated' => '2025-01-03 02:55:55', 'status' => ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
+                'report' => null, 'ts_started' => '2025-01-01 08:00:00', 'processing_host' => 'host4', 'process_id' => 22555
+            ],
+        ];
+
+        $sql = 'INSERT INTO ' . Common::prefixTable('archive_invalidations')
+            . ' (`idarchive`, `name`, `idsite`, `date1`, `date2`, `period`, `ts_invalidated`, `status`, `report`, `ts_started`, `processing_host`, `process_id`)'
+            . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+
+        foreach ($invalidationsToInsert as $invalidation) {
+            Db::query($sql, $invalidation);
+        }
+
+        $inProgressInvalidationCount = $this->getInProgressInvalidationCount();
+
+        $code = $this->applicationTester->run([
+            'command' => 'core:reset-invalidations',
+            '--dry-run' => true,
+        ]);
+
+        $inProgressInvalidationCountAfterDryRun = $this->getInProgressInvalidationCount();
+
+        self::assertEquals($inProgressInvalidationCount, $inProgressInvalidationCountAfterDryRun);
+        self::assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+
+        $expectedOutput = '2 invalidations found:
++------+--------+--------+------------+------------+--------+---------------------+---------------------+-----------------+------------+
+| name | idsite | report | date1      | date2      | period | ts_invalidated      | ts_started          | processing_host | process_id |
++------+--------+--------+------------+------------+--------+---------------------+---------------------+-----------------+------------+
+| done | 1      |        | 2025-01-01 | 2025-01-01 | 1      | 2025-01-03 02:55:55 | 2025-01-01 08:00:00 | host4           | 22555      |
+| done | 1      |        | 2025-01-01 | 2025-01-01 | 1      | 2025-01-01 16:00:00 | 2025-02-05 11:30:00 | host1           | 1256       |
++------+--------+--------+------------+------------+--------+---------------------+---------------------+-----------------+------------+
+';
+
+        self::assertStringContainsString($expectedOutput, $this->applicationTester->getDisplay(true));
+
+        $code = $this->applicationTester->run([
+            'command' => 'core:reset-invalidations',
+            '-vvv' => true,
+        ]);
+
+        self::assertEquals(0, $this->getInProgressInvalidationCount());
+        self::assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+
+        $rows = Db::fetchAll('SELECT * FROM ' . Common::prefixTable('archive_invalidations'));
+
+        self::assertEquals(1, count($rows));
+
+        self::assertStringContainsString('Found duplicate invalidation for params (name = done, idsite = 1, date1 = 2025-01-01, date2 = 2025-01-01, period = 1, report = ). Removing invalidation 2 instead of resetting it.', $this->getLogOutput());
+    }
+
     /**
      * @return array<string, mixed>
      */


### PR DESCRIPTION
### Description:

Currently invalidations might be reset when they are either considered stuck (after 24 hours) or with using the new `core:reset-invalidations` command. 

However, both ways currently simply reset the in progress invalidations, without checking if there might be other identical invalidations not yet been started.

This might cause unneeded archiving work, as a freshly built archive might be directly rebuilt through the other exisiting invalidtion afterwards.

To ensure that won't happen any longer, this PR introduce some additional checks so that duplicate invalidations are being removed instead of reset.

fixes #22972

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
