### PR TITLE
Fix possible archiving error "Column "referer_type" in WHERE is ambiguous - in plugin Referrers"

### DIFF
--- a/plugins/Referrers/RecordBuilders/AIReferrers.php
+++ b/plugins/Referrers/RecordBuilders/AIReferrers.php
@@ -166,7 +166,7 @@ class AIReferrers extends RecordBuilder
      */
     protected function aggregateFromConversions(LogAggregator $logAggregator, array $reports, array $dimensions): void
     {
-        $where = 'referer_type = ' . Common::REFERRER_TYPE_AI_ASSISTANT;
+        $where = '%s.referer_type = ' . Common::REFERRER_TYPE_AI_ASSISTANT;
         $query = $logAggregator->queryConversionsByDimension($dimensions, $where);
 
         while ($row = $query->fetch()) {


### PR DESCRIPTION
### Description

When archiving specific segments it can currently happen that the error "Mysqli prepare error: Column "referer_type" in WHERE is ambiguous - in plugin Referrers" occurs.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
