### PR TITLE
add event to compliance policy status change

### DIFF
--- a/core/Policy/CompliancePolicy.php
+++ b/core/Policy/CompliancePolicy.php
@@ -131,7 +131,10 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
         }
 
         /**
-         * This event is triggered when the status of a compliance policy changes.
+         * This event is triggered when the status of a compliance policy changes, and
+         * is to be used to perform extra actions when a policy is activated/deactivated.
+         *
+         * The status of a policy cannot be changed via this event.
          *
          * @param bool $isActive Whether the policy is being activated or deactivated
          * @param int|null $idSite

--- a/core/Policy/CompliancePolicy.php
+++ b/core/Policy/CompliancePolicy.php
@@ -130,6 +130,13 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
             static::setSystemValue($isActive);
         }
 
+        /**
+         * This event is triggered when the status of a compliance policy changes.
+         *
+         * @param bool $isActive Whether the policy is being activated or deactivated
+         * @param int|null $idSite
+         * @param class-string<CompliancePolicy> The compliance policy in question
+         */
         Piwik::postEvent('CompliancePolicy.setActiveStatus', [$isActive, $idSite, static::class]);
     }
 

--- a/core/Policy/CompliancePolicy.php
+++ b/core/Policy/CompliancePolicy.php
@@ -126,9 +126,11 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
             if (static::getSystemValue() && !$isActive) {
                 static::setSystemValue($isActive);
             }
-            return;
+        } else {
+            static::setSystemValue($isActive);
         }
-        static::setSystemValue($isActive);
+
+        Piwik::postEvent('CompliancePolicy.setActiveStatus', [$isActive, $idSite, static::class]);
     }
 
     /**


### PR DESCRIPTION
### Description

adds event when compliance policies are made active/inactive.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
