### PR TITLE
Require token to display migration details during core update

### DIFF
--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -30,6 +30,7 @@ use Piwik\SettingsPiwik;
 use Piwik\SettingsServer;
 use Piwik\Updater as DbUpdater;
 use Piwik\Updater\Migration\Db as DbMigration;
+use Piwik\Url;
 use Piwik\Version;
 use Piwik\View;
 use Piwik\View\OneClickDone;
@@ -243,8 +244,17 @@ class Controller extends \Piwik\Plugin\Controller
             $view = new View('@CoreUpdater/updateHttpError');
             $view->error = $error;
         } else {
+            $updateDetailsToken = $this->createUpdateDetailsTokenIfMissing();
+            $runUpdaterUrl = Url::getCurrentUrlWithoutQueryString();
+
+            if ($updateDetailsToken !== null) {
+                $runUpdaterUrl .= '?module=CoreUpdater&updateDetailsToken=' . urlencode($updateDetailsToken);
+            }
+
             $view = new View('@CoreUpdater/updateSuccess');
+            $view->runUpdaterUrl = $runUpdaterUrl;
         }
+
         $messages = safe_unserialize(Request::fromPost()->getStringParameter('messages', ''));
         if (!is_array($messages)) {
             $messages = array();
@@ -295,6 +305,9 @@ class Controller extends \Piwik\Plugin\Controller
         $componentsWithUpdateFile = $updater->getComponentUpdates();
 
         if (empty($componentsWithUpdateFile)) {
+            // remove token if updater screen is not displayed
+            $this->removeUpdateDetailsToken();
+
             throw new NoUpdatesFoundException("Everything is already up to date.");
         }
 
@@ -311,7 +324,7 @@ class Controller extends \Piwik\Plugin\Controller
         $this->addCustomLogoInfo($viewDone);
         $this->setBasicVariablesView($viewDone);
 
-        $doExecuteUpdates = Common::getRequestVar('updateCorePlugins', 0, 'integer') == 1;
+        $doExecuteUpdates = Request::fromRequest()->getBoolParameter('updateCorePlugins', 0);
 
         if (is_null($doDryRun)) {
             $doDryRun = !$doExecuteUpdates;
@@ -320,20 +333,24 @@ class Controller extends \Piwik\Plugin\Controller
         if ($doDryRun) {
             $migrations = $updater->getSqlQueriesToExecute();
             $queryCount = count($migrations);
-
             $migrations = $this->groupMigrations($migrations);
+
             $viewWelcome->migrations = $migrations;
             $viewWelcome->queryCount = $queryCount;
             $viewWelcome->isMajor = $updater->hasMajorDbUpdate();
+            $viewWelcome->showUpdateDetails = $this->checkUpdateDetailsToken();
+
             $this->doWelcomeUpdates($viewWelcome, $componentsWithUpdateFile);
+
             return $viewWelcome->render();
         }
 
         // Web
         if ($doExecuteUpdates) {
-            $this->warningMessages = array();
-            $this->doExecuteUpdates($viewDone, $updater, $componentsWithUpdateFile);
+            $this->warningMessages = [];
 
+            $this->doExecuteUpdates($viewDone, $updater, $componentsWithUpdateFile);
+            $this->removeUpdateDetailsToken();
             $this->redirectToDashboardWhenNoError($updater);
 
             return $viewDone->render();
@@ -444,5 +461,45 @@ class Controller extends \Piwik\Plugin\Controller
     private function getIncompatiblePlugins($piwikVersion)
     {
         return PluginManager::getInstance()->getIncompatiblePlugins($piwikVersion);
+    }
+
+    private function checkUpdateDetailsToken(): bool
+    {
+        $config = Config::getInstance();
+
+        if (empty($config->General['update_details_token'])) {
+            return false;
+        }
+
+        return $config->General['update_details_token'] === Request::fromRequest()->getStringParameter('updateDetailsToken', '');
+    }
+
+    private function createUpdateDetailsTokenIfMissing(): ?string
+    {
+        $config = Config::getInstance();
+
+        if (!empty($config->General['update_details_token'])) {
+            return null;
+        }
+
+        $token = Common::generateUniqId();
+
+        $config->General['update_details_token'] = $token;
+        $config->forceSave();
+
+        return $token;
+    }
+
+    private function removeUpdateDetailsToken(): void
+    {
+        $config = Config::getInstance();
+
+        if (empty($config->General['update_details_token'])) {
+            return;
+        }
+
+        unset($config->General['update_details_token']);
+
+        $config->forceSave();
     }
 }

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -324,7 +324,7 @@ class Controller extends \Piwik\Plugin\Controller
         $this->addCustomLogoInfo($viewDone);
         $this->setBasicVariablesView($viewDone);
 
-        $doExecuteUpdates = Request::fromRequest()->getBoolParameter('updateCorePlugins', 0);
+        $doExecuteUpdates = Request::fromRequest()->getBoolParameter('updateCorePlugins', false);
 
         if (is_null($doDryRun)) {
             $doDryRun = !$doExecuteUpdates;

--- a/plugins/CoreUpdater/lang/en.json
+++ b/plugins/CoreUpdater/lang/en.json
@@ -98,6 +98,9 @@
         "TriggerDatabaseConversion": "Trigger database conversion in background",
         "Utf8mb4ConversionHelp": "Your database is currently not using utf8mb4 charset. This makes it impossible to store 4-byte characters, such as emojis, less common characters of asian languages, various historic scripts or mathematical symbols. Those are currently replaced with %1$s.<br \/><br \/>Your database supports the utf8mb4 charset and it would be possible to convert it.<br \/><br \/>If you are able to run console commands we recommend using this command: %2$s<br \/><br \/>Alternatively you can enable the conversion here. It will then be triggered automatically as a scheduled task in the background.<br \/><br \/>Attention: Converting the database might take up to a couple of hours depending on the database size. As tracking might not work during this process, we do not recommend to use the trigger for bigger instances.<br \/><br \/>You can find more information about this topic in this %3$sFAQ%4$s.",
         "SkipCacheClearDesc": "Skips clearing of caches before updating. This is only useful if you can ensure that instances running this command have not created a cache at all yet, and if clearing the cache for many Matomo accounts can become a bottleneck.",
-        "SkipCacheClear": "Skipping clearing caches."
+        "SkipCacheClear": "Skipping clearing caches.",
+        "UpdateDetailsHidden1": "Update details are hidden for security. To view them:",
+        "UpdateDetailsHidden2": "Add the %1$s GET parameter to the URL (%2$s in %3$s), or",
+        "UpdateDetailsHidden3": "Run the update via command line."
     }
 }

--- a/plugins/CoreUpdater/templates/runUpdaterAndExit_welcome.twig
+++ b/plugins/CoreUpdater/templates/runUpdaterAndExit_welcome.twig
@@ -54,13 +54,24 @@
                 <p>{{ 'CoreUpdater_HighTrafficPiwikServerEnableMaintenance'|translate(externallink('https://matomo.org/faq/how-to/faq_111'), '</a>')|raw }}</p>
 
                 {% if migrations is not empty %}
-                    <p>{{ 'CoreUpdater_ListOfSqlQueriesFYI'|translate(piwik_version) }}</p>
-                    <p><a href="#" id="showSql">› {{ 'CoreUpdater_ClickHereToViewSqlQueries'|translate }}</a></p>
-                    {% for group in migrations %}
-                    <div class="sqlQueries" style="display:none;">
-                        <pre># {% if group.type == 'sql' %}{{ 'CoreUpdater_TheseSqlQueriesWillBeExecuted'|translate }}{% else %}{{ 'CoreUpdater_TheseCommandsWillBeExecuted'|translate }}{% endif %} <br/>{% for migration in group.migrations %}{{ migration }}<br/>{% endfor %}</pre>
-                    </div>
-                    {% endfor %}
+                    {% if showUpdateDetails %}
+                        <p>{{ 'CoreUpdater_ListOfSqlQueriesFYI'|translate(piwik_version) }}</p>
+                        <p><a href="#" id="showSql">› {{ 'CoreUpdater_ClickHereToViewSqlQueries'|translate }}</a></p>
+                        {% for group in migrations %}
+                        <div class="sqlQueries" style="display:none;">
+                            <pre># {% if group.type == 'sql' %}{{ 'CoreUpdater_TheseSqlQueriesWillBeExecuted'|translate }}{% else %}{{ 'CoreUpdater_TheseCommandsWillBeExecuted'|translate }}{% endif %} <br/>{% for migration in group.migrations %}{{ migration }}<br/>{% endfor %}</pre>
+                        </div>
+                        {% endfor %}
+                    {% else %}
+                        <div class="alert alert-info">
+                            {{ 'CoreUpdater_UpdateDetailsHidden1'|translate }}<br>
+                            <ul style="margin-left: 0; width: 100%">
+
+                                <li style="list-style-type: disc">{{ 'CoreUpdater_UpdateDetailsHidden2'|translate('<code>updateTokenDetails</code>', '<code>[General] update_details_token</code>', '<code>config.ini.php</code>')|raw }}</li>
+                                <li style="list-style-type: disc">{{ 'CoreUpdater_UpdateDetailsHidden3'|translate }}</li>
+                            </ul>
+                        </div>
+                    {% endif %}
                 {% endif %}
 
                 <h2>{{ 'CoreUpdater_NeedHelpUpgrading'|translate }}</h2>

--- a/plugins/CoreUpdater/templates/updateSuccess.twig
+++ b/plugins/CoreUpdater/templates/updateSuccess.twig
@@ -45,7 +45,7 @@
     </div>
 
     <div class="footer">
-        <a href="index.php">{{ 'General_ContinueToPiwik'|translate }}</a>
+        <a href="{{ runUpdaterUrl }}">{{ 'General_ContinueToPiwik'|translate }}</a>
     </div>
 
 {% endblock %}

--- a/plugins/CoreUpdater/tests/UI/CoreUpdaterDb_spec.js
+++ b/plugins/CoreUpdater/tests/UI/CoreUpdaterDb_spec.js
@@ -12,8 +12,13 @@ describe("CoreUpdaterDb", function () {
 
     this.fixture = "Piwik\\Plugins\\CoreUpdater\\tests\\Fixtures\\DbUpdaterTestFixture";
 
+    const updateDetailsToken = 'uiTestUpdateDetailsToken'
+
     before(function () {
         testEnvironment.tablesPrefix = 'piwik_';
+        testEnvironment.configOverride.General = {
+            update_details_token: updateDetailsToken
+        };
         testEnvironment.save();
     });
 
@@ -46,6 +51,20 @@ describe("CoreUpdaterDb", function () {
             });
         });
 
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('main_no_update_token');
+    });
+
+    it("should show update details if correct token is provided", async function () {
+        const currentUrl = await page.getWholeCurrentUrl();
+
+        await page.goto(currentUrl + '&updateDetailsToken=' + updateDetailsToken);
+        await page.evaluate(function () {
+            $('p').each(function () {
+                var replace = $(this).html().replace(/(?!1\.0)\d+\.\d+(\.\d+)?([\-a-z]*\d+|-alpha)?(\.[0-9]{14})?/g, '');
+                $(this).html(replace);
+            });
+        });
+
         expect(await page.screenshot({ fullPage: true })).to.matchImage('main');
     });
 
@@ -57,12 +76,12 @@ describe("CoreUpdaterDb", function () {
     });
 
     it("should show instance id in updating screen", async function() {
-        testEnvironment.configOverride.General = {
-            instance_id: 'custom.instance'
-        };
+        testEnvironment.configOverride.General.instance_id = 'custom.instance';
         testEnvironment.save();
 
-        await page.goto("");
+        const currentUrl = await page.getWholeCurrentUrl();
+
+        await page.goto(currentUrl + '&updateDetailsToken=' + updateDetailsToken);
         await page.evaluate(function () {
             $('p').each(function () {
                 var replace = $(this).html().replace(/(?!1\.0)\d+\.\d+(\.\d+)?([\-a-z]*\d+|-alpha)?(\.[0-9]{14})?/g, '');

--- a/plugins/CoreUpdater/tests/UI/expected-screenshots/CoreUpdaterDb_main_no_update_token.png
+++ b/plugins/CoreUpdater/tests/UI/expected-screenshots/CoreUpdaterDb_main_no_update_token.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f5a9d087bd50c60cea214a48d819a6ee0077f811e5b7ef0d9060002c0a3613a
+size 326127


### PR DESCRIPTION
### Description:

Hides migration details behind a token during the update process. The details will be visible to the user initiating the update, or with knowledge of the specific token value.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
