### PR TITLE
Add a mechanism to pseudonymise ecommerce order ID when compliance policy enforced

### DIFF
--- a/core/Policy/CnilPolicy.php
+++ b/core/Policy/CnilPolicy.php
@@ -36,14 +36,12 @@ class CnilPolicy extends CompliancePolicy
                 'title' => Piwik::translate('General_ComplianceCNILUnknownSettingOptOutTitle'),
                 'note' =>
                     Piwik::translate('General_ComplianceCNILUnknownSettingOptOutNotes', [
-                        '<a href="' .
-                        Url::addCampaignParametersToMatomoLink(
+                        Url::getExternalLinkTag(
                             'https://matomo.org/faq/general/faq_20000/',
                             null,
                             null,
                             'App.PrivacyManager.compliance'
-                        ) .
-                        '" target="_blank" rel="noreferrer noopener">',
+                        ),
                         '</a>',
                     ]),
             ],

--- a/core/Policy/PolicyManager.php
+++ b/core/Policy/PolicyManager.php
@@ -134,6 +134,7 @@ class PolicyManager
             $underPolicy[] = $setting;
         }
 
+        sort($underPolicy); // keep consistent order
         return $underPolicy;
     }
 

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -20,7 +20,9 @@ use Piwik\Plugin\Dimension\ConversionDimension;
 use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugin\Manager;
 use Piwik\Plugins\CustomVariables\CustomVariables;
+use Piwik\Plugins\Ecommerce\Ecommerce;
 use Piwik\Plugins\Events\Actions\ActionEvent;
+use Piwik\SettingsPiwik;
 use Piwik\Tracker\Visit\VisitProperties;
 
 /**
@@ -355,6 +357,17 @@ class GoalManager
             $debugMessage = 'The conversion is an Ecommerce order';
 
             $orderId = $request->getParam('ec_id');
+            $idSite = $request->getIdSiteIfExists();
+
+            if (Ecommerce::isEcommerceRestrictedByCompliancePolicy($idSite)) {
+                // pseudonymize order ID if compliance policy restricts ecommerce tracking, because of these limitations:
+                // - we can't deal with this earlier or remove or nullify ec_id param as that would turn orders into cart updates
+                // - we can't discard or nullify order ID completely as it's used within a primary key for the order items
+                // - we can't set it to 0 or null as that would break the uniqueness constraint in log_conversion table and primary key in log_conversion_items
+                //
+                // limit to max 100 characters as that's the db column size for idorder (the hash is 64 chars long, so keeping it just to be safe)
+                $orderId = substr(hash_hmac('sha256', $idSite . '|' . $orderId, SettingsPiwik::getSalt()), 0, 100);
+            }
 
             $conversion['idorder'] = $orderId;
             $conversion['idgoal']  = self::IDGOAL_ORDER;

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -710,6 +710,7 @@ class GoalManager
     /**
      * Records a standard non-Ecommerce goal in the DB (URL/Title matching),
      * linking the conversion to the action that triggered it
+     *
      * @param VisitProperties $visitProperties
      * @param Request $request
      * @param array $goal

--- a/plugins/Ecommerce/Ecommerce.php
+++ b/plugins/Ecommerce/Ecommerce.php
@@ -12,9 +12,14 @@ namespace Piwik\Plugins\Ecommerce;
 use Piwik\Columns\ComputedMetricFactory;
 use Piwik\Columns\MetricsList;
 use Piwik\Common;
+use Piwik\Container\StaticContainer;
 use Piwik\Plugin\ArchivedMetric;
 use Piwik\Plugin\ComputedMetric;
 use Piwik\Plugins\Ecommerce\Columns\ProductCategory;
+use Piwik\Plugins\Ecommerce\Settings\EcommerceRestricted;
+use Piwik\Plugins\FeatureFlags\FeatureFlagManager;
+use Piwik\Plugins\PrivacyManager\FeatureFlags\PrivacyCompliance;
+use Piwik\Tracker\Cache as TrackerCache;
 
 /**
  *
@@ -82,5 +87,26 @@ class Ecommerce extends \Piwik\Plugin
                 }
             }
         }
+    }
+
+    /**
+     * Check if compliance policy restricts ecommerce tracking and reporting
+     *
+     * @param int|null $idSite
+     * @return bool
+     * @throws \Piwik\Exception\DI\DependencyException
+     * @throws \Piwik\Exception\DI\NotFoundException
+     */
+    public static function isEcommerceRestrictedByCompliancePolicy(?int $idSite = null): bool
+    {
+        // in privacy compliance mode, we can only detect/return generic device type, but not the model
+        $featureFlagManager = StaticContainer::get(FeatureFlagManager::class);
+        if ($featureFlagManager->isFeatureActive(PrivacyCompliance::class)) {
+            $cache = TrackerCache::getCacheWebsiteAttributes($idSite);
+            $cacheKey = EcommerceRestricted::class;
+            return (($cache[$cacheKey] ?? false) === true);
+        }
+
+        return false;
     }
 }

--- a/plugins/Ecommerce/Settings/EcommerceRestricted.php
+++ b/plugins/Ecommerce/Settings/EcommerceRestricted.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Piwik\Plugins\WebsiteMeasurable\Settings;
+namespace Piwik\Plugins\Ecommerce\Settings;
 
 use Piwik\Piwik;
 use Piwik\Plugins\PrivacyManager\Settings\CompliancePolicyEnforcedSetting;

--- a/plugins/PrivacyManager/tests/System/expected/test___PrivacyManager.getComplianceStatus.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test___PrivacyManager.getComplianceStatus.xml
@@ -4,11 +4,6 @@
 	<complianceConfigControlled>0</complianceConfigControlled>
 	<complianceRequirements>
 		<row>
-			<name>Ecommerce</name>
-			<value>non_compliant</value>
-			<notes>Ecommerce must be disabled</notes>
-		</row>
-		<row>
 			<name>Device model detection disabled</name>
 			<value>non_compliant</value>
 			<notes>Device model detection and device model report must be disabled.</notes>
@@ -17,6 +12,11 @@
 			<name>Only major versions</name>
 			<value>non_compliant</value>
 			<notes>Only major OS and browser versions are stored.</notes>
+		</row>
+		<row>
+			<name>Ecommerce</name>
+			<value>non_compliant</value>
+			<notes>Ecommerce must be disabled</notes>
 		</row>
 		<row>
 			<name>Turn off visits log and visitor profiles</name>
@@ -49,14 +49,14 @@
 			<notes>Retention period is set to 180 days.</notes>
 		</row>
 		<row>
-			<name>Limit available segments</name>
-			<value>non_compliant</value>
-			<notes>Limit the available segments to be compliant.</notes>
-		</row>
-		<row>
 			<name>Screen resolution detection disabled</name>
 			<value>non_compliant</value>
 			<notes>Screen resolution detection and screen resolution report must be disabled.</notes>
+		</row>
+		<row>
+			<name>Limit available segments</name>
+			<value>non_compliant</value>
+			<notes>Limit the available segments to be compliant.</notes>
 		</row>
 		<row>
 			<name>User ID disabled</name>
@@ -66,7 +66,7 @@
 		<row>
 			<name>Opt out</name>
 			<value>unknown</value>
-			<notes>Opt out must be manually set up and configured. &lt;a href=&quot;https://matomo.org/faq/general/faq_20000/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Learn more&lt;/a&gt;</notes>
+			<notes>Opt out must be manually set up and configured. &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/faq/general/faq_20000/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot;&gt;Learn more&lt;/a&gt;</notes>
 		</row>
 	</complianceRequirements>
 </result>

--- a/plugins/PrivacyManager/tests/System/expected/test_configControlledDisabled__PrivacyManager.getComplianceStatus.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_configControlledDisabled__PrivacyManager.getComplianceStatus.xml
@@ -4,11 +4,6 @@
 	<complianceConfigControlled>1</complianceConfigControlled>
 	<complianceRequirements>
 		<row>
-			<name>Ecommerce</name>
-			<value>non_compliant</value>
-			<notes>Ecommerce must be disabled</notes>
-		</row>
-		<row>
 			<name>Device model detection disabled</name>
 			<value>non_compliant</value>
 			<notes>Device model detection and device model report must be disabled.</notes>
@@ -17,6 +12,11 @@
 			<name>Only major versions</name>
 			<value>non_compliant</value>
 			<notes>Only major OS and browser versions are stored.</notes>
+		</row>
+		<row>
+			<name>Ecommerce</name>
+			<value>non_compliant</value>
+			<notes>Ecommerce must be disabled</notes>
 		</row>
 		<row>
 			<name>Turn off visits log and visitor profiles</name>
@@ -49,14 +49,14 @@
 			<notes>Retention period is set to 180 days.</notes>
 		</row>
 		<row>
-			<name>Limit available segments</name>
-			<value>non_compliant</value>
-			<notes>Limit the available segments to be compliant.</notes>
-		</row>
-		<row>
 			<name>Screen resolution detection disabled</name>
 			<value>non_compliant</value>
 			<notes>Screen resolution detection and screen resolution report must be disabled.</notes>
+		</row>
+		<row>
+			<name>Limit available segments</name>
+			<value>non_compliant</value>
+			<notes>Limit the available segments to be compliant.</notes>
 		</row>
 		<row>
 			<name>User ID disabled</name>
@@ -66,7 +66,7 @@
 		<row>
 			<name>Opt out</name>
 			<value>unknown</value>
-			<notes>Opt out must be manually set up and configured. &lt;a href=&quot;https://matomo.org/faq/general/faq_20000/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Learn more&lt;/a&gt;</notes>
+			<notes>Opt out must be manually set up and configured. &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/faq/general/faq_20000/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot;&gt;Learn more&lt;/a&gt;</notes>
 		</row>
 	</complianceRequirements>
 </result>

--- a/plugins/PrivacyManager/tests/System/expected/test_configControlledEnabled__PrivacyManager.getComplianceStatus.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_configControlledEnabled__PrivacyManager.getComplianceStatus.xml
@@ -4,11 +4,6 @@
 	<complianceConfigControlled>1</complianceConfigControlled>
 	<complianceRequirements>
 		<row>
-			<name>Ecommerce</name>
-			<value>compliant</value>
-			<notes>Ecommerce must be disabled</notes>
-		</row>
-		<row>
 			<name>Device model detection disabled</name>
 			<value>compliant</value>
 			<notes>Device model detection and device model report must be disabled.</notes>
@@ -17,6 +12,11 @@
 			<name>Only major versions</name>
 			<value>compliant</value>
 			<notes>Only major OS and browser versions are stored.</notes>
+		</row>
+		<row>
+			<name>Ecommerce</name>
+			<value>compliant</value>
+			<notes>Ecommerce must be disabled</notes>
 		</row>
 		<row>
 			<name>Turn off visits log and visitor profiles</name>
@@ -49,14 +49,14 @@
 			<notes>Retention period is set to 180 days.</notes>
 		</row>
 		<row>
-			<name>Limit available segments</name>
-			<value>compliant</value>
-			<notes>Limit the available segments to be compliant.</notes>
-		</row>
-		<row>
 			<name>Screen resolution detection disabled</name>
 			<value>compliant</value>
 			<notes>Screen resolution detection and screen resolution report must be disabled.</notes>
+		</row>
+		<row>
+			<name>Limit available segments</name>
+			<value>compliant</value>
+			<notes>Limit the available segments to be compliant.</notes>
 		</row>
 		<row>
 			<name>User ID disabled</name>
@@ -66,7 +66,7 @@
 		<row>
 			<name>Opt out</name>
 			<value>unknown</value>
-			<notes>Opt out must be manually set up and configured. &lt;a href=&quot;https://matomo.org/faq/general/faq_20000/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Learn more&lt;/a&gt;</notes>
+			<notes>Opt out must be manually set up and configured. &lt;a target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot; href=&quot;https://matomo.org/faq/general/faq_20000/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot;&gt;Learn more&lt;/a&gt;</notes>
 		</row>
 	</complianceRequirements>
 </result>


### PR DESCRIPTION
### Description

Adds a mechanism to pseudonymise order ID when compliance policy is enforced.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
