### PR TITLE
Ensure all translations required for password confirmation are always loaded

### DIFF
--- a/plugins/CorePluginsAdmin/CorePluginsAdmin.php
+++ b/plugins/CorePluginsAdmin/CorePluginsAdmin.php
@@ -166,5 +166,10 @@ class CorePluginsAdmin extends Plugin
         $translations[] = 'CorePluginsAdmin_PluginFreeTrialStarted';
         $translations[] = 'CorePluginsAdmin_PluginFreeTrialStartedAccountCreatedMessage';
         $translations[] = 'CorePluginsAdmin_PluginFreeTrialStartedAccountCreatedTitle';
+        $translations[] = 'General_Confirm';
+        $translations[] = 'General_Cancel';
+        $translations[] = 'UsersManager_ConfirmThisChange';
+        $translations[] = 'UsersManager_ConfirmWithPassword';
+        $translations[] = 'UsersManager_YourCurrentPassword';
     }
 }


### PR DESCRIPTION
### Description:

The translations used in Password Confirm might currently not always be loaded if certain plugins are disabled.

fixes #23174