### PR TITLE
Match browser name with `name` only, rather than `name;version`

### DIFF
--- a/plugins/DevicesDetection/functions.php
+++ b/plugins/DevicesDetection/functions.php
@@ -97,9 +97,10 @@ function getBrowserLogo($short)
 
     // If name is given instead of short code, try to find matching shortcode
     if (!empty($short) && strlen($short) > 2) {
-        if (in_array($short, BrowserParser::getAvailableBrowsers())) {
+        $browser = explode(";", $short)[0];
+        if (in_array($browser, BrowserParser::getAvailableBrowsers())) {
             $flippedBrowsers = array_flip(BrowserParser::getAvailableBrowsers());
-            $short           = $flippedBrowsers[$short];
+            $short           = $flippedBrowsers[$browser];
         } else {
             $short = substr($short, 0, 2);
         }


### PR DESCRIPTION
### Description:

In `plugins/DevicesDetection/VisitorDetails.php#116`, it calling `getBrowserLogo($short)` function with `name;version` as short name.

Cuase `plugins/DevicesDetection/function.php#100` never able to match `name;version` with `BrowserParser::getAvailableBrowsers()`, since `BrowserParser::getAvailableBrowsers()` returns browser name only, not version number.

This PR is modify `function.php` to split browser name and version, to properly match browser name.

Related PR:
https://github.com/matomo-org/device-detector/pull/8029

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
