### PR TITLE
Update DDEV config to have stable chrome version, and stable font rendering for consistent UI tests

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -14,7 +14,7 @@ hooks:
         - exec: MYSQL_PWD=root mysql -uroot -e "GRANT ALL PRIVILEGES ON *.* to 'db'@'%'"
           service: db
         - exec-host: ddev matomo:init
-webimage_extra_packages: [build-essential, chromium, default-jre, fonts-dejavu, fonts-liberation, gconf-service, imagemagick, imagemagick-doc, libappindicator1, libasound2, libatk1.0-0, libcairo2, libdrm2, libgbm1, libgconf-2-4, libgdk-pixbuf2.0-0, libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libpangocairo-1.0-0, libx11-xcb1, libxcomposite1, libxcursor1, libxdamage1, libxfixes3, libxi6, libxrandr2, libxrender1, libxshmfence1, libxss1, libxtst6, ripgrep, ttf-mscorefonts-installer, xdg-utils]
+webimage_extra_packages: [build-essential, default-jre, fonts-dejavu, fonts-liberation, gconf-service, imagemagick, imagemagick-doc, libappindicator1, libasound2, libatk1.0-0, libcairo2, libdrm2, libgbm1, libgconf-2-4, libgdk-pixbuf2.0-0, libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libpangocairo-1.0-0, libx11-xcb1, libxcomposite1, libxcursor1, libxdamage1, libxfixes3, libxi6, libxrandr2, libxrender1, libxshmfence1, libxss1, libxtst6, ripgrep, ttf-mscorefonts-installer, xdg-utils]
 use_dns_when_possible: true
 composer_version: "2"
 web_environment:

--- a/.ddev/docker-compose.override.yaml
+++ b/.ddev/docker-compose.override.yaml
@@ -1,0 +1,3 @@
+services:
+  web:
+    platform: linux/amd64

--- a/.ddev/initial-config/config.js
+++ b/.ddev/initial-config/config.js
@@ -5,7 +5,6 @@ exports.phpServer = {
     REMOTE_ADDR: '127.0.0.1'
 };
 exports.browserConfig = {
-  args: ['--no-sandbox', '--ignore-certificate-errors'],
-  executablePath: '/usr/bin/chromium'
+  args: ['--no-sandbox', '--ignore-certificate-errors']
 };
 

--- a/.ddev/web-build/Dockerfile.fonts
+++ b/.ddev/web-build/Dockerfile.fonts
@@ -1,0 +1,17 @@
+RUN mkdir -p /etc/fonts && \
+    tee /etc/fonts/local.conf > /dev/null <<EOF
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <match target="font">
+    <edit name="rgba" mode="assign"><const>rgb</const></edit>
+    <edit name="antialias" mode="assign"><bool>true</bool></edit>
+    <edit name="hinting" mode="assign"><bool>true</bool></edit>
+    <edit name="hintstyle" mode="assign"><const>hintslight</const></edit>
+    <edit name="lcdfilter" mode="assign"><const>lcddefault</const></edit>
+  </match>
+</fontconfig>
+EOF
+
+# Rebuild font cache
+RUN fc-cache -f -v


### PR DESCRIPTION
[DO NOT MERGE]

### Description

There are currently inconsistencies between the UI test results in CI and those run locally in DDEV — particularly around font rendering (e.g., anti-aliasing, subpixel differences).

This change addresses two key issues:

1. **Font rendering parity**  
   It introduces system-level fontconfig settings to ensure consistent anti-aliasing and subpixel rendering between CI and DDEV.

2. **Consistent Chromium version**  
   It forces the use of **Puppeteer v8’s bundled Chromium (revision 856583)**, which matches what CI runs.

Additionally, this update sets the architecture to `linux/amd64` to ensure Puppeteer can install and run the correct Chromium binary. Newer versions of Puppeteer support `arm64`, but v8 does not.

---

###  For Apple Silicon Users

If you're using a Mac with Apple Silicon (M1/M2):

- Make sure **Rosetta** is enabled in Docker Desktop → Settings → Features in development → *Use Rosetta for x86/amd64 emulation on Apple Silicon*. This will improve the emulation performance.

---

###  Known Issue: Node Architecture Mismatch

On Apple Silicon, Docker may pull a version of Node.js that does not match the forced `amd64` platform. If Puppeteer fails to run or Chromium won’t launch, run the following inside the container:

```bash
ddev ssh

sudo apt-get purge -y nodejs npm
sudo rm -rf /usr/local/bin/node /usr/local/bin/npm ~/.n
sudo apt-get update
curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
sudo apt-get install -y nodejs
hash -r
```

This installs an amd64-compatible Node.js build that matches the Puppeteer/Chromium environment.

---

### Notes
Some UI tests still fail, but font rendering is now significantly more consistent across environments.

This lays the groundwork for further snapshot cleanup or visual regression stabilization.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
