### PR TITLE
Fix skip-to-content link

### DIFF
--- a/plugins/CoreHome/templates/_topScreen.twig
+++ b/plugins/CoreHome/templates/_topScreen.twig
@@ -1,6 +1,6 @@
 <nav>
     <div class="nav-wrapper">
-        <a href="#main" tabindex="1" class="accessibility-skip-to-content">{{'CoreHome_SkipToContent'|translate}}</a>
+        <a href="javascript:$('a[name=main]')[0].scrollIntoView()" tabindex="1" class="accessibility-skip-to-content">{{'CoreHome_SkipToContent'|translate}}</a>
         {% include "@CoreHome/_logo.twig" %}
         {% include "@CoreHome/_topBar.twig" %}
     </div>


### PR DESCRIPTION
### Description:

The skip to content link is currently broken, as our internal handling of the url hash breaks the link.
This PR replaces the handling to use pure javascript for that link instead.

fixes #23060

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
