### PR TITLE
API Versioning

### DIFF
--- a/core/API/APIVersion.php
+++ b/core/API/APIVersion.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\API;
+
+use InvalidArgumentException;
+
+class APIVersion
+{
+    /**
+     * @var int
+     */
+    private $majorVersion;
+
+    /**
+     * @var ?int
+     */
+    private $minorVersion;
+
+    /**
+     * @var ?int
+     */
+    private $patchVersion;
+
+    public function __construct(int $majorVersion, ?int $minorVersion, ?int $patchVersion)
+    {
+        $this->majorVersion = $majorVersion;
+        $this->minorVersion = $minorVersion;
+        $this->patchVersion = $patchVersion;
+    }
+
+    public static function createFromVersionString(string $versionString): APIVersion
+    {
+        return new self(...self::extractVersions($versionString));
+    }
+
+    public function getMajorVersion(): int
+    {
+        return $this->majorVersion;
+    }
+
+    public function getMinorVersion(): ?int
+    {
+        return $this->minorVersion;
+    }
+
+    public function getPatchVersion(): ?int
+    {
+        return $this->patchVersion;
+    }
+
+    public function getClassString(string $pluginName): string // TODO - there's an annotation for strings representing classes
+    {
+        // So the idea is that consumers can specify a major version, which should always be backwards compatible,
+        // and they get the latest copy of that major version.
+        //
+        // We still allow specifying at a more granular level.
+        //
+        // I was hoping to automatically figure out the version level, but I think it's cleaner and safer for
+        // the plugin to maintain those links - e.g. \Plugin\API\2\API just inherits from \Plugin\API\2.3.4
+        // manually.
+        $version = 'V_' . strval($this->majorVersion);
+        if (null !== $this->minorVersion) {
+            $version .= '_' . strval($this->minorVersion);
+            if (null !== $this->patchVersion) {
+                $version .= '_' . strval($this->patchVersion);
+            }
+        }
+        return sprintf('\Piwik\Plugins\%s\API\%s\API', $pluginName, $version);
+    }
+
+    private static function extractVersions(string $versionString): array
+    {
+        // Validate input: must be 1 to 3 dot-separated numbers
+        if (!preg_match('/^\d+(\.\d+){0,2}$/', $versionString)) {
+            throw new InvalidArgumentException("Invalid version string: $versionString");
+        }
+
+        // Split into parts
+        $parts = explode('.', $versionString);
+        assert(isset($parts[0]));
+
+        // Assign major, minor, patch with null defaults
+        $majorVersion = (int) $parts[0];
+        $minorVersion = isset($parts[1]) ? (int) $parts[1] : null;
+        $patchVersion = isset($parts[2]) ? (int) $parts[2] : null;
+
+        return [$majorVersion, $minorVersion, $patchVersion];
+    }
+}

--- a/core/API/Proxy.php
+++ b/core/API/Proxy.php
@@ -165,7 +165,7 @@ class Proxy
             $object = $this->getApiClass($pluginName, $className, $apiVersion);
 
             // check method exists
-            $this->checkMethodExists(get_class($object), $methodName);
+            $this->checkMethodExists('\\'. get_class($object), $methodName);
 
             // get the list of parameters required by the method
             $parameterNamesDefaultValuesAndTypes = $this->getParametersListWithTypes($className, $methodName);

--- a/core/API/Proxy.php
+++ b/core/API/Proxy.php
@@ -153,22 +153,19 @@ class Proxy
      * @return mixed|null
      * @throws Exception|\Piwik\NoAccessException
      */
-    public function call($className, $methodName, $parametersRequest)
+    public function call(string $className, string $methodName, array $parametersRequest, ?APIVersion $apiVersion = null)
     {
         // Temporarily sets the Request array to this API call context
-        return Context::executeWithQueryParameters($parametersRequest, function () use ($className, $methodName, $parametersRequest) {
-            $this->registerClass($className);
+        return Context::executeWithQueryParameters($parametersRequest, function () use ($className, $methodName, $parametersRequest, $apiVersion) {
+            $pluginName = $this->getModuleNameFromClassName($className); // - awkward as we're translating plugin name to classname, then untranslating it
+            $this->registerClass($className); // needs to be made version aware, but has a role in docs.
 
             $request = new \Piwik\Request($parametersRequest);
 
-            /**
-             * instantiate the object
-             * @var API $object
-             */
-            $object = $className::getInstance();
+            $object = $this->getApiClass($pluginName, $className, $apiVersion);
 
             // check method exists
-            $this->checkMethodExists($className, $methodName);
+            $this->checkMethodExists(get_class($object), $methodName);
 
             // get the list of parameters required by the method
             $parameterNamesDefaultValuesAndTypes = $this->getParametersListWithTypes($className, $methodName);
@@ -179,9 +176,6 @@ class Proxy
             } else {
                 $finalParameters = $this->getRequestParametersArray($parameterNamesDefaultValuesAndTypes, $request);
             }
-
-            // allow plugins to manipulate the value
-            $pluginName = $this->getModuleNameFromClassName($className);
 
             $returnedValue = null;
 
@@ -345,6 +339,18 @@ class Proxy
 
             return $returnedValue;
         });
+    }
+
+    // TODO - add some extra safety checks as to if the class exists
+    public function getApiClass(string $pluginName, string $className, ?APIVersion $apiVersion): API
+    {
+        // If no version specified, get original style API.
+        if (null === $apiVersion) {
+            return $className::getInstance();
+        }
+
+        $versionedClassname = $apiVersion->getClassString($pluginName);
+        return $versionedClassname::getInstance();
     }
 
     /**

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -258,6 +258,12 @@ class Request
 
             // read parameters
             $moduleMethod = Common::getRequestVar('method', null, 'string', $this->request);
+            $versionString = \Piwik\Request::fromGet()->getStringParameter('apiVersion', '');
+            if ('' === $versionString) {
+                $apiVersion = null;
+            } else {
+                $apiVersion = APIVersion::createFromVersionString($versionString);
+            }
 
             [$module, $method] = $this->extractModuleAndMethod($moduleMethod);
             [$module, $method] = self::getRenamedModuleAndAction($module, $method);
@@ -274,7 +280,7 @@ class Request
             }
 
             // call the method
-            $returnedValue = Proxy::getInstance()->call($apiClassName, $method, $this->request);
+            $returnedValue = Proxy::getInstance()->call($apiClassName, $method, $this->request, $apiVersion);
 
             // get the response with the request query parameters loaded, since DataTablePost processor will use the Report
             // class instance, which may inspect the query parameters. (eg, it may look for the idCustomReport parameters

--- a/htaccess-apiversion-example
+++ b/htaccess-apiversion-example
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^api/([^/]+)/([^/]+)/([^/]+)$ ?module=API&method=$2.get$3&apiVersion=$1 [QSA,L]


### PR DESCRIPTION
This is a quick sketch of how API version routing could work in a backwards compatible way.

Mapping of functions to get/post/etc is not done.