### PR TITLE
Implement EOL warning for used database version

### DIFF
--- a/core/Db/Schema.php
+++ b/core/Db/Schema.php
@@ -325,4 +325,28 @@ class Schema extends Singleton
     {
         return $this->getSchema()->getSupportedReadIsolationTransactionLevel();
     }
+
+    /**
+     * Returns the type of the current database (e.g. MySQL, MariaDb, ...)
+     */
+    public function getDatabaseType(): string
+    {
+        return $this->getSchema()->getDatabaseType();
+    }
+
+    /**
+     * Returns the version of the currently used database server
+     */
+    public function getVersion(): string
+    {
+        return $this->getSchema()->getVersion();
+    }
+
+    /**
+     * Returns if the currently used database version has reach its EOL
+     */
+    public function hasReachedEOL(): string
+    {
+        return $this->getSchema()->hasReachedEOL();
+    }
 }

--- a/core/Db/Schema/Mariadb.php
+++ b/core/Db/Schema/Mariadb.php
@@ -9,11 +9,18 @@
 
 namespace Piwik\Db\Schema;
 
+use Piwik\Date;
+
 /**
  * Mariadb schema
  */
 class Mariadb extends Mysql
 {
+    public function getDatabaseType(): string
+    {
+        return 'MariaDb';
+    }
+
     /**
      * Adds a max_statement_time hint into a SELECT query if $limit is bigger than 0
      *
@@ -47,6 +54,47 @@ class Mariadb extends Mysql
 
     public function supportsRankingRollupWithoutExtraSorting(): bool
     {
+        return false;
+    }
+
+    public function hasReachedEOL(): bool
+    {
+        $currentVersion = $this->getVersion();
+
+        // End of security update for certain MariaDb versions as of https://mariadb.org/about/#maintenance-policy
+
+        // Support for 10.6 LTS ends on 6th July 2026
+        if (
+            version_compare($currentVersion, '10.6', '>=') &&
+            version_compare($currentVersion, '10.7', '<') &&
+            Date::today()->isEarlier(Date::factory('2026-07-07'))
+        ) {
+            return false;
+        }
+
+        // Support for 10.11 LTS ends on 16th February 2028
+        if (
+            version_compare($currentVersion, '10.11', '>=') &&
+            version_compare($currentVersion, '10.12', '<') &&
+            Date::today()->isEarlier(Date::factory('2028-02-17'))
+        ) {
+            return false;
+        }
+
+        // Support for 11.4 LTS ends on 29th May 2029
+        if (
+            version_compare($currentVersion, '11.4', '>=') &&
+            version_compare($currentVersion, '11.5', '<') &&
+            Date::today()->isEarlier(Date::factory('2029-05-30'))
+        ) {
+            return false;
+        }
+
+        // Support for all versions prior 11.8 already ended
+        if (version_compare($currentVersion, '11.8', '<')) {
+            return true;
+        }
+
         return false;
     }
 }

--- a/core/Db/Schema/Mariadb.php
+++ b/core/Db/Schema/Mariadb.php
@@ -18,7 +18,7 @@ class Mariadb extends Mysql
 {
     public function getDatabaseType(): string
     {
-        return 'MariaDb';
+        return 'MariaDB';
     }
 
     /**
@@ -90,7 +90,7 @@ class Mariadb extends Mysql
             return false;
         }
 
-        // Support for all versions prior 11.8 already ended
+        // Support for all versions prior to 11.8 (not covered by conditions above) already ended
         if (version_compare($currentVersion, '11.8', '<')) {
             return true;
         }

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -33,6 +33,11 @@ class Mysql implements SchemaInterface
 
     private $tablesInstalled = null;
 
+    public function getDatabaseType(): string
+    {
+        return 'MySQL';
+    }
+
     /**
      * Get the SQL to create Piwik tables
      *
@@ -786,6 +791,43 @@ class Mysql implements SchemaInterface
         return 'READ UNCOMMITTED';
     }
 
+    public function hasReachedEOL(): bool
+    {
+        $currentVersion = $this->getVersion();
+
+        // Aurora is managed by AWS and is updated automatically if EOL, therefor we can ignore that here
+        if (str_contains(strtolower($currentVersion), 'aurora')) {
+            return false;
+        }
+
+        // End of security update for certain MySQL versions as of https://en.wikipedia.org/wiki/MySQL#Release_history
+
+        // Support for 8.0 LTS ends in April 2026
+        if (
+            version_compare($currentVersion, '8.0', '>=') &&
+            version_compare($currentVersion, '8.1', '<') &&
+            Date::today()->isEarlier(Date::factory('2026-05-01'))
+        ) {
+            return false;
+        }
+
+        // Support for 8.4 LTS ends in April 2032
+        if (
+            version_compare($currentVersion, '8.4', '>=') &&
+            version_compare($currentVersion, '8.5', '<') &&
+            Date::today()->isEarlier(Date::factory('2032-05-01'))
+        ) {
+            return false;
+        }
+
+        // Support for all other versions prior 9.3 already ended
+        if (version_compare($currentVersion, '9.3', '<')) {
+            return true;
+        }
+
+        return false;
+    }
+
     protected function getDatabaseCreateOptions(): string
     {
         $charset = DbHelper::getDefaultCharset();
@@ -825,7 +867,7 @@ class Mysql implements SchemaInterface
         return $this->getDbSettings()->getTablePrefix();
     }
 
-    protected function getVersion(): string
+    public function getVersion(): string
     {
         return Db::fetchOne("SELECT VERSION()");
     }

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -796,7 +796,9 @@ class Mysql implements SchemaInterface
         $currentVersion = $this->getVersion();
 
         // Aurora is managed by AWS and is updated automatically if EOL, therefor we can ignore that here
-        if (str_contains(strtolower($currentVersion), 'aurora')) {
+        $auroraQuery = $this->getDb()->query('SHOW VARIABLES LIKE "aurora%"');
+
+        if ($this->getDb()->rowCount($auroraQuery) > 0) {
             return false;
         }
 

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -820,7 +820,7 @@ class Mysql implements SchemaInterface
             return false;
         }
 
-        // Support for all other versions prior 9.3 already ended
+        // Support for all other versions prior to 9.3 (not covered by conditions above) already ended
         if (version_compare($currentVersion, '9.3', '<')) {
             return true;
         }

--- a/core/Db/Schema/Tidb.php
+++ b/core/Db/Schema/Tidb.php
@@ -14,6 +14,11 @@ namespace Piwik\Db\Schema;
  */
 class Tidb extends Mysql
 {
+    public function getDatabaseType(): string
+    {
+        return 'TiDb';
+    }
+
     /**
      * TiDB performs a sanity check before performing e.g. ALTER TABLE statements. If any of the used columns does not
      * exist before the query fails. This also happens if the column would be added in the same query.
@@ -87,5 +92,11 @@ class Tidb extends Mysql
     {
         // TiDB doesn't support READ UNCOMMITTED
         return 'READ COMMITTED';
+    }
+
+    public function hasReachedEOL(): bool
+    {
+        // ignore in EOL checks
+        return false;
     }
 }

--- a/core/Db/SchemaInterface.php
+++ b/core/Db/SchemaInterface.php
@@ -15,7 +15,7 @@ namespace Piwik\Db;
 interface SchemaInterface
 {
     /**
-     * Returns the type of the current database (e.g. MySQL, MariaDb, ...)
+     * Returns the type of the current database (e.g. MySQL, MariaDB, ...)
      */
     public function getDatabaseType(): string;
 

--- a/core/Db/SchemaInterface.php
+++ b/core/Db/SchemaInterface.php
@@ -15,6 +15,11 @@ namespace Piwik\Db;
 interface SchemaInterface
 {
     /**
+     * Returns the type of the current database (e.g. MySQL, MariaDb, ...)
+     */
+    public function getDatabaseType(): string;
+
+    /**
      * Get the SQL to create a specific Matomo table
      *
      * @param string $tableName
@@ -192,4 +197,16 @@ interface SchemaInterface
      * @return bool
      */
     public function supportsSortingInSubquery(): bool;
+
+    /**
+     * Returns the version of the database server
+     * @return string
+     */
+    public function getVersion(): string;
+
+    /**
+     * Returns if the used database version has reached its EOL
+     * @return bool
+     */
+    public function hasReachedEOL(): bool;
 }

--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -304,7 +304,7 @@ abstract class ControllerAdmin extends Controller
         NotificationManager::notify('PHPVersionCheck', $notification);
     }
 
-    private static function notifyWhenDatabaseVersionIsEOL()
+    private static function notifyWhenDatabaseVersionIsEOL(): void
     {
         if (defined('PIWIK_TEST_MODE')) { // to avoid changing every admin UI test
             return;

--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -13,6 +13,7 @@ use Piwik\Config as PiwikConfig;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
+use Piwik\Db\Schema;
 use Piwik\Development;
 use Piwik\Exception\MissingFilePermissionException;
 use Piwik\Menu\MenuAdmin;
@@ -303,6 +304,31 @@ abstract class ControllerAdmin extends Controller
         NotificationManager::notify('PHPVersionCheck', $notification);
     }
 
+    private static function notifyWhenDatabaseVersionIsEOL()
+    {
+        if (defined('PIWIK_TEST_MODE')) { // to avoid changing every admin UI test
+            return;
+        }
+
+        $isEOL = Piwik::hasUserSuperUserAccess() && Schema::getInstance()->hasReachedEOL();
+        if (!$isEOL) {
+            return;
+        }
+
+        $databaseVersion = Schema::getInstance()->getVersion();
+
+        $message = Piwik::translate('General_WarningDatabaseVersionXIsTooOld', [Schema::getInstance()->getDatabaseType(), $databaseVersion]);
+
+        $notification = new Notification($message);
+        $notification->raw = true;
+        $notification->title = Piwik::translate('General_Warning');
+        $notification->priority = Notification::PRIORITY_LOW;
+        $notification->context = Notification::CONTEXT_WARNING;
+        $notification->type = Notification::TYPE_TRANSIENT;
+        $notification->flags = Notification::FLAG_NO_CLEAR;
+        NotificationManager::notify('DatabaseVersionCheck', $notification);
+    }
+
     private static function notifyWhenDebugOnDemandIsEnabled($trackerSetting)
     {
         if (
@@ -373,6 +399,7 @@ abstract class ControllerAdmin extends Controller
         self::notifyAnyInvalidPlugin();
         self::notifyWhenPhpVersionIsEOL();
         self::notifyWhenPhpVersionIsNotCompatibleWithNextMajorPiwik();
+        self::notifyWhenDatabaseVersionIsEOL();
         self::notifyWhenDebugOnDemandIsEnabled('debug');
         self::notifyWhenDebugOnDemandIsEnabled('debug_on_demand');
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -534,6 +534,7 @@
         "WarningFileIntegrityNoHashFile": "File integrity check could not be completed due to missing hash_file() function.",
         "WarningPasswordStored": "%1$sWarning:%2$s This password will be stored in the config file visible to everybody who can access it.",
         "WarningPhpVersionXIsTooOld": "The PHP version %s you are using has reached its End of Life (EOL). You are strongly urged to upgrade to a current version, as using this version may expose you to security vulnerabilities and bugs that have been fixed in more recent versions of PHP.",
+        "WarningDatabaseVersionXIsTooOld": "The %1$s version %2$s you are using has reached its End of Life (EOL). You are strongly urged to upgrade to a current version, as using this version may expose you to security vulnerabilities and bugs that have been fixed in more recent versions of %1$s.",
         "WarningPiwikWillStopSupportingPHPVersion": "Matomo will stop supporting PHP %1$s in the next major version. Upgrade your PHP to at least PHP %2$s, before it's too late!",
         "Warnings": "Warnings",
         "Website": "Website",


### PR DESCRIPTION
### Description:

Matomo already warns if someone is using an outdated PHP version that has reached EOL.
However, this was not yet done for the used database version.

This PR adds such a warning depending on the used database type, as the version numbers meanwhile differ between MariaDb and MySQL.

If Aurora is detected there will never be a warning, as it's managed by AWS and therefor never should be considered EOL.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
