### PR TITLE
Simplify check for changing UserId

### DIFF
--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -208,10 +208,7 @@ class VisitRequestProcessor extends RequestProcessor
             return true;
         }
 
-        if (
-            !TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid', $request->getIdSiteIfExists())
-            && !$this->lastUserIdWasSetAndDoesMatch($visitProperties, $request)
-        ) {
+        if (!$this->lastUserIdWasSetAndDoesMatch($visitProperties, $request)) {
             Common::printDebug("Visitor detected, but last user_id does not match...");
             return true;
         }

--- a/plugins/CoreHome/tests/Integration/Tracker/VisitRequestProcessorTest.php
+++ b/plugins/CoreHome/tests/Integration/Tracker/VisitRequestProcessorTest.php
@@ -29,10 +29,10 @@ class VisitRequestProcessorTest extends IntegrationTestCase
 {
     public function testIsVisitNewReturnsTrueIfTrackerAlwaysNewVisitorIsSet()
     {
-        $this->setDimensionsWithOnNewVisit(array(false, false, false));
+        $this->setDimensionsWithOnNewVisit([false, false, false]);
 
         /** @var VisitRequestProcessor $visit */
-        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction(
+        [$visit, $visitProperties, $request] = $this->makeVisitorAndAction(
             $lastActionTime = '2012-01-02 08:08:34',
             $thisActionTime = '2012-01-02 08:12:45',
             $isVisitorKnown = true,
@@ -46,10 +46,10 @@ class VisitRequestProcessorTest extends IntegrationTestCase
 
     public function testIsVisitNewReturnsTrueIfNewVisitQueryParamIsSet()
     {
-        $this->setDimensionsWithOnNewVisit(array(false, false, false));
+        $this->setDimensionsWithOnNewVisit([false, false, false]);
 
         /** @var VisitRequestProcessor $visit */
-        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction(
+        [$visit, $visitProperties, $request] = $this->makeVisitorAndAction(
             $lastActionTime = '2012-01-02 08:08:34',
             $thisActionTime = '2012-01-02 08:12:45',
             $isVisitorKnown = true,
@@ -64,10 +64,10 @@ class VisitRequestProcessorTest extends IntegrationTestCase
 
     public function testIsVisitNewReturnsFalseIfLastActionTimestampIsWithinVisitTimeLengthAndNoDimensionForcesVisitAndVisitorKnown()
     {
-        $this->setDimensionsWithOnNewVisit(array(false, false, false));
+        $this->setDimensionsWithOnNewVisit([false, false, false]);
 
         /** @var VisitRequestProcessor $visit */
-        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction(
+        [$visit, $visitProperties, $request] = $this->makeVisitorAndAction(
             $lastActionTime = '2012-01-02 08:08:34',
             $thisActionTime = '2012-01-02 08:12:45',
             $isVisitorKnown = true
@@ -80,11 +80,11 @@ class VisitRequestProcessorTest extends IntegrationTestCase
 
     public function testIsVisitNewReturnsTrueIfLastActionTimestampWasYesterday()
     {
-        $this->setDimensionsWithOnNewVisit(array(false, false, false));
+        $this->setDimensionsWithOnNewVisit([false, false, false]);
 
         // test same day
         /** @var VisitRequestProcessor $visit */
-        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction(
+        [$visit, $visitProperties, $request] = $this->makeVisitorAndAction(
             $lastActionTime = '2012-01-01 23:59:58',
             $thisActionTime = '2012-01-01 23:59:59',
             $isVisitorKnown = true
@@ -93,7 +93,7 @@ class VisitRequestProcessorTest extends IntegrationTestCase
         $this->assertFalse($result);
 
         // test different day
-        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction(
+        [$visit, $visitProperties, $request] = $this->makeVisitorAndAction(
             $lastActionTime = '2012-01-01 23:59:58',
             $thisActionTime = '2012-01-02 00:00:01',
             $isVisitorKnown = true
@@ -105,10 +105,10 @@ class VisitRequestProcessorTest extends IntegrationTestCase
 
     public function testIsVisitNewReturnsTrueIfLastActionTimestampIsNotWithinVisitTimeLengthAndNoDimensionForcesVisitAndVisitorNotKnown()
     {
-        $this->setDimensionsWithOnNewVisit(array(false, false, false));
+        $this->setDimensionsWithOnNewVisit([false, false, false]);
 
         /** @var VisitRequestProcessor $visit */
-        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction($lastActionTime = '2012-01-02 08:08:34', $thisActionTime = '2012-01-02 09:12:45');
+        [$visit, $visitProperties, $request] = $this->makeVisitorAndAction($lastActionTime = '2012-01-02 08:08:34', $thisActionTime = '2012-01-02 09:12:45');
 
         $result = $visit->isVisitNew($visitProperties, $request, null);
 
@@ -117,10 +117,10 @@ class VisitRequestProcessorTest extends IntegrationTestCase
 
     public function testIsVisitNewReturnsTrueIfLastActionTimestampIsWithinVisitTimeLengthAndDimensionForcesVisit()
     {
-        $this->setDimensionsWithOnNewVisit(array(false, false, true));
+        $this->setDimensionsWithOnNewVisit([false, false, true]);
 
         /** @var VisitRequestProcessor $visit */
-        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction($lastActionTime = '2012-01-02 08:08:34', $thisActionTime = '2012-01-02 08:12:45');
+        [$visit, $visitProperties, $request] = $this->makeVisitorAndAction($lastActionTime = '2012-01-02 08:08:34', $thisActionTime = '2012-01-02 08:12:45');
 
         $result = $visit->isVisitNew($visitProperties, $request, null);
 
@@ -129,23 +129,23 @@ class VisitRequestProcessorTest extends IntegrationTestCase
 
     public function testIsVisitNewReturnsTrueIfDimensionForcesVisitAndVisitorKnown()
     {
-        $this->setDimensionsWithOnNewVisit(array(false, false, true));
+        $this->setDimensionsWithOnNewVisit([false, false, true]);
 
         /** @var VisitRequestProcessor $visit */
-        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction($lastActionTime = '2012-01-02 08:08:34', $thisActionTime = '2012-01-02 08:12:45');
+        [$visit, $visitProperties, $request] = $this->makeVisitorAndAction($lastActionTime = '2012-01-02 08:08:34', $thisActionTime = '2012-01-02 08:12:45');
 
         $result = $visit->isVisitNew($visitProperties, $request, null);
 
         $this->assertTrue($result);
     }
 
-    public function testIsVisitNewReturnsFalseWhenUserIdChanges()
+    public function testIsVisitNewReturnsTrueWhenUserIdChanges()
     {
-        $this->setDimensionsWithOnNewVisit(array(false, false, false));
+        $this->setDimensionsWithOnNewVisit([false, false, false]);
 
         /** @var VisitRequestProcessor $visit */
         /** @var Request $request */
-        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction(
+        [$visit, $visitProperties, $request] = $this->makeVisitorAndAction(
             $lastActionTime = '2012-01-02 08:08:34',
             $thisActionTime = '2012-01-02 08:12:45',
             $isVisitorKnown = true
@@ -154,12 +154,12 @@ class VisitRequestProcessorTest extends IntegrationTestCase
         $visitProperties->setProperty('user_id', 'foo_different');
         $request->setParam('uid', 'foo');
         $result = $visit->isVisitNew($visitProperties, $request, null);
-        $this->assertFalse($result);
+        $this->assertTrue($result);
     }
 
     public function testIsVisitNewReturnsTrueWhenUserChangesAndUserIdNotOverwritesVisitorId()
     {
-        $this->setDimensionsWithOnNewVisit(array(false, false, false));
+        $this->setDimensionsWithOnNewVisit([false, false, false]);
         $config = Config::getInstance();
         $tracker = $config->Tracker;
         $tracker['enable_userid_overwrites_visitorid'] = 0;
@@ -168,7 +168,7 @@ class VisitRequestProcessorTest extends IntegrationTestCase
         /** @var VisitRequestProcessor $visit */
         /** @var VisitProperties $visitProperties */
         /** @var Request $request */
-        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction(
+        [$visit, $visitProperties, $request] = $this->makeVisitorAndAction(
             $lastActionTime = '2012-01-02 08:08:34',
             $thisActionTime = '2012-01-02 08:12:45',
             $isVisitorKnown = true
@@ -190,7 +190,7 @@ class VisitRequestProcessorTest extends IntegrationTestCase
         $idsite = API::getInstance()->addSite("name", "http://piwik.net/");
 
         /** @var Request $request */
-        list($visit, $request) = $this->prepareVisitWithRequest(
+        [$visit, $request] = $this->prepareVisitWithRequest(
             array_merge(['idsite' => $idsite], $extraRequestParams),
             $currentActionTime,
             $processorParams
@@ -200,15 +200,15 @@ class VisitRequestProcessorTest extends IntegrationTestCase
         $visitProperties->setProperty('visit_last_action_time', Date::factory($lastActionTimestamp)->getTimestamp());
         $request->setMetadata('CoreHome', 'isVisitorKnown', $isVisitorKnown);
 
-        return array($visit, $visitProperties, $request);
+        return [$visit, $visitProperties, $request];
     }
 
     private function setDimensionsWithOnNewVisit($dimensionOnNewVisitResults)
     {
-        $dimensions = array();
+        $dimensions = [];
         foreach ($dimensionOnNewVisitResults as $onNewVisitResult) {
             $dim = $this->getMockBuilder(VisitDimension::class)
-                        ->onlyMethods(array('shouldForceNewVisit', 'getColumnName'))
+                ->onlyMethods(['shouldForceNewVisit', 'getColumnName'])
                         ->getMock();
             $dim->expects($this->any())->method('shouldForceNewVisit')->will($this->returnValue($onNewVisitResult));
             $dimensions[] = $dim;
@@ -226,6 +226,6 @@ class VisitRequestProcessorTest extends IntegrationTestCase
 
         $visit = self::$fixture->piwikEnvironment->getContainer()->make('Piwik\Plugins\CoreHome\Tracker\VisitRequestProcessor', $params);
 
-        return array($visit, $request);
+        return [$visit, $request];
     }
 }


### PR DESCRIPTION
### Description:

Technically this change should not have any effect.
If `enable_userid_overwrites_visitorid` is enabled, a new visitorid will be set anyway when the userid changes. This also causes a new visit, as the visitorid then always differs from the previous one.

But as we always want to force a new visit when the user id changes, the config check shouldn't be done here at all.

refs #19927

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
