### PR TITLE
4.x port of Reactivate previously active plugins after core upgrade

### DIFF
--- a/core/Version.php
+++ b/core/Version.php
@@ -21,7 +21,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    const VERSION = '4.16.1';
+    const VERSION = '4.16.2';
 
     const MAJOR_VERSION = 4;
 

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -94,7 +94,11 @@ class Updater
 
         $newVersion = $this->getLatestVersion();
         $url = $this->getArchiveUrl($newVersion, $https);
-        $messages = array();
+        $messages = [];
+
+        $pluginManager = PluginManager::getInstance();
+        $activatedPlugins = $pluginManager->getActivatedPlugins();
+        Option::set('OneClickUpdate_ActivatedPlugins', json_encode($activatedPlugins));
 
         try {
             $archiveFile = $this->downloadArchive($newVersion, $url);
@@ -194,6 +198,37 @@ class Updater
             } catch (Exception $e) {
                 throw new UpdaterException($e, $messages);
             }
+        }
+
+        // get a list of previously activated plugins and try to reactivate them if there are no missing requirements
+        $previouslyActivePlugins = Option::get('OneClickUpdate_ActivatedPlugins');
+        if (false !== $previouslyActivePlugins) {
+            $previouslyActivePlugins = json_decode($previouslyActivePlugins, true);
+        } else {
+            $previouslyActivePlugins = [];
+        }
+        Option::delete('OneClickUpdate_ActivatedPlugins');
+
+        $reactivatedPlugins = [];
+        if (!empty($previouslyActivePlugins)) {
+            $pluginManager = PluginManager::getInstance();
+            foreach ($previouslyActivePlugins as $previouslyActivePluginName) {
+                if (!$pluginManager->isPluginActivated($previouslyActivePluginName)) {
+                    try {
+                        $plugin = $pluginManager->loadPlugin($previouslyActivePluginName);
+                        if (empty($plugin->getMissingDependencies($newVersion))) {
+                            $pluginManager->activatePlugin($previouslyActivePluginName);
+                            $reactivatedPlugins[] = $previouslyActivePluginName;
+                        }
+                    } catch (\Throwable $e) {
+                        // noop - we will try to reactivate other plugins in the list.
+                    }
+                }
+            }
+        }
+
+        if (!empty($reactivatedPlugins)) {
+            $messages[] = $this->translator->translate('CoreUpdater_ReactivatedPlugins', implode(', ', $reactivatedPlugins));
         }
 
         try {

--- a/plugins/CoreUpdater/lang/en.json
+++ b/plugins/CoreUpdater/lang/en.json
@@ -98,6 +98,7 @@
         "TriggerDatabaseConversion": "Trigger database conversion in background",
         "Utf8mb4ConversionHelp": "Your database is currently not using utf8mb4 charset. This makes it impossible to store 4-byte characters, such as emojis, less common characters of asian languages, various historic scripts or mathematical symbols. Those are currently replaced with %1$s.<br \/><br \/>Your database supports the utf8mb4 charset and it would be possible to convert it.<br \/><br \/>If you are able to run console commands we recommend using this command: %2$s<br \/><br \/>Alternatively you can enable the conversion here. It will then be triggered automatically as a scheduled task in the background.<br \/><br \/>Attention: Converting the database might take up to a couple of hours depending on the database size. As tracking might not work during this process, we do not recommend to use the trigger for bigger instances.<br \/><br \/>You can find more information about this topic in this %3$sFAQ%4$s.",
         "SkipCacheClearDesc": "Skips clearing of caches before updating. This is only useful if you can ensure that instances running this command have not created a cache at all yet, and if clearing the cache for many Matomo accounts can become a bottleneck.",
-        "SkipCacheClear": "Skipping clearing caches."
+        "SkipCacheClear": "Skipping clearing caches.",
+        "ReactivatedPlugins": "Reactivated plugins: %1$s"
     }
 }


### PR DESCRIPTION
### Description:

Adds a mechanism to store which plugins were active before core upgrade and tries to reactivate them after the upgrade if they don't have any missing requirements.

This will likely go into one last patch for 4.x branch (4.16.2) and we will also force 4.x users to update to this new patch version before going to 5.x via an api.matomo.org mechanism (related PR https://github.com/matomo-org/api.matomo.org/pull/29)

Note: tests won't run on this as we never updated the CI to work with 4.x branch.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
