### PR TITLE
Fix external theme that are using CSS custom props

### DIFF
--- a/plugins/Morpheus/stylesheets/base/mixins.less
+++ b/plugins/Morpheus/stylesheets/base/mixins.less
@@ -63,8 +63,8 @@ strong {
 }
 
 .vertical-scroll-shadows(@bg-color: @color-white) {
-  background: linear-gradient(@bg-color 30%, fade(@bg-color, 0)) center top no-repeat local,
-    linear-gradient(fade(@bg-color, 0), @bg-color 70%) center bottom no-repeat local,
+  background: linear-gradient(@bg-color 30%, transparent) center top no-repeat local,
+    linear-gradient(transparent, @bg-color 70%) center bottom no-repeat local,
     radial-gradient(farthest-side at 50% 0, fade(@color-silver, 60%), fade(@color-silver, 0%) ) center top no-repeat scroll,
     radial-gradient(farthest-side at 50% 100%, fade(@color-silver, 60%), fade(@color-silver, 0%) ) center bottom no-repeat scroll;
   background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;


### PR DESCRIPTION
### Description

Some external themes use CSS custom props (*and that’s awesome!*), but we cannot manipulate the theme colors using less mixin in this case.
So the best solution is to use generic transparent black instead of custom transparent color, for now, and see later how we can create tools that works for every architecture.

fixes https://github.com/matomo-org/matomo/issues/23824

✅ Tested [Modern Theme](https://github.com/whitespace-se/matomo-modern-theme) locally.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
