### PR TITLE
Fix CLI "plugin:list" JSON output for deactivated plugins

### DIFF
--- a/plugins/CorePluginsAdmin/Commands/ListPlugins.php
+++ b/plugins/CorePluginsAdmin/Commands/ListPlugins.php
@@ -59,7 +59,6 @@ class ListPlugins extends ConsoleCommand
                 if (isset($plugin["version"]) && !isset($plugin["activated"])) {
                     $plugin["version"] = '';
                 }
-                $plugin["activated"] = isset($plugin["activated"]);
                 return $plugin;
             }, $plugins);
 

--- a/plugins/CorePluginsAdmin/Commands/ListPlugins.php
+++ b/plugins/CorePluginsAdmin/Commands/ListPlugins.php
@@ -56,7 +56,7 @@ class ListPlugins extends ConsoleCommand
         if ($this->getInput()->getOption('json')) {
             $plugins = array_map(function ($plugin) {
                 $plugin["comment"] = !isset($plugin["activated"]) ? 'Plugin not found in filesystem.' : '';
-                if (isset($plugin["version"]) && $plugin["activated"] === null) {
+                if (isset($plugin["version"]) && !isset($plugin["activated"])) {
                     $plugin["version"] = '';
                 }
                 return $plugin;

--- a/plugins/CorePluginsAdmin/Commands/ListPlugins.php
+++ b/plugins/CorePluginsAdmin/Commands/ListPlugins.php
@@ -56,7 +56,7 @@ class ListPlugins extends ConsoleCommand
         if ($this->getInput()->getOption('json')) {
             $plugins = array_map(function ($plugin) {
                 $plugin["comment"] = !isset($plugin["activated"]) ? 'Plugin not found in filesystem.' : '';
-                if (isset($plugin["version"]) && !isset($plugin["activated"])) {
+                if (isset($plugin["version"]) && $plugin["activated"] === null) {
                     $plugin["version"] = '';
                 }
                 return $plugin;


### PR DESCRIPTION
### Description:

This ensures that `false` is outputted for `activated` in case of deactivated plugins. Also pass through `null` in case a plugin is not found.

Also ensure the version is outputted in case of deactivated plugins.

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
