### PR TITLE
handle idGoal in API.getMetadata similarly to API.getProcessedReport

### DIFF
--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -246,6 +246,15 @@ class API extends \Piwik\Plugin\API
             $translator->setCurrentLanguage($language);
         }
 
+        // mirror the logic in ProcessedReport::getProcessedReport()
+        $idGoal = \Piwik\Request::fromRequest()->getParameter('idGoal', false);
+        if (
+            !empty($idGoal)
+            && empty($apiParameters['idGoal'])
+        ) {
+            $apiParameters['idGoal'] = $idGoal;
+        }
+
         $metadata = $this->processedReport->getMetadata($idSite, $apiModule, $apiAction, $apiParameters, $language, $period, $date, $hideMetricsDoc, $showSubtableReports);
         return $metadata;
     }

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -236,7 +236,8 @@ class API extends \Piwik\Plugin\API
         $period = false,
         $date = false,
         $hideMetricsDoc = false,
-        $showSubtableReports = false
+        $showSubtableReports = false,
+        $idGoal = false
     ) {
         Piwik::checkUserHasViewAccess($idSite);
 
@@ -247,7 +248,6 @@ class API extends \Piwik\Plugin\API
         }
 
         // mirror the logic in ProcessedReport::getProcessedReport()
-        $idGoal = \Piwik\Request::fromRequest()->getParameter('idGoal', false);
         if (
             !empty($idGoal)
             && empty($apiParameters['idGoal'])

--- a/plugins/Ecommerce/tests/System/EcommerceOrderWithItemsTest.php
+++ b/plugins/Ecommerce/tests/System/EcommerceOrderWithItemsTest.php
@@ -159,6 +159,19 @@ class EcommerceOrderWithItemsTest extends SystemTestCase
                     ],
                 ],
 
+                [
+                    'API.getMetadata',
+                    [
+                        'idSite'     => $idSite,
+                        'date'       => $dateTime,
+                        'periods'    => ['day'],
+                        'apiModule'  => 'Goals',
+                        'apiAction'  => 'get',
+                        'idGoal'     => Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER,
+                        'testSuffix' => '_MetadataOnly_Goals.Get_Order',
+                    ],
+                ],
+
                 // test metadata products
                 [
                     $processedReportApi,

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_MetadataOnly_Goals.Get_Order__API.getMetadata_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_MetadataOnly_Goals.Get_Order__API.getMetadata_day.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<category>Ecommerce</category>
+		<name>Ecommerce Orders</name>
+		<module>Goals</module>
+		<action>get</action>
+		<parameters>
+			<idGoal>ecommerceOrder</idGoal>
+		</parameters>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
+		<metrics>
+			<nb_conversions>Ecommerce Orders</nb_conversions>
+			<nb_visits_converted>Visits with Conversions</nb_visits_converted>
+			<conversion_rate>Conversion Rate</conversion_rate>
+			<revenue>Revenue</revenue>
+			<revenue_subtotal>Subtotal</revenue_subtotal>
+			<revenue_tax>Tax</revenue_tax>
+			<revenue_shipping>Shipping</revenue_shipping>
+			<revenue_discount>Discount</revenue_discount>
+			<items>Purchased Products</items>
+		</metrics>
+		<metricsDocumentation>
+			<nb_visits_converted>Number of visits where at least one goal was successfully converted.</nb_visits_converted>
+			<conversion_rate>The percentage of visits that triggered a conversion. The conversion rate is calculated using the number of visits that converted at least one goal. Visits converting multiple goals are only counted once in the conversion rate.</conversion_rate>
+		</metricsDocumentation>
+		<processedMetrics>
+			<avg_order_revenue>Average Order Value</avg_order_revenue>
+		</processedMetrics>
+		<metricTypes>
+			<nb_conversions>number</nb_conversions>
+			<nb_visits_converted>number</nb_visits_converted>
+			<conversion_rate>percent</conversion_rate>
+			<revenue>money</revenue>
+			<revenue_subtotal>money</revenue_subtotal>
+			<revenue_tax>money</revenue_tax>
+			<revenue_shipping>money</revenue_shipping>
+			<revenue_discount>money</revenue_discount>
+			<avg_order_revenue>money</avg_order_revenue>
+		</metricTypes>
+		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Goals&amp;apiAction=get&amp;idGoal=ecommerceOrder&amp;period=day&amp;date=2011-03-07,2011-04-05</imageGraphUrl>
+		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Goals&amp;apiAction=get&amp;idGoal=ecommerceOrder&amp;period=day&amp;date=2011-03-07,2011-04-05</imageGraphEvolutionUrl>
+		<uniqueId>Goals_get_idGoal--ecommerceOrder</uniqueId>
+	</row>
+</result>


### PR DESCRIPTION
### Description:

Currently, in API.getProcessedReport, if an idGoal is supplied, it is added to `$apiParameters` before matching report metadata. This is not done in API.getMetadata, which means requests to API.getProcessedReport can be matched to reports that requests with the same exact request parameters to API.getMetadata will not.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
