### PR TITLE
Bugfix 23538

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This is the Developer Changelog for Matomo platform developers. All changes in o
 
 The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)** lets you see more details about any Matomo release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
+## Matomo 5.4.1
+
+### Bugfixes
+
+When deactivating internet features like Marketplace the plugins are no longer loaded.
+
 ## Matomo 5.4.0
 
 ### Authentication changes

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -1250,7 +1250,9 @@ class Manager
         }
 
         $newPlugin = $this->makePluginClass($pluginName);
-
+        if (!SettingsPiwik::isInternetEnabled() && $newPlugin->requiresInternetConnection()) {
+            return null;
+        }
         $this->addLoadedPlugin($pluginName, $newPlugin);
         return $newPlugin;
     }


### PR DESCRIPTION
### Description:

Currently enable_internet_features is 0 plugins like marketplace are still loaded.
This leads to javascript issues.
Issue occured when marketplace itself was down and I disabled the internet features.
Matomo UI was not working any longer.

Please dont close this PR without any reason since it is fixing a bug

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
