### PR TITLE
Fix: Client DOM XSS

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2661,7 +2661,6 @@ if (typeof window.Matomo !== 'object') {
              * IE6 apart from some rare very old ones
              */
             function getPathName(url) {
-                var parser = document.createElement('a');
                 if (url.indexOf('//') !== 0 && url.indexOf('http') !== 0) {
                     if (url.indexOf('*') === 0) {
                         url = url.substr(1);
@@ -2672,7 +2671,7 @@ if (typeof window.Matomo !== 'object') {
                     url = 'http://' + url;
                 }
 
-                parser.href = content.toAbsoluteUrl(url);
+                const parser = new URL(content.toAbsoluteUrl(url));
 
                 if (parser.pathname) {
                     return parser.pathname;

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2657,7 +2657,7 @@ if (typeof window.Matomo !== 'object') {
             }
 
             function sanitizeURL(url) {
-                if (!/^https?:\/\//i.test(url)) {
+                if (/^javascript:/i.test(url)) {
                     throw "Invalid URL";
                 }
 

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2661,6 +2661,7 @@ if (typeof window.Matomo !== 'object') {
              * IE6 apart from some rare very old ones
              */
             function getPathName(url) {
+                var parser = document.createElement('a');
                 if (url.indexOf('//') !== 0 && url.indexOf('http') !== 0) {
                     if (url.indexOf('*') === 0) {
                         url = url.substr(1);
@@ -2671,7 +2672,7 @@ if (typeof window.Matomo !== 'object') {
                     url = 'http://' + url;
                 }
 
-                const parser = new URL(content.toAbsoluteUrl(url));
+                parser.href = encodeURI(content.toAbsoluteUrl(url)); // Sanitization and encoding
 
                 if (parser.pathname) {
                     return parser.pathname;

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2656,6 +2656,15 @@ if (typeof window.Matomo !== 'object') {
                 return false;
             }
 
+            function sanitizeURL(url) {
+                if (!/^https?:\/\//i.test(url)) {
+                    throw "Invalid URL";
+                }
+
+                return url.replace(/[<>]/g, "");
+            }
+
+
             /*
              * Extract pathname from URL. element.pathname is actually supported by pretty much all browsers including
              * IE6 apart from some rare very old ones
@@ -2672,7 +2681,7 @@ if (typeof window.Matomo !== 'object') {
                     url = 'http://' + url;
                 }
 
-                parser.href = encodeURI(content.toAbsoluteUrl(url)); // Sanitization and encoding
+                parser.href = sanitizeURL(content.toAbsoluteUrl(url));
 
                 if (parser.pathname) {
                     return parser.pathname;


### PR DESCRIPTION
### Description:

The method getPathName embeds untrusted data in generated output with href, at line 2675 of piwik.js. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.
### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
