### PR TITLE
Fix invalidation processing for report specific archives for periods including today

### DIFF
--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -613,10 +613,17 @@ class QueueConsumer
     public function usableArchiveExists(array $invalidatedArchive): array
     {
         $site = new Site($invalidatedArchive['idsite']);
-
         $periodLabel = $this->periodIdsToLabels[$invalidatedArchive['period']];
         $dateStr = $periodLabel == 'range' ? ($invalidatedArchive['date1'] . ',' . $invalidatedArchive['date2']) : $invalidatedArchive['date1'];
         $period = PeriodFactory::build($periodLabel, $dateStr);
+
+        // if requested period does not include today, invalidation always needs to be processed
+        // so we always return no usable archive was found
+        $today = Date::factoryInTimezone('today', Site::getTimezoneFor($site->getId()));
+        $isArchiveIncludesToday = $period->isDateInPeriod($today);
+        if (!$isArchiveIncludesToday) {
+            return [false, null];
+        }
 
         $segment = new Segment($invalidatedArchive['segment'], [$invalidatedArchive['idsite']]);
 
@@ -625,17 +632,10 @@ class QueueConsumer
             $params->setRequestedPlugin($invalidatedArchive['plugin']);
         }
         if (!empty($invalidatedArchive['report'])) {
-            $params->setRequestedPlugin($invalidatedArchive['report']);
+            $params->setArchiveOnlyReport($invalidatedArchive['report']);
         }
 
-        // if latest archive includes today and is usable (DONE_OK or DONE_INVALIDATED and recent enough), skip
-        $today = Date::factoryInTimezone('today', Site::getTimezoneFor($site->getId()));
-        $isArchiveIncludesToday = $period->isDateInPeriod($today);
-        if (!$isArchiveIncludesToday) {
-            return [false, null];
-        }
-
-        // if valid archive already exists, do not re-archive
+        // For archives including today we look if there are existing usable archives (DONE_OK or DONE_INVALIDATED) that are recent enough
         $minDateTimeProcessedUTC = Date::now()->subSeconds(Rules::getPeriodArchiveTimeToLiveDefault($periodLabel));
         $archiveIdAndVisits = ArchiveSelector::getArchiveIdAndVisits($params, $minDateTimeProcessedUTC, $includeInvalidated = false);
         $idArchives = $archiveIdAndVisits['idArchives'];

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -247,7 +247,7 @@ class QueueConsumer
                 continue;
             }
 
-            list($isUsableExists, $archivedTime) = $this->usableArchiveExists($invalidatedArchive);
+            [$isUsableExists, $archivedTime] = $this->usableArchiveExists($invalidatedArchive);
             if ($isUsableExists) {
                 $now = Date::now()->getDatetime();
                 $this->addInvalidationToExclude($invalidatedArchive);
@@ -623,6 +623,9 @@ class QueueConsumer
         $params = new Parameters($site, $period, $segment);
         if (!empty($invalidatedArchive['plugin'])) {
             $params->setRequestedPlugin($invalidatedArchive['plugin']);
+        }
+        if (!empty($invalidatedArchive['report'])) {
+            $params->setRequestedPlugin($invalidatedArchive['report']);
         }
 
         // if latest archive includes today and is usable (DONE_OK or DONE_INVALIDATED and recent enough), skip


### PR DESCRIPTION
### Description:

While working on some archiving related stuff I came across the fact, that `QueueConsumer::usableArchiveExists` did not respect if only a specific report is requested.

Not taking the requested report into account can cause problems in one specific edgecase:

- A plugin specific archive for a period including today already exists, but does not include all reports for that plugin
- An invalidation for a specific report of that plugin, which is not included in the existing archive, is requested

Currently the invalidation request would be simply discarded, as the existing archive would be considered usable, even though it actually doesn't contain the requested report.

For validation: The newly added test case `testUsableArchiveExistsReturnsFalseIfPeriodIncludesTodayAndExistingPluginArchiveIsRecentButDoesNotContainRequestedReport` should currently fail on `5.x-dev`

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
