### PR TITLE
Fix/improve tests

### DIFF
--- a/plugins/CoreAdminHome/tests/Integration/Commands/ResetInvalidationsTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/ResetInvalidationsTest.php
@@ -358,7 +358,7 @@ class ResetInvalidationsTest extends ConsoleCommandTestCase
 
 
         foreach ($invalidationsToInsert as $invalidation) {
-            Db::query($sql, $invalidation);
+            Db::query($sql, array_values($invalidation));
         }
     }
 }

--- a/plugins/Login/tests/UI/ResetPassword_spec.js
+++ b/plugins/Login/tests/UI/ResetPassword_spec.js
@@ -164,6 +164,8 @@ describe('ResetPassword', function () {
             await page.waitForNetworkIdle();
 
             await page.click('#confirm-cancel-reset-password');
+            await page.waitForNetworkIdle();
+
             expect(await page.screenshot({ fullPage: true })).to.matchImage('cancel');
         });
 


### PR DESCRIPTION
### Description:

1. The tests for the new `core:reset-invalidations` command are currently failing for PHP 8.4 and the `mysqli` adapter:

> ArgumentCountError : mysqli_stmt::bind_param() does not accept unknown named parameters

Since (at least) PHP 8.0 it is no longer possible to pass an associative array of arguments to a query using positional parameters. Using named parameters directly in the query does not work because `Zend_Statement` will throw in that case.

2. The `ResetPassword` tests are sometimes failing the screenshot comparison after not loading an icon. Adding a tiny `waitForNetworkIdle` should make it a bit more resilient.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
