### PR TITLE
Fix deprecation around nullable parameter in UsersManager\API

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1720,7 +1720,7 @@ class API extends \Piwik\Plugin\API
             ]);
     }
 
-    private function executeConcurrencySafe(string $userLogin, callable $callback = null)
+    private function executeConcurrencySafe(string $userLogin, ?callable $callback = null): void
     {
         $lock = new Lock(StaticContainer::get(LockBackend::class), 'UsersManager.changePermissions');
         $lock->execute($userLogin, $callback);

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1720,7 +1720,7 @@ class API extends \Piwik\Plugin\API
             ]);
     }
 
-    private function executeConcurrencySafe(string $userLogin, ?callable $callback = null): void
+    private function executeConcurrencySafe(string $userLogin, callable $callback): void
     {
         $lock = new Lock(StaticContainer::get(LockBackend::class), 'UsersManager.changePermissions');
         $lock->execute($userLogin, $callback);


### PR DESCRIPTION
### Description:

This will fix the deprecation warning that can also be spotted within the test:

```
Deprecated: Piwik\Plugins\UsersManager\API::executeConcurrencySafe(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/matomo/matomo/matomo/plugins/UsersManager/API.php on line 1723
```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
