### PR TITLE
Reactivate previously active plugins after core upgrade

### DIFF
--- a/core/UpdateCheck/ReleaseChannel.php
+++ b/core/UpdateCheck/ReleaseChannel.php
@@ -12,22 +12,22 @@ namespace Piwik\UpdateCheck;
 /**
  * Base class to define a custom release channel. Plugins can add their own custom release channels by extending this
  * class in a `plugin/$plugin/ReleaseChannel` folder. Custom release channels can be useful for example to provide
- * nightly builds, to manage updates for clients via a central server, to package a special Piwik version for clients
+ * nightly builds, to manage updates for clients via a central server, to package a special Matomo version for clients
  * with custom plugins etc.
  *
- * This is not a public API and it may change without any announcement.
+ * This is not a public API, and it may change without any announcement.
  */
 abstract class ReleaseChannel
 {
     /**
-     * Get the ID for this release channel. This string will be eg saved in the config to identify the chosen release
+     * Get the ID for this release channel. E.g., this string will be saved in the config to identify the chosen release
      * channel
      * @return string
      */
     abstract public function getId();
 
     /**
-     * Get a human readable name for this release channel, will be visible in the UI. Should be already translated.
+     * Get a human-readable name for this release channel, will be visible in the UI. Should be already translated.
      * @return string
      */
     abstract public function getName();
@@ -50,7 +50,7 @@ abstract class ReleaseChannel
     abstract public function getUrlToCheckForLatestAvailableVersion();
 
     /**
-     * Get the URL to download a specific Piwik archive for the given version number. The returned URL should not
+     * Get the URL to download a specific Matomo archive for the given version number. The returned URL should not
      * include a URI scheme, meaning it should start with '://...'.
      *
      * @param string $version

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -95,7 +95,11 @@ class Updater
 
         $newVersion = $this->getLatestVersion();
         $url = $this->getArchiveUrl($newVersion, $https);
-        $messages = array();
+        $messages = [];
+
+        $pluginManager = PluginManager::getInstance();
+        $activatedPlugins = $pluginManager->getActivatedPlugins();
+        Option::set('OneClickUpdate_ActivatedPlugins', json_encode($activatedPlugins));
 
         try {
             $archiveFile = $this->downloadArchive($newVersion, $url);
@@ -194,6 +198,37 @@ class Updater
             } catch (Exception $e) {
                 throw new UpdaterException($e, $messages);
             }
+        }
+
+        // get a list of previously activated plugins and try to reactivate them if there are no missing requirements
+        $previouslyActivePlugins = Option::get('OneClickUpdate_ActivatedPlugins');
+        if (false !== $previouslyActivePlugins) {
+            $previouslyActivePlugins = json_decode($previouslyActivePlugins, true);
+        } else {
+            $previouslyActivePlugins = [];
+        }
+        Option::delete('OneClickUpdate_ActivatedPlugins');
+
+        $reactivatedPlugins = [];
+        if (!empty($previouslyActivePlugins)) {
+            $pluginManager = PluginManager::getInstance();
+            foreach ($previouslyActivePlugins as $previouslyActivePluginName) {
+                if (!$pluginManager->isPluginActivated($previouslyActivePluginName)) {
+                    try {
+                        $plugin = $pluginManager->loadPlugin($previouslyActivePluginName);
+                        if (empty($plugin->getMissingDependencies($newVersion))) {
+                            $pluginManager->activatePlugin($previouslyActivePluginName);
+                            $reactivatedPlugins[] = $previouslyActivePluginName;
+                        }
+                    } catch (\Throwable $e) {
+                        // noop - we will try to reactivate other plugins in the list.
+                    }
+                }
+            }
+        }
+
+        if (!empty($reactivatedPlugins)) {
+            $messages[] = $this->translator->translate('CoreUpdater_ReactivatedPlugins', implode(', ', $reactivatedPlugins));
         }
 
         try {

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -134,7 +134,7 @@ class Updater
                 $messages = array_merge($messages, $responseCliMulti);
             } else {
                 // there was likely an error eg such as an invalid ssl certificate... let's try executing it directly
-                // in case this works. For explample $response is in this case not an array but a string because the "communcation"
+                // in case this works. For example $response is in this case not an array but a string because the "communication"
                 // with the controller went wrong: "Got invalid response from API request: https://ABC/?module=CoreUpdater&action=oneClickUpdatePartTwo&nonce=ABC. Response was \'curl_exec: SSL certificate problem: unable to get local issuer certificate. Hostname requested was: ABC"
                 try {
                     $response = $this->oneClickUpdatePartTwo($newVersion);

--- a/plugins/CoreUpdater/lang/en.json
+++ b/plugins/CoreUpdater/lang/en.json
@@ -101,6 +101,7 @@
         "SkipCacheClear": "Skipping clearing caches.",
         "UpdateDetailsHidden1": "Update details are hidden for security. To view them:",
         "UpdateDetailsHidden2": "Add the %1$s GET parameter to the URL (%2$s in %3$s), or",
-        "UpdateDetailsHidden3": "Run the update via command line."
+        "UpdateDetailsHidden3": "Run the update via command line.",
+        "ReactivatedPlugins": "Reactivated plugins: %1$s"
     }
 }

--- a/tests/PHPUnit/Fixtures/LastForcedInstall.php
+++ b/tests/PHPUnit/Fixtures/LastForcedInstall.php
@@ -9,10 +9,48 @@
 
 namespace Piwik\Tests\Fixtures;
 
+use Piwik\Container\StaticContainer;
+use Piwik\Plugins\CorePluginsAdmin\PluginInstaller;
+
 class LastForcedInstall extends LatestStableInstall
 {
+    public const FORCED_VERSION = "4.16.2";
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->installAndActivateTreemapPlugin();
+    }
+
     protected function getDownloadUrl()
     {
-        return 'http://builds.matomo.org/matomo-4.15.0.zip';
+        return 'http://builds.matomo.org/matomo-' . self::FORCED_VERSION . '.zip';
+    }
+
+    private function installAndActivateTreemapPlugin()
+    {
+        // creating a new instance here as otherwise we would change the "global" environment,
+        // but we only want to change Matomo version temporarily for this task here
+        $environment = StaticContainer::getContainer()->make('Piwik\Plugins\Marketplace\Environment');
+        $environment->setPiwikVersion(self::FORCED_VERSION);
+        /** @var \Piwik\Plugins\Marketplace\Api\Client $marketplaceClient */
+        $marketplaceClient = StaticContainer::getContainer()->make('Piwik\Plugins\Marketplace\Api\Client', [
+            'environment' => $environment,
+        ]);
+
+        $oldGlobal = $GLOBALS['MATOMO_PLUGIN_COPY_DIR'] ?? false;
+        $GLOBALS['MATOMO_PLUGIN_COPY_DIR'] = $this->getInstallSubdirectoryPath() . '/plugins/';
+
+        $pluginInstaller = new PluginInstaller($marketplaceClient);
+        $pluginInstaller->installOrUpdatePluginFromMarketplace('TreemapVisualization');
+
+        if ($oldGlobal) {
+            $GLOBALS['MATOMO_PLUGIN_COPY_DIR'] = $oldGlobal;
+        } else {
+            unset($GLOBALS['MATOMO_PLUGIN_COPY_DIR']);
+        }
+
+        passthru($this->getInstallSubdirectoryPath() . '/console plugin:activate TreemapVisualization');
     }
 }

--- a/tests/PHPUnit/Fixtures/LatestStableInstall.php
+++ b/tests/PHPUnit/Fixtures/LatestStableInstall.php
@@ -157,7 +157,7 @@ class LatestStableInstall extends Fixture
         return PIWIK_INCLUDE_PATH . DIRECTORY_SEPARATOR . 'test_latest_stable.zip';
     }
 
-    private function getInstallSubdirectoryPath()
+    protected function getInstallSubdirectoryPath()
     {
         return PIWIK_INCLUDE_PATH . DIRECTORY_SEPARATOR . $this->subdirToInstall;
     }

--- a/tests/UI/expected-screenshots/OneClickLastForcedUpdate_update_screen.png
+++ b/tests/UI/expected-screenshots/OneClickLastForcedUpdate_update_screen.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea3ee95ac1bf4e1d39ab975e6189f18a8012c67f5df6dd909a7d4697fed1b240
-size 56135
+oid sha256:02564befd658e386f14c3dd27d2f2e565591189569a0a22096b23109e9344850
+size 58620

--- a/tests/UI/expected-screenshots/OneClickLastForcedUpdate_update_success.png
+++ b/tests/UI/expected-screenshots/OneClickLastForcedUpdate_update_success.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a86bfc4544a493b68e2d6b5437078e8d9ebda3fc3601c095e6cc38e98a1ae3a
-size 74704
+oid sha256:74a4810588d85e8df0e30b81a111a53a8dbc44ecf9783d70ad4c60438e8c3295
+size 80671

--- a/tests/UI/specs/OneClickLastForcedUpdate_spec.js
+++ b/tests/UI/specs/OneClickLastForcedUpdate_spec.js
@@ -18,6 +18,7 @@ describe("OneClickLastForcedUpdate", function () {
 
     var latestStableUrl = config.piwikUrl + '/latestStableInstall/index.php';
     var settingsUrl = latestStableUrl + '?module=CoreAdminHome&action=home&idSite=1&period=day&date=yesterday';
+    var pluginsUrl = latestStableUrl + '?module=CorePluginsAdmin&action=plugins';
 
     it('should show the new version available button in the admin screen', async function () {
         await page.goto(latestStableUrl);
@@ -95,6 +96,15 @@ describe("OneClickLastForcedUpdate", function () {
         // avoid taking an unnecessary screenshot, as knowing we land on #site-without-data is enough
         await page.waitForSelector('#site-without-data', { visible: true });
         await page.evaluate(() => window.stop()); // stop ongoing requests
+    });
+
+    it('should have TreemapVisualization plugin active after the update', async function () {
+        await page.goto(pluginsUrl);
+        await page.waitForNetworkIdle();
+        await page.waitForSelector('#plugins', { visible: true });
+
+        const activatedPluginRow = page.$('tr.active-plugin:has(td.name a[name="TreemapVisualization"])');
+        expect(activatedPluginRow).to.be.ok;
     });
 
     it('should have a working cron archiving process', async function () {

--- a/tests/UI/specs/OneClickLastForcedUpdate_spec.js
+++ b/tests/UI/specs/OneClickLastForcedUpdate_spec.js
@@ -21,20 +21,22 @@ describe("OneClickLastForcedUpdate", function () {
 
     it('should show the new version available button in the admin screen', async function () {
         await page.goto(latestStableUrl);
+        await page.waitForNetworkIdle();
         await page.waitForSelector('#login_form_login', { visible: true });
 
         await page.type('#login_form_login', superUserLogin);
         await page.type('#login_form_password', superUserPassword);
-        await page.click('#login_form_submit');
+        await page.evaluate(function(){
+          $('#login_form_submit').click();
+        });
 
         await page.waitForNetworkIdle();
         await page.waitForSelector('.pageWrap');
 
         await page.goto(settingsUrl);
+        await page.waitForNetworkIdle();
 
         const element = await page.waitForSelector('#header_message', { visible: true });
-
-        await page.waitForTimeout(250);
 
         expect(await element.screenshot()).to.matchImage('latest_version_available');
     });

--- a/tests/UI/specs/OneClickUpdate_spec.js
+++ b/tests/UI/specs/OneClickUpdate_spec.js
@@ -29,16 +29,20 @@ describe("OneClickUpdate", function () {
 
     it('should show the new version available button in the admin screen', async function () {
         await page.goto(latestStableUrl);
+        await page.waitForNetworkIdle();
         await page.waitForSelector('#login_form_login', { visible: true });
 
         await page.type('#login_form_login', superUserLogin);
         await page.type('#login_form_password', superUserPassword);
-        await page.click('#login_form_submit');
+        await page.evaluate(function(){
+          $('#login_form_submit').click();
+        });
 
         await page.waitForNetworkIdle();
         await page.waitForSelector('.pageWrap');
 
         await page.goto(settingsUrl);
+        await page.waitForNetworkIdle();
 
         const element = await page.waitForSelector('#header_message', { visible: true });
         expect(await element.screenshot()).to.matchImage('latest_version_available');


### PR DESCRIPTION
### Description

This change allows to store a list of active plugins before core is upgraded and then read it and reactivate previously active plugins after core upgrade, if they don't have any missing requirements.

fixes #22998

### Checklist

* [NA] I have understood, reviewed, and tested all AI outputs before use
* [NA] All AI instructions respect security, IP, and privacy rules

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
