### PR TITLE
Fix parameter type hint for Row::getColumn

### DIFF
--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -188,7 +188,7 @@ class Row extends \ArrayObject
     /**
      * Returns a column by name.
      *
-     * @param string $name The column name.
+     * @param string|int $name The column name.
      * @return mixed|false  The column value or false if it doesn't exist.
      */
     public function getColumn($name)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1141,11 +1141,6 @@ parameters:
 			path: core/DataTable/Filter/PivotByDimension.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Piwik\\\\DataTable\\\\Row\\:\\:getColumn\\(\\) expects string, int\\<min, \\-1\\>\\|int\\<1, max\\> given\\.$#"
-			count: 1
-			path: core/DataTable/Filter/PivotByDimension.php
-
-		-
 			message: "#^Property Piwik\\\\DataTable\\\\Filter\\\\PivotByDimension\\:\\:\\$pivotByDimension \\(Piwik\\\\Columns\\\\Dimension\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: core/DataTable/Filter/PivotByDimension.php
@@ -1273,11 +1268,6 @@ parameters:
 		-
 			message: "#^Method Piwik\\\\DataTable\\\\Row\\:\\:compareElements\\(\\) should return bool but returns int\\<\\-1, 1\\>\\.$#"
 			count: 1
-			path: core/DataTable/Row.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of method Piwik\\\\DataTable\\\\Row\\:\\:getColumn\\(\\) expects string, int given\\.$#"
-			count: 2
 			path: core/DataTable/Row.php
 
 		-
@@ -3309,11 +3299,6 @@ parameters:
 			path: plugins/Actions/ArchivingHelper.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Piwik\\\\DataTable\\\\Row\\:\\:getColumn\\(\\) expects string, int given\\.$#"
-			count: 3
-			path: plugins/Actions/ArchivingHelper.php
-
-		-
 			message: "#^Parameter \\#1 \\$name of method Piwik\\\\DataTable\\\\Row\\:\\:setColumn\\(\\) expects string, int given\\.$#"
 			count: 1
 			path: plugins/Actions/ArchivingHelper.php
@@ -4374,11 +4359,6 @@ parameters:
 			path: plugins/Goals/API.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Piwik\\\\DataTable\\\\Row\\:\\:getColumn\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: plugins/Goals/API.php
-
-		-
 			message: "#^Parameter \\#1 \\$oldName of method Piwik\\\\DataTable\\\\Row\\:\\:renameColumn\\(\\) expects string, int given\\.$#"
 			count: 1
 			path: plugins/Goals/API.php
@@ -5179,11 +5159,6 @@ parameters:
 			path: plugins/Referrers/API.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Piwik\\\\DataTable\\\\Row\\:\\:getColumn\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: plugins/Referrers/API.php
-
-		-
 			message: "#^Variable \\$numericArchives in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: plugins/Referrers/API.php
@@ -5501,11 +5476,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$label of function Piwik\\\\Plugins\\\\Referrers\\\\getReferrerTypeLabel expects string, int given\\.$#"
 			count: 1
-			path: plugins/Transitions/API.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of method Piwik\\\\DataTable\\\\Row\\:\\:getColumn\\(\\) expects string, int given\\.$#"
-			count: 2
 			path: plugins/Transitions/API.php
 
 		-


### PR DESCRIPTION
### Description:

Parameter can be of type int, for columns using Ids internally.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
