### PR TITLE
Fix incorrect processedMetrics property values

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3284,11 +3284,6 @@ parameters:
 			path: plugins/Actions/RecordBuilders/ActionReports.php
 
 		-
-			message: "#^Property Piwik\\\\Plugin\\\\Report\\:\\:\\$processedMetrics \\(array\\) does not accept false\\.$#"
-			count: 1
-			path: plugins/Actions/Reports/Base.php
-
-		-
 			message: "#^Variable \\$action in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: plugins/Actions/Tracker/ActionsRequestProcessor.php
@@ -4074,21 +4069,6 @@ parameters:
 			path: plugins/Ecommerce/Controller.php
 
 		-
-			message: "#^Property Piwik\\\\Plugin\\\\Report\\:\\:\\$processedMetrics \\(array\\) does not accept false\\.$#"
-			count: 1
-			path: plugins/Ecommerce/Reports/GetDaysToConversionAbandonedCart.php
-
-		-
-			message: "#^Property Piwik\\\\Plugin\\\\Report\\:\\:\\$processedMetrics \\(array\\) does not accept false\\.$#"
-			count: 1
-			path: plugins/Ecommerce/Reports/GetDaysToConversionEcommerceOrder.php
-
-		-
-			message: "#^Property Piwik\\\\Plugin\\\\Report\\:\\:\\$processedMetrics \\(array\\) does not accept false\\.$#"
-			count: 1
-			path: plugins/Ecommerce/Reports/GetVisitsUntilConversionAbandonedCart.php
-
-		-
 			message: "#^Method Piwik\\\\Plugins\\\\Events\\\\API\\:\\:getSecondaryDimensions\\(\\) should return array but returns false\\.$#"
 			count: 1
 			path: plugins/Events/API.php
@@ -4102,11 +4082,6 @@ parameters:
 			message: "#^Method Piwik\\\\Plugins\\\\Events\\\\Columns\\\\TotalEvents\\:\\:onExistingVisit\\(\\) should return int but returns string\\.$#"
 			count: 1
 			path: plugins/Events/Columns/TotalEvents.php
-
-		-
-			message: "#^Property Piwik\\\\Plugin\\\\Report\\:\\:\\$processedMetrics \\(array\\) does not accept false\\.$#"
-			count: 1
-			path: plugins/Events/Reports/GetNameFromCategoryId.php
 
 		-
 			message: "#^Method Piwik\\\\Plugins\\\\Events\\\\VisitorDetails\\:\\:renderAction\\(\\) should return string but empty return statement found\\.$#"
@@ -4337,11 +4312,6 @@ parameters:
 			message: "#^Property Piwik\\\\Plugins\\\\CoreVisualizations\\\\Visualizations\\\\Sparklines\\\\Config\\:\\:\\$title_attributes \\(string\\) does not accept array\\<string, float\\|int\\<min, \\-1\\>\\|int\\<1, max\\>\\|string\\>\\.$#"
 			count: 1
 			path: plugins/Goals/Reports/Get.php
-
-		-
-			message: "#^Property Piwik\\\\Plugin\\\\Report\\:\\:\\$processedMetrics \\(array\\) does not accept false\\.$#"
-			count: 1
-			path: plugins/Goals/Reports/GetDaysToConversion.php
 
 		-
 			message: "#^Right side of && is always true\\.$#"

--- a/plugins/Actions/Reports/Base.php
+++ b/plugins/Actions/Reports/Base.php
@@ -23,7 +23,7 @@ abstract class Base extends \Piwik\Plugin\Report
     protected function init()
     {
         $this->categoryId = 'General_Actions';
-        $this->processedMetrics = false;
+        $this->processedMetrics = [];
         $this->recursiveLabelSeparator = '/';
     }
 

--- a/plugins/Ecommerce/Reports/GetDaysToConversionAbandonedCart.php
+++ b/plugins/Ecommerce/Reports/GetDaysToConversionAbandonedCart.php
@@ -22,7 +22,7 @@ class GetDaysToConversionAbandonedCart extends Base
         $this->name = Piwik::translate('General_AbandonedCarts') . ' - ' . Piwik::translate('Goals_DaysToConv');
         $this->dimension = new DaysToConversion();
         $this->constantRowsCount = true;
-        $this->processedMetrics = false;
+        $this->processedMetrics = [];
         $this->metrics = array('nb_conversions');
         $this->order = 25;
 

--- a/plugins/Ecommerce/Reports/GetDaysToConversionEcommerceOrder.php
+++ b/plugins/Ecommerce/Reports/GetDaysToConversionEcommerceOrder.php
@@ -22,7 +22,7 @@ class GetDaysToConversionEcommerceOrder extends Base
         $this->name = Piwik::translate('General_EcommerceOrders') . ' - ' . Piwik::translate('Goals_DaysToConv');
         $this->dimension = new DaysToConversion();
         $this->constantRowsCount = true;
-        $this->processedMetrics = false;
+        $this->processedMetrics = [];
         $this->metrics = array('nb_conversions');
         $this->order = 12;
 

--- a/plugins/Ecommerce/Reports/GetVisitsUntilConversionAbandonedCart.php
+++ b/plugins/Ecommerce/Reports/GetVisitsUntilConversionAbandonedCart.php
@@ -22,7 +22,7 @@ class GetVisitsUntilConversionAbandonedCart extends Base
         $this->name = Piwik::translate('General_AbandonedCarts') . ' - ' . Piwik::translate('Goals_VisitsUntilConv');
         $this->dimension = new VisitsUntilConversion();
         $this->constantRowsCount = true;
-        $this->processedMetrics = false;
+        $this->processedMetrics = [];
         $this->metrics = array('nb_conversions');
         $this->order = 20;
 

--- a/plugins/Events/Reports/GetNameFromCategoryId.php
+++ b/plugins/Events/Reports/GetNameFromCategoryId.php
@@ -20,7 +20,7 @@ class GetNameFromCategoryId extends Base
     protected function init()
     {
         $this->categoryId = 'Events_Events';
-        $this->processedMetrics = false;
+        $this->processedMetrics = [];
 
         $this->dimension     = new EventName();
         $this->name          = Piwik::translate('Events_EventNames');

--- a/plugins/Goals/Reports/GetDaysToConversion.php
+++ b/plugins/Goals/Reports/GetDaysToConversion.php
@@ -26,7 +26,7 @@ class GetDaysToConversion extends Base
         $this->documentation = Piwik::translate('Goals_DaysToConvReportDocumentation');
         $this->dimension = new DaysToConversion();
         $this->constantRowsCount = true;
-        $this->processedMetrics = false;
+        $this->processedMetrics = [];
         $this->parameters = array();
 
         $this->metrics = array('nb_conversions');


### PR DESCRIPTION
### Description

`processedMetrics` property should always be an array.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
