### PR TITLE
Log a warning when sending insecure requests

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -260,6 +260,12 @@ class Http
             }
         }
 
+        // When sending an insecure request, but https is forced, and we would care about valid certificates, log a warning
+        // Note: accepting invalid ssl certificates should only be used when requesting data from a configured website
+        if ($parsedUrl['scheme'] === 'http' && SettingsPiwik::isHttpsForced() && $acceptInvalidSslCertificate === true) {
+            Log::warning('Matomo is configured to force HTTPS, but is sending an insecure request to ' . $aUrl);
+        }
+
         $contentLength = 0;
         $fileLength = 0;
 

--- a/core/Http.php
+++ b/core/Http.php
@@ -262,7 +262,7 @@ class Http
 
         // When sending an insecure request, but https is forced, and we would care about valid certificates, log a warning
         // Note: accepting invalid ssl certificates should only be used when requesting data from a configured website
-        if ($parsedUrl['scheme'] === 'http' && SettingsPiwik::isHttpsForced() && $acceptInvalidSslCertificate === true) {
+        if ($parsedUrl['scheme'] === 'http' && SettingsPiwik::isHttpsForced() && $acceptInvalidSslCertificate === false) {
             Log::warning('Matomo is configured to force HTTPS, but is sending an insecure request to ' . $aUrl);
         }
 


### PR DESCRIPTION
### Description:

When `force_ssl` is configured, Matomo should not attempt to request data using HTTP only.
To ensure we do not miss any unexpected insecure requests, this PR adds logging of a warning when ever this happens.

In case we do not care about valid certificates (which should only be used when requesting data from a customer configured website), we do not log a warning. This should prevent to log warning if a user configured a `http` url for tracking and we send requests there to gather information, in order to suggest a tracking method.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
