### PR TITLE
Improve test restoreDbTables for negative numerics

### DIFF
--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -829,7 +829,7 @@ abstract class SystemTestCase extends TestCase
                         $values[] = 'NULL';
                     } else {
                         // is_numeric cannot be used here since some strings will look like floating point numbers (eg 3e456)
-                        $isNumeric = preg_match('/^\d+(\.\d+)?$/', $value);
+                        $isNumeric = preg_match('/^-?\d+(\.\d+)?$/', $value);
                         if ($isNumeric) {
                             $values[] = $value;
                         } elseif (!ctype_print($value)) {


### PR DESCRIPTION
### Description:

When an integration test calls `setUpBeforeClass`, a snapshot of tables with data is taken, and restored when calling `setUp`.

Some checks are done to handle binary data in the SQL statements that write the data back to the database:

https://github.com/matomo-org/matomo/blob/7084519a8435cf91340558ffb78b12455f78b08b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php#L831-L840

The regex to detect float/integer values however never supported negative values.

As PHP 8.1 has deprecated passing non-string values to the called `ctype_print` function. That means that a negative integer value will be passed to `ctype_print` and create a deprecation message:

> Deprecated: ctype_print(): Argument of type float will be interpreted as string in the future in /home/runner/work/matomo/matomo/matomo/tests/PHPUnit/Framework/TestCase/SystemTestCase.php on line 835

Up to now there are now (core) tests triggering this deprecation.

With the upcoming PR #23173, the table restore feature is used to avoid having to run archiving dozens of times. And that PR triggers the deprecation: https://github.com/matomo-org/matomo/actions/runs/14198027218/job/39777848277#step:3:521

This change is the minimal change to only silence the deprecations and does not intend to change or improve how the snapshot/restore mechanism is working.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
