### PR TITLE
Add "unknown" settings support to CNIL policy and dashboard

### DIFF
--- a/core/Policy/CnilPolicy.php
+++ b/core/Policy/CnilPolicy.php
@@ -21,6 +21,16 @@ class CnilPolicy extends CompliancePolicy
         return Piwik::translate('General_ComplianceCNILTitle');
     }
 
+    public static function getUnknownSettings(): array
+    {
+        return [
+            [
+                Piwik::translate('General_ComplianceCNILUnknownSettingOptOutTitle'),
+                Piwik::translate('General_ComplianceCNILUnknownSettingOptOutNotes'),
+            ],
+        ];
+    }
+
     protected static function getMinimumRequiredPlugins(): array
     {
         return [

--- a/core/Policy/CnilPolicy.php
+++ b/core/Policy/CnilPolicy.php
@@ -25,8 +25,8 @@ class CnilPolicy extends CompliancePolicy
     {
         return [
             [
-                Piwik::translate('General_ComplianceCNILUnknownSettingOptOutTitle'),
-                Piwik::translate('General_ComplianceCNILUnknownSettingOptOutNotes'),
+                'title' => Piwik::translate('General_ComplianceCNILUnknownSettingOptOutTitle'),
+                'note' => Piwik::translate('General_ComplianceCNILUnknownSettingOptOutNotes'),
             ],
         ];
     }

--- a/core/Policy/CompliancePolicy.php
+++ b/core/Policy/CompliancePolicy.php
@@ -30,7 +30,7 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
     abstract public static function getDescription(): string;
     abstract public static function getTitle(): string;
     /**
-     * @return array<array<string>> of string tuples, each an unknown setting title and notes
+     * @return array<array<string>> of [['title' => (string) 'TITLE', 'note' => (string) 'NOTE']]
      */
     abstract public static function getUnknownSettings(): array;
 

--- a/core/Policy/CompliancePolicy.php
+++ b/core/Policy/CompliancePolicy.php
@@ -29,6 +29,10 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
     abstract public static function getName(): string;
     abstract public static function getDescription(): string;
     abstract public static function getTitle(): string;
+    /**
+     * @return array<array<string>> of string tuples, each an unknown setting title and notes
+     */
+    abstract public static function getUnknownSettings(): array;
 
     /**
      * @return array<string> of plugin names that are required for this policy to function

--- a/core/Policy/PolicyManager.php
+++ b/core/Policy/PolicyManager.php
@@ -98,7 +98,7 @@ class PolicyManager
 
     /**
      * @param class-string<CompliancePolicy> $policyClass
-     * @return array<array<string>> of tuples of unknown setting title and notes
+     * @return array<array<string>> of [['title' => (string) 'TITLE', 'note' => (string) 'NOTE']]
      * @throws \Exception when $policyClass is not a valid policy
      */
     public static function getAllUnknownSettings(string $policyClass): array

--- a/core/Policy/PolicyManager.php
+++ b/core/Policy/PolicyManager.php
@@ -95,4 +95,18 @@ class PolicyManager
         }
         return $policyClass::isActive($idSite);
     }
+
+    /**
+     * @param class-string<CompliancePolicy> $policyClass
+     * @return array<array<string>> of tuples of unknown setting title and notes
+     * @throws \Exception when $policyClass is not a valid policy
+     */
+    public static function getAllUnknownSettings(string $policyClass): array
+    {
+        if (!is_a($policyClass, CompliancePolicy::class, true)) {
+            throw new Exception('Invalid compliance policy.');
+        }
+
+        return $policyClass::getUnknownSettings();
+    }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -105,6 +105,8 @@
         "Comparisons": "Comparisons",
         "ComplianceCNILTitle": "CNIL website analytics consent exemption conditions",
         "ComplianceCNILDescription": "This table provides an indication of whether certain settings align with CNIL guidance. It does not guarantee full legal compliance. To qualify for the consent exemption under CNIL rules, all required configurations must be implemented. If any setting is shown as “Non-Compliant,” the exemption conditions are not met, and consent must be obtained from users. If any setting is shown as “Unknown” Matomo cannot determine whether this requirement has been implemented. In such cases, these measures must be manually verified.",
+        "ComplianceCNILUnknownSettingOptOutTitle": "Opt out",
+        "ComplianceCNILUnknownSettingOptOutNotes": "Opt out must be manually set up and configured",
         "ComputedMetricAverage": "Avg. %1$s per %2$s",
         "ComputedMetricAverageDocumentation": "Average value of \"%1$s\" per \"%2$s\".",
         "ComputedMetricAverageShortDocumentation": "Average value of \"%1$s\".",

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -536,9 +536,9 @@ class API extends \Piwik\Plugin\API
         $unknownSettings = PolicyManager::getAllUnknownSettings($policy);
         foreach ($unknownSettings as $unknownSetting) {
             $payload['complianceRequirements'][] = [
-                'name' => $unknownSetting[0],
+                'name' => $unknownSetting['title'],
                 'value' => 'unknown',
-                'notes' => $unknownSetting[1]
+                'notes' => $unknownSetting['note']
             ];
         }
         return $payload;

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -538,7 +538,7 @@ class API extends \Piwik\Plugin\API
             $payload['complianceRequirements'][] = [
                 'name' => $unknownSetting['title'],
                 'value' => 'unknown',
-                'notes' => $unknownSetting['note']
+                'notes' => $unknownSetting['note'],
             ];
         }
         return $payload;

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -533,6 +533,14 @@ class API extends \Piwik\Plugin\API
                 'notes' => $setting::getComplianceRequirementNote($idSite),
             ];
         }
+        $unknownSettings = PolicyManager::getAllUnknownSettings($policy);
+        foreach ($unknownSettings as $unknownSetting) {
+            $payload['complianceRequirements'][] = [
+                'name' => $unknownSetting[0],
+                'value' => 'unknown',
+                'notes' => $unknownSetting[1]
+            ];
+        }
         return $payload;
     }
 

--- a/plugins/PrivacyManager/tests/System/expected/test___PrivacyManager.getComplianceStatus.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test___PrivacyManager.getComplianceStatus.xml
@@ -27,5 +27,10 @@
 			<value>compliant</value>
 			<notes>Retention period is set to 180 days</notes>
 		</row>
+        <row>
+            <name>Opt out</name>
+            <value>unknown</value>
+            <notes>Opt out must be manually set up and configured</notes>
+        </row>
 	</complianceRequirements>
 </result>

--- a/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_compliance.png
+++ b/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_compliance.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5b12517fc1cb489cc535c8fade22f1d3b1f39dc2d6f7025ef53095d7df4e389f
-size 106210
+oid sha256:0ed71b1a47fd19955e1c8f01036308ff7a93cd269cb2eddade6270b6075814cc
+size 110967

--- a/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_compliance_different_site.png
+++ b/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_compliance_different_site.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:030d11424d1eef8d7a8482adf5b6ac39334b01fc868f116cc08bf43b72f778f2
-size 106322
+oid sha256:d59bad464d34abcf97d7aad542b86abe868e954beea9fa8616886edf702e6b69
+size 111040

--- a/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_compliance_enforced.png
+++ b/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_compliance_enforced.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a4faed042a85f7dbe504a1bacd206cae9ffca4136e9c296c626a7f76413f96f
-size 105044
+oid sha256:6bd037da9d7aae7324dfd097e431effc5e48d4fb7e7ec1bd36bb7fb825258650
+size 110199

--- a/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
+++ b/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
@@ -81,7 +81,7 @@ class TestPolicy extends \Piwik\Policy\CompliancePolicy
         return [
             [
                 'title' => 'Unknown setting title',
-                'note' => 'Unknown setting note'
+                'note' => 'Unknown setting note',
             ]
         ];
     }

--- a/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
+++ b/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
@@ -82,7 +82,7 @@ class TestPolicy extends \Piwik\Policy\CompliancePolicy
             [
                 'title' => 'Unknown setting title',
                 'note' => 'Unknown setting note',
-            ]
+            ],
         ];
     }
 }

--- a/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
+++ b/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
@@ -75,4 +75,14 @@ class TestPolicy extends \Piwik\Policy\CompliancePolicy
             self::$perSite = [];
         }
     }
+
+    public static function getUnknownSettings(): array
+    {
+        return [
+            [
+                'title' => 'Unknown setting title',
+                'note' => 'Unknown setting note'
+            ]
+        ];
+    }
 }

--- a/tests/PHPUnit/Unit/Policy/PolicyManagerTest.php
+++ b/tests/PHPUnit/Unit/Policy/PolicyManagerTest.php
@@ -47,4 +47,14 @@ class PolicyManagerTest extends TestCase
         $this->assertCount(1, $settings);
         $this->assertTrue(is_a($settings[0], FakePolicySetting::class, true));
     }
+
+    public function testGetAllUnknownSettings()
+    {
+        $settings = MockPolicyManager::getAllUnknownSettings(TestPolicy::class);
+        $this->assertCount(1, $settings);
+        foreach ($settings as $unknownSetting) {
+            $this->assertArrayHasKey('title', $unknownSetting);
+            $this->assertArrayHasKey('note', $unknownSetting);
+        }
+    }
 }


### PR DESCRIPTION
### Description:

There are some settings/configurations that are required by CNIL, but are unable to be controlled via the compliance dashboard. This PR adds a new 'unknown' type of setting to policies, where these uncontrollable settings can be defined for the dashboard.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
