### PR TITLE
fix Prototype-polluting function `jqplot.themeEngine` 

### DIFF
--- a/libs/jqplot/jqplot.themeEngine.js
+++ b/libs/jqplot/jqplot.themeEngine.js
@@ -672,6 +672,10 @@
             if ( (options = arguments[ i ]) != null ) {
                 // Extend the base object
                 for ( var name in options ) {
+                    // Skip dangerous property names to prevent prototype pollution
+                    if (name === "__proto__" || name === "constructor") {
+                        continue;
+                    }
                     var src = target[ name ], copy = options[ name ];
 
                     // Prevent never-ending loop


### PR DESCRIPTION
https://github.com/matomo-org/matomo/blob/6b6ab13f3197015a39e36ce80520cca84ce72bc6/libs/jqplot/jqplot.themeEngine.js#L691-L691

fix the prototype pollution vulnerability in the `$.jqplot.extend` function:
1. Add a check to block dangerous property names (`__proto__` and `constructor`) from being copied.
2. Ensure that the function only processes properties that are safe and do not affect the prototype chain.

The fix involves modifying the loop that iterates over the properties of `options` (line 674) to skip these dangerous property names. This ensures that malicious inputs cannot modify `Object.prototype`.


Most JavaScript objects inherit the properties of the built-in `Object.prototype` object. Prototype pollution is a type of vulnerability in which an attacker is able to modify `Object.prototype`. Since most objects inherit from the compromised `Object.prototype`, the attacker can use this to tamper with the application logic, and often escalate to remote code execution or cross-site scripting. One way to cause prototype pollution is through use of an unsafe merge or extend function to recursively copy properties from one object to another, or through the use of a deep assignment function to assign to an unverified chain of property names. Such a function has the potential to modify any object reachable from the destination object, and the built-in `Object.prototype` is usually reachable through the special properties `__proto__` and `constructor.prototype`.


## POC
This function recursively copies properties from `src` to `dst`:
```js
function merge(dst, src) {
    for (let key in src) {
        if (!src.hasOwnProperty(key)) continue;
        if (isObject(dst[key])) {
            merge(dst[key], src[key]);
        } else {
            dst[key] = src[key];
        }
    }
}
```
However, if `src` is the object `{"__proto__": {"isAdmin": true}}`, it will inject the property `isAdmin: true` in `Object.prototype`.
```js
function merge(dst, src) {
    for (let key in src) {
        if (!src.hasOwnProperty(key)) continue;
        if (dst.hasOwnProperty(key) && isObject(dst[key])) {
            merge(dst[key], src[key]);
        } else {
            dst[key] = src[key];
        }
    }
}
```
Alternatively, block the `__proto__` and `constructor` properties:
```js
function merge(dst, src) {
    for (let key in src) {
        if (!src.hasOwnProperty(key)) continue;
        if (key === "__proto__" || key === "constructor") continue;
        if (isObject(dst[key])) {
            merge(dst[key], src[key]);
        } else {
            dst[key] = src[key];
        }
    }
}
```
## References
[lodash](https://hackerone.com/reports/380873), [jQuery](https://hackerone.com/reports/454365), [extend](https://hackerone.com/reports/381185), [just-extend](https://hackerone.com/reports/430291), [merge.recursive](https://hackerone.com/reports/381194)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-79](https://cwe.mitre.org/data/definitions/79.html)
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)
[CWE-400](https://cwe.mitre.org/data/definitions/400.html)
[CWE-471](https://cwe.mitre.org/data/definitions/471.html)
[CWE-915](https://cwe.mitre.org/data/definitions/915.html)


### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
