### PR TITLE
Improve pattern quoting when matching AI urls, to allow contained path

### DIFF
--- a/plugins/Referrers/AIAssistant.php
+++ b/plugins/Referrers/AIAssistant.php
@@ -148,7 +148,7 @@ class AIAssistant extends Singleton
     public function isAIAssistantUrl(string $url, ?string $aiAssistantName = null): bool
     {
         foreach ($this->getDefinitions() as $domain => $name) {
-            if (preg_match('/(^|[\.\/])' . $domain . '([\.\/]|$)/', $url) && ($aiAssistantName === null || $name === $aiAssistantName)) {
+            if (preg_match('#(^|[\.\/])' . preg_quote($domain) . '(\/|$)#', $url) && ($aiAssistantName === null || $name === $aiAssistantName)) {
                 return true;
             }
         }
@@ -163,7 +163,7 @@ class AIAssistant extends Singleton
     public function getAIAssistantFromDomain(string $url): string
     {
         foreach ($this->getDefinitions() as $domain => $name) {
-            if (preg_match('/(^|[\.\/])' . $domain . '([\.\/]|$)/', $url)) {
+            if (preg_match('#(^|[\.\/])' . preg_quote($domain) . '(\/|$)#', $url)) {
                 return $name;
             }
         }
@@ -204,9 +204,9 @@ class AIAssistant extends Singleton
      *
      * @see plugins/Morpheus/icons/dist/aiAssistants/
      */
-    public function getLogoFromUrl(string $domain): string
+    public function getLogoFromUrl(string $url): string
     {
-        $ai = $this->getAIAssistantFromDomain($domain);
+        $ai = $this->getAIAssistantFromDomain($url);
         $ais = $this->getDefinitions();
 
         $filePattern = 'plugins/Morpheus/icons/dist/aiAssistants/%s.png';

--- a/plugins/Referrers/tests/Unit/AIAssistantTest.php
+++ b/plugins/Referrers/tests/Unit/AIAssistantTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Referrers\tests\Unit;
+
+use Piwik\Plugins\Referrers\AIAssistant;
+
+/**
+ * @group AIAssistant
+ * @group Plugins
+ */
+class AIAssistantTest extends \PHPUnit\Framework\TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // inject definitions to avoid database usage
+        $yml = file_get_contents(PIWIK_PATH_TEST_TO_ROOT . AIAssistant::DEFINITION_FILE);
+        AIAssistant::getInstance()->loadYmlData($yml);
+        parent::setUpBeforeClass();
+    }
+
+    public function isAIAssistantUrlTestData(): iterable
+    {
+        yield 'chatgpt.com with correct assumed assistant name' => [
+            'https://chatgpt.com',
+            'ChatGPT',
+            true,
+        ];
+
+        yield 'chatgpt.com with incorrect assumed assistant name' => [
+            'https://chatgpt.com',
+            'Copilot',
+            false,
+        ];
+
+        yield 'chatgpt.com without assumed assistant name' => [
+            'https://chatgpt.com',
+            null,
+            true,
+        ];
+
+        yield 'copilot.microsoft.com with correct assumed assistant name' => [
+            'https://copilot.microsoft.com',
+            'Copilot',
+            true,
+        ];
+    }
+
+    /**
+     * @dataProvider isAIAssistantUrlTestData
+     */
+    public function testIsAIAssistantUrl($url, $assumedSocial, $expected)
+    {
+        $this->assertEquals($expected, AIAssistant::getInstance()->isAIAssistantUrl($url, $assumedSocial));
+    }
+
+    public function getAIAssistantFromDomainTestData(): iterable
+    {
+        yield 'ChatGPT url is correctly detected' => [
+            'https://chatgpt.com',
+            'ChatGPT',
+        ];
+
+        # @todo enable this test once https://github.com/matomo-org/searchengine-and-social-list/pull/123 was merged
+        #yield 'Grok url with path is correctly detected' => [
+        #    'https://x.com/i/grok',
+        #    'Grok',
+        #];
+
+        yield 'ChatGPT url with path is correctly detected' => [
+            'http://chatgpt.com/i/16564-4345-5sdff-333',
+            'ChatGPT',
+        ];
+
+        yield 'ChatGPT subdomain url is correctly detected' => [
+            'https://custom.chatgpt.com/i/16564-4345-5sdff-333',
+            'ChatGPT',
+        ];
+
+        yield 'ChatGPT look-a-url is detected as Unknown' => [
+            'https://chatgpt.com.custom.org/i/16564-4345-5sdff-333',
+            \Piwik\Piwik::translate('General_Unknown'),
+        ];
+
+        yield 'Unknown url is detected as Unknown' => [
+            'https://xwayn.com',
+            \Piwik\Piwik::translate('General_Unknown'),
+        ];
+    }
+
+    /**
+     * @dataProvider getAIAssistantFromDomainTestData
+     */
+    public function testGetSocialNetworkFromDomain($url, $expected)
+    {
+        $this->assertEquals($expected, AIAssistant::getInstance()->getAIAssistantFromDomain($url));
+    }
+
+    public function getLogoFromUrlTestData()
+    {
+        return array(
+            array('https://chatgpt.com', 'chatgpt.com.png'),
+            array('www.chatgpt.com', 'chatgpt.com.png',),
+            array('grok.com', 'grok.com.png',),
+        );
+    }
+
+    /**
+     * @dataProvider getLogoFromUrlTestData
+     */
+    public function testGetLogoFromUrl($url, $expected)
+    {
+        self::assertStringContainsString($expected, AIAssistant::getInstance()->getLogoFromUrl($url));
+    }
+}

--- a/plugins/Referrers/tests/Unit/GroupDifferentSocialWritingsTest.php
+++ b/plugins/Referrers/tests/Unit/GroupDifferentSocialWritingsTest.php
@@ -7,7 +7,7 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Referrers\tests;
+namespace Piwik\Plugins\Referrers\tests\Unit;
 
 use Piwik\DataTable;
 use Piwik\DataTable\Row;

--- a/plugins/Referrers/tests/Unit/ReferrersTest.php
+++ b/plugins/Referrers/tests/Unit/ReferrersTest.php
@@ -7,7 +7,7 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Referrers\tests;
+namespace Piwik\Plugins\Referrers\tests\Unit;
 
 require_once PIWIK_INCLUDE_PATH . '/plugins/Referrers/Referrers.php';
 

--- a/plugins/Referrers/tests/Unit/SearchEngineTest.php
+++ b/plugins/Referrers/tests/Unit/SearchEngineTest.php
@@ -7,7 +7,7 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Referrers\tests;
+namespace Piwik\Plugins\Referrers\tests\Unit;
 
 use Piwik\Plugins\Referrers\SearchEngine;
 use Spyc;

--- a/plugins/Referrers/tests/Unit/SocialTest.php
+++ b/plugins/Referrers/tests/Unit/SocialTest.php
@@ -7,7 +7,7 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Referrers\tests;
+namespace Piwik\Plugins\Referrers\tests\Unit;
 
 use Piwik\Plugins\Referrers\Social;
 
@@ -59,6 +59,7 @@ class SocialTest extends \PHPUnit\Framework\TestCase
             array('m.facebook.com', 'Facebook'),
             array('http://lastfm.com.tr', 'Last.fm'),
             array('http://t.co/test', 'Twitter'),
+            array('http://x.com/', 'Twitter'),
             array('http://xxt.co/test', \Piwik\Piwik::translate('General_Unknown')),
             array('asdfasdfadsf.com', \Piwik\Piwik::translate('General_Unknown')),
             array('http://xwayn.com', \Piwik\Piwik::translate('General_Unknown')),


### PR DESCRIPTION
### Description:

Currently AI are defined with their hostname only. But we need to extend that to be able to match by path.
This currently doesn't work as it breaks the generated regex for matching.

refs https://github.com/matomo-org/searchengine-and-social-list/pull/123

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
