### PR TITLE
Fix Bing SEO metric test skip

### DIFF
--- a/plugins/SEO/tests/Integration/SEOTest.php
+++ b/plugins/SEO/tests/Integration/SEOTest.php
@@ -13,6 +13,7 @@ use Piwik\DataTable\Renderer;
 use Piwik\EventDispatcher;
 use Piwik\Piwik;
 use Piwik\Plugins\SEO\API;
+use Piwik\Plugins\SEO\Metric\Bing;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -49,7 +50,11 @@ class SEOTest extends IntegrationTestCase
     {
         // skip testing Bing metric as it's flaky
         EventDispatcher::getInstance()->addObserver('SEO.getMetricsProviders', function (&$providers) {
-            unset($providers['Piwik\Plugins\SEO\Metric\Bing']);
+            foreach ($providers as $idx => $provider) {
+                if ($provider instanceof Bing) {
+                    unset($providers[$idx]);
+                }
+            }
         });
 
         $dataTable = API::getInstance()->getRank('http://matomo.org/');


### PR DESCRIPTION
### Description:

With the amount of failed CI pipelines, it showed that the Bing SEO metric skipping was never really working, and the now often seen "please solve this captcha" Bing results are annoying.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
