### PR TITLE
Fix sending secure token in bulk request body & add support for "Authorization: Bearer" header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 
 ## Matomo 5.4.0
 
+### Authentication changes
+
+Matomo now supports providing authentication using Bearer header tokens. Instead of sending your auth token as GET or POST param, you can use a header like `Authorization: Bearer myAuthToken`.
+
 ### Breaking Changes
 
 The ImageGraph URLs returned by some of our APIs do no longer contain the `token_auth`. If you are using such URLs to e.g. directly fetch their content, you may need to adjust your implementation to append a valid `token_auth` again.

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -541,6 +541,19 @@ class Request
     }
 
     /**
+     * Returns true if a token_auth parameter was supplied via a secure mechanism and is not present as a URL parameter
+     * At the moment POST requests are checked, but in future other mechanism such as Authorisation HTTP header
+     * and bearer tokens might be used as well.
+     *
+     * @return bool True if token was supplied in a secure way
+     * @deprecated will be removed in Matomo 6
+     */
+    public static function isTokenAuthProvidedSecurely(): bool
+    {
+        return StaticContainer::get(AuthenticationToken::class)->wasTokenAuthProvidedSecurely();
+    }
+
+    /**
      * Returns array($class, $method) from the given string $class.$method
      *
      * @param string $parameter

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -11,6 +11,7 @@ namespace Piwik\API;
 
 use Exception;
 use Piwik\Access;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Cache;
 use Piwik\Common;
 use Piwik\Config;
@@ -242,7 +243,7 @@ class Request
             $corsHandler = new CORSHandler();
             $corsHandler->handle();
 
-            $tokenAuth = Common::getRequestVar('token_auth', '', 'string', $this->request);
+            $tokenAuth = StaticContainer::get(AuthenticationToken::class)->getAuthToken($this->request);
 
             // IP check is needed here as we cannot listen to API.Request.authenticate as it would then not return proper API format response.
             // We can also not do it by listening to API.Request.dispatch as by then the user is already authenticated and we want to make sure
@@ -423,7 +424,7 @@ class Request
     public static function reloadAuthUsingTokenAuth($request = null)
     {
         // if a token_auth is specified in the API request, we load the right permissions
-        $token_auth = Common::getRequestVar('token_auth', '', 'string', $request);
+        $token_auth = StaticContainer::get(AuthenticationToken::class)->getAuthToken($request);
 
         if (self::shouldReloadAuthUsingTokenAuth($request)) {
             self::forceReloadAuthUsingTokenAuth($token_auth);
@@ -522,7 +523,7 @@ class Request
     public static function shouldReloadAuthUsingTokenAuth($request)
     {
         if (is_null($request)) {
-            $request = self::getDefaultRequest();
+            return StaticContainer::get(AuthenticationToken::class)->getAuthToken() != Access::getInstance()->getTokenAuth();
         }
 
         if (!isset($request['token_auth'])) {
@@ -537,19 +538,6 @@ class Request
         // we do not need to reload.
 
         return $tokenAuth != Access::getInstance()->getTokenAuth();
-    }
-
-    /**
-     * Returns true if a token_auth parameter was supplied via a secure mechanism and is not present as a URL parameter
-     * At the moment POST requests are checked, but in future other mechanism such as Authorisation HTTP header
-     * and bearer tokens might be used as well.
-     *
-     * @return bool True if token was supplied in a secure way
-     */
-    public static function isTokenAuthProvidedSecurely(): bool
-    {
-        return (\Piwik\Request::fromGet()->getStringParameter('token_auth', '') === '' &&
-                \Piwik\Request::fromPost()->getStringParameter('token_auth', '') !== '');
     }
 
     /**

--- a/core/Access.php
+++ b/core/Access.php
@@ -13,6 +13,7 @@ use Exception;
 use Piwik\Access\CapabilitiesProvider;
 use Piwik\API\Request;
 use Piwik\Access\RolesProvider;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Container\StaticContainer;
 use Piwik\Plugins\SitesManager\API as SitesManagerApi;
 use Piwik\Session\SessionAuth;
@@ -158,15 +159,14 @@ class Access
 
         $result = null;
 
-        $forceApiSessionPost = Common::getRequestVar('force_api_session', 0, 'int', $_POST);
-        $forceApiSessionGet = Common::getRequestVar('force_api_session', 0, 'int', $_GET);
         $isApiRequest = Piwik::getModule() === 'API' && (Piwik::getAction() === 'index' || !Piwik::getAction());
         $apiMethod = Request::getMethodIfApiRequest(null);
         $isGetApiRequest = !empty($apiMethod) && 1 === substr_count($apiMethod, '.') && strpos($apiMethod, '.get') > 0;
 
-        if (($forceApiSessionPost && $isApiRequest) || ($forceApiSessionGet && $isApiRequest && $isGetApiRequest)) {
-            $request = ($forceApiSessionGet && $isApiRequest && $isGetApiRequest) ? $_GET : $_POST;
-            $tokenAuth = Common::getRequestVar('token_auth', '', 'string', $request);
+        $token = StaticContainer::get(AuthenticationToken::class);
+
+        if ($isApiRequest && ($token->wasTokenAuthProvidedSecurely() || $isGetApiRequest)) {
+            $tokenAuth = $token->getAuthToken();
             Session::start();
             $auth = StaticContainer::get(SessionAuth::class);
             $auth->setTokenAuth($tokenAuth);

--- a/core/Access.php
+++ b/core/Access.php
@@ -165,7 +165,7 @@ class Access
 
         $token = StaticContainer::get(AuthenticationToken::class);
 
-        if ($isApiRequest && ($token->wasTokenAuthProvidedSecurely() || $isGetApiRequest)) {
+        if ($isApiRequest && $token->isSessionToken() && ($token->wasTokenAuthProvidedSecurely() || $isGetApiRequest)) {
             $tokenAuth = $token->getAuthToken();
             Session::start();
             $auth = StaticContainer::get(SessionAuth::class);

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -11,6 +11,7 @@ namespace Piwik;
 
 use Exception;
 use Piwik\API\Request;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Config\GeneralConfig;
 use Piwik\Container\StaticContainer;
 use Piwik\DataTable\Manager;
@@ -445,7 +446,7 @@ class FrontController extends Singleton
         // Force the auth to use the token_auth if specified, so that embed dashboard
         // and all other non widgetized controller methods works fine
         if (
-            Common::getRequestVar('token_auth', '', 'string') !== ''
+            StaticContainer::get(AuthenticationToken::class)->getAuthToken() !== ''
             && Request::shouldReloadAuthUsingTokenAuth(null)
         ) {
             Request::reloadAuthUsingTokenAuth();
@@ -491,7 +492,7 @@ class FrontController extends Singleton
             throw new Exception("Invalid module name '$module'");
         }
 
-        list($module, $action) = Request::getRenamedModuleAndAction($module, $action);
+        [$module, $action] = Request::getRenamedModuleAndAction($module, $action);
 
         if (!SettingsPiwik::isInternetEnabled() && \Piwik\Plugin\Manager::getInstance()->doesPluginRequireInternetConnection($module)) {
             throw new PluginRequiresInternetException($module);
@@ -575,7 +576,7 @@ class FrontController extends Singleton
 
         if (
             $isDashboardReferrer
-            && !empty($_POST['token_auth'])
+            && StaticContainer::get(AuthenticationToken::class)->wasTokenAuthProvidedSecurely()
             && Common::getRequestVar('widget', 0, 'int') === 1
         ) {
             Session::close();
@@ -610,7 +611,7 @@ class FrontController extends Singleton
      */
     private function doDispatch($module, $action, $parameters)
     {
-        list($module, $action, $parameters) = $this->prepareDispatch($module, $action, $parameters);
+        [$module, $action, $parameters] = $this->prepareDispatch($module, $action, $parameters);
 
         /**
          * Triggered directly before controller actions are dispatched.
@@ -710,7 +711,9 @@ class FrontController extends Singleton
             return null;
         }
 
-        if (Common::getRequestVar('token_auth', '', 'string') !== '' && !Common::getRequestVar('force_api_session', 0)) {
+        $token = StaticContainer::get(AuthenticationToken::class);
+
+        if ($token->getAuthToken() !== '' && !$token->isSessionToken()) {
              return null;
         }
 
@@ -820,7 +823,7 @@ class FrontController extends Singleton
             return true;
         }
 
-        if (Common::getRequestVar('token_auth', '', 'string') !== '') {
+        if (StaticContainer::get(AuthenticationToken::class)->getAuthToken() !== '') {
             return true;
         }
 

--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -13,6 +13,7 @@ use Exception;
 use Piwik\Access;
 use Piwik\API\Proxy;
 use Piwik\API\Request;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Changes\Model as ChangesModel;
 use Piwik\Changes\UserChanges;
 use Piwik\Common;
@@ -1056,7 +1057,7 @@ abstract class Controller
      */
     protected function checkTokenInUrl()
     {
-        $tokenRequest = Common::getRequestVar('token_auth', false);
+        $tokenRequest = StaticContainer::get(AuthenticationToken::class)->getAuthToken();
         $tokenUser = Piwik::getCurrentUserTokenAuth();
 
         if (empty($tokenRequest) && empty($tokenUser)) {

--- a/core/Request/AuthenticationToken.php
+++ b/core/Request/AuthenticationToken.php
@@ -81,7 +81,7 @@ class AuthenticationToken
         if (!empty($requestBody) && strpos($requestBody, '{') === 0) {
             $jsonContent = json_decode($requestBody, true);
 
-            if (!empty($jsonContent['token_auth'])) {
+            if (!empty($jsonContent['token_auth']) && is_string($jsonContent['token_auth'])) {
                 $this->authToken = $jsonContent['token_auth'];
                 $this->wasTokenProvidedSecurely = true;
                 return true;

--- a/core/Request/AuthenticationToken.php
+++ b/core/Request/AuthenticationToken.php
@@ -100,6 +100,7 @@ class AuthenticationToken
             $this->authToken = $tokenAuth;
             $this->wasTokenProvidedSecurely = true;
             $this->isSessionToken = $request->getBoolParameter('force_api_session', false);
+            return true;
         }
 
         return false;
@@ -114,6 +115,7 @@ class AuthenticationToken
             $this->authToken = $tokenAuth;
             $this->wasTokenProvidedSecurely = false;
             $this->isSessionToken = $request->getBoolParameter('force_api_session', false);
+            return true;
         }
 
         return false;

--- a/core/Request/AuthenticationToken.php
+++ b/core/Request/AuthenticationToken.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Request;
+
+use Piwik\Request;
+use Piwik\SettingsServer;
+
+/**
+ * Main class to handle actions related to auth tokens.
+ */
+class AuthenticationToken
+{
+    protected $authToken = '';
+    protected $wasTokenProvidedSecurely = false;
+    protected $isSessionToken = false;
+
+    /**
+     * @param array|null $request
+     * @return string
+     */
+    public function getAuthToken(?array $request = null): string
+    {
+        $this->detectToken();
+
+        if ($request !== null) {
+            return (new Request($request))->getStringParameter('token_auth', '');
+        }
+        return $this->authToken;
+    }
+
+    /**
+     * Returns true if a token_auth parameter was supplied via a secure mechanism and is not present as a URL parameter
+     *
+     * @return bool True if token was supplied in a secure way
+     */
+    public function wasTokenAuthProvidedSecurely(): bool
+    {
+        $this->detectToken();
+
+        return $this->wasTokenProvidedSecurely;
+    }
+
+    public function isSessionToken(): bool
+    {
+        $this->detectToken();
+
+        return $this->isSessionToken;
+    }
+
+    private function detectToken(): void
+    {
+        $this->initTokenFromHeader() || $this->initTokenFromJsonRequestBody() || $this->initTokenFromPostRequest() || $this->initTokenFromGetRequest();
+    }
+
+    private function initTokenFromHeader(): bool
+    {
+        if (!empty($_SERVER['HTTP_AUTHORIZATION']) && strpos($_SERVER['HTTP_AUTHORIZATION'], 'Bearer ') === 0) {
+            $this->authToken = substr($_SERVER['HTTP_AUTHORIZATION'], 7);
+            $this->wasTokenProvidedSecurely = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    private function initTokenFromJsonRequestBody(): bool
+    {
+        // Token in JSON request body is only support for tracking requests
+        if (!SettingsServer::isTrackerApiRequest()) {
+            return false;
+        }
+
+        $requestBody = file_get_contents('php://input');
+        if (!empty($requestBody) && strpos($requestBody, '{') === 0) {
+            $jsonContent = json_decode($requestBody, true);
+
+            if (!empty($jsonContent['token_auth'])) {
+                $this->authToken = $jsonContent['token_auth'];
+                $this->wasTokenProvidedSecurely = true;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function initTokenFromPostRequest(): bool
+    {
+        $request = Request::fromPost();
+        $tokenAuth = $request->getStringParameter('token_auth', '');
+
+        if ($tokenAuth !== '') {
+            $this->authToken = $tokenAuth;
+            $this->wasTokenProvidedSecurely = true;
+            $this->isSessionToken = $request->getBoolParameter('force_api_session', false);
+        }
+
+        return false;
+    }
+
+    private function initTokenFromGetRequest(): bool
+    {
+        $request = Request::fromGet();
+        $tokenAuth = $request->getStringParameter('token_auth', '');
+
+        if ($tokenAuth !== '') {
+            $this->authToken = $tokenAuth;
+            $this->wasTokenProvidedSecurely = false;
+            $this->isSessionToken = $request->getBoolParameter('force_api_session', false);
+        }
+
+        return false;
+    }
+}

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -10,6 +10,7 @@
 namespace Piwik\Tracker;
 
 use Exception;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Cookie;
@@ -63,12 +64,12 @@ class Request
 
     /**
      * @param $params
-     * @param bool|string $tokenAuth
+     * @param string $tokenAuth
      */
     public function __construct(
         $params,
         #[\SensitiveParameter]
-        $tokenAuth = false
+        $tokenAuth = ''
     ) {
         if (!is_array($params)) {
             $params = array();
@@ -172,8 +173,12 @@ class Request
                 return;
             }
 
+            if (empty($tokenAuth) && !empty($this->params)) {
+                $tokenAuth = StaticContainer::get(AuthenticationToken::class)->getAuthToken($this->params);
+            }
+
             if (empty($tokenAuth)) {
-                $tokenAuth = Common::getRequestVar('token_auth', false, 'string', $this->params);
+                $tokenAuth = StaticContainer::get(AuthenticationToken::class)->getAuthToken();
             }
 
             $cache = PiwikCache::getTransientCache();

--- a/core/Tracker/RequestSet.php
+++ b/core/Tracker/RequestSet.php
@@ -9,7 +9,8 @@
 
 namespace Piwik\Tracker;
 
-use Piwik\Common;
+use Piwik\Request\AuthenticationToken;
+use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 
 class RequestSet
@@ -81,7 +82,7 @@ class RequestSet
             return $this->tokenAuth;
         }
 
-        return Common::getRequestVar('token_auth', false);
+        return StaticContainer::get(AuthenticationToken::class)->getAuthToken();
     }
 
     private function areRequestsInitialized()

--- a/core/View.php
+++ b/core/View.php
@@ -11,6 +11,7 @@ namespace Piwik;
 
 use Exception;
 use Piwik\AssetManager\UIAssetCacheBuster;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Container\StaticContainer;
 use Piwik\Plugins\CoreAdminHome\Controller;
 use Piwik\Plugins\CorePluginsAdmin\CorePluginsAdmin;
@@ -495,8 +496,8 @@ class View implements ViewInterface
      */
     private function validTokenAuthInUrl()
     {
-        $tokenAuth = Common::getRequestVar('token_auth', '', 'string', $_GET);
-        return ($tokenAuth && $tokenAuth === Piwik::getCurrentUserTokenAuth());
+        $token = StaticContainer::get(AuthenticationToken::class);
+        return (!$token->wasTokenAuthProvidedSecurely() && $token->getAuthToken() === Piwik::getCurrentUserTokenAuth());
     }
 
     /**

--- a/piwik.php
+++ b/piwik.php
@@ -29,6 +29,7 @@ if (!defined('PIWIK_INCLUDE_PATH')) {
 
 require_once PIWIK_INCLUDE_PATH . '/core/bootstrap.php';
 
+require_once PIWIK_INCLUDE_PATH . '/core/Request/AuthenticationToken.php';
 require_once PIWIK_INCLUDE_PATH . '/core/Plugin/Controller.php';
 require_once PIWIK_INCLUDE_PATH . '/core/Exception/NotYetInstalledException.php';
 require_once PIWIK_INCLUDE_PATH . '/core/Plugin/ControllerAdmin.php';

--- a/plugins/API/Controller.php
+++ b/plugins/API/Controller.php
@@ -12,8 +12,10 @@ namespace Piwik\Plugins\API;
 use Piwik\API\DocumentationGenerator;
 use Piwik\API\Proxy;
 use Piwik\API\Request;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 use Piwik\Plugins\API\Renderer\Original;
 use Piwik\Url;
@@ -27,7 +29,7 @@ class Controller extends \Piwik\Plugin\Controller
 {
     public function index()
     {
-        $tokenAuth = Common::getRequestVar('token_auth', 'anonymous', 'string');
+        $tokenAuth = StaticContainer::get(AuthenticationToken::class)->getAuthToken() ?: 'anonymous';
         $format = Common::getRequestVar('format', false);
         $serialize = Common::getRequestVar('serialize', false);
 

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\Login;
 
 use Exception;
 use Piwik\API\Request;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
@@ -139,7 +140,7 @@ class Login extends \Piwik\Plugin
         // Only throw an exception if this is an API request
         if ($this->isModuleIsAPI()) {
             // Throw an exception if a token was provided but it was invalid
-            if (Request::isTokenAuthProvidedSecurely()) {
+            if (StaticContainer::get(AuthenticationToken::class)->wasTokenAuthProvidedSecurely()) {
                 throw new NoAccessException('Unable to authenticate with the provided token. It is either invalid or expired.');
             } else {
                 throw new NoAccessException('Unable to authenticate with the provided token. It is either invalid, expired or is required to be sent as a POST parameter.');

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1472,15 +1472,17 @@ class API extends \Piwik\Plugin\API
      * @param string $expireHours Optionally number of hours for how long the token should be valid before it expires.
      *                            If expireDate is set and expireHours, then expireDate will be used.
      *                            If expireDate is set and expireHours, then expireDate will be used.
+     * @param bool $secureOnly Defines if the token can be used securely only (if true, token can't be provided as param in GET requests)
      * @return string
      */
     public function createAppSpecificTokenAuth(
-        $userLogin,
+        string $userLogin,
         #[\SensitiveParameter]
-        $passwordConfirmation,
-        $description,
+        string $passwordConfirmation,
+        string $description,
         $expireDate = null,
-        $expireHours = 0
+        $expireHours = 0,
+        bool $secureOnly = false
     ) {
         $user = $this->model->getUser($userLogin);
         if (empty($user) && Piwik::isValidEmailString($userLogin)) {
@@ -1509,7 +1511,7 @@ class API extends \Piwik\Plugin\API
         }
 
         $generatedToken = $this->model->generateRandomTokenAuth();
-        $this->model->addTokenAuth($userLogin, $generatedToken, $description, Date::now()->getDatetime(), $expireDate);
+        $this->model->addTokenAuth($userLogin, $generatedToken, $description, Date::now()->getDatetime(), $expireDate, false, $secureOnly);
 
         return $generatedToken;
     }

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -10,8 +10,10 @@
 namespace Piwik\Plugins\UsersManager;
 
 use Piwik\Auth\Password;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Common;
 use Piwik\Config\GeneralConfig;
+use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Db;
 use Piwik\Option;
@@ -610,7 +612,9 @@ class Model
             return (is_array($row) ? $row : null);
         }
 
-        $token = $this->getTokenByTokenAuthIfNotExpired($tokenAuth, \Piwik\API\Request::isTokenAuthProvidedSecurely());
+        $isTokenProvidedSecurely = StaticContainer::get(AuthenticationToken::class)->wasTokenAuthProvidedSecurely();
+
+        $token = $this->getTokenByTokenAuthIfNotExpired($tokenAuth, $isTokenProvidedSecurely);
         if (!empty($token)) {
             $db = $this->getDb();
             $row = $db->fetchRow("SELECT * FROM " . $this->userTable . " WHERE `login` = ?", $token['login']);

--- a/plugins/Widgetize/Controller.php
+++ b/plugins/Widgetize/Controller.php
@@ -10,7 +10,9 @@
 namespace Piwik\Plugins\Widgetize;
 
 use Piwik\API\Request;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Common;
+use Piwik\Container\StaticContainer;
 use Piwik\FrontController;
 use Piwik\Piwik;
 use Piwik\Url;
@@ -31,8 +33,7 @@ class Controller extends \Piwik\Plugin\Controller
     public function iframe()
     {
         // also called by FrontController, we call it explicitly as a safety measure in case something changes in the future
-        $token_auth = Common::getRequestVar('token_auth', '', 'string');
-        if (!empty($token_auth)) {
+        if (StaticContainer::get(AuthenticationToken::class)->getAuthToken()) {
             Request::checkTokenAuthIsNotLimited('Widgetize', 'iframe');
         }
 

--- a/tests/PHPUnit/Integration/AccessTest.php
+++ b/tests/PHPUnit/Integration/AccessTest.php
@@ -17,6 +17,7 @@ use Piwik\Piwik;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Version;
 
 class TestCustomCap extends Access\Capability
 {
@@ -648,6 +649,26 @@ class AccessTest extends IntegrationTestCase
         curl_close($ch);
 
         $this->assertEquals(401, $responseInfo["http_code"]);
+    }
+
+    public function testAPIWithAuthorizationHeader()
+    {
+        Fixture::createSuperUser();
+
+        $url = Fixture::getTestRootUrl() . '?' . http_build_query([
+                'module' => 'API',
+                'method' => 'API.getMatomoVersion',
+            ]);
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Bearer ' . Fixture::getTokenAuth()]);
+        $response = curl_exec($ch);
+        $responseInfo = curl_getinfo($ch);
+        curl_close($ch);
+
+        $this->assertEquals(200, $responseInfo["http_code"]);
+        self::assertStringContainsString('<result>' . Version::VERSION . '</result>', $response);
     }
 
     private function switchUser($user)

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Tests\System;
 
+use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Db;
 use Piwik\Log\Logger;
@@ -61,17 +62,34 @@ class TrackerTest extends IntegrationTestCase
      *
      * With invalid token_auth the request would still work
      */
+
     public function testTrackingApiWithBulkRequestsViaCurlWithWrongTokenAuth()
     {
         $token_auth = '33dc3f2536d3025974cccb4b4d2d98f4';
-        $this->issueBulkTrackingRequest($token_auth, $expectTrackingToSucceed = true);
+        // one tracking request is supposed to be invalid, as the token doesn't allow tracking custom ip
+        $this->issueBulkTrackingRequest($token_auth, true, 1, 1);
     }
 
     public function testTrackingApiWithBulkRequestsViaCurlWithCorrectTokenAuth()
     {
         $token_auth = Fixture::getTokenAuth();
         \Piwik\Filesystem::deleteAllCacheOnUpdate();
-        $this->issueBulkTrackingRequest($token_auth, $expectTrackingToSucceed = true);
+        // both requests shoulde btracked, as the token doesn't allow tracking custom ip
+        $this->issueBulkTrackingRequest($token_auth, true, 2, 0);
+    }
+
+    public function testTrackingApiWithBulkRequestsViaCurlWithSecureTokenAuth()
+    {
+        \Piwik\Filesystem::deleteAllCacheOnUpdate();
+
+        $token = Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
+            'userLogin'            => Fixture::ADMIN_USER_LOGIN,
+            'passwordConfirmation' => Fixture::ADMIN_USER_PASSWORD,
+            'description'          => 'secure one',
+            'secureOnly'           => true,
+        ]);
+
+        $this->issueBulkTrackingRequest($token, true, 2, 0);
     }
 
     public function testTrackingEcommerceOrderWithHtmlEscapedTextInsertsCorrectLogs()
@@ -263,26 +281,32 @@ class TrackerTest extends IntegrationTestCase
         }
     }
 
-    protected function issueBulkTrackingRequest($token_auth, $expectTrackingToSucceed)
+    protected function issueBulkTrackingRequest($token_auth, $expectTrackingToSucceed, $tracked, $invalid)
     {
         $piwikHost = Fixture::getRootUrl() . 'tests/PHPUnit/proxy/matomo.php';
 
-        $command = 'curl -s -X POST -d \'{"requests":["?idsite=1&url=http://example.org&action_name=Test bulk log Pageview&rec=1","?idsite=1&url=http://example.net/test.htm&action_name=Another bulk page view&rec=1"],"token_auth":"' . $token_auth . '"}\' ' . $piwikHost;
+        // Note: The first request requires a valid super user token, because of the custom ip
+        $command = 'curl -s -X POST -d \'{"requests":["?idsite=1&url=http://example.org&action_name=Test bulk log Pageview&cip=1.1.1.1&rec=1","?idsite=1&url=http://example.net/test.htm&action_name=Another bulk page view&rec=1"],"token_auth":"' . $token_auth . '"}\' ' . $piwikHost;
 
         exec($command, $output, $result);
         if ($result !== 0) {
             throw new \Exception("tracking bulk failed: " . implode("\n", $output) . "\n\ncommand used: $command");
         }
+
         $output = implode("", $output);
+
         $this->assertStringStartsWith('{"status":', $output);
 
+        $response = json_decode($output, true);
+
         if ($expectTrackingToSucceed) {
-            self::assertStringNotContainsString('error', $output);
-            self::assertStringContainsString('success', $output);
+            self::assertEquals('success', $response['status']);
         } else {
-            self::assertStringContainsString('error', $output);
-            self::assertStringNotContainsString('success', $output);
+            self::assertEquals('error', $response['status']);
         }
+
+        self::assertEquals($tracked, $response['tracked']);
+        self::assertEquals($invalid, $response['invalid']);
     }
 
     private function sendTrackingRequestByCurl($url)

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -74,7 +74,7 @@ class TrackerTest extends IntegrationTestCase
     {
         $token_auth = Fixture::getTokenAuth();
         \Piwik\Filesystem::deleteAllCacheOnUpdate();
-        // both requests shoulde btracked, as the token doesn't allow tracking custom ip
+        // both requests should be tracked, as the token doesn't allow tracking custom ip
         $this->issueBulkTrackingRequest($token_auth, true, 2, 0);
     }
 

--- a/tests/PHPUnit/Unit/DeprecatedMethodsTest.php
+++ b/tests/PHPUnit/Unit/DeprecatedMethodsTest.php
@@ -93,6 +93,7 @@ class DeprecatedMethodsTest extends \PHPUnit\Framework\TestCase
         $this->assertDeprecatedMethodIsRemovedInMatomo6('Piwik\Db', 'optimizeTables');
         $this->assertDeprecatedMethodIsRemovedInMatomo6('Piwik\Db\TransactionLevel', 'setUncommitted');
         $this->assertDeprecatedMethodIsRemovedInMatomo6('Piwik\Plugins\SitesManager\API', 'setGlobalExcludedQueryParameters');
+        $this->assertDeprecatedMethodIsRemovedInMatomo6('Piwik\API\Request', 'isTokenAuthProvidedSecurely');
     }
 
 

--- a/tests/PHPUnit/Unit/Request/AuthenticationToken.php
+++ b/tests/PHPUnit/Unit/Request/AuthenticationToken.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Request;
+
+class AuthenticationToken extends \PHPUnit\Framework\TestCase
+{
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $_GET = $_POST = [];
+        unset($_SERVER['HTTP_AUTHORIZATION']);
+    }
+
+    /**
+     * @dataProvider provideGetAuthenticationTokenData
+     */
+    public function testGetAuthenticationToken($getParams, $postParams, $authorizationHeader, $requestParams, $expectedToken, $isSecure, $isSessionToken)
+    {
+        $_GET = $getParams;
+        $_POST = $postParams;
+        $_SERVER['HTTP_AUTHORIZATION'] = $authorizationHeader;
+
+        $token = new \Piwik\Request\AuthenticationToken();
+        self::assertEquals($expectedToken, $token->getAuthToken($requestParams));
+        self::assertEquals($isSecure, $token->wasTokenAuthProvidedSecurely());
+        self::assertEquals($isSessionToken, $token->isSessionToken());
+    }
+
+    public function provideGetAuthenticationTokenData(): iterable
+    {
+        yield 'token in GET request only' => [
+            ['token_auth' => 'randomGetAccessToken'],
+            [],
+            null,
+            null,
+            'randomGetAccessToken',
+            false, // insecure
+            false, // no session token
+        ];
+
+        yield 'session token in GET request only' => [
+            ['token_auth' => 'randomGetAccessToken', 'force_api_session' => 1],
+            [],
+            null,
+            null,
+            'randomGetAccessToken',
+            false, // insecure
+            true, // session token
+        ];
+
+        yield 'token in POST request only' => [
+            [],
+            ['token_auth' => 'randomPostAccessToken'],
+            null,
+            null,
+            'randomPostAccessToken',
+            true, // secure
+            false, // no session token
+        ];
+
+        yield 'session token in POST request only' => [
+            [],
+            ['token_auth' => 'randomPostAccessToken', 'force_api_session' => 1],
+            null,
+            null,
+            'randomPostAccessToken',
+            true, // secure
+            true, // session token
+        ];
+
+        yield 'token in auth header only' => [
+            [],
+            [],
+            'Bearer randomHeaderAccessToken',
+            null,
+            'randomHeaderAccessToken',
+            true, // secure
+            false, // no session token
+        ];
+
+        yield 'token in POST request overwrites GET token' => [
+            ['token_auth' => 'randomGetAccessToken'],
+            ['token_auth' => 'randomPostAccessToken'],
+            null,
+            null,
+            'randomPostAccessToken',
+            true, // secure
+            false, // no session token
+        ];
+
+        yield 'token in POST request overwrites GET session token' => [
+            ['token_auth' => 'randomGetAccessToken', 'force_api_session' => 1],
+            ['token_auth' => 'randomPostAccessToken'],
+            null,
+            null,
+            'randomPostAccessToken',
+            true, // secure
+            false, // no session token
+        ];
+
+        yield 'token in header overwrites GET token' => [
+            ['token_auth' => 'randomGetAccessToken'],
+            [],
+            'Bearer randomHeaderAccessToken',
+            null,
+            'randomHeaderAccessToken',
+            true, // secure
+            false, // no session token
+        ];
+
+        yield 'token in header overwrites GET session token' => [
+            ['token_auth' => 'randomGetAccessToken', 'force_api_session' => 1],
+            [],
+            'Bearer randomHeaderAccessToken',
+            null,
+            'randomHeaderAccessToken',
+            true, // secure
+            false, // no session token
+        ];
+
+        yield 'token in header overwrites POST token' => [
+            [],
+            ['token_auth' => 'randomPostAccessToken'],
+            'Bearer randomHeaderAccessToken',
+            null,
+            'randomHeaderAccessToken',
+            true, // secure
+            false, // no session token
+        ];
+
+        yield 'token in header overwrites POST session token' => [
+            [],
+            ['token_auth' => 'randomPostAccessToken', 'force_api_session' => 1],
+            'Bearer randomHeaderAccessToken',
+            null,
+            'randomHeaderAccessToken',
+            true, // secure
+            false, // no session token
+        ];
+
+        yield 'token in header overwrites GET and POST token' => [
+            ['token_auth' => 'randomGetAccessToken'],
+            ['token_auth' => 'randomPostAccessToken'],
+            'Bearer randomHeaderAccessToken',
+            null,
+            'randomHeaderAccessToken',
+            true, // secure
+            false, // no session token
+        ];
+
+        yield 'token in header overwrites GET session and POST token' => [
+            ['token_auth' => 'randomGetAccessToken', 'force_api_session' => 1],
+            ['token_auth' => 'randomPostAccessToken'],
+            'Bearer randomHeaderAccessToken',
+            null,
+            'randomHeaderAccessToken',
+            true, // secure
+            false, // no session token
+        ];
+
+        yield 'token in header overwrites GET and POST session token' => [
+            ['token_auth' => 'randomGetAccessToken'],
+            ['token_auth' => 'randomPostAccessToken', 'force_api_session' => 1],
+            'Bearer randomHeaderAccessToken',
+            null,
+            'randomHeaderAccessToken',
+            true, // secure
+            false, // no session token
+        ];
+
+        yield 'token in header overwrites GET session and POST session token' => [
+            ['token_auth' => 'randomGetAccessToken', 'force_api_session' => 1],
+            ['token_auth' => 'randomPostAccessToken', 'force_api_session' => 1],
+            'Bearer randomHeaderAccessToken',
+            null,
+            'randomHeaderAccessToken',
+            true, // secure
+            false, // no session token
+        ];
+
+
+        yield 'incorrectly provided token in header will be discarded' => [
+            [],
+            [],
+            'realm=randomHeaderAccessToken',
+            null,
+            '',
+            false, // secure
+            false, // no session token
+        ];
+    }
+}

--- a/tests/PHPUnit/Unit/Tracker/RequestSetTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestSetTest.php
@@ -174,9 +174,9 @@ class RequestSetTest extends UnitTestCase
         $this->assertFalse($this->requestSet->hasRequests());
     }
 
-    public function testGetTokenAuthShouldReturnFalseIfNoTokenIsSetAndNoRequestParam()
+    public function testGetTokenAuthShouldReturnEmptyStringIfNoTokenIsSetAndNoRequestParam()
     {
-        $this->assertFalse($this->requestSet->getTokenAuth());
+        $this->assertEquals('', $this->requestSet->getTokenAuth());
     }
 
     public function testGetTokenAuthSetTokenAuthShouldOverwriteTheToken()
@@ -192,7 +192,7 @@ class RequestSetTest extends UnitTestCase
         $this->assertNotEmpty($this->requestSet->getTokenAuth());
 
         $this->requestSet->setTokenAuth(null);
-        $this->assertFalse($this->requestSet->getTokenAuth()); // does now fallback to get param
+        $this->assertEquals('', $this->requestSet->getTokenAuth()); // does now fallback to get param
     }
 
     public function testGetTokenAuthShouldFallbackToRequestParamIfNoTokenSet()

--- a/tests/PHPUnit/Unit/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestTest.php
@@ -124,7 +124,7 @@ class RequestTest extends UnitTestCase
     public function testGetTokenAuthShouldReturnDefaultValueIfNoneSet()
     {
         $request = $this->buildRequest(array('idsite' => 1));
-        $this->assertFalse($request->getTokenAuth());
+        $this->assertEquals('', $request->getTokenAuth());
     }
 
     public function testGetTokenAuthShouldReturnSetTokenAuth()

--- a/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1f57d4d25dca70ac092c4fadec5169fcdaf60362d48fce4dabe332e4102da1c2
-size 4860494
+oid sha256:cda81ad24c3b9762e02391cc80e4b43da8cf96e9694ed24acf5bf462a1b39ed8
+size 4864597


### PR DESCRIPTION
### Description:

Currently the auth token is used in various places to authenticate the user. This PR centralizes that handling to it's easier in the future to make certain adjustments.

In addition that PR fixes the authentication problem in bulk tracking requests, when a secure only token is provided in the request body.

Also it adds support to provide the token as `Authorization: Bearer`-Header.

fixes #21905, fixes #20677

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
