### PR TITLE
Pg 4582 promote copy function

### DIFF
--- a/plugins/ProfessionalServices/changes.json
+++ b/plugins/ProfessionalServices/changes.json
@@ -2,9 +2,7 @@
   {
     "title": "New Copy function - Custom Reports, Heatmaps, and more",
     "description": "A new a copy function is available across multiple features to make your setup faster and easier. Simply duplicate an existing item and settings are automatically copied - ready for you to adjust!",
-    "version": "5.5.0",
-    "link_name": "Learn more about how to copy Custom Reports",
-    "link": "https://matomo.org/faq/reports/create-and-analyse-custom-reports/"
+    "version": "5.5.0"
   },
   {
     "title": "CustomReports - Now supports more than 3 dimensions",

--- a/plugins/ProfessionalServices/changes.json
+++ b/plugins/ProfessionalServices/changes.json
@@ -1,5 +1,12 @@
 [
   {
+    "title": "New Copy function - Custom Reports, Heatmaps, and more",
+    "description": "A new a copy function is available across multiple features to make your setup faster and easier. Simply duplicate an existing item and settings are automatically copied - ready for you to adjust!",
+    "version": "5.5.0",
+    "link_name": "Learn more about how to copy Custom Reports",
+    "link": "https://matomo.org/faq/reports/create-and-analyse-custom-reports/"
+  },
+  {
     "title": "CustomReports - Now supports more than 3 dimensions",
     "description": "On-Premise Matomo users can now configure the maximum number of dimensions allowed in a custom report at the instance level. For example, you can adjust the maximum number of dimensions from 3 (default) to 6 or 10.",
     "version": "5.3.3",


### PR DESCRIPTION
### Description:

Add info about new copy functionality to "What's new"

I've removed the link, as IMO it's confusing and doesn't improve user experience.

Is the "version" number right?  The functionality was released in different plugins, after 5.4, but before 5.5.