### PR TITLE
Use #[\SensitiveParameter] php attribute to hide sensitive parameters from strack traces

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3850,12 +3850,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/matomo-coding-standards.git",
-                "reference": "940f7ae7e058ff0d9afbed46a08a134d1a3622f0"
+                "reference": "3822ff585bd30a351761218a651d252ed86c53cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/matomo-coding-standards/zipball/940f7ae7e058ff0d9afbed46a08a134d1a3622f0",
-                "reference": "940f7ae7e058ff0d9afbed46a08a134d1a3622f0",
+                "url": "https://api.github.com/repos/matomo-org/matomo-coding-standards/zipball/3822ff585bd30a351761218a651d252ed86c53cf",
+                "reference": "3822ff585bd30a351761218a651d252ed86c53cf",
                 "shasum": ""
             },
             "require": {
@@ -3871,7 +3871,7 @@
                 "source": "https://github.com/matomo-org/matomo-coding-standards/tree/master",
                 "issues": "https://github.com/matomo-org/matomo-coding-standards/issues"
             },
-            "time": "2024-07-19T08:27:04+00:00"
+            "time": "2025-05-30T10:29:02+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -301,8 +301,11 @@ class Request
         return $toReturn;
     }
 
-    private function restoreAuthUsingTokenAuth($tokenToRestore, $hadSuperUserAccess)
-    {
+    private function restoreAuthUsingTokenAuth(
+        #[\SensitiveParameter]
+        $tokenToRestore,
+        $hadSuperUserAccess
+    ) {
         // if we would not make sure to unset super user access, the tokenAuth would be not authenticated and any
         // token would just keep super user access (eg if the token that was reloaded before had super user access)
         Access::getInstance()->setSuperUserAccess(false);
@@ -434,8 +437,10 @@ class Request
      * @param string $tokenAuth
      * @return void
      */
-    private static function forceReloadAuthUsingTokenAuth($tokenAuth)
-    {
+    private static function forceReloadAuthUsingTokenAuth(
+        #[\SensitiveParameter]
+        $tokenAuth
+    ) {
         /**
          * Triggered when authenticating an API request, but only if the **token_auth**
          * query parameter is found in the request.

--- a/core/Auth.php
+++ b/core/Auth.php
@@ -61,7 +61,10 @@ interface Auth
      *
      * @param string $token_auth authentication token
      */
-    public function setTokenAuth($token_auth);
+    public function setTokenAuth(
+        #[\SensitiveParameter]
+        $token_auth
+    );
 
     /**
      * Returns the login of the user being authenticated.
@@ -94,7 +97,10 @@ interface Auth
      *
      * @param string $password Password (not hashed).
      */
-    public function setPassword($password);
+    public function setPassword(
+        #[\SensitiveParameter]
+        $password
+    );
 
     /**
      * Sets the hash of the password to authenticate with. The hash will be an MD5 hash.
@@ -102,7 +108,10 @@ interface Auth
      * @param string $passwordHash The hashed password.
      * @throws Exception if authentication by hashed password is not supported.
      */
-    public function setPasswordHash($passwordHash);
+    public function setPasswordHash(
+        #[\SensitiveParameter]
+        $passwordHash
+    );
 
     /**
      * Authenticates a user using the login and password set using the setters. Can also authenticate

--- a/core/Auth/Password.php
+++ b/core/Auth/Password.php
@@ -72,8 +72,10 @@ class Password
      * @param string $password
      * @return string
      */
-    public function hash($password)
-    {
+    public function hash(
+        #[\SensitiveParameter]
+        $password
+    ) {
         return password_hash($password, $this->preferredAlgorithm(), $this->algorithmOptions());
     }
 
@@ -114,8 +116,12 @@ class Password
      * @param string $hash
      * @return boolean
      */
-    public function verify($password, $hash)
-    {
+    public function verify(
+        #[\SensitiveParameter]
+        $password,
+        #[\SensitiveParameter]
+        $hash
+    ) {
         return password_verify($password, $hash);
     }
 }

--- a/core/AuthResult.php
+++ b/core/AuthResult.php
@@ -50,8 +50,12 @@ class AuthResult
      * @param string $login identity
      * @param string $tokenAuth
      */
-    public function __construct($code, $login, $tokenAuth)
-    {
+    public function __construct(
+        $code,
+        $login,
+        #[\SensitiveParameter]
+        $tokenAuth
+    ) {
         $this->code      = (int)$code;
         $this->login     = $login;
         $this->tokenAuth = $tokenAuth;

--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -24,8 +24,12 @@ class Adapter
      * @param bool $connect
      * @return AdapterInterface
      */
-    public static function factory($adapterName, &$dbInfos, $connect = true)
-    {
+    public static function factory(
+        $adapterName,
+        #[\SensitiveParameter]
+        &$dbInfos,
+        $connect = true
+    ) {
         if ($connect) {
             if (isset($dbInfos['port']) && is_string($dbInfos['port']) && $dbInfos['port'][0] === '/') {
                 $dbInfos['unix_socket'] = $dbInfos['port'];

--- a/core/Plugin/API.php
+++ b/core/Plugin/API.php
@@ -118,8 +118,10 @@ abstract class API
      * @param $passwordConfirmation
      * @throws Exception
      */
-    protected function confirmCurrentUserPassword($passwordConfirmation)
-    {
+    protected function confirmCurrentUserPassword(
+        #[\SensitiveParameter]
+        $passwordConfirmation
+    ) {
         $loginCurrentUser = Piwik::getCurrentUserLogin();
 
         if (!Piwik::doesUserRequirePasswordConfirmation($loginCurrentUser)) {

--- a/core/Session/SessionAuth.php
+++ b/core/Session/SessionAuth.php
@@ -57,8 +57,10 @@ class SessionAuth implements Auth
         // empty
     }
 
-    public function setTokenAuth($token_auth)
-    {
+    public function setTokenAuth(
+        #[\SensitiveParameter]
+        $token_auth
+    ) {
         $this->tokenAuth = $token_auth;
     }
 
@@ -79,13 +81,17 @@ class SessionAuth implements Auth
         // empty
     }
 
-    public function setPassword($password)
-    {
+    public function setPassword(
+        #[\SensitiveParameter]
+        $password
+    ) {
         // empty
     }
 
-    public function setPasswordHash($passwordHash)
-    {
+    public function setPasswordHash(
+        #[\SensitiveParameter]
+        $passwordHash
+    ) {
         // empty
     }
 
@@ -160,8 +166,11 @@ class SessionAuth implements Auth
         return new AuthResult(AuthResult::FAILURE, null, null);
     }
 
-    private function makeAuthSuccess($user, $tokenAuth)
-    {
+    private function makeAuthSuccess(
+        $user,
+        #[\SensitiveParameter]
+        $tokenAuth
+    ) {
         $this->user = $user;
         $this->tokenAuth = $tokenAuth;
 

--- a/core/Session/SessionFingerprint.php
+++ b/core/Session/SessionFingerprint.php
@@ -85,8 +85,13 @@ class SessionFingerprint
         $_SESSION[self::SESSION_INFO_TWO_FACTOR_AUTH_VERIFIED] = 1;
     }
 
-    public function initialize($userName, $tokenAuth, $isRemembered = false, $time = null)
-    {
+    public function initialize(
+        $userName,
+        #[\SensitiveParameter]
+        $tokenAuth,
+        $isRemembered = false,
+        $time = null
+    ) {
         $time = $time ?: Date::now()->getTimestampUTC();
         $_SESSION[self::USER_NAME_SESSION_VAR_NAME] = $userName;
         $_SESSION[self::SESSION_INFO_TWO_FACTOR_AUTH_VERIFIED] = 0;

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -65,8 +65,11 @@ class Request
      * @param $params
      * @param bool|string $tokenAuth
      */
-    public function __construct($params, $tokenAuth = false)
-    {
+    public function __construct(
+        $params,
+        #[\SensitiveParameter]
+        $tokenAuth = false
+    ) {
         if (!is_array($params)) {
             $params = array();
         }
@@ -154,8 +157,10 @@ class Request
      * This method allows to set custom IP + server time + visitor ID, when using Tracking API.
      * These two attributes can be only set by the Super User (passing token_auth).
      */
-    protected function authenticateTrackingApi($tokenAuth)
-    {
+    protected function authenticateTrackingApi(
+        #[\SensitiveParameter]
+        $tokenAuth
+    ) {
         $shouldAuthenticate = TrackerConfig::getConfigValue('tracking_requests_require_authentication', $this->getIdSiteIfExists());
 
         if ($shouldAuthenticate) {
@@ -200,8 +205,11 @@ class Request
         }
     }
 
-    public static function authenticateSuperUserOrAdminOrWrite($tokenAuth, $idSite)
-    {
+    public static function authenticateSuperUserOrAdminOrWrite(
+        #[\SensitiveParameter]
+        $tokenAuth,
+        $idSite
+    ) {
         if (empty($tokenAuth)) {
             return false;
         }

--- a/core/Tracker/RequestSet.php
+++ b/core/Tracker/RequestSet.php
@@ -50,8 +50,10 @@ class RequestSet
         }
     }
 
-    public function setTokenAuth($tokenAuth)
-    {
+    public function setTokenAuth(
+        #[\SensitiveParameter]
+        $tokenAuth
+    ) {
         $this->tokenAuth = $tokenAuth;
     }
 

--- a/core/View/OneClickDone.php
+++ b/core/View/OneClickDone.php
@@ -46,8 +46,10 @@ class OneClickDone
      */
     public $httpsFail = false;
 
-    public function __construct($tokenAuth)
-    {
+    public function __construct(
+        #[\SensitiveParameter]
+        $tokenAuth
+    ) {
         $this->tokenAuth = $tokenAuth;
     }
 

--- a/libs/Zend/Db/Adapter/Abstract.php
+++ b/libs/Zend/Db/Adapter/Abstract.php
@@ -160,8 +160,10 @@ abstract class Zend_Db_Adapter_Abstract
      * @param  array|Zend_Config $config An array or instance of Zend_Config having configuration data
      * @throws Zend_Db_Adapter_Exception
      */
-    public function __construct($config)
-    {
+    public function __construct(
+        #[\SensitiveParameter]
+        $config
+    ) {
         /*
          * Verify that adapter parameters are in an array.
          */
@@ -278,8 +280,10 @@ abstract class Zend_Db_Adapter_Abstract
      * @param array $config
      * @throws Zend_Db_Adapter_Exception
      */
-    protected function _checkRequiredOptions(array $config)
-    {
+    protected function _checkRequiredOptions(
+        #[\SensitiveParameter]
+        array $config
+    ) {
         // we need at least a dbname
         if (! array_key_exists('dbname', $config)) {
             /** @see Zend_Db_Adapter_Exception */

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -711,8 +711,12 @@ class Controller extends ControllerAdmin
         }
     }
 
-    private function createSuperUser($login, $password, $email)
-    {
+    private function createSuperUser(
+        $login,
+        #[\SensitiveParameter]
+        $password,
+        $email
+    ) {
         Access::doAsSuperUser(function () use ($login, $password, $email) {
             $api = APIUsersManager::getInstance();
             $api->addUser($login, $password, $email);

--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -77,8 +77,11 @@ class Auth implements \Piwik\Auth
         return new AuthResult(AuthResult::FAILURE, $this->login, $this->token_auth);
     }
 
-    private function authenticateWithPassword($login, $passwordHash)
-    {
+    private function authenticateWithPassword(
+        $login,
+        #[\SensitiveParameter]
+        $passwordHash
+    ) {
         $user = $this->userModel->getUser($login);
 
         if (empty($user['login'])) {
@@ -181,8 +184,10 @@ class Auth implements \Piwik\Auth
      *
      * @param string $password
      */
-    public function setPassword($password)
-    {
+    public function setPassword(
+        #[\SensitiveParameter]
+        $password
+    ) {
         if (empty($password)) {
             $this->hashedPassword = null;
         } else {
@@ -195,8 +200,10 @@ class Auth implements \Piwik\Auth
      *
      * @param string $passwordHash The password hash.
      */
-    public function setPasswordHash($passwordHash)
-    {
+    public function setPasswordHash(
+        #[\SensitiveParameter]
+        $passwordHash
+    ) {
         if ($passwordHash === null) {
             $this->hashedPassword = null;
             return;

--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -174,8 +174,10 @@ class Auth implements \Piwik\Auth
      *
      * @param string $token_auth authentication token
      */
-    public function setTokenAuth($token_auth)
-    {
+    public function setTokenAuth(
+        #[\SensitiveParameter]
+        $token_auth
+    ) {
         $this->token_auth = $token_auth;
     }
 

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -317,8 +317,14 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
      * @param string $urlToRedirect URL to redirect to, if successfully authenticated
      * @param bool $passwordHashed indicates if $password is hashed
      */
-    protected function authenticateAndRedirect($login, $password, $urlToRedirect = false, $passwordHashed = false)
-    {
+    protected function authenticateAndRedirect(
+        $login,
+        #[\SensitiveParameter]
+        $password,
+        $urlToRedirect = false,
+        #[\SensitiveParameter]
+        $passwordHashed = false
+    ) {
         Nonce::discardNonce('Login.login');
 
         $this->auth->setLogin($login);

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -241,8 +241,10 @@ class Login extends \Piwik\Plugin
      * Set login name and authentication token for API request.
      * Listens to API.Request.authenticate hook.
      */
-    public function apiRequestAuthenticate($tokenAuth)
-    {
+    public function apiRequestAuthenticate(
+        #[\SensitiveParameter]
+        $tokenAuth
+    ) {
         $this->beforeLoginCheckBruteForce();
 
         /** @var \Piwik\Auth $auth */

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -287,8 +287,11 @@ class PasswordResetter
      * @throws Exception If there is no user with login '$login', if $resetToken is not a
      *                   valid token or if the token has expired.
      */
-    public function setHashedPasswordForLogin($login, $passwordHash)
-    {
+    public function setHashedPasswordForLogin(
+        $login,
+        #[\SensitiveParameter]
+        $passwordHash
+    ) {
         /*
          * Executed as super user, as we need to update the password, without the current user being authenticated yet.
          */
@@ -364,8 +367,12 @@ class PasswordResetter
         return $token;
     }
 
-    public function doesResetPasswordHashMatchesPassword($passwordPlain, $passwordHash)
-    {
+    public function doesResetPasswordHashMatchesPassword(
+        #[\SensitiveParameter]
+        $passwordPlain,
+        #[\SensitiveParameter]
+        $passwordHash
+    ) {
         $passwordPlain = UsersManager::getPasswordHash($passwordPlain);
         return $this->passwordHelper->verify($passwordPlain, $passwordHash);
     }
@@ -446,8 +453,10 @@ class PasswordResetter
      * @param string $newPassword The password to check.
      * @throws Exception if $newPassword is inferior in some way.
      */
-    protected function checkNewPassword($newPassword)
-    {
+    protected function checkNewPassword(
+        #[\SensitiveParameter]
+        $newPassword
+    ) {
         UsersManager::checkPassword($newPassword);
     }
 
@@ -489,8 +498,10 @@ class PasswordResetter
      * @param string $passwordHash The password hash to check.
      * @throws Exception if the password hash length is incorrect.
      */
-    protected function checkPasswordHash($passwordHash)
-    {
+    protected function checkPasswordHash(
+        #[\SensitiveParameter]
+        $passwordHash
+    ) {
         $hashInfo = $this->passwordHelper->info($passwordHash);
 
         if (!isset($hashInfo['algo']) || 0 >= $hashInfo['algo']) {
@@ -570,8 +581,12 @@ class PasswordResetter
      *
      * @throws Exception if a password reset was already requested within one hour
      */
-    private function savePasswordResetInfo($login, $newPassword, $keySuffix)
-    {
+    private function savePasswordResetInfo(
+        $login,
+        #[\SensitiveParameter]
+        $newPassword,
+        $keySuffix
+    ) {
         $optionName = self::getPasswordResetInfoOptionName($login);
 
         $existingResetInfo = Option::get($optionName);

--- a/plugins/Login/PasswordVerifier.php
+++ b/plugins/Login/PasswordVerifier.php
@@ -40,8 +40,11 @@ class PasswordVerifier
         return new SessionNamespace('Login');
     }
 
-    public function isPasswordCorrect($userLogin, $password)
-    {
+    public function isPasswordCorrect(
+        $userLogin,
+        #[\SensitiveParameter]
+        $password
+    ) {
         /**
          * @ignore
          * @internal

--- a/plugins/Login/SessionInitializer.php
+++ b/plugins/Login/SessionInitializer.php
@@ -196,8 +196,11 @@ class SessionInitializer
      * @param string $token_auth authentication token
      * @return string hashed authentication token
      */
-    public static function getHashTokenAuth($login, $token_auth)
-    {
+    public static function getHashTokenAuth(
+        $login,
+        #[\SensitiveParameter]
+        $token_auth
+    ) {
         return md5($login . $token_auth);
     }
 }

--- a/plugins/Marketplace/Api/Service.php
+++ b/plugins/Marketplace/Api/Service.php
@@ -40,8 +40,10 @@ class Service
         $this->domain = $domain;
     }
 
-    public function authenticate($accessToken)
-    {
+    public function authenticate(
+        #[\SensitiveParameter]
+        $accessToken
+    ) {
         if (empty($accessToken)) {
             $this->accessToken = null;
         } elseif (ctype_alnum($accessToken)) {

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -166,6 +166,7 @@ class API extends \Piwik\Plugin\API
         $anonymizeUserId = false,
         $unsetVisitColumns = [],
         $unsetLinkVisitActionColumns = [],
+        #[\SensitiveParameter]
         $passwordConfirmation = ''
     ) {
         Piwik::checkUserHasSuperUserAccess();
@@ -342,6 +343,7 @@ class API extends \Piwik\Plugin\API
         $keepYear = 0,
         $keepRange = 0,
         $keepSegments = 0,
+        #[\SensitiveParameter]
         $passwordConfirmation = ''
     ) {
         Piwik::checkUserHasSuperUserAccess();
@@ -377,8 +379,10 @@ class API extends \Piwik\Plugin\API
      *
      * @internal
      */
-    public function executeDataPurge($passwordConfirmation)
-    {
+    public function executeDataPurge(
+        #[\SensitiveParameter]
+        $passwordConfirmation
+    ) {
         $this->confirmCurrentUserPassword($passwordConfirmation);
         Piwik::checkUserHasSuperUserAccess();
 

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -868,8 +868,11 @@ class API extends \Piwik\Plugin\API
      * @param string $passwordConfirmation the current user's password, only required when the request is authenticated with session token auth
      * @throws Exception
      */
-    public function deleteSite($idSite, $passwordConfirmation = null)
-    {
+    public function deleteSite(
+        $idSite,
+        #[\SensitiveParameter]
+        $passwordConfirmation = null
+    ) {
         Piwik::checkUserHasSuperUserAccess();
         SitesManager::dieIfSitesAdminIsDisabled();
 

--- a/plugins/TwoFactorAuth/API.php
+++ b/plugins/TwoFactorAuth/API.php
@@ -23,8 +23,11 @@ class API extends \Piwik\Plugin\API
         $this->twoFa = $twoFa;
     }
 
-    public function resetTwoFactorAuth($userLogin, $passwordConfirmation = '')
-    {
+    public function resetTwoFactorAuth(
+        $userLogin,
+        #[\SensitiveParameter]
+        $passwordConfirmation = ''
+    ) {
         Piwik::checkUserHasSuperUserAccess();
 
         $this->confirmCurrentUserPassword($passwordConfirmation);

--- a/plugins/TwoFactorAuth/Controller.php
+++ b/plugins/TwoFactorAuth/Controller.php
@@ -338,8 +338,10 @@ class Controller extends \Piwik\Plugin\Controller
         ));
     }
 
-    private function getTwoFaBarCodeSetupUrl($secret)
-    {
+    private function getTwoFaBarCodeSetupUrl(
+        #[\SensitiveParameter]
+        $secret
+    ) {
         $title = $this->settings->twoFactorAuthTitle->getValue();
         $descr = Piwik::getCurrentUserLogin();
 

--- a/plugins/TwoFactorAuth/TwoFactorAuth.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuth.php
@@ -167,8 +167,10 @@ class TwoFactorAuth extends \Piwik\Plugin
         return StaticContainer::get(Validator::class);
     }
 
-    private function isValidTokenAuth($tokenAuth)
-    {
+    private function isValidTokenAuth(
+        #[\SensitiveParameter]
+        $tokenAuth
+    ) {
         $model = new Model();
         $user = $model->getUserByTokenAuth($tokenAuth);
         return !empty($user);

--- a/plugins/TwoFactorAuth/TwoFactorAuthentication.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuthentication.php
@@ -77,8 +77,11 @@ class TwoFactorAuthentication
         return strtolower($login) === 'anonymous';
     }
 
-    public function saveSecret($login, $secret)
-    {
+    public function saveSecret(
+        $login,
+        #[\SensitiveParameter]
+        $secret
+    ) {
         if (self::isAnonymous($login)) {
             throw new Exception('Anonymous cannot use two-factor authentication');
         }
@@ -113,8 +116,11 @@ class TwoFactorAuthentication
         return $model->getUser($login);
     }
 
-    private function wasTwoFaCodeUsedRecently($login, $authCode)
-    {
+    private function wasTwoFaCodeUsedRecently(
+        $login,
+        #[\SensitiveParameter]
+        $authCode
+    ) {
         $time = Option::get($this->gettwoFaCodeUsedKey($login, $authCode));
         if (empty($time)) {
             return false;
@@ -126,13 +132,19 @@ class TwoFactorAuthentication
         return false;
     }
 
-    private function gettwoFaCodeUsedKey($login, $authCode)
-    {
+    private function gettwoFaCodeUsedKey(
+        $login,
+        #[\SensitiveParameter]
+        $authCode
+    ) {
         return self::OPTION_PREFIX_TWO_FA_CODE_USED . md5($login . $authCode . SettingsPiwik::getSalt());
     }
 
-    private function setTwoFaCodeWasUsed($login, $authCode)
-    {
+    private function setTwoFaCodeWasUsed(
+        $login,
+        #[\SensitiveParameter]
+        $authCode
+    ) {
         $table = Common::prefixTable('option');
         $bind = array($this->gettwoFaCodeUsedKey($login, $authCode), time(), 0);
         try {
@@ -158,8 +170,11 @@ class TwoFactorAuthentication
         }
     }
 
-    public function validateAuthCode($login, $authCode)
-    {
+    public function validateAuthCode(
+        $login,
+        #[\SensitiveParameter]
+        $authCode
+    ) {
         if (!self::isUserUsingTwoFactorAuthentication($login)) {
             return false;
         }
@@ -188,8 +203,12 @@ class TwoFactorAuthentication
         return false;
     }
 
-    public function validateAuthCodeDuringSetup($authCode, $secret)
-    {
+    public function validateAuthCodeDuringSetup(
+        #[\SensitiveParameter]
+        $authCode,
+        #[\SensitiveParameter]
+        $secret
+    ) {
         $twoFactorAuth = $this->makeAuthenticator();
 
         if (!empty($secret) && $twoFactorAuth->verifyCode($secret, $authCode, 2)) {

--- a/plugins/UserCountryMap/Controller.php
+++ b/plugins/UserCountryMap/Controller.php
@@ -303,8 +303,13 @@ class Controller extends \Piwik\Plugin\Controller
         }
     }
 
-    private function getMetrics($idSite, $period, $date, $token_auth)
-    {
+    private function getMetrics(
+        $idSite,
+        $period,
+        $date,
+        #[\SensitiveParameter]
+        $token_auth
+    ) {
         $request = new Request(
             'method=API.getMetadata&format=json'
             . '&apiModule=UserCountry&apiAction=getCountry'
@@ -330,8 +335,17 @@ class Controller extends \Piwik\Plugin\Controller
         return $metrics;
     }
 
-    private function getApiRequestUrl($module, $action, $idSite, $period, $date, $token_auth, $filter_by_country = false, $segmentOverride = false)
-    {
+    private function getApiRequestUrl(
+        $module,
+        $action,
+        $idSite,
+        $period,
+        $date,
+        #[\SensitiveParameter]
+        $token_auth,
+        $filter_by_country = false,
+        $segmentOverride = false
+    ) {
         // use processed reports
         $url = "?module=" . $module
             . "&method=" . $module . "." . $action . "&format=JSON"
@@ -354,8 +368,17 @@ class Controller extends \Piwik\Plugin\Controller
         return $url;
     }
 
-    private function report($module, $action, $idSite, $period, $date, $token_auth, $filter_by_country = false, $segmentOverride = false)
-    {
+    private function report(
+        $module,
+        $action,
+        $idSite,
+        $period,
+        $date,
+        #[\SensitiveParameter]
+        $token_auth,
+        $filter_by_country = false,
+        $segmentOverride = false
+    ) {
         return $this->getApiRequestUrl(
             'API',
             'getProcessedReport&apiModule=' . $module . '&apiAction=' . $action,

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -107,6 +107,7 @@ class API extends \Piwik\Plugin\API
     public function __construct(
         Model $model,
         UserAccessFilter $filter,
+        #[\SensitiveParameter]
         Password $password,
         ?Access $access = null,
         ?Access\RolesProvider $roleProvider = null,

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -739,8 +739,16 @@ class API extends \Piwik\Plugin\API
      *
      * @see userExists()
      */
-    public function addUser($userLogin, $password, $email, $_isPasswordHashed = false, $initialIdSite = null, $passwordConfirmation = null)
-    {
+    public function addUser(
+        $userLogin,
+        #[\SensitiveParameter]
+        $password,
+        $email,
+        $_isPasswordHashed = false,
+        $initialIdSite = null,
+        #[\SensitiveParameter]
+        $passwordConfirmation = null
+    ) {
         Piwik::checkUserHasSomeAdminAccess();
         UsersManager::dieIfUsersAdminIsDisabled();
 
@@ -782,8 +790,14 @@ class API extends \Piwik\Plugin\API
     /**
      * @throws Exception
      */
-    public function inviteUser($userLogin, $email, $initialIdSite = null, $expiryInDays = null, $passwordConfirmation = null)
-    {
+    public function inviteUser(
+        $userLogin,
+        $email,
+        $initialIdSite = null,
+        $expiryInDays = null,
+        #[\SensitiveParameter]
+        $passwordConfirmation = null
+    ) {
         Piwik::checkUserHasSomeAdminAccess();
         UsersManager::dieIfUsersAdminIsDisabled();
 
@@ -825,8 +839,12 @@ class API extends \Piwik\Plugin\API
      *                                     sent as a POST parameter.
      * @throws \Exception
      */
-    public function setSuperUserAccess($userLogin, $hasSuperUserAccess, $passwordConfirmation = null)
-    {
+    public function setSuperUserAccess(
+        $userLogin,
+        $hasSuperUserAccess,
+        #[\SensitiveParameter]
+        $passwordConfirmation = null
+    ) {
         $this->executeConcurrencySafe($userLogin, function () use ($userLogin, $hasSuperUserAccess, $passwordConfirmation) {
             Piwik::checkUserHasSuperUserAccess();
             $this->checkUserIsNotAnonymous($userLogin);
@@ -896,9 +914,11 @@ class API extends \Piwik\Plugin\API
      */
     public function updateUser(
         $userLogin,
+        #[\SensitiveParameter]
         $password = false,
         $email = false,
         $_isPasswordHashed = false,
+        #[\SensitiveParameter]
         $passwordConfirmation = false
     ) {
         $email = Common::unsanitizeInputValue($email);
@@ -992,8 +1012,11 @@ class API extends \Piwik\Plugin\API
      * @throws Exception if the user doesn't exist or if deleting the users would leave no superusers.
      *
      */
-    public function deleteUser($userLogin, $passwordConfirmation = null)
-    {
+    public function deleteUser(
+        $userLogin,
+        #[\SensitiveParameter]
+        $passwordConfirmation = null
+    ) {
         Piwik::checkUserHasSomeAdminAccess();
         UsersManager::dieIfUsersAdminIsDisabled();
         $this->checkUserIsNotAnonymous($userLogin);
@@ -1106,8 +1129,13 @@ class API extends \Piwik\Plugin\API
      * @throws Exception if the access parameter doesn't have a correct value
      * @throws Exception if any of the given website ID doesn't exist
      */
-    public function setUserAccess($userLogin, $access, $idSites, $passwordConfirmation = null)
-    {
+    public function setUserAccess(
+        $userLogin,
+        $access,
+        $idSites,
+        #[\SensitiveParameter]
+        $passwordConfirmation = null
+    ) {
         UsersManager::dieIfUsersAdminIsDisabled();
 
         if ($access != 'noaccess') {
@@ -1447,6 +1475,7 @@ class API extends \Piwik\Plugin\API
      */
     public function createAppSpecificTokenAuth(
         $userLogin,
+        #[\SensitiveParameter]
         $passwordConfirmation,
         $description,
         $expireDate = null,
@@ -1602,8 +1631,12 @@ class API extends \Piwik\Plugin\API
      * @param string | null $passwordConfirmation
      * @throws NoAccessException
      */
-    public function resendInvite($userLogin, $expiryInDays = 7, $passwordConfirmation = null)
-    {
+    public function resendInvite(
+        $userLogin,
+        $expiryInDays = 7,
+        #[\SensitiveParameter]
+        $passwordConfirmation = null
+    ) {
         Piwik::checkUserHasSomeAdminAccess();
 
         // check password confirmation only when using session auth
@@ -1643,8 +1676,12 @@ class API extends \Piwik\Plugin\API
      * @return string
      * @throws NoAccessException
      */
-    public function generateInviteLink($userLogin, $expiryInDays = 7, $passwordConfirmation = null)
-    {
+    public function generateInviteLink(
+        $userLogin,
+        $expiryInDays = 7,
+        #[\SensitiveParameter]
+        $passwordConfirmation = null
+    ) {
         Piwik::checkUserHasSomeAdminAccess();
 
         // check password confirmation only when using session auth

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -189,9 +189,9 @@ class Model
     ) {
         $siteAccessFilter = new SiteAccessFilter($userLogin, $pattern, $access, $idSites);
 
-        list($joins, $bind) = $siteAccessFilter->getJoins('a');
+        [$joins, $bind] = $siteAccessFilter->getJoins('a');
 
-        list($where, $whereBind) = $siteAccessFilter->getWhere();
+        [$where, $whereBind] = $siteAccessFilter->getWhere();
         $bind = array_merge($bind, $whereBind);
 
         $limitSql = '';
@@ -238,9 +238,9 @@ class Model
     {
         $siteAccessFilter = new SiteAccessFilter($userLogin, $filter_search, $filter_access, $idSites);
 
-        list($joins, $bind) = $siteAccessFilter->getJoins('a');
+        [$joins, $bind] = $siteAccessFilter->getJoins('a');
 
-        list($where, $whereBind) = $siteAccessFilter->getWhere();
+        [$where, $whereBind] = $siteAccessFilter->getWhere();
         $bind = array_merge($bind, $whereBind);
 
         $sql = 'SELECT s.idsite FROM ' . Common::prefixTable('access') . " a $joins $where";
@@ -271,8 +271,10 @@ class Model
         return reset($matchedUsers);
     }
 
-    public function hashTokenAuth($tokenAuth)
-    {
+    public function hashTokenAuth(
+        #[\SensitiveParameter]
+        $tokenAuth
+    ) {
         $salt = SettingsPiwik::getSalt();
         return hash(self::TOKEN_HASH_ALGO, $tokenAuth . $salt);
     }
@@ -606,8 +608,13 @@ class Model
      * @param $email
      * @param $dateRegistered
      */
-    public function addUser($userLogin, $hashedPassword, $email, $dateRegistered)
-    {
+    public function addUser(
+        $userLogin,
+        #[\SensitiveParameter]
+        $hashedPassword,
+        $email,
+        $dateRegistered
+    ) {
         $user = array(
           'login'                => $userLogin,
           'password'             => $hashedPassword,
@@ -678,8 +685,12 @@ class Model
         return $users;
     }
 
-    public function updateUser($userLogin, $hashedPassword, $email)
-    {
+    public function updateUser(
+        $userLogin,
+        #[\SensitiveParameter]
+        $hashedPassword,
+        $email
+    ) {
         $fields = array(
           'email' => $email,
         );
@@ -806,8 +817,8 @@ class Model
     ) {
         $filter = new UserTableFilter($access, $idSite, $pattern, $status, $logins);
 
-        list($joins, $bind) = $filter->getJoins('u');
-        list($where, $whereBind) = $filter->getWhere();
+        [$joins, $bind] = $filter->getJoins('u');
+        [$where, $whereBind] = $filter->getWhere();
 
         $bind = array_merge($bind, $whereBind);
 

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -339,6 +339,7 @@ class Model
      */
     public function addTokenAuth(
         $login,
+        #[\SensitiveParameter]
         $tokenAuth,
         $description,
         $dateCreated,
@@ -375,8 +376,10 @@ class Model
         return $db->lastInsertId();
     }
 
-    private function getTokenByTokenAuth($tokenAuth)
-    {
+    private function getTokenByTokenAuth(
+        #[\SensitiveParameter]
+        $tokenAuth
+    ) {
         $tokenAuth = $this->hashTokenAuth($tokenAuth);
         $db = $this->getDb();
 
@@ -412,8 +415,11 @@ class Model
      * @return array|bool               An array representing the token record, or null if not found
      * @throws \Exception
      */
-    private function getTokenByTokenAuthIfNotExpired(?string $tokenAuth, bool $isTokenSecured)
-    {
+    private function getTokenByTokenAuthIfNotExpired(
+        #[\SensitiveParameter]
+        ?string $tokenAuth,
+        bool $isTokenSecured
+    ) {
         // If the token wasn't provided via a secure mechanism and use of secure tokens is enforced globally
         // then don't attempt to find the token
         if (GeneralConfig::getConfigValue('only_allow_secure_auth_tokens') && !$isTokenSecured) {
@@ -519,8 +525,11 @@ class Model
         );
     }
 
-    public function setTokenAuthWasUsed($tokenAuth, $dateLastUsed)
-    {
+    public function setTokenAuthWasUsed(
+        #[\SensitiveParameter]
+        $tokenAuth,
+        $dateLastUsed
+    ) {
         $token = $this->getTokenByTokenAuth($tokenAuth);
         if (!empty($token)) {
             $lastUsage = !empty($token['last_used']) ? strtotime($token['last_used']) : 0;
@@ -568,8 +577,10 @@ class Model
     }
 
 
-    public function getUserByInviteToken($tokenAuth)
-    {
+    public function getUserByInviteToken(
+        #[\SensitiveParameter]
+        $tokenAuth
+    ) {
         $token = $this->hashTokenAuth($tokenAuth);
         if (!empty($token)) {
             $db = $this->getDb();
@@ -585,8 +596,10 @@ class Model
      * @return array|null
      * @throws \Exception
      */
-    public function getUserByTokenAuth(?string $tokenAuth): ?array
-    {
+    public function getUserByTokenAuth(
+        #[\SensitiveParameter]
+        ?string $tokenAuth
+    ): ?array {
         if ($tokenAuth === 'anonymous') {
             $row = $this->getUser('anonymous');
             return (is_array($row) ? $row : null);

--- a/plugins/UsersManager/Repository/UserRepository.php
+++ b/plugins/UsersManager/Repository/UserRepository.php
@@ -68,6 +68,7 @@ class UserRepository
         string $userLogin,
         string $email,
         ?int $initialIdSite = null,
+        #[\SensitiveParameter]
         string $password = '',
         bool $isPasswordHashed = false
     ): void {

--- a/plugins/UsersManager/UserUpdater.php
+++ b/plugins/UsersManager/UserUpdater.php
@@ -23,6 +23,7 @@ class UserUpdater
      */
     public function updateUserWithoutCurrentPassword(
         $userLogin,
+        #[\SensitiveParameter]
         $password = false,
         $email = false,
         $_isPasswordHashed = false

--- a/plugins/UsersManager/UsersManager.php
+++ b/plugins/UsersManager/UsersManager.php
@@ -112,8 +112,11 @@ class UsersManager extends \Piwik\Plugin
         }
     }
 
-    public static function hashTrackingToken($tokenAuth, $idSite)
-    {
+    public static function hashTrackingToken(
+        #[\SensitiveParameter]
+        $tokenAuth,
+        $idSite
+    ) {
         return sha1($idSite . $tokenAuth . SettingsPiwik::getSalt());
     }
 
@@ -159,8 +162,10 @@ class UsersManager extends \Piwik\Plugin
         return $l >= self::PASSWORD_MIN_LENGTH;
     }
 
-    public static function checkPassword($password)
-    {
+    public static function checkPassword(
+        #[\SensitiveParameter]
+        $password
+    ) {
         /**
          * Triggered before core password validator check password.
          *
@@ -225,8 +230,11 @@ class UsersManager extends \Piwik\Plugin
      * @param string $exceptionMessage Message of the exception thrown.
      * @throws Exception if the password hash length is incorrect.
      */
-    public static function checkPasswordHash($passwordHash, $exceptionMessage)
-    {
+    public static function checkPasswordHash(
+        #[\SensitiveParameter]
+        $passwordHash,
+        $exceptionMessage
+    ) {
         if (strlen($passwordHash) != 32 || !ctype_xdigit($passwordHash)) {  // MD5 hash length
             throw new Exception($exceptionMessage);
         }

--- a/plugins/UsersManager/UsersManager.php
+++ b/plugins/UsersManager/UsersManager.php
@@ -199,8 +199,10 @@ class UsersManager extends \Piwik\Plugin
         }
     }
 
-    public static function getPasswordHash($password)
-    {
+    public static function getPasswordHash(
+        #[\SensitiveParameter]
+        $password
+    ) {
         if (SettingsPiwik::isUserCredentialsSanityCheckEnabled()) {
             self::checkBasicPasswordStrength($password);
         }
@@ -209,8 +211,10 @@ class UsersManager extends \Piwik\Plugin
         return md5($password);
     }
 
-    public static function checkBasicPasswordStrength($password)
-    {
+    public static function checkBasicPasswordStrength(
+        #[\SensitiveParameter]
+        $password
+    ) {
         $ex = new \Exception('This password is too weak, please supply another value or reset it.');
 
         $numDistinctCharacters = strlen(count_chars($password, 3));


### PR DESCRIPTION
### Description:

Since PHP 8.2 the `#[\SensitiveParameter]` attribute can be used to hide sensitive parameters from being included in stack traces.

This PR aims to mark sensitive parameters across the code base.

Note: As PHP 7 does not support such attributes, they need be placed on a single line before the parameter. That way PHP 7 ignores them as comment, while PHP 8.2+ will use them

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
