### PR TITLE
Integrate compliance setting disabling device model detection and reporting

### DIFF
--- a/core/Tracker/Cache.php
+++ b/core/Tracker/Cache.php
@@ -71,12 +71,12 @@ class Cache
     public static function getCacheWebsiteAttributes($idSite)
     {
         if ('all' === $idSite) {
-            return array();
+            return [];
         }
 
         $idSite = (int)$idSite;
         if ($idSite <= 0) {
-            return array();
+            return [];
         }
 
         $cache = self::getCache();
@@ -109,7 +109,7 @@ class Cache
 
         Tracker::initCorePiwikInTrackerMode();
 
-        $content = array();
+        $content = [];
         /*
          * Updating cached websites attributes might be triggered by various events, including actions performed by non super users.
          * Therefore we execute below code as super user, to ensure the cache is built without restrictions.
@@ -127,13 +127,13 @@ class Cache
              *     public function getSiteAttributes($content, $idSite)
              *     {
              *         $sql = "SELECT info FROM " . Common::prefixTable('myplugin_extra_site_info') . " WHERE idsite = ?";
-             *         $content['myplugin_site_data'] = Db::fetchOne($sql, array($idSite));
+             *         $content['myplugin_site_data'] = Db::fetchOne($sql, [$idSite]);
              *     }
              *
              * @param array &$content Array mapping of site attribute names with values.
              * @param int $idSite The site ID to get attributes for.
              */
-            Piwik::postEvent('Tracker.Cache.getSiteAttributes', array(&$content, $idSite));
+            Piwik::postEvent('Tracker.Cache.getSiteAttributes', [&$content, $idSite]);
 
             $logger = StaticContainer::get(LoggerInterface::class);
             $logger->debug("Website $idSite tracker cache was re-created.");
@@ -189,10 +189,10 @@ class Cache
     public static function updateGeneralCache()
     {
         Tracker::initCorePiwikInTrackerMode();
-        $cacheContent = array(
+        $cacheContent = [
             'isBrowserTriggerEnabled' => Rules::isBrowserTriggerEnabled(),
             'lastTrackerCronRun' => Option::get('lastTrackerCronRun'),
-        );
+        ];
 
         /**
          * Triggered before the [general tracker cache](/guides/all-about-tracking#the-tracker-cache)
@@ -214,7 +214,7 @@ class Cache
          * @param array &$cacheContent Array of cached data. Each piece of data must be
          *                             mapped by name.
          */
-        Piwik::postEvent('Tracker.setTrackerCacheGeneral', array(&$cacheContent));
+        Piwik::postEvent('Tracker.setTrackerCacheGeneral', [&$cacheContent]);
         self::setCacheGeneral($cacheContent);
 
         $logger = StaticContainer::get(LoggerInterface::class);
@@ -243,10 +243,10 @@ class Cache
      *
      * @param array|int $idSites Array of idSites to clear cache for
      */
-    public static function regenerateCacheWebsiteAttributes($idSites = array())
+    public static function regenerateCacheWebsiteAttributes($idSites = [])
     {
         if (!is_array($idSites)) {
-            $idSites = array($idSites);
+            $idSites = [$idSites];
         }
 
         foreach ($idSites as $idSite) {

--- a/plugins/DevicesDetection/API.php
+++ b/plugins/DevicesDetection/API.php
@@ -10,11 +10,14 @@
 namespace Piwik\Plugins\DevicesDetection;
 
 use DeviceDetector\Parser\Device\AbstractDeviceParser;
+use Exception;
 use Piwik\Archive;
+use Piwik\Container\StaticContainer;
 use Piwik\DataTable;
 use Piwik\Metrics;
 use Piwik\Piwik;
 use DeviceDetector\Parser\Client\Browser as BrowserParser;
+use Piwik\Plugins\DevicesDetection\Columns\DeviceModel;
 
 /**
  * The DevicesDetection API lets you access reports on your visitors devices, brands, models, Operating system, Browsers.
@@ -111,6 +114,11 @@ class API extends \Piwik\Plugin\API
      */
     public function getModel($idSite, $period, $date, $segment = false)
     {
+        $translator = StaticContainer::get('Piwik\Translation\Translator');
+        if (DeviceModel::isDisabledByCompliancePolicy($idSite)) {
+            throw new Exception($translator->translate('DevicesDetection_DeviceModelReportDisabledByCompliancePolicy'));
+        }
+
         $dataTable = $this->getDataTable('DevicesDetection_models', $idSite, $period, $date, $segment);
 
         $dataTable->filter(function (DataTable $table) {

--- a/plugins/DevicesDetection/API.php
+++ b/plugins/DevicesDetection/API.php
@@ -17,7 +17,6 @@ use Piwik\DataTable;
 use Piwik\Metrics;
 use Piwik\Piwik;
 use DeviceDetector\Parser\Client\Browser as BrowserParser;
-use Piwik\Plugins\DevicesDetection\Columns\DeviceModel;
 
 /**
  * The DevicesDetection API lets you access reports on your visitors devices, brands, models, Operating system, Browsers.
@@ -115,7 +114,7 @@ class API extends \Piwik\Plugin\API
     public function getModel($idSite, $period, $date, $segment = false)
     {
         $translator = StaticContainer::get('Piwik\Translation\Translator');
-        if (DeviceModel::isDisabledByCompliancePolicy($idSite)) {
+        if (DevicesDetection::isDeviceModelDetectionDisabledByCompliancePolicy($idSite)) {
             throw new Exception($translator->translate('DevicesDetection_DeviceModelReportDisabledByCompliancePolicy'));
         }
 

--- a/plugins/DevicesDetection/Columns/DeviceModel.php
+++ b/plugins/DevicesDetection/Columns/DeviceModel.php
@@ -9,11 +9,7 @@
 
 namespace Piwik\Plugins\DevicesDetection\Columns;
 
-use Piwik\Container\StaticContainer;
-use Piwik\Plugins\DevicesDetection\Settings\DeviceModelDetectionDisabled;
-use Piwik\Plugins\FeatureFlags\FeatureFlagManager;
-use Piwik\Plugins\PrivacyManager\FeatureFlags\PrivacyCompliance;
-use Piwik\Tracker\Cache as TrackerCache;
+use Piwik\Plugins\DevicesDetection\DevicesDetection;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\Visitor;
 use Piwik\Tracker\Action;
@@ -47,7 +43,7 @@ class DeviceModel extends Base
         }
 
         // in privacy compliance mode, we can only detect/return generic device type, but not the model
-        if (self::isDisabledByCompliancePolicy($request->getIdSiteIfExists())) {
+        if (DevicesDetection::isDeviceModelDetectionDisabledByCompliancePolicy($request->getIdSiteIfExists())) {
             return $genericDevice;
         }
 
@@ -69,26 +65,5 @@ class DeviceModel extends Base
     public function onAnyGoalConversion(Request $request, Visitor $visitor, $action)
     {
         return $visitor->getVisitorColumn($this->columnName);
-    }
-
-    /**
-     * Check if compliance policy disables device model detection
-     *
-     * @param int|null $idSite
-     * @return bool
-     * @throws \Piwik\Exception\DI\DependencyException
-     * @throws \Piwik\Exception\DI\NotFoundException
-     */
-    public static function isDisabledByCompliancePolicy(?int $idSite = null): bool
-    {
-        // in privacy compliance mode, we can only detect/return generic device type, but not the model
-        $featureFlagManager = StaticContainer::get(FeatureFlagManager::class);
-        if ($featureFlagManager->isFeatureActive(PrivacyCompliance::class)) {
-            $cache = TrackerCache::getCacheWebsiteAttributes($idSite);
-            $cacheKey = DeviceModelDetectionDisabled::class;
-            return (($cache[$cacheKey] ?? false) === true);
-        }
-
-        return false;
     }
 }

--- a/plugins/DevicesDetection/Columns/DeviceModel.php
+++ b/plugins/DevicesDetection/Columns/DeviceModel.php
@@ -9,6 +9,11 @@
 
 namespace Piwik\Plugins\DevicesDetection\Columns;
 
+use Piwik\Container\StaticContainer;
+use Piwik\Plugins\DevicesDetection\Settings\DeviceModelDetectionDisabled;
+use Piwik\Plugins\FeatureFlags\FeatureFlagManager;
+use Piwik\Plugins\PrivacyManager\FeatureFlags\PrivacyCompliance;
+use Piwik\Tracker\Cache as TrackerCache;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\Visitor;
 use Piwik\Tracker\Action;
@@ -27,11 +32,24 @@ class DeviceModel extends Base
      * @param Request $request
      * @param Visitor $visitor
      * @param Action|null $action
-     * @return mixed
+     * @return string
      */
     public function onNewVisit(Request $request, Visitor $visitor, $action)
     {
-        $parser    = $this->getUAParser($request->getUserAgent(), $request->getClientHints());
+        $parser = $this->getUAParser($request->getUserAgent(), $request->getClientHints());
+        $genericDevice = '';
+
+        $deviceType = $parser->getDeviceName();
+        if (!empty($deviceType)) {
+            $genericDevice = 'generic ' . $deviceType;
+        } elseif ($parser->isMobile()) {
+            $genericDevice = 'generic mobile';
+        }
+
+        // in privacy compliance mode, we can only detect/return generic device type, but not the model
+        if (self::isDisabledByCompliancePolicy($request->getIdSiteIfExists())) {
+            return $genericDevice;
+        }
 
         $model = $parser->getModel();
 
@@ -39,17 +57,7 @@ class DeviceModel extends Base
             return mb_substr($model, 0, 100);
         }
 
-        $deviceType = $parser->getDeviceName();
-
-        if (!empty($deviceType)) {
-            return 'generic ' . $deviceType;
-        }
-
-        if ($parser->isMobile()) {
-            return 'generic mobile';
-        }
-
-        return '';
+        return $genericDevice;
     }
 
     /**
@@ -61,5 +69,26 @@ class DeviceModel extends Base
     public function onAnyGoalConversion(Request $request, Visitor $visitor, $action)
     {
         return $visitor->getVisitorColumn($this->columnName);
+    }
+
+    /**
+     * Check if compliance policy disables device model detection
+     *
+     * @param int|null $idSite
+     * @return bool
+     * @throws \Piwik\Exception\DI\DependencyException
+     * @throws \Piwik\Exception\DI\NotFoundException
+     */
+    public static function isDisabledByCompliancePolicy(?int $idSite = null): bool
+    {
+        // in privacy compliance mode, we can only detect/return generic device type, but not the model
+        $featureFlagManager = StaticContainer::get(FeatureFlagManager::class);
+        if ($featureFlagManager->isFeatureActive(PrivacyCompliance::class)) {
+            $cache = TrackerCache::getCacheWebsiteAttributes($idSite);
+            $cacheKey = DeviceModelDetectionDisabled::class;
+            return (($cache[$cacheKey] ?? false) === true);
+        }
+
+        return false;
     }
 }

--- a/plugins/DevicesDetection/DevicesDetection.php
+++ b/plugins/DevicesDetection/DevicesDetection.php
@@ -9,6 +9,12 @@
 
 namespace Piwik\Plugins\DevicesDetection;
 
+use Piwik\Container\StaticContainer;
+use Piwik\Plugins\DevicesDetection\Settings\DeviceModelDetectionDisabled;
+use Piwik\Plugins\FeatureFlags\FeatureFlagManager;
+use Piwik\Plugins\PrivacyManager\FeatureFlags\PrivacyCompliance;
+use Piwik\Tracker\Cache as TrackerCache;
+
 require_once PIWIK_INCLUDE_PATH . '/plugins/DevicesDetection/functions.php';
 
 class DevicesDetection extends \Piwik\Plugin
@@ -46,5 +52,26 @@ class DevicesDetection extends \Piwik\Plugin
     public function getStylesheetFiles(&$files)
     {
         $files[] = 'plugins/DevicesDetection/vue/src/DetectionPage/DetectionPage.less';
+    }
+
+    /**
+     * Check if compliance policy disables device model detection
+     *
+     * @param int|null $idSite
+     * @return bool
+     * @throws \Piwik\Exception\DI\DependencyException
+     * @throws \Piwik\Exception\DI\NotFoundException
+     */
+    public static function isDeviceModelDetectionDisabledByCompliancePolicy(?int $idSite = null): bool
+    {
+        // in privacy compliance mode, we can only detect/return generic device type, but not the model
+        $featureFlagManager = StaticContainer::get(FeatureFlagManager::class);
+        if ($featureFlagManager->isFeatureActive(PrivacyCompliance::class)) {
+            $cache = TrackerCache::getCacheWebsiteAttributes($idSite);
+            $cacheKey = DeviceModelDetectionDisabled::class;
+            return (($cache[$cacheKey] ?? false) === true);
+        }
+
+        return false;
     }
 }

--- a/plugins/DevicesDetection/Reports/GetModel.php
+++ b/plugins/DevicesDetection/Reports/GetModel.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\DevicesDetection\Reports;
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\DevicesDetection\Columns\DeviceModel;
+use Piwik\Plugins\DevicesDetection\DevicesDetection;
 use Piwik\Request;
 
 class GetModel extends Base
@@ -37,6 +38,6 @@ class GetModel extends Base
     public function isEnabled()
     {
         $idSite = Request::fromRequest()->getIntegerParameter('idSite', 0);
-        return false === DeviceModel::isDisabledByCompliancePolicy($idSite);
+        return false === DevicesDetection::isDeviceModelDetectionDisabledByCompliancePolicy($idSite);
     }
 }

--- a/plugins/DevicesDetection/Reports/GetModel.php
+++ b/plugins/DevicesDetection/Reports/GetModel.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\DevicesDetection\Reports;
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\DevicesDetection\Columns\DeviceModel;
+use Piwik\Request;
 
 class GetModel extends Base
 {
@@ -31,5 +32,11 @@ class GetModel extends Base
         $view->config->show_search = true;
         $view->config->show_exclude_low_population = false;
         $view->config->addTranslation('label', Piwik::translate("DevicesDetection_dataTableLabelModels"));
+    }
+
+    public function isEnabled()
+    {
+        $idSite = Request::fromRequest()->getIntegerParameter('idSite', 0);
+        return false === DeviceModel::isDisabledByCompliancePolicy($idSite);
     }
 }

--- a/plugins/DevicesDetection/lang/en.json
+++ b/plugins/DevicesDetection/lang/en.json
@@ -69,6 +69,7 @@
         "WidgetBrowsersDocumentation": "This report contains information about what kind of browser your visitors were using.",
         "WidgetBrowserVersionsDocumentation": "This report contains information about what kind of browser your visitors were using. Each browser version is listed separately.",
         "DeviceModelDetectionDisabled": "Device model detection disabled",
-        "DeviceModelDetectionDisabledRequirementNote": "Device model detection and device model report must be disabled."
+        "DeviceModelDetectionDisabledRequirementNote": "Device model detection and device model report must be disabled.",
+        "DeviceModelReportDisabledByCompliancePolicy": "Device model report is disabled by compliance policy."
     }
 }

--- a/plugins/DevicesDetection/tests/System/expected/test_compliancePolicyEnforcedSystem__DevicesDetection.getModel_day.xml
+++ b/plugins/DevicesDetection/tests/System/expected/test_compliancePolicyEnforcedSystem__DevicesDetection.getModel_day.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<error message="Device model report is disabled by compliance policy.
+ 
+ --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
+</result>


### PR DESCRIPTION
### Description:

As per the title, disable device model report and device model API endpoint response when compliance policy is enforced. Update relevant test files.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
