### PR TITLE
Fix NoAccess UI test

### DIFF
--- a/plugins/Login/tests/UI/NoAccess_spec.js
+++ b/plugins/Login/tests/UI/NoAccess_spec.js
@@ -40,13 +40,14 @@ describe("NoAccess", function () {
 
     it("should show session timeout error", async function() {
         await page.clearCookies();
-        await page.goto("?module=CoreHome&action=index&idSite=1&period=day&date=yesterday#?idSite=1&period=day&date=yesterday&category=General_Visitors&subcategory=General_Overview");
+        await page.goto("?module=CoreHome&action=index&idSite=1&period=day&date=yesterday#?idSite=1&period=day&date=yesterday&category=General_Visitors&subcategory=UserId_UserReportTitle");
         await page.waitForNetworkIdle();
         await page.type("#login_form_login", "oliverqueen");
         await page.type("#login_form_password", "smartypants");
         await page.evaluate(function(){
             $('#login_form_submit').click();
         });
+        await page.waitForNetworkIdle();
 
         await page.waitForTimeout(60500); // wait for session timeout
 


### PR DESCRIPTION
### Description



### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
