### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4101,16 +4101,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.20",
+            "version": "1.12.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "3240b1972042c7f73cf1045e879ea5bd5f761bb7"
+                "reference": "14276fdef70575106a3392a4ed553c06a984df28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/3240b1972042c7f73cf1045e879ea5bd5f761bb7",
-                "reference": "3240b1972042c7f73cf1045e879ea5bd5f761bb7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/14276fdef70575106a3392a4ed553c06a984df28",
+                "reference": "14276fdef70575106a3392a4ed553c06a984df28",
                 "shasum": ""
             },
             "require": {
@@ -4155,7 +4155,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-05T13:37:43+00:00"
+            "time": "2025-03-09T09:24:50+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
                                                      Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading phpstan/phpstan (1.12.20 => 1.12.21)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downloading phpstan/phpstan (1.12.21)
  - Upgrading phpstan/phpstan (1.12.20 => 1.12.21): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
53 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.
```
