### PR TITLE
Avoid using signal constants outside of handleSignal method

### DIFF
--- a/core/Scheduler/Scheduler.php
+++ b/core/Scheduler/Scheduler.php
@@ -82,9 +82,9 @@ class Scheduler
     private $lock;
 
     /**
-     * @var int|null
+     * @var bool
      */
-    private $signal = null;
+    private $hasReceivedAbortSignal = false;
 
     public function __construct(TaskLoader $loader, LoggerInterface $logger, ScheduledTaskLock $lock)
     {
@@ -96,7 +96,7 @@ class Scheduler
 
     public function handleSignal(int $signal): void
     {
-        $this->signal = $signal;
+        $this->hasReceivedAbortSignal = in_array($signal, [\SIGINT, \SIGTERM], true);
     }
 
     /**
@@ -131,7 +131,7 @@ class Scheduler
 
             // loop through each task
             foreach ($tasks as $task) {
-                if (in_array($this->signal, [\SIGINT, \SIGTERM], true)) {
+                if ($this->hasReceivedAbortSignal) {
                     $this->logger->info("Scheduler: Aborting due to received signal");
                     return $executionResults;
                 }


### PR DESCRIPTION
### Description:

On system where `pcntl` extension is not available, the signal constants are undefined. Therefor we can't use them outside of the `handleSignal` method (which is only called when signal handling is available).

replaces #23109

fixes #23106

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
