### PR TITLE
Revert "Only log exception message without stack trace when PIWIK_PRINT_ERROR_BACKTRACE not set"

### DIFF
--- a/core/ExceptionHandler.php
+++ b/core/ExceptionHandler.php
@@ -192,13 +192,6 @@ class ExceptionHandler
         return $result;
     }
 
-    public static function shouldPrintBackTraceWithMessage(): bool
-    {
-        return (defined('PIWIK_PRINT_ERROR_BACKTRACE') && PIWIK_PRINT_ERROR_BACKTRACE)
-            || !empty($GLOBALS['PIWIK_PRINT_ERROR_BACKTRACE'])
-            || !empty($GLOBALS['PIWIK_TRACKER_DEBUG']);
-    }
-
     private static function logException($exception, $loglevel = Log::ERROR)
     {
         try {

--- a/core/Log/Logger.php
+++ b/core/Log/Logger.php
@@ -9,23 +9,10 @@
 
 namespace Piwik\Log;
 
-use Piwik\ExceptionHandler;
-
 /**
  * Proxy class for \Monolog\Logger
  * @see \Monolog\Logger
  */
 class Logger extends \Monolog\Logger implements LoggerInterface
 {
-    public function addRecord($level, $message, array $context = array())
-    {
-        // if we're logging an exception, make sure we only log the message and not the stack trace if not permitted
-        if (array_key_exists('exception', $context) && is_a($context['exception'], \Exception::class)) {
-            if (!ExceptionHandler::shouldPrintBackTraceWithMessage()) {
-                $context['exception'] = $context['exception']->getMessage();
-            }
-        }
-
-        return parent::addRecord($level, $message, $context);
-    }
 }

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -94,7 +94,11 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
             return true;
         }
 
-        return \Piwik\ExceptionHandler::shouldPrintBackTraceWithMessage();
+        $bool = (defined('PIWIK_PRINT_ERROR_BACKTRACE') && PIWIK_PRINT_ERROR_BACKTRACE)
+                || !empty($GLOBALS['PIWIK_PRINT_ERROR_BACKTRACE'])
+                || !empty($GLOBALS['PIWIK_TRACKER_DEBUG']);
+
+        return $bool;
     }
 
     /**


### PR DESCRIPTION
The changes might cause some unexpected behaviours in LogProcessor classes, as exceptions are turned into strings and some special handling therefor might fail.

e.g.
https://github.com/matomo-org/matomo/blob/9a3ef94df61682e7d543f3f8b438c368f6eb71a6/plugins/Monolog/Processor/ExceptionToTextProcessor.php#L42-L44

Reverts matomo-org/matomo#23311