### PR TITLE
Remove port 80 from tests config in local ddev environment

### DIFF
--- a/.ddev/commands/host/matomo_init_tests
+++ b/.ddev/commands/host/matomo_init_tests
@@ -10,8 +10,7 @@ ddev matomo:console config:set \
   'database_tests.username="db"' \
   'database_tests.password="db"' \
   'tests.http_host="matomo.ddev.site"' \
-  'tests.request_uri="/"' \
-  'tests.port=80'
+  'tests.request_uri="/"'
 
 echo "Copy UI tests config file ..."
 echo "@see https://developer.matomo.org/guides/tests-ui#configuring-ui-tests"


### PR DESCRIPTION
### Description:

Removing as this breaks system tests locally, where the port is added to the hostname when it's configured, even though port 80 is the default, breaking the mechanism in `TestRequest\Response::replacePiwikUrl` when it's searching for matomo.ddev.site:80 and response contains just matomo.ddev.site.

Alternatively, we can adjust the `replacePiwikUrl` method to disregard port 80 even if set.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
