### PR TITLE
Define missing constants SIGINT and SIGTERM

### DIFF
--- a/core/bootstrap.php
+++ b/core/bootstrap.php
@@ -15,6 +15,14 @@ if (!defined('PIWIK_USER_PATH')) {
     define('PIWIK_USER_PATH', PIWIK_DOCUMENT_ROOT);
 }
 
+if (!defined('SIGINT')) {
+    define('SIGINT', 2); // Standard SIGINT value on Unix
+}
+
+if (!defined('SIGTERM')) {
+    define('SIGTERM', 15); // Standard SIGTERM value on Unix
+}
+
 $errorLevel = E_ALL;
 
 // We cannot enable deprecations for PHP 8.4 until we are able to update php-di/php-di to a version compatible


### PR DESCRIPTION
### Description:

We introduced signal handling in Matomo 5.3.0. Although behind a feature flag we still used constants that are only available in `PCNTL` 

Which won't be possible on Windows and some custom compiled PHP CLI.

I managed to replicate locally compiling PHP like this:

```
Configure Command =>  './configure'  '--disable-pcntl' '--with-curl' '--with-freetype' '--with-jpeg' '--with-openssl' '--with-zlib' '--with-zip' '--enable-mbstring' '--enable-gd' '--with-mysqli' '--with-pdo-mysql' '--with-xml' '--enable-session' '--with-iconv'
```

Here is the output before:
```
INFO      [2025-03-10 02:19:37] 2144  SCHEDULED TASKS
INFO      [2025-03-10 02:19:37] 2144  Starting Scheduled tasks...
ERROR     [2025-03-10 02:19:37] 2144  Uncaught exception: Error: Undefined constant "SIGINT" in /var/www/html/core/Scheduler/Scheduler.php:134
Stack trace:
#0 /var/www/html/core/CronArchive.php(767): Piwik\Scheduler\Scheduler->run()
#1 /var/www/html/core/CronArchive.php(310): Piwik\CronArchive->runScheduledTasks()
#2 /var/www/html/core/Access.php(663): Piwik\CronArchive->Piwik\{closure}()
#3 /var/www/html/core/CronArchive.php(301): Piwik\Access::doAsSuperUser(Object(Closure))
#4 /var/www/html/plugins/CoreConsole/Commands/CoreArchiver.php(54): Piwik\CronArchive->main()
#5 /var/www/html/core/Plugin/ConsoleCommand.php(143): Piwik\Plugins\CoreConsole\Commands\CoreArchiver->doExecute()
#6 /var/www/html/vendor/symfony/console/Command/Command.php(298): Piwik\Plugin\ConsoleCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /var/www/html/core/Plugin/ConsoleCommand.php(158): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /var/www/html/vendor/symfony/console/Application.php(1040): Piwik\Plugin\ConsoleCommand->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /var/www/html/vendor/symfony/console/Application.php(301): Symfony\Component\Console\Application->doRunCommand(Object(Piwik\Plugins\CoreConsole\Commands\CoreArchiver), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /var/www/html/core/Console.php(113): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 [internal function]: Piwik\Console->originDoRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /var/www/html/core/Console.php(156): call_user_func(Array, Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /var/www/html/core/Access.php(672): Piwik\Console->Piwik\{closure}()
#14 /var/www/html/core/Console.php(154): Piwik\Access::doAsSuperUser(Object(Closure))
#15 /var/www/html/core/Console.php(92): Piwik\Console->doRunImpl(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /var/www/html/vendor/symfony/console/Application.php(171): Piwik\Console->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 /var/www/html/console(32): Symfony\Component\Console\Application->run()
#18 {main}
Uncaught exception in /var/www/html/core/Scheduler/Scheduler.php line 134:
Undefined constant "SIGINT"
Failed to run matomo_console core:archive: exit status 1
```

Here is after this change
```
INFO      [2025-03-10 02:38:28] 2960  ---------------------------
INFO      [2025-03-10 02:38:28] 2960  START
INFO      [2025-03-10 02:38:28] 2960  Starting Matomo reports archiving...
INFO      [2025-03-10 02:38:28] 2960  2 out of 3 archivers running currently
INFO      [2025-03-10 02:38:28] 2960  Start processing archives for site 1.
INFO      [2025-03-10 02:38:28] 2960  Finished archiving for site 1, 0 API requests, Time elapsed: 0.012s [1 / 1 done]
INFO      [2025-03-10 02:38:28] 2960  Done archiving!
INFO      [2025-03-10 02:38:28] 2960  ---------------------------
INFO      [2025-03-10 02:38:28] 2960  SUMMARY
INFO      [2025-03-10 02:38:28] 2960  Processed 0 archives.
INFO      [2025-03-10 02:38:28] 2960  Total API requests: 0
INFO      [2025-03-10 02:38:28] 2960  done: 0 req, 39 ms, no error
INFO      [2025-03-10 02:38:28] 2960  Time elapsed: 0.039s
INFO      [2025-03-10 02:38:28] 2960  ---------------------------
INFO      [2025-03-10 02:38:28] 2960  SCHEDULED TASKS
INFO      [2025-03-10 02:38:28] 2960  Starting Scheduled tasks...
INFO      [2025-03-10 02:38:28] 2960  done
INFO      [2025-03-10 02:38:28] 2960  ---------------------------
```

Fixes #23106 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
