### PR TITLE
Blank measurable default description/longdescription

### DIFF
--- a/core/Measurable/Type.php
+++ b/core/Measurable/Type.php
@@ -14,8 +14,8 @@ class Type
     public const ID = '';
     protected $name = 'General_Measurable';
     protected $namePlural = 'General_Measurables';
-    protected $description = 'Default measurable type';
-    protected $longDescription = 'Default measurable type long description';
+    protected $description = '';
+    protected $longDescription = '';
     protected $howToSetupUrl = '';
 
     public function isType($typeId)


### PR DESCRIPTION
### Description:

Follow on from https://github.com/matomo-org/matomo/pull/23277 and 
https://github.com/innocraft/plugin-RollUpReporting/pull/137

This takes care of the case that core is updated, but the plugin isn't.  Is this a common scenario we should be watching out for?

From: 

![image](https://github.com/user-attachments/assets/2bbf7cd3-77e2-4f4a-b419-1a46ea3107e5)


To:

![image](https://github.com/user-attachments/assets/b4c36d30-8797-4e49-8f18-b127ca916476)

### To Test:

Create a new measurable at /index.php?module=SitesManager&action=index&pluginName=RollUpReporting and see.

Ensure you haven't updated the RollUpReporting plugin.




### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
