### PR TITLE
adding role to pause image for better accessibility

### DIFF
--- a/plugins/Live/vue/src/LivePage/LivePage.vue
+++ b/plugins/Live/vue/src/LivePage/LivePage.vue
@@ -21,7 +21,7 @@
           :title="translate('Live_OnClickPause', translate('Live_VisitorsInRealTime'))"
           @click.prevent="onClickPause()"
         >
-          <img id="pauseImage" border="0" src="plugins/Live/images/pause.png" />
+          <img id="pauseImage" border="0" src="plugins/Live/images/pause.png" role="presentation" />
         </a>
         <a
           :title="translate('Live_OnClickStart', translate('Live_VisitorsInRealTime'))"
@@ -32,6 +32,7 @@
             style="display: none;"
             border="0"
             src="plugins/Live/images/play.png"
+            role="presentation"
           />
         </a>
         <span v-if="!disableLink">


### PR DESCRIPTION
### Description:

Adding the role presentation to image that have decorative representation. This small change makes the widget better from a WCAG-perspective.

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
