### PR TITLE
Update text used in system settings update notification email to be more accurate

### DIFF
--- a/plugins/CoreAdminHome/Emails/SecurityNotificationEmail.php
+++ b/plugins/CoreAdminHome/Emails/SecurityNotificationEmail.php
@@ -16,7 +16,7 @@ use Piwik\Piwik;
 abstract class SecurityNotificationEmail extends Mail
 {
     public static $notifyPluginList = [
-        'Login' => 'CoreAdminHome_BruteForce',
+        'Login' => 'CoreAdminHome_Login',
         'TwoFactorAuth' => 'CoreAdminHome_TwoFactorAuth',
         'CoreAdminHome' => 'CoreAdminHome_Cors'
     ];

--- a/plugins/CoreAdminHome/lang/en.json
+++ b/plugins/CoreAdminHome/lang/en.json
@@ -5,6 +5,7 @@
         "ArchivingSettings": "Archiving settings",
         "BrandingSettings": "Branding settings",
         "BruteForce": "Brute Force",
+        "Login": "Login",
         "CheckToOptIn": "Check this box to opt-in.",
         "ClickHereToOptIn": "Click here to opt in.",
         "ClickHereToOptOut": "Click here to opt out.",


### PR DESCRIPTION
### Description:

The old text in the system settings email was specific to only 1 settings present in the Login section of system settings. Now it more accurately reflects what has changed.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
