### PR TITLE
Simplify visitor profile popup url parameter

### DIFF
--- a/plugins/UserId/javascripts/rowaction.js
+++ b/plugins/UserId/javascripts/rowaction.js
@@ -24,12 +24,18 @@
         var visitorId = this.getRowMetadata($(tr)).idvisitor || '';
         visitorId = encodeURIComponent(visitorId);
         if (visitorId.length > 0) {
-            DataTable_RowAction.prototype.openPopover.apply(this, ['module=Live&action=getVisitorProfilePopup&visitorId=' + visitorId]);
+            DataTable_RowAction.prototype.openPopover.apply(this, [visitorId]);
         }
     };
 
     DataTable_RowActions_VisitorDetails.prototype.doOpenPopover = function (urlParam) {
-        Piwik_Popover.createPopupAndLoadUrl(urlParam, _pk_translate('Live_VisitorProfile'), 'visitor-profile-popup');
+        var legacyUrlMatch = urlParam.match(/^module=Live&action=getVisitorProfilePopup&visitorId=([a-f0-9]{16})$/i);
+        if (legacyUrlMatch && legacyUrlMatch.length === 2) {
+            urlParam = legacyUrlMatch[1];
+        }
+        if (urlParam.match(/^[a-f0-9]{16}$/i)) {
+            Piwik_Popover.createPopupAndLoadUrl('module=Live&action=getVisitorProfilePopup&visitorId=' + urlParam, _pk_translate('Live_VisitorProfile'), 'visitor-profile-popup');
+        }
     };
 
     DataTable_RowActions_Registry.register({

--- a/plugins/UserId/tests/UI/UserId_spec.js
+++ b/plugins/UserId/tests/UI/UserId_spec.js
@@ -16,13 +16,24 @@ describe("UserId", function () {
     expect(await page.screenshotSelector('#widgetUserIdgetUsers')).to.matchImage('report');
   });
 
-    it('should switch to table with engagement metrics', async function () {
-      await page.click('.activateVisualizationSelection > span');
-      await page.click('.tableIcon[data-footer-icon-id=tableAllColumns]');
-      await page.mouse.move(-10, -10);
-      await page.waitForNetworkIdle();
-      expect(await page.screenshotSelector('#widgetUserIdgetUsers')).to.matchImage('report_engagement');
+  it('should switch to table with engagement metrics', async function () {
+    await page.click('.activateVisualizationSelection > span');
+    await page.click('.tableIcon[data-footer-icon-id=tableAllColumns]');
+    await page.mouse.move(-10, -10);
+    await page.waitForNetworkIdle();
+    expect(await page.screenshotSelector('#widgetUserIdgetUsers')).to.matchImage('report_engagement');
   });
 
-
+  it('should correctly open the visitor profile', async function () {
+    var rowToMatch = 'td.label:contains(user1):first';
+    await (await page.jQuery('table.dataTable tbody ' + rowToMatch)).hover();
+    await page.waitForTimeout(100);
+    await (await page.jQuery(rowToMatch + ' a.actionvisitorDetails:visible')).hover();
+    await (await page.jQuery(rowToMatch + ' a.actionvisitorDetails:visible')).click();
+    await page.mouse.move(-10, -10);
+    await page.waitForTimeout(250);
+    await page.waitForNetworkIdle();
+    expect(await page.getWholeCurrentUrl()).to.match(/&popover=RowAction%243AvisitorDetails%243A[a-f0-9]{16}$/);
+    expect(await page.screenshotSelector('#Piwik_Popover')).to.matchImage('visitor_profile_popup');
+  });
 });

--- a/plugins/UserId/tests/UI/expected-screenshots/UserId_visitor_profile_popup.png
+++ b/plugins/UserId/tests/UI/expected-screenshots/UserId_visitor_profile_popup.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c265d8bd86abec7fb5c5bd380b307018d78269e3f64a94a820e746dfa70272b
+size 203471


### PR DESCRIPTION
### Description

Reduces the popup param value for visitor profile action to the visitorid (while still including a legacy matching for old urls).

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
