### PR TITLE
Ensure partial archives are marked correctly

### DIFF
--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -276,11 +276,9 @@ class Loader
         if ($createSeparateArchiveForCoreMetrics) {
             $requestedPlugin = $this->params->getRequestedPlugin();
             $requestedReport = $this->params->getArchiveOnlyReport();
-            $isPartialArchive = $this->params->isPartialArchive();
 
             $this->params->setRequestedPlugin('VisitsSummary');
             $this->params->setArchiveOnlyReport(null);
-            $this->params->setIsPartialArchive(false);
 
             $metrics = Context::executeWithQueryParameters(['requestedReport' => ''], function () {
                 $pluginsArchiver = new PluginsArchiver($this->params);
@@ -291,7 +289,6 @@ class Loader
 
             $this->params->setRequestedPlugin($requestedPlugin);
             $this->params->setArchiveOnlyReport($requestedReport);
-            $this->params->setIsPartialArchive($isPartialArchive);
 
             $visits = $metrics['nb_visits'];
             $visitsConverted = $metrics['nb_visits_converted'];

--- a/core/ArchiveProcessor/Parameters.php
+++ b/core/ArchiveProcessor/Parameters.php
@@ -53,7 +53,7 @@ class Parameters
     /**
      * @var bool
      */
-    private $isArchiveOnlyReportHandled;
+    private $isArchiveOnlyReportHandled = false;
 
     /**
      * @var string[]|null
@@ -290,6 +290,10 @@ class Parameters
             return false;
         }
 
+        if (!empty($this->getArchiveOnlyReport())) {
+            return true;
+        }
+
         return $this->isArchiveOnlyReportHandled;
     }
 
@@ -299,6 +303,7 @@ class Parameters
      * in an Archiver's __construct method.
      *
      * @param bool $isArchiveOnlyReportHandled
+     * @deprecated use `setArchiveOnlyReport` instead
      */
     public function setIsPartialArchive($isArchiveOnlyReportHandled)
     {

--- a/core/Plugin/Archiver.php
+++ b/core/Plugin/Archiver.php
@@ -205,11 +205,6 @@ class Archiver
                 $allRecordBuilders = $this->getRecordBuilders($pluginName);
                 $recordBuilders = $this->filterRecordBuildersByRequestedRecords($allRecordBuilders, $this->processor->getParams()->getArchiveOnlyReportAsArray());
 
-                // If the plugin provides record builders and only a specific record was requested, we mark the archive as partial
-                if (count($allRecordBuilders) > 0 && $this->processor->getParams()->getArchiveOnlyReport()) {
-                    $this->processor->getParams()->setIsPartialArchive(true);
-                }
-
                 foreach ($recordBuilders as $recordBuilder) {
                     if (!$recordBuilder->isEnabled($this->getProcessor())) {
                         continue;
@@ -247,11 +242,6 @@ class Archiver
             if (Manager::getInstance()->isPluginLoaded($pluginName)) {
                 $allRecordBuilders = $this->getRecordBuilders($pluginName);
                 $recordBuilders = $this->filterRecordBuildersByRequestedRecords($allRecordBuilders, $this->processor->getParams()->getArchiveOnlyReportAsArray());
-
-                // If the plugin provides record builders and only a specific record was requested, we mark the archive as partial
-                if (count($allRecordBuilders) > 0 && $this->processor->getParams()->getArchiveOnlyReport()) {
-                    $this->processor->getParams()->setIsPartialArchive(true);
-                }
 
                 foreach ($recordBuilders as $recordBuilder) {
                     if (!$recordBuilder->isEnabled($this->getProcessor())) {

--- a/plugins/Goals/tests/System/ProcessDependentArchiveTest.php
+++ b/plugins/Goals/tests/System/ProcessDependentArchiveTest.php
@@ -43,13 +43,13 @@ class ProcessDependentArchiveTest extends SystemTestCase
     public function testNumArchivesCreated()
     {
         API::getInstance()->get(self::$fixture->idSite, 'range', $this->requestRange);
-        $this->assertNumRangeArchives(6);
+        $this->assertNumRangeArchives(5);
     }
 
     public function testNumArchivesCreatedWithSegment()
     {
         API::getInstance()->get(self::$fixture->idSite, 'range', $this->requestRange, 'userId!@%2540matomo.org;userId!=hello%2540matomo.org');
-        $this->assertNumRangeArchives(6);
+        $this->assertNumRangeArchives(5);
     }
 
     private function assertNumRangeArchives($expectedArchives, $period = 5)

--- a/tests/PHPUnit/Integration/Archive/PartialArchiveTest.php
+++ b/tests/PHPUnit/Integration/Archive/PartialArchiveTest.php
@@ -107,7 +107,7 @@ class PartialArchiveTest extends IntegrationTestCase
         $this->assertEquals([
             // expect only one blob for new range partial archive
             ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => 5, 'name' => 'done.Goals', 'value' => 5, 'blob_count' => 0],
-            ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => 5, 'name' => 'done.VisitsSummary', 'value' => 1, 'blob_count' => 0],
+            ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => 5, 'name' => 'done.VisitsSummary', 'value' => 5, 'blob_count' => 0],
         ], $archiveInfo);
     }
 

--- a/tests/PHPUnit/Integration/Archive/PartialArchiveTest.php
+++ b/tests/PHPUnit/Integration/Archive/PartialArchiveTest.php
@@ -13,9 +13,11 @@ use Piwik\Archive\ArchiveInvalidator;
 use Piwik\Cache;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
+use Piwik\DataAccess\ArchiveWriter;
 use Piwik\Date;
 use Piwik\Db;
 use Piwik\Metrics;
+use Piwik\Period\Range;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Plugins\Goals\API as GoalsApi;
@@ -59,9 +61,9 @@ class PartialArchiveTest extends IntegrationTestCase
         ], $data->getFirstRow()->getColumns());
 
         // check archive is all plugins archive as expected
-        [$idArchives, $archiveInfo] = $this->getArchiveInfo('2020_04', 5, false);
+        [$idArchives, $archiveInfo] = $this->getArchiveInfo('2020_04', Range::PERIOD_ID, false);
         $this->assertEquals([
-            ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => 5, 'name' => 'done', 'value' => 1, 'blob_count' => 58],
+            ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => Range::PERIOD_ID, 'name' => 'done', 'value' => ArchiveWriter::DONE_OK, 'blob_count' => 58],
         ], $archiveInfo);
 
         $maxIdArchive = $this->getMaxIdArchive('2020_04');
@@ -92,7 +94,7 @@ class PartialArchiveTest extends IntegrationTestCase
             'conversion_rate_returning_visit' => 'Intl_NumberFormatPercent',
         ], $data->getFirstRow()->getColumns());
 
-        [$idArchives, $archiveInfo] = $this->getArchiveInfo('2020_04', 5, false, $maxIdArchive);
+        [$idArchives, $archiveInfo] = $this->getArchiveInfo('2020_04', Range::PERIOD_ID, false, $maxIdArchive);
 
         $archiveNames = $this->getArchiveNames('2020_04', $idArchives[0], 'numeric');
         $this->assertEquals([
@@ -106,8 +108,8 @@ class PartialArchiveTest extends IntegrationTestCase
 
         $this->assertEquals([
             // expect only one blob for new range partial archive
-            ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => 5, 'name' => 'done.Goals', 'value' => 5, 'blob_count' => 0],
-            ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => 5, 'name' => 'done.VisitsSummary', 'value' => 5, 'blob_count' => 0],
+            ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => Range::PERIOD_ID, 'name' => 'done.Goals', 'value' => ArchiveWriter::DONE_PARTIAL, 'blob_count' => 0],
+            ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => Range::PERIOD_ID, 'name' => 'done.VisitsSummary', 'value' => ArchiveWriter::DONE_PARTIAL, 'blob_count' => 0],
         ], $archiveInfo);
     }
 
@@ -120,9 +122,9 @@ class PartialArchiveTest extends IntegrationTestCase
         $this->assertEquals(['label' => '0-0', Metrics::INDEX_NB_CONVERSIONS => 1], $data->getFirstRow()->getColumns());
 
         // check archive is all plugins archive as expected
-        [$idArchives, $archiveInfo] = $this->getArchiveInfo('2020_04', 5, false);
+        [$idArchives, $archiveInfo] = $this->getArchiveInfo('2020_04', Range::PERIOD_ID, false);
         $this->assertEquals([
-            ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => 5, 'name' => 'done', 'value' => 1, 'blob_count' => 58],
+            ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => Range::PERIOD_ID, 'name' => 'done', 'value' => ArchiveWriter::DONE_OK, 'blob_count' => 58],
         ], $archiveInfo);
 
         $maxIdArchive = $this->getMaxIdArchive('2020_04');
@@ -140,14 +142,14 @@ class PartialArchiveTest extends IntegrationTestCase
         $data = GoalsApi::getInstance()->getDaysToConversion(1, 'range', '2020-04-06,2020-04-09', false, $this->idGoal);
         $this->assertEquals(['label' => '0-0', Metrics::INDEX_NB_CONVERSIONS => 2], $data->getFirstRow()->getColumns());
 
-        [$idArchives, $archiveInfo] = $this->getArchiveInfo('2020_04', 5, false, $maxIdArchive);
+        [$idArchives, $archiveInfo] = $this->getArchiveInfo('2020_04', Range::PERIOD_ID, false, $maxIdArchive);
 
         $archiveNames = $this->getArchiveNames('2020_04', $idArchives[0]);
         $this->assertEquals(['Goal_1_days_until_conv'], $archiveNames);
 
         $this->assertEquals([
             // expect only one blob for new range partial archive
-            ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => 5, 'name' => 'done.Goals', 'value' => 5, 'blob_count' => 1],
+            ['idsite' => 1, 'date1' => '2020-04-06', 'date2' => '2020-04-09', 'period' => Range::PERIOD_ID, 'name' => 'done.Goals', 'value' => ArchiveWriter::DONE_PARTIAL, 'blob_count' => 1],
         ], $archiveInfo);
     }
 

--- a/tests/PHPUnit/Integration/ArchiveProcessingTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessingTest.php
@@ -435,7 +435,7 @@ class ArchiveProcessingTest extends IntegrationTestCase
 
         foreach ($allMetrics as $date => $metrics) {
             /** @var ArchiveWriter $archiveWriter */
-            list($archiveProcessor, $archiveWriter, $params) = $this->createArchiveProcessorInst('day', $date, $site->getId());
+            [$archiveProcessor, $archiveWriter, $params] = $this->createArchiveProcessorInst('day', $date, $site->getId());
             $archiveWriter->initNewArchive();
 
             $archiveProcessor->insertNumericRecords($metrics);
@@ -444,7 +444,7 @@ class ArchiveProcessingTest extends IntegrationTestCase
         }
 
         /** @var ArchiveProcessor $archiveProcessor */
-        list($archiveProcessor, $archiveWriter, $params) = $this->createArchiveProcessorInst('week', '2015-02-03', $site->getId());
+        [$archiveProcessor, $archiveWriter, $params] = $this->createArchiveProcessorInst('week', '2015-02-03', $site->getId());
         $archiveWriter->initNewArchive();
 
         $archiveProcessor->captureInserts();
@@ -489,7 +489,7 @@ class ArchiveProcessingTest extends IntegrationTestCase
 
         foreach ($allMetrics as $date => $metrics) {
             /** @var ArchiveWriter $archiveWriter */
-            list($archiveProcessor, $archiveWriter) = $this->createArchiveProcessorInst('day', $date, $site->getId());
+            [$archiveProcessor, $archiveWriter] = $this->createArchiveProcessorInst('day', $date, $site->getId());
             $archiveWriter->initNewArchive();
 
             $archiveProcessor->insertNumericRecords($metrics);
@@ -498,8 +498,8 @@ class ArchiveProcessingTest extends IntegrationTestCase
         }
 
         /** @var ArchiveProcessor $archiveProcessor */
-        list($archiveProcessor, $archiveWriter, $params) = $this->createArchiveProcessorInst('week', '2015-02-03', $site->getId(), 'nb_visits', 'VisitsSummary');
-        $params->setIsPartialArchive(true);
+        [$archiveProcessor, $archiveWriter, $params] = $this->createArchiveProcessorInst('week', '2015-02-03', $site->getId(), 'nb_visits', 'VisitsSummary');
+        $params->setArchiveOnlyReport('report');
         $idArchive = $archiveWriter->initNewArchive();
 
         $archiveProcessor->captureInserts();
@@ -548,7 +548,7 @@ class ArchiveProcessingTest extends IntegrationTestCase
 
         foreach ($tables as $date => $table) {
             /** @var ArchiveWriter $archiveWriter */
-            list($archiveProcessor, $archiveWriter) = $this->createArchiveProcessorInst('day', $date, $site->getId());
+            [$archiveProcessor, $archiveWriter] = $this->createArchiveProcessorInst('day', $date, $site->getId());
             $archiveWriter->initNewArchive();
 
             $tableSerialized = $table->getSerialized();
@@ -557,7 +557,7 @@ class ArchiveProcessingTest extends IntegrationTestCase
             $archiveWriter->finalizeArchive();
         }
 
-        list($archiveProcessor, $archiveWriter) = $this->createArchiveProcessorInst('week', '2015-02-03', $site->getId());
+        [$archiveProcessor, $archiveWriter] = $this->createArchiveProcessorInst('week', '2015-02-03', $site->getId());
         $archiveWriter->initNewArchive();
 
         $archiveProcessor->captureInserts();
@@ -614,7 +614,7 @@ END;
 
         foreach ($tables as $date => $table) {
             /** @var ArchiveWriter $archiveWriter */
-            list($archiveProcessor, $archiveWriter) = $this->createArchiveProcessorInst('day', $date, $site->getId());
+            [$archiveProcessor, $archiveWriter] = $this->createArchiveProcessorInst('day', $date, $site->getId());
             $archiveWriter->initNewArchive();
 
             $tableSerialized = $table->getSerialized();
@@ -624,8 +624,8 @@ END;
         }
 
         /** @var ArchiveProcessor $archiveProcessor */
-        list($archiveProcessor, $archiveWriter, $params) = $this->createArchiveProcessorInst('week', '2015-02-03', $site->getId(), 'Actions_test_value', 'VisitsSummary');
-        $params->setIsPartialArchive(true);
+        [$archiveProcessor, $archiveWriter, $params] = $this->createArchiveProcessorInst('week', '2015-02-03', $site->getId(), 'Actions_test_value', 'VisitsSummary');
+        $params->setArchiveOnlyReport('report');
         $idArchive = $archiveWriter->initNewArchive();
 
         $archiveProcessor->captureInserts();
@@ -668,7 +668,7 @@ END;
 
         foreach ($tables as $date => $table) {
             /** @var ArchiveWriter $archiveWriter */
-            list($archiveProcessor, $archiveWriter) = $this->createArchiveProcessorInst('day', $date, $site->getId());
+            [$archiveProcessor, $archiveWriter] = $this->createArchiveProcessorInst('day', $date, $site->getId());
             $archiveWriter->initNewArchive();
 
             $tableSerialized = $table->getSerialized();
@@ -677,7 +677,7 @@ END;
             $archiveWriter->finalizeArchive();
         }
 
-        list($archiveProcessor, $archiveWriter) = $this->createArchiveProcessorInst('week', '2015-02-03', $site->getId());
+        [$archiveProcessor, $archiveWriter] = $this->createArchiveProcessorInst('week', '2015-02-03', $site->getId());
         $archiveWriter->initNewArchive();
 
         $archiveProcessor->captureInserts();

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -111,7 +111,7 @@ class ArchiveTest extends IntegrationTestCase
         $params = new Parameters(new Site($idSite), Factory::build('day', '2014-05-07'), new Segment('', [$idSite]));
         $params->setRequestedPlugin('ExamplePlugin');
         $params->onlyArchiveRequestedPlugin();
-        $params->setIsPartialArchive(true);
+        $params->setArchiveOnlyReport(['ExamplePlugin_archive2metric', 'ExamplePlugin_archive3metric']);
         $archiveWriter = new ArchiveWriter($params);
         $archiveWriter->initNewArchive();
         $archiveWriter->insertRecord('ExamplePlugin_archive2metric', 2);
@@ -124,7 +124,7 @@ class ArchiveTest extends IntegrationTestCase
         $params = new Parameters(new Site($idSite), Factory::build('day', '2014-05-07'), new Segment('', [$idSite]));
         $params->setRequestedPlugin('ExamplePlugin');
         $params->onlyArchiveRequestedPlugin();
-        $params->setIsPartialArchive(true);
+        $params->setArchiveOnlyReport('ExamplePlugin_archive3metric');
         $archiveWriter = new ArchiveWriter($params);
         $archiveWriter->initNewArchive();
         $archiveWriter->insertRecord('ExamplePlugin_archive3metric', 7);

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -194,9 +194,9 @@ class ArchiveTest extends IntegrationTestCase
         $archives = Db::fetchAll("SELECT date1, date2, name, value FROM " . Common::prefixTable('archive_numeric_2020_03')
             . " WHERE `name` IN ('done', 'done.VisitsSummary')");
         $expected = [
-            ['date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => '1'],
-            ['date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'value' => '1'],
-            ['date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'value' => '1'],
+            ['date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => ArchiveWriter::DONE_PARTIAL],
+            ['date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'value' => ArchiveWriter::DONE_OK],
+            ['date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'value' => ArchiveWriter::DONE_OK],
         ];
         $this->assertEquals($expected, $archives);
 
@@ -217,9 +217,9 @@ class ArchiveTest extends IntegrationTestCase
         $archives = Db::fetchAll("SELECT date1, date2, name, value FROM " . Common::prefixTable('archive_numeric_2020_03')
             . " WHERE `name` IN ('done', 'done.VisitsSummary')");
         $expected = [
-            ['date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => '4'],
-            ['date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'value' => '1'],
-            ['date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'value' => '4'],
+            ['date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => ArchiveWriter::DONE_INVALIDATED],
+            ['date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'value' => ArchiveWriter::DONE_OK],
+            ['date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'value' => ArchiveWriter::DONE_INVALIDATED],
         ];
         $this->assertEquals($expected, $archives);
 
@@ -231,9 +231,10 @@ class ArchiveTest extends IntegrationTestCase
         $archives = Db::fetchAll("SELECT idarchive, date1, date2, name, value FROM " . Common::prefixTable('archive_numeric_2020_03')
             . " WHERE `name` IN ('done', 'done.VisitsSummary')");
         $expected = [
-            ['idarchive' => '2', 'date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'value' => '1'],
-            ['idarchive' => '5', 'date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'value' => '4'],
-            ['idarchive' => '8', 'date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => '1'],
+            ['idarchive' => '1', 'date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => ArchiveWriter::DONE_INVALIDATED],
+            ['idarchive' => '2', 'date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'value' => ArchiveWriter::DONE_OK],
+            ['idarchive' => '5', 'date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'value' => ArchiveWriter::DONE_INVALIDATED],
+            ['idarchive' => '8', 'date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => ArchiveWriter::DONE_PARTIAL],
         ];
         $this->assertEquals($expected, $archives);
 
@@ -246,9 +247,10 @@ class ArchiveTest extends IntegrationTestCase
         $archives = Db::fetchAll("SELECT idarchive, date1, date2, name, value FROM " . Common::prefixTable('archive_numeric_2020_03')
             . " WHERE `name` IN ('done', 'done.VisitsSummary')");
         $expected = [
-            ['idarchive' => '2', 'date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'value' => '1'],
-            ['idarchive' => '8', 'date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => '1'],
-            ['idarchive' => '9', 'date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'value' => '1'],
+            ['idarchive' => '1', 'date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => ArchiveWriter::DONE_INVALIDATED],
+            ['idarchive' => '2', 'date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'value' => ArchiveWriter::DONE_OK],
+            ['idarchive' => '8', 'date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => ArchiveWriter::DONE_PARTIAL],
+            ['idarchive' => '9', 'date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'value' => ArchiveWriter::DONE_OK],
         ];
         $this->assertEquals($expected, $archives);
 
@@ -259,9 +261,11 @@ class ArchiveTest extends IntegrationTestCase
         $archives = Db::fetchAll("SELECT idarchive, date1, date2, name, value FROM " . Common::prefixTable('archive_numeric_2020_03')
             . " WHERE `name` IN ('done', 'done.VisitsSummary')");
         $expected = [
-            ['idarchive' => '2', 'date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'value' => '1'],
-            ['idarchive' => '9', 'date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'value' => '1'],
-            ['idarchive' => '12', 'date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => '1'],
+            ['idarchive' => '1', 'date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => ArchiveWriter::DONE_INVALIDATED],
+            ['idarchive' => '2', 'date1' => '2020-03-04', 'date2' => '2020-03-04', 'name' => 'done', 'value' => ArchiveWriter::DONE_OK],
+            ['idarchive' => '8', 'date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => ArchiveWriter::DONE_PARTIAL],
+            ['idarchive' => '9', 'date1' => '2020-03-05', 'date2' => '2020-03-05', 'name' => 'done', 'value' => ArchiveWriter::DONE_OK],
+            ['idarchive' => '12', 'date1' => '2020-03-04', 'date2' => '2020-03-05', 'name' => 'done.VisitsSummary', 'value' => ArchiveWriter::DONE_PARTIAL],
         ];
         $this->assertEquals($expected, $archives);
     }

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveWriterTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveWriterTest.php
@@ -269,7 +269,7 @@ class ArchiveWriterTest extends IntegrationTestCase
         $params  = new Parameters(new Site($this->idSite), $oPeriod, $segment);
         if ($isPartial) {
             $params->setRequestedPlugin('ExamplePlugin');
-            $params->setIsPartialArchive(true);
+            $params->setArchiveOnlyReport('report');
         }
         $writer  = new TestArchiveWriter($params);
         return $writer;


### PR DESCRIPTION
### Description:

When only specific reports are requested, e.g. during range or browser archiving, Matomo might only built those requested reports. Archives created should then be marked as partial, to ensure they are considered as full archives (as certain metrics might be missing).

Currenlty that handling is done by multiple methods that actually have similar purpose:
`setArchiveOnlyReport` and `setIsPartialArchive`.

This PR aims to combine that. As soon as `setArchiveOnlyReport` is being used to set requested reports, the archive should be automatically considered partial. Therefor `setIsPartialArchive` will be deprecated and should no longer be used.

Based on https://github.com/matomo-org/matomo/pull/23412

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
