### PR TITLE
Improve handling of Exception logging

### DIFF
--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -16,6 +16,7 @@ use Piwik\DataTable\DataTableInterface;
 use Piwik\DataTable\Filter\ColumnDelete;
 use Piwik\DataTable\Filter\Pattern;
 use Piwik\DataTable\Renderer;
+use Piwik\ExceptionHandler;
 use Piwik\Http\HttpCodeException;
 use Piwik\Plugins\Monolog\Processor\ExceptionToTextProcessor;
 
@@ -42,7 +43,7 @@ class ResponseBuilder
         $this->outputFormat = $outputFormat;
         $this->request      = $request;
         $this->apiRenderer  = ApiRenderer::factory($outputFormat, $request);
-        $this->shouldPrintBacktrace = $shouldPrintBacktrace === null ? \Piwik_ShouldPrintBackTraceWithMessage() : $shouldPrintBacktrace;
+        $this->shouldPrintBacktrace = $shouldPrintBacktrace === null ? ExceptionHandler::shouldPrintBackTraceWithMessage() : $shouldPrintBacktrace;
     }
 
     public function disableSendHeader()

--- a/core/Db/BatchInsert.php
+++ b/core/Db/BatchInsert.php
@@ -15,6 +15,7 @@ use Piwik\Config;
 use Piwik\Config\DatabaseConfig;
 use Piwik\Container\StaticContainer;
 use Piwik\Db;
+use Piwik\ExceptionHandler;
 use Piwik\Log;
 use Piwik\SettingsServer;
 use Piwik\SettingsPiwik;
@@ -252,7 +253,7 @@ class BatchInsert
             } catch (Exception $e) {
                 $code = $e->getCode();
                 $message = $e->getMessage() . ($code ? "[$code]" : '');
-                if (\Piwik_ShouldPrintBackTraceWithMessage()) {
+                if (ExceptionHandler::shouldPrintBackTraceWithMessage()) {
                     $message .= "\n" . $e->getTraceAsString();
                 }
                 $exceptions[] = "\n  Try #" . (count($exceptions) + 1) . ': ' . $queryStart . ": " . $message;

--- a/core/ErrorHandler.php
+++ b/core/ErrorHandler.php
@@ -155,7 +155,7 @@ class ErrorHandler
                 Common::sendResponseCode(500);
                 // Convert the error to an exception with an HTML message
                 $e = new \Exception();
-                $backtrace = \Piwik_ShouldPrintBackTraceWithMessage() ? $e->getTraceAsString() : '';
+                $backtrace = ExceptionHandler::shouldPrintBackTraceWithMessage() ? $e->getTraceAsString() : '';
                 $message = self::getHtmlMessage($errno, $errstr, $errfile, $errline, $backtrace);
                 throw new ErrorException($message, 0, $errno, $errfile, $errline);
             case E_WARNING:

--- a/core/ExceptionHandler.php
+++ b/core/ExceptionHandler.php
@@ -108,7 +108,7 @@ class ExceptionHandler
         exit(1);
     }
 
-    public static function replaceSensitiveValues($trace)
+    public static function replaceSensitiveValues(string $message): string
     {
         $dbConfig = Db::getDatabaseConfig();
 
@@ -131,7 +131,7 @@ class ExceptionHandler
 
         $valuesToReplace[PIWIK_DOCUMENT_ROOT] = '';
 
-        return str_replace(array_keys($valuesToReplace), array_values($valuesToReplace), $trace);
+        return str_replace(array_keys($valuesToReplace), array_values($valuesToReplace), $message);
     }
 
     /**

--- a/core/ExceptionHandler.php
+++ b/core/ExceptionHandler.php
@@ -108,12 +108,38 @@ class ExceptionHandler
         exit(1);
     }
 
+    public static function replaceSensitiveValues($trace)
+    {
+        $dbConfig = Db::getDatabaseConfig();
+
+        $valuesToReplace = [
+            Piwik::getCurrentUserTokenAuth() => 'tokenauth',
+            SettingsPiwik::getSalt()         => 'generalSalt',
+            $dbConfig['username']            => 'dbuser',
+            $dbConfig['password']            => 'dbpass',
+        ];
+
+        $mailConfig = Config::getInstance()->mail;
+
+        if (!empty($mailConfig['username'])) {
+            $valuesToReplace[$mailConfig['username']] = 'smtpuser';
+        }
+
+        if (!empty($mailConfig['password'])) {
+            $valuesToReplace[$mailConfig['password']] = 'smtppass';
+        }
+
+        $valuesToReplace[PIWIK_DOCUMENT_ROOT] = '';
+
+        return str_replace(array_keys($valuesToReplace), array_values($valuesToReplace), $trace);
+    }
+
     /**
      * @param Exception|\Throwable $ex
      */
     private static function getErrorResponse($ex)
     {
-        $debugTrace = $ex->getTraceAsString();
+        $debugTrace = self::replaceSensitiveValues($ex->getTraceAsString());
 
         $message = $ex->getMessage();
 
@@ -190,6 +216,29 @@ class ExceptionHandler
         }
 
         return $result;
+    }
+
+    public static function shouldPrintBackTraceWithMessage(): bool
+    {
+        if (
+            class_exists('\Piwik\SettingsServer')
+            && class_exists('\Piwik\Common')
+            && \Piwik\SettingsServer::isArchivePhpTriggered()
+            && \Piwik\Common::isPhpCliMode()
+        ) {
+            return true;
+        }
+
+        try {
+            $isDevelopmentModeEnabled = Development::isEnabled();
+        } catch (Exception $e) {
+            $isDevelopmentModeEnabled = false;
+        }
+
+        return $isDevelopmentModeEnabled
+            || (defined('PIWIK_PRINT_ERROR_BACKTRACE') && PIWIK_PRINT_ERROR_BACKTRACE)
+            || !empty($GLOBALS['PIWIK_PRINT_ERROR_BACKTRACE'])
+            || !empty($GLOBALS['PIWIK_TRACKER_DEBUG']);
     }
 
     private static function logException($exception, $loglevel = Log::ERROR)

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -85,20 +85,7 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
      */
     function Piwik_ShouldPrintBackTraceWithMessage()
     {
-        if (
-            class_exists('\Piwik\SettingsServer')
-            && class_exists('\Piwik\Common')
-            && \Piwik\SettingsServer::isArchivePhpTriggered()
-            && \Piwik\Common::isPhpCliMode()
-        ) {
-            return true;
-        }
-
-        $bool = (defined('PIWIK_PRINT_ERROR_BACKTRACE') && PIWIK_PRINT_ERROR_BACKTRACE)
-                || !empty($GLOBALS['PIWIK_PRINT_ERROR_BACKTRACE'])
-                || !empty($GLOBALS['PIWIK_TRACKER_DEBUG']);
-
-        return $bool;
+        return \Piwik\ExceptionHandler::shouldPrintBackTraceWithMessage();
     }
 
     /**
@@ -210,7 +197,7 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
         $content = '<h2>' . $message . '</h2>'
             . $redirectSection
             . $backLinks
-            . ' ' . (Piwik_ShouldPrintBackTraceWithMessage() ? $optionalTrace : '')
+            . ' ' . (\Piwik\ExceptionHandler::shouldPrintBackTraceWithMessage() ? $optionalTrace : '')
             . ' ' . $optionalLinks;
 
 

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -13,6 +13,7 @@
  * This file must be compatible with PHP 5.3.
  */
 
+use Piwik\ExceptionHandler;
 use Piwik\Url;
 
 $piwik_errorMessage = '';
@@ -85,7 +86,11 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
      */
     function Piwik_ShouldPrintBackTraceWithMessage()
     {
-        return \Piwik\ExceptionHandler::shouldPrintBackTraceWithMessage();
+        if (!class_exists(ExceptionHandler::class)) {
+            return false;
+        }
+
+        return ExceptionHandler::shouldPrintBackTraceWithMessage();
     }
 
     /**
@@ -157,12 +162,21 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
         }
 
         if ($optionalLinks) {
+
+            $adjustUrl = function ($url) {
+                if (class_exists(Url::class)) {
+                    return Url::addCampaignParametersToMatomoLink($url);
+                }
+
+                return $url;
+            };
+
             $optionalLinks = '<ul>
-                            <li><a rel="noreferrer noopener" target="_blank" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org') . '">Matomo.org homepage</a></li>
-                            <li><a rel="noreferrer noopener" target="_blank" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/') . '">Frequently Asked Questions</a></li>
-                            <li><a rel="noreferrer noopener" target="_blank" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/') . '">User Guides</a></li>
-                            <li><a rel="noreferrer noopener" target="_blank" href="' . Url::addCampaignParametersToMatomoLink('https://forum.matomo.org/') . '">Matomo Forums</a></li>
-                            <li><a rel="noreferrer noopener" target="_blank" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/support/') . '">Professional Support for Matomo</a></li>
+                            <li><a rel="noreferrer noopener" target="_blank" href="' . $adjustUrl('https://matomo.org') . '">Matomo.org homepage</a></li>
+                            <li><a rel="noreferrer noopener" target="_blank" href="' . $adjustUrl('https://matomo.org/faq/') . '">Frequently Asked Questions</a></li>
+                            <li><a rel="noreferrer noopener" target="_blank" href="' . $adjustUrl('https://matomo.org/docs/') . '">User Guides</a></li>
+                            <li><a rel="noreferrer noopener" target="_blank" href="' . $adjustUrl('https://forum.matomo.org/') . '">Matomo Forums</a></li>
+                            <li><a rel="noreferrer noopener" target="_blank" href="' . $adjustUrl('https://matomo.org/support/') . '">Professional Support for Matomo</a></li>
                             </ul>';
         }
         if ($optionalLinkBack) {
@@ -197,7 +211,7 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
         $content = '<h2>' . $message . '</h2>'
             . $redirectSection
             . $backLinks
-            . ' ' . (\Piwik\ExceptionHandler::shouldPrintBackTraceWithMessage() ? $optionalTrace : '')
+            . ' ' . (Piwik_ShouldPrintBackTraceWithMessage() ? $optionalTrace : '')
             . ' ' . $optionalLinks;
 
 

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -13,9 +13,6 @@
  * This file must be compatible with PHP 5.3.
  */
 
-use Piwik\ExceptionHandler;
-use Piwik\Url;
-
 $piwik_errorMessage = '';
 
 // Minimum requirement: stream_resolve_include_path, working json_encode in 5.3.3, namespaces in 5.3
@@ -68,7 +65,7 @@ if ($minimumPhpInvalid) {
                     "<br/>" . $composerInstall .
                     " This will initialize composer for Matomo and download libraries we use in vendor/* directory." .
                     "\n\n<br/><br/>Then reload this page to access your analytics reports." .
-                    "\n\n<br/><br/>For more information check out this FAQ: <a href='" . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to-install/faq_18271/') . "' rel='noreferrer noopener' target='_blank'>How do I use Matomo from the Git repository?</a>." .
+            "\n\n<br/><br/>For more information check out this FAQ: <a href='https://matomo.org/faq/how-to-install/faq_18271/' rel='noreferrer noopener' target='_blank'>How do I use Matomo from the Git repository?</a>." .
                     "\n\n<br/><br/>Note: if for some reasons you cannot install composer, instead install the latest Matomo release from " .
                     "<a href='https://builds.matomo.org/piwik.zip' rel='noreferrer noopener'>builds.matomo.org</a>.</p>";
     }
@@ -86,11 +83,11 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
      */
     function Piwik_ShouldPrintBackTraceWithMessage()
     {
-        if (!class_exists(ExceptionHandler::class)) {
+        if (!class_exists(\Piwik\ExceptionHandler::class)) {
             return false;
         }
 
-        return ExceptionHandler::shouldPrintBackTraceWithMessage();
+        return \Piwik\ExceptionHandler::shouldPrintBackTraceWithMessage();
     }
 
     /**
@@ -162,10 +159,9 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
         }
 
         if ($optionalLinks) {
-
             $adjustUrl = function ($url) {
-                if (class_exists(Url::class)) {
-                    return Url::addCampaignParametersToMatomoLink($url);
+                if (class_exists(\Piwik\Url::class)) {
+                    return \Piwik\Url::addCampaignParametersToMatomoLink($url);
                 }
 
                 return $url;

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -15,6 +15,7 @@ use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Exception\MissingFilePermissionException;
+use Piwik\ExceptionHandler;
 use Piwik\Filechecks;
 use Piwik\Filesystem;
 use Piwik\Nonce;
@@ -373,7 +374,7 @@ class Controller extends Plugin\ControllerAdmin
 
             if (
                 !empty($lastError['backtrace'])
-                && \Piwik_ShouldPrintBackTraceWithMessage()
+                && ExceptionHandler::shouldPrintBackTraceWithMessage()
             ) {
                 $errorMessage .= $lastError['backtrace'];
             }
@@ -392,7 +393,7 @@ class Controller extends Plugin\ControllerAdmin
             throw new Exception("Error: " . var_export($lastError, true));
         }
 
-        if (!\Piwik_ShouldPrintBackTraceWithMessage()) {
+        if (!ExceptionHandler::shouldPrintBackTraceWithMessage()) {
             unset($lastError['backtrace']);
         }
 

--- a/plugins/Monolog/Processor/ExceptionToTextProcessor.php
+++ b/plugins/Monolog/Processor/ExceptionToTextProcessor.php
@@ -10,13 +10,10 @@
 namespace Piwik\Plugins\Monolog\Processor;
 
 use Piwik\Common;
-use Piwik\Config;
-use Piwik\Db;
 use Piwik\ErrorHandler;
 use Piwik\Exception\InvalidRequestParameterException;
+use Piwik\ExceptionHandler;
 use Piwik\Log;
-use Piwik\Piwik;
-use Piwik\SettingsPiwik;
 use Piwik\Url;
 
 /**
@@ -24,16 +21,16 @@ use Piwik\Url;
  */
 class ExceptionToTextProcessor
 {
-    private $forcePrintBacktrace = false;
+    private $forcePrintBacktrace;
 
-    public function __construct($forcePrintBacktrace = false)
+    public function __construct(bool $forcePrintBacktrace = false)
     {
         $this->forcePrintBacktrace = $forcePrintBacktrace;
     }
 
     public function __invoke(array $record)
     {
-        if (! $this->contextContainsException($record)) {
+        if (!$this->contextContainsException($record)) {
             return $record;
         }
 
@@ -46,7 +43,7 @@ class ExceptionToTextProcessor
 
         $exceptionStr = sprintf(
             "%s(%d): %s",
-            $exception instanceof \Exception ? $exception->getFile() : $exception['file'],
+            ExceptionHandler::replaceSensitiveValues($exception instanceof \Exception ? $exception->getFile() : $exception['file']),
             $exception instanceof \Exception ? $exception->getLine() : $exception['line'],
             $this->getStackTrace($exception)
         );
@@ -57,7 +54,7 @@ class ExceptionToTextProcessor
         ) {
             $record['message'] = $exceptionStr;
         } else {
-            $record['message'] = str_replace('{exception}', $exceptionStr, $record['message']);
+            $record['message'] = str_replace('{exception}', $exceptionStr, ExceptionHandler::replaceSensitiveValues($record['message']));
         }
 
         $record['message'] .= ' [' . $this->getErrorContext() . ']';
@@ -80,14 +77,14 @@ class ExceptionToTextProcessor
     private function getMessage($exception)
     {
         if ($exception instanceof \ErrorException) {
-            return ErrorHandler::getErrNoString($exception->getSeverity()) . ' - ' . $exception->getMessage();
+            return ErrorHandler::getErrNoString($exception->getSeverity()) . ' - ' . ExceptionHandler::replaceSensitiveValues($exception->getMessage());
         }
 
         if (is_array($exception) && isset($exception['message'])) {
-            return $exception['message'];
+            return ExceptionHandler::replaceSensitiveValues($exception['message']);
         }
 
-        return $exception->getMessage();
+        return ExceptionHandler::replaceSensitiveValues($exception->getMessage());
     }
 
     private function getStackTrace($exception)
@@ -100,17 +97,17 @@ class ExceptionToTextProcessor
      * @param bool|null $shouldPrintBacktrace
      * @return mixed|string
      */
-    public static function getMessageAndWholeBacktrace($exception, $shouldPrintBacktrace = null)
+    public static function getMessageAndWholeBacktrace($exception, ?bool $shouldPrintBacktrace = null)
     {
         if ($shouldPrintBacktrace === null) {
-            $shouldPrintBacktrace = \Piwik_ShouldPrintBackTraceWithMessage();
+            $shouldPrintBacktrace = ExceptionHandler::shouldPrintBackTraceWithMessage();
         }
 
         if (is_array($exception)) {
-            $message = $exception['message'] ?? '';
+            $message = ExceptionHandler::replaceSensitiveValues($exception['message'] ?? '');
             if ($shouldPrintBacktrace && isset($exception['backtrace'])) {
                 $trace = $exception['backtrace'];
-                $trace = self::replaceSensitiveValues($trace);
+                $trace = ExceptionHandler::replaceSensitiveValues($trace);
                 return $message . "\n" . $trace;
             } else {
                 return $message;
@@ -118,7 +115,7 @@ class ExceptionToTextProcessor
         }
 
         if (!$shouldPrintBacktrace) {
-            return $exception->getMessage();
+            return ExceptionHandler::replaceSensitiveValues($exception->getMessage());
         }
 
         $message = "";
@@ -129,37 +126,11 @@ class ExceptionToTextProcessor
                 $message .= ",\ncaused by: ";
             }
 
-            $message .= $e->getMessage();
-            if ($shouldPrintBacktrace) {
-                $message .= "\n" . self::replaceSensitiveValues($e->getTraceAsString());
-            }
+            $message .= ExceptionHandler::replaceSensitiveValues($e->getMessage());
+            $message .= "\n" . ExceptionHandler::replaceSensitiveValues($e->getTraceAsString());
         } while ($e = $e->getPrevious());
 
         return $message;
-    }
-
-    private static function replaceSensitiveValues($trace)
-    {
-        $dbConfig = Db::getDatabaseConfig();
-
-        $valuesToReplace = [
-            Piwik::getCurrentUserTokenAuth() => 'tokenauth',
-            SettingsPiwik::getSalt() => 'generalSalt',
-            $dbConfig['username'] => 'dbuser',
-            $dbConfig['password'] => 'dbpass',
-        ];
-
-        $mailConfig = Config::getInstance()->mail;
-
-        if (!empty($mailConfig['username'])) {
-            $valuesToReplace[$mailConfig['username']] = 'smtpuser';
-        }
-
-        if (!empty($mailConfig['password'])) {
-            $valuesToReplace[$mailConfig['password']] = 'smtppass';
-        }
-
-        return str_replace(array_keys($valuesToReplace), array_values($valuesToReplace), $trace);
     }
 
     private function getErrorContext()
@@ -169,8 +140,7 @@ class ExceptionToTextProcessor
             $context .= ', CLI mode: ' . (int)Common::isPhpCliMode();
             return $context;
         } catch (\Exception $ex) {
-            $context = "cannot get url or cli mode: " . $ex->getMessage();
-            return $context;
+            return 'cannot get url or cli mode: ' . ExceptionHandler::replaceSensitiveValues($ex->getMessage());
         }
     }
 }

--- a/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
@@ -65,7 +65,7 @@ class ExceptionToTextProcessorTest extends \PHPUnit\Framework\TestCase
         $result = $processor($record);
 
         $expected = array(
-            'message' => __FILE__ . "(%d): [message and stack trace] [Query: , CLI mode: 1]",
+            'message' => str_replace(PIWIK_INCLUDE_PATH, '', __FILE__) . "(%d): [message and stack trace] [Query: , CLI mode: 1]",
             'context' => array(
                 'exception' => $exception,
             ),

--- a/tests/PHPUnit/Integration/FrontControllerTest.php
+++ b/tests/PHPUnit/Integration/FrontControllerTest.php
@@ -32,7 +32,7 @@ class FrontControllerTest extends IntegrationTestCase
         $this->assertEquals('error', $response['result']);
 
         $expectedFormat = <<<FORMAT
-Allowed memory size of %s bytes exhausted (tried to allocate %s bytes) on {includePath}/tests/resources/trigger-fatal.php(23) #0 {includePath}/tests/resources/trigger-fatal.php(36): MyClass-&gt;triggerError(arg1=&quot;argval&quot;, arg2=&quot;another&quot;) #1 {includePath}/tests/resources/trigger-fatal.php(52): MyDerivedClass::staticMethod() #2 {includePath}/tests/resources/trigger-fatal.php(58): myFunction()
+Allowed memory size of %s bytes exhausted (tried to allocate %s bytes) on /tests/resources/trigger-fatal.php(23) #0 /tests/resources/trigger-fatal.php(36): MyClass-&gt;triggerError(arg1=&quot;argval&quot;, arg2=&quot;another&quot;) #1 /tests/resources/trigger-fatal.php(52): MyDerivedClass::staticMethod() #2 /tests/resources/trigger-fatal.php(58): myFunction()
 FORMAT;
 
         $this->assertStringMatchesFormat($expectedFormat, $response['message']);
@@ -49,12 +49,12 @@ FORMAT;
         $this->assertEquals('error', $response['result']);
 
         $expectedFormat = <<<FORMAT
-test message on {includePath}/tests/resources/trigger-fatal-exception.php(23) #0 [internal function]: {closure}('CoreHome', 'index', Array) #1 {includePath}/core/EventDispatcher.php(141): call_user_func_array(Object(Closure), Array) #2 {includePath}/core/Piwik.php(845): Piwik\EventDispatcher-&gt;postEvent('Request.dispatc...', Array, false, Array) #3 {includePath}/core/FrontController.php(606): Piwik\Piwik::postEvent('Request.dispatc...', Array) #4 {includePath}/core/FrontController.php(168): Piwik\FrontController-&gt;doDispatch('CoreHome', 'index', Array) #5 {includePath}/tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('CoreHome', 'index') #6 {main}
+test message on /tests/resources/trigger-fatal-exception.php(23) #0 [internal function]: {closure}('CoreHome', 'index', Array) #1 /core/EventDispatcher.php(141): call_user_func_array(Object(Closure), Array) #2 /core/Piwik.php(845): Piwik\EventDispatcher-&gt;postEvent('Request.dispatc...', Array, false, Array) #3 /core/FrontController.php(606): Piwik\Piwik::postEvent('Request.dispatc...', Array) #4 /core/FrontController.php(168): Piwik\FrontController-&gt;doDispatch('CoreHome', 'index', Array) #5 /tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('CoreHome', 'index') #6 {main}
 FORMAT;
 
         if (version_compare(PHP_VERSION, '8.4.0-dev', '>=')) {
             $expectedFormat = <<<FORMAT
-test message on {includePath}/tests/resources/trigger-fatal-exception.php(23) #0 [internal function]: {closure:{includePath}/tests/resources/trigger-fatal-exception.php:20}('...', '...', Array) #1 {includePath}/core/EventDispatcher.php(147): call_user_func_array(Object(Closure), Array) #2 {includePath}/core/Piwik.php(880): Piwik\EventDispatcher-&gt;postEvent('...', Array, false, Array) #3 {includePath}/core/FrontController.php(625): Piwik\Piwik::postEvent('...', Array) #4 {includePath}/core/FrontController.php(169): Piwik\FrontController-&gt;doDispatch('...', '...', Array) #5 {includePath}/tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('...', '...') #6 {main}
+test message on /tests/resources/trigger-fatal-exception.php(23) #0 [internal function]: {closure:/tests/resources/trigger-fatal-exception.php:20}('...', '...', Array) #1 /core/EventDispatcher.php(147): call_user_func_array(Object(Closure), Array) #2 /core/Piwik.php(880): Piwik\EventDispatcher-&gt;postEvent('...', Array, false, Array) #3 /core/FrontController.php(625): Piwik\Piwik::postEvent('...', Array) #4 /core/FrontController.php(169): Piwik\FrontController-&gt;doDispatch('...', '...', Array) #5 /tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('...', '...') #6 {main}
 FORMAT;
         }
 
@@ -92,9 +92,7 @@ FORMAT;
 
     private function cleanMessage($message)
     {
-        $message = trim($message);
-        $message = str_replace(PIWIK_INCLUDE_PATH, '{includePath}', $message);
-        return $message;
+        return trim($message);
     }
 
     /**

--- a/tests/PHPUnit/proxy/piwik.php
+++ b/tests/PHPUnit/proxy/piwik.php
@@ -36,7 +36,7 @@ try {
     include PIWIK_INCLUDE_PATH . '/matomo.php';
 } catch (Exception $ex) {
     $stacktrace = '';
-    if (\Piwik_ShouldPrintBackTraceWithMessage()) {
+    if (\Piwik\ExceptionHandler::shouldPrintBackTraceWithMessage()) {
         $stacktrace = "\n" . $ex->getTraceAsString();
     }
     echo "Unexpected error during tracking: " . $ex->getMessage() . $stacktrace . "\n";


### PR DESCRIPTION
### Description:

* restructures exception handling code
* ensures stack traces are only shown when configured or in development mode
* ensures path to Matomo root directory is redacted from error messages and stack traces
* ensure sensitive values are removed from all exception messages and stack traces
* fixes the error page shown, when old PHP is used or composer is missing

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
