### PR TITLE
Update config file list to remove empty sections

### DIFF
--- a/plugins/Diagnostics/Controller.php
+++ b/plugins/Diagnostics/Controller.php
@@ -35,9 +35,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $configValues = $this->configReader->getConfigValuesFromFiles();
         $configValues = $this->configReader->addConfigValuesFromSystemSettings($configValues, $allSettings);
         $configValues = $this->sortConfigValues($configValues);
-        $configValues = array_filter($configValues, function ($configSection) {
-            return !empty($configSection);
-        });
+        $configValues = array_filter($configValues);
 
         return $this->renderTemplate('configfile', array(
             'allConfigValues' => $configValues,

--- a/plugins/Diagnostics/Controller.php
+++ b/plugins/Diagnostics/Controller.php
@@ -35,6 +35,9 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $configValues = $this->configReader->getConfigValuesFromFiles();
         $configValues = $this->configReader->addConfigValuesFromSystemSettings($configValues, $allSettings);
         $configValues = $this->sortConfigValues($configValues);
+        $configValues = array_filter($configValues, function ($configSection) {
+            return !empty($configSection);
+        });
 
         return $this->renderTemplate('configfile', array(
             'allConfigValues' => $configValues,

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1be9d526b60d8dc684b5dee2daa25f2cc167c6ac9b09514ffe7f597e785096db
-size 5206629
+oid sha256:16ee6a02cb5d43d29ef2ad08c9bc49863089f4fc57b77eadc4a2f4609bfc809e
+size 5198599


### PR DESCRIPTION
### Description:

The Config File page under Admin->Diagnostic currently shows a list of sections found in the configuration of Matomo. Some of these sections are empty. This PR removes empty sections such that only sections with actual settings are shown.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
