### PR TITLE
Removing host from test configs

### DIFF
--- a/.ddev/commands/host/matomo_init_tests
+++ b/.ddev/commands/host/matomo_init_tests
@@ -9,7 +9,6 @@ ddev matomo:console config:set \
   'database_tests.host="db"' \
   'database_tests.username="db"' \
   'database_tests.password="db"' \
-  'tests.http_host="matomo.ddev.site"' \
   'tests.request_uri="/"' \
   'tests.port=80'
 


### PR DESCRIPTION
### Description:

On Ubuntu 24.04, I found that while running `ddev matomo:init:tests` the building of the OmniFixture failed due to a `Connection refused` error. Once I removed the `http_host` from the `tests` configs, everything ran as expected.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
