### PR TITLE
Avoid requesting flat row evolution for page url report

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable_rowactions.js
+++ b/plugins/CoreHome/javascripts/dataTable_rowactions.js
@@ -364,7 +364,54 @@ DataTable_RowActions_RowEvolution.prototype.performAction = function (label, tr,
     }
 
     if (this.dataTable.param.flat !== undefined) {
-        extraParams['flat'] = this.dataTable.param.flat;
+        var unflattenActionLabel = function(label) {
+            return label.split(',').map(function(item) {
+                var hasAt = item.startsWith('@');
+                if (hasAt) {
+                    item = item.slice(1);
+                }
+
+                item = decodeURIComponent(item);
+
+                if (item === '/') {
+                    return (hasAt ? '@' : '') + encodeURIComponent('/index');
+                }
+
+                var isIndex = false;
+
+                if (item.endsWith('/')) {
+                    item = item.slice(0, -1);
+                    isIndex = true;
+                }
+                if (item.startsWith('/')) {
+                    item = item.slice(1);
+                }
+
+                var parts = item.split('/').map(encodeURIComponent);
+
+                if (isIndex) {
+                    parts.push(encodeURIComponent('/index'));
+                } else {
+                    parts[parts.length - 1] = '/' + parts[parts.length - 1];
+                }
+
+                if (hasAt) {
+                    parts[parts.length - 1] = '@' + parts[parts.length - 1];
+                }
+
+                return parts.join(' > ');
+            }).join(',');
+        };
+
+        if (
+          this.dataTable.param.module === 'Actions' && this.dataTable.param.action === 'getPageUrls'
+          && this.dataTable.param.flat && label.indexOf(' > ') === -1
+        ) {
+            label = unflattenActionLabel(label);
+            extraParams['flat'] = 0;
+        } else {
+            extraParams['flat'] = this.dataTable.param.flat;
+        }
     }
 
     var apiMethod = this.dataTable.param.module + '.' + this.dataTable.param.action;

--- a/plugins/CoreHome/javascripts/dataTable_rowactions.js
+++ b/plugins/CoreHome/javascripts/dataTable_rowactions.js
@@ -407,6 +407,13 @@ DataTable_RowActions_RowEvolution.prototype.performAction = function (label, tr,
           this.dataTable.param.module === 'Actions' && this.dataTable.param.action === 'getPageUrls'
           && this.dataTable.param.flat && label.indexOf(' > ') === -1
         ) {
+            // Requesting a row evolution for a flattened page url report can easily reach memory limits
+            // This happens due to the fact, that requesting a report flattened, will currently process
+            // the data for ALL subtables, for all periods shown in the row evolution.
+            // We actually would only need to fetch the data for the requested labels.
+            // Till this was refactored in the backend, this hack will convert the flattened request
+            // into a request that would come from a subtable. This is handled differently by the backend
+            // and will only process the requested labels in the backend.
             label = unflattenActionLabel(label);
             extraParams['flat'] = 0;
         } else {

--- a/plugins/CoreHome/javascripts/dataTable_rowactions.js
+++ b/plugins/CoreHome/javascripts/dataTable_rowactions.js
@@ -365,16 +365,24 @@ DataTable_RowActions_RowEvolution.prototype.performAction = function (label, tr,
 
     if (this.dataTable.param.flat !== undefined) {
         var unflattenActionLabel = function(label) {
+            // To "unflatten" a label we need to convert labels from e.g.
+            // * @%2Fblog%2Fauthor%2Fjulien%2F
+            // * @%2Fcontact
+            // * @%2Fanalytics%2Fcultizer
+            // to e.g.
+            // * blog > author > julien > @%2Findex
+            // * @%2Fcontact
+            // * analytics > @%2Fcultizer
             return label.split(',').map(function(item) {
-                var hasAt = item.startsWith('@');
-                if (hasAt) {
+                var startsWithAt  = item.startsWith('@');
+                if (startsWithAt ) {
                     item = item.slice(1);
                 }
 
                 item = decodeURIComponent(item);
 
                 if (item === '/') {
-                    return (hasAt ? '@' : '') + encodeURIComponent('/index');
+                    return (startsWithAt  ? '@' : '') + encodeURIComponent('/index');
                 }
 
                 var isIndex = false;
@@ -395,7 +403,7 @@ DataTable_RowActions_RowEvolution.prototype.performAction = function (label, tr,
                     parts[parts.length - 1] = '/' + parts[parts.length - 1];
                 }
 
-                if (hasAt) {
+                if (startsWithAt ) {
                     parts[parts.length - 1] = '@' + parts[parts.length - 1];
                 }
 


### PR DESCRIPTION
### Description:

Requesting a row evolution on a flattened action report currently can be very memory intense and slow.

This is caused by the fact, that for each period shown in the row evolution the full flattened report will be generated and afterwards filtered. This can easily exhaust the memory limit.

Requesting a row evolution for a subtable record within the action report however is a lot faster. In this case initially only the main report will be requested. The label filter will then load only those subtables that are needed. So lees memory is used in this case.

This PR doesn't fix the root cause, as that would require some larger changes how filtered flattened reports are processed.
Instead this PR adjusts the JavaScript so when a row evolution for a flattened action report is requested, the request will be converted into an equal request for a subtable row evolution.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
