### PR TITLE
Fix invitation links in user invite email template for demo

### DIFF
--- a/plugins/UsersManager/templates/_userInviteEmail.twig
+++ b/plugins/UsersManager/templates/_userInviteEmail.twig
@@ -1,8 +1,8 @@
 {% set closingHeadTag %}<code>{{ '</head>'|e('html') }}</code>{% endset %}
 <p>{{ 'General_HelloUser'|translate(login) }}</p>
 <p>{{ content|raw }}</p>
-<a target="_blank" href="{{ piwikUrl }}?module={{ loginPlugin }}&action=acceptInvitation&token={{ token }}"
+<a target="_blank" href="{{ piwikUrl }}{{ piwikUrl ends with '/' ? '' : '/' }}index.php?module={{ loginPlugin }}&action=acceptInvitation&token={{ token }}"
 >{{ 'CoreAdminHome_AcceptInvite'|translate }}</a> |
-<a target="_blank" href="{{ piwikUrl }}?module={{ loginPlugin }}&action=declineInvitation&token={{ token }}"
+<a target="_blank" href="{{ piwikUrl }}{{ piwikUrl ends with '/' ? '' : '/' }}index.php?module={{ loginPlugin }}&action=declineInvitation&token={{ token }}"
 >{{ 'CoreAdminHome_DeclineInvite'|translate }}</a>
 <p>{{ notes }}</p>


### PR DESCRIPTION
### Description:

When inviting a user on demo.matomo.org the link doesn't work because it redirects to demo.matomo.cloud because of the missing index.php. See DEV-19533.

Initially was thinking to add a filter for the slash appendix to be able to reuse it more but decided not worth it for this use case. Right now we don't need to look in other places for similar issues.

Tested it on demo.matomo.org and it works.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
