### PR TITLE
Pg 4133 2 reset password button disable

### DIFF
--- a/plugins/Login/javascripts/login.js
+++ b/plugins/Login/javascripts/login.js
@@ -55,6 +55,25 @@
           }
         };
 
+        var disableOrEnableChangePasswordButton = function () {
+
+          let anyFieldEmpty = (
+            $('#reset_form_login').val() === ''
+            || $('#reset_form_password').val() === ''
+            || $('#reset_form_password_bis').val() === ''
+          );
+
+          let passwordsDoNotMatch =
+            $('#reset_form_password').val() !== $('#reset_form_password_bis').val();
+
+          if (anyFieldEmpty || passwordsDoNotMatch)
+          {
+            $('#reset_form_submit').attr('disabled', 'disabled');
+          } else {
+            $('#reset_form_submit').removeAttr('disabled');
+          }
+        };
+
         // set login form redirect url
         $('#login_form_redirect').val(window.location.href);
 
@@ -115,6 +134,12 @@
         $('#login_form_login').on('input', disableOrEnableLoginSubmitButton);
         $('#login_form_password').on('input', disableOrEnableLoginSubmitButton);
         disableOrEnableLoginSubmitButton();
+
+        // Disable reset password button when required fields are not filled out
+        $('#reset_form_login').on('input', disableOrEnableChangePasswordButton);
+        $('#reset_form_password').on('input', disableOrEnableChangePasswordButton);
+        $('#reset_form_password_bis').on('input', disableOrEnableChangePasswordButton);
+        disableOrEnableChangePasswordButton();
 
         $('#login_form_login').focus();
 

--- a/plugins/Login/tests/UI/ResetPassword_spec.js
+++ b/plugins/Login/tests/UI/ResetPassword_spec.js
@@ -60,6 +60,34 @@ describe('ResetPassword', function () {
         expect(await page.screenshot({ fullPage: true })).to.matchImage('forgot_password');
     });
 
+    // Enable/disable change password button.
+    it('should enable the Change Password button when correct fields are entered', async function () {
+      await goToForgotPasswordPage();
+
+      // Assert that the button starts off disabled.
+      await page.waitForSelector('#reset_form_submit[disabled]');
+
+      // Button still disabled with user, but no password entered.
+      await page.type('#reset_form_login', 'u');
+      await page.waitForSelector('#reset_form_submit[disabled]');
+
+      // Button disabled with user and password both entered.
+      await page.type('#reset_form_password', 'pass');
+      await page.waitForSelector('#reset_form_submit[disabled]');
+
+      // Button disabled with differing password fields.
+      await page.type('#reset_form_password_bis', 'p');
+      await page.waitForSelector('#reset_form_submit[disabled]');
+
+      // Button enabled with user and matching password fields.
+      await page.type('#reset_form_password_bis', 'ass');
+      await page.waitForSelector('#reset_form_submit:not([disabled])');
+
+      // Button disabled again if a fields no longer match.
+      await page.keyboard.press('Backspace');
+      await page.waitForSelector('#reset_form_submit[disabled]');
+    });
+
     it('should show reset password form and error message on error', async function () {
         await goToForgotPasswordPage();
 


### PR DESCRIPTION
### Description:

PG-4133

- Reset password now matches login design.

![image](https://github.com/user-attachments/assets/b95637be-e5d2-4abe-a5ee-f7a41cff8eaa)



### To test:

- Go to reset password page when not logged in.
- See change password button disabled.
- Type something into user, pass, and pass(repeat) fields.
- See login button enabled if pass and pass(repeat) match.
- break match, or empty a field
- See login button disabled.

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
