### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3850,12 +3850,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/matomo-coding-standards.git",
-                "reference": "3822ff585bd30a351761218a651d252ed86c53cf"
+                "reference": "2690e81df6f7429c9d63f7ba4062657f31a3a961"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/matomo-coding-standards/zipball/3822ff585bd30a351761218a651d252ed86c53cf",
-                "reference": "3822ff585bd30a351761218a651d252ed86c53cf",
+                "url": "https://api.github.com/repos/matomo-org/matomo-coding-standards/zipball/2690e81df6f7429c9d63f7ba4062657f31a3a961",
+                "reference": "2690e81df6f7429c9d63f7ba4062657f31a3a961",
                 "shasum": ""
             },
             "require": {
@@ -3864,14 +3864,27 @@
                 "slevomat/coding-standard": "~8.14.0",
                 "squizlabs/php_codesniffer": "~3.10"
             },
+            "require-dev": {
+                "phpunit/phpunit": "~8.5|~9.6"
+            },
             "default-branch": true,
             "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "Matomo\\": "Matomo/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Matomo\\": "tests/"
+                }
+            },
             "description": "Coding standards for Matomo",
             "support": {
                 "source": "https://github.com/matomo-org/matomo-coding-standards/tree/master",
                 "issues": "https://github.com/matomo-org/matomo-coding-standards/issues"
             },
-            "time": "2025-05-30T10:29:02+00:00"
+            "time": "2025-06-03T21:54:18+00:00"
         },
         {
             "name": "myclabs/deep-copy",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
                                                      Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading matomo-org/matomo-coding-standards (dev-master 3822ff5 => dev-master 2690e81)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downloading matomo-org/matomo-coding-standards (dev-master 2690e81)
  - Upgrading matomo-org/matomo-coding-standards (dev-master 3822ff5 => dev-master 2690e81): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
53 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.
```
