### PR TITLE
Make period in report emails translatable

### DIFF
--- a/plugins/CoreHome/templates/ReportRenderer/_htmlReportHeader.twig
+++ b/plugins/CoreHome/templates/ReportRenderer/_htmlReportHeader.twig
@@ -8,7 +8,7 @@
         {% if isAttachedFile is defined and isAttachedFile %}
         {{ 'ScheduledReports_PleaseFindAttachedFile'|translate(frequency, reportTitle|escape|preventLinking)|raw }}
         {% else %}
-        {{ 'ScheduledReports_PleaseFindBelow'|translate(period, reportTitle|escape|preventLinking)|raw }}
+        {{ 'ScheduledReports_PleaseFindBelow'|translate(('Intl_Period' ~ period|capitalize)|translate, reportTitle|escape|preventLinking)|raw }}
         {% endif %}
         <br />{{ description|escape|preventLinking }}
         <br />{{ 'General_DateRange'|translate }} {{ prettyDate }}


### PR DESCRIPTION
### Description:

The period within report email was inserted untranslated before.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
