### PR TITLE
Fix return value for FakeAccess token auth

### DIFF
--- a/tests/PHPUnit/Framework/Mock/FakeAccess.php
+++ b/tests/PHPUnit/Framework/Mock/FakeAccess.php
@@ -42,7 +42,7 @@ class FakeAccess extends Access
 
     public function getTokenAuth()
     {
-        return false;
+        return null;
     }
 
     public function __construct($superUser = false, $idSitesAdmin = array(), $idSitesView = array(), $identity = 'superUserLogin', $idSitesWrite = array())


### PR DESCRIPTION
### Description:

The access mock used in several tests is return a fixed `false` value. The interface however is typed as `string|null`:

https://github.com/matomo-org/matomo/blob/aa6585c860585a9ba9ebd134e5a1be29a043aad0/core/Access.php#L344-L352

Changing the value to match the interface should prevent problems if we decide to enforce the return type later.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
