### PR TITLE
Only log exception message without stack trace when PIWIK_PRINT_ERROR_BACKTRACE not set

### DIFF
--- a/core/ExceptionHandler.php
+++ b/core/ExceptionHandler.php
@@ -192,6 +192,13 @@ class ExceptionHandler
         return $result;
     }
 
+    public static function shouldPrintBackTraceWithMessage(): bool
+    {
+        return (defined('PIWIK_PRINT_ERROR_BACKTRACE') && PIWIK_PRINT_ERROR_BACKTRACE)
+            || !empty($GLOBALS['PIWIK_PRINT_ERROR_BACKTRACE'])
+            || !empty($GLOBALS['PIWIK_TRACKER_DEBUG']);
+    }
+
     private static function logException($exception, $loglevel = Log::ERROR)
     {
         try {

--- a/core/Log/Logger.php
+++ b/core/Log/Logger.php
@@ -9,10 +9,23 @@
 
 namespace Piwik\Log;
 
+use Piwik\ExceptionHandler;
+
 /**
  * Proxy class for \Monolog\Logger
  * @see \Monolog\Logger
  */
 class Logger extends \Monolog\Logger implements LoggerInterface
 {
+    public function addRecord($level, $message, array $context = array())
+    {
+        // if we're logging an exception, make sure we only log the message and not the stack trace if not permitted
+        if (array_key_exists('exception', $context) && is_a($context['exception'], \Exception::class)) {
+            if (!ExceptionHandler::shouldPrintBackTraceWithMessage()) {
+                $context['exception'] = $context['exception']->getMessage();
+            }
+        }
+
+        return parent::addRecord($level, $message, $context);
+    }
 }

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -94,11 +94,7 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
             return true;
         }
 
-        $bool = (defined('PIWIK_PRINT_ERROR_BACKTRACE') && PIWIK_PRINT_ERROR_BACKTRACE)
-                || !empty($GLOBALS['PIWIK_PRINT_ERROR_BACKTRACE'])
-                || !empty($GLOBALS['PIWIK_TRACKER_DEBUG']);
-
-        return $bool;
+        return \Piwik\ExceptionHandler::shouldPrintBackTraceWithMessage();
     }
 
     /**

--- a/plugins/Monolog/tests/Integration/LogTest.php
+++ b/plugins/Monolog/tests/Integration/LogTest.php
@@ -62,14 +62,12 @@ class LogTest extends IntegrationTestCase
     /**
      * Data provider for every test.
      */
-    public function getLoggingConfigs()
+    public function getLoggingConfigs(): iterable
     {
-        return [
-            'file no backtrace' => ['file', false],
-            'file with backtrace' => ['file', true],
-            'database no backtrace' => ['database', false],
-            'database with backtrace' => ['database', true],
-        ];
+        yield 'file no backtrace' => ['file', false];
+        yield 'file with backtrace' => ['file', true];
+        yield 'database no backtrace' => ['database', false];
+        yield 'database with backtrace' => ['database', true];
     }
 
     /**

--- a/plugins/Monolog/tests/Integration/LogTest.php
+++ b/plugins/Monolog/tests/Integration/LogTest.php
@@ -284,16 +284,10 @@ class LogTest extends IntegrationTestCase
             'ini.log.logger_file_path' => self::getLogFileLocation(),
             Log\LoggerInterface::class => \Piwik\DI::get(Log\Logger::class),
             'Tests.log.allowAllHandlers' => true,
-            'define_backtrace_constant' => function () use ($forcePrintBacktrace) {
-                $GLOBALS['PIWIK_PRINT_ERROR_BACKTRACE'] = $forcePrintBacktrace;
-
-                return true;
-            },
         ));
         $newEnv->init();
 
-        // set backtrace global via a dummy get
-        $newEnv->getContainer()->get('define_backtrace_constant');
+        $GLOBALS['PIWIK_PRINT_ERROR_BACKTRACE'] = $forcePrintBacktrace;
 
         $newMonologLogger = $newEnv->getContainer()->make(Log\LoggerInterface::class);
         $oldLogger = new Log($newMonologLogger);

--- a/plugins/Monolog/tests/Integration/LogTest.php
+++ b/plugins/Monolog/tests/Integration/LogTest.php
@@ -37,6 +37,8 @@ class LogTest extends IntegrationTestCase
     public static $expectedErrorOutputWithQuery = '[Monolog] [<PID>] dummyerrorfile.php(%d): dummy error message
   dummy backtrace [Query: ?a=b&d=f, CLI mode: 1]';
 
+    public static $expectedDummyErrorMessage = '[Monolog] [<PID>] dummy error message';
+
     public function setUp(): void
     {
         parent::setUp();
@@ -60,20 +62,22 @@ class LogTest extends IntegrationTestCase
     /**
      * Data provider for every test.
      */
-    public function getBackendsToTest()
+    public function getLoggingConfigs()
     {
-        return array(
-            'file'     => array('file'),
-            'database' => array('database'),
-        );
+        return [
+            'file no backtrace' => ['file', false],
+            'file with backtrace' => ['file', true],
+            'database no backtrace' => ['database', false],
+            'database with backtrace' => ['database', true],
+        ];
     }
 
     /**
-     * @dataProvider getBackendsToTest
+     * @dataProvider getLoggingConfigs
      */
-    public function testLoggingWorksWhenMessageIsString($backend)
+    public function testLoggingWorksWhenMessageIsString($backend, $forcePrintBacktrace)
     {
-        $this->recreateLogSingleton($backend);
+        $this->recreateLogSingleton($backend, $forcePrintBacktrace);
 
         Log::warning(self::TESTMESSAGE);
 
@@ -81,11 +85,11 @@ class LogTest extends IntegrationTestCase
     }
 
     /**
-     * @dataProvider getBackendsToTest
+     * @dataProvider getLoggingConfigs
      */
-    public function testLoggingWorksWhenMessageIsSprintfString($backend)
+    public function testLoggingWorksWhenMessageIsSprintfString($backend, $forcePrintBacktrace)
     {
-        $this->recreateLogSingleton($backend);
+        $this->recreateLogSingleton($backend, $forcePrintBacktrace);
 
         Log::warning(self::TESTMESSAGE, " subst ");
 
@@ -93,52 +97,55 @@ class LogTest extends IntegrationTestCase
     }
 
     /**
-     * @dataProvider getBackendsToTest
+     * @dataProvider getLoggingConfigs
      */
-    public function testLoggingWorksWhenMessageIsError($backend)
+    public function testLoggingWorksWhenMessageIsError($backend, $forcePrintBacktrace)
     {
-        $this->recreateLogSingleton($backend);
+        $this->recreateLogSingleton($backend, $forcePrintBacktrace);
 
-        $error = new \ErrorException("dummy error string", 0, 102, "dummyerrorfile.php", 145);
+        $error = new \ErrorException("dummy error message", 0, 102, "dummyerrorfile.php", 145);
         Log::error($error);
 
-        $this->checkBackend($backend, str_replace('<PID>', getmypid(), self::$expectedErrorOutput), $formatMessage = false, $tag = 'Monolog');
+        $expectedOutput = $forcePrintBacktrace ? self::$expectedErrorOutput : self::$expectedDummyErrorMessage;
+        $this->checkBackend($backend, str_replace('<PID>', getmypid(), $expectedOutput), $formatMessage = false, $tag = 'Monolog');
     }
 
     /**
-     * @dataProvider getBackendsToTest
+     * @dataProvider getLoggingConfigs
      */
-    public function testLoggingContextWorks($backend)
+    public function testLoggingContextWorks($backend, $forcePrintBacktrace)
     {
-        $this->recreateLogSingleton($backend);
+        $this->recreateLogSingleton($backend, $forcePrintBacktrace);
 
         $_SERVER['QUERY_STRING'] = 'a=b&d=f';
 
-        $error = new \ErrorException("dummy error string", 0, 102, "dummyerrorfile.php", 145);
+        $error = new \ErrorException("dummy error message", 0, 102, "dummyerrorfile.php", 145);
         Log::error($error);
 
-        $this->checkBackend($backend, str_replace('<PID>', getmypid(), self::$expectedErrorOutputWithQuery), $formatMessage = false, $tag = 'Monolog');
+        $expectedOutput = $forcePrintBacktrace ? self::$expectedErrorOutputWithQuery : self::$expectedDummyErrorMessage;
+        $this->checkBackend($backend, str_replace('<PID>', getmypid(), $expectedOutput), $formatMessage = false, $tag = 'Monolog');
     }
 
     /**
-     * @dataProvider getBackendsToTest
+     * @dataProvider getLoggingConfigs
      */
-    public function testLoggingWorksWhenMessageIsException($backend)
+    public function testLoggingWorksWhenMessageIsException($backend, $forcePrintBacktrace)
     {
-        $this->recreateLogSingleton($backend);
+        $this->recreateLogSingleton($backend, $forcePrintBacktrace);
 
         $exception = new Exception("dummy error message");
         Log::error($exception);
 
-        $this->checkBackend($backend, str_replace('<PID>', getmypid(), self::$expectedExceptionOutput), $formatMessage = false, $tag = 'Monolog');
+        $expectedOutput = $forcePrintBacktrace ? self::$expectedExceptionOutput : self::$expectedDummyErrorMessage;
+        $this->checkBackend($backend, str_replace('<PID>', getmypid(), $expectedOutput), $formatMessage = false, $tag = 'Monolog');
     }
 
     /**
-     * @dataProvider getBackendsToTest
+     * @dataProvider getLoggingConfigs
      */
-    public function testLoggingCorrectlyIdentifiesPlugin($backend)
+    public function testLoggingCorrectlyIdentifiesPlugin($backend, $forcePrintBacktrace)
     {
-        $this->recreateLogSingleton($backend);
+        $this->recreateLogSingleton($backend, $forcePrintBacktrace);
 
         LoggerWrapper::doLog(self::TESTMESSAGE);
 
@@ -146,11 +153,11 @@ class LogTest extends IntegrationTestCase
     }
 
     /**
-     * @dataProvider getBackendsToTest
+     * @dataProvider getLoggingConfigs
      */
-    public function testLogMessagesIgnoredWhenNotWithinLevel($backend)
+    public function testLogMessagesIgnoredWhenNotWithinLevel($backend, $forcePrintBacktrace)
     {
-        $this->recreateLogSingleton($backend, 'ERROR');
+        $this->recreateLogSingleton($backend, $forcePrintBacktrace, 'ERROR');
 
         Log::info(self::TESTMESSAGE);
 
@@ -158,11 +165,11 @@ class LogTest extends IntegrationTestCase
     }
 
     /**
-     * @dataProvider getBackendsToTest
+     * @dataProvider getLoggingConfigs
      */
-    public function testLogMessagesAreTrimmed($backend)
+    public function testLogMessagesAreTrimmed($backend, $forcePrintBacktrace)
     {
-        $this->recreateLogSingleton($backend);
+        $this->recreateLogSingleton($backend, $forcePrintBacktrace);
 
         LoggerWrapper::doLog(" \n   " . self::TESTMESSAGE . "\n\n\n   \n");
 
@@ -170,11 +177,11 @@ class LogTest extends IntegrationTestCase
     }
 
     /**
-     * @dataProvider getBackendsToTest
+     * @dataProvider getLoggingConfigs
      */
-    public function testTokenAuthIsRemoved($backend)
+    public function testTokenAuthIsRemoved($backend, $forcePrintBacktrace)
     {
-        $this->recreateLogSingleton($backend);
+        $this->recreateLogSingleton($backend, $forcePrintBacktrace);
 
         Log::error('token_auth=9b1cefc915ff6180071fb7dcd13ec5a4');
 
@@ -188,7 +195,7 @@ class LogTest extends IntegrationTestCase
      */
     public function testNoInfiniteLoopWhenLoggingToDatabase()
     {
-        $this->recreateLogSingleton('database');
+        $this->recreateLogSingleton('database', true);
 
         Log::info(self::TESTMESSAGE);
 
@@ -196,11 +203,11 @@ class LogTest extends IntegrationTestCase
     }
 
     /**
-     * @dataProvider getBackendsToTest
+     * @dataProvider getLoggingConfigs
      */
-    public function testLoggingNonString($backend)
+    public function testLoggingNonString($backend, $forcePrintBacktrace)
     {
-        $this->recreateLogSingleton($backend);
+        $this->recreateLogSingleton($backend, $forcePrintBacktrace);
 
         Log::warning(123);
 
@@ -269,7 +276,7 @@ class LogTest extends IntegrationTestCase
         return StaticContainer::get('path.tmp') . '/logs/piwik.test.log';
     }
 
-    private function recreateLogSingleton($backend, $level = 'INFO')
+    private function recreateLogSingleton(string $backend, bool $forcePrintBacktrace = false, string $level = 'INFO')
     {
         $newEnv = new Environment('test', array(
             'ini.log.log_writers' => array($backend),
@@ -279,8 +286,16 @@ class LogTest extends IntegrationTestCase
             'ini.log.logger_file_path' => self::getLogFileLocation(),
             Log\LoggerInterface::class => \Piwik\DI::get(Log\Logger::class),
             'Tests.log.allowAllHandlers' => true,
+            'define_backtrace_constant' => function () use ($forcePrintBacktrace) {
+                $GLOBALS['PIWIK_PRINT_ERROR_BACKTRACE'] = $forcePrintBacktrace;
+
+                return true;
+            },
         ));
         $newEnv->init();
+
+        // set backtrace global via a dummy get
+        $newEnv->getContainer()->get('define_backtrace_constant');
 
         $newMonologLogger = $newEnv->getContainer()->make(Log\LoggerInterface::class);
         $oldLogger = new Log($newMonologLogger);


### PR DESCRIPTION
### Description:

Override the logger `addRecord` method to update the exception in context only to its message if printing backtrace is not enabled.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
