### PR TITLE
Correctly escape line breaks in CSV and TSV exports

### DIFF
--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -230,6 +230,7 @@ class Csv extends Renderer
             if (
                 strpos($value, '"') !== false
                 || strpos($value, $this->separator) !== false
+                || strpos($value, $this->lineEnd) !== false
                 || strpos($value, ',') !== false
                 || strpos($value, ';') !== false
             ) {

--- a/plugins/API/tests/Unit/CsvRendererTest.php
+++ b/plugins/API/tests/Unit/CsvRendererTest.php
@@ -132,6 +132,7 @@ The\nOutput', $response);
             array('-test()', '\'-test()'),
             array('-te,st()', '"\'-te,st()"'),
             array('-te"st()', '"\'-te""st()"'),
+            array("value\nbreak", "\"value\nbreak\""),
 
             // we do not need to prefix with quote
             array('1', '1'),

--- a/tests/PHPUnit/Unit/DataTable/Renderer/CsvTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/CsvTest.php
@@ -250,6 +250,16 @@ b,d,f,g',
             "'\0%00\0%00=@A1\n'%00\0%00%00=SUM(A)",
         ];
 
+        yield "line break in value should be escaped" => [
+            function () {
+                return [
+                    "header\nbreak" => "value",
+                    "header"        => "value\nbreak",
+                ];
+            },
+            "\"header\nbreak\",header\nvalue,\"value\nbreak\"",
+        ];
+
         yield 'renders headers and values correctly escaped' => [
             function () {
                 return self::getDataTableSimpleWithCommasInCells();

--- a/tests/PHPUnit/Unit/DataTable/Renderer/TsvTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/TsvTest.php
@@ -251,6 +251,17 @@ b\td\tf\tg",
             "'\0%00\0%00=@A1\n'%00\0%00%00=SUM(A)",
         ];
 
+        yield "line break in value should be escaped" => [
+            function () {
+                return [
+                    "header\nbreak" => "value",
+                    "header"        => "value\nbreak",
+                ];
+            },
+            "\"header\nbreak\"\theader\nvalue\t\"value\nbreak\"",
+        ];
+
+
         yield 'renders headers and values correctly escaped' => [
             function () {
                 return self::getDataTableSimpleWithCommasInCells();


### PR DESCRIPTION
### Description:

Tested some exports locally. Using TSV Excel is able to import such a file correctly. For CSV it didn't work properly, even when defining separator and escaping chars it failed.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
