### PR TITLE
Avoid performing complex update query when invalidating range archives

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -337,10 +337,9 @@ class Model
      * @param int[] $idSites
      * @param string[][] $datesByPeriodType
      * @param Segment $segment
-     * @return \Zend_Db_Statement
      * @throws Exception
      */
-    public function updateRangeArchiveAsInvalidated($archiveTable, $idSites, $allPeriodsToInvalidate, ?Segment $segment = null)
+    public function updateRangeArchiveAsInvalidated($archiveTable, $idSites, $allPeriodsToInvalidate, ?Segment $segment = null): void
     {
         if (empty($idSites)) {
             return;
@@ -366,15 +365,22 @@ class Model
         if ($segment) {
             $nameCondition = "name LIKE '" . Rules::getDoneFlagArchiveContainsAllPlugins($segment) . "%'";
         } else {
-            $nameCondition = "name LIKE 'done%'";
+            $nameCondition = "(name LIKE 'done%' OR name LIKE 'done.%')";
         }
 
-        $sql = "UPDATE $archiveTable SET value = " . ArchiveWriter::DONE_INVALIDATED
+        $sql = "SELECT idarchive, name FROM $archiveTable "
              . " WHERE $nameCondition
                    AND idsite IN (" . implode(", ", $idSites) . ")
                    AND (" . implode(" OR ", $periodConditions) . ")";
 
-        return Db::query($sql, $bind);
+        $recordsToUpdate = Db::fetchAll($sql, $bind);
+
+        foreach ($recordsToUpdate as $record) {
+            $sql = "UPDATE $archiveTable SET value = " . ArchiveWriter::DONE_INVALIDATED
+                . " WHERE idarchive = ? AND name = ?";
+
+            Db::query($sql, [$record['idarchive'], $record['name']]);
+        }
     }
 
     public function getTemporaryArchivesOlderThan($archiveTable, $purgeArchivesOlderThan)

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -196,7 +196,7 @@ class Model
 
                 // set status to DONE_INVALIDATED for finished archives
                 $sql = "UPDATE `$archiveTable` SET `value` = " . ArchiveWriter::DONE_INVALIDATED . " WHERE idarchive IN ("
-                    . implode(',', $idArchives) . ") AND value != " . ArchiveWriter::DONE_ERROR . " AND $nameCondition";
+                    . implode(',', $idArchives) . ") AND value NOT IN (" . ArchiveWriter::DONE_ERROR . ", " . ArchiveWriter::DONE_ERROR_INVALIDATED . ") AND $nameCondition";
 
                 Db::query($sql);
 
@@ -362,10 +362,11 @@ class Model
             }
         }
 
-        if ($segment) {
-            $nameCondition = "name LIKE '" . Rules::getDoneFlagArchiveContainsAllPlugins($segment) . "%'";
+        if (null === $segment) {
+            $nameCondition = "name LIKE 'done%'";
         } else {
-            $nameCondition = "(name = 'done' OR name LIKE 'done.%')";
+            $doneFlag = Rules::getDoneFlagArchiveContainsAllPlugins($segment);
+            $nameCondition = "(name = '$doneFlag' OR name LIKE '$doneFlag.%')";
         }
 
         $sql = "SELECT idarchive FROM $archiveTable "
@@ -375,10 +376,20 @@ class Model
 
         $recordsToUpdate = Db::fetchAll($sql, $bind);
 
+        if (empty($recordsToUpdate)) {
+            return;
+        }
+
         $idArchives = array_map('intval', array_column($recordsToUpdate, 'idarchive'));
 
         $updateSql = "UPDATE $archiveTable SET value = " . ArchiveWriter::DONE_INVALIDATED
-                   . " WHERE idarchive IN (" . implode(', ', $idArchives) . ") AND $nameCondition";
+            . " WHERE idarchive IN (" . implode(', ', $idArchives) . ") AND $nameCondition"
+            . " AND value NOT IN (" . ArchiveWriter::DONE_ERROR . ", " . ArchiveWriter::DONE_ERROR_INVALIDATED . ")";
+
+        Db::query($updateSql);
+
+        $updateSql = "UPDATE $archiveTable SET value = " . ArchiveWriter::DONE_ERROR_INVALIDATED
+                   . " WHERE idarchive IN (" . implode(', ', $idArchives) . ") AND $nameCondition AND value = " . ArchiveWriter::DONE_ERROR;
 
         Db::query($updateSql);
     }

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -365,22 +365,22 @@ class Model
         if ($segment) {
             $nameCondition = "name LIKE '" . Rules::getDoneFlagArchiveContainsAllPlugins($segment) . "%'";
         } else {
-            $nameCondition = "(name LIKE 'done%' OR name LIKE 'done.%')";
+            $nameCondition = "(name = 'done' OR name LIKE 'done.%')";
         }
 
-        $sql = "SELECT idarchive, name FROM $archiveTable "
+        $sql = "SELECT idarchive FROM $archiveTable "
              . " WHERE $nameCondition
                    AND idsite IN (" . implode(", ", $idSites) . ")
                    AND (" . implode(" OR ", $periodConditions) . ")";
 
         $recordsToUpdate = Db::fetchAll($sql, $bind);
 
-        foreach ($recordsToUpdate as $record) {
-            $sql = "UPDATE $archiveTable SET value = " . ArchiveWriter::DONE_INVALIDATED
-                . " WHERE idarchive = ? AND name = ?";
+        $idArchives = array_map('intval', array_column($recordsToUpdate, 'idarchive'));
 
-            Db::query($sql, [$record['idarchive'], $record['name']]);
-        }
+        $updateSql = "UPDATE $archiveTable SET value = " . ArchiveWriter::DONE_INVALIDATED
+                   . " WHERE idarchive IN (" . implode(', ', $idArchives) . ") AND $nameCondition";
+
+        Db::query($updateSql);
     }
 
     public function getTemporaryArchivesOlderThan($archiveTable, $purgeArchivesOlderThan)


### PR DESCRIPTION
### Description:

The update query currently performed in `updateRangeArchiveAsInvalidated` has quite complex where conditions. This might cause the query to take a bit longer, which can result in transaction locks.

refs #21749

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
