### PR TITLE
Increase 2FA key size

### DIFF
--- a/plugins/TwoFactorAuth/Dao/TwoFaSecretRandomGenerator.php
+++ b/plugins/TwoFactorAuth/Dao/TwoFaSecretRandomGenerator.php
@@ -16,6 +16,6 @@ class TwoFaSecretRandomGenerator
     public function generateSecret()
     {
         $authenticator = new \TwoFactorAuthenticator();
-        return $authenticator->createSecret(16);
+        return $authenticator->createSecret(32);
     }
 }

--- a/plugins/TwoFactorAuth/tests/Integration/Dao/TwoFaSecretRandomGeneratorTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/Dao/TwoFaSecretRandomGeneratorTest.php
@@ -33,7 +33,7 @@ class TwoFaSecretRandomGeneratorTest extends IntegrationTestCase
 
     public function testGeneratorCodeLength()
     {
-        $this->assertSame(16, mb_strlen($this->generator->generateSecret()));
+        $this->assertSame(32, mb_strlen($this->generator->generateSecret()));
     }
 
     public function testGeneratorCodeAlwaysDifferent()

--- a/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthenticationTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthenticationTest.php
@@ -56,7 +56,7 @@ class TwoFactorAuthenticationTest extends IntegrationTestCase
 
     public function testGenerateSecret()
     {
-        $this->assertSame(16, mb_strlen($this->twoFa->generateSecret()));
+        $this->assertSame(32, mb_strlen($this->twoFa->generateSecret()));
     }
 
     public function testIsUserRequiredToHaveTwoFactorEnabledNotByDefault()


### PR DESCRIPTION
### Description:

When scanning the 2FA codes with FreeOTP it reports that the tokens contain insecure cryptographic parameters. The key is too short. Google authenicator standard is 32 characters.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
