### PR TITLE
Fix update script version & preview release version detection

### DIFF
--- a/core/Updates/5.4.0-b3.php
+++ b/core/Updates/5.4.0-b3.php
@@ -13,7 +13,7 @@ use Piwik\Updater;
 use Piwik\Updater\Migration\Factory as MigrationFactory;
 use Piwik\Updates;
 
-class Updates_5_4_0_b2 extends Updates
+class Updates_5_4_0_b3 extends Updates
 {
     /**
      * @var MigrationFactory

--- a/core/Version.php
+++ b/core/Version.php
@@ -22,7 +22,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    public const VERSION = '5.4.0-b2';
+    public const VERSION = '5.4.0-b3';
 
     public const MAJOR_VERSION = 5;
 
@@ -89,16 +89,7 @@ final class Version
             return $version . '.' . $dt;
         } else {
             // -b1, -rc1
-            $newVersion = preg_replace_callback(
-                '/^(\d+\.\d+\.\d+-(?:rc|b|beta))(\d+)$/i',
-                function ($matches) {
-                    $matches[2] = $matches[2] + 1;
-                    return $matches[1] . $matches[2];
-                },
-                $version
-            );
-
-            return $newVersion . '.' . $dt;
+            return $version . '.' . $dt;
         }
     }
 }

--- a/tests/PHPUnit/Unit/VersionTest.php
+++ b/tests/PHPUnit/Unit/VersionTest.php
@@ -109,13 +109,9 @@ class VersionTest extends \PHPUnit\Framework\TestCase
         // stable bumps patch and adds alpha
         $this->assertCorrectPreviewVersionWithoutSuffix('3.3.3', '3.3.4-alpha');
 
-        // non-stable bumps b1, rc1
-        $this->assertCorrectPreviewVersionWithoutSuffix('3.3.3-b1', '3.3.3-b2');
-        $this->assertCorrectPreviewVersionWithoutSuffix('3.3.3-rc1', '3.3.3-rc2');
-        $this->assertCorrectPreviewVersionWithoutSuffix('3.3.3-b1.20201224180000', '3.3.3-b1');
-        $this->assertCorrectPreviewVersionWithoutSuffix('3.3.3-rc1.20201224180000', '3.3.3-rc1');
-
-        // preview does not bump x.y.z, only dt suffix
+        // non stable and preview does not bump x.y.z, only dt suffix
+        $this->assertCorrectPreviewVersionWithoutSuffix('3.3.3-b1', '3.3.3-b1');
+        $this->assertCorrectPreviewVersionWithoutSuffix('3.3.3-rc1', '3.3.3-rc1');
         $this->assertCorrectPreviewVersionWithoutSuffix('3.3.3-alpha.20201224180000', '3.3.3-alpha');
         $this->assertCorrectPreviewVersionWithoutSuffix('3.3.3-b1.20201224180000', '3.3.3-b1');
         $this->assertCorrectPreviewVersionWithoutSuffix('3.3.3-rc1.20201224180000', '3.3.3-rc1');


### PR DESCRIPTION
### Description:

We currently bump the beta version number for preview releases. This actually doesn't make sense, as e.g. `5.4.0-b1` would be considered a lower version than `5.4.0-b1.06070560000`. So after `5.4.0-b1` was release following preview releases should be named `5.4.0-b1.06070560000` until `5.4.0-b2` was released.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
