### PR TITLE
Revert "add helper function to expose policy setting names"

### DIFF
--- a/core/Settings/Interfaces/SettingValueInterface.php
+++ b/core/Settings/Interfaces/SettingValueInterface.php
@@ -20,6 +20,4 @@ interface SettingValueInterface
     public static function getTitle(): string;
 
     public static function getInlineHelp(): string;
-
-    public static function getSettingName(): string;
 }

--- a/plugins/Live/Settings/VisitorLogDisabled.php
+++ b/plugins/Live/Settings/VisitorLogDisabled.php
@@ -132,9 +132,4 @@ class VisitorLogDisabled implements MeasurableSettingInterface, PolicyComparison
     {
         return ($value1 || $value2);
     }
-
-    public static function getSettingName(): string
-    {
-        return self::getSystemName();
-    }
 }

--- a/plugins/PrivacyManager/Settings/IPAnonymisation.php
+++ b/plugins/PrivacyManager/Settings/IPAnonymisation.php
@@ -37,15 +37,10 @@ class IPAnonymisation implements CustomSettingInterface, PolicyComparisonInterfa
         return $this->value;
     }
 
-    private static function getCustomSettingName(): string
-    {
-        return 'ipAnonymizerEnabled';
-    }
-
     public static function getCustomValue(?int $idSite = null)
     {
         // disallowing compliance override to prevent indefinite loop in getting the value
-        return (new Config($idSite))->getFromOption(self::getCustomSettingName(), $allowPolicyComplianceOverride = false);
+        return (new Config($idSite))->getFromOption('ipAnonymizerEnabled', $allowPolicyComplianceOverride = false);
     }
 
     public static function getTitle(): string
@@ -102,10 +97,5 @@ class IPAnonymisation implements CustomSettingInterface, PolicyComparisonInterfa
             return $value1;
         }
         return $value2;
-    }
-
-    public static function getSettingName(): string
-    {
-        return self::getCustomSettingName();
     }
 }

--- a/plugins/PrivacyManager/Settings/IpAddressMaskLength.php
+++ b/plugins/PrivacyManager/Settings/IpAddressMaskLength.php
@@ -37,15 +37,10 @@ class IpAddressMaskLength implements CustomSettingInterface, PolicyComparisonInt
         return $this->value;
     }
 
-    private static function getCustomSettingName(): string
-    {
-        return 'ipAddressMaskLength';
-    }
-
     public static function getCustomValue(?int $idSite = null)
     {
         // disallowing compliance override to prevent indefinite loop in getting the value
-        return (new Config($idSite))->getFromOption(self::getCustomSettingName(), $allowPolicyComplianceOverride = false);
+        return (new Config($idSite))->getFromOption('ipAddressMaskLength', $allowPolicyComplianceOverride = false);
     }
 
     public static function getTitle(): string
@@ -100,10 +95,5 @@ class IpAddressMaskLength implements CustomSettingInterface, PolicyComparisonInt
             return $value1;
         }
         return $value2;
-    }
-
-    public static function getSettingName(): string
-    {
-        return self::getCustomSettingName();
     }
 }

--- a/plugins/PrivacyManager/Settings/ReportRetention.php
+++ b/plugins/PrivacyManager/Settings/ReportRetention.php
@@ -121,9 +121,4 @@ class ReportRetention implements
         }
         return $value2;
     }
-
-    public static function getSettingName(): string
-    {
-        return self::getConfigSettingName();
-    }
 }

--- a/plugins/WebsiteMeasurable/Settings/EcommerceEnabled.php
+++ b/plugins/WebsiteMeasurable/Settings/EcommerceEnabled.php
@@ -131,9 +131,4 @@ class EcommerceEnabled implements MeasurableSettingInterface, PolicyComparisonIn
         }
         return $value2;
     }
-
-    public static function getSettingName(): string
-    {
-        return self::getMeasurableName();
-    }
 }

--- a/tests/PHPUnit/Framework/Mock/Settings/FakePolicySetting.php
+++ b/tests/PHPUnit/Framework/Mock/Settings/FakePolicySetting.php
@@ -71,9 +71,4 @@ class FakePolicySetting implements PolicyComparisonInterface, SettingValueInterf
     {
         return 'Fake policy setting inline help text';
     }
-
-    public static function getSettingName(): string
-    {
-        return 'fake_setting_name';
-    }
 }


### PR DESCRIPTION
Reverts matomo-org/matomo#23682 as it breaks a released version of the Heatmaps plugin.