### PR TITLE
add helper function to expose policy setting names

### DIFF
--- a/core/Settings/Interfaces/SettingValueInterface.php
+++ b/core/Settings/Interfaces/SettingValueInterface.php
@@ -20,4 +20,6 @@ interface SettingValueInterface
     public static function getTitle(): string;
 
     public static function getInlineHelp(): string;
+
+    public static function getSettingName(): string;
 }

--- a/plugins/Live/Settings/VisitorLogDisabled.php
+++ b/plugins/Live/Settings/VisitorLogDisabled.php
@@ -135,6 +135,6 @@ class VisitorLogDisabled implements MeasurableSettingInterface, PolicyComparison
 
     public static function getSettingName(): string
     {
-        return self::getSystemName(); 
+        return self::getSystemName();
     }
 }

--- a/plugins/Live/Settings/VisitorLogDisabled.php
+++ b/plugins/Live/Settings/VisitorLogDisabled.php
@@ -132,4 +132,9 @@ class VisitorLogDisabled implements MeasurableSettingInterface, PolicyComparison
     {
         return ($value1 || $value2);
     }
+
+    public static function getSettingName(): string
+    {
+        return self::getSystemName(); 
+    }
 }

--- a/plugins/PrivacyManager/Settings/IPAnonymisation.php
+++ b/plugins/PrivacyManager/Settings/IPAnonymisation.php
@@ -37,10 +37,15 @@ class IPAnonymisation implements CustomSettingInterface, PolicyComparisonInterfa
         return $this->value;
     }
 
+    private static function getCustomSettingName(): string
+    {
+        return 'ipAnonymizerEnabled';
+    }
+
     public static function getCustomValue(?int $idSite = null)
     {
         // disallowing compliance override to prevent indefinite loop in getting the value
-        return (new Config($idSite))->getFromOption('ipAnonymizerEnabled', $allowPolicyComplianceOverride = false);
+        return (new Config($idSite))->getFromOption(self::getCustomSettingName(), $allowPolicyComplianceOverride = false);
     }
 
     public static function getTitle(): string
@@ -97,5 +102,10 @@ class IPAnonymisation implements CustomSettingInterface, PolicyComparisonInterfa
             return $value1;
         }
         return $value2;
+    }
+
+    public static function getSettingName(): string
+    {
+        return self::getCustomSettingName();
     }
 }

--- a/plugins/PrivacyManager/Settings/IpAddressMaskLength.php
+++ b/plugins/PrivacyManager/Settings/IpAddressMaskLength.php
@@ -37,10 +37,15 @@ class IpAddressMaskLength implements CustomSettingInterface, PolicyComparisonInt
         return $this->value;
     }
 
+    private static function getCustomSettingName(): string
+    {
+        return 'ipAddressMaskLength';
+    }
+
     public static function getCustomValue(?int $idSite = null)
     {
         // disallowing compliance override to prevent indefinite loop in getting the value
-        return (new Config($idSite))->getFromOption('ipAddressMaskLength', $allowPolicyComplianceOverride = false);
+        return (new Config($idSite))->getFromOption(self::getCustomSettingName(), $allowPolicyComplianceOverride = false);
     }
 
     public static function getTitle(): string
@@ -95,5 +100,10 @@ class IpAddressMaskLength implements CustomSettingInterface, PolicyComparisonInt
             return $value1;
         }
         return $value2;
+    }
+
+    public static function getSettingName(): string
+    {
+        return self::getCustomSettingName();
     }
 }

--- a/plugins/PrivacyManager/Settings/ReportRetention.php
+++ b/plugins/PrivacyManager/Settings/ReportRetention.php
@@ -121,4 +121,9 @@ class ReportRetention implements
         }
         return $value2;
     }
+
+    public static function getSettingName(): string
+    {
+        return self::getConfigSettingName(); 
+    }
 }

--- a/plugins/PrivacyManager/Settings/ReportRetention.php
+++ b/plugins/PrivacyManager/Settings/ReportRetention.php
@@ -124,6 +124,6 @@ class ReportRetention implements
 
     public static function getSettingName(): string
     {
-        return self::getConfigSettingName(); 
+        return self::getConfigSettingName();
     }
 }

--- a/plugins/WebsiteMeasurable/Settings/EcommerceEnabled.php
+++ b/plugins/WebsiteMeasurable/Settings/EcommerceEnabled.php
@@ -131,4 +131,9 @@ class EcommerceEnabled implements MeasurableSettingInterface, PolicyComparisonIn
         }
         return $value2;
     }
+
+    public static function getSettingName(): string
+    {
+        return self::getMeasurableName();
+    }
 }

--- a/tests/PHPUnit/Framework/Mock/Settings/FakePolicySetting.php
+++ b/tests/PHPUnit/Framework/Mock/Settings/FakePolicySetting.php
@@ -71,4 +71,9 @@ class FakePolicySetting implements PolicyComparisonInterface, SettingValueInterf
     {
         return 'Fake policy setting inline help text';
     }
+
+    public static function getSettingName(): string
+    {
+        return 'fake_setting_name';
+    }
 }


### PR DESCRIPTION
### Description:

A small PR to add a method to all policy settings which exposes the setting name, which can be used as a pseudo ID for the setting.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
