### PR TITLE
Ensure parameters are encoded properly

### DIFF
--- a/plugins/SitesManager/SiteContentDetection/WordPress.php
+++ b/plugins/SitesManager/SiteContentDetection/WordPress.php
@@ -62,8 +62,8 @@ class WordPress extends SiteContentDetectionAbstract
             $authLink = SettingsPiwik::getPiwikUrl() . 'index.php?' .
                 Url::getQueryStringFromParameters([
                                                       'idSite' => $idSite,
-                                                      'date'   => $date,
-                                                      'period' => $period,
+                                                      'date'   => urlencode($date),
+                                                      'period' => urlencode($period),
                                                       'module' => 'UsersManager',
                                                       'action' => 'addNewToken',
                                                   ]);


### PR DESCRIPTION
### Description:

Those parameters might be provided by the user, therefor they should be encoded properly when used to build a new URL.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
