### PR TITLE
Remove Config::sanityCheck method as it doesn't make sense

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -413,13 +413,6 @@ class Config
                 throw $this->getConfigNotWritableException();
             }
 
-            if (!$this->sanityCheck($localPath, $output)) {
-                // If sanity check fails, try to write the contents once more before logging the issue.
-                if (@file_put_contents($localPath, $output, LOCK_EX) === false || !$this->sanityCheck($localPath, $output, true)) {
-                    StaticContainer::get(LoggerInterface::class)->info("The configuration file {$localPath} did not write correctly.");
-                }
-            }
-
             $this->settings->getIniFileChain()->deleteConfigCache();
 
             /**
@@ -474,39 +467,5 @@ class Config
         $section = self::getInstance()->$sectionName;
         $section[$name] = $value;
         self::getInstance()->$sectionName = $section;
-    }
-
-    /**
-     * Sanity check a config file by checking contents
-     *
-     * @param string $localPath
-     * @param string $expectedContent
-     * @param bool $notify
-     * @return bool
-     */
-    public function sanityCheck(string $localPath, string $expectedContent, bool $notify = false): bool
-    {
-        clearstatcache(true, $localPath);
-
-        if (function_exists('opcache_invalidate')) {
-            @opcache_invalidate($localPath, $force = true);
-        }
-
-        $content = @file_get_contents($localPath);
-
-        if (trim($content) !== trim($expectedContent)) {
-            if ($notify) {
-                /**
-                 * Triggered when the INI config file was not written correctly with the expected content.
-                 *
-                 * @param string $localPath Absolute path to the changed file on the server.
-                 */
-                Piwik::postEvent('Core.configFileSanityCheckFailed', [$localPath]);
-            }
-
-            return false;
-        }
-
-        return true;
     }
 }


### PR DESCRIPTION
The sanityCheck function does not make sense (we should assume the OS wrote the file) and it introduced a race condition.