### PR TITLE
Improve PivotByDimension UI test stability

### DIFF
--- a/tests/UI/expected-screenshots/PivotByDimension_pivoted.png
+++ b/tests/UI/expected-screenshots/PivotByDimension_pivoted.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b524e7e11a4145ad665ac7b534095bf75c23ef21bab645590670a67631a4b04f
-size 73742
+oid sha256:c654c1bb2c652067af6f21ef4609ae4f4924b67e540360aa32c949675483c0fc
+size 71200

--- a/tests/UI/specs/PivotByDimension_spec.js
+++ b/tests/UI/specs/PivotByDimension_spec.js
@@ -20,10 +20,8 @@ describe("PivotByDimension", function () {
         await element.click();
         await page.waitForNetworkIdle();
 
-        await page.evaluate(function(){
-            $('.dropdownConfigureIcon').click();
-            $('.dataTablePivotBySubtable').click();
-        });
+        await page.click('.dropdownConfigureIcon');
+        await page.click('.dataTablePivotBySubtable');
         await page.waitForNetworkIdle();
 
         await page.mouse.move(-150, -150); // make sure nothing is highlighted

--- a/tests/UI/specs/PivotByDimension_spec.js
+++ b/tests/UI/specs/PivotByDimension_spec.js
@@ -21,6 +21,7 @@ describe("PivotByDimension", function () {
         await page.waitForNetworkIdle();
 
         await page.click('.dropdownConfigureIcon');
+        await page.waitForTimeout(100);
         await page.click('.dataTablePivotBySubtable');
         await page.waitForNetworkIdle();
 


### PR DESCRIPTION
### Description:

By accident in https://github.com/matomo-org/matomo/pull/22827 we added the wrong screenshot for one of the PivotByDimension tests. It has been a little flaky ever since, but not enough to detect it is broken more often than right.

Another test that is pivoting a table does not seem to be flaky. Updating the interaction steps for pivoting the table should improve the test stability.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
