### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -738,12 +738,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/searchengine-and-social-list.git",
-                "reference": "4e6bdf8a6d831fa179b0743803feb6a3deffee90"
+                "reference": "4a0558b1ef137f4ed4efa59de65d3b2c02dfa63c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/searchengine-and-social-list/zipball/4e6bdf8a6d831fa179b0743803feb6a3deffee90",
-                "reference": "4e6bdf8a6d831fa179b0743803feb6a3deffee90",
+                "url": "https://api.github.com/repos/matomo-org/searchengine-and-social-list/zipball/4a0558b1ef137f4ed4efa59de65d3b2c02dfa63c",
+                "reference": "4a0558b1ef137f4ed4efa59de65d3b2c02dfa63c",
                 "shasum": ""
             },
             "replace": {
@@ -760,7 +760,7 @@
                 "issues": "https://github.com/matomo-org/searchengine-and-social-list/issues",
                 "source": "https://github.com/matomo-org/searchengine-and-social-list/tree/master"
             },
-            "time": "2025-05-27T12:49:16+00:00"
+            "time": "2025-09-03T07:03:28+00:00"
         },
         {
             "name": "maxmind-db/reader",
@@ -5445,16 +5445,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.2",
+            "version": "3.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
+                "reference": "5be16e10d07a2b0c629a8fc52c653fd57458bdf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
-                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5be16e10d07a2b0c629a8fc52c653fd57458bdf8",
+                "reference": "5be16e10d07a2b0c629a8fc52c653fd57458bdf8",
                 "shasum": ""
             },
             "require": {
@@ -5525,7 +5525,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-06-17T22:17:01+00:00"
+            "time": "2025-09-04T19:19:52+00:00"
         },
         {
             "name": "symfony/yaml",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
                                                      Updating dependencies
Lock file operations: 0 installs, 2 updates, 0 removals
  - Upgrading matomo/searchengine-and-social-list (dev-master 4e6bdf8 => dev-master 4a0558b)
  - Upgrading squizlabs/php_codesniffer (3.13.2 => 3.13.3)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 2 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.13.3)
  - Downloading matomo/searchengine-and-social-list (dev-master 4a0558b)
  - Upgrading squizlabs/php_codesniffer (3.13.2 => 3.13.3): Extracting archive
  - Upgrading matomo/searchengine-and-social-list (dev-master 4e6bdf8 => dev-master 4a0558b): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
54 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
PHP CodeSniffer Config installed_paths set to ../../matomo-org/matomo-coding-standards,../../slevomat/coding-standard
No security vulnerability advisories found.
```
