### PR TITLE
Use the idGoal from Sparkline URL, when updating the DataTable

### DIFF
--- a/plugins/CoreHome/javascripts/sparkline.js
+++ b/plugins/CoreHome/javascripts/sparkline.js
@@ -100,6 +100,9 @@ window.initializeSparklines = function () {
                     if (urlParams.rows) {
                         params.rows = decodeURIComponent(urlParams.rows);
                     }
+                    if (urlParams.idGoal) {
+                        params.idGoal = decodeURIComponent(urlParams.idGoal);
+                    }
                 }
 
                 // on click, reload the graph with the new url


### PR DESCRIPTION
### Description:

Use the idGoal from Sparkline URL to update the datatable, instead of always using page default / first idGoal, so that the Ecommerce Overview is able to load the abandoned cart metrics, instead of always falling back to idGoal=ecommerceOrder

adresses #22713 (edit: also #21957 / #22014 )

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
