### PR TITLE
Update ecommerce overview comparisons to use correct data

### DIFF
--- a/plugins/Ecommerce/Controller.php
+++ b/plugins/Ecommerce/Controller.php
@@ -90,7 +90,12 @@ class Controller extends \Piwik\Plugins\Goals\Controller
             $date = Common::getRequestVar('date');
 
             /** @var DataTable $previousData */
-            $previousData = Request::processRequest('Goals.get', ['date' => $lastPeriodDate, 'format_metrics' => 0]);
+            $previousData = Request::processRequest(
+                'Goals.get',
+                ['date' => $lastPeriodDate,
+                'format_metrics' => 0,
+                'idGoal' => $idGoal]
+            );
             $previousDataRow = $previousData->getFirstRow();
 
             $return = $this->addSparklineEvolutionValues($return, $idGoal, $date, $lastPeriodDate, $dataRow, $previousDataRow);

--- a/plugins/Goals/tests/UI/GoalsPages_spec.js
+++ b/plugins/Goals/tests/UI/GoalsPages_spec.js
@@ -22,6 +22,13 @@ describe("GoalsPages", function () {
     expect(await page.screenshotSelector('.pageWrap')).to.matchImage('ecommerce');
   });
 
+  it('should show the correct relative data for the revenue in-cart tooltip', async function() {
+    const element = await page.jQuery('#rightcolumn sparkline:eq(1) .metricEvolution');
+    await element.hover();
+    const tooltip = await page.waitForSelector('.ui-tooltip', { visible: true });
+    expect(await tooltip.screenshot()).to.matchImage('revenue_incart_tooltip');
+  });
+
   it('should load the goals > overview page correctly', async function () {
     await page.goto("?" + urlBase + "#?" + generalParams + "&category=Goals_Goals&subcategory=General_Overview");
     await page.waitForNetworkIdle();

--- a/plugins/Goals/tests/UI/GoalsPages_spec.js
+++ b/plugins/Goals/tests/UI/GoalsPages_spec.js
@@ -23,6 +23,9 @@ describe("GoalsPages", function () {
   });
 
   it('should show the correct relative data for the revenue in-cart tooltip', async function() {
+    var monthParams = 'idSite=1&period=month&date=2012-08-09';
+    await page.goto("?" + urlBase + "#?" + monthParams + "&category=Goals_Ecommerce&subcategory=General_Overview");
+    await page.waitForNetworkIdle();
     const element = await page.jQuery('#rightcolumn .sparkline:eq(1) .metricEvolution');
     await element.hover();
     const tooltip = await page.waitForSelector('.ui-tooltip', { visible: true });

--- a/plugins/Goals/tests/UI/GoalsPages_spec.js
+++ b/plugins/Goals/tests/UI/GoalsPages_spec.js
@@ -23,7 +23,7 @@ describe("GoalsPages", function () {
   });
 
   it('should show the correct relative data for the revenue in-cart tooltip', async function() {
-    var monthParams = 'idSite=1&period=month&date=2012-08-09';
+    var monthParams = 'idSite=1&period=month&date=2012-01-09';
     await page.goto("?" + urlBase + "#?" + monthParams + "&category=Goals_Ecommerce&subcategory=General_Overview");
     await page.waitForNetworkIdle();
     const element = await page.jQuery('#rightcolumn .sparkline:eq(1) .metricEvolution');

--- a/plugins/Goals/tests/UI/GoalsPages_spec.js
+++ b/plugins/Goals/tests/UI/GoalsPages_spec.js
@@ -23,7 +23,7 @@ describe("GoalsPages", function () {
   });
 
   it('should show the correct relative data for the revenue in-cart tooltip', async function() {
-    const element = await page.jQuery('#rightcolumn sparkline:eq(1) .metricEvolution');
+    const element = await page.jQuery('#rightcolumn .sparkline:eq(1) .metricEvolution');
     await element.hover();
     const tooltip = await page.waitForSelector('.ui-tooltip', { visible: true });
     expect(await tooltip.screenshot()).to.matchImage('revenue_incart_tooltip');

--- a/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_overview_row_evolution.png
+++ b/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_overview_row_evolution.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5362685bd11c4af1a5deb794dc5ae041279ceb0d05f5badb3321004efcf1751b
-size 182819
+oid sha256:623e6eff83615f6159c983aa8a5f0d4fcbc774114489d89b47d4d5495a7c86d0
+size 182564

--- a/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_overview_row_evolution.png
+++ b/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_overview_row_evolution.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:623e6eff83615f6159c983aa8a5f0d4fcbc774114489d89b47d4d5495a7c86d0
-size 182564
+oid sha256:5362685bd11c4af1a5deb794dc5ae041279ceb0d05f5badb3321004efcf1751b
+size 182819

--- a/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_revenue_incart_tooltip.png
+++ b/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_revenue_incart_tooltip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91c1562102d1d7bbfd5daea1b62692f93d57f710687b2da0666d06c043cb3ab5
+size 129053

--- a/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_revenue_incart_tooltip.png
+++ b/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_revenue_incart_tooltip.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8afb39a15b5831e8f8f6d62694f0c0b0c6c2f6d75026dfe96f8cff1159a6c4f6
-size 6622
+oid sha256:a68180751bcd14d5ca8fd4e515c75ff026fc05ab1de3a88cc08217d805708c93
+size 6888

--- a/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_revenue_incart_tooltip.png
+++ b/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_revenue_incart_tooltip.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:91c1562102d1d7bbfd5daea1b62692f93d57f710687b2da0666d06c043cb3ab5
-size 129053
+oid sha256:8afb39a15b5831e8f8f6d62694f0c0b0c6c2f6d75026dfe96f8cff1159a6c4f6
+size 6622

--- a/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_revenue_incart_tooltip.png
+++ b/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_revenue_incart_tooltip.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a68180751bcd14d5ca8fd4e515c75ff026fc05ab1de3a88cc08217d805708c93
-size 6888
+oid sha256:8df99e6b6c05b8d45ab403d471a11566610b4f190a76f82710050121932b911b
+size 7775


### PR DESCRIPTION
### Description:

addresses #23417

The current sparklines on the ecommerce overview pages are seperated into two groups, orders and abandoned carts. The abandoned carts sparklines are using incorrect data for the previous periods, which is resulting in incorrect relative percentages and absolute values.

This change fixes that by ensuring the correct data is retrieved when the sparklines are created. Previously the `idGoal` was not being passed to the API call which retrieves the data, and so the API defaults to `ecommerceOrder`, where it should be `ecommerceAbandonedCart` for the abandoned cart call. This is addressed by correctly passing the `idGoal` parameter to the API. This fixes the resulting  sparklines to use the correct data.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
