### PR TITLE
Ignore dynamically created local static sites for tracking testing

### DIFF
--- a/.ddev/.gitignore
+++ b/.ddev/.gitignore
@@ -6,6 +6,7 @@
 /.importdb*
 /.sshimageBuild
 /.webimageBuild
+/apache/apache-static-sites.conf
 /commands/.gitattributes
 /config.local.y*ml
 /config.*.local.y*ml

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ php_errors.log
 /misc/user/logo.svg
 /misc/user/favicon.png
 /misc/user/*.js
+/misc/static-sites
 /piwik-min.js
 /plugins/*.zip
 /plugins/ImageGraph/fonts/unifont.ttf


### PR DESCRIPTION
### Description:

Two simple .gitignore additions so that dynamically created internal static sites are ignored.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
