### PR TITLE
Avoid sending notifications to empty recipients

### DIFF
--- a/plugins/UsersManager/TokenNotifications/TokenEmailNotification.php
+++ b/plugins/UsersManager/TokenNotifications/TokenEmailNotification.php
@@ -36,7 +36,7 @@ abstract class TokenEmailNotification extends TokenNotification
     ) {
         parent::__construct($tokenId, $tokenName, $tokenCreationDate);
 
-        $this->recipients = $recipients;
+        $this->recipients = array_filter($recipients);
         $this->emailData = $emailData;
     }
 

--- a/plugins/UsersManager/TokenNotifications/TokenExpirationWarningNotificationProvider.php
+++ b/plugins/UsersManager/TokenNotifications/TokenExpirationWarningNotificationProvider.php
@@ -25,13 +25,15 @@ class TokenExpirationWarningNotificationProvider extends TokenNotificationProvid
     protected function getTokensToNotify(string $periodThreshold): array
     {
         $db = Db::get();
-        $sql = "SELECT * FROM " . Common::prefixTable('user_token_auth')
-            . " WHERE date_expired IS NOT null"
-            . " AND (date_expired <= ?)"
-            . " AND (date_created <= ?)"
-            . " AND ts_expiration_warning_notified IS NULL"
-            . " AND system_token = 0"
-            . " AND login != ?";
+        // Join on user table is done, to ensure we only fetch tokens, where the user still exists
+        $sql = "SELECT * FROM " . Common::prefixTable('user_token_auth') . " t"
+            . " JOIN  " . Common::prefixTable('user') . " u ON t.login = u.login"
+            . " WHERE t.date_expired IS NOT null"
+            . " AND (t.date_expired <= ?)"
+            . " AND (t.date_created <= ?)"
+            . " AND t.ts_expiration_warning_notified IS NULL"
+            . " AND t.system_token = 0"
+            . " AND t.login != ?";
 
         $tokensToNotify = $db->fetchAll($sql, [
             $periodThreshold,

--- a/plugins/UsersManager/TokenNotifications/TokenRotationNotificationProvider.php
+++ b/plugins/UsersManager/TokenNotifications/TokenRotationNotificationProvider.php
@@ -25,12 +25,14 @@ class TokenRotationNotificationProvider extends TokenNotificationProvider
     protected function getTokensToNotify(string $periodThreshold): array
     {
         $db = Db::get();
-        $sql = "SELECT * FROM " . Common::prefixTable('user_token_auth')
-            . " WHERE (date_expired is null or date_expired > ?)"
-            . " AND (date_created <= ?)"
-            . " AND ts_rotation_notified is null"
-            . " AND system_token = 0"
-            . " AND login != ?";
+        // Join on user table is done, to ensure we only fetch tokens, where the user still exists
+        $sql = "SELECT * FROM " . Common::prefixTable('user_token_auth') . " t"
+            . " JOIN  " . Common::prefixTable('user') . " u ON t.login = u.login"
+            . " WHERE (t.date_expired is null or t.date_expired > ?)"
+            . " AND (t.date_created <= ?)"
+            . " AND t.ts_rotation_notified is null"
+            . " AND t.system_token = 0"
+            . " AND t.login != ?";
 
         $tokensToNotify = $db->fetchAll($sql, [
             $this->today,

--- a/plugins/UsersManager/UserNotifications/UserEmailNotification.php
+++ b/plugins/UsersManager/UserNotifications/UserEmailNotification.php
@@ -39,7 +39,7 @@ abstract class UserEmailNotification extends UserNotification
     ) {
         parent::__construct($users);
 
-        $this->recipients = $recipients;
+        $this->recipients = array_filter($recipients);
         $this->emailData = $emailData;
     }
 


### PR DESCRIPTION
### Description:

Currently the tasks may fatal if a token exists for a user that has already been removed.

Changing the queries ensures we do not even fetch such tokens, however the additional array_filter is meant as a safety net if any plugin would provide any data without a recipient.

fixes #23534

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
