### PR TITLE
Fix the bug that plugins get loaded with disabled internet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This is the Developer Changelog for Matomo platform developers. All changes in o
 
 The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)** lets you see more details about any Matomo release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
+## Matomo 5.4.1
+
+### Bugfixes
+
+When deactivating internet features like Marketplace the plugins are no longer loaded.
+
 ## Matomo 5.4.0
 
 ### Authentication changes

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -1250,7 +1250,9 @@ class Manager
         }
 
         $newPlugin = $this->makePluginClass($pluginName);
-
+        if (!SettingsPiwik::isInternetEnabled() && $newPlugin->requiresInternetConnection()) {
+            return null;
+        }
         $this->addLoadedPlugin($pluginName, $newPlugin);
         return $newPlugin;
     }


### PR DESCRIPTION
### Description:

Currently `enable_internet_features` is 0 plugins like marketplace are still loaded.
This leads to javascript issues.
Issue occured when marketplace itself was down and I disabled the internet features.
Matomo UI was not working any longer.
