### PR TITLE
Remove ng-non-bindable unused attribute

### DIFF
--- a/plugins/Login/templates/confirmPassword.twig
+++ b/plugins/Login/templates/confirmPassword.twig
@@ -18,7 +18,7 @@
                 {% endif %}
             </div>
 
-            <form action="{{ linkTo({'module': loginPlugin, 'action': 'confirmPassword'}) }}" ng-non-bindable method="post">
+            <form action="{{ linkTo({'module': loginPlugin, 'action': 'confirmPassword'}) }}" method="post">
                 <div class="row">
                     <div class="col s12 input-field">
                         <input type="hidden" name="nonce" id="login_form_nonce" value="{{ nonce }}"/>

--- a/plugins/Login/templates/confirmResetPassword.twig
+++ b/plugins/Login/templates/confirmResetPassword.twig
@@ -19,7 +19,7 @@
             </div>
             <br>
 
-            <form action="{{ linkTo({'module': loginPlugin, 'action': 'confirmResetPassword'}) }}" ng-non-bindable method="post">
+            <form action="{{ linkTo({'module': loginPlugin, 'action': 'confirmResetPassword'}) }}" method="post">
                 <div class="row">
                     <div class="col s12 input-field">
                         <input type="hidden" name="nonce" value="{{ nonce }}"/>

--- a/plugins/Login/templates/initiateCancelResetPassword.twig
+++ b/plugins/Login/templates/initiateCancelResetPassword.twig
@@ -9,7 +9,7 @@
                 {% if errorMessage is empty %}
                     <p>{{ 'Login_PasswordResetCancelConfirmDescription'|translate }}</p>
                     <br>
-                    <form action="{{ linkTo({'module': loginPlugin, 'action': 'cancelResetPassword', 'login': login, 'resetToken': resetToken}) }}" ng-non-bindable method="post">
+                    <form action="{{ linkTo({'module': loginPlugin, 'action': 'cancelResetPassword', 'login': login, 'resetToken': resetToken}) }}" method="post">
                         <div class="row actions">
                             <div class="col s12">
                                 <input type="hidden" name="nonce" value="{{ nonce }}"/>

--- a/plugins/Login/templates/login.twig
+++ b/plugins/Login/templates/login.twig
@@ -94,7 +94,7 @@
                 <div class="message_container">
                 </div>
 
-                <form id="reset_form" method="post" ng-non-bindable>
+                <form id="reset_form" method="post">
                     <div class="row">
                         <div class="col s12 input-field">
                             <input type="hidden" name="form_nonce" id="reset_form_nonce" value="{{ nonce }}"/>

--- a/plugins/Marketplace/templates/plugin-details.twig
+++ b/plugins/Marketplace/templates/plugin-details.twig
@@ -65,17 +65,17 @@
                                     <div class="alert alert-warning">{{ 'Marketplace_PluginLicenseExceededDescription'|translate }}</div>
                                 {% endif %}
 
-                                <div ng-non-bindable>{{ latestVersion.readmeHtml.description|raw }}</div>
+                                <div>{{ latestVersion.readmeHtml.description|raw }}</div>
                             </div>
 
                             {% if latestVersion.readmeHtml.faq %}
-                                <div id="tabs-faq" class="tab-content col s12" ng-non-bindable>
+                                <div id="tabs-faq" class="tab-content col s12">
                                     {{ latestVersion.readmeHtml.faq|raw }}
                                 </div>
                             {% endif %}
 
                             {% if latestVersion.readmeHtml.documentation %}
-                                <div id="tabs-documentation" class="tab-content col s12" ng-non-bindable>
+                                <div id="tabs-documentation" class="tab-content col s12">
                                     {{ latestVersion.readmeHtml.documentation|raw }}
                                 </div>
                             {% endif %}

--- a/plugins/ScheduledReports/templates/unsubscribe.twig
+++ b/plugins/ScheduledReports/templates/unsubscribe.twig
@@ -38,7 +38,7 @@
                     {% elseif success is defined %}
                         <p class="message">{{ 'ScheduledReports_SuccessfullyUnsubscribed'|translate('<strong>'~reportName|rawSafeDecoded~'</strong>')|raw }}</p>
                     {% else %}
-                        <form method="POST" ng-non-bindable>
+                        <form method="POST">
                             <div class="row">
                                 <div class="col s12">
                                     <br/>


### PR DESCRIPTION
### Description:

Removing as it seems the attribute hasn't been removed after the refactor to Vue on the front-end.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
