### PR TITLE
Add escapeshellarg to required functions check

### DIFF
--- a/plugins/Diagnostics/Diagnostic/PhpFunctionsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpFunctionsCheck.php
@@ -59,6 +59,7 @@ class PhpFunctionsCheck implements Diagnostic
     {
         return array(
             'debug_backtrace',
+            'escapeshellarg',
             'eval',
             'hash',
             'gzcompress',


### PR DESCRIPTION
Added escapeshellarg to required functions check. Updating Matomo (on web) fails with an exception if this function is disabled in PHP settings.

See usage in core/CliMulti.php: 

https://github.com/matomo-org/matomo/blob/f51b30f890f5308ba1f79bc326c8ba6425dbb020/core/CliMulti.php#L259

For example this function is added to disable_functions by DirectAdmin's "secure_php" functionality. I had this function added in disable_functions for years but on recent Matomo versions (or the update to PHP 8.4?) updating Matomo fails with an exception.