### PR TITLE
Persist search trigger id and sorting information

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -893,34 +893,47 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                 searchForPattern();
             }
         }
-        function showSearch(event) {
-            event.preventDefault();
-            event.stopPropagation();
 
-            var triggerField;
-            if (typeof self.param.filter_trigger_id != "undefined"
-              && self.param.filter_trigger_id.length > 0) {
-              triggerField = document.getElementById(self.param.filter_trigger_id);
-            } else if (event && event.target) {
+        function getTriggerField(event) {
+          if (typeof self.param.filter_trigger_id !== "undefined" &&
+            self.param.filter_trigger_id.length > 0) {
+            return document.getElementById(self.param.filter_trigger_id);
+          } else {
+            if (event && event.target) {
               if (event.target.nodeName.toLowerCase() === 'span') {
-                triggerField = $(event.target).siblings('input');
+                return $(event.target).siblings('input');
               } else {
-                triggerField = $(event.target).children('input');
+                return $(event.target).children('input');
               }
             }
+          }
+        }
 
-            var $searchAction = $(this);
-            $searchAction.addClass('searchActive forceActionVisible');
-            var width = getOptimalWidthForSearchField($searchAction);
-            $searchAction.css('width', width + 'px');
+        function restoreSearchFieldFocus(event)
+        {
+            var triggerField = getTriggerField(event);
 
             if (triggerField) {
               triggerField.focus();
             }
+        }
 
+        function showSearchInputFields($searchAction) {
+            $searchAction.addClass('searchActive forceActionVisible');
+            var width = getOptimalWidthForSearchField($searchAction);
+            $searchAction.css('width', width + 'px');
             $searchAction.find('.icon-search').on('click', searchForPattern);
             $searchAction.off('click', showSearch);
         }
+
+        function showSearch(event) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            showSearchInputFields($(this));
+            restoreSearchFieldFocus(event);
+        }
+
 
         function searchForPattern(event) {
             var keyword = '';
@@ -974,11 +987,16 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             }
         });
 
+        $searchInput.on("blur", function () {
+            self.param.filter_trigger_id = 0;
+        });
+
         var $dataTable = $searchInput.parents('.dataTable').first();
         if (currentPattern) {
             $dataTable.addClass('hasSearchKeyword');
             $searchInput.val(currentPattern);
-            $searchAction.click();
+            showSearchInputFields($searchAction);
+            restoreSearchFieldFocus();
         } else {
             $dataTable.removeClass('hasSearchKeyword');
         }

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1377,7 +1377,12 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
     getFilterParams: function (params) {
         return Object.keys(params)
-           .filter(key => key.startsWith('filter_column') || key.startsWith('filter_pattern'))
+           .filter(key => {
+               return key === 'filter_trigger_id'
+                   || key.startsWith('filter_column')
+                   || key.startsWith('filter_pattern')
+                   || key.startsWith('filter_sort')
+           })
            .reduce((filterParams, key) => {
                filterParams[key] = params[key];
                return filterParams;

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -988,7 +988,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         });
 
         $searchInput.on("blur", function () {
-            self.param.filter_trigger_id = 0;
+            delete self.param.filter_trigger_id;
         });
 
         var $dataTable = $searchInput.parents('.dataTable').first();

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1377,12 +1377,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
     getFilterParams: function (params) {
         return Object.keys(params)
-           .filter(key => {
-               return key === 'filter_trigger_id'
-                   || key.startsWith('filter_column')
-                   || key.startsWith('filter_pattern')
-                   || key.startsWith('filter_sort')
-           })
+           .filter(key => key.startsWith('filter_column') || key.startsWith('filter_pattern'))
            .reduce((filterParams, key) => {
                filterParams[key] = params[key];
                return filterParams;

--- a/tests/UI/expected-screenshots/SearchFilterPersistenceTest_persisted_date.png
+++ b/tests/UI/expected-screenshots/SearchFilterPersistenceTest_persisted_date.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d730a0285bcf4e94246d2d5f6fc538d89dbe2275af98446ee25d829aec898d9
-size 92384
+oid sha256:e4435e784f478a983f2048ae9736951268ffac65410d1a100fe7fb3a216003e8
+size 92380

--- a/tests/UI/expected-screenshots/SearchFilterPersistenceTest_persisted_segment.png
+++ b/tests/UI/expected-screenshots/SearchFilterPersistenceTest_persisted_segment.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a21a7c43e4f0a4c7679e6914599688be635dc4d9d168cfe1e7ec42f2d247defb
-size 96297
+oid sha256:ed621400442ed112906a9d5a064ed9eb463dde4939235c542d62643d2ce65846
+size 96294

--- a/tests/UI/expected-screenshots/SearchFilterPersistenceTest_persisted_sorting.png
+++ b/tests/UI/expected-screenshots/SearchFilterPersistenceTest_persisted_sorting.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8f998f1ca2f0e9e3d866b3c00ee161a5eb6f6d30867c22031fe56ab79de29675
-size 95469
+oid sha256:91e898b1e1990ec03b60388c8f13fd1cfe7792f60d23e7bb16dd043ebbca3c4d
+size 95465

--- a/tests/UI/expected-screenshots/ViewDataTableTest_flatten_search.png
+++ b/tests/UI/expected-screenshots/ViewDataTableTest_flatten_search.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e06c1be7b093a5141f71ebefe800ee7cd87244bc6b61b01356f376cf3944240c
-size 47535
+oid sha256:ae39d59f847c1efb13b09f41aef6ddf016df6237a4ca2dbc386f7b4fbc032f1b
+size 47511


### PR DESCRIPTION
### Description:

When search term is persisted during date and segment changes, it previously always focused the bottom search field even if the top one was used to action the search.

This also adds persistence for sort column and the sorting order which was missed previously.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
