### PR TITLE
Allow legacy/bc timezones when creating sites (through API)

### DIFF
--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -959,13 +959,10 @@ class API extends \Piwik\Plugin\API
 
     private function checkValidTimezone($timezone)
     {
-        $timezones = $this->getTimezonesList();
-        foreach (array_values($timezones) as $cities) {
-            foreach ($cities as $timezoneId => $city) {
-                if ($timezoneId == $timezone) {
-                    return true;
-                }
-            }
+        $timezones = DateTimeZone::listIdentifiers(DateTimeZone::ALL_WITH_BC);
+        $timezones = array_merge($timezones, array_keys($this->getTimezonesListUTCOffsets()));
+        if (in_array($timezone, $timezones)) {
+            return true;
         }
         throw new Exception($this->translator->translate('SitesManager_ExceptionInvalidTimezone', [$timezone]));
     }

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -959,6 +959,12 @@ class API extends \Piwik\Plugin\API
 
     private function checkValidTimezone($timezone)
     {
+        try {
+            Date::factory('today', $timezone);
+        } catch (\Exception $e) {
+            throw new Exception($this->translator->translate('SitesManager_ExceptionInvalidTimezone', [$timezone]));
+        }
+
         $timezones = DateTimeZone::listIdentifiers(DateTimeZone::ALL_WITH_BC);
         $timezones = array_merge($timezones, array_keys($this->getTimezonesListUTCOffsets()));
         if (in_array($timezone, $timezones)) {

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -1828,6 +1828,30 @@ class ApiTest extends IntegrationTestCase
         ];
     }
 
+    public function testAddSiteWithLegacyTimezoneWorks()
+    {
+        $timezone = current(array_diff(
+            \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC),
+            \DateTimeZone::listIdentifiers(\DateTimeZone::ALL)
+        ));
+
+        $idSite = API::getInstance()->addSite(
+            "site1",
+            ['http://example.org'],
+            $ecommerce = 0,
+            $siteSearch = 1,
+            $searchKeywordParameters = null,
+            $searchCategoryParameters = null,
+            $ip = '',
+            $params = '',
+            $timezone
+        );
+
+        $site = new Site($idSite);
+
+        self::assertSame($timezone, $site->getTimezone());
+    }
+
     private function setCommonPIIParamsInConfig(array $urlParams): void
     {
         $config = Config::getInstance();

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -1828,12 +1828,14 @@ class ApiTest extends IntegrationTestCase
         ];
     }
 
-    public function testAddSiteWithLegacyTimezoneWorks()
+    /**
+     * @dataProvider getTimezonesToTest
+     */
+    public function testAddSiteWithLegacyTimezoneWorks($timezone)
     {
-        $timezone = current(array_diff(
-            \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC),
-            \DateTimeZone::listIdentifiers(\DateTimeZone::ALL)
-        ));
+        if (in_array($timezone, ['leapseconds', 'tzdata.zi'])) {
+            $this->markTestSkipped('Unsupported legacy timezone');
+        }
 
         $idSite = API::getInstance()->addSite(
             "site1",
@@ -1850,6 +1852,26 @@ class ApiTest extends IntegrationTestCase
         $site = new Site($idSite);
 
         self::assertSame($timezone, $site->getTimezone());
+    }
+
+    public function getTimezonesToTest(): iterable
+    {
+        $timezoneListFromApi = API::getInstance()->getTimezonesList();
+
+        foreach ($timezoneListFromApi as $countries) {
+            foreach ($countries as $timezone => $timezoneName) {
+                yield $timezone => [$timezone];
+            }
+        }
+
+        $timezones = array_diff(
+            \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC),
+            \DateTimeZone::listIdentifiers(\DateTimeZone::ALL)
+        );
+
+        foreach ($timezones as $timezone) {
+            yield $timezone => [$timezone];
+        }
     }
 
     private function setCommonPIIParamsInConfig(array $urlParams): void


### PR DESCRIPTION
### Description:

When importing sites from Google Analytics, it might happen that Google provides a legacy timezone name. This would currently cause a failure in the import, as the site can't be created with the timezone.
Allowing legacy timezones fixes that problem. The UI however won't allow to select such legacy timezones.

fixes PG-4242

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
