### PR TITLE
Add endpoint for fetching compliance status

### DIFF
--- a/plugins/MultiSites/API.php
+++ b/plugins/MultiSites/API.php
@@ -246,7 +246,7 @@ class API extends \Piwik\Plugin\API
         ?string $period = null,
         ?string $date = null,
         ?string $segment = null,
-        string $pattern,
+        string $pattern = '',
         int $filter_limit = 0
     ): array {
         Piwik::checkUserHasSomeViewAccess();

--- a/plugins/MultiSites/API.php
+++ b/plugins/MultiSites/API.php
@@ -246,7 +246,7 @@ class API extends \Piwik\Plugin\API
         ?string $period = null,
         ?string $date = null,
         ?string $segment = null,
-        string $pattern = '',
+        string $pattern,
         int $filter_limit = 0
     ): array {
         Piwik::checkUserHasSomeViewAccess();

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\PrivacyManager;
 
+use Exception;
 use Piwik\API\Request;
 use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
@@ -415,11 +416,11 @@ class API extends \Piwik\Plugin\API
     public function getComplianceStatus(string $idSite, string $complianceType): array
     {
         if ($this->featureFlagManager->isFeatureActive(PrivacyCompliance::class) === false) {
-            return [];
+            throw new Exception('Feature not available');
         }
 
         if ($complianceType !== 'cnil') {
-            return [];
+            throw new Exception('Invalid compliance type');
         }
 
         Piwik::checkUserHasSuperUserAccess();

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -422,12 +422,6 @@ class API extends \Piwik\Plugin\API
             return [];
         }
 
-        $idSites = Site::getIdSitesFromIdSitesString($idSite);
-
-        if (empty($idSites)) {
-            return [];
-        }
-
         Piwik::checkUserHasSuperUserAccess();
 
         return [

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -14,7 +14,9 @@ use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 use Piwik\Config as PiwikConfig;
 use Piwik\Plugin\Manager;
+use Piwik\Plugins\FeatureFlags\FeatureFlagManager;
 use Piwik\Plugins\Live\Live;
+use Piwik\Plugins\PrivacyManager\FeatureFlags\PrivacyCompliance;
 use Piwik\Plugins\PrivacyManager\Model\DataSubjects;
 use Piwik\Plugins\PrivacyManager\Dao\LogDataAnonymizer;
 use Piwik\Plugins\PrivacyManager\Model\LogDataAnonymizations;
@@ -49,16 +51,23 @@ class API extends \Piwik\Plugin\API
      */
     private $referrerAnonymizer;
 
+    /**
+     * @var FeatureFlagManager
+     */
+    private $featureFlagManager;
+
     public function __construct(
         DataSubjects $gdpr,
         LogDataAnonymizations $logDataAnonymizations,
         LogDataAnonymizer $logDataAnonymizer,
-        ReferrerAnonymizer $referrerAnonymizer
+        ReferrerAnonymizer $referrerAnonymizer,
+        FeatureFlagManager $featureFlagManager
     ) {
         $this->gdpr = $gdpr;
         $this->logDataAnonymizations = $logDataAnonymizations;
         $this->logDataAnonymizer = $logDataAnonymizer;
         $this->referrerAnonymizer = $referrerAnonymizer;
+        $this->featureFlagManager = $featureFlagManager;
     }
 
     private function checkDataSubjectVisits($visits)
@@ -398,6 +407,42 @@ class API extends \Piwik\Plugin\API
             $reportsPurger = ReportsPurger::make($settings, PrivacyManager::getAllMetricsToKeep());
             $reportsPurger->purgeData(true);
         }
+    }
+
+    /**
+     * @internal
+     */
+    public function getComplianceStatus(string $idSite, string $complianceType): array
+    {
+        if ($this->featureFlagManager->isFeatureActive(PrivacyCompliance::class) === false) {
+            return [];
+        }
+
+        if ($complianceType !== 'cnil') {
+            return [];
+        }
+
+        $idSites = Site::getIdSitesFromIdSitesString($idSite);
+
+        if (empty($idSites)) {
+            return [];
+        }
+
+        Piwik::checkUserHasSuperUserAccess();
+
+        return [
+            'complianceModeEnabled' => true,
+            'complianceIndicators' => [
+                ['name' => 'Anonymize IP', 'value' => 'unknown', 'notes' => 'Set to at least 2 byte masking'],
+                ['name' => 'retention period', 'value' => 'non_compliant', 'notes' => 'Retention periods is set to 1,200 days'],
+                ['name' => 'consent before tracking', 'value' => 'compliant', 'notes' => ''],
+                ['name' => 'cookie-less tracking', 'value' => 'non_compliant', 'notes' => ''],
+                ['name' => 'geoIP accuracy', 'value' => 'unknown', 'notes' => ''],
+                ['name' => 'heatmaps & session recording', 'value' => 'compliant', 'notes' => ''],
+                ['name' => 'tag manager', 'value' => 'non_compliant', 'notes' => ''],
+                ['name' => 'data export options', 'value' => 'compliant', 'notes' => ''],
+            ]
+        ];
     }
 
     private function savePurgeDataSettings($settings)

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -415,7 +415,7 @@ class API extends \Piwik\Plugin\API
      */
     public function getComplianceStatus(string $idSite, string $complianceType): array
     {
-        if ($this->featureFlagManager->isFeatureActive(PrivacyCompliance::class) === false) {
+        if (false === $this->featureFlagManager->isFeatureActive(PrivacyCompliance::class)) {
             throw new Exception('Feature not available');
         }
 

--- a/plugins/PrivacyManager/tests/System/APITest.php
+++ b/plugins/PrivacyManager/tests/System/APITest.php
@@ -173,7 +173,7 @@ class APITest extends SystemTestCase
         }
     }
 
-    public function testGetComplianceStatusReturnsEmptyArrayIfFeatureFlagDisabled(): void
+    public function testGetComplianceStatusReturnsErrorIfFeatureFlagDisabled(): void
     {
         $this->setComplianceFeatureFlag(false);
 
@@ -186,7 +186,7 @@ class APITest extends SystemTestCase
         ]);
     }
 
-    public function testGetComplianceStatusReturnsEmptyArrayIfComplianceTypeIsNotCnil(): void
+    public function testGetComplianceStatusReturnsErrorIfComplianceTypeIsNotCnil(): void
     {
         $this->setComplianceFeatureFlag(true);
 

--- a/plugins/PrivacyManager/tests/System/APITest.php
+++ b/plugins/PrivacyManager/tests/System/APITest.php
@@ -10,8 +10,10 @@
 namespace Piwik\Plugins\PrivacyManager\tests\System;
 
 use Piwik\Common;
+use Piwik\Config;
 use Piwik\Db;
 use Piwik\Plugins\PrivacyManager\API;
+use Piwik\Plugins\PrivacyManager\FeatureFlags\PrivacyCompliance;
 use Piwik\Plugins\PrivacyManager\tests\Fixtures\MultipleSitesMultipleVisitsFixture;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
@@ -158,6 +160,57 @@ class APITest extends SystemTestCase
         ]);
     }
 
+    private function setComplianceFeatureFlag(bool $enableFlag): void
+    {
+        $config = Config::getInstance();
+        $featureFlag = new PrivacyCompliance();
+        $featureFlagConfig = $featureFlag->getName() . '_feature';
+
+        if ($enableFlag) {
+            $config->FeatureFlags = [$featureFlagConfig => 'enabled'];
+        } else {
+            $config->FeatureFlags = [$featureFlagConfig => 'disabled'];
+        }
+    }
+
+    public function testGetComplianceStatusReturnsEmptyArrayIfFeatureFlagDisabled(): void
+    {
+        $this->setComplianceFeatureFlag(false);
+
+        $this->runApiTests('PrivacyManager.getComplianceStatus', [
+            'testSuffix' => 'featureFlagDisabled',
+            'otherRequestParameters' => [
+                'idSite' => '1',
+                'complianceType' => 'cnil'
+            ]
+        ]);
+    }
+
+    public function testGetComplianceStatusReturnsEmptyArrayIfComplianceTypeIsNotCnil(): void
+    {
+        $this->setComplianceFeatureFlag(true);
+
+        $this->runApiTests('PrivacyManager.getComplianceStatus', [
+            'testSuffix' => 'complianceTypeNotCnil',
+            'otherRequestParameters' => [
+                'idSite' => '1',
+                'complianceType' => 'something else not valid'
+            ]
+        ]);
+    }
+
+    public function testGetComplianceStatusReturnsComplianceStatus(): void
+    {
+        $this->setComplianceFeatureFlag(true);
+
+        $this->runApiTests('PrivacyManager.getComplianceStatus', [
+            'otherRequestParameters' => [
+                'idSite' => '1',
+                'complianceType' => 'cnil'
+            ]
+        ]);
+    }
+
     public static function getOutputPrefix()
     {
         return '';
@@ -166,6 +219,20 @@ class APITest extends SystemTestCase
     public static function getPathToTestDirectory()
     {
         return dirname(__FILE__);
+    }
+
+    public function provideContainerConfig()
+    {
+        return [
+            'observers.global' => \Piwik\DI::add([
+                [
+                    'Test.Mail.send', \Piwik\DI::value(function (PHPMailer $mail) {
+                    $this->mail = $mail;
+                    $this->mail->preSend();
+                })
+                ],
+            ]),
+        ];
     }
 }
 

--- a/plugins/PrivacyManager/tests/System/APITest.php
+++ b/plugins/PrivacyManager/tests/System/APITest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\PrivacyManager\tests\System;
 
+use Piwik\Access;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Db;
@@ -195,6 +196,21 @@ class APITest extends SystemTestCase
             'otherRequestParameters' => [
                 'idSite' => '1',
                 'complianceType' => 'something else not valid'
+            ]
+        ]);
+    }
+
+    public function testGetComplianceStatusReturnsErrorIfNotSuperAdmin(): void
+    {
+        Access::getInstance()->setSuperUserAccess(false);
+
+        $this->setComplianceFeatureFlag(true);
+
+        $this->runApiTests('PrivacyManager.getComplianceStatus', [
+            'testSuffix' => 'notSuperAdmin',
+            'otherRequestParameters' => [
+                'idSite' => '1',
+                'complianceType' => 'cnil'
             ]
         ]);
     }

--- a/plugins/PrivacyManager/tests/System/APITest.php
+++ b/plugins/PrivacyManager/tests/System/APITest.php
@@ -220,20 +220,6 @@ class APITest extends SystemTestCase
     {
         return dirname(__FILE__);
     }
-
-    public function provideContainerConfig()
-    {
-        return [
-            'observers.global' => \Piwik\DI::add([
-                [
-                    'Test.Mail.send', \Piwik\DI::value(function (PHPMailer $mail) {
-                    $this->mail = $mail;
-                    $this->mail->preSend();
-                })
-                ],
-            ]),
-        ];
-    }
 }
 
 APITest::$fixture = new MultipleSitesMultipleVisitsFixture();

--- a/plugins/PrivacyManager/tests/System/APITest.php
+++ b/plugins/PrivacyManager/tests/System/APITest.php
@@ -202,17 +202,24 @@ class APITest extends SystemTestCase
 
     public function testGetComplianceStatusReturnsErrorIfNotSuperAdmin(): void
     {
-        Access::getInstance()->setSuperUserAccess(false);
+        $access = Access::getInstance();
+        $originalAccess = $access->hasSuperUserAccess();
 
-        $this->setComplianceFeatureFlag(true);
+        try {
+            $access->setSuperUserAccess(false);
 
-        $this->runApiTests('PrivacyManager.getComplianceStatus', [
-            'testSuffix' => 'notSuperAdmin',
-            'otherRequestParameters' => [
-                'idSite' => '1',
-                'complianceType' => 'cnil'
-            ]
-        ]);
+            $this->setComplianceFeatureFlag(true);
+
+            $this->runApiTests('PrivacyManager.getComplianceStatus', [
+                'testSuffix' => 'notSuperAdmin',
+                'otherRequestParameters' => [
+                    'idSite' => '1',
+                    'complianceType' => 'cnil'
+                ]
+            ]);
+        } finally {
+            $access->setSuperUserAccess($originalAccess);
+        }
     }
 
     public function testGetComplianceStatusReturnsComplianceStatus(): void

--- a/plugins/PrivacyManager/tests/System/expected/test___PrivacyManager.getComplianceStatus.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test___PrivacyManager.getComplianceStatus.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<complianceModeEnabled>1</complianceModeEnabled>
+	<complianceIndicators>
+		<row>
+			<name>Anonymize IP</name>
+			<value>unknown</value>
+			<notes>Set to at least 2 byte masking</notes>
+		</row>
+		<row>
+			<name>retention period</name>
+			<value>non_compliant</value>
+			<notes>Retention periods is set to 1,200 days</notes>
+		</row>
+		<row>
+			<name>consent before tracking</name>
+			<value>compliant</value>
+			<notes />
+		</row>
+		<row>
+			<name>cookie-less tracking</name>
+			<value>non_compliant</value>
+			<notes />
+		</row>
+		<row>
+			<name>geoIP accuracy</name>
+			<value>unknown</value>
+			<notes />
+		</row>
+		<row>
+			<name>heatmaps &amp; session recording</name>
+			<value>compliant</value>
+			<notes />
+		</row>
+		<row>
+			<name>tag manager</name>
+			<value>non_compliant</value>
+			<notes />
+		</row>
+		<row>
+			<name>data export options</name>
+			<value>compliant</value>
+			<notes />
+		</row>
+	</complianceIndicators>
+</result>

--- a/plugins/PrivacyManager/tests/System/expected/test_complianceTypeNotCnil__PrivacyManager.getComplianceStatus.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_complianceTypeNotCnil__PrivacyManager.getComplianceStatus.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result />

--- a/plugins/PrivacyManager/tests/System/expected/test_complianceTypeNotCnil__PrivacyManager.getComplianceStatus.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_complianceTypeNotCnil__PrivacyManager.getComplianceStatus.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<result />
+<result>
+	<error message="Invalid compliance type
+ 
+ --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
+</result>

--- a/plugins/PrivacyManager/tests/System/expected/test_featureFlagDisabled__PrivacyManager.getComplianceStatus.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_featureFlagDisabled__PrivacyManager.getComplianceStatus.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result />

--- a/plugins/PrivacyManager/tests/System/expected/test_featureFlagDisabled__PrivacyManager.getComplianceStatus.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_featureFlagDisabled__PrivacyManager.getComplianceStatus.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<result />
+<result>
+	<error message="Feature not available
+ 
+ --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
+</result>

--- a/plugins/PrivacyManager/tests/System/expected/test_notSuperAdmin__PrivacyManager.getComplianceStatus.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_notSuperAdmin__PrivacyManager.getComplianceStatus.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<error message="You can't access this resource as it requires a 'superuser' access.
+ 
+ --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
+</result>


### PR DESCRIPTION
### Description:

Related to: https://github.com/matomo-org/matomo/pull/23468

Just a basic endpoint with dummy data for the privacy work.

Contains the API validation (the built in).
Plus some additional checks as well, along with a system test.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
