### PR TITLE
Add API endpoint for setting status

### DIFF
--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -440,6 +440,30 @@ class API extends \Piwik\Plugin\API
         ];
     }
 
+    /**
+     * @internal
+     */
+    public function setComplianceStatus(string $idSite, string $complianceType, bool $enabled): bool
+    {
+        if (!$this->featureFlagManager->isFeatureActive(PrivacyCompliance::class)) {
+            return false;
+        }
+
+        if ($complianceType !== 'cnil') {
+            return false;
+        }
+
+        $idSites = Site::getIdSitesFromIdSitesString($idSite);
+
+        if (empty($idSites)) {
+            return false;
+        }
+
+        Piwik::checkUserHasSuperUserAccess();
+
+        return $enabled;
+    }
+
     private function savePurgeDataSettings($settings)
     {
         Piwik::checkUserHasSuperUserAccess();

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -446,17 +446,11 @@ class API extends \Piwik\Plugin\API
     public function setComplianceStatus(string $idSite, string $complianceType, bool $enabled): bool
     {
         if (!$this->featureFlagManager->isFeatureActive(PrivacyCompliance::class)) {
-            return false;
+            throw new Exception('Feature not available');
         }
 
         if ($complianceType !== 'cnil') {
-            return false;
-        }
-
-        $idSites = Site::getIdSitesFromIdSitesString($idSite);
-
-        if (empty($idSites)) {
-            return false;
+            throw new Exception('Invalid compliance type');
         }
 
         Piwik::checkUserHasSuperUserAccess();

--- a/plugins/PrivacyManager/tests/Integration/ApiTest.php
+++ b/plugins/PrivacyManager/tests/Integration/ApiTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\PrivacyManager\tests\Integration;
+
+use Piwik\Plugins\PrivacyManager\API;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group PrivacyManager
+ * @group ApiTest
+ * @group Api
+ * @group Plugins
+ */
+class ApiTest extends IntegrationTestCase
+{
+    /**
+     * @var API
+     */
+    private $api;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createSuperUser();
+        Fixture::createWebsite('2014-01-01 01:02:03');
+        $this->api = API::getInstance();
+    }
+
+    public function testSetComplianceStatusReturnsFalseIfFeatureFlagDisabled(): void
+    {
+        $this->api->setComplianceStatus(123);
+    }
+
+    public function testSetComplianceStatusReturnsFalseIfUserDoesntHaveSuperAdmin(): void
+    {
+
+    }
+
+    public function testSetComplianceStatusReturnsTheNewStateIfEnabled(): void
+    {
+
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
+    }
+}

--- a/plugins/PrivacyManager/tests/Integration/ApiTest.php
+++ b/plugins/PrivacyManager/tests/Integration/ApiTest.php
@@ -9,6 +9,10 @@
 
 namespace Piwik\Plugins\PrivacyManager\tests\Integration;
 
+use Piwik\Access;
+use Piwik\Config;
+use Piwik\Container\StaticContainer;
+use Piwik\NoAccessException;
 use Piwik\Plugins\PrivacyManager\API;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
@@ -27,28 +31,75 @@ class ApiTest extends IntegrationTestCase
      */
     private $api;
 
+    /**
+     * @var int
+     */
+    private $siteId;
+
     public function setUp(): void
     {
         parent::setUp();
 
         Fixture::createSuperUser();
-        Fixture::createWebsite('2014-01-01 01:02:03');
+        $this->siteId = Fixture::createWebsite('2014-01-01 01:02:03');
         $this->api = API::getInstance();
     }
 
-    public function testSetComplianceStatusReturnsFalseIfFeatureFlagDisabled(): void
+    public function testSetComplianceStatusThrowsExceptionIfFeatureFlagDisabled(): void
     {
-        $this->api->setComplianceStatus(123);
+        $container = StaticContainer::getContainer();
+        $container->get(Config::class)->FeatureFlags = ['PrivacyCompliance_feature' => 'disabled'];
+
+        $this->expectExceptionMessage('Feature not available');
+        $this->api->setComplianceStatus(
+            (string) $this->siteId,
+            'cnil',
+            true
+        );
     }
 
-    public function testSetComplianceStatusReturnsFalseIfUserDoesntHaveSuperAdmin(): void
+    public function testSetComplianceStatusThrowsExceptionIfInvalidComplianceType(): void
     {
+        $container = StaticContainer::getContainer();
+        $container->get(Config::class)->FeatureFlags = ['PrivacyCompliance_feature' => 'enabled'];
 
+        $this->expectExceptionMessage('Invalid compliance type');
+        $this->api->setComplianceStatus(
+            (string) $this->siteId,
+            'egg',
+            true
+        );
+    }
+
+    public function testSetComplianceStatusThrowsExceptionIfUserDoesntHaveSuperAdmin(): void
+    {
+        $container = StaticContainer::getContainer();
+        $container->get(Config::class)->FeatureFlags = ['PrivacyCompliance_feature' => 'enabled'];
+
+        $fakeAccess = $container->get(Access::class);
+        $fakeAccess->setSuperUserAccess(false);
+
+        $this->expectException(NoAccessException::class);
+
+        $this->api->setComplianceStatus(
+            (string) $this->siteId,
+            'cnil',
+            true
+        );
     }
 
     public function testSetComplianceStatusReturnsTheNewStateIfEnabled(): void
     {
+        $container = StaticContainer::getContainer();
+        $container->get(Config::class)->FeatureFlags = ['PrivacyCompliance_feature' => 'enabled'];
 
+        $result = $this->api->setComplianceStatus(
+            (string) $this->siteId,
+            'cnil',
+            true
+        );
+
+        $this->assertTrue($result);
     }
 
     public function provideContainerConfig()


### PR DESCRIPTION
### Description:

Mock endpoint again for setting the compliance status for a given site ID / compliance type.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
