### PR TITLE
Ensure Piwik\Log\Logger class is always defined

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -95,6 +95,7 @@ return [
      */
     'DocumentationGenerator.customParameters' => [],
 
+    \Piwik\Log\Logger::class => Piwik\DI::create(\Piwik\Log\NullLogger::class),
     \Piwik\Log\LoggerInterface::class => Piwik\DI::create(\Piwik\Log\NullLogger::class),
 
     'Piwik\Translation\Loader\LoaderInterface' => Piwik\DI::autowire('Piwik\Translation\Loader\LoaderCache')


### PR DESCRIPTION
### Description:

The definition for `Piwik\Log\Logger` is currently only placed within the Monolog plugin. Therefor disabling the plugin might currently break places that try to use the Logger.

Step to reproduce:
1. disable Monolog plugin
2. visit admin area
3. see an error message as FeatureFlags tries to access the Logger directly.

fixes #23688

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
