### PR TITLE
Improve memory usage of Live.getLastVisitDetails

### DIFF
--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -414,7 +414,13 @@ class API extends \Piwik\Plugin\API
 
                 $visitorDetailsArray['actionDetails'] = array();
                 if (!$doNotFetchActions) {
-                    $bulkFetchedActions  = isset($actionsByVisitId[$visitorDetailsArray['idVisit']]) ? $actionsByVisitId[$visitorDetailsArray['idVisit']] : array();
+                    $bulkFetchedActions = [];
+
+                    if (isset($actionsByVisitId[$visitorDetailsArray['idVisit']])) {
+                        $bulkFetchedActions = $actionsByVisitId[$visitorDetailsArray['idVisit']];
+                        unset($actionsByVisitId[$visitorDetailsArray['idVisit']]);
+                    }
+
                     $visitorDetailsArray = Visitor::enrichVisitorArrayWithActions($visitorDetailsArray, $bulkFetchedActions);
                 }
 


### PR DESCRIPTION
### Description:

The data table filter used in the `Live.getLastVisitDetails` API is consuming a lot of unnecessary memory.

This happens because all actions for all visits are fetched at once and then enriched to populate the visit information. As the old actions list is not cleaned up, this leads to a nearly full duplication of the memory requirement during iteration.

With the actions are already being indexed by visit, it should be safe to remove them from the list when iterating over the visit.

The peak memory usage for the data table filter goes down by up to 45%, if actions are not filtered or limited in any way. The peak memory usage for the complete request though will not go down that much, as the peak is later growing e.g. during output rendering. Though it should not be unexpected to get more than 10% total reduction for the complete request.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
