### PR TITLE
Fix creation of MySQL optimizer hint comments for multiple hints

### DIFF
--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -653,18 +653,10 @@ class Mysql implements SchemaInterface
             return $sql;
         }
 
-        $sql = trim($sql);
-        $pos = stripos($sql, 'SELECT');
-        $isMaxExecutionTimeoutAlreadyPresent = (stripos($sql, 'MAX_EXECUTION_TIME(') !== false);
-        if ($pos !== false && !$isMaxExecutionTimeoutAlreadyPresent) {
-            $timeInMs = $limit * 1000;
-            $timeInMs = (int) $timeInMs;
-            $maxExecutionTimeHint = ' /*+ MAX_EXECUTION_TIME(' . $timeInMs . ') */ ';
+        $timeInMs = $limit * 1000;
+        $timeInMs = (int) $timeInMs;
 
-            $sql = substr_replace($sql, 'SELECT ' . $maxExecutionTimeHint, $pos, strlen('SELECT'));
-        }
-
-        return $sql;
+        return DbHelper::addOptimizerHintToQuery($sql, 'MAX_EXECUTION_TIME(' . $timeInMs . ')');
     }
 
     public function supportsComplexColumnUpdates(): bool

--- a/core/DbHelper.php
+++ b/core/DbHelper.php
@@ -367,15 +367,58 @@ class DbHelper
      */
     public static function addJoinPrefixHintToQuery(string $sql, string $prefix): string
     {
-        if (strpos(trim($sql), '/*+ JOIN_PREFIX(') === false) {
-            $select = 'SELECT';
-            if (0 === strpos(trim($sql), $select)) {
-                $sql = trim($sql);
-                $sql = 'SELECT /*+ JOIN_PREFIX(' . $prefix . ') */' . substr($sql, strlen($select));
-            }
+        return self::addOptimizerHintToQuery($sql, 'JOIN_PREFIX(' . $prefix . ')');
+    }
+
+    /**
+     * Add an optimizer hint to the query.
+     *
+     * Creating and using a "add_x_HintToQuery" functions is preferred
+     * over using this function directly, as some optimizer hints depend
+     * on the database used.
+     *
+     * If an optimizer hint is already present (check is done by name only)
+     * in the query the new value will be silently discarded.
+     *
+     * @param string $sql   SQL query string
+     * @param string $hint  Hint to add
+     *
+     * @return string       Modified query string with hint added
+     */
+    public static function addOptimizerHintToQuery(string $sql, string $hint): string
+    {
+        $sql = trim($sql);
+
+        // only apply hints to SELECT queries
+        if (0 !== stripos($sql, 'SELECT')) {
+            return $sql;
         }
 
-        return $sql;
+        $reCommentStart = preg_quote('/*+', '/');
+        $reCommentEnd = preg_quote('*/', '/');
+        preg_match('/^SELECT\s+(' . $reCommentStart . '\s*(.*?)\s*' . $reCommentEnd . ')/im', $sql, $matches);
+
+        if (empty($matches)) {
+            return 'SELECT /*+ ' . $hint . ' */' . substr($sql, strlen('SELECT'));
+        }
+
+        $originalComment = $matches[1];
+        $hints = $matches[2];
+
+        $newHintNameEnd = stripos($hint, '(') ?: strlen($hint);
+        $newHintName = substr($hint, 0, $newHintNameEnd);
+
+        // only add new hints
+        if (!preg_match('/(?:^| )' . preg_quote($newHintName) . '(?:\\(|$)/', $hints)) {
+            $hints = trim($hint . ' ' . $hints);
+        }
+
+        return substr_replace(
+            $sql,
+            '/*+ ' . $hints . ' */',
+            strpos($sql, $originalComment),
+            strlen($originalComment)
+        );
     }
 
     /**

--- a/core/DbHelper.php
+++ b/core/DbHelper.php
@@ -394,9 +394,15 @@ class DbHelper
             return $sql;
         }
 
-        $reCommentStart = preg_quote('/*+', '/');
-        $reCommentEnd = preg_quote('*/', '/');
-        preg_match('/^SELECT\s+(' . $reCommentStart . '\s*(.*?)\s*' . $reCommentEnd . ')/is', $sql, $matches);
+        $pattern =
+            '@^SELECT\s+' .
+            // ignore non-hint comments ("/* ... */")
+            '(?:|/\*[^+]*?\*/\s*)' .
+            // capture hint comments ("/*+ ... */")
+            '(/\*\+\s*(.*?)\s*\*/)' .
+            '@is';
+
+        preg_match($pattern, $sql, $matches);
 
         if (empty($matches)) {
             return 'SELECT /*+ ' . $hint . ' */' . substr($sql, strlen('SELECT'));

--- a/core/DbHelper.php
+++ b/core/DbHelper.php
@@ -396,7 +396,7 @@ class DbHelper
 
         $reCommentStart = preg_quote('/*+', '/');
         $reCommentEnd = preg_quote('*/', '/');
-        preg_match('/^SELECT\s+(' . $reCommentStart . '\s*(.*?)\s*' . $reCommentEnd . ')/im', $sql, $matches);
+        preg_match('/^SELECT\s+(' . $reCommentStart . '\s*(.*?)\s*' . $reCommentEnd . ')/is', $sql, $matches);
 
         if (empty($matches)) {
             return 'SELECT /*+ ' . $hint . ' */' . substr($sql, strlen('SELECT'));
@@ -409,9 +409,11 @@ class DbHelper
         $newHintName = substr($hint, 0, $newHintNameEnd);
 
         // only add new hints
-        if (!preg_match('/(?:^| )' . preg_quote($newHintName) . '(?:\\(|$)/', $hints)) {
-            $hints = trim($hint . ' ' . $hints);
+        if (preg_match('/(?:^|\s)' . preg_quote($newHintName) . '(?:\\(|\s|$)/i', $hints)) {
+            return $sql;
         }
+
+        $hints = trim($hint . ' ' . $hints);
 
         return substr_replace(
             $sql,

--- a/plugins/Live/tests/Integration/ModelTest.php
+++ b/plugins/Live/tests/Integration/ModelTest.php
@@ -369,7 +369,7 @@ class ModelTest extends IntegrationTestCase
             $minTimestamp = false,
             $filterSortOrder = false
         );
-        $expectedSql = 'SELECT  /*+ MAX_EXECUTION_TIME(30000) */ 
+        $expectedSql = 'SELECT /*+ MAX_EXECUTION_TIME(30000) */
 				log_visit.*';
 
         $this->setMaxExecutionTime(-1);

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -579,7 +579,7 @@ class LogAggregatorTest extends IntegrationTestCase
         );
 
         $expected = [
-            'sql' => "SELECT  /*+ MAX_EXECUTION_TIME(5000) */  /*+ JOIN_PREFIX(log_visit) */ /* sites 1 */ /* 2010-03-01,2010-03-31 */ /* MyPluginName */
+            'sql' => "SELECT /*+ MAX_EXECUTION_TIME(5000) JOIN_PREFIX(log_visit) */ /* sites 1 */ /* 2010-03-01,2010-03-31 */ /* MyPluginName */
 				CASE WHEN HOUR(log_visit.visit_first_action_time) <= 11 THEN 'l'ELSE 'r'END AS label, 
 			count(distinct log_visit.idvisitor) AS `1`, 
 			count(*) AS `2`, 

--- a/tests/PHPUnit/Unit/DbHelperTest.php
+++ b/tests/PHPUnit/Unit/DbHelperTest.php
@@ -62,9 +62,9 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider getTestQueries
+     * @dataProvider getMaxExecutionTimeTestData
      */
-    public function testAddMaxExecutionTimeHintToQuery($expected, $query, $timeLimit, $schema)
+    public function testAddMaxExecutionTimeHintToQuery($expected, $query, $timeLimit, $schema): void
     {
         Schema::unsetInstance();
         Config::getInstance()->database['schema'] = $schema;
@@ -72,12 +72,12 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function getTestQueries()
+    public function getMaxExecutionTimeTestData(): iterable
     {
         return [
             // MySql Schema
-            ['SELECT  /*+ MAX_EXECUTION_TIME(1500) */  * FROM table', 'SELECT * FROM table', 1.5, 'Mysql'],
-            ['SELECT  /*+ MAX_EXECUTION_TIME(20000) */  column FROM (SELECT * FROM table)', 'SELECT column FROM (SELECT * FROM table)', 20, 'Mysql'],
+            ['SELECT /*+ MAX_EXECUTION_TIME(1500) */ * FROM table', 'SELECT * FROM table', 1.5, 'Mysql'],
+            ['SELECT /*+ MAX_EXECUTION_TIME(20000) */ column FROM (SELECT * FROM table)', 'SELECT column FROM (SELECT * FROM table)', 20, 'Mysql'],
             ['SELECT * FROM table', 'SELECT * FROM table', 0, 'Mysql'],
             ['SELECT /*+ MAX_EXECUTION_TIME(1000) */ * FROM table', 'SELECT /*+ MAX_EXECUTION_TIME(1000) */ * FROM table', 3.5, 'Mysql'], // should not append/change MAX_EXECUTION_TIME hint if already present
             ['UPDATE table SET column = value', 'UPDATE table SET column = value', 150, 'Mysql'],
@@ -87,6 +87,106 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
             ['SELECT * FROM table', 'SELECT * FROM table', 0, 'Mariadb'],
             ['SET STATEMENT max_statement_time=2 FOR SELECT * FROM table', 'SET STATEMENT max_statement_time=2 FOR SELECT * FROM table', 3.5, 'Mariadb'], // should not append/change max_statement_time hint if already present
             ['UPDATE table SET column = value', 'UPDATE table SET column = value', 150, 'Mariadb'],
+        ];
+    }
+
+    /**
+     * @dataProvider getAddOptimizerHintTestData
+     */
+    public function testAddOptimizerHint($expected, $query, $hint): void
+    {
+        $result = DbHelper::addOptimizerHintToQuery($query, $hint);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function getAddOptimizerHintTestData(): iterable
+    {
+        yield 'no previous hints' => [
+            'SELECT /*+ HINT_ONE(1) */ * FROM table',
+            'SELECT * FROM table',
+            'HINT_ONE(1)',
+        ];
+
+        yield 'different previous hint' => [
+            'SELECT /*+ HINT_TWO(2) HINT_ONE(1) */ * FROM table',
+            'SELECT /*+ HINT_ONE(1) */ * FROM table',
+            'HINT_TWO(2)',
+        ];
+
+        yield 'multiline query with previous hint' => [
+            'SELECT
+                    /*+ HINT_TWO(2) HINT_ONE(1) */
+                    * FROM table',
+            'SELECT
+                    /*+ HINT_ONE(1) */
+                    * FROM table',
+            'HINT_TWO(2)',
+        ];
+
+        yield 'different previous hint (same start)' => [
+            'SELECT /*+ HINT_ONE_OTHER(2) HINT_ONE(1) */ * FROM table',
+            'SELECT /*+ HINT_ONE(1) */ * FROM table',
+            'HINT_ONE_OTHER(2)',
+        ];
+
+        yield 'different previous hint (same end)' => [
+            'SELECT /*+ OTHER_HINT_ONE(2) HINT_ONE(1) */ * FROM table',
+            'SELECT /*+ HINT_ONE(1) */ * FROM table',
+            'OTHER_HINT_ONE(2)',
+        ];
+
+        yield 'duplicate hint' => [
+            'SELECT /*+ HINT_ONE(1) */ * FROM table',
+            'SELECT /*+ HINT_ONE(1) */ * FROM table',
+            'HINT_ONE("different value")',
+        ];
+
+        yield 'duplicate hint without parenthesis' => [
+            'SELECT /*+ STRAIGHT_JOIN */ * FROM table',
+            'SELECT /*+ STRAIGHT_JOIN */ * FROM table',
+            'STRAIGHT_JOIN',
+        ];
+
+        yield 'empty hint comment' => [
+            'SELECT /*+ HINT_ONE(1) */ * FROM table',
+            'SELECT /*+*/ * FROM table',
+            'HINT_ONE(1)',
+        ];
+
+        yield 'regular SQL comment' => [
+            'SELECT /*+ HINT_ONE(1) */ /* comment */ * FROM table',
+            'SELECT /* comment */ * FROM table',
+            'HINT_ONE(1)',
+        ];
+
+        yield 'hint without parenthesis' => [
+            'SELECT /*+ STRAIGHT_JOIN HINT_ONE(1) */ * FROM table',
+            'SELECT /*+ HINT_ONE(1) */ * FROM table',
+            'STRAIGHT_JOIN'
+        ];
+
+        yield 'not a SELECT query' => [
+            'UPDATE table SET value = 1',
+            'UPDATE table SET value = 1',
+            'HINT_ONE(1)',
+        ];
+
+        yield 'only applies to queries starting with a SELECT' => [
+            'DELETE FROM table WHERE value in (SELECT value FROM table)',
+            'DELETE FROM table WHERE value in (SELECT value FROM table)',
+            'HINT_ONE(1)',
+        ];
+
+        yield 'hints on multiple levels' => [
+            'SELECT /*+ MAX_EXECUTION_TIME(100) */ * FROM (SELECT /*+ HINT_ONE(1) */ value FROM table)',
+            'SELECT * FROM (SELECT /*+ HINT_ONE(1) */ value FROM table)',
+            'MAX_EXECUTION_TIME(100)',
+        ];
+
+        yield 'repeated hint' => [
+            'SELECT /*+ MAX_EXECUTION_TIME(100) HINT_ONE(1) */ * FROM (SELECT /*+ HINT_ONE(1) */ value FROM table)',
+            'SELECT /*+ HINT_ONE(1) */ * FROM (SELECT /*+ HINT_ONE(1) */ value FROM table)',
+            'MAX_EXECUTION_TIME(100)',
         ];
     }
 }

--- a/tests/PHPUnit/Unit/DbHelperTest.php
+++ b/tests/PHPUnit/Unit/DbHelperTest.php
@@ -113,11 +113,39 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
             'HINT_TWO(2)',
         ];
 
+        yield 'comment before previous hint' => [
+            'SELECT /* comment */ /*+ HINT_TWO(2) HINT_ONE(1) */ * FROM table',
+            'SELECT /* comment */ /*+ HINT_ONE(1) */ * FROM table',
+            'HINT_TWO(2)',
+        ];
+
+        yield 'comments around previous hint' => [
+            'SELECT /* comment */ /*+ HINT_TWO(2) HINT_ONE(1) */ /* comment */ * FROM table',
+            'SELECT /* comment */ /*+ HINT_ONE(1) */ /* comment */ * FROM table',
+            'HINT_TWO(2)',
+        ];
+
         yield 'multiline query with previous hint' => [
             'SELECT
                     /*+ HINT_TWO(2) HINT_ONE(1) */
                     * FROM table',
             'SELECT
+                    /*+ HINT_ONE(1) */
+                    * FROM table',
+            'HINT_TWO(2)',
+        ];
+
+        yield 'multiline comment with previous hint' => [
+            'SELECT
+                    /*
+                      comment
+                    */
+                    /*+ HINT_TWO(2) HINT_ONE(1) */
+                    * FROM table',
+            'SELECT
+                    /*
+                      comment
+                    */
                     /*+ HINT_ONE(1) */
                     * FROM table',
             'HINT_TWO(2)',
@@ -220,6 +248,12 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
         yield 'repeated hint' => [
             'SELECT /*+ MAX_EXECUTION_TIME(100) HINT_ONE(1) */ * FROM (SELECT /*+ HINT_ONE(1) */ value FROM table)',
             'SELECT /*+ HINT_ONE(1) */ * FROM (SELECT /*+ HINT_ONE(1) */ value FROM table)',
+            'MAX_EXECUTION_TIME(100)',
+        ];
+
+        yield 'hints on multiple levels with comments' => [
+            'SELECT /*+ MAX_EXECUTION_TIME(100) */ /* comment */ * FROM (SELECT /*+ HINT_ONE(1) */ /* comment */ value FROM table)',
+            'SELECT /* comment */ * FROM (SELECT /*+ HINT_ONE(1) */ /* comment */ value FROM table)',
             'MAX_EXECUTION_TIME(100)',
         ];
     }

--- a/tests/PHPUnit/Unit/DbHelperTest.php
+++ b/tests/PHPUnit/Unit/DbHelperTest.php
@@ -123,6 +123,18 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
             'HINT_TWO(2)',
         ];
 
+        yield 'multiline hint with previous hint' => [
+            'SELECT
+                    /*+ HINT_TWO(2) HINT_ONE(1) */
+                    * FROM table',
+            'SELECT
+                    /*+
+                      HINT_ONE(1)
+                    */
+                    * FROM table',
+            'HINT_TWO(2)',
+        ];
+
         yield 'different previous hint (same start)' => [
             'SELECT /*+ HINT_ONE_OTHER(2) HINT_ONE(1) */ * FROM table',
             'SELECT /*+ HINT_ONE(1) */ * FROM table',
@@ -141,9 +153,31 @@ class DbHelperTest extends \PHPUnit\Framework\TestCase
             'HINT_ONE("different value")',
         ];
 
+        yield 'multiline hint with duplicate hint' => [
+            'SELECT /*+
+                      HINT_ONE(1)
+                      HINT_TWO(2)
+                    */ * FROM table',
+            'SELECT /*+
+                      HINT_ONE(1)
+                      HINT_TWO(2)
+                    */ * FROM table',
+            'HINT_ONE("different value")',
+        ];
+
         yield 'duplicate hint without parenthesis' => [
             'SELECT /*+ STRAIGHT_JOIN */ * FROM table',
             'SELECT /*+ STRAIGHT_JOIN */ * FROM table',
+            'STRAIGHT_JOIN',
+        ];
+
+        yield 'multiline hint without parenthesis and extra whitespace' => [
+            'SELECT /*+
+                      STRAIGHT_JOIN    HINT_ONE(1)
+                    */ * FROM table',
+            'SELECT /*+
+                      STRAIGHT_JOIN    HINT_ONE(1)
+                    */ * FROM table',
             'STRAIGHT_JOIN',
         ];
 


### PR DESCRIPTION
### Description:

Matomo can add MySQL optimizer hints to SQL queries by using [DbHelper::addMaxExecutionTimeHintToQuery](https://github.com/matomo-org/matomo/blob/64e6ea2ea98fb5af4002fd0a02b2a87ed5be9b33/core/DbHelper.php#L309) and [DbHelper::addJoinPrefixHintToQuery](https://github.com/matomo-org/matomo/blob/64e6ea2ea98fb5af4002fd0a02b2a87ed5be9b33/core/DbHelper.php#L368).

Individually they both work fine, but using both is not working as expected. Only the last applied (first occurring) hint will be applied by MySQL: [Optimizer Hints](https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html#optimizer-hints-syntax) 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
