### PR TITLE
Add rule to prevent imports from vue/src that cause hard-to-debug build issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,5 +34,10 @@ module.exports = {
     'no-undef': 'off',
     'no-undef-init': 'off',
     'import/extensions': 'off',
+
+    // error on imports using ../vue/src paths - use e.g. `from 'CoreHome'` instead
+    'no-restricted-imports': ['error', {
+      patterns: ['**/vue/src'],
+    }],
   },
 };


### PR DESCRIPTION
### Description:

Initially adding this rule, then we can look into options on how to e.g. help IDEs to create correct imports for us.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
