### PR TITLE
Create scheduled task to send inactive users security notification

### DIFF
--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -60,6 +60,7 @@ class Mysql implements SchemaInterface
                           invite_accept_at TIMESTAMP NULL,
                           ts_changes_shown TIMESTAMP NULL,
                           ts_last_seen TIMESTAMP NULL,
+                          ts_inactivity_notified TIMESTAMP NULL,
                             PRIMARY KEY(login),
                             UNIQUE INDEX `uniq_email` (`email`)
                           ) $tableOptions

--- a/core/Updates/5.4.0-b4.php
+++ b/core/Updates/5.4.0-b4.php
@@ -40,6 +40,7 @@ class Updates_5_4_0_b4 extends PiwikUpdates
     {
         return [
           $this->migration->db->addColumns('user', ['ts_last_seen' => 'TIMESTAMP null DEFAULT null']),
+          $this->migration->db->addColumns('user', ['ts_inactivity_notified' => 'TIMESTAMP null DEFAULT null']),
         ];
     }
 

--- a/plugins/UsersManager/Emails/InactiveUsersNotificationEmail.php
+++ b/plugins/UsersManager/Emails/InactiveUsersNotificationEmail.php
@@ -30,6 +30,7 @@ class InactiveUsersNotificationEmail extends Mail
     /** @var array */
     private $emailData;
 
+    /** @var Model */
     private $userModel;
 
     public function __construct(UserNotification $notification, string $recipient, array $emailData)

--- a/plugins/UsersManager/Emails/InactiveUsersNotificationEmail.php
+++ b/plugins/UsersManager/Emails/InactiveUsersNotificationEmail.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\Emails;
+
+use Piwik\Mail;
+use Piwik\Piwik;
+use Piwik\Plugins\UsersManager\Model;
+use Piwik\Plugins\UsersManager\UserNotifications\UserNotification;
+use Piwik\SettingsPiwik;
+use Piwik\Url;
+use Piwik\View;
+
+class InactiveUsersNotificationEmail extends Mail
+{
+    /**
+     * @var UserNotification
+     */
+    private $notification;
+
+    /** @var string */
+    private $recipient;
+
+    /** @var array */
+    private $emailData;
+
+    private $userModel;
+
+    public function __construct(UserNotification $notification, string $recipient, array $emailData)
+    {
+        parent::__construct();
+
+        $this->notification = $notification;
+        $this->recipient = $recipient;
+        $this->emailData = $emailData;
+        $this->userModel = new Model();
+
+        $this->setUpEmail();
+    }
+
+    private function setUpEmail(): void
+    {
+        $this->setDefaultFromPiwik();
+        $this->addTo($this->recipient);
+        $this->setSubject($this->getDefaultSubject());
+        $this->addReplyTo($this->getFrom(), $this->getFromName());
+        $this->setBodyText($this->getDefaultBodyText());
+        $this->setWrappedHtmlBody($this->getDefaultBodyView());
+    }
+
+    protected function getManageUsersLink(): string
+    {
+        return SettingsPiwik::getPiwikUrl()
+            . 'index.php?'
+            . Url::getQueryStringFromParameters(['module' => 'UsersManager', 'action' => 'index']);
+    }
+
+    protected function getDefaultSubject(): string
+    {
+        return Piwik::translate('UsersManager_InactiveUsersNotificationEmailSubject');
+    }
+
+    protected function getDefaultBodyText(): string
+    {
+        $view = new View('@UsersManager/_inactiveUsersNotificationTextEmail.twig');
+        $view->setContentType('text/plain');
+
+        $this->assignCommonParameters($view);
+
+        return $view->render();
+    }
+
+    protected function getDefaultBodyView(): View
+    {
+        $view = new View('@UsersManager/_inactiveUsersNotificationHtmlEmail.twig');
+
+        $this->assignCommonParameters($view);
+
+        return $view;
+    }
+
+    protected function assignCommonParameters(View $view): void
+    {
+        $view->inactiveUsers = $this->notification->getUsers();
+        $view->manageUsersLink = $this->getManageUsersLink();
+        $view->superuserLogin = $this->userModel->getUserByEmail($this->recipient)['login'];
+
+        foreach ($this->emailData as $item => $value) {
+            $view->assign($item, $value);
+        }
+    }
+}

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -935,4 +935,35 @@ class Model
         $bind = [Date::factory($timestamp)->getDatetime(), $userLogin];
         $db->query($sql, $bind);
     }
+
+    public function getUsersWithoutActivityForDays(int $days = 180): array
+    {
+        $db = $this->getDb();
+        $sql = "
+            SELECT
+                u.login,
+                u.ts_last_login,
+                MAX(COALESCE(t.last_used, t.date_created)) AS ts_last_token_activity
+            FROM " . $this->userTable . " u
+            LEFT JOIN " . $this->tokenTable . " t ON u.login = t.login
+            WHERE 
+                u.login != ? AND
+                u.ts_inactivity_notified IS NULL
+            GROUP BY
+                u.login,
+                u.email,
+                u.ts_last_login,
+                u.date_registered
+            HAVING COALESCE(u.ts_last_login, u.date_registered) < NOW() - INTERVAL ? DAY;
+        ";
+        $bind = ['anonymous', $days];
+        return $db->fetchAll($sql, $bind);
+    }
+
+    public function setInactiveUserNotificationWasSentForUsers(array $users, string $dtNotified): void
+    {
+        foreach ($users as $user) {
+            $this->updateUserFields($user['login'], ['ts_inactivity_notified' => $dtNotified]);
+        }
+    }
 }

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -942,7 +942,7 @@ class Model
         $sql = "
             SELECT
                 u.login,
-                u.ts_last_login,
+                COALESCE(u.ts_last_seen, u.date_registered) as ts_last_seen,
                 MAX(COALESCE(t.last_used, t.date_created)) AS ts_last_token_activity
             FROM " . $this->userTable . " u
             LEFT JOIN " . $this->tokenTable . " t ON u.login = t.login
@@ -952,11 +952,11 @@ class Model
             GROUP BY
                 u.login,
                 u.email,
-                u.ts_last_login,
+                u.ts_last_seen,
                 u.date_registered
-            HAVING COALESCE(u.ts_last_login, u.date_registered) < NOW() - INTERVAL ? DAY;
+            HAVING COALESCE(u.ts_last_seen, u.date_registered) < (? - INTERVAL ? DAY);
         ";
-        $bind = ['anonymous', $days];
+        $bind = ['anonymous', Date::factory('now')->getDatetime(), $days];
         return $db->fetchAll($sql, $bind);
     }
 

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -954,7 +954,8 @@ class Model
                 u.email,
                 u.ts_last_seen,
                 u.date_registered
-            HAVING COALESCE(u.ts_last_seen, u.date_registered) < (? - INTERVAL ? DAY);
+            HAVING COALESCE(u.ts_last_seen, u.date_registered) < (? - INTERVAL ? DAY)
+            ORDER BY u.login;
         ";
         $bind = ['anonymous', Date::factory('now')->getDatetime(), $days];
         return $db->fetchAll($sql, $bind);

--- a/plugins/UsersManager/Repository/UserRepository.php
+++ b/plugins/UsersManager/Repository/UserRepository.php
@@ -176,6 +176,7 @@ class UserRepository
         unset($user['invite_token']);
         unset($user['invite_link_token']);
         unset($user['ts_last_seen']);
+        unset($user['ts_inactivity_notified']);
 
         if ($lastSeen = LastSeenTimeLogger::getLastSeenTimeForUser($user['login'])) {
             $user['last_seen'] = Date::getDatetimeFromTimestamp($lastSeen);

--- a/plugins/UsersManager/Tasks.php
+++ b/plugins/UsersManager/Tasks.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\UsersManager;
 use Piwik\Access;
 use Piwik\Date;
 use Piwik\Plugins\UsersManager\TokenNotifications\TokenNotifierTask;
+use Piwik\Plugins\UsersManager\UserNotifications\UserNotifierTask;
 
 class Tasks extends \Piwik\Plugin\Tasks
 {
@@ -38,6 +39,7 @@ class Tasks extends \Piwik\Plugin\Tasks
         $this->daily("cleanUpExpiredInvites");
 
         $this->scheduleTask(new TokenNotifierTask());
+        $this->scheduleTask(new UserNotifierTask());
     }
 
     public function cleanupExpiredTokens()

--- a/plugins/UsersManager/UserNotifications/InactiveUsersEmailNotification.php
+++ b/plugins/UsersManager/UserNotifications/InactiveUsersEmailNotification.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\UserNotifications;
+
+use Piwik\Plugins\UsersManager\Emails\InactiveUsersNotificationEmail;
+
+final class InactiveUsersEmailNotification extends UserEmailNotification
+{
+    public function __construct(
+        array $users,
+        array $recipients,
+        array $emailData = []
+    ) {
+        parent::__construct(
+            $users,
+            $recipients,
+            $emailData
+        );
+    }
+
+    public function getEmailClass(): string
+    {
+        return InactiveUsersNotificationEmail::class;
+    }
+}

--- a/plugins/UsersManager/UserNotifications/InactiveUsersEmailNotification.php
+++ b/plugins/UsersManager/UserNotifications/InactiveUsersEmailNotification.php
@@ -13,6 +13,11 @@ use Piwik\Plugins\UsersManager\Emails\InactiveUsersNotificationEmail;
 
 final class InactiveUsersEmailNotification extends UserEmailNotification
 {
+    /**
+     * @param array $users A list of users this notification is about
+     * @param array $recipients A list of recipients this notification will be sent to
+     * @param array $emailData Optional additional data passed to the email notification indexed by a recipient
+     */
     public function __construct(
         array $users,
         array $recipients,

--- a/plugins/UsersManager/UserNotifications/InactiveUsersNotificationProvider.php
+++ b/plugins/UsersManager/UserNotifications/InactiveUsersNotificationProvider.php
@@ -9,8 +9,10 @@
 
 namespace Piwik\Plugins\UsersManager\UserNotifications;
 
+use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Piwik;
+use Piwik\Plugins\UsersManager\SystemSettings;
 
 final class InactiveUsersNotificationProvider extends UserNotificationProvider
 {
@@ -21,6 +23,11 @@ final class InactiveUsersNotificationProvider extends UserNotificationProvider
 
     protected function getSetsOfUsersToNotify(): array
     {
+        $settings = StaticContainer::get(SystemSettings::class);
+        if (!$settings->enableInactiveUsersNotifications->getValue()) {
+            return [];
+        }
+
         return [$this->userModel->getUsersWithoutActivityForDays()];
     }
 

--- a/plugins/UsersManager/UserNotifications/InactiveUsersNotificationProvider.php
+++ b/plugins/UsersManager/UserNotifications/InactiveUsersNotificationProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\UserNotifications;
+
+use Piwik\Date;
+use Piwik\Piwik;
+
+final class InactiveUsersNotificationProvider extends UserNotificationProvider
+{
+    protected function createNotification(array $users): UserNotificationInterface
+    {
+        return new InactiveUsersEmailNotification($users, Piwik::getAllSuperUserAccessEmailAddresses());
+    }
+
+    protected function getSetsOfUsersToNotify(): array
+    {
+        return [$this->userModel->getUsersWithoutActivityForDays()];
+    }
+
+    public function setUserNotificationDispatched(array $users): void
+    {
+        $this->userModel->setInactiveUserNotificationWasSentForUsers(
+            $users,
+            Date::factory('now')->getDatetime()
+        );
+    }
+}

--- a/plugins/UsersManager/UserNotifications/UserEmailNotification.php
+++ b/plugins/UsersManager/UserNotifications/UserEmailNotification.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\UserNotifications;
+
+use Piwik\Container\StaticContainer;
+
+abstract class UserEmailNotification extends UserNotification
+{
+    /**
+     * A list of recipient emails
+     *
+     * @var array
+     */
+    private $recipients;
+
+    /**
+     * Data in the format of ['email@example.com' => ['item1' => 'value1'], ...] that will be passed to the email class
+     *
+     * @var array
+     */
+    private $emailData;
+
+    public function __construct(
+        array $users,
+        array $recipients,
+        array $emailData = []
+    ) {
+        parent::__construct($users);
+
+        $this->recipients = $recipients;
+        $this->emailData = $emailData;
+    }
+
+    abstract public function getEmailClass(): string;
+
+    public function dispatch(): bool
+    {
+        foreach ($this->recipients as $recipient) {
+            $email = StaticContainer::getContainer()->make(
+                $this->getEmailClass(),
+                [
+                    'notification' => $this,
+                    'recipient' => $recipient,
+                    'emailData' => $this->emailData[$recipient] ?? [],
+                ]
+            );
+            $email->safeSend();
+        }
+
+        return true;
+    }
+}

--- a/plugins/UsersManager/UserNotifications/UserEmailNotification.php
+++ b/plugins/UsersManager/UserNotifications/UserEmailNotification.php
@@ -27,6 +27,11 @@ abstract class UserEmailNotification extends UserNotification
      */
     private $emailData;
 
+    /**
+     * @param array $users A list of users this notification is about
+     * @param array $recipients A list of recipients this notification will be sent to
+     * @param array $emailData Optional additional data passed to the email notification indexed by a recipient
+     */
     public function __construct(
         array $users,
         array $recipients,

--- a/plugins/UsersManager/UserNotifications/UserNotification.php
+++ b/plugins/UsersManager/UserNotifications/UserNotification.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\UserNotifications;
+
+abstract class UserNotification implements UserNotificationInterface
+{
+    /**
+     * Data to hold for users, keyed by their username.
+     *
+     * @var array
+     */
+    private $users;
+
+    public function __construct(
+        array $users
+    ) {
+        $this->users = $users;
+    }
+
+    public function getUsers(): array
+    {
+        return $this->users;
+    }
+
+    abstract public function dispatch(): bool;
+}

--- a/plugins/UsersManager/UserNotifications/UserNotificationInterface.php
+++ b/plugins/UsersManager/UserNotifications/UserNotificationInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\UserNotifications;
+
+interface UserNotificationInterface
+{
+    public function getUsers(): array;
+
+    public function dispatch(): bool;
+}

--- a/plugins/UsersManager/UserNotifications/UserNotificationProvider.php
+++ b/plugins/UsersManager/UserNotifications/UserNotificationProvider.php
@@ -29,7 +29,7 @@ abstract class UserNotificationProvider implements UserNotificationProviderInter
     {
         $notifications = [];
 
-        foreach ($this->getSetsOfUsersToNotify() as $setOfUsers) {
+        foreach (array_filter($this->getSetsOfUsersToNotify()) as $setOfUsers) {
             $notifications[] = $this->createNotification($setOfUsers);
         }
 

--- a/plugins/UsersManager/UserNotifications/UserNotificationProvider.php
+++ b/plugins/UsersManager/UserNotifications/UserNotificationProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\UserNotifications;
+
+use Piwik\Plugins\UsersManager\Model as UserModel;
+
+abstract class UserNotificationProvider implements UserNotificationProviderInterface
+{
+    /** @var UserModel */
+    protected $userModel;
+
+    public function __construct()
+    {
+        $this->userModel = new UserModel();
+    }
+
+    abstract protected function createNotification(array $users): UserNotificationInterface;
+
+    abstract protected function getSetsOfUsersToNotify(): array;
+
+    public function getUserNotificationsForDispatch(): array
+    {
+        $notifications = [];
+
+        foreach ($this->getSetsOfUsersToNotify() as $setOfUsers) {
+            $notifications[] = $this->createNotification($setOfUsers);
+        }
+
+        return $notifications;
+    }
+}

--- a/plugins/UsersManager/UserNotifications/UserNotificationProviderInterface.php
+++ b/plugins/UsersManager/UserNotifications/UserNotificationProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\UserNotifications;
+
+interface UserNotificationProviderInterface
+{
+    /**
+     * Provides a list of user notifications to be dispatched,
+     * each with their data that can be used, e.g. to populate a notification email
+     *
+     * @return UserNotificationInterface[]
+     */
+    public function getUserNotificationsForDispatch(): array;
+
+    /**
+     * Sets information that a notification for a set of users has been dispatched
+     *
+     * @param array $users
+     * @return void
+     */
+    public function setUserNotificationDispatched(array $users): void;
+}

--- a/plugins/UsersManager/UserNotifications/UserNotifierTask.php
+++ b/plugins/UsersManager/UserNotifications/UserNotifierTask.php
@@ -20,7 +20,7 @@ use Piwik\Scheduler\Scheduler;
 use Piwik\Scheduler\Task;
 
 /**
- * Send token notifications for each provider
+ * Send user notifications for each provider
  */
 class UserNotifierTask extends Task
 {

--- a/plugins/UsersManager/UserNotifications/UserNotifierTask.php
+++ b/plugins/UsersManager/UserNotifications/UserNotifierTask.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\UserNotifications;
+
+use Exception;
+use Piwik\Container\StaticContainer;
+use Piwik\Date;
+use Piwik\Log\LoggerInterface;
+use Piwik\Option;
+use Piwik\Plugin\Manager as PluginManager;
+use Piwik\Scheduler\Schedule\Monthly;
+use Piwik\Scheduler\Scheduler;
+use Piwik\Scheduler\Task;
+
+/**
+ * Send token notifications for each provider
+ */
+class UserNotifierTask extends Task
+{
+    public const LAST_RUN_TIME_OPTION_NAME = 'UserNotifier.lastRunTime';
+
+    public function __construct()
+    {
+        $monthlyOnFirst = new Monthly();
+        $monthlyOnFirst->setDay(1);
+
+        parent::__construct($this, 'dispatchNotifications', null, $monthlyOnFirst);
+    }
+
+    /**
+     * Get a list of providers (class names) that may provide user notifications to be dispatched
+     *
+     * @return array
+     */
+    private function getUserNotificationProviderClasses(): array
+    {
+        return PluginManager::getInstance()->findMultipleComponents(
+            'UserNotifications',
+            UserNotificationProviderInterface::class
+        );
+    }
+
+    /**
+     * Dispatch notifications for each provider and its users
+     */
+    public function dispatchNotifications()
+    {
+        $container = StaticContainer::getContainer();
+        $logger = $container->get(LoggerInterface::class);
+
+        try {
+            Option::set(self::LAST_RUN_TIME_OPTION_NAME, Date::factory('today')->getTimestamp());
+
+            $notificationsToDispatchCount = 0;
+            $notificationsDispatchedCount = 0;
+
+            foreach ($this->getUserNotificationProviderClasses() as $providerClass) {
+                /** @var UserNotificationProviderInterface $provider */
+                $provider = $container->get($providerClass);
+
+                $providerUserNotificationsForDispatch = $provider->getUserNotificationsForDispatch();
+                $notificationsToDispatchCount += count($providerUserNotificationsForDispatch);
+
+                foreach ($providerUserNotificationsForDispatch as $userNotification) {
+                    $dispatched = $userNotification->dispatch();
+                    if ($dispatched) {
+                        $provider->setUserNotificationDispatched($userNotification->getUsers());
+                        $notificationsDispatchedCount++;
+                    }
+                }
+            }
+
+            // reschedule for next run
+            /** @var Scheduler $scheduler */
+            $scheduler = $container->get(Scheduler::class);
+            // reschedule to ensure it's not run again in an hour
+            $scheduler->rescheduleTask(new static());
+
+            if ($notificationsToDispatchCount) {
+                $logger->info(
+                    "Number of user notifications dispatched: {number} of {total}.",
+                    ['number' => $notificationsDispatchedCount, 'total' => $notificationsToDispatchCount]
+                );
+            } else {
+                $logger->info("No user notifications to dispatch, task rescheduled.");
+            }
+        } catch (Exception $ex) {
+            $container->get(LoggerInterface::class)->error($ex);
+            throw $ex;
+        }
+    }
+}

--- a/plugins/UsersManager/lang/en.json
+++ b/plugins/UsersManager/lang/en.json
@@ -260,6 +260,21 @@
         "AuthTokenExpirationWarningEmail01": "You’re receiving this email because your %1$s personal access token will expire on %2$s.",
         "AuthTokenExpirationWarningEmail02": "To generate a new token and delete the old one, go to Personal > Security settings in your Matomo instance.",
         "AuthTokenExpirationWarningEmail03": "If you believe you received this email in error, please contact your Matomo administrator.",
-        "AuthTokenExpirationWarningEmail04": "Manage your access tokens"
+        "AuthTokenExpirationWarningEmail04": "Manage your access tokens",
+        "InactiveUsersNotificationEmailSubject": "Security notice: Review inactive user accounts",
+        "InactiveUsersNotificationEmail01": "As part of Matomo’s commitment to data security and user account hygiene, we’re sending you this summary of user accounts that have not logged into your Matomo instance in the past 6 months.",
+        "InactiveUsersNotificationEmail02": "Regularly reviewing and removing inactive accounts helps reduce your security risk by:",
+        "InactiveUsersNotificationEmail02a": "Minimising exposure to account takeovers due to weak or reused passwords",
+        "InactiveUsersNotificationEmail02b": "Reducing the surface area of access in case of a breach",
+        "InactiveUsersNotificationEmail02c": "Ensuring only active users retain access to analytics data",
+        "InactiveUsersNotificationEmail03": "The following users have not logged in for over 6 months:",
+        "InactiveUsersNotificationEmail04": "You can review and manage all users here:",
+        "InactiveUsersNotificationEmail05": "If you determine these users no longer require access, we recommend removing their accounts from the system.",
+        "InactiveUsersNotificationEmail06": "For inactive superusers, please ensure none of their authentication tokens are used for tracking before deactivating them.",
+        "InactiveUsersNotificationEmail07": "This monthly security notification is enabled by default. If you prefer not to receive these updates in the future, you can disable the feature under: Administration > System > General Settings > UsersManager settings.",
+        "InactiveUserAccounts": "Inactive user accounts",
+        "DisablingThisNotification": "Disabling this notification",
+        "LastLoginDate": "Last login date",
+        "LastAPIUsageDate": "Last API usage date"
     }
 }

--- a/plugins/UsersManager/templates/_inactiveUsersNotificationHtmlEmail.twig
+++ b/plugins/UsersManager/templates/_inactiveUsersNotificationHtmlEmail.twig
@@ -22,7 +22,7 @@
     {% for inactiveUser in inactiveUsers %}
         <tr>
             <td>{{ inactiveUser.login }}</td>
-            <td>{{ inactiveUser.ts_last_login }}</td>
+            <td>{{ inactiveUser.ts_last_seen }}</td>
             <td>{{ inactiveUser.ts_last_token_activity|default('n/a') }}</td>
         </tr>
     {% endfor %}

--- a/plugins/UsersManager/templates/_inactiveUsersNotificationHtmlEmail.twig
+++ b/plugins/UsersManager/templates/_inactiveUsersNotificationHtmlEmail.twig
@@ -1,0 +1,38 @@
+<p>{{ 'General_HelloUser'|translate(superuserLogin) }}</p>
+<p>{{ 'UsersManager_InactiveUsersNotificationEmail01'|translate }}</p>
+<p>{{ 'UsersManager_InactiveUsersNotificationEmail02'|translate }}</p>
+<ul>
+    <li>{{ 'UsersManager_InactiveUsersNotificationEmail02a'|translate }}</li>
+    <li>{{ 'UsersManager_InactiveUsersNotificationEmail02b'|translate }}</li>
+    <li>{{ 'UsersManager_InactiveUsersNotificationEmail02c'|translate }}</li>
+</ul>
+
+<strong>{{ 'UsersManager_InactiveUserAccounts'|translate }}</strong>
+<p>{{ 'UsersManager_InactiveUsersNotificationEmail03'|translate }}</p>
+
+<table>
+    <thead>
+        <tr>
+            <th>{{ 'General_Username'|translate }}</th>
+            <th>{{ 'UsersManager_LastLoginDate'|translate }}</th>
+            <th>{{ 'UsersManager_LastAPIUsageDate'|translate }}</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for inactiveUser in inactiveUsers %}
+        <tr>
+            <td>{{ inactiveUser.login }}</td>
+            <td>{{ inactiveUser.ts_last_login }}</td>
+            <td>{{ inactiveUser.ts_last_token_activity|default('n/a') }}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+<p>{{ 'UsersManager_InactiveUsersNotificationEmail04'|translate }} <a href="{{ manageUsersLink|escape('html_attr') }}">{{ 'UsersManager_UsersManagement'|translate }}</a></p>
+<p>{{ 'UsersManager_InactiveUsersNotificationEmail05'|translate }}</p>
+<p>{{ 'UsersManager_InactiveUsersNotificationEmail06'|translate }}</p>
+
+<strong>{{ 'UsersManager_DisablingThisNotification'|translate }}</strong>
+
+<p>{{ 'UsersManager_InactiveUsersNotificationEmail07'|translate }}</p>

--- a/plugins/UsersManager/templates/_inactiveUsersNotificationTextEmail.twig
+++ b/plugins/UsersManager/templates/_inactiveUsersNotificationTextEmail.twig
@@ -14,7 +14,7 @@
 
 {{ 'General_Username'|translate }} | {{ 'UsersManager_LastLoginDate'|translate }} | {{ 'UsersManager_LastAPIUsageDate'|translate }}
 {% for inactiveUser in inactiveUsers %}
-{{ inactiveUser.login }} | {{ inactiveUser.ts_last_login }} | {{ inactiveUser.ts_last_token_activity|default('n/a') }}
+{{ inactiveUser.login }} | {{ inactiveUser.ts_last_seen }} | {{ inactiveUser.ts_last_token_activity|default('n/a') }}
 {% endfor %}
 
 {{ 'UsersManager_InactiveUsersNotificationEmail04'|translate }} {{ manageUsersLink }}

--- a/plugins/UsersManager/templates/_inactiveUsersNotificationTextEmail.twig
+++ b/plugins/UsersManager/templates/_inactiveUsersNotificationTextEmail.twig
@@ -1,0 +1,27 @@
+{% autoescape false %}
+{{ 'General_HelloUser'|translate(superuserLogin) }}
+
+{{ 'UsersManager_InactiveUsersNotificationEmail01'|translate }}
+{{ 'UsersManager_InactiveUsersNotificationEmail02'|translate }}
+
+- {{ 'UsersManager_InactiveUsersNotificationEmail02a'|translate }}
+- {{ 'UsersManager_InactiveUsersNotificationEmail02b'|translate }}
+- {{ 'UsersManager_InactiveUsersNotificationEmail02c'|translate }}
+
+{{ 'UsersManager_InactiveUserAccounts'|translate }}
+
+{{ 'UsersManager_InactiveUsersNotificationEmail03'|translate }}
+
+{{ 'General_Username'|translate }} | {{ 'UsersManager_LastLoginDate'|translate }} | {{ 'UsersManager_LastAPIUsageDate'|translate }}
+{% for inactiveUser in inactiveUsers %}
+{{ inactiveUser.login }} | {{ inactiveUser.ts_last_login }} | {{ inactiveUser.ts_last_token_activity|default('n/a') }}
+{% endfor %}
+
+{{ 'UsersManager_InactiveUsersNotificationEmail04'|translate }} {{ manageUsersLink }}
+{{ 'UsersManager_InactiveUsersNotificationEmail05'|translate }}
+{{ 'UsersManager_InactiveUsersNotificationEmail06'|translate }}
+
+{{ 'UsersManager_DisablingThisNotification'|translate }}
+
+{{ 'UsersManager_InactiveUsersNotificationEmail07'|translate }}
+{% endautoescape %}

--- a/plugins/UsersManager/tests/Fixtures/Tokens.php
+++ b/plugins/UsersManager/tests/Fixtures/Tokens.php
@@ -10,37 +10,46 @@
 namespace Piwik\Plugins\UsersManager\tests\Fixtures;
 
 use Piwik\Common;
+use Piwik\Date;
 use Piwik\Db;
 use Piwik\Plugins\UsersManager\API;
 use Piwik\Plugins\UsersManager\Model as UsersManagerModel;
 use Piwik\Tests\Framework\Fixture;
 
 /**
- * Generates auth tokens for token notification tests
+ * Generates auth tokens for token notification tests with an optional last_used date
  */
 class Tokens extends Fixture
 {
     public $tokens = [
         'user1' => [
-            ['user1, not expired user token, secure only', '2024-01-01 00:00:00', null, '0', '1'],
-            ['user1, not expired user token, not secure only', '2025-01-01 00:00:00', null, '0', '0'],
-            ['user1, not expired system token, secure only', '2024-01-01 00:00:00', null, '1', '1'],
-            ['user1, not expired system token, not secure only', '2025-01-01 00:00:00', null, '1', '0'],
-            ['user1, expired user token, secure only', '2024-01-01 00:00:00', '2024-02-01 00:00:00', '0', '1'],
-            ['user1, expired user token, not secure only', '2025-01-01 00:00:00', '2024-02-01 00:00:00', '0', '0'],
-            ['user1, expired system token, secure only', '2024-01-01 00:00:00', '2024-02-01 00:00:00', '1', '1'],
-            ['user1, expired system token, not secure only', '2025-01-01 00:00:00', '2024-02-01 00:00:00', '1', '0'],
+            [['user1, not expired user token, secure only', '2024-01-01 00:00:00', null, '0', '1'], '2024-09-01 00:00:00'],
+            [['user1, not expired user token, not secure only', '2025-01-01 00:00:00', null, '0', '0'], '2025-02-01 00:00:00'],
+            [['user1, not expired system token, secure only', '2024-01-01 00:00:00', null, '1', '1'], null],
+            [['user1, not expired system token, not secure only', '2025-01-01 00:00:00', null, '1', '0'], null],
+            [['user1, expired user token, secure only', '2024-01-01 00:00:00', '2024-02-01 00:00:00', '0', '1'], null],
+            [['user1, expired user token, not secure only', '2025-01-01 00:00:00', '2024-02-01 00:00:00', '0', '0'], null],
+            [['user1, expired system token, secure only', '2024-01-01 00:00:00', '2024-02-01 00:00:00', '1', '1'], null],
+            [['user1, expired system token, not secure only', '2025-01-01 00:00:00', '2024-02-01 00:00:00', '1', '0'], null],
         ],
         'user2' => [
-            ['user2, not expired user token, secure only', '2024-01-01 00:00:00', null, '0', '1'],
-            ['user2, not expired user token, not secure only', '2025-01-01 00:00:00', null, '0', '0'],
-            ['user2, not expired system token, secure only', '2024-01-01 00:00:00', null, '1', '1'],
-            ['user2, not expired system token, not secure only', '2025-01-01 00:00:00', null, '1', '0'],
-            ['user2, expired user token, secure only', '2024-01-01 00:00:00', '2024-02-01 00:00:00', '0', '1'],
-            ['user2, expired user token, not secure only', '2025-01-01 00:00:00', '2024-02-01 00:00:00', '0', '0'],
-            ['user2, expired system token, secure only', '2024-01-01 00:00:00', '2024-02-01 00:00:00', '1', '1'],
-            ['user2, expired system token, not secure only', '2025-01-01 00:00:00', '2024-02-01 00:00:00', '1', '0'],
+            [['user2, not expired user token, secure only', '2024-01-01 00:00:00', null, '0', '1'], null],
+            [['user2, not expired user token, not secure only', '2025-01-01 00:00:00', null, '0', '0'], null],
+            [['user2, not expired system token, secure only', '2024-01-01 00:00:00', null, '1', '1'], null],
+            [['user2, not expired system token, not secure only', '2025-01-01 00:00:00', null, '1', '0'], null],
+            [['user2, expired user token, secure only', '2024-01-01 00:00:00', '2024-02-01 00:00:00', '0', '1'], '2024-01-10 00:00:00'],
+            [['user2, expired user token, not secure only', '2025-01-01 00:00:00', '2024-02-01 00:00:00', '0', '0'], null],
+            [['user2, expired system token, secure only', '2024-01-01 00:00:00', '2024-02-01 00:00:00', '1', '1'], null],
+            [['user2, expired system token, not secure only', '2025-01-01 00:00:00', '2024-02-01 00:00:00', '1', '0'], null],
         ],
+        'user3' => [
+            [['user3, not expired user token, secure only, not used', '2024-01-01 00:00:00', null, '0', '1'], null],
+            [['user3, not expired user token, secure only, used', '2024-01-01 00:00:00', null, '0', '1'], '2024-09-01 00:00:00'],
+            [['user3, expired user token, secure only, not used', '2024-01-01 00:00:00', '2024-02-01 00:00:00', '0', '1'], null],
+            [['user3, expired user token, secure only, used', '2024-01-01 00:00:00', '2024-02-01 00:00:00', '0', '1'], '2024-09-01 00:00:00'],
+            [['user3, not expired system token, secure only, not used', '2024-01-01 00:00:00', null, '1', '1'], null],
+            [['user3, not expired system token, secure only, used', '2024-01-01 00:00:00', null, '1', '1'], '2024-09-01 00:00:00'],
+        ]
     ];
 
     public function setUp(): void
@@ -52,16 +61,26 @@ class Tokens extends Fixture
 
     private function setUpUsersAndTokens()
     {
-        $api = API::getInstance();
-        $api->addUser('user1', 'password1', 'user1@example.com');
-        $api->addUser('user2', 'password2', 'user2@example.com');
-        $api->setUserAccess('user2', 'view', [1]);
+        Date::$now = Date::factory('2024-01-01')->getTimestamp();
 
+        $api = API::getInstance();
         $model = new UsersManagerModel();
 
+        for ($i = 1; $i <= 5; $i++) {
+            $api->addUser("user$i", "password$i", "user$i@example.com");
+            $api->setUserAccess("user$i", 'view', [1]);
+        }
+        $model->setSuperUserAccess('user1', true);
+        $model->setLastSeenTimestamp('user2', Date::factory('2024-09-29')->getTimestamp());
+        $model->setLastSeenTimestamp('user4', Date::factory('2024-09-29')->getTimestamp());
+
         foreach ($this->tokens as $user => $tokens) {
-            foreach ($tokens as $token) {
-                $model->addTokenAuth($user, $model->generateRandomTokenAuth(), ...$token);
+            foreach ($tokens as $tokenArray) {
+                $tokenAuth = $model->generateRandomTokenAuth();
+                $model->addTokenAuth($user, $tokenAuth, ...$tokenArray[0]);
+                if ($lastUsed = $tokenArray[1]) {
+                    $model->setTokenAuthWasUsed($tokenAuth, $lastUsed);
+                }
             }
         }
     }
@@ -69,5 +88,10 @@ class Tokens extends Fixture
     public function resetTsRotationNotification()
     {
         Db::get()->query("UPDATE " . Common::prefixTable('user_token_auth') . " SET ts_rotation_notified = NULL");
+    }
+
+    public function resetTsInactivityNotification()
+    {
+        Db::get()->query("UPDATE " . Common::prefixTable('user') . " SET ts_inactivity_notified = NULL");
     }
 }

--- a/plugins/UsersManager/tests/Integration/AuthTokenRotationNotificationEmailTest.php
+++ b/plugins/UsersManager/tests/Integration/AuthTokenRotationNotificationEmailTest.php
@@ -69,9 +69,9 @@ class AuthTokenRotationNotificationEmailTest extends IntegrationTestCase
 
         // for standard 180 days, we have one token notification for each of two users
         $this->clearCaptureAndDispatch();
-        self::assertEquals(2, count($this->capturedNotifications));
-        self::assertEquals(['user1', 'user2'], array_column($this->capturedNotifications, 1));
-        self::assertEquals(['2024-01-01 00:00:00', '2024-01-01 00:00:00'], array_column($this->capturedNotifications, 3));
+        self::assertEquals(5, count($this->capturedNotifications));
+        self::assertEquals(['user1', 'user2', 'user3', 'user3', 'superUserLogin'], array_column($this->capturedNotifications, 1));
+        self::assertEquals(['2024-01-01 00:00:00'], array_unique(array_column($this->capturedNotifications, 3)));
 
         // all notifications sent already, should be zero now
         $this->clearCaptureAndDispatch();
@@ -79,8 +79,8 @@ class AuthTokenRotationNotificationEmailTest extends IntegrationTestCase
 
         // after removing the notification timestamp, we should have two notifications again, both in 2024
         $this->clearCaptureAndDispatch(true);
-        self::assertEquals(2, count($this->capturedNotifications));
-        self::assertEquals(['2024-01-01 00:00:00', '2024-01-01 00:00:00'], array_column($this->capturedNotifications, 3));
+        self::assertEquals(5, count($this->capturedNotifications));
+        self::assertEquals(['2024-01-01 00:00:00'], array_unique(array_column($this->capturedNotifications, 3)));
 
         // change rotation notification interval to 30 days
         Config::getInstance()->General['auth_token_rotation_notification_days'] = 30;

--- a/plugins/UsersManager/tests/Integration/InactiveUsersNotificationEmailTest.php
+++ b/plugins/UsersManager/tests/Integration/InactiveUsersNotificationEmailTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Integration;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use Piwik\Container\StaticContainer;
+use Piwik\Date;
+use Piwik\Plugins\UsersManager\SystemSettings;
+use Piwik\Plugins\UsersManager\tests\Fixtures\Tokens as TokensFixture;
+use Piwik\Plugins\UsersManager\UserNotifications\UserNotifierTask;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group UsersManager
+ * @group InactiveUsersNotificationEmailTest
+ * @group UserNotifications
+ * @group Plugins
+ */
+class InactiveUsersNotificationEmailTest extends IntegrationTestCase
+{
+    /**
+     * @var TokensFixture
+     */
+    public static $fixture;
+
+    protected $capturedNotifications = [];
+
+    protected $task;
+
+    protected $systemSetting;
+
+    /**
+     * @throws \Exception
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createSuperUser();
+        Fixture::loadAllTranslations();
+
+        $this->task = new UserNotifierTask();
+
+        $settings = StaticContainer::get(SystemSettings::class);
+        $this->systemSetting = $settings->enableInactiveUsersNotifications;
+
+        $this->enableInactiveUsersNotifications();
+    }
+
+    public function tearDown(): void
+    {
+        $this->disableInactiveUsersNotifications();
+    }
+
+    private function enableInactiveUsersNotifications(): void
+    {
+        $this->systemSetting->setValue(true);
+    }
+
+    private function disableInactiveUsersNotifications(): void
+    {
+        $this->systemSetting->setValue(false);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function clearCaptureAndDispatch(bool $resetTsNotified = false): void
+    {
+        if ($resetTsNotified) {
+            self::$fixture->resetTsInactivityNotification();
+        }
+        $this->capturedNotifications = [];
+        $this->task->dispatchNotifications();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testDispatchAuthTokenNotificationEmail()
+    {
+        Date::$now = Date::factory('2025-04-01')->getTimestamp();
+
+        // for standard 180 days, we have one notification for each of two superusers
+        $this->clearCaptureAndDispatch();
+        self::assertEquals(2, count($this->capturedNotifications));
+
+        // all notifications sent already, should be zero now
+        $this->clearCaptureAndDispatch();
+        self::assertEquals(0, count($this->capturedNotifications));
+
+        // after removing the notification timestamp, we should have two notifications again, both in 2024
+        $this->clearCaptureAndDispatch(true);
+        self::assertEquals(2, count($this->capturedNotifications));
+
+        // TODO: add assertions on the actual table data for user names, last seen and last activity
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testNoNotificationIsSentWhenTodayIsBeforeUsersCreated()
+    {
+        Date::$now = Date::factory('2023-12-01')->getTimestamp();
+        $this->clearCaptureAndDispatch(true);
+        self::assertEquals(0, count($this->capturedNotifications));
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testNoNotificationIsSentWhenFeatureDisabled()
+    {
+        $this->disableInactiveUsersNotifications();
+        $this->clearCaptureAndDispatch(true);
+
+        self::assertEquals(0, count($this->capturedNotifications));
+    }
+
+    public function provideContainerConfig(): array
+    {
+        return [
+            'Piwik\Access' => new FakeAccess(),
+            'observers.global' => \Piwik\DI::add([
+                ['Test.Mail.send', \Piwik\DI::value(function (PHPMailer $mail) {
+                    $body = $mail->createBody();
+                    $body = preg_replace("/=[\r\n]+/", '', $body);
+                    preg_match('|Hello, (.*?)!.*<tbody>(.*)</tbody>|isu', $body, $matches);
+                    if (count($matches) === 3) {
+                        $superuser = $matches[1];
+                        preg_match_all('|<tr>(.*?)</tr>|isu', $matches[2], $tableRows);
+                        if (count($tableRows) > 0) {
+                            foreach ($tableRows[1] as $tableRow) {
+                                preg_match_all('|<td>(.*?)</td>|isu', $tableRow, $tableCells);
+                                if (count($tableCells) === 2) {
+                                    $inactiveUserInfo = [
+                                        'login' => $tableCells[1][0],
+                                        'last_seen' => $tableCells[1][1],
+                                        'last_token_activity' => $tableCells[1][2],
+                                    ];
+                                    $this->capturedNotifications[$superuser][] = $inactiveUserInfo;
+                                }
+                            }
+                        }
+                    }
+                })],
+            ]),
+        ];
+    }
+}
+
+InactiveUsersNotificationEmailTest::$fixture = new TokensFixture();

--- a/plugins/UsersManager/tests/Integration/InactiveUsersNotificationEmailTest.php
+++ b/plugins/UsersManager/tests/Integration/InactiveUsersNotificationEmailTest.php
@@ -12,6 +12,7 @@ namespace Integration;
 use PHPMailer\PHPMailer\PHPMailer;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
+use Piwik\Plugins\UsersManager\Model as UsersManagerModel;
 use Piwik\Plugins\UsersManager\SystemSettings;
 use Piwik\Plugins\UsersManager\tests\Fixtures\Tokens as TokensFixture;
 use Piwik\Plugins\UsersManager\UserNotifications\UserNotifierTask;
@@ -38,6 +39,8 @@ class InactiveUsersNotificationEmailTest extends IntegrationTestCase
 
     protected $systemSetting;
 
+    protected $userModel;
+
     /**
      * @throws \Exception
      */
@@ -49,6 +52,7 @@ class InactiveUsersNotificationEmailTest extends IntegrationTestCase
         Fixture::loadAllTranslations();
 
         $this->task = new UserNotifierTask();
+        $this->userModel = new UsersManagerModel();
 
         $settings = StaticContainer::get(SystemSettings::class);
         $this->systemSetting = $settings->enableInactiveUsersNotifications;
@@ -98,11 +102,36 @@ class InactiveUsersNotificationEmailTest extends IntegrationTestCase
         $this->clearCaptureAndDispatch();
         self::assertEquals(0, count($this->capturedNotifications));
 
-        // after removing the notification timestamp, we should have two notifications again, both in 2024
+        // after removing the notification timestamp, we should have two notifications again
         $this->clearCaptureAndDispatch(true);
         self::assertEquals(2, count($this->capturedNotifications));
+        self::assertEquals(['superUserLogin', 'user1'], array_keys($this->capturedNotifications));
 
-        // TODO: add assertions on the actual table data for user names, last seen and last activity
+        // after removing super access from the second user, we should only get one notification
+        $this->userModel->setSuperUserAccess('user1', false);
+        $this->clearCaptureAndDispatch(true);
+        self::assertEquals(1, count($this->capturedNotifications));
+        self::assertEquals(['superUserLogin'], array_keys($this->capturedNotifications));
+
+        $notification = $this->capturedNotifications['superUserLogin'];
+        self::assertEquals(6, count($notification));
+
+        // if there's a token for a user, and it hasn't been used, and the user haven't logged in
+        // the token activity is the same as last seen for the user, which is both when they were created
+        self::assertEquals($notification[0]['last_token_activity'], $notification[0]['last_seen']);
+
+        // for user1, the fixture sets a custom last token activity
+        self::assertEquals('user1', $notification[1]['login']);
+        self::assertEquals('2025-02-01 00:00:00', $notification[1]['last_token_activity']);
+
+        // for user2, the fixture sets a custom last seen date, which is within 180 days from 'now'
+        self::assertEquals('user2', $notification[2]['login']);
+        self::assertEquals('2024-09-29 00:00:00', $notification[2]['last_seen']);
+
+        // for user4, the fixture does not create a token, so it was never used, and sets a custom last-seen date
+        self::assertEquals('user4', $notification[4]['login']);
+        self::assertEquals('2024-09-29 00:00:00', $notification[4]['last_seen']);
+        self::assertEquals('n/a', $notification[4]['last_token_activity']);
     }
 
     /**

--- a/plugins/UsersManager/tests/Integration/UsersManagerTest.php
+++ b/plugins/UsersManager/tests/Integration/UsersManagerTest.php
@@ -113,6 +113,7 @@ class UsersManagerTest extends IntegrationTestCase
         unset($userAfter['invite_accept_at']);
         unset($userAfter['invited_by']);
         unset($userAfter['ts_last_seen']);
+        unset($userAfter['ts_inactivity_notified']);
 
         // implicitly checks password!
         $user['email'] = $newEmail;


### PR DESCRIPTION
### Description:

- Add a scheduled task to run once a month
- Add email templates for inactive users security notification
- Add notification providers and other classes similar to how token notifications are handled
- Add integration tests

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
