### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -715,12 +715,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/referrer-spam-list.git",
-                "reference": "14b861957cb5e58f48734a7aebbf4a9c94ab1c63"
+                "reference": "68dc5c026beb7d65b5f2a2e8d0b6aca5d7a801aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/14b861957cb5e58f48734a7aebbf4a9c94ab1c63",
-                "reference": "14b861957cb5e58f48734a7aebbf4a9c94ab1c63",
+                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/68dc5c026beb7d65b5f2a2e8d0b6aca5d7a801aa",
+                "reference": "68dc5c026beb7d65b5f2a2e8d0b6aca5d7a801aa",
                 "shasum": ""
             },
             "replace": {
@@ -738,7 +738,7 @@
                 "issues": "https://github.com/matomo-org/referrer-spam-list/issues",
                 "source": "https://github.com/matomo-org/referrer-spam-list/tree/master"
             },
-            "time": "2025-04-28T16:11:02+00:00"
+            "time": "2025-06-16T22:04:58+00:00"
         },
         {
             "name": "matomo/searchengine-and-social-list",
@@ -5367,16 +5367,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.1",
+            "version": "3.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "1b71b4dd7e7ef651ac749cea67e513c0c832f4bd"
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1b71b4dd7e7ef651ac749cea67e513c0c832f4bd",
-                "reference": "1b71b4dd7e7ef651ac749cea67e513c0c832f4bd",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
                 "shasum": ""
             },
             "require": {
@@ -5447,7 +5447,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-06-12T15:04:34+00:00"
+            "time": "2025-06-17T22:17:01+00:00"
         },
         {
             "name": "symfony/yaml",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
                                                      Updating dependencies
Lock file operations: 0 installs, 2 updates, 0 removals
  - Upgrading matomo/referrer-spam-list (dev-master 14b8619 => dev-master 68dc5c0)
  - Upgrading squizlabs/php_codesniffer (3.13.1 => 3.13.2)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 2 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.13.2)
  - Downloading matomo/referrer-spam-list (dev-master 68dc5c0)
  - Upgrading squizlabs/php_codesniffer (3.13.1 => 3.13.2): Extracting archive
  - Upgrading matomo/referrer-spam-list (dev-master 14b8619 => dev-master 68dc5c0): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
53 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
PHP CodeSniffer Config installed_paths set to ../../matomo-org/matomo-coding-standards,../../slevomat/coding-standard
No security vulnerability advisories found.
```
