### PR TITLE
Only show plugins update count for superusers

### DIFF
--- a/plugins/CoreHome/templates/_menu.twig
+++ b/plugins/CoreHome/templates/_menu.twig
@@ -1,4 +1,4 @@
-{% macro menu(menu, anchorlink, cssClass, currentModule, currentAction, collapsible, hasSomeAdminAccess) %}
+{% macro menu(menu, anchorlink, cssClass, currentModule, currentAction, collapsible, isSuperUser) %}
     <div id="secondNavBar" class="{{ cssClass }} z-depth-1">
         <ul class="navbar {% if collapsible %}collapsible collapsible-accordion{% endif %} hide-on-med-and-down" aria-label="{{ 'CoreHome_MainNavigation'|translate|e('html_attr') }}" role="menu">
             {% for level1,level2 in menu %}
@@ -53,7 +53,7 @@
             {% endfor %}
         </ul>
         <div vue-entry="CoreHome.MobileLeftMenu" menu="{{ menu|json_encode }}"></div>
-        {% if hasSomeAdminAccess %}
+        {% if isSuperUser %}
             <div vue-entry="CorePluginsAdmin.PluginsUpdateCount" selector=".item.manage-plugins" class="hidden"></div>
         {%  endif %}
     </div>

--- a/plugins/Morpheus/templates/admin.twig
+++ b/plugins/Morpheus/templates/admin.twig
@@ -51,7 +51,7 @@
         {% if showMenu is not defined or showMenu %}
             {% import '@CoreHome/_menu.twig' as menu %}
             {% set collapsibleMenu = hasSomeAdminAccess %}
-            {{ menu.menu(adminMenu, false, 'Menu--admin', currentModule, currentAction, collapsibleMenu, hasSomeAdminAccess) }}
+            {{ menu.menu(adminMenu, false, 'Menu--admin', currentModule, currentAction, collapsibleMenu, isSuperUser) }}
         {% endif %}
 
 


### PR DESCRIPTION
### Description:

Follow up to https://github.com/matomo-org/matomo/pull/23648 to only apply the vue component for super users, not all admins.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
