### PR TITLE
Fix handling of range invalidations during intersecting period check

### DIFF
--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -443,7 +443,7 @@ class QueueConsumer
             }
 
             $processedPeriodLabel = $periods[$archiveBeingProcessed['period']];
-            $processedPeriodDate = 'range' === $periods[$archiveBeingProcessed['period']]
+            $processedPeriodDate = 'range' === $processedPeriodLabel
                 ? $archiveBeingProcessed['date1'] . ',' . $archiveBeingProcessed['date2']
                 : $archiveBeingProcessed['date1'];
 

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -442,21 +442,29 @@ class QueueConsumer
                 continue;
             }
 
-            $archiveBeingProcessed['periodObj'] = PeriodFactory::build($periods[$archiveBeingProcessed['period']], $archiveBeingProcessed['date1']);
+            $processedPeriodLabel = $periods[$archiveBeingProcessed['period']];
+            $processedPeriodDate = 'range' === $periods[$archiveBeingProcessed['period']]
+                ? $archiveBeingProcessed['date1'] . ',' . $archiveBeingProcessed['date2']
+                : $archiveBeingProcessed['date1'];
+
+            $archiveBeingProcessed['periodObj'] = PeriodFactory::build(
+                $processedPeriodLabel,
+                $processedPeriodDate
+            );
 
             if (!$this->isArchiveOfLowerPeriod($archiveToProcess, $archiveBeingProcessed)) {
                 continue;
             }
 
             if (empty($archiveToProcess['segment']) && !empty($archiveBeingProcessed['segment'])) {
-                return "segment archive in progress for same site with lower or same period ({$archiveBeingProcessed['segment']}, period = {$periods[$archiveBeingProcessed['period']]}, date = {$archiveBeingProcessed['date1']})";
+                return "segment archive in progress for same site with lower or same period ({$archiveBeingProcessed['segment']}, period = {$processedPeriodLabel}, date = {$processedPeriodDate})";
             }
 
             if (!empty($archiveToProcess['segment']) && empty($archiveBeingProcessed['segment'])) {
-                return "all visits archive in progress for same site with lower or same period (period = {$periods[$archiveBeingProcessed['period']]}, date = {$archiveBeingProcessed['date1']})";
+                return "all visits archive in progress for same site with lower or same period (period = {$processedPeriodLabel}, date = {$processedPeriodDate})";
             }
 
-            return "lower or same period in progress (period = {$periods[$archiveBeingProcessed['period']]}, date = {$archiveBeingProcessed['date1']})";
+            return "lower or same period in progress (period = {$processedPeriodLabel}, date = {$processedPeriodDate})";
         }
 
         return null;

--- a/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
+++ b/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
@@ -1198,7 +1198,18 @@ class QueueConsumerTest extends IntegrationTestCase
 
         $periods = array_flip(Piwik::$idPeriods);
 
-        $archiveToProcess['periodObj'] = Factory::build($periods[$archiveToProcess['period']], $archiveToProcess['date1']);
+        if ('range' === $periods[$archiveToProcess['period']]) {
+            $archiveToProcess['periodObj'] = Factory::build(
+                $periods[$archiveToProcess['period']],
+                $archiveToProcess['date1'] . ',' . $archiveToProcess['date2']
+            );
+        } else {
+            $archiveToProcess['periodObj'] = Factory::build(
+                $periods[$archiveToProcess['period']],
+                $archiveToProcess['date1']
+            );
+        }
+
         $actual = $queueConsumer->shouldSkipArchiveBecauseLowerPeriodOrSegmentIsInProgress($archiveToProcess);
         $this->assertSame($expected, $actual);
     }
@@ -1460,6 +1471,38 @@ class QueueConsumerTest extends IntegrationTestCase
             ],
             'archiveToProcess' => ['name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc', 'idsite' => 1, 'date1' => '2020-03-04', 'date2' => '2020-03-04', 'period' => Day::PERIOD_ID, 'segment' => 'browserCode==IE'],
             'expected' => null
+        ];
+
+        yield 'day period should not be detected as intersecting when range is processed' => [
+            'existingInvalidations' => [
+                ['name' => 'done', 'idsite' => 5, 'date1' => '2020-03-03', 'date2' => '2020-03-05', 'period' => Range::PERIOD_ID, 'status' => 1, 'ts_started' => date('Y-m-d H:i:s')],
+            ],
+            'archiveToProcess' => ['name' => 'done', 'idsite' => 5, 'date1' => '2020-03-04', 'date2' => '2020-03-04', 'period' => Day::PERIOD_ID],
+            'expected' => null,
+        ];
+
+        yield 'range period should be detected as intersecting when day is processed' => [
+            'existingInvalidations' => [
+                ['name' => 'done', 'idsite' => 5, 'date1' => '2020-03-04', 'date2' => '2020-03-04', 'period' => Day::PERIOD_ID, 'status' => 1, 'ts_started' => date('Y-m-d H:i:s')],
+            ],
+            'archiveToProcess' => ['name' => 'done', 'idsite' => 5, 'date1' => '2020-03-03', 'date2' => '2020-03-05', 'period' => Range::PERIOD_ID],
+            'expected' => 'lower or same period in progress (period = day, date = 2020-03-04)',
+        ];
+
+        yield 'range period should be detected as intersecting when overlapping range is processed' => [
+            'existingInvalidations' => [
+                ['name' => 'done', 'idsite' => 5, 'date1' => '2020-03-02', 'date2' => '2020-03-04', 'period' => Range::PERIOD_ID, 'status' => 1, 'ts_started' => date('Y-m-d H:i:s')],
+            ],
+            'archiveToProcess' => ['name' => 'done', 'idsite' => 5, 'date1' => '2020-03-03', 'date2' => '2020-03-05', 'period' => Range::PERIOD_ID],
+            'expected' => 'lower or same period in progress (period = range, date = 2020-03-02)',
+        ];
+
+        yield 'range period should not be detected as intersecting when non-overlapping range is processed' => [
+            'existingInvalidations' => [
+                ['name' => 'done', 'idsite' => 5, 'date1' => '2020-03-01', 'date2' => '2020-03-02', 'period' => Range::PERIOD_ID, 'status' => 1, 'ts_started' => date('Y-m-d H:i:s')],
+            ],
+            'archiveToProcess' => ['name' => 'done', 'idsite' => 5, 'date1' => '2020-03-04', 'date2' => '2020-03-05', 'period' => Range::PERIOD_ID],
+            'expected' => null,
         ];
     }
 

--- a/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
+++ b/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
@@ -1494,7 +1494,7 @@ class QueueConsumerTest extends IntegrationTestCase
                 ['name' => 'done', 'idsite' => 5, 'date1' => '2020-03-02', 'date2' => '2020-03-04', 'period' => Range::PERIOD_ID, 'status' => 1, 'ts_started' => date('Y-m-d H:i:s')],
             ],
             'archiveToProcess' => ['name' => 'done', 'idsite' => 5, 'date1' => '2020-03-03', 'date2' => '2020-03-05', 'period' => Range::PERIOD_ID],
-            'expected' => 'lower or same period in progress (period = range, date = 2020-03-02)',
+            'expected' => 'lower or same period in progress (period = range, date = 2020-03-02,2020-03-04)',
         ];
 
         yield 'range period should not be detected as intersecting when non-overlapping range is processed' => [


### PR DESCRIPTION
### Description:

During the intersection period check, a check that involves range period invalidations can lead to an exception, preventing further archiving until that invalidation is either reset or finished.

```
Exception: General_ExceptionInvalidDateRange

/home/runner/work/matomo/matomo/matomo/core/Period/Range.php:275
/home/runner/work/matomo/matomo/matomo/core/Period.php:132
/home/runner/work/matomo/matomo/matomo/core/Period/Range.php:153
/home/runner/work/matomo/matomo/matomo/core/Period.php:274
/home/runner/work/matomo/matomo/matomo/core/CronArchive/QueueConsumer.php:474
/home/runner/work/matomo/matomo/matomo/core/CronArchive/QueueConsumer.php:447
```

_Should be backported to 5.3.x-dev!_

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
