### PR TITLE
Remove CASE/WHEN around aggregate function in favour of a simple boolean expression

### DIFF
--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -487,11 +487,9 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
     protected function updateQuerySelectFromForSiteSearch(string &$select, array &$from): void
     {
         $selectFlagNoResultKeywords = ",
-                CASE WHEN (MAX(log_link_visit_action.search_count) = 0)
-                THEN 1 ELSE 0 END
-                    AS `" . PiwikMetrics::INDEX_SITE_SEARCH_HAS_NO_RESULT . "`";
+                MAX(log_link_visit_action.search_count) = 0 AS `" . PiwikMetrics::INDEX_SITE_SEARCH_HAS_NO_RESULT . "`";
 
-        //we need an extra JOIN to know whether the referrer "idaction_name_ref" was a Site Search request
+        // we need an extra JOIN to know whether the referrer "idaction_name_ref" was a Site Search request
         $from[] = array(
             "table"      => "log_action",
             "tableAlias" => "log_action_name_ref",


### PR DESCRIPTION
### Description:

A tweak to support Oracle Heatwave compatibility. The resulting value should be logically identical.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
