### PR TITLE
PG-4508 evolution archiving fix

### DIFF
--- a/core/ArchiveProcessor/Parameters.php
+++ b/core/ArchiveProcessor/Parameters.php
@@ -310,7 +310,7 @@ class Parameters
         $this->isArchiveOnlyReportHandled = $isArchiveOnlyReportHandled;
     }
 
-    public function getArchiveOnlyReportAsArray()
+    public function getArchiveOnlyReportAsArray(): array
     {
         $requestedReport = $this->getArchiveOnlyReport();
         if (empty($requestedReport)) {

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -224,9 +224,24 @@ abstract class RecordBuilder
                 return $r->getName();
             }, $autoAggregateMetrics);
 
+            // if $requestedReports exists, then keep autoAggregateMetrics only if they are in requested reports and not in found requested reports.
+            // So the problem is that the requestedReports name and the name doesn't match
+            // name is right, requestedReports is wrong b- should be full metric name, not just report name
+
+            // Below code works, but it hacky.
+
+
             if (!empty($requestedReports)) {
                 $autoAggregateMetrics = array_filter($autoAggregateMetrics, function ($name) use ($requestedReports, $foundRequestedReports) {
-                    return in_array($name, $requestedReports) && !in_array($name, $foundRequestedReports);
+                    foreach ($requestedReports as $requestedReport) {
+                        if (strncmp($name, $requestedReport, strlen($requestedReport)) === 0) {
+                            if (in_array($name, $foundRequestedReports)) {
+                                return false;
+                            }
+                            return true;
+                        }
+                    }
+                    return false;
                 });
             }
 

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -153,6 +153,7 @@ abstract class RecordBuilder
 
         $aggregatedCounts = [];
 
+        // make sure if there are requested numeric records that depend on blob records, that the blob records will be archived first
         foreach ($numericRecords as $record) {
             if (
                 empty($record->getCountOfRecordName())

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -223,8 +223,10 @@ abstract class RecordBuilder
                 return $r->getName();
             }, $autoAggregateMetrics);
 
-            $autoAggregateMetrics = $this->removeFoundReports($autoAggregateMetrics, $foundRequestedReports);
-            $autoAggregateMetrics = $this->keepOnlyRequestedReports($autoAggregateMetrics, $requestedReports);
+            if (!empty($requestedReports)) {
+                $autoAggregateMetrics = $this->removeFoundReports($autoAggregateMetrics, $foundRequestedReports);
+                $autoAggregateMetrics = $this->keepOnlyRequestedReports($autoAggregateMetrics, $requestedReports);
+            }
 
             $autoAggregateMetrics = array_values($autoAggregateMetrics);
 

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -157,13 +157,13 @@ abstract class RecordBuilder
         foreach ($numericRecords as $record) {
             if (
                 empty($record->getCountOfRecordName())
-                || !in_array($record->getName(), $requestedReports) // Wrong?
+                || !$this->isNameInRequestedReport($record->getName(), $requestedReports)
             ) {
                 continue;
             }
 
             $dependentRecordName = $record->getCountOfRecordName();
-            if (!in_array($dependentRecordName, $requestedReports)) { // Wrong?
+            if (!in_array($dependentRecordName, $requestedReports)) {
                 $requestedReports[] = $dependentRecordName;
             }
 
@@ -178,7 +178,7 @@ abstract class RecordBuilder
         foreach ($blobRecords as $record) {
             if (
                 !empty($requestedReports)
-                && (!in_array($record->getName(), $requestedReports)
+                && (!$this->isNameInRequestedReport($record->getName(), $requestedReports)
                     || in_array($record->getName(), $foundRequestedReports))
             ) {
                 continue;
@@ -225,8 +225,13 @@ abstract class RecordBuilder
             }, $autoAggregateMetrics);
 
             if (!empty($requestedReports)) {
-                $autoAggregateMetrics = $this->removeFoundReports($autoAggregateMetrics, $foundRequestedReports);
-                $autoAggregateMetrics = $this->keepOnlyRequestedReports($autoAggregateMetrics, $requestedReports);
+                // Remove found reports.
+                $autoAggregateMetrics = array_diff($autoAggregateMetrics, $foundRequestedReports);
+
+                // Keep only requested reports
+                $autoAggregateMetrics = array_filter($autoAggregateMetrics, function ($name) use ($requestedReports) {
+                    return $this->isNameInRequestedReport($name, $requestedReports);
+                });
             }
 
             $autoAggregateMetrics = array_values($autoAggregateMetrics);
@@ -267,31 +272,29 @@ abstract class RecordBuilder
         }
     }
 
-    public function removeFoundReports(array $autoAggregateMetrics, array $foundRequestedReports): array
-    {
-        return array_filter($autoAggregateMetrics, function ($name) use ($foundRequestedReports) {
-            // Don't process if we already found the metric
-            return !in_array($name, $foundRequestedReports);
-        });
-    }
 
-    public function keepOnlyRequestedReports(array $autoAggregateMetrics, array $requestedReports): array
+    private function isNameInRequestedReport(string $name, array $requestedReports): bool
     {
-        return array_filter($autoAggregateMetrics, function ($name) use ($requestedReports) {
-            // Do process if this is a metric matching the report we specifically asked for
-            if (in_array($name, $requestedReports)) {
+        // Do process if this is a metric matching the report we specifically asked for
+        if (in_array($name, $requestedReports)) {
+            return true;
+        }
+        // Do process if this is a metric for that specific report
+        //
+        // We name custom reports like CustomReports_customreport_1_1 (<Plugin>_customreport_<customreportid>_<revisionid>).
+        // We need to reprocess individual metrics for the requested report.
+        // These are named like CustomReports_customreport_1_1_nb_visits
+        // (<Plugin>_customreport_<customreportid>_<revisionid>_<metricname>).
+        //
+        // So we want to reprocess reports named <reportname>_* to capture all needed metrics.
+        foreach ($requestedReports as $requestedReport) {
+            $requestedReportWithUnderscore = $requestedReport . '_';
+            if (strncmp($name, $requestedReportWithUnderscore, strlen($requestedReportWithUnderscore)) === 0) {
                 return true;
             }
-            // Do process if this is a metric for that specific report
-            foreach ($requestedReports as $requestedReport) {
-                $requestedReportWithUnderscore = $requestedReport . '_';
-                if (strncmp($name, $requestedReportWithUnderscore, strlen($requestedReportWithUnderscore)) === 0) {
-                    return true;
-                }
-            }
-            // Do not process if we did not ask for this.
-            return false;
-        });
+        }
+        // Do not process if we did not ask for this.
+        return false;
     }
 
     /**

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -153,17 +153,16 @@ abstract class RecordBuilder
 
         $aggregatedCounts = [];
 
-        // make sure if there are requested numeric records that depend on blob records, that the blob records will be archived first
         foreach ($numericRecords as $record) {
             if (
                 empty($record->getCountOfRecordName())
-                || !in_array($record->getName(), $requestedReports)
+                || !in_array($record->getName(), $requestedReports) // Wrong?
             ) {
                 continue;
             }
 
             $dependentRecordName = $record->getCountOfRecordName();
-            if (!in_array($dependentRecordName, $requestedReports)) {
+            if (!in_array($dependentRecordName, $requestedReports)) { // Wrong?
                 $requestedReports[] = $dependentRecordName;
             }
 
@@ -224,26 +223,8 @@ abstract class RecordBuilder
                 return $r->getName();
             }, $autoAggregateMetrics);
 
-            // if $requestedReports exists, then keep autoAggregateMetrics only if they are in requested reports and not in found requested reports.
-            // So the problem is that the requestedReports name and the name doesn't match
-            // name is right, requestedReports is wrong b- should be full metric name, not just report name
-
-            // Below code works, but it hacky.
-
-
-            if (!empty($requestedReports)) {
-                $autoAggregateMetrics = array_filter($autoAggregateMetrics, function ($name) use ($requestedReports, $foundRequestedReports) {
-                    foreach ($requestedReports as $requestedReport) {
-                        if (strncmp($name, $requestedReport, strlen($requestedReport)) === 0) {
-                            if (in_array($name, $foundRequestedReports)) {
-                                return false;
-                            }
-                            return true;
-                        }
-                    }
-                    return false;
-                });
-            }
+            $autoAggregateMetrics = $this->removeFoundReports($autoAggregateMetrics, $foundRequestedReports);
+            $autoAggregateMetrics = $this->keepOnlyRequestedReports($autoAggregateMetrics, $requestedReports);
 
             $autoAggregateMetrics = array_values($autoAggregateMetrics);
 
@@ -281,6 +262,33 @@ abstract class RecordBuilder
                 $archiveProcessor->insertNumericRecords($recordCountMetricValues);
             }
         }
+    }
+
+    public function removeFoundReports(array $autoAggregateMetrics, array $foundRequestedReports): array
+    {
+        return array_filter($autoAggregateMetrics, function ($name) use ($foundRequestedReports) {
+            // Don't process if we already found the metric
+            return !in_array($name, $foundRequestedReports);
+        });
+    }
+
+    public function keepOnlyRequestedReports(array $autoAggregateMetrics, array $requestedReports): array
+    {
+        return array_filter($autoAggregateMetrics, function ($name) use ($requestedReports) {
+            // Do process if this is a metric matching the report we specifically asked for
+            if (in_array($name, $requestedReports)) {
+                return true;
+            }
+            // Do process if this is a metric for that specific report
+            foreach ($requestedReports as $requestedReport) {
+                $requestedReportWithUnderscore = $requestedReport . '_';
+                if (strncmp($name, $requestedReportWithUnderscore, strlen($requestedReportWithUnderscore)) === 0) {
+                    return true;
+                }
+            }
+            // Do not process if we did not ask for this.
+            return false;
+        });
     }
 
     /**

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -157,7 +157,7 @@ abstract class RecordBuilder
         foreach ($numericRecords as $record) {
             if (
                 empty($record->getCountOfRecordName())
-                || !$this->isNameInRequestedReport($record->getName(), $requestedReports)
+                || !$this->isReportNameInRequestedReports($record->getName(), $requestedReports)
             ) {
                 continue;
             }
@@ -178,7 +178,7 @@ abstract class RecordBuilder
         foreach ($blobRecords as $record) {
             if (
                 !empty($requestedReports)
-                && (!$this->isNameInRequestedReport($record->getName(), $requestedReports)
+                && (!$this->isReportNameInRequestedReports($record->getName(), $requestedReports)
                     || in_array($record->getName(), $foundRequestedReports))
             ) {
                 continue;
@@ -230,7 +230,7 @@ abstract class RecordBuilder
 
                 // Keep only requested reports
                 $autoAggregateMetrics = array_filter($autoAggregateMetrics, function ($name) use ($requestedReports) {
-                    return $this->isNameInRequestedReport($name, $requestedReports);
+                    return $this->isReportNameInRequestedReports($name, $requestedReports);
                 });
             }
 
@@ -272,28 +272,32 @@ abstract class RecordBuilder
         }
     }
 
-
-    private function isNameInRequestedReport(string $name, array $requestedReports): bool
+    /**
+     * Check if report name or related metric (for CustomReports with evolutions) is in the requestedReports array.
+     */
+    private function isReportNameInRequestedReports(string $reportName, array $requestedReports): bool
     {
-        // Do process if this is a metric matching the report we specifically asked for
-        if (in_array($name, $requestedReports)) {
+        // Exact match
+        if (in_array($reportName, $requestedReports)) {
             return true;
         }
-        // Do process if this is a metric for that specific report
+
+        // Check if reportName is a metric for a requested report.
         //
-        // We name custom reports like CustomReports_customreport_1_1 (<Plugin>_customreport_<customreportid>_<revisionid>).
+        // We name custom reports like CustomReports_customreport_1_1
+        //(<Plugin>_customreport_<customreportid>_<revisionid>).
+        //
         // We need to reprocess individual metrics for the requested report.
+        //
         // These are named like CustomReports_customreport_1_1_nb_visits
         // (<Plugin>_customreport_<customreportid>_<revisionid>_<metricname>).
-        //
-        // So we want to reprocess reports named <reportname>_* to capture all needed metrics.
         foreach ($requestedReports as $requestedReport) {
             $requestedReportWithUnderscore = $requestedReport . '_';
-            if (strncmp($name, $requestedReportWithUnderscore, strlen($requestedReportWithUnderscore)) === 0) {
+            if (strncmp($reportName, $requestedReportWithUnderscore, strlen($requestedReportWithUnderscore)) === 0) {
                 return true;
             }
         }
-        // Do not process if we did not ask for this.
+
         return false;
     }
 

--- a/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
+++ b/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
@@ -247,7 +247,6 @@ class RecordBuilderTest extends TestCase
         $this->assertEmpty($this->blobRecordsInserted);
     }
 
-    // here
     public function testBuildForNonDayPeriodAggregatesAllChildReportsIfNoRequestedReportsAreSpecified()
     {
         $recordBuilder = new class () extends ArchiveProcessor\RecordBuilder {
@@ -300,7 +299,6 @@ class RecordBuilderTest extends TestCase
         $this->assertEquals($expectedBlobRecords, $this->blobRecordsInserted);
     }
 
-    // here
     public function testBuildForNonDayPeriodAggregatesOnlyRequestedReportsIfRequestedReportsSpecifiedAndNoneAlreadyExist()
     {
         $recordBuilder = new class () extends ArchiveProcessor\RecordBuilder {

--- a/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
+++ b/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
@@ -247,6 +247,7 @@ class RecordBuilderTest extends TestCase
         $this->assertEmpty($this->blobRecordsInserted);
     }
 
+    // here
     public function testBuildForNonDayPeriodAggregatesAllChildReportsIfNoRequestedReportsAreSpecified()
     {
         $recordBuilder = new class () extends ArchiveProcessor\RecordBuilder {
@@ -299,6 +300,7 @@ class RecordBuilderTest extends TestCase
         $this->assertEquals($expectedBlobRecords, $this->blobRecordsInserted);
     }
 
+    // here
     public function testBuildForNonDayPeriodAggregatesOnlyRequestedReportsIfRequestedReportsSpecifiedAndNoneAlreadyExist()
     {
         $recordBuilder = new class () extends ArchiveProcessor\RecordBuilder {
@@ -382,6 +384,42 @@ class RecordBuilderTest extends TestCase
                 ],
             ],
         ];
+
+        $this->assertEquals($expectedNumericRecords, $this->numericRecordsInserted);
+        $this->assertEquals($expectedBlobRecords, $this->blobRecordsInserted);
+    }
+
+    public function testBuildForNonDayPeriodAggregatesMetricsRelatedToRequestedReport()
+    {
+        $recordBuilder = new class () extends ArchiveProcessor\RecordBuilder {
+            public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    Record::make(Record::TYPE_NUMERIC, 'CustomReports_customreport_1_1_nb_visits'),
+                    Record::make(Record::TYPE_NUMERIC, 'CustomReports_customreport_1_1_other_metric'),
+                ];
+            }
+
+            protected function aggregate(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    'CustomReports_customreport_1_1_nb_visits' => 50,
+                    'CustomReports_customreport_1_1_other_metric' => 100,
+                ];
+            }
+        };
+
+        $mockArchiveProcessor = $this->getMockArchiveProcessor(
+            'week',
+            ['CustomReports_customreport_1_1']
+        );
+        $recordBuilder->buildForNonDayPeriod($mockArchiveProcessor);
+
+        $expectedNumericRecords = [
+            'CustomReports_customreport_1_1_nb_visits' => 9000,
+            'CustomReports_customreport_1_1_other_metric' => 10500,
+        ];
+        $expectedBlobRecords = [];
 
         $this->assertEquals($expectedNumericRecords, $this->numericRecordsInserted);
         $this->assertEquals($expectedBlobRecords, $this->blobRecordsInserted);


### PR DESCRIPTION
### Description:

Fixes PG-4508 .

When creating or editing a custom report of type "Evolution" non daily metrics don't get archived until manual re-archiving


### To replicate

- Create a new custom report of type "Evolution" and trigger archiving.
- See that non daily metrics are not successfully recorded in the database.

### What's happening

When a custom report is created or edited in a material fashion, rearchiving is scheduled /for the specific report/.

When re-archiving, the archiver RecordBuilder skips reports that are not specifically requested.  In the case of an evolution report (where we requested something like "CustomReports_customreport_1_1") individual metrics are skipped (which have a name something like "CustomReports_customreport_1_1_nb_visits").

This PR updates the code to check for these metrics.

These extra metrics are added in plugins/CustomReports/RecordBuilders/CustomReport.php->getRecordMetadata()


### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [n/a] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [n/a] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [n/a] Existing documentation updated if needed
