### PR TITLE
Use shell_exec instead of backticks

### DIFF
--- a/core/Metrics/Formatter.php
+++ b/core/Metrics/Formatter.php
@@ -120,7 +120,7 @@ class Formatter
     /**
      * Returns a prettified memory size value.
      *
-     * @param number $size The size in bytes.
+     * @param string|int|float $size The size in bytes.
      * @param string $unit The specific unit to use, if any. If null, the unit is determined by $size.
      * @param int $precision The precision to use when rounding.
      * @return string eg, `'128 M'` or `'256 K'`.

--- a/plugins/CoreConsole/Commands/ComputeJsAssetSize.php
+++ b/plugins/CoreConsole/Commands/ComputeJsAssetSize.php
@@ -255,15 +255,15 @@ class ComputeJsAssetSize extends ConsoleCommand
 
     private function printCurrentGitHashAndBranch($plugin = null)
     {
-        $branchName = trim(`git rev-parse --abbrev-ref HEAD`);
-        $lastCommit = trim(`git log --pretty=format:'%h' -n 1`);
+        $branchName = trim(shell_exec("git rev-parse --abbrev-ref HEAD"));
+        $lastCommit = trim(shell_exec("git log --pretty=format:'%h' -n 1"));
 
         $pluginSuffix = '';
         if ($plugin) {
             $prefix = 'cd "' . addslashes(PIWIK_INCLUDE_PATH . '/plugins/' . $plugin) . '"; ';
 
-            $pluginBranchName = trim(`$prefix git rev-parse --abbrev-ref HEAD`);
-            $pluginLastCommit = trim(`$prefix git log --pretty=format:'%h' -n 1`);
+            $pluginBranchName = trim(shell_exec("$prefix git rev-parse --abbrev-ref HEAD"));
+            $pluginLastCommit = trim(shell_exec("$prefix git log --pretty=format:'%h' -n 1"));
 
             $pluginSuffix = " [$plugin: $pluginBranchName ($pluginLastCommit)]";
         }

--- a/plugins/CoreConsole/Commands/ComputeJsAssetSize.php
+++ b/plugins/CoreConsole/Commands/ComputeJsAssetSize.php
@@ -10,6 +10,7 @@
 namespace Piwik\Plugins\CoreConsole\Commands;
 
 use Piwik\AssetManager;
+use Piwik\AssetManager\UIAssetFetcher\PluginUmdAssetFetcher;
 use Piwik\Development;
 use Piwik\Metrics\Formatter;
 use Piwik\Plugin;
@@ -19,9 +20,18 @@ use Piwik\ProxyHttp;
 use Piwik\SettingsPiwik;
 use Piwik\Theme;
 
+/**
+ * @phpstan-type TOTALS array{merged: int, gzip: int}
+ */
 class ComputeJsAssetSize extends ConsoleCommand
 {
-    private $totals = [];
+    /**
+     * @var TOTALS
+     */
+    private $totals = [
+        'merged' => 0,
+        'gzip'   => 0,
+    ];
 
     protected function configure()
     {
@@ -41,7 +51,12 @@ class ComputeJsAssetSize extends ConsoleCommand
         $input = $this->getInput();
         $output = $this->getOutput();
         $noDelete = $input->getOption('no-delete');
+        /** @var null|string $plugin */
         $plugin = $input->getOption('plugin');
+
+        if (!empty($plugin) && !Manager::getInstance()->isValidPluginName($plugin)) {
+            throw new \Exception('Invalid plugin name: ' . $plugin);
+        }
 
         $this->checkDevelopmentModeDisabled();
 
@@ -54,11 +69,11 @@ class ComputeJsAssetSize extends ConsoleCommand
         $this->deleteMergedAssets();
         $this->buildAssets($fetcher);
 
-        $output->writeln("");
+        $output->writeln('');
 
         $this->printCurrentGitHashAndBranch($plugin);
 
-        $output->writeln("");
+        $output->writeln('');
         $this->printFilesizes($fetcher);
 
         if (!$noDelete) {
@@ -68,7 +83,7 @@ class ComputeJsAssetSize extends ConsoleCommand
         return self::SUCCESS;
     }
 
-    private function ensureThirdPartyPluginsActivated($plugin = null)
+    private function ensureThirdPartyPluginsActivated(?string $plugin = null): void
     {
         $expectedPluginsLoadedAndActivated = [
             "CorePluginsAdmin",
@@ -180,7 +195,7 @@ class ComputeJsAssetSize extends ConsoleCommand
         }
     }
 
-    private function buildAssets(AssetManager\UIAssetFetcher\PluginUmdAssetFetcher $fetcher)
+    private function buildAssets(PluginUmdAssetFetcher $fetcher): void
     {
         AssetManager::getInstance()->getMergedCoreJavaScript();
         AssetManager::getInstance()->getMergedNonCoreJavaScript();
@@ -191,12 +206,12 @@ class ComputeJsAssetSize extends ConsoleCommand
         }
     }
 
-    private function deleteMergedAssets()
+    private function deleteMergedAssets(): void
     {
         AssetManager::getInstance()->removeMergedAssets();
     }
 
-    private function printFilesizes(AssetManager\UIAssetFetcher\PluginUmdAssetFetcher $fetcher)
+    private function printFilesizes(PluginUmdAssetFetcher $fetcher): void
     {
         $fileSizes = [];
 
@@ -218,28 +233,32 @@ class ComputeJsAssetSize extends ConsoleCommand
         $this->renderTable(['File', 'Size', 'Size (gzipped)'], $fileSizes);
     }
 
-    private function getFileSize($fileLocation, $type)
+    /**
+     * @param string $fileLocation
+     * @param key-of<TOTALS> $type
+     * @return string
+     */
+    private function getFileSize(string $fileLocation, string $type): string
     {
-        $size = filesize($fileLocation);
-        $this->totals[$type] = ($this->totals[$type] ?? 0) + $size;
+        $size = (int)filesize($fileLocation);
+        $this->totals[$type] += $size;
         return $this->getFormattedSize($size);
     }
 
-    private function getFormattedSize($size)
+    private function getFormattedSize(int $size): string
     {
         $formatter = new Formatter();
-        $size = $formatter->getPrettySizeFromBytes($size, 'K', 2);
-        return $size;
+        return $formatter->getPrettySizeFromBytes($size, 'K', 2);
     }
 
-    private function checkDevelopmentModeDisabled()
+    private function checkDevelopmentModeDisabled(): void
     {
         if (Development::isEnabled()) {
             throw new \Exception("This command is to estimate production build sizes, so development mode must be disabled for it.");
         }
     }
 
-    private function getGzippedFileSize($path)
+    private function getGzippedFileSize(string $path): string
     {
         $data = file_get_contents($path);
         $data = ProxyHttp::gzencode($data);
@@ -253,17 +272,17 @@ class ComputeJsAssetSize extends ConsoleCommand
         return $this->getFileSize($compressedPath, 'gzip');
     }
 
-    private function printCurrentGitHashAndBranch($plugin = null)
+    private function printCurrentGitHashAndBranch(?string $plugin = null): void
     {
-        $branchName = trim(shell_exec("git rev-parse --abbrev-ref HEAD"));
-        $lastCommit = trim(shell_exec("git log --pretty=format:'%h' -n 1"));
+        $branchName = trim(shell_exec("git rev-parse --abbrev-ref HEAD") ?: '');
+        $lastCommit = trim(shell_exec("git log --pretty=format:'%h' -n 1") ?: '');
 
         $pluginSuffix = '';
         if ($plugin) {
-            $prefix = 'cd "' . addslashes(PIWIK_INCLUDE_PATH . '/plugins/' . $plugin) . '"; ';
+            $prefix = 'cd ' . escapeshellarg(PIWIK_INCLUDE_PATH . '/plugins/' . $plugin) . '; ';
 
-            $pluginBranchName = trim(shell_exec("$prefix git rev-parse --abbrev-ref HEAD"));
-            $pluginLastCommit = trim(shell_exec("$prefix git log --pretty=format:'%h' -n 1"));
+            $pluginBranchName = trim(shell_exec($prefix . 'git rev-parse --abbrev-ref HEAD') ?: '');
+            $pluginLastCommit = trim(shell_exec($prefix . 'git log --pretty=format:\'%h\' -n 1') ?: '');
 
             $pluginSuffix = " [$plugin: $pluginBranchName ($pluginLastCommit)]";
         }
@@ -271,7 +290,7 @@ class ComputeJsAssetSize extends ConsoleCommand
         $this->getOutput()->writeln("<info>$branchName ($lastCommit)$pluginSuffix</info>");
     }
 
-    private function makeUmdFetcher()
+    private function makeUmdFetcher(): PluginUmdAssetFetcher
     {
         $plugins = Manager::getInstance()->getPluginsLoadedAndActivated();
         $pluginNames = array_map(function ($p) {
@@ -283,11 +302,14 @@ class ComputeJsAssetSize extends ConsoleCommand
             $theme = new Theme();
         }
 
-        $fetcher = new AssetManager\UIAssetFetcher\PluginUmdAssetFetcher($pluginNames, $theme, null);
-        return $fetcher;
+        return new PluginUmdAssetFetcher($pluginNames, $theme, null);
     }
 
-    private function getFileSizeRow(AssetManager\UIAsset $asset)
+
+    /**
+     * @return array{0: string, 1: string, 2: string}
+     */
+    private function getFileSizeRow(AssetManager\UIAsset $asset): array
     {
         return [$asset->getRelativeLocation(), $this->getFileSize($asset->getAbsoluteLocation(), 'merged'), $this->getGzippedFileSize($asset->getAbsoluteLocation())];
     }

--- a/plugins/CoreConsole/Commands/ComputeJsAssetSize.php
+++ b/plugins/CoreConsole/Commands/ComputeJsAssetSize.php
@@ -21,12 +21,12 @@ use Piwik\SettingsPiwik;
 use Piwik\Theme;
 
 /**
- * @phpstan-type TOTALS array{merged: int, gzip: int}
+ * @phpstan-type TotalsType array{merged: int, gzip: int}
  */
 class ComputeJsAssetSize extends ConsoleCommand
 {
     /**
-     * @var TOTALS
+     * @var TotalsType
      */
     private $totals = [
         'merged' => 0,
@@ -234,9 +234,7 @@ class ComputeJsAssetSize extends ConsoleCommand
     }
 
     /**
-     * @param string $fileLocation
-     * @param key-of<TOTALS> $type
-     * @return string
+     * @param key-of<TotalsType> $type
      */
     private function getFileSize(string $fileLocation, string $type): string
     {


### PR DESCRIPTION
### Description:

Using backticks is bad practice and might become deprecated with PHP 9, so we should avoid using them.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
