### PR TITLE
Bring Notification class to PHPStan level 5

### DIFF
--- a/core/Notification.php
+++ b/core/Notification.php
@@ -148,7 +148,7 @@ class Notification
      * The notification's priority. The higher the priority, the higher the order. See `PRIORITY_*`
      * constants in {@link Notification} to see possible priority values.
      *
-     * @var int
+     * @var ?int
      */
     public $priority;
 

--- a/core/Notification/Manager.php
+++ b/core/Notification/Manager.php
@@ -20,15 +20,16 @@ use Piwik\Session\SessionNamespace;
 class Manager
 {
     public const MAX_NOTIFICATIONS_IN_SESSION = 30;
+
     /**
-     * @var SessionNamespace
+     * @var ?SessionNamespace
      */
     private static $session = null;
 
     /**
-     * @var Notification[]
+     * @var array<string, Notification>
      */
-    private static $notifications = array();
+    private static $notifications = [];
 
     /**
      * Posts a notification that will be shown in Piwik's status bar. If a notification with the same ID
@@ -42,7 +43,7 @@ class Manager
      *                   pending ones.
      * @api
      */
-    public static function notify($id, Notification $notification)
+    public static function notify($id, Notification $notification): bool
     {
         self::checkId($id);
 
@@ -55,7 +56,7 @@ class Manager
      *
      * @param string $id The notification ID, see {@link notify()}.
      */
-    public static function cancel($id)
+    public static function cancel($id): void
     {
         self::checkId($id);
 
@@ -68,22 +69,22 @@ class Manager
      * Call this method after the notifications have been
      * displayed to make sure temporary notifications won't be displayed twice.
      */
-    public static function cancelAllNonPersistent()
+    public static function cancelAllNonPersistent(): void
     {
-        foreach (static::getAllNotifications() as $id => $notification) {
+        foreach (self::getAllNotifications() as $id => $notification) {
             if (Notification::TYPE_PERSISTENT != $notification->type) {
-                static::removeNotification($id);
+                self::removeNotification($id);
             }
         }
     }
 
     /**
      * Determine all notifications that needs to be displayed. They are sorted by priority. Highest priorities first.
-     * @return \ArrayObject
+     * @return array<string, Notification>
      */
-    public static function getAllNotificationsToDisplay()
+    public static function getAllNotificationsToDisplay(): array
     {
-        $notifications = static::getAllNotifications();
+        $notifications = self::getAllNotifications();
 
         uasort($notifications, function ($n1, $n2) {
             /** @var Notification $n1 */ /** @var Notification $n2 */
@@ -101,7 +102,7 @@ class Manager
      * @param $id
      * @throws \Exception In case id is empty or if id contains non word characters
      */
-    private static function checkId($id)
+    private static function checkId($id): void
     {
         if (empty($id)) {
             throw new \Exception('Notification ID is empty.');
@@ -112,7 +113,7 @@ class Manager
         }
     }
 
-    private static function addNotification($id, Notification $notification)
+    private static function addNotification($id, Notification $notification): bool
     {
         self::saveNotificationAcrossUiRequestsIfNeeded($id, $notification);
 
@@ -127,17 +128,17 @@ class Manager
         return true;
     }
 
-    private static function saveNotificationAcrossUiRequestsIfNeeded($id, Notification $notification)
+    private static function saveNotificationAcrossUiRequestsIfNeeded($id, Notification $notification): void
     {
         if (self::isSessionEnabled()) {
             // we need to save even non persistent notifications if possible. Otherwise if there's a redirect
             // a notification is not shown on the next page view
-            $session = static::getSession();
+            $session = self::getSession();
             $session->notifications[$id] = $notification;
         }
     }
 
-    private static function removeOldestNotificationsIfThereAreTooMany()
+    private static function removeOldestNotificationsIfThereAreTooMany(): void
     {
         if (!self::isSessionEnabled()) {
             return;
@@ -145,17 +146,20 @@ class Manager
 
         $maxNotificationsInSession = self::MAX_NOTIFICATIONS_IN_SESSION;
 
-        $session = static::getSession();
+        $session = self::getSession();
 
         while (count($session->notifications) >= $maxNotificationsInSession) {
             array_shift($session->notifications);
         }
     }
 
-    private static function getAllNotifications()
+    /**
+     * @return array<string, Notification>
+     */
+    private static function getAllNotifications(): array
     {
         if (!self::isSessionEnabled()) {
-            return array();
+            return [];
         }
 
         $notifications = self::$notifications;
@@ -166,58 +170,56 @@ class Manager
             self::saveNotificationAcrossUiRequestsIfNeeded($id, $notification);
         }
 
-        if (self::isSessionEnabled()) {
-            $session = static::getSession();
-            foreach ($session->notifications as $id => $notification) {
-                $notifications[$id] = $notification;
-            }
+        $session = self::getSession();
+        foreach ($session->notifications as $id => $notification) {
+            $notifications[$id] = $notification;
         }
 
         return $notifications;
     }
 
-    private static function removeNotification($id)
+    private static function removeNotification($id): void
     {
         if (array_key_exists($id, self::$notifications)) {
             unset(self::$notifications[$id]);
         }
 
         if (self::isSessionEnabled()) {
-            $session = static::getSession();
+            $session = self::getSession();
             if (array_key_exists($id, $session->notifications)) {
                 unset($session->notifications[$id]);
             }
         }
     }
 
-    private static function isSessionEnabled()
+    private static function isSessionEnabled(): bool
     {
         return Session::isWritable() && Session::isReadable();
     }
 
-    /**
-     * @return SessionNamespace
-     */
-    private static function getSession()
+    private static function getSession(): SessionNamespace
     {
-        if (!isset(static::$session)) {
-            static::$session = new SessionNamespace('notification');
+        if (!isset(self::$session)) {
+            self::$session = new SessionNamespace('notification');
         }
 
-        if (empty(static::$session->notifications) && self::isSessionEnabled()) {
-            static::$session->notifications = array();
+        if (empty(self::$session->notifications) && self::isSessionEnabled()) {
+            self::$session->notifications = [];
         }
 
-        return static::$session;
+        return self::$session;
     }
 
-    public static function cancelAllNotifications()
+    public static function cancelAllNotifications(): void
     {
         self::$notifications = [];
     }
 
-    // for tests
-    public static function getPendingInMemoryNotifications()
+    /**
+     * for tests
+     * @return array<string, Notification>
+     */
+    public static function getPendingInMemoryNotifications(): array
     {
         return self::$notifications;
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1726,59 +1726,9 @@ parameters:
 			path: core/Metrics/Sorter.php
 
 		-
-			message: "#^Access to an undefined property Piwik\\\\Session\\\\SessionNamespace\\:\\:\\$nonce\\.$#"
-			count: 3
-			path: core/Nonce.php
-
-		-
 			message: "#^Parameter \\#1 \\$default of static method Piwik\\\\Url\\:\\:getCurrentHost\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: core/Nonce.php
-
-		-
-			message: "#^Property Piwik\\\\Notification\\:\\:\\$priority \\(int\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: core/Notification.php
-
-		-
-			message: "#^Access to an undefined property Piwik\\\\Session\\\\SessionNamespace\\:\\:\\$notifications\\.$#"
-			count: 7
-			path: core/Notification/Manager.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: core/Notification/Manager.php
-
-		-
-			message: "#^Method Piwik\\\\Notification\\\\Manager\\:\\:getAllNotificationsToDisplay\\(\\) should return ArrayObject but returns array\\.$#"
-			count: 1
-			path: core/Notification/Manager.php
-
-		-
-			message: "#^Static property Piwik\\\\Notification\\\\Manager\\:\\:\\$session \\(Piwik\\\\Session\\\\SessionNamespace\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: core/Notification/Manager.php
-
-		-
-			message: "#^Unsafe access to private property Piwik\\\\Notification\\\\Manager\\:\\:\\$session through static\\:\\:\\.$#"
-			count: 5
-			path: core/Notification/Manager.php
-
-		-
-			message: "#^Unsafe call to private method Piwik\\\\Notification\\\\Manager\\:\\:getAllNotifications\\(\\) through static\\:\\:\\.$#"
-			count: 2
-			path: core/Notification/Manager.php
-
-		-
-			message: "#^Unsafe call to private method Piwik\\\\Notification\\\\Manager\\:\\:getSession\\(\\) through static\\:\\:\\.$#"
-			count: 4
-			path: core/Notification/Manager.php
-
-		-
-			message: "#^Unsafe call to private method Piwik\\\\Notification\\\\Manager\\:\\:removeNotification\\(\\) through static\\:\\:\\.$#"
-			count: 1
-			path: core/Notification/Manager.php
 
 		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$maximumFractionDigits$#"
@@ -4494,11 +4444,6 @@ parameters:
 			path: plugins/Dashboard/Categories/DashboardCategory.php
 
 		-
-			message: "#^Access to an undefined property Piwik\\\\Session\\\\SessionNamespace\\:\\:\\$dashboardLayout\\.$#"
-			count: 2
-			path: plugins/Dashboard/Controller.php
-
-		-
 			message: "#^Parameter \\#2 \\$varDefault of static method Piwik\\\\Common\\:\\:getRequestVar\\(\\) expects string\\|null, int given\\.$#"
 			count: 3
 			path: plugins/Dashboard/Controller.php
@@ -6222,11 +6167,6 @@ parameters:
 			message: "#^Variable \\$excludedQueryParameters on left side of \\?\\? always exists and is always null\\.$#"
 			count: 1
 			path: plugins/SitesManager/API.php
-
-		-
-			message: "#^Access to an undefined property Piwik\\\\Session\\\\SessionNamespace\\:\\:\\$ignoreMessage\\.$#"
-			count: 1
-			path: plugins/SitesManager/Controller.php
 
 		-
 			message: "#^Parameter \\#2 \\$varDefault of static method Piwik\\\\Common\\:\\:getRequestVar\\(\\) expects string\\|null, false given\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -34,3 +34,4 @@ parameters:
         - Piwik\Config
         - Piwik\View
         - Piwik\ViewDataTable\Config
+        - Piwik\Session\SessionNamespace


### PR DESCRIPTION
### Description:

Note: I've also added `Piwik\Session\SessionNamespace` as `universalObjectCratesClasses`, as it's sort of expected to use magic properties for that class.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
