### PR TITLE
Ensure login username is provided as string value

### DIFF
--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -261,9 +261,9 @@ class Login extends \Piwik\Plugin
     {
         $login = StaticContainer::get(\Piwik\Auth::class)->getLogin();
         if (empty($login) || $login == 'anonymous') {
-            $login = Common::getRequestVar('form_login', false);
+            $login = \Piwik\Request::fromRequest()->getStringParameter('form_login', '');
             if (Piwik::getAction() === 'logme') {
-                $login = Common::getRequestVar('login', $login);
+                $login = \Piwik\Request::fromRequest()->getStringParameter('login', $login);
             }
         }
 


### PR DESCRIPTION
### Description:

providing the login as an array in the login/logme request currently results in a fatal error. With this PR a string will be expected, causing a proper error to be shown if an array is provided instead.

fixes #22929

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
