### PR TITLE
Update navbar help icon

### DIFF
--- a/plugins/CoreAdminHome/tests/UI/expected-screenshots/CustomLogo_admin.png
+++ b/plugins/CoreAdminHome/tests/UI/expected-screenshots/CustomLogo_admin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d22db693d8d599c202298a90a70031b7dad204fe7f4d61568afc2656c81850fd
-size 14897
+oid sha256:525eb944aaa7d09b82b55bdc69523b8f6a7eb6bef6616f5ce3e81c45d354a64b
+size 15033

--- a/plugins/CoreAdminHome/tests/UI/expected-screenshots/CustomLogo_admin_svg.png
+++ b/plugins/CoreAdminHome/tests/UI/expected-screenshots/CustomLogo_admin_svg.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7407b3025c94d46bc32e1ca339a8bcd31f4769d4989f103aefe3c65f0f75f62e
-size 11468
+oid sha256:4d3ba5e0ebf253a81aa373a3ffae9ef9053443e43e7419207a28c07fa0e8180a
+size 11560

--- a/plugins/CoreHome/tests/UI/expected-screenshots/WhatIsNew_menu.png
+++ b/plugins/CoreHome/tests/UI/expected-screenshots/WhatIsNew_menu.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24e94cd2cd874dedfed6880639533064f215b3fad284a5388b17aca44ea21f59
-size 8648
+oid sha256:e5989fb2889b1ccb4f5779df30f07455657a2e3945ff0f5d464c393893502f55
+size 8792

--- a/plugins/ExamplePlugin/tests/UI/expected-screenshots/SimpleUITest_simplePage.png
+++ b/plugins/ExamplePlugin/tests/UI/expected-screenshots/SimpleUITest_simplePage.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:20038e852a6786d204af3c1cbcb1562507f9bd0fb7892f67a72ce5f9a77eb51b
-size 23443
+oid sha256:9d0dacfa5c392ef55bcb7c1aee658a3d318f5b297810ee5eb42577fc0be2ab58
+size 23524

--- a/plugins/ExamplePlugin/tests/UI/expected-screenshots/SimpleUITest_simplePagePartial.png
+++ b/plugins/ExamplePlugin/tests/UI/expected-screenshots/SimpleUITest_simplePagePartial.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c5e814c58db53aea9eb3df7498338559e73a7a2613a90f78efb7f2d349bfe946
-size 18546
+oid sha256:95e89ed955854f579196c592b099676ce5145974b11bf0fb4dbbd5ddf744c285
+size 18647

--- a/plugins/Feedback/Menu.php
+++ b/plugins/Feedback/Menu.php
@@ -16,7 +16,7 @@ class Menu extends \Piwik\Plugin\Menu
 {
     public function configureTopMenu(MenuTop $menu)
     {
-        $menu->registerMenuIcon('General_Help', 'icon-info');
+        $menu->registerMenuIcon('General_Help', 'icon-help');
         $menu->addItem('General_Help', null, array('module' => 'Feedback', 'action' => 'index'), $order = 990, Piwik::translate('General_Help'));
     }
 }

--- a/plugins/Goals/tests/UI/expected-screenshots/Goals_action_goals_visualization_page_urls.png
+++ b/plugins/Goals/tests/UI/expected-screenshots/Goals_action_goals_visualization_page_urls.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9d0e2dbba813241379ba47872d6a076bf5c2d8402405ec75d40956112eb821ac
-size 86748
+oid sha256:25f9f34f40c59efa5be35337fa718f78d2ddfc83173b958b06a4f3d11175ceba
+size 86867

--- a/plugins/Goals/tests/UI/expected-screenshots/Goals_action_goals_visualization_page_urls_subtable.png
+++ b/plugins/Goals/tests/UI/expected-screenshots/Goals_action_goals_visualization_page_urls_subtable.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e7486f0b9dc59631243958a85a87820cd0ea8e21b5dd0d13adcbea70683a5ada
-size 99630
+oid sha256:f3d2c7fb74444a5d7fcb6791ec0f2bd494b24e91395a9a0cf73d609258fb9dcc
+size 99737

--- a/plugins/SegmentEditor/tests/UI/expected-screenshots/SegmentSelectorEditorTest_complex_segment.png
+++ b/plugins/SegmentEditor/tests/UI/expected-screenshots/SegmentSelectorEditorTest_complex_segment.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:768df92f8932a9d00221301798692800ec6876315ca4d5abcd18ce1c2d7947f2
-size 416752
+oid sha256:fca015e1a6de79f0f2c29edd791edb617bbae8853ddef560ffbcbde536ffa67b
+size 416878

--- a/tests/UI/expected-screenshots/SearchFilterPersistenceTest_load_ok.png
+++ b/tests/UI/expected-screenshots/SearchFilterPersistenceTest_load_ok.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec184229054016e8d8ad582a9318b47581fa2f92cbdcc4a7ceb3419ba28ec11d
-size 105837
+oid sha256:f0d32537c608a1b7719604cec0351f85bce6ff6b827992cdff32af2b82ef5668
+size 105979

--- a/tests/UI/expected-screenshots/SearchFilterPersistenceTest_persisted_date.png
+++ b/tests/UI/expected-screenshots/SearchFilterPersistenceTest_persisted_date.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9404beea9319cb8238401efe02883fd10f55ddddc6149004e8a7fa3cd5697fff
-size 91853
+oid sha256:e7d30b38acd1642dd97760f578a2dfacd184f1af4d582c19ee32286064fdf3ed
+size 91956

--- a/tests/UI/expected-screenshots/SearchFilterPersistenceTest_persisted_segment.png
+++ b/tests/UI/expected-screenshots/SearchFilterPersistenceTest_persisted_segment.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:913aee420b92b785e151e66256bf8474cfb9e69b2f2dfa5a2bb4d489eecf6798
-size 95774
+oid sha256:0f21bc406913229b92ad9ea8e82916aa4233f3f0377e835c65cfdf3fc58516ad
+size 95890

--- a/tests/UI/expected-screenshots/SearchFilterPersistenceTest_persisted_sorting.png
+++ b/tests/UI/expected-screenshots/SearchFilterPersistenceTest_persisted_sorting.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:320a9fe096a121771fb0ee46265b3d8411d2f7d80a35e6da31bc91c5d8e951a8
-size 95063
+oid sha256:9825a28ef66f0adf6a5d4ee3d6050e97ec6afa63b6bcd049fd506436a1a30a4a
+size 95144

--- a/tests/UI/expected-screenshots/SearchFilterPersistenceTest_search_results.png
+++ b/tests/UI/expected-screenshots/SearchFilterPersistenceTest_search_results.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fcbb5f8164b8b54bcb89173597f8fe452c941b3b6aa37ac3049db2eabc1fc2fc
-size 95030
+oid sha256:5043b542dc29eed67ce64cdf8db5b44210795f0fedde091f25be505cc8ca6a09
+size 95102

--- a/tests/UI/expected-screenshots/Theme_home.png
+++ b/tests/UI/expected-screenshots/Theme_home.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:75c196ac63ba8166bd86be70b5564451f1777fbf0dde41c0f656ecb5c95d5f14
-size 71760
+oid sha256:cc3e68463a736c2f6c72a2654f091e802c914545568d686789bb1a2a8d72812b
+size 71888

--- a/tests/UI/expected-screenshots/UIIntegrationTest_period_select_date_range_click.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_period_select_date_range_click.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4690a3fd0897b9511cc0b37882b0f70145f1f32d8e3635128ad3d2121cd5c4c6
-size 86498
+oid sha256:ee89deb34b1e17e30470099d72dcc91aeefaa14032b005ddd40b6deea09365a1
+size 86606

--- a/tests/UI/expected-screenshots/enable_framed_pages_embed_whole_app.png
+++ b/tests/UI/expected-screenshots/enable_framed_pages_embed_whole_app.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d437edc919edc6a98c747bca75e62f1103bace2956d845baa3e3911f9968ea0d
-size 236889
+oid sha256:765400f743a88a1951a8018c2a2099e923def9790efe0fd71ab381fcc1b72a42
+size 237015


### PR DESCRIPTION
### Description:

Update the navbar icon that opens the help center. It’s now a « ? » instead of a « i ».

| before | after |
| ---- | ---- |
| <img width="731" height="113" alt="Screenshot 2025-10-27 at 16 07 41" src="https://github.com/user-attachments/assets/a06d6ae4-b34f-4ee1-a2df-363628f5c054" /> | <img width="731" height="113" alt="Screenshot 2025-10-27 at 16 07 49" src="https://github.com/user-attachments/assets/459ced23-7712-42e7-a9d9-8fcd2eaf0a8d" /> |

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
