### PR TITLE
Create reusable `Url::getExternalLinkTag` method and replace manual link creation with it

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -487,7 +487,7 @@ class Request
         if (Access::getInstance()->hasSuperUserAccess()) {
             $ex = new \Piwik\Exception\Exception(Piwik::translate(
                 'Widgetize_TooHighAccessLevel',
-                ['<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/troubleshooting/faq_147/') . '" rel="noreferrer noopener">', '</a>']
+                [Url::getExternalLinkTag('https://matomo.org/faq/troubleshooting/faq_147/'), '</a>']
             ));
             $ex->setIsHtmlMessage();
             throw $ex;
@@ -507,8 +507,7 @@ class Request
             // option is set.
             $ex = new \Piwik\Exception\Exception(Piwik::translate(
                 'Widgetize_ViewAccessRequired',
-                ['<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/troubleshooting/faq_147/') .
-                '" rel="noreferrer noopener">https://matomo.org/faq/troubleshooting/faq_147/</a>']
+                [Url::getExternalLinkTag('https://matomo.org/faq/troubleshooting/faq_147/') . 'https://matomo.org/faq/troubleshooting/faq_147/</a>']
             ));
             $ex->setIsHtmlMessage();
             throw $ex;

--- a/core/Nonce.php
+++ b/core/Nonce.php
@@ -104,13 +104,13 @@ class Nonce
         if (Url::isSecureConnectionAssumedByPiwikButNotForcedYet()) {
             $additionalErrors =  '<br/><br/>' . Piwik::translate(
                 'Login_InvalidNonceSSLMisconfigured',
-                array(
-                  '<a target="_blank" rel="noreferrer noopener" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to/faq_91/') . '">',
+                [
+                  Url::getExternalLinkTag('https://matomo.org/faq/how-to/faq_91/'),
                   '</a>',
                   'config/config.ini.php',
                   '<pre>force_ssl=1</pre>',
                   '<pre>[General]</pre>',
-                )
+                ]
             );
         }
 
@@ -124,10 +124,10 @@ class Nonce
         if (!empty($referrer)) {
             // Allow the instance host by default, if no allowedReferrerHost is specified.
             if (empty($allowedReferrerHost) && !Url::isLocalUrl($referrer)) {
-                return Piwik::translate('Login_InvalidNonceReferrer', array(
-                        '<a target="_blank" rel="noreferrer noopener" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to-install/faq_98') . '">',
+                return Piwik::translate('Login_InvalidNonceReferrer', [
+                        Url::getExternalLinkTag('https://matomo.org/faq/how-to-install/faq_98'),
                         '</a>',
-                    )) . $additionalErrors;
+                    ]) . $additionalErrors;
             }
 
             // Test that referrer matches what is allowed.

--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -167,7 +167,7 @@ abstract class ControllerAdmin extends Controller
 
         $message .= Piwik::translate(
             'General_ReadThisToLearnMore',
-            ['<a rel="noreferrer noopener" target="_blank" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to/faq_91/') . '">', '</a>']
+            [Url::getExternalLinkTag('https://matomo.org/faq/how-to/faq_91/'), '</a>']
         );
 
         $notification = new Notification($message);

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -284,7 +284,7 @@ class Twig
     private function addFunctionExternalLink()
     {
         $externalLink = new TwigFunction('externallink', function ($url) {
-            return Url::getExternalLink($url);
+            return Url::getExternalLinkTag($url);
         });
         $this->twig->addFunction($externalLink);
     }

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -284,10 +284,7 @@ class Twig
     private function addFunctionExternalLink()
     {
         $externalLink = new TwigFunction('externallink', function ($url) {
-            // Add tracking parameters if a matomo.org link
-            $url = Url::addCampaignParametersToMatomoLink($url);
-
-            return "<a target='_blank' rel='noreferrer noopener' href='" . $url . "'>";
+            return Url::getExternalLink($url);
         });
         $this->twig->addFunction($externalLink);
     }

--- a/core/Url.php
+++ b/core/Url.php
@@ -916,4 +916,20 @@ class Url
         $pathAndQueryString = UrlHelper::getPathAndQueryFromUrl($url, $newParams, true);
         return 'https://' . $domain . '/' . $pathAndQueryString;
     }
+
+    /**
+     * Create an external link tag with optional campaign params if link goes to matomo.org
+     *
+     * @since 5.6.0
+     */
+    public static function getExternalLinkTag(
+        string $url,
+        ?string $campaign = null,
+        ?string $source = null,
+        ?string $medium = null
+    ): string {
+        $url = self::addCampaignParametersToMatomoLink($url, $campaign, $source, $medium);
+
+        return '<a target="_blank" rel="noreferrer noopener" href="' . $url . '">';
+    }
 }

--- a/plugins/Actions/Categories/SiteSearchSubcategory.php
+++ b/plugins/Actions/Categories/SiteSearchSubcategory.php
@@ -23,7 +23,7 @@ class SiteSearchSubcategory extends Subcategory
     {
         return '<p>' . Piwik::translate('Actions_SiteSearchSubcategoryHelp1') . '</p>'
             . '<p>' . Piwik::translate('Actions_SiteSearchSubcategoryHelp2') . '</p>'
-            . '<p><a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/site-search/', null, null, 'App.Actions.getSiteSearchCategories')
-            . '" rel="noreferrer noopener" target="_blank">' . Piwik::translate('Actions_SiteSearchSubcategoryHelp3') . '</a></p>';
+            . '<p>' . Url::getExternalLinkTag('https://matomo.org/docs/site-search/', null, null, 'App.Actions.getSiteSearchCategories')
+            . Piwik::translate('Actions_SiteSearchSubcategoryHelp3') . '</a></p>';
     }
 }

--- a/plugins/Contents/Categories/ContentsSubcategory.php
+++ b/plugins/Contents/Categories/ContentsSubcategory.php
@@ -22,7 +22,7 @@ class ContentsSubcategory extends Subcategory
     public function getHelp()
     {
         return '<p>' . Piwik::translate('Contents_ContentsSubcategoryHelp1') . '</p>'
-            . '<p><a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/content-tracking', null, null, 'App.Contents.getContentNames')
-            . '" rel="noreferrer noopener" target="_blank">' . Piwik::translate('Contents_ContentsSubcategoryHelp2') . '</a></p>';
+            . '<p>' . Url::getExternalLinkTag('https://matomo.org/docs/content-tracking', null, null, 'App.Contents.getContentNames')
+            . Piwik::translate('Contents_ContentsSubcategoryHelp2') . '</a></p>';
     }
 }

--- a/plugins/CorePluginsAdmin/tests/System/expected/test_CorePluginsAdmin__CorePluginsAdmin.getSystemSettings.xml
+++ b/plugins/CorePluginsAdmin/tests/System/expected/test_CorePluginsAdmin__CorePluginsAdmin.getSystemSettings.xml
@@ -478,7 +478,7 @@
 					<latest_5x_beta>Latest beta 5.X (Long Term Support version)</latest_5x_beta>
 				</availableValues>
 				<description />
-				<inlineHelp>While our development process includes thousands of automated tests, Beta Testers play a key role in achieving the &quot;No bug policy&quot; in Matomo.&lt;br/&gt;If Matomo is a critical part of your business, we recommend you use the latest stable release. If you use the latest beta and you find a bug or have a suggestion, please &lt;a target='_blank' rel='noreferrer noopener' href='https://developer.matomo.org/guides/core-team-workflow#influencing-piwik-development'&gt;see here&lt;/a&gt;.&lt;br/&gt;LTS (Long Term Support) versions receive only security and bug-fixes.</inlineHelp>
+				<inlineHelp>While our development process includes thousands of automated tests, Beta Testers play a key role in achieving the &quot;No bug policy&quot; in Matomo.&lt;br/&gt;If Matomo is a critical part of your business, we recommend you use the latest stable release. If you use the latest beta and you find a bug or have a suggestion, please &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://developer.matomo.org/guides/core-team-workflow#influencing-piwik-development&quot;&gt;see here&lt;/a&gt;.&lt;br/&gt;LTS (Long Term Support) versions receive only security and bug-fixes.</inlineHelp>
 				<introduction>Release channel</introduction>
 				<condition />
 				<fullWidth>0</fullWidth>

--- a/plugins/CorePluginsAdmin/tests/System/expected/test_CorePluginsAdmin_compliancePolicyEnforced__CorePluginsAdmin.getSystemSettings.xml
+++ b/plugins/CorePluginsAdmin/tests/System/expected/test_CorePluginsAdmin_compliancePolicyEnforced__CorePluginsAdmin.getSystemSettings.xml
@@ -478,7 +478,7 @@
 					<latest_5x_beta>Latest beta 5.X (Long Term Support version)</latest_5x_beta>
 				</availableValues>
 				<description />
-				<inlineHelp>While our development process includes thousands of automated tests, Beta Testers play a key role in achieving the &quot;No bug policy&quot; in Matomo.&lt;br/&gt;If Matomo is a critical part of your business, we recommend you use the latest stable release. If you use the latest beta and you find a bug or have a suggestion, please &lt;a target='_blank' rel='noreferrer noopener' href='https://developer.matomo.org/guides/core-team-workflow#influencing-piwik-development'&gt;see here&lt;/a&gt;.&lt;br/&gt;LTS (Long Term Support) versions receive only security and bug-fixes.</inlineHelp>
+				<inlineHelp>While our development process includes thousands of automated tests, Beta Testers play a key role in achieving the &quot;No bug policy&quot; in Matomo.&lt;br/&gt;If Matomo is a critical part of your business, we recommend you use the latest stable release. If you use the latest beta and you find a bug or have a suggestion, please &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://developer.matomo.org/guides/core-team-workflow#influencing-piwik-development&quot;&gt;see here&lt;/a&gt;.&lt;br/&gt;LTS (Long Term Support) versions receive only security and bug-fixes.</inlineHelp>
 				<introduction>Release channel</introduction>
 				<condition />
 				<fullWidth>0</fullWidth>

--- a/plugins/CorePluginsAdmin/tests/System/expected/test_CorePluginsAdmin_compliancePolicyFeatureFlagEnabled__CorePluginsAdmin.getSystemSettings.xml
+++ b/plugins/CorePluginsAdmin/tests/System/expected/test_CorePluginsAdmin_compliancePolicyFeatureFlagEnabled__CorePluginsAdmin.getSystemSettings.xml
@@ -478,7 +478,7 @@
 					<latest_5x_beta>Latest beta 5.X (Long Term Support version)</latest_5x_beta>
 				</availableValues>
 				<description />
-				<inlineHelp>While our development process includes thousands of automated tests, Beta Testers play a key role in achieving the &quot;No bug policy&quot; in Matomo.&lt;br/&gt;If Matomo is a critical part of your business, we recommend you use the latest stable release. If you use the latest beta and you find a bug or have a suggestion, please &lt;a target='_blank' rel='noreferrer noopener' href='https://developer.matomo.org/guides/core-team-workflow#influencing-piwik-development'&gt;see here&lt;/a&gt;.&lt;br/&gt;LTS (Long Term Support) versions receive only security and bug-fixes.</inlineHelp>
+				<inlineHelp>While our development process includes thousands of automated tests, Beta Testers play a key role in achieving the &quot;No bug policy&quot; in Matomo.&lt;br/&gt;If Matomo is a critical part of your business, we recommend you use the latest stable release. If you use the latest beta and you find a bug or have a suggestion, please &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://developer.matomo.org/guides/core-team-workflow#influencing-piwik-development&quot;&gt;see here&lt;/a&gt;.&lt;br/&gt;LTS (Long Term Support) versions receive only security and bug-fixes.</inlineHelp>
 				<introduction>Release channel</introduction>
 				<condition />
 				<fullWidth>0</fullWidth>

--- a/plugins/CoreUpdater/Diagnostic/HttpsUpdateCheck.php
+++ b/plugins/CoreUpdater/Diagnostic/HttpsUpdateCheck.php
@@ -34,7 +34,7 @@ class HttpsUpdateCheck implements Diagnostic
     public function execute()
     {
         $faqLink = [
-          '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/faq-how-to-disable-https-for-matomo-org-and-api-matomo-org-requests') . '" rel="noreferrer noopener" target="_blank">',
+          Url::getExternalLinkTag('https://matomo.org/faq/faq-how-to-disable-https-for-matomo-org-and-api-matomo-org-requests'),
           '</a>',
         ];
         $label = $this->translator->translate('Installation_SystemCheckUpdateHttps');

--- a/plugins/CoreUpdater/SystemSettings.php
+++ b/plugins/CoreUpdater/SystemSettings.php
@@ -104,8 +104,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
                             . '<br/>'
                             . Piwik::translate(
                                 'CoreAdminHome_StableReleases',
-                                ["<a target='_blank' rel='noreferrer noopener' href='" . Url::addCampaignParametersToMatomoLink('https://developer.matomo.org/guides/core-team-workflow#influencing-piwik-development') . "'>",
-                                "</a>"]
+                                [Url::getExternalLinkTag('https://developer.matomo.org/guides/core-team-workflow#influencing-piwik-development'), '</a>']
                             )
                             . '<br/>'
                             . Piwik::translate('CoreAdminHome_LtsReleases');
@@ -132,7 +131,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
             $field->inlineHelp = Piwik::translate('CoreUpdater_Utf8mb4ConversionHelp', [
                 '�',
                 '<code>' . PIWIK_INCLUDE_PATH . '/console core:convert-to-utf8mb4</code>',
-                '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to-update/how-to-convert-the-database-to-utf8mb4-charset/') . '" rel="noreferrer noopener" target="_blank">',
+                Url::getExternalLinkTag('https://matomo.org/faq/how-to-update/how-to-convert-the-database-to-utf8mb4-charset/'),
                 '</a>',
             ]);
         });

--- a/plugins/CustomDimensions/tests/System/expected/test___API.getReportPagesMetadata.xml
+++ b/plugins/CustomDimensions/tests/System/expected/test___API.getReportPagesMetadata.xml
@@ -189,7 +189,7 @@
 			<id>Transitions_Transitions</id>
 			<name>Transitions</name>
 			<order>46</order>
-			<help>&lt;p&gt;Transitions is a report showing the things your visitors did directly before and after viewing a given page. This page explains how to access, understand, and use the powerful &quot;Transitions&quot; report.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/transitions/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Transitions.getTransitions&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;More details&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;Transitions is a report showing the things your visitors did directly before and after viewing a given page. This page explains how to access, understand, and use the powerful &quot;Transitions&quot; report.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/transitions/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Transitions.getTransitions&quot;&gt;More details&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -446,7 +446,7 @@
 			<id>Actions_SubmenuSitesearch</id>
 			<name>Site Search</name>
 			<order>25</order>
-			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -535,7 +535,7 @@
 			<id>Events_Events</id>
 			<name>Events</name>
 			<order>40</order>
-			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -658,7 +658,7 @@
 			<id>Contents_Contents</id>
 			<name>Contents</name>
 			<order>45</order>
-			<help>&lt;p&gt;Content tracking helps you determine the popularity of specific pieces of content on any page of your website or app. This section reports the number of impressions and interactions the various pieces of content on your site receive.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/content-tracking?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Contents.getContentNames&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Content Tracking guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;Content tracking helps you determine the popularity of specific pieces of content on any page of your website or app. This section reports the number of impressions and interactions the various pieces of content on your site receive.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/content-tracking?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Contents.getContentNames&quot;&gt;Learn more in the Content Tracking guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -1477,7 +1477,7 @@
 			<id>Live_VisitorLog</id>
 			<name>Visits Log</name>
 			<order>5</order>
-			<help>&lt;p&gt;The visits log shows you every visit your website receives in detail. Find out which actions each visitor has performed, how they got to your site, a bit about who they are, and more (while still complying with your local privacy regulations).&lt;/p&gt;&lt;p&gt;While other reports in Matomo show how your visitors behave at an aggregate level, the visits log provides granular detail. You can also use segments to narrow it down to specific types of visits to understand your visitors better.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/real-time/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Live.getLastVisitsDetails&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Learn more in the visit-log guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The visits log shows you every visit your website receives in detail. Find out which actions each visitor has performed, how they got to your site, a bit about who they are, and more (while still complying with your local privacy regulations).&lt;/p&gt;&lt;p&gt;While other reports in Matomo show how your visitors behave at an aggregate level, the visits log provides granular detail. You can also use segments to narrow it down to specific types of visits to understand your visitors better.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/real-time/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Live.getLastVisitsDetails&quot;&gt;Learn more in the visit-log guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -1513,7 +1513,7 @@
 			<id>UserId_UserReportTitle</id>
 			<name>User IDs</name>
 			<order>40</order>
-			<help>&lt;p&gt;The user ID report shows visits associated with all your registered and logged in users. Understand website usage by its specific users and find out who your most and least active users are.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noopener noreferrer&quot; href=&quot;https://matomo.org/docs/user-id?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.UserId.getUsers&quot;&gt;&lt;span class=&quot;icon-info&quot;&gt;&lt;/span&gt; Learn more&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The user ID report shows visits associated with all your registered and logged in users. Understand website usage by its specific users and find out who your most and least active users are.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/user-id?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.UserId.getUsers&quot;&gt;&lt;span class=&quot;icon-info&quot;&gt;&lt;/span&gt; Learn more&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -1546,7 +1546,7 @@
 			<id>CustomVariables_CustomVariables</id>
 			<name>Custom Variables</name>
 			<order>45</order>
-			<help>&lt;p&gt;This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/custom-variables/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Read more about this topic in the online guide.&lt;/a&gt;&lt;/p&gt;</help>
+            <help>&lt;p&gt;This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values.&lt;/p&gt;&lt;p&gt;&lt;a href="https://matomo.org/docs/custom-variables/" rel="noreferrer noopener" target="_blank"&gt;Read more about this topic in the online guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>

--- a/plugins/Diagnostics/Diagnostic/CronArchivingCheck.php
+++ b/plugins/Diagnostics/Diagnostic/CronArchivingCheck.php
@@ -42,7 +42,7 @@ class CronArchivingCheck implements Diagnostic
             $isBrowserTriggerEnabled = Rules::isBrowserTriggerEnabled();
             if ($isBrowserTriggerEnabled) {
                 $comment = $this->translator->translate('Diagnostics_BrowserTriggeredArchivingEnabled', [
-                    '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/setup-auto-archiving/') . '" target="_blank" rel="noreferrer noopener">', '</a>']);
+                    Url::getExternalLinkTag('https://matomo.org/docs/setup-auto-archiving/'), '</a>']);
                 $result[] = DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_WARNING, $comment);
 
                 $archiveLastStarted = Option::get(CronArchive::OPTION_ARCHIVING_STARTED_TS);
@@ -54,7 +54,7 @@ class CronArchivingCheck implements Diagnostic
                     $lastStarted = $formatter->getPrettyTimeFromSeconds(time() - $archiveLastStarted, true);
                     $label = $this->translator->translate('Diagnostics_BrowserAndAutoArchivingEnabledLabel');
                     $comment = $this->translator->translate('Diagnostics_BrowserAndAutoArchivingEnabledComment', [
-                        '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/setup-auto-archiving/') . '" target="_blank" rel="noreferrer noopener">', '</a>', $lastStarted]);
+                        Url::getExternalLinkTag('https://matomo.org/docs/setup-auto-archiving/'), '</a>', $lastStarted]);
                     $result[] = DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_WARNING, $comment);
                 }
             }
@@ -78,7 +78,7 @@ class CronArchivingCheck implements Diagnostic
                 . ' (' . $this->translator->translate('General_Reasons') . ': ' . $reasonText . ')'
                 . $this->translator->translate(
                     'General_LearnMore',
-                    [' <a target="_blank" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/troubleshooting/how-to-make-the-diagnostic-managing-processes-via-cli-to-display-ok/') . '">', '</a>']
+                    [' ' . Url::getExternalLinkTag('https://matomo.org/faq/troubleshooting/how-to-make-the-diagnostic-managing-processes-via-cli-to-display-ok/') . '">', '</a>']
                 );
             $status = DiagnosticResult::STATUS_INFORMATIONAL;
         }

--- a/plugins/Diagnostics/Diagnostic/CronArchivingLastRunCheck.php
+++ b/plugins/Diagnostics/Diagnostic/CronArchivingLastRunCheck.php
@@ -60,7 +60,7 @@ class CronArchivingLastRunCheck implements Diagnostic
             $comment = $this->translator->translate('Diagnostics_CronArchivingHasNotRun')
                 . '<br/><br/>' . $this->translator->translate(
                     'Diagnostics_CronArchivingRunDetails',
-                    [$coreArchiveShort, $mailto, $commandToRerun, '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/setup-auto-archiving/') . '" target="_blank" rel="noreferrer noopener">', '</a>']
+                    [$coreArchiveShort, $mailto, $commandToRerun, Url::getExternalLinkTag('https://matomo.org/docs/setup-auto-archiving/'), '</a>']
                 );
             return [DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_ERROR, $comment)];
         }
@@ -77,7 +77,7 @@ class CronArchivingLastRunCheck implements Diagnostic
             $this->translator->translate(
                 'Diagnostics_CronArchivingRunDetails',
                 [$coreArchiveShort, $mailto, $commandToRerun,
-                    '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/setup-auto-archiving/') . '" target="_blank" rel="noreferrer noopener">',
+                    Url::getExternalLinkTag('https://matomo.org/docs/setup-auto-archiving/'),
                     '</a>',
                 ]
             );

--- a/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
@@ -77,7 +77,7 @@ class DatabaseAbilitiesCheck implements Diagnostic
                 $this->translator->translate('Diagnostics_DatabaseUtf8mb4CharsetAvailableButNotUsed', '<code>' . PIWIK_INCLUDE_PATH . '/console core:convert-to-utf8mb4</code>') .
                 '<br/><br/>' .
                 $this->translator->translate('Diagnostics_DatabaseUtf8Requirement', ['�',
-                    '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to-update/how-to-convert-the-database-to-utf8mb4-charset/') . '" rel="noreferrer noopener" target="_blank">', '</a>']) .
+                    Url::getExternalLinkTag('https://matomo.org/faq/how-to-update/how-to-convert-the-database-to-utf8mb4-charset/'), '</a>']) .
                 '<br/>'
             );
         }
@@ -88,7 +88,7 @@ class DatabaseAbilitiesCheck implements Diagnostic
             $this->translator->translate('Diagnostics_DatabaseUtf8mb4CharsetRecommended') .
             '<br/><br/>' .
             $this->translator->translate('Diagnostics_DatabaseUtf8Requirement', ['�',
-                '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to-update/how-to-convert-the-database-to-utf8mb4-charset/') . '" rel="noreferrer noopener" target="_blank">', '</a>']) .
+                Url::getExternalLinkTag('https://matomo.org/faq/how-to-update/how-to-convert-the-database-to-utf8mb4-charset/'), '</a>']) .
             '<br/>'
         );
     }
@@ -161,7 +161,7 @@ class DatabaseAbilitiesCheck implements Diagnostic
                 '<br/><strong>%s:</strong> %s<br/>%s',
                 $this->translator->translate('General_Error'),
                 $errorMessage,
-                'Troubleshooting: <a target="_blank" rel="noreferrer noopener" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/troubleshooting/faq_194') . '">FAQ on matomo.org</a>'
+                'Troubleshooting: ' . Url::getExternalLinkTag('https://matomo.org/faq/troubleshooting/faq_194') . 'FAQ on matomo.org</a>'
             );
         }
 
@@ -195,7 +195,7 @@ class DatabaseAbilitiesCheck implements Diagnostic
         } catch (\Exception $e) {
             $status = DiagnosticResult::STATUS_ERROR;
             $comment .= '<br/>' . $this->translator->translate('Diagnostics_MysqlTemporaryTablesWarning');
-            $comment .= '<br/>Troubleshooting: <a target="_blank" rel="noreferrer noopener" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to-install/faq_23484/') . '">FAQ on matomo.org</a>';
+            $comment .= '<br/>Troubleshooting: ' . Url::getExternalLinkTag('https://matomo.org/faq/how-to-install/faq_23484/') . 'FAQ on matomo.org</a>';
         }
 
         return new DiagnosticResultItem($status, $comment);

--- a/plugins/Diagnostics/Diagnostic/DbMaxPacket.php
+++ b/plugins/Diagnostics/Diagnostic/DbMaxPacket.php
@@ -7,6 +7,7 @@ use Piwik\Piwik;
 use Piwik\SettingsPiwik;
 use Piwik\Translation\Translator;
 use Piwik\Metrics\Formatter;
+use Piwik\Url;
 
 /**
  * Check if Piwik is connected with database through ssl.
@@ -45,10 +46,12 @@ class DbMaxPacket implements Diagnostic
             $configured = str_replace(array(' M', '&nbsp;M'), 'MB', $pretty);
             $comment = Piwik::translate(
                 'Diagnostics_MysqlMaxPacketSizeWarning',
-                ['<a href="https://dev.mysql.com/doc/refman/en/packet-too-large.html" rel="noreferrer noopener" target="_blank">',
-                '</a>',
-                '64MB',
-                $configured]
+                [
+                    Url::getExternalLinkTag('https://dev.mysql.com/doc/refman/en/packet-too-large.html'),
+                    '</a>',
+                    '64MB',
+                    $configured,
+                ]
             );
         }
 

--- a/plugins/Diagnostics/Diagnostic/DbOverSSLCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DbOverSSLCheck.php
@@ -55,7 +55,7 @@ class DbOverSSLCheck implements Diagnostic
             }
         }
 
-        $comment .= '<br />' . '<a target="_blank" rel="noreferrer noopener" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/') . '"> FAQ on matomo.org</a>';
+        $comment .= '<br />' . Url::getExternalLinkTag('https://matomo.org/faq/') . 'FAQ on matomo.org</a>';
 
         return array(DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_WARNING, $comment));
     }

--- a/plugins/Diagnostics/Diagnostic/RecommendedFunctionsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/RecommendedFunctionsCheck.php
@@ -76,9 +76,9 @@ class RecommendedFunctionsCheck implements Diagnostic
             'gzopen'         => 'Installation_SystemCheckZlibHelp',
         );
 
-        $translation_params = array(
-            'shell_exec'     => ["<a href='" . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/troubleshooting/how-to-make-the-diagnostic-managing-processes-via-cli-to-display-ok/') . "' rel='noopener' target='_blank'>", "</a>"],
-        );
+        $translation_params = [
+            'shell_exec'     => [Url::getExternalLinkTag('https://matomo.org/faq/troubleshooting/how-to-make-the-diagnostic-managing-processes-via-cli-to-display-ok/'), '</a>'],
+        ];
 
         return $this->translator->translate($messages[$function], $translation_params[$function] ?? []);
     }

--- a/plugins/Diagnostics/Diagnostic/RecommendedPrivateDirectories.php
+++ b/plugins/Diagnostics/Diagnostic/RecommendedPrivateDirectories.php
@@ -31,7 +31,7 @@ class RecommendedPrivateDirectories extends AbstractPrivateDirectories
             DiagnosticResult::STATUS_INFORMATIONAL,
             $this->translator->translate('Diagnostics_UrlsAccessibleViaBrowser') . ' ' .
             $this->translator->translate('General_ReadThisToLearnMore', [
-                '<a target="_blank" rel="noopener noreferrer" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/troubleshooting/how-do-i-fix-the-error-private-directories-are-accessible/') . '">',
+                Url::getExternalLinkTag('https://matomo.org/faq/troubleshooting/how-do-i-fix-the-error-private-directories-are-accessible/'),
                 '</a>',
             ])
         ));

--- a/plugins/Diagnostics/Diagnostic/RequiredPrivateDirectories.php
+++ b/plugins/Diagnostics/Diagnostic/RequiredPrivateDirectories.php
@@ -31,7 +31,7 @@ class RequiredPrivateDirectories extends AbstractPrivateDirectories
         if ($this->configIniAccessible) {
             $pathIsAccessible .= '<br/><br/>' . $this->translator->translate('Diagnostics_ConfigIniAccessible');
         }
-        $pathIsAccessible .= '<br/><br/><a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/troubleshooting/how-do-i-fix-the-error-private-directories-are-accessible/') . '" target="_blank" rel="noopener noreferrer">' . $this->translator->translate('General_ReadThisToLearnMore', ['', '']) . '</a>';
+        $pathIsAccessible .= '<br/><br/>' . Url::getExternalLinkTag('https://matomo.org/faq/troubleshooting/how-do-i-fix-the-error-private-directories-are-accessible/') . $this->translator->translate('General_ReadThisToLearnMore', ['', '']) . '</a>';
         $result->setLongErrorMessage($pathIsAccessible);
     }
 

--- a/plugins/Diagnostics/Diagnostic/TimezoneCheck.php
+++ b/plugins/Diagnostics/Diagnostic/TimezoneCheck.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\Diagnostics\Diagnostic;
 
 use Piwik\SettingsServer;
 use Piwik\Translation\Translator;
+use Piwik\Url;
 
 /**
  * Check that the PHP timezone setting is set.
@@ -38,7 +39,7 @@ class TimezoneCheck implements Diagnostic
         $comment = sprintf(
             '%s<br />%s.',
             $this->translator->translate('SitesManager_AdvancedTimezoneSupportNotFound'),
-            '<a href="https://php.net/manual/en/datetime.installation.php" rel="noreferrer noopener" target="_blank">Timezone PHP documentation</a>'
+            Url::getExternalLinkTag('https://php.net/manual/en/datetime.installation.php') . 'Timezone PHP documentation</a>'
         );
 
         return array(DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_WARNING, $comment));

--- a/plugins/Diagnostics/Diagnostics.php
+++ b/plugins/Diagnostics/Diagnostics.php
@@ -59,7 +59,7 @@ class Diagnostics extends Plugin
         $lastSuccessfulRun = CronArchivingLastRunCheck::getTimeSinceLastSuccessfulRun();
         if ($lastSuccessfulRun > CronArchivingLastRunCheck::SECONDS_IN_DAY) {
             $content = Piwik::translate('Diagnostics_NoDataForReportArchivingNotRun', [
-                '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/setup-auto-archiving/') . '" target="_blank" rel="noreferrer noopener">',
+                Url::getExternalLinkTag('https://matomo.org/docs/setup-auto-archiving/'),
                 '</a>',
             ]);
 

--- a/plugins/Ecommerce/Categories/EcommerceOverviewSubcategory.php
+++ b/plugins/Ecommerce/Categories/EcommerceOverviewSubcategory.php
@@ -23,7 +23,7 @@ class EcommerceOverviewSubcategory extends Subcategory
     {
         return '<p>' . Piwik::translate('Ecommerce_EcommerceOverviewSubcategoryHelp1') . '</p>'
             . '<p>' . Piwik::translate('Ecommerce_EcommerceOverviewSubcategoryHelp2') . '</p>'
-            . '<p><a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/ecommerce-analytics/', null, null, 'App.Ecommerce.Overview')
-            . '" rel="noreferrer noopener" target="_blank">' . Piwik::translate('Ecommerce_EcommerceOverviewSubcategoryHelp3') . '</a></p>';
+            . '<p>' . Url::getExternalLinkTag('https://matomo.org/docs/ecommerce-analytics/', null, null, 'App.Ecommerce.Overview')
+            . Piwik::translate('Ecommerce_EcommerceOverviewSubcategoryHelp3') . '</a></p>';
     }
 }

--- a/plugins/Events/Categories/EventsSubcategory.php
+++ b/plugins/Events/Categories/EventsSubcategory.php
@@ -22,7 +22,7 @@ class EventsSubcategory extends Subcategory
     public function getHelp()
     {
         return '<p>' . Piwik::translate('Events_EventsSubcategoryHelp1') . '</p>'
-            . '<p><a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/event-tracking/', null, null, 'App.Events.getCategory')
-            . '" rel="noreferrer noopener" target="_blank">' . Piwik::translate('Events_EventsSubcategoryHelp2') . '</a></p>';
+            . '<p>' . Url::getExternalLinkTag('https://matomo.org/docs/event-tracking/', null, null, 'App.Events.getCategory')
+            . Piwik::translate('Events_EventsSubcategoryHelp2') . '</a></p>';
     }
 }

--- a/plugins/GeoIp2/LocationProvider/GeoIp2/Php.php
+++ b/plugins/GeoIp2/LocationProvider/GeoIp2/Php.php
@@ -442,7 +442,7 @@ class Php extends GeoIp2
             );
         }
 
-        $installDocs = '<a rel="noreferrer"  target="_blank" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to/faq_163') . '">'
+        $installDocs = Url::getExternalLinkTag('https://matomo.org/faq/how-to/faq_163')
             . Piwik::translate('UserCountry_HowToInstallGeoIPDatabases')
             . '</a>';
 

--- a/plugins/GeoIp2/LocationProvider/GeoIp2/ServerModule.php
+++ b/plugins/GeoIp2/LocationProvider/GeoIp2/ServerModule.php
@@ -355,7 +355,7 @@ class ServerModule extends GeoIp2
     {
         $comment = Piwik::translate('GeoIp2_GeoIPLocationProviderNotRecommended') . ' ';
         $comment .= Piwik::translate('GeoIp2_LocationProviderDesc_ServerModule2', array(
-            '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/geo-locate/') . '" rel="noreferrer noopener" target="_blank">', '', '', '</a>',
+            Url::getExternalLinkTag('https://matomo.org/docs/geo-locate/'), '', '', '</a>',
         ));
 
         return $comment;

--- a/plugins/Goals/Categories/GoalsOverviewSubcategory.php
+++ b/plugins/Goals/Categories/GoalsOverviewSubcategory.php
@@ -23,7 +23,7 @@ class GoalsOverviewSubcategory extends Subcategory
     {
         return '<p>' . Piwik::translate('Goals_GoalsOverviewSubcategoryHelp1') . '</p>'
             . '<p>' . Piwik::translate('Goals_GoalsOverviewSubcategoryHelp2') . '</p>'
-            . '<p><a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/tracking-goals-web-analytics/', null, null, 'App.Goals.Overview')
-            . '" rel="noreferrer noopener" target="_blank">' . Piwik::translate('Goals_ManageGoalsSubcategoryHelp2') . '</a></p>';
+            . '<p>' . Url::getExternalLinkTag('https://matomo.org/docs/tracking-goals-web-analytics/', null, null, 'App.Goals.Overview')
+            . Piwik::translate('Goals_ManageGoalsSubcategoryHelp2') . '</a></p>';
     }
 }

--- a/plugins/Goals/Categories/ManageGoalsSubcategory.php
+++ b/plugins/Goals/Categories/ManageGoalsSubcategory.php
@@ -22,6 +22,6 @@ class ManageGoalsSubcategory extends Subcategory
     public function getHelp()
     {
         return '<p>' . Piwik::translate('Goals_ManageGoalsSubcategoryHelp1') . '</p>'
-            . '<p><a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/tracking-goals-web-analytics/') . '" rel="noreferrer noopener" target="_blank">' . Piwik::translate('Goals_ManageGoalsSubcategoryHelp2') . '</a></p>';
+            . '<p>' . Url::getExternalLinkTag('https://matomo.org/docs/tracking-goals-web-analytics/') . Piwik::translate('Goals_ManageGoalsSubcategoryHelp2') . '</a></p>';
     }
 }

--- a/plugins/Goals/Visualizations/Goals.php
+++ b/plugins/Goals/Visualizations/Goals.php
@@ -79,7 +79,7 @@ class Goals extends HtmlTable
             // TODO: should not use query parameter
             $this->config->documentation = Piwik::translate(
                 'Goals_ConversionByTypeReportDocumentation',
-                ['<br />', '<br />', '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/tracking-goals-web-analytics/') . '" rel="noreferrer noopener" target="_blank">', '</a>']
+                ['<br />', '<br />', Url::getExternalLinkTag('https://matomo.org/docs/tracking-goals-web-analytics/'), '</a>']
             );
         }
 

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -812,7 +812,7 @@ class Controller extends ControllerAdmin
                 Piwik::translate('Installation_ErrorExpired6') .
                 "\n<br/>" .
                 Piwik::translate('Installation_ErrorExpired7', [
-                    '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to-install/manage-secure-access-to-the-matomo-installer/') . '" rel="noreferrer noopener" target="_blank">',
+                    Url::getExternalLinkTag('https://matomo.org/faq/how-to-install/manage-secure-access-to-the-matomo-installer/'),
                     '</a>',
                 ])
             );

--- a/plugins/Installation/FormSuperUser.php
+++ b/plugins/Installation/FormSuperUser.php
@@ -64,7 +64,7 @@ class FormSuperUser extends QuickForm2
 
         );
 
-        $privacyNoticeLink = '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/privacy-policy/') . '" target="_blank" rel="noreferrer noopener">';
+        $privacyNoticeLink = Url::getExternalLinkTag('https://matomo.org/privacy-policy/');
         $privacyNotice = '<div class="form-help email-privacy-notice">' . Piwik::translate('Installation_EmailPrivacyNotice', [$privacyNoticeLink, '</a>'])
             . '</div>';
 

--- a/plugins/Live/Categories/VisitorLogSubcategory.php
+++ b/plugins/Live/Categories/VisitorLogSubcategory.php
@@ -23,8 +23,8 @@ class VisitorLogSubcategory extends Subcategory
     {
         $help = '<p>' . Piwik::translate('Live_VisitorLogSubcategoryHelp1') . '</p>';
         $help .= '<p>' . Piwik::translate('Live_VisitorLogSubcategoryHelp2') . '</p>';
-        $help .= '<p><a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/real-time/', null, null, 'App.Live.getLastVisitsDetails')
-            . '" target="_blank" rel="noreferrer noopener">' . Piwik::translate('Live_VisitorLogSubcategoryHelp3') . '</a></p>';
+        $help .= '<p>' . Url::getExternalLinkTag('https://matomo.org/docs/real-time/', null, null, 'App.Live.getLastVisitsDetails')
+            . Piwik::translate('Live_VisitorLogSubcategoryHelp3') . '</a></p>';
         return $help;
     }
 }

--- a/plugins/Marketplace/Controller.php
+++ b/plugins/Marketplace/Controller.php
@@ -503,7 +503,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                         $downloadLink = Url::addCampaignParametersToMatomoLink('https://plugins.matomo.org/' . $pluginName);
                         $translateKey = 'Marketplace_PluginDownloadLinkMissingFree';
                     }
-                    $message = Piwik::translate($translateKey, [$pluginName, "<a href='$downloadLink' target='_blank' rel='noreferrer noopener'>", '</a>', "<a href='$faqLink' target='_blank' rel='noreferrer noopener'>", '</a>']);
+                    $message = Piwik::translate($translateKey, [$pluginName, Url::getExternalLinkTag($downloadLink), '</a>', Url::getExternalLinkTag($faqLink), '</a>']);
                     $isRaw = true;
                 }
                 $notification = new Notification($message);

--- a/plugins/Marketplace/Plugins/InvalidLicenses.php
+++ b/plugins/Marketplace/Plugins/InvalidLicenses.php
@@ -160,7 +160,7 @@ class InvalidLicenses
             return '';
         }
 
-        return '<a href="' . $info['loginUrl'] . '" target="_blank" rel="noreferrer noopener">';
+        return Url::getExternalLinkTag($info['loginUrl']);
     }
 
     private function getSubscritionSummaryMessage()

--- a/plugins/Marketplace/tests/Integration/Plugins/InvalidLicensesTest.php
+++ b/plugins/Marketplace/tests/Integration/Plugins/InvalidLicensesTest.php
@@ -215,7 +215,7 @@ class InvalidLicensesTest extends IntegrationTestCase
         $this->assertNull($expired->getMessageExceededLicenses());
         $this->assertNull($expired->getMessageExpiredLicenses());
         $this->assertEquals(
-            'The following plugins have been deactivated because you are using them without a license: <strong>PaidPlugin3</strong>. <br/>To resolve this issue either update your license key, <strong><a href="https://shop.piwik.org/my-account" target="_blank" rel="noreferrer noopener">get a subscription now</a></strong> or deactivate the plugin. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>',
+            'The following plugins have been deactivated because you are using them without a license: <strong>PaidPlugin3</strong>. <br/>To resolve this issue either update your license key, <strong><a target="_blank" rel="noreferrer noopener" href="https://shop.piwik.org/my-account">get a subscription now</a></strong> or deactivate the plugin. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>',
             $expired->getMessageNoLicense()
         );
     }
@@ -228,7 +228,7 @@ class InvalidLicensesTest extends IntegrationTestCase
 
         $this->assertEquals('', $expired->getMessageExceededLicenses());
         $this->assertEquals('', $expired->getMessageExpiredLicenses());
-        $this->assertEquals('The following plugins have been deactivated because you are using them without a license: <strong>PaidPlugin1</strong>. <br/>To resolve this issue either update your license key, <strong><a href="https://shop.piwik.org/my-account" target="_blank" rel="noreferrer noopener">get a subscription now</a></strong> or deactivate the plugin. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageNoLicense());
+        $this->assertEquals('The following plugins have been deactivated because you are using them without a license: <strong>PaidPlugin1</strong>. <br/>To resolve this issue either update your license key, <strong><a target="_blank" rel="noreferrer noopener" href="https://shop.piwik.org/my-account">get a subscription now</a></strong> or deactivate the plugin. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageNoLicense());
     }
 
     public function testGetMessageExceededLicensesGetMessageExpiredLicensesInvalidLicensesPaidPluginActivated()
@@ -236,20 +236,20 @@ class InvalidLicensesTest extends IntegrationTestCase
         $expired = $this->buildWithExpiredLicense();
 
         $this->assertNull($expired->getMessageExceededLicenses());
-        $this->assertEquals('The licenses for the following plugins are expired: <strong>PaidPlugin1</strong>. <br/>You will no longer receive any updates for these plugins. To resolve this issue either <strong><a href="https://shop.piwik.org/my-account" target="_blank" rel="noreferrer noopener">renew your subscription now</a></strong>, or deactivate the plugin if you no longer use it. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageExpiredLicenses());
+        $this->assertEquals('The licenses for the following plugins are expired: <strong>PaidPlugin1</strong>. <br/>You will no longer receive any updates for these plugins. To resolve this issue either <strong><a target="_blank" rel="noreferrer noopener" href="https://shop.piwik.org/my-account">renew your subscription now</a></strong>, or deactivate the plugin if you no longer use it. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageExpiredLicenses());
     }
 
     public function testGetMessageExceededLicensesGetMessageExpiredLicensesExceededLicensesPaidPluginActivated()
     {
         $expired = $this->buildWithExceededLicense();
-        $this->assertEquals('The licenses for the following plugins are no longer valid as the number of authorized users for the license is exceeded: <strong>PaidPlugin2</strong>. <br/>You will not be able to download updates for these plugins. To resolve this issue either delete some users or <strong><a href="https://shop.piwik.org/my-account" target="_blank" rel="noreferrer noopener">upgrade the subscription now</a></strong>. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageExceededLicenses());
-        $this->assertEquals('The licenses for the following plugins are expired: <strong>PaidPlugin1</strong>. <br/>You will no longer receive any updates for these plugins. To resolve this issue either <strong><a href="https://shop.piwik.org/my-account" target="_blank" rel="noreferrer noopener">renew your subscription now</a></strong>, or deactivate the plugin if you no longer use it. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageExpiredLicenses());
+        $this->assertEquals('The licenses for the following plugins are no longer valid as the number of authorized users for the license is exceeded: <strong>PaidPlugin2</strong>. <br/>You will not be able to download updates for these plugins. To resolve this issue either delete some users or <strong><a target="_blank" rel="noreferrer noopener" href="https://shop.piwik.org/my-account">upgrade the subscription now</a></strong>. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageExceededLicenses());
+        $this->assertEquals('The licenses for the following plugins are expired: <strong>PaidPlugin1</strong>. <br/>You will no longer receive any updates for these plugins. To resolve this issue either <strong><a target="_blank" rel="noreferrer noopener" href="https://shop.piwik.org/my-account">renew your subscription now</a></strong>, or deactivate the plugin if you no longer use it. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageExpiredLicenses());
     }
 
     public function testGetMessageMissingLicensesGetMessageMissingLicensesPaidPluginActivated()
     {
         $expired = $this->buildWithNoLicense();
-        $this->assertEquals('The following plugins have been deactivated because you are using them without a license: <strong>PaidPlugin1</strong>. <br/>To resolve this issue either update your license key, <strong><a href="https://shop.piwik.org/my-account" target="_blank" rel="noreferrer noopener">get a subscription now</a></strong> or deactivate the plugin. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageNoLicense());
+        $this->assertEquals('The following plugins have been deactivated because you are using them without a license: <strong>PaidPlugin1</strong>. <br/>To resolve this issue either update your license key, <strong><a target="_blank" rel="noreferrer noopener" href="https://shop.piwik.org/my-account">get a subscription now</a></strong> or deactivate the plugin. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageNoLicense());
     }
 
     private function buildWithValidLicense()

--- a/plugins/Referrers/Categories/SearchEnginesSubcategory.php
+++ b/plugins/Referrers/Categories/SearchEnginesSubcategory.php
@@ -24,11 +24,12 @@ class SearchEnginesSubcategory extends Subcategory
         return '<p>' . Piwik::translate('Referrers_SearchEnginesSubcategoryHelp1') . '</p>'
             . '<p>' . Piwik::translate(
                 'Referrers_SearchEnginesSubcategoryHelp2',
-                ['<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/matomo-cloud/', null, null, 'App.Referrers.getSearchEngines')
-                 . '" rel="noreferrer noopener" target="_blank">', '</a>',
-                 '<a href="' . Url::addCampaignParametersToMatomoLink('https://plugins.matomo.org/SearchEngineKeywordsPerformance', null, null, 'App.Referrers.getSearchEngines')
-                . '" rel="noreferrer noopener" target="_blank">',
-                '</a>']
+                [
+                    Url::getExternalLinkTag('https://matomo.org/matomo-cloud/', null, null, 'App.Referrers.getSearchEngines'),
+                    '</a>',
+                    Url::getExternalLinkTag('https://plugins.matomo.org/SearchEngineKeywordsPerformance', null, null, 'App.Referrers.getSearchEngines'),
+                    '</a>',
+                ]
             ) . '</p>';
     }
 }

--- a/plugins/Referrers/Reports/GetKeywordsFromCampaignId.php
+++ b/plugins/Referrers/Reports/GetKeywordsFromCampaignId.php
@@ -23,7 +23,7 @@ class GetKeywordsFromCampaignId extends Base
         $this->name          = Piwik::translate('Referrers_Campaigns');
         $this->documentation = Piwik::translate(
             'Referrers_CampaignsReportDocumentation',
-            ['<br />', '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/tracking-campaigns/') . '" rel="noreferrer noopener" target="_blank">', '</a>']
+            ['<br />', Url::getExternalLinkTag('https://matomo.org/docs/tracking-campaigns/'), '</a>']
         );
         $this->isSubtableReport = true;
         $this->order = 10;

--- a/plugins/SitesManager/Controller.php
+++ b/plugins/SitesManager/Controller.php
@@ -307,7 +307,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                 'type'              => SiteContentDetectionAbstract::TYPE_OTHER,
                 'othersInstruction' => Piwik::translate(
                     'CoreAdminHome_ImportFromGoogleAnalyticsDescription',
-                    ['<a href="' . Url::addCampaignParametersToMatomoLink('https://plugins.matomo.org/GoogleAnalyticsImporter') . '" rel="noopener noreferrer" target="_blank">', '</a>']
+                    [Url::getExternalLinkTag('https://plugins.matomo.org/GoogleAnalyticsImporter'), '</a>']
                 ),
             ];
         }
@@ -341,7 +341,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                 'type'              => SiteContentDetectionAbstract::TYPE_OTHER,
                 'othersInstruction' => Piwik::translate(
                     'SitesManager_ImageTrackingDescription',
-                    ['<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/tracking-api/reference/') . '" rel="noreferrer noopener" target="_blank">', '</a>']
+                    [Url::getExternalLinkTag('https://matomo.org/docs/tracking-api/reference/'), '</a>']
                 ),
             ],
             [
@@ -350,7 +350,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                 'type'              => SiteContentDetectionAbstract::TYPE_OTHER,
                 'othersInstruction' => Piwik::translate(
                     'SitesManager_LogAnalyticsDescription',
-                    ['<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/log-analytics/') . '" rel="noreferrer noopener" target="_blank">', '</a>']
+                    [Url::getExternalLinkTag('https://matomo.org/log-analytics/'), '</a>']
                 ),
             ],
             [
@@ -359,7 +359,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                 'type'              => SiteContentDetectionAbstract::TYPE_OTHER,
                 'othersInstruction' => Piwik::translate(
                     'SitesManager_MobileAppsAndSDKsDescription',
-                    ['<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/integrate/#programming-language-platforms-and-frameworks') . '" rel="noreferrer noopener" target="_blank">', '</a>']
+                    [Url::getExternalLinkTag('https://matomo.org/integrate/#programming-language-platforms-and-frameworks'), '</a>']
                 ),
             ],
             [
@@ -368,7 +368,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                 'type'              => SiteContentDetectionAbstract::TYPE_OTHER,
                 'othersInstruction' => Piwik::translate(
                     'CoreAdminHome_HttpTrackingApiDescription',
-                    ['<a href="' . Url::addCampaignParametersToMatomoLink('https://developer.matomo.org/api-reference/tracking-api') . '" rel="noreferrer noopener" target="_blank">', '</a>']
+                    [Url::getExternalLinkTag('https://developer.matomo.org/api-reference/tracking-api'), '</a>']
                 ),
             ]
         );
@@ -415,7 +415,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             'SitesManager_SiteWithoutDataDetectedSite',
             [
                 $detectedCms::getName(),
-                '<a target="_blank" rel="noreferrer noopener" href="' . $detectedCms::getInstructionUrl() . '">',
+                Url::getExternalLinkTag($detectedCms::getInstructionUrl()),
                 '</a>',
             ]
         );

--- a/plugins/SitesManager/SiteContentDetection/GoogleTagManager.php
+++ b/plugins/SitesManager/SiteContentDetection/GoogleTagManager.php
@@ -92,7 +92,7 @@ class GoogleTagManager extends SiteContentDetectionAbstract
             Piwik::translate(
                 'SitesManager_SiteWithoutDataGoogleTagManagerDescription',
                 [
-                    '<a target="_blank" rel="noreferrer noopener" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/new-to-piwik/how-do-i-use-matomo-analytics-within-gtm-google-tag-manager') . '">',
+                    Url::getExternalLinkTag('https://matomo.org/faq/new-to-piwik/how-do-i-use-matomo-analytics-within-gtm-google-tag-manager'),
                     '</a>',
                 ]
             )

--- a/plugins/SitesManager/SiteContentDetection/Matomo.php
+++ b/plugins/SitesManager/SiteContentDetection/Matomo.php
@@ -109,7 +109,7 @@ class Matomo extends SiteContentDetectionAbstract
         $consentManagerName = $consentManager::getName();
         $consentManagerUrl = $consentManager::getInstructionUrl();
         $consentManagerIsConnected = in_array($consentManagerId, $detector->connectedConsentManagers);
-        $notificationMessage = '<p>' . Piwik::translate('PrivacyManager_ConsentManagerDetected', [$consentManagerName, '<a href="' . $consentManagerUrl . '" target="_blank" rel="noreferrer noopener">', '</a>']) . '</p>';
+        $notificationMessage = '<p>' . Piwik::translate('PrivacyManager_ConsentManagerDetected', [$consentManagerName, Url::getExternalLinkTag($consentManagerUrl), '</a>']) . '</p>';
 
         if (!empty($consentManagerIsConnected)) {
             $notificationMessage .= '<p>' . Piwik::translate('SitesManager_ConsentManagerConnected', [$consentManagerName]) . '</p>';

--- a/plugins/SitesManager/SiteContentDetection/MatomoTagManager.php
+++ b/plugins/SitesManager/SiteContentDetection/MatomoTagManager.php
@@ -52,7 +52,7 @@ class MatomoTagManager extends SiteContentDetectionAbstract
         return '<h3>' . Piwik::translate('SitesManager_SiteWithoutDataMatomoTagManager') . '</h3>
             <p>' . Piwik::translate(
             'SitesManager_SiteWithoutDataMatomoTagManagerNotActive',
-            ['<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/tag-manager/') . '" rel="noreferrer noopener" target="_blank">', '</a>']
+            [Url::getExternalLinkTag('https://matomo.org/docs/tag-manager/'), '</a>']
         ) . '</p>';
     }
 }

--- a/plugins/SitesManager/SiteContentDetection/ReactJs.php
+++ b/plugins/SitesManager/SiteContentDetection/ReactJs.php
@@ -76,9 +76,9 @@ class ReactJs extends SiteContentDetectionAbstract
             Piwik::translate(
                 'SitesManager_SiteWithoutDataReactDescription',
                 [
-                    '<a target="_blank" rel="noreferrer noopener" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/guide/tag-manager/') . '">',
+                    Url::getExternalLinkTag('https://matomo.org/guide/tag-manager/'),
                     '</a>',
-                    '<a target="_blank" rel="noreferrer noopener" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/new-to-piwik/how-do-i-start-tracking-data-with-matomo-on-websites-that-use-react/') . '">',
+                    Url::getExternalLinkTag('https://matomo.org/faq/new-to-piwik/how-do-i-start-tracking-data-with-matomo-on-websites-that-use-react/'),
                     '</a>',
                 ]
             )

--- a/plugins/SitesManager/SiteContentDetection/VueJs.php
+++ b/plugins/SitesManager/SiteContentDetection/VueJs.php
@@ -69,8 +69,8 @@ class VueJs extends SiteContentDetectionAbstract
             Piwik::translate(
                 'SitesManager_SiteWithoutDataVueDescription',
                 [
-                    '<a target="_blank" rel="noreferrer noopener" href="' . Url::addCampaignParametersToMatomoLink('https://github.com/AmazingDreams/vue-matomo') . '">vue-matomo</a>',
-                    '<a target="_blank" rel="noreferrer noopener" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/new-to-piwik/how-do-i-install-the-matomo-tracking-code-on-websites-that-use-vue-js/') . '">',
+                    Url::getExternalLinkTag('https://github.com/AmazingDreams/vue-matomo') . 'vue-matomo</a>',
+                    Url::getExternalLinkTag('https://matomo.org/faq/new-to-piwik/how-do-i-install-the-matomo-tracking-code-on-websites-that-use-vue-js/'),
                     '</a>',
                 ]
             )

--- a/plugins/SitesManager/SiteContentDetection/WordPress.php
+++ b/plugins/SitesManager/SiteContentDetection/WordPress.php
@@ -82,7 +82,7 @@ class WordPress extends SiteContentDetectionAbstract
             Piwik::translate(
                 'SitesManager_SiteWithoutDataWordpressDescription',
                 [
-                    '<a target="_blank" rel="noreferrer noopener" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/new-to-piwik/how-do-i-install-the-matomo-tracking-code-on-wordpress/') . '">',
+                    Url::getExternalLinkTag('https://matomo.org/faq/new-to-piwik/how-do-i-install-the-matomo-tracking-code-on-wordpress/'),
                     '</a>',
                 ]
             )

--- a/plugins/Transitions/Categories/TransitionsSubcategory.php
+++ b/plugins/Transitions/Categories/TransitionsSubcategory.php
@@ -22,7 +22,7 @@ class TransitionsSubcategory extends Subcategory
     public function getHelp()
     {
         return '<p>' . Piwik::translate('Transitions_TransitionsSubcategoryHelp1') . '</p>'
-            . '<p><a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/transitions/', null, null, 'App.Transitions.getTransitions')
-            . '" rel="noreferrer noopener" target="_blank">' . Piwik::translate('Transitions_TransitionsSubcategoryHelp2') . '</a></p>';
+            . '<p>' . Url::getExternalLinkTag('https://matomo.org/docs/transitions/', null, null, 'App.Transitions.getTransitions')
+            . Piwik::translate('Transitions_TransitionsSubcategoryHelp2') . '</a></p>';
     }
 }

--- a/plugins/UserCountry/LocationProvider/DefaultProvider.php
+++ b/plugins/UserCountry/LocationProvider/DefaultProvider.php
@@ -180,7 +180,7 @@ class DefaultProvider extends LocationProvider
                 'UserCountry_DefaultLocationProviderDesc2',
                 ['<strong>', '', '', '</strong>']
             )
-            . '</p><p><a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to/faq_163') . '" rel="noreferrer noopener"  target="_blank">'
+            . '</p><p>' . Url::getExternalLinkTag('https://matomo.org/faq/how-to/faq_163')
             . Piwik::translate('UserCountry_HowToInstallGeoIPDatabases')
             . '</a></p>';
         return ['id' => self::ID, 'title' => self::TITLE, 'description' => $desc, 'order' => 1];
@@ -190,7 +190,7 @@ class DefaultProvider extends LocationProvider
     {
         $comment = Piwik::translate('UserCountry_DefaultLocationProviderDesc1') . ' ';
         $comment .= Piwik::translate('UserCountry_DefaultLocationProviderDesc2', [
-            '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/geo-locate/') . '" rel="noreferrer noopener" target="_blank">', '', '', '</a>',
+            Url::getExternalLinkTag('https://matomo.org/docs/geo-locate/'), '', '', '</a>',
         ]);
 
         return $comment;

--- a/plugins/UserCountry/LocationProvider/DisabledProvider.php
+++ b/plugins/UserCountry/LocationProvider/DisabledProvider.php
@@ -89,7 +89,7 @@ class DisabledProvider extends LocationProvider
     {
         $comment = Piwik::translate('UserCountry_DefaultLocationProviderDesc1') . ' ';
         $comment .= Piwik::translate('UserCountry_DefaultLocationProviderDesc2', array(
-            '<a href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/geo-locate/') . '" rel="noreferrer noopener" target="_blank">', '', '', '</a>',
+            Url::getExternalLinkTag('https://matomo.org/docs/geo-locate/'), '', '', '</a>',
         ));
 
         return $comment;

--- a/plugins/UserCountry/Reports/Base.php
+++ b/plugins/UserCountry/Reports/Base.php
@@ -27,10 +27,12 @@ abstract class Base extends \Piwik\Plugin\Report
     {
         return Piwik::translate(
             'UserCountry_GeoIPDocumentationSuffix',
-            array('<a rel="noreferrer noopener" target="_blank" href="http://www.maxmind.com/?rId=piwik">',
+            [
+                Url::getExternalLinkTag('http://www.maxmind.com/?rId=piwik'),
                 '</a>',
-                '<a rel="noreferrer noopener" target="_blank" href="http://www.maxmind.com/en/city_accuracy?rId=piwik">',
-                '</a>')
+                Url::getExternalLinkTag('http://www.maxmind.com/en/city_accuracy?rId=piwik'),
+                '</a>',
+            ]
         );
     }
 
@@ -51,18 +53,20 @@ abstract class Base extends \Piwik\Plugin\Report
                 $userCountry = new UserCountry();
                 // if GeoIP is working, don't display this part of the message
                 if (!$userCountry->isGeoIPWorking()) {
-                    $params = array('module' => 'UserCountry', 'action' => 'adminIndex');
+                    $params = ['module' => 'UserCountry', 'action' => 'adminIndex'];
                     $footerMessage .= ' ' . Piwik::translate(
                         'UserCountry_NoDataForGeoIPReport2',
-                        array('<a target="_blank" href="' . Url::getCurrentQueryStringWithParametersModified($params) . '">',
-                                '</a>',
-                                '<a rel="noreferrer noopener" target="_blank" href="https://db-ip.com/?refid=mtm">',
-                        '</a>')
+                        [
+                            '<a target="_blank" href="' . Url::getCurrentQueryStringWithParametersModified($params) . '">',
+                            '</a>',
+                            Url::getExternalLinkTag('https://db-ip.com/?refid=mtm'),
+                            '</a>',
+                        ]
                     );
                 } else {
                     $footerMessage .= ' ' . Piwik::translate(
                         'UserCountry_ToGeolocateOldVisits',
-                        array('<a rel="noreferrer noopener" target="_blank" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/how-to/faq_167') . '">', '</a>')
+                        [Url::getExternalLinkTag('https://matomo.org/faq/how-to/faq_167'), '</a>']
                     );
                 }
 

--- a/plugins/UserCountry/Reports/GetCountry.php
+++ b/plugins/UserCountry/Reports/GetCountry.php
@@ -38,7 +38,7 @@ class GetCountry extends Base
             $footerMessage = Piwik::translate("General_Note") . ': '
                 . Piwik::translate(
                     'UserCountry_DefaultLocationProviderExplanation',
-                    ['<a rel="noreferrer noopener" target="_blank" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/geo-locate/') . '">', '</a>']
+                    [Url::getExternalLinkTag('https://matomo.org/docs/geo-locate/'), '</a>']
                 );
 
             $view->config->show_footer_message = $footerMessage;

--- a/plugins/UserId/Categories/VisitorsUserSubcategory.php
+++ b/plugins/UserId/Categories/VisitorsUserSubcategory.php
@@ -23,8 +23,7 @@ class VisitorsUserSubcategory extends Subcategory
     public function getHelp()
     {
         return '<p>' . Piwik::translate('UserId_VisitorsUserSubcategoryHelp') . '</p>'
-            . '<p><a target="_blank" rel="noopener noreferrer" href="'
-            . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/user-id', null, null, 'App.UserId.getUsers')
-            . '"><span class="icon-info"></span> ' . Piwik::translate('CoreAdminHome_LearnMore') . '</a></p>';
+            . '<p>' . Url::getExternalLinkTag('https://matomo.org/docs/user-id', null, null, 'App.UserId.getUsers')
+            . '<span class="icon-info"></span> ' . Piwik::translate('CoreAdminHome_LearnMore') . '</a></p>';
     }
 }

--- a/plugins/UserId/Reports/GetUsers.php
+++ b/plugins/UserId/Reports/GetUsers.php
@@ -64,8 +64,8 @@ class GetUsers extends Base
         $view->config->no_data_message = Piwik::translate('CoreHome_ThereIsNoDataForThisReport') . '<br><br>'
           . sprintf(
               Piwik::translate('UserId_ThereIsNoDataForThisReportHelp'),
-              "<a target='_blank' rel='noreferrer noopener' href='" . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/user-id/') . "'>",
-              "</a>"
+              Url::getExternalLinkTag('https://matomo.org/docs/user-id/'),
+              '</a>'
           );
 
         if ($view->isViewDataTableId(HtmlTable::ID)) {

--- a/plugins/VisitsSummary/Controller.php
+++ b/plugins/VisitsSummary/Controller.php
@@ -79,7 +79,7 @@ class Controller extends \Piwik\Plugin\Controller
             . $this->translator->translate('General_ColumnNbActionsDocumentation') . '<br />'
 
             . '<b>' . $this->translator->translate('General_ColumnNbUsers') . ':</b> '
-            . $this->translator->translate('General_ColumnNbUsersDocumentation') . ' (<a rel="noreferrer noopener" target="_blank" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/docs/user-id/') . '">User ID</a>)<br />'
+            . $this->translator->translate('General_ColumnNbUsersDocumentation') . ' (' . Url::getExternalLinkTag('https://matomo.org/docs/user-id/') . 'User ID</a>)<br />'
 
             . '<b>' . $this->translator->translate('General_ColumnActionsPerVisit') . ':</b> '
             . $this->translator->translate('General_ColumnActionsPerVisitDocumentation');

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__CorePluginsAdmin.getSystemSettings.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__CorePluginsAdmin.getSystemSettings.xml
@@ -288,7 +288,7 @@
 					<latest_4x_beta>Latest beta 3.X (Long Term Support version)</latest_4x_beta>
 				</availableValues>
 				<description />
-				<inlineHelp>While our &lt;a target='_blank' rel='noreferrer noopener' href='https://matomo.org/participate/development-process/'&gt;development process&lt;/a&gt; includes thousands of automated tests, Beta Testers play a key role in achieving the &quot;No bug policy&quot; in Matomo.&lt;br/&gt;If Matomo is a critical part of your business, we recommend you use the latest stable release. If you use the latest beta and you find a bug or have a suggestion, please &lt;a target='_blank' rel='noreferrer noopener' href='https://developer.matomo.org/guides/core-team-workflow#influencing-piwik-development'&gt;see here&lt;/a&gt;.&lt;br /&gt;LTS (Long Term Support) versions receive only security and bug fixes.</inlineHelp>
+				<inlineHelp>While our &lt;a target="_blank" rel="noreferrer noopener" href="https://matomo.org/participate/development-process/"&gt;development process&lt;/a&gt; includes thousands of automated tests, Beta Testers play a key role in achieving the &quot;No bug policy&quot; in Matomo.&lt;br/&gt;If Matomo is a critical part of your business, we recommend you use the latest stable release. If you use the latest beta and you find a bug or have a suggestion, please &lt;a target='_blank' rel='noreferrer noopener' href='https://developer.matomo.org/guides/core-team-workflow#influencing-piwik-development'&gt;see here&lt;/a&gt;.&lt;br /&gt;LTS (Long Term Support) versions receive only security and bug fixes.</inlineHelp>
 				<templateFile />
 				<introduction>Release channel</introduction>
 				<condition />
@@ -439,9 +439,9 @@
 			<row>
 				<name>description</name>
 				<title>Description for value</title>
-				<value>This is the value: 
+				<value>This is the value:
 Another line</value>
-				<defaultValue>This is the value: 
+				<defaultValue>This is the value:
 Another line</defaultValue>
 				<type>string</type>
 				<uiControl>textarea</uiControl>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getGlossaryReports.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getGlossaryReports.xml
@@ -47,7 +47,7 @@
 	</row>
 	<row>
 		<name>City (Visitors)</name>
-		<documentation>Shows the cities your visitors connected from when accessing your website.&lt;br/&gt;Set up GeoIP in the Geolocation admin tab to provide data for this report. The commercial &lt;a rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot; href=&quot;http://www.maxmind.com/?rId=piwik&quot;&gt;MaxMind&lt;/a&gt; GeoIP databases are more accurate than the gratis ones. &lt;a rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot; href=&quot;http://www.maxmind.com/en/city_accuracy?rId=piwik&quot;&gt;Click here&lt;/a&gt; to see how accurate they are.</documentation>
+		<documentation>Shows the cities your visitors connected from when accessing your website.&lt;br/&gt;Set up GeoIP in the Geolocation admin tab to provide data for this report. The commercial &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;http://www.maxmind.com/?rId=piwik&quot;&gt;MaxMind&lt;/a&gt; GeoIP databases are more accurate than the gratis ones. &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;http://www.maxmind.com/en/city_accuracy?rId=piwik&quot;&gt;Click here&lt;/a&gt; to see how accurate they are.</documentation>
 	</row>
 	<row>
 		<name>Configurations (Visitors)</name>
@@ -73,7 +73,7 @@
 	</row>
 	<row>
 		<name>Custom Variables (Visitors)</name>
-		<documentation>This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values. &lt;br /&gt; For more information about Custom Variables in general, read the &lt;a href=&quot;https://matomo.org/docs/custom-variables/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Custom Variables documentation on matomo.org&lt;/a&gt;</documentation>
+        <documentation>This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values. &lt;br /&gt; For more information about Custom Variables in general, read the &lt;a href="https://matomo.org/docs/custom-variables/" rel="noreferrer noopener" target="_blank"&gt;Custom Variables documentation on matomo.org&lt;/a&gt;</documentation>
 		<onlineGuideUrl>https://matomo.org/docs/custom-variables/</onlineGuideUrl>
 	</row>
 	<row>
@@ -252,7 +252,7 @@
 	</row>
 	<row>
 		<name>Region (Visitors)</name>
-		<documentation>Shows which region your visitors connected from when accessing website.&lt;br/&gt;Set up GeoIP in the Geolocation admin tab to provide data for this report. The commercial &lt;a rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot; href=&quot;http://www.maxmind.com/?rId=piwik&quot;&gt;MaxMind&lt;/a&gt; GeoIP databases are more accurate than the gratis ones. &lt;a rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot; href=&quot;http://www.maxmind.com/en/city_accuracy?rId=piwik&quot;&gt;Click here&lt;/a&gt; to see how accurate they are.</documentation>
+		<documentation>Shows which region your visitors connected from when accessing website.&lt;br/&gt;Set up GeoIP in the Geolocation admin tab to provide data for this report. The commercial &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;http://www.maxmind.com/?rId=piwik&quot;&gt;MaxMind&lt;/a&gt; GeoIP databases are more accurate than the gratis ones. &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;http://www.maxmind.com/en/city_accuracy?rId=piwik&quot;&gt;Click here&lt;/a&gt; to see how accurate they are.</documentation>
 	</row>
 	<row>
 		<name>Returning Visits (Actions)</name>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getReportMetadata_day.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getReportMetadata_day.xml
@@ -271,7 +271,7 @@
 		<module>UserCountry</module>
 		<action>getRegion</action>
 		<dimension>Region</dimension>
-		<documentation>Shows which region your visitors connected from when accessing website.&lt;br/&gt;Set up GeoIP in the Geolocation admin tab to provide data for this report. The commercial &lt;a rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot; href=&quot;http://www.maxmind.com/?rId=piwik&quot;&gt;MaxMind&lt;/a&gt; GeoIP databases are more accurate than the gratis ones. &lt;a rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot; href=&quot;http://www.maxmind.com/en/city_accuracy?rId=piwik&quot;&gt;Click here&lt;/a&gt; to see how accurate they are.</documentation>
+		<documentation>Shows which region your visitors connected from when accessing website.&lt;br/&gt;Set up GeoIP in the Geolocation admin tab to provide data for this report. The commercial &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;http://www.maxmind.com/?rId=piwik&quot;&gt;MaxMind&lt;/a&gt; GeoIP databases are more accurate than the gratis ones. &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;http://www.maxmind.com/en/city_accuracy?rId=piwik&quot;&gt;Click here&lt;/a&gt; to see how accurate they are.</documentation>
 		<metrics>
 			<nb_visits>Visits</nb_visits>
 			<nb_uniq_visitors>Unique visitors</nb_uniq_visitors>
@@ -378,7 +378,7 @@
 		<module>UserCountry</module>
 		<action>getCity</action>
 		<dimension>City</dimension>
-		<documentation>Shows the cities your visitors connected from when accessing your website.&lt;br/&gt;Set up GeoIP in the Geolocation admin tab to provide data for this report. The commercial &lt;a rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot; href=&quot;http://www.maxmind.com/?rId=piwik&quot;&gt;MaxMind&lt;/a&gt; GeoIP databases are more accurate than the gratis ones. &lt;a rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot; href=&quot;http://www.maxmind.com/en/city_accuracy?rId=piwik&quot;&gt;Click here&lt;/a&gt; to see how accurate they are.</documentation>
+		<documentation>Shows the cities your visitors connected from when accessing your website.&lt;br/&gt;Set up GeoIP in the Geolocation admin tab to provide data for this report. The commercial &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;http://www.maxmind.com/?rId=piwik&quot;&gt;MaxMind&lt;/a&gt; GeoIP databases are more accurate than the gratis ones. &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;http://www.maxmind.com/en/city_accuracy?rId=piwik&quot;&gt;Click here&lt;/a&gt; to see how accurate they are.</documentation>
 		<metrics>
 			<nb_visits>Visits</nb_visits>
 			<nb_uniq_visitors>Unique visitors</nb_uniq_visitors>
@@ -1242,7 +1242,7 @@
 		<module>CustomVariables</module>
 		<action>getCustomVariables</action>
 		<dimension>Custom Variable name</dimension>
-		<documentation>This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values. &lt;br /&gt; For more information about Custom Variables in general, read the &lt;a href=&quot;https://matomo.org/docs/custom-variables/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Custom Variables documentation on matomo.org&lt;/a&gt;</documentation>
+        <documentation>This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values. &lt;br /&gt; For more information about Custom Variables in general, read the &lt;a href="https://matomo.org/docs/custom-variables/" rel="noreferrer noopener" target="_blank"&gt;Custom Variables documentation on matomo.org&lt;/a&gt;</documentation>
 		<onlineGuideUrl>https://matomo.org/docs/custom-variables/</onlineGuideUrl>
 		<dimensions>
 			<CustomVariables_CustomVariableName>Custom Variable name</CustomVariables_CustomVariableName>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getReportPagesMetadata.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getReportPagesMetadata.xml
@@ -121,7 +121,7 @@
 			<id>Transitions_Transitions</id>
 			<name>Transitions</name>
 			<order>46</order>
-			<help>&lt;p&gt;Transitions is a report showing the things your visitors did directly before and after viewing a given page. This page explains how to access, understand, and use the powerful &quot;Transitions&quot; report.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/transitions/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Transitions.getTransitions&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;More details&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;Transitions is a report showing the things your visitors did directly before and after viewing a given page. This page explains how to access, understand, and use the powerful &quot;Transitions&quot; report.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/transitions/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Transitions.getTransitions&quot;&gt;More details&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -378,7 +378,7 @@
 			<id>Actions_SubmenuSitesearch</id>
 			<name>Site Search</name>
 			<order>25</order>
-			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -467,7 +467,7 @@
 			<id>Events_Events</id>
 			<name>Events</name>
 			<order>40</order>
-			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -590,7 +590,7 @@
 			<id>Contents_Contents</id>
 			<name>Contents</name>
 			<order>45</order>
-			<help>&lt;p&gt;Content tracking helps you determine the popularity of specific pieces of content on any page of your website or app. This section reports the number of impressions and interactions the various pieces of content on your site receive.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/content-tracking?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Contents.getContentNames&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Content Tracking guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;Content tracking helps you determine the popularity of specific pieces of content on any page of your website or app. This section reports the number of impressions and interactions the various pieces of content on your site receive.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/content-tracking?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Contents.getContentNames&quot;&gt;Learn more in the Content Tracking guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -1307,7 +1307,7 @@
 			<id>Live_VisitorLog</id>
 			<name>Visits Log</name>
 			<order>5</order>
-			<help>&lt;p&gt;The visits log shows you every visit your website receives in detail. Find out which actions each visitor has performed, how they got to your site, a bit about who they are, and more (while still complying with your local privacy regulations).&lt;/p&gt;&lt;p&gt;While other reports in Matomo show how your visitors behave at an aggregate level, the visits log provides granular detail. You can also use segments to narrow it down to specific types of visits to understand your visitors better.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/real-time/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Live.getLastVisitsDetails&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Learn more in the visit-log guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The visits log shows you every visit your website receives in detail. Find out which actions each visitor has performed, how they got to your site, a bit about who they are, and more (while still complying with your local privacy regulations).&lt;/p&gt;&lt;p&gt;While other reports in Matomo show how your visitors behave at an aggregate level, the visits log provides granular detail. You can also use segments to narrow it down to specific types of visits to understand your visitors better.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/real-time/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Live.getLastVisitsDetails&quot;&gt;Learn more in the visit-log guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -1343,7 +1343,7 @@
 			<id>UserId_UserReportTitle</id>
 			<name>User IDs</name>
 			<order>40</order>
-			<help>&lt;p&gt;The user ID report shows visits associated with all your registered and logged in users. Understand website usage by its specific users and find out who your most and least active users are.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noopener noreferrer&quot; href=&quot;https://matomo.org/docs/user-id?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.UserId.getUsers&quot;&gt;&lt;span class=&quot;icon-info&quot;&gt;&lt;/span&gt; Learn more&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The user ID report shows visits associated with all your registered and logged in users. Understand website usage by its specific users and find out who your most and least active users are.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/user-id?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.UserId.getUsers&quot;&gt;&lt;span class=&quot;icon-info&quot;&gt;&lt;/span&gt; Learn more&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -1376,7 +1376,7 @@
 			<id>CustomVariables_CustomVariables</id>
 			<name>Custom Variables</name>
 			<order>45</order>
-			<help>&lt;p&gt;This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/custom-variables/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Read more about this topic in the online guide.&lt;/a&gt;&lt;/p&gt;</help>
+            <help>&lt;p&gt;This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values.&lt;/p&gt;&lt;p&gt;&lt;a href="https://matomo.org/docs/custom-variables/" rel="noreferrer noopener" target="_blank"&gt;Read more about this topic in the online guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -1639,7 +1639,7 @@
 			<id>Referrers_SubmenuSearchEngines</id>
 			<name>Search Engines &amp; Keywords</name>
 			<order>10</order>
-			<help>&lt;p&gt;This section helps you analyse your search engine optimisation and performance. You can analyse your most popular keywords with the combined keyword reports or see which keywords perform well on specific search engines for more targeted analysis and optimisation.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/matomo-cloud/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Referrers.getSearchEngines&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Matomo Cloud&lt;/a&gt; and &lt;a href=&quot;https://plugins.matomo.org/SearchEngineKeywordsPerformance?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Referrers.getSearchEngines&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Search Engine Keywords Performance&lt;/a&gt; plugin users will receive the best results from this report.&lt;/p&gt;</help>
+			<help>&lt;p&gt;This section helps you analyse your search engine optimisation and performance. You can analyse your most popular keywords with the combined keyword reports or see which keywords perform well on specific search engines for more targeted analysis and optimisation.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/matomo-cloud/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Referrers.getSearchEngines&quot;&gt;Matomo Cloud&lt;/a&gt; and &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://plugins.matomo.org/SearchEngineKeywordsPerformance?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Referrers.getSearchEngines&quot;&gt;Search Engine Keywords Performance&lt;/a&gt; plugin users will receive the best results from this report.&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -4425,7 +4425,7 @@
 			<id>General_Overview</id>
 			<name>Overview</name>
 			<order>2</order>
-			<help>&lt;p&gt;The Goals Overview reports on the performance of the goals defined for your website. You can access your goal’s conversion percentages, amount of revenue generated and full reports for each.&lt;/p&gt;&lt;p&gt;Click on an individual metric within the sparkline chart to focus on it within the full-sized evolution graph.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/tracking-goals-web-analytics/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Goals.Overview&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in our Goals guide here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Goals Overview reports on the performance of the goals defined for your website. You can access your goal’s conversion percentages, amount of revenue generated and full reports for each.&lt;/p&gt;&lt;p&gt;Click on an individual metric within the sparkline chart to focus on it within the full-sized evolution graph.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/tracking-goals-web-analytics/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Goals.Overview&quot;&gt;Learn more in our Goals guide here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -5306,7 +5306,7 @@
 			<id>Goals_ManageGoals</id>
 			<name>Manage Goals</name>
 			<order>9999</order>
-			<help>&lt;p&gt;This section allows you to create and edit Goals for specific actions which visitors take on your site, such as visiting a certain page or submitting a specific form. Goal reports vary but can help you track your website performance against business objectives such as lead generation, online sales and increased brand exposure.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/tracking-goals-web-analytics/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in our Goals guide here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;This section allows you to create and edit Goals for specific actions which visitors take on your site, such as visiting a certain page or submitting a specific form. Goal reports vary but can help you track your website performance against business objectives such as lead generation, online sales and increased brand exposure.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/tracking-goals-web-analytics/&quot;&gt;Learn more in our Goals guide here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>
@@ -5368,7 +5368,7 @@
 			<id>General_Overview</id>
 			<name>Overview</name>
 			<order>2</order>
-			<help>&lt;p&gt;The Ecommerce Overview section is the best place to get a high-level view of your online store’s performance. At a glance, you can see how many sales you’re making, how much revenue you are generating, and your website’s conversion rate.&lt;/p&gt;&lt;p&gt;Click on an individual metric within the sparkline chart to focus on it within the full-sized evolution graph.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/ecommerce-analytics/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Ecommerce.Overview&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in our Ecommerce guide here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Ecommerce Overview section is the best place to get a high-level view of your online store’s performance. At a glance, you can see how many sales you’re making, how much revenue you are generating, and your website’s conversion rate.&lt;/p&gt;&lt;p&gt;Click on an individual metric within the sparkline chart to focus on it within the full-sized evolution graph.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/ecommerce-analytics/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Ecommerce.Overview&quot;&gt;Learn more in our Ecommerce guide here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<widgets>
 			<row>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getWidgetMetadata.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getWidgetMetadata.xml
@@ -226,7 +226,7 @@
 			<id>Live_VisitorLog</id>
 			<name>Visits Log</name>
 			<order>5</order>
-			<help>&lt;p&gt;The visits log shows you every visit your website receives in detail. Find out which actions each visitor has performed, how they got to your site, a bit about who they are, and more (while still complying with your local privacy regulations).&lt;/p&gt;&lt;p&gt;While other reports in Matomo show how your visitors behave at an aggregate level, the visits log provides granular detail. You can also use segments to narrow it down to specific types of visits to understand your visitors better.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/real-time/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Live.getLastVisitsDetails&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Learn more in the visit-log guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The visits log shows you every visit your website receives in detail. Find out which actions each visitor has performed, how they got to your site, a bit about who they are, and more (while still complying with your local privacy regulations).&lt;/p&gt;&lt;p&gt;While other reports in Matomo show how your visitors behave at an aggregate level, the visits log provides granular detail. You can also use segments to narrow it down to specific types of visits to understand your visitors better.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/real-time/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Live.getLastVisitsDetails&quot;&gt;Learn more in the visit-log guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Live</module>
 		<action>getLastVisitsDetails</action>
@@ -895,7 +895,7 @@
 			<id>UserId_UserReportTitle</id>
 			<name>User IDs</name>
 			<order>40</order>
-			<help>&lt;p&gt;The user ID report shows visits associated with all your registered and logged in users. Understand website usage by its specific users and find out who your most and least active users are.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noopener noreferrer&quot; href=&quot;https://matomo.org/docs/user-id?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.UserId.getUsers&quot;&gt;&lt;span class=&quot;icon-info&quot;&gt;&lt;/span&gt; Learn more&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The user ID report shows visits associated with all your registered and logged in users. Understand website usage by its specific users and find out who your most and least active users are.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/user-id?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.UserId.getUsers&quot;&gt;&lt;span class=&quot;icon-info&quot;&gt;&lt;/span&gt; Learn more&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>UserId</module>
 		<action>getUsers</action>
@@ -923,7 +923,7 @@
 			<id>CustomVariables_CustomVariables</id>
 			<name>Custom Variables</name>
 			<order>45</order>
-			<help>&lt;p&gt;This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/custom-variables/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Read more about this topic in the online guide.&lt;/a&gt;&lt;/p&gt;</help>
+            <help>&lt;p&gt;This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values.&lt;/p&gt;&lt;p&gt;&lt;a href="https://matomo.org/docs/custom-variables/" rel="noreferrer noopener" target="_blank"&gt;Read more about this topic in the online guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>CustomVariables</module>
 		<action>getCustomVariables</action>
@@ -1119,7 +1119,7 @@
 			<id>Actions_SubmenuSitesearch</id>
 			<name>Site Search</name>
 			<order>25</order>
-			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Actions</module>
 		<action>getPageTitlesFollowingSiteSearch</action>
@@ -1147,7 +1147,7 @@
 			<id>Actions_SubmenuSitesearch</id>
 			<name>Site Search</name>
 			<order>25</order>
-			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Actions</module>
 		<action>getPageUrlsFollowingSiteSearch</action>
@@ -1175,7 +1175,7 @@
 			<id>Actions_SubmenuSitesearch</id>
 			<name>Site Search</name>
 			<order>25</order>
-			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Actions</module>
 		<action>getSiteSearchCategories</action>
@@ -1203,7 +1203,7 @@
 			<id>Actions_SubmenuSitesearch</id>
 			<name>Site Search</name>
 			<order>25</order>
-			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Actions</module>
 		<action>getSiteSearchKeywords</action>
@@ -1231,7 +1231,7 @@
 			<id>Actions_SubmenuSitesearch</id>
 			<name>Site Search</name>
 			<order>25</order>
-			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Site Search section shows which keywords visitors use when searching your website. It also displays which pages users view after performing a search and which on-site search keywords return no results at all.&lt;/p&gt;&lt;p&gt;These reports can give you ideas about missing content on your site, insight into what your visitors are looking for but can’t find easily, and more.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/site-search/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Actions.getSiteSearchCategories&quot;&gt;Learn more in the Site Search guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Actions</module>
 		<action>getSiteSearchNoResultKeywords</action>
@@ -1315,7 +1315,7 @@
 			<id>Events_Events</id>
 			<name>Events</name>
 			<order>40</order>
-			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Events</module>
 		<action>getAction</action>
@@ -1344,7 +1344,7 @@
 			<id>Events_Events</id>
 			<name>Events</name>
 			<order>40</order>
-			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Events</module>
 		<action>getAction</action>
@@ -1373,7 +1373,7 @@
 			<id>Events_Events</id>
 			<name>Events</name>
 			<order>40</order>
-			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Events</module>
 		<action>getCategory</action>
@@ -1402,7 +1402,7 @@
 			<id>Events_Events</id>
 			<name>Events</name>
 			<order>40</order>
-			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Events</module>
 		<action>getCategory</action>
@@ -1431,7 +1431,7 @@
 			<id>Events_Events</id>
 			<name>Events</name>
 			<order>40</order>
-			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Events</module>
 		<action>getName</action>
@@ -1460,7 +1460,7 @@
 			<id>Events_Events</id>
 			<name>Events</name>
 			<order>40</order>
-			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Events section offers reports on the custom events associated with your site. Events typically require custom configuration. Once configured you can review reports broken down by category, action and name.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/event-tracking/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Events.getCategory&quot;&gt;Learn more about event tracking here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Events</module>
 		<action>getName</action>
@@ -1489,7 +1489,7 @@
 			<id>Contents_Contents</id>
 			<name>Contents</name>
 			<order>45</order>
-			<help>&lt;p&gt;Content tracking helps you determine the popularity of specific pieces of content on any page of your website or app. This section reports the number of impressions and interactions the various pieces of content on your site receive.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/content-tracking?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Contents.getContentNames&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Content Tracking guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;Content tracking helps you determine the popularity of specific pieces of content on any page of your website or app. This section reports the number of impressions and interactions the various pieces of content on your site receive.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/content-tracking?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Contents.getContentNames&quot;&gt;Learn more in the Content Tracking guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Contents</module>
 		<action>getContentNames</action>
@@ -1517,7 +1517,7 @@
 			<id>Contents_Contents</id>
 			<name>Contents</name>
 			<order>45</order>
-			<help>&lt;p&gt;Content tracking helps you determine the popularity of specific pieces of content on any page of your website or app. This section reports the number of impressions and interactions the various pieces of content on your site receive.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/content-tracking?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Contents.getContentNames&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Content Tracking guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;Content tracking helps you determine the popularity of specific pieces of content on any page of your website or app. This section reports the number of impressions and interactions the various pieces of content on your site receive.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/content-tracking?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Contents.getContentNames&quot;&gt;Learn more in the Content Tracking guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Contents</module>
 		<action>getContentNames</action>
@@ -1545,7 +1545,7 @@
 			<id>Contents_Contents</id>
 			<name>Contents</name>
 			<order>45</order>
-			<help>&lt;p&gt;Content tracking helps you determine the popularity of specific pieces of content on any page of your website or app. This section reports the number of impressions and interactions the various pieces of content on your site receive.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/content-tracking?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Contents.getContentNames&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Content Tracking guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;Content tracking helps you determine the popularity of specific pieces of content on any page of your website or app. This section reports the number of impressions and interactions the various pieces of content on your site receive.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/content-tracking?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Contents.getContentNames&quot;&gt;Learn more in the Content Tracking guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Contents</module>
 		<action>getContentPieces</action>
@@ -1573,7 +1573,7 @@
 			<id>Contents_Contents</id>
 			<name>Contents</name>
 			<order>45</order>
-			<help>&lt;p&gt;Content tracking helps you determine the popularity of specific pieces of content on any page of your website or app. This section reports the number of impressions and interactions the various pieces of content on your site receive.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/content-tracking?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Contents.getContentNames&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in the Content Tracking guide.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;Content tracking helps you determine the popularity of specific pieces of content on any page of your website or app. This section reports the number of impressions and interactions the various pieces of content on your site receive.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/content-tracking?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Contents.getContentNames&quot;&gt;Learn more in the Content Tracking guide.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Contents</module>
 		<action>getContentPieces</action>
@@ -1601,7 +1601,7 @@
 			<id>Transitions_Transitions</id>
 			<name>Transitions</name>
 			<order>46</order>
-			<help>&lt;p&gt;Transitions is a report showing the things your visitors did directly before and after viewing a given page. This page explains how to access, understand, and use the powerful &quot;Transitions&quot; report.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/transitions/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Transitions.getTransitions&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;More details&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;Transitions is a report showing the things your visitors did directly before and after viewing a given page. This page explains how to access, understand, and use the powerful &quot;Transitions&quot; report.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/transitions/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Transitions.getTransitions&quot;&gt;More details&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>Transitions</module>
 		<action>getTransitions</action>
@@ -1885,7 +1885,7 @@
 			<id>Referrers_SubmenuSearchEngines</id>
 			<name>Search Engines &amp; Keywords</name>
 			<order>10</order>
-			<help>&lt;p&gt;This section helps you analyse your search engine optimisation and performance. You can analyse your most popular keywords with the combined keyword reports or see which keywords perform well on specific search engines for more targeted analysis and optimisation.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/matomo-cloud/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Referrers.getSearchEngines&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Matomo Cloud&lt;/a&gt; and &lt;a href=&quot;https://plugins.matomo.org/SearchEngineKeywordsPerformance?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Referrers.getSearchEngines&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Search Engine Keywords Performance&lt;/a&gt; plugin users will receive the best results from this report.&lt;/p&gt;</help>
+			<help>&lt;p&gt;This section helps you analyse your search engine optimisation and performance. You can analyse your most popular keywords with the combined keyword reports or see which keywords perform well on specific search engines for more targeted analysis and optimisation.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/matomo-cloud/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Referrers.getSearchEngines&quot;&gt;Matomo Cloud&lt;/a&gt; and &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://plugins.matomo.org/SearchEngineKeywordsPerformance?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Referrers.getSearchEngines&quot;&gt;Search Engine Keywords Performance&lt;/a&gt; plugin users will receive the best results from this report.&lt;/p&gt;</help>
 		</subcategory>
 		<module>Referrers</module>
 		<action>getKeywords</action>
@@ -1913,7 +1913,7 @@
 			<id>Referrers_SubmenuSearchEngines</id>
 			<name>Search Engines &amp; Keywords</name>
 			<order>10</order>
-			<help>&lt;p&gt;This section helps you analyse your search engine optimisation and performance. You can analyse your most popular keywords with the combined keyword reports or see which keywords perform well on specific search engines for more targeted analysis and optimisation.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/matomo-cloud/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Referrers.getSearchEngines&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Matomo Cloud&lt;/a&gt; and &lt;a href=&quot;https://plugins.matomo.org/SearchEngineKeywordsPerformance?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Referrers.getSearchEngines&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Search Engine Keywords Performance&lt;/a&gt; plugin users will receive the best results from this report.&lt;/p&gt;</help>
+			<help>&lt;p&gt;This section helps you analyse your search engine optimisation and performance. You can analyse your most popular keywords with the combined keyword reports or see which keywords perform well on specific search engines for more targeted analysis and optimisation.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/matomo-cloud/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Referrers.getSearchEngines&quot;&gt;Matomo Cloud&lt;/a&gt; and &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://plugins.matomo.org/SearchEngineKeywordsPerformance?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Referrers.getSearchEngines&quot;&gt;Search Engine Keywords Performance&lt;/a&gt; plugin users will receive the best results from this report.&lt;/p&gt;</help>
 		</subcategory>
 		<module>Referrers</module>
 		<action>getSearchEngines</action>
@@ -2079,7 +2079,7 @@
 			<id>General_Overview</id>
 			<name>Overview</name>
 			<order>2</order>
-			<help>&lt;p&gt;The Ecommerce Overview section is the best place to get a high-level view of your online store’s performance. At a glance, you can see how many sales you’re making, how much revenue you are generating, and your website’s conversion rate.&lt;/p&gt;&lt;p&gt;Click on an individual metric within the sparkline chart to focus on it within the full-sized evolution graph.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/ecommerce-analytics/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Ecommerce.Overview&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in our Ecommerce guide here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Ecommerce Overview section is the best place to get a high-level view of your online store’s performance. At a glance, you can see how many sales you’re making, how much revenue you are generating, and your website’s conversion rate.&lt;/p&gt;&lt;p&gt;Click on an individual metric within the sparkline chart to focus on it within the full-sized evolution graph.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/ecommerce-analytics/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Ecommerce.Overview&quot;&gt;Learn more in our Ecommerce guide here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>CoreHome</module>
 		<action>renderWidgetContainer</action>
@@ -3159,7 +3159,7 @@
 			<id>General_Overview</id>
 			<name>Overview</name>
 			<order>2</order>
-			<help>&lt;p&gt;The Goals Overview reports on the performance of the goals defined for your website. You can access your goal’s conversion percentages, amount of revenue generated and full reports for each.&lt;/p&gt;&lt;p&gt;Click on an individual metric within the sparkline chart to focus on it within the full-sized evolution graph.&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://matomo.org/docs/tracking-goals-web-analytics/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Goals.Overview&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more in our Goals guide here.&lt;/a&gt;&lt;/p&gt;</help>
+			<help>&lt;p&gt;The Goals Overview reports on the performance of the goals defined for your website. You can access your goal’s conversion percentages, amount of revenue generated and full reports for each.&lt;/p&gt;&lt;p&gt;Click on an individual metric within the sparkline chart to focus on it within the full-sized evolution graph.&lt;/p&gt;&lt;p&gt;&lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/docs/tracking-goals-web-analytics/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.Goals.Overview&quot;&gt;Learn more in our Goals guide here.&lt;/a&gt;&lt;/p&gt;</help>
 		</subcategory>
 		<module>CoreHome</module>
 		<action>renderWidgetContainer</action>

--- a/tests/PHPUnit/Unit/UrlTest.php
+++ b/tests/PHPUnit/Unit/UrlTest.php
@@ -546,7 +546,10 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->resetGlobalVariables();
         $_GET['module'] = 'CoreHomeAdmin';
         $_GET['action'] = 'trackingCodeGenerator';
-        $this->assertEquals($expected, Url::addCampaignParametersToMatomoLink($url, $campaign, $source, $medium));
+        $this->assertSame($expected, Url::addCampaignParametersToMatomoLink($url, $campaign, $source, $medium));
+
+        $expectedLink = '<a target="_blank" rel="noreferrer noopener" href="' . $expected . '">';
+        $this->assertSame($expectedLink, Url::getExternalLinkTag($url, $campaign, $source, $medium));
     }
 
     public function getCampaignParametersToMatomoLink()
@@ -612,6 +615,8 @@ class UrlTest extends \PHPUnit\Framework\TestCase
              'SomeCampaign', 'SomeSource', 'SomeMedium',
             ],
 
+            // Empty url
+            ['', '', null, null, null],
         ];
     }
 


### PR DESCRIPTION
### Description:

Plenty of places manually create external links that open in a new tab and provide 'noopener noreferrer' rel attribute. This unifies and simplifies that.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
