### PR TITLE
Improve rollup ranking queries

### DIFF
--- a/core/RankingQuery.php
+++ b/core/RankingQuery.php
@@ -444,13 +444,13 @@ class RankingQuery
 			GROUP BY $groupBy
 		";
 
-        if (!Schema::getInstance()->supportsSortingInSubquery()) {
+        if ($withRollup) {
+            // Sort the final result if a rollup was used
+            // to ensure rollup values are returned first, and "Others" last
+            $groupOthers .= " ORDER BY counter, counterRollup";
+        } elseif (!Schema::getInstance()->supportsSortingInSubquery()) {
             // When subqueries aren't sorted, we need to sort the result manually again
             $groupOthers .= " ORDER BY counter";
-
-            if ($withRollup) {
-                $groupOthers .= ", counterRollup";
-            }
         }
 
         return $groupOthers;

--- a/core/RankingQuery.php
+++ b/core/RankingQuery.php
@@ -293,33 +293,49 @@ class RankingQuery
 
         // generate select clauses for label columns
         $labelColumnsString = '`' . implode('`, `', array_keys($this->labelColumns)) . '`';
-        $labelColumnsOthersSwitch = array();
-        $withRollupColumns = array();
+
+        $labelColumnsOthersSwitch = [];
+        $withRollupColumns = [];
+        $withRollupOthersGroupBy  = [];
 
         foreach (array_keys($this->labelColumns) as $column) {
-            $rollupWhen = '';
             if ($withRollup) {
-                $rollupLimitValue = empty($withRollupColumns) ?
-                                        "'" . $this->othersLabelValue . "'"
-                                        :
-                                        'NULL';
+                if ([] === $withRollupColumns) {
+                    // support "Others" row for first label column
+                    $rollupWhen = "
+                        WHEN counterRollup = $limit THEN '" . $this->othersLabelValue . "'
+                        WHEN counterRollup > 0 THEN `$column`
+                        WHEN counter = $limit AND counterRollup = 0 THEN `$column`
+                        WHEN counter = $limit THEN '" . $this->othersLabelValue . "'
+                    ";
+                } else {
+                    // support "Others" row for secondary label columns
+                    $rollupWhen = "
+                        WHEN `$column` IS NULL THEN NULL
+                        WHEN counter = $limit AND counterRollup = 0 THEN '" . $this->othersLabelValue . "'
+                    ";
+                }
 
-                $rollupWhen = "
-                    WHEN counterRollup = $limit THEN $rollupLimitValue
-                    WHEN counterRollup > 0 THEN `$column`
+                $switch = "
+                    CASE
+                        $rollupWhen
+                        ELSE `$column`
+                    END
                 ";
 
-                $withRollupColumns[] = $column;
+                $labelColumnsOthersSwitch[] = "$switch AS `$column`";
+                $withRollupColumns[]        = $column;
+                $withRollupOthersGroupBy[]  = $switch;
+            } else {
+                $labelColumnsOthersSwitch[] = "
+                    CASE
+                        WHEN counter = $limit THEN '" . $this->othersLabelValue . "'
+                        ELSE `$column`
+                    END AS `$column`
+                ";
             }
-
-            $labelColumnsOthersSwitch[] = "
-                CASE
-                    $rollupWhen
-                    WHEN counter = $limit THEN '" . $this->othersLabelValue . "'
-                    ELSE `$column`
-                END AS `$column`
-            ";
         }
+
         $labelColumnsOthersSwitch = implode(', ', $labelColumnsOthersSwitch);
 
         // generate select clauses for additional columns
@@ -346,21 +362,21 @@ class RankingQuery
 
         $counterRollupExpression = '';
 
-        if ($withRollup && !empty($withRollupColumns)) {
+        if ($withRollup) {
             $initCounter .= ' ( SELECT @counterRollup:=0 ) initCounterRollup,';
             $counterRollupWhen = '';
 
             if (count($withRollupColumns) >= 2) {
                 $counterRollupWhen = "
                     WHEN `" . implode('` IS NULL AND `', $withRollupColumns) . "` IS NULL THEN -1
-                    ";
+                ";
             }
 
             foreach ($withRollupColumns as $withRollupColumn) {
                 $counterRollupWhen .= "
                     WHEN `$withRollupColumn` IS NULL AND @counterRollup = $limit THEN $limit
                     WHEN `$withRollupColumn` IS NULL THEN @counterRollup := @counterRollup + 1
-                    ";
+                ";
             }
 
             $counterRollupExpression = "
@@ -368,7 +384,7 @@ class RankingQuery
                     $counterRollupWhen
                     ELSE 0
                 END AS counterRollup
-                ";
+            ";
         }
 
         if (false === strpos($innerQuery, ' LIMIT ') && !Schema::getInstance()->supportsSortingInSubquery()) {
@@ -389,7 +405,7 @@ class RankingQuery
 				( $innerQuery ) actualQuery
 		";
 
-        if ($withRollup && !empty($withRollupColumns) && !Schema::getInstance()->supportsRankingRollupWithoutExtraSorting()) {
+        if ($withRollup && !Schema::getInstance()->supportsRankingRollupWithoutExtraSorting()) {
             // MariaDB requires an additional sorting layer to return
             // the counter/counterRollup values we expect
             $rollupColumnSorts = [];
@@ -410,13 +426,16 @@ class RankingQuery
         // group by the counter - this groups "Others" because the counter stops at $limit
         $groupBy = 'counter';
 
-        if ($withRollup && !empty($counterRollupExpression)) {
-            $groupBy .= ', counterRollup';
+        if ($withRollup) {
+            // group rollups additionally by the rollup counter and the
+            // full "Others" switch to ensure correct secondary level "Others" calculation
+            $groupBy .= ', counterRollup, ' . implode(', ', $withRollupOthersGroupBy);
         }
 
         if ($this->partitionColumn !== false) {
             $groupBy .= ', `' . $this->partitionColumn . '`';
         }
+
         $groupOthers = "
 			SELECT
 				$labelColumnsOthersSwitch
@@ -429,8 +448,8 @@ class RankingQuery
             // When subqueries aren't sorted, we need to sort the result manually again
             $groupOthers .= " ORDER BY counter";
 
-            if (!empty($counterRollupExpression)) {
-                $groupOthers .= ', counterRollup';
+            if ($withRollup) {
+                $groupOthers .= ", counterRollup";
             }
         }
 

--- a/plugins/CustomDimensions/RecordBuilders/CustomDimension.php
+++ b/plugins/CustomDimensions/RecordBuilders/CustomDimension.php
@@ -234,6 +234,8 @@ class CustomDimension extends RecordBuilder
         }
 
         if ($withRollup) {
+            $previousLabel = null;
+
             foreach ($actionRows as $row) {
                 if (!isset($row[Metrics::INDEX_NB_VISITS])) {
                     return;
@@ -261,6 +263,15 @@ class CustomDimension extends RecordBuilder
                     continue;
                 }
 
+                // skip subtable creation if only one "Others" row would appear
+                if (
+                    $label !== $previousLabel
+                    && $url === RankingQuery::LABEL_SUMMARY_ROW
+                ) {
+                    continue;
+                }
+
+                $previousLabel = $label;
                 $columns = [];
 
                 foreach ($metricIds as $id) {

--- a/plugins/CustomDimensions/RecordBuilders/CustomDimension.php
+++ b/plugins/CustomDimensions/RecordBuilders/CustomDimension.php
@@ -186,8 +186,6 @@ class CustomDimension extends RecordBuilder
         $metricIds[] = Metrics::INDEX_BOUNCE_COUNT;
         $metricIds[] = Metrics::INDEX_PAGE_EXIT_NB_VISITS;
 
-        $actionRows = [];
-
         while ($row = $resultSet->fetch()) {
             if (!isset($row[Metrics::INDEX_NB_VISITS])) {
                 return;
@@ -195,91 +193,58 @@ class CustomDimension extends RecordBuilder
 
             $label = $row[$valueField];
 
-            if ($withRollup) {
-                $url = $row['url'];
-
-                if (is_null($label)) {
-                    continue;
-                }
-
-                if (!is_null($url)) {
-                    $actionRows[] = $row;
-                    continue;
-                }
+            if ($withRollup && $label === null) {
+                // top-level rollup result
+                continue;
             }
 
             $columns = [];
+
             foreach ($metricIds as $id) {
                 $columns[$id] = (float) ($row[$id] ?? 0);
             }
+
             $label = $this->cleanCustomDimensionValue($label);
-            $tableRow = $report->sumRowWithLabel($label, $columns);
+            $url = $row['url'];
 
             if (!$withRollup) {
-                $url = $row['url'];
-                if (empty($url)) {
+                $tableRow = $report->sumRowWithLabel($label, $columns);
+            } else {
+                if ($url === null) {
+                    // second-level rollup result
+                    $report->sumRowWithLabel($label, $columns);
                     continue;
                 }
 
-                // make sure we always work with normalized URL no matter how the individual action stores it
-                $normalized = Tracker\PageUrl::normalizeUrl($url);
-                $url = $normalized['url'];
-
-                if (empty($url)) {
-                    continue;
-                }
-
-                $tableRow->sumRowWithLabelToSubtable($url, $columns);
-            }
-        }
-
-        if ($withRollup) {
-            $previousLabel = null;
-
-            foreach ($actionRows as $row) {
-                if (!isset($row[Metrics::INDEX_NB_VISITS])) {
-                    return;
-                }
-
-                $label = $row[$valueField];
-                $url = $row['url'];
-
-                if (is_null($label) || is_null($url)) {
-                    continue;
-                }
-
-                $label = $this->cleanCustomDimensionValue($label);
                 $tableRow = $report->getRowFromLabel($label);
 
-                if (empty($tableRow)) {
+                if (false === $tableRow) {
+                    // non-rollup row but rollup row is missing
+                    // should not happen, but don't break
                     continue;
                 }
-
-                // make sure we always work with normalized URL no matter how the individual action stores it
-                $normalized = Tracker\PageUrl::normalizeUrl($url);
-                $url = $normalized['url'];
-
-                if (empty($url)) {
-                    continue;
-                }
-
-                // skip subtable creation if only one "Others" row would appear
-                if (
-                    $label !== $previousLabel
-                    && $url === RankingQuery::LABEL_SUMMARY_ROW
-                ) {
-                    continue;
-                }
-
-                $previousLabel = $label;
-                $columns = [];
-
-                foreach ($metricIds as $id) {
-                    $columns[$id] = (float) ($row[$id] ?? 0);
-                }
-
-                $tableRow->sumRowWithLabelToSubtable($url, $columns);
             }
+
+            // make sure we always work with normalized URL no matter how the individual action stores it
+            $normalized = Tracker\PageUrl::normalizeUrl($url);
+            $url = $normalized['url'];
+
+            if (empty($url)) {
+                continue;
+            }
+
+            if (
+                $withRollup
+                && $url === RankingQuery::LABEL_SUMMARY_ROW
+                && !$tableRow->isSubtableLoaded()
+            ) {
+                // skip creating the subtable if:
+                // - we are using rollups
+                // - the only row would be "Others"
+                continue;
+            }
+
+            $tableRow->sumRowWithLabelToSubtable($url, $columns);
         }
     }
 

--- a/plugins/CustomDimensions/tests/System/expected/test_ranking_limit_with_rollup_by_archiving_query__CustomDimensions.getCustomDimension_day.xml
+++ b/plugins/CustomDimensions/tests/System/expected/test_ranking_limit_with_rollup_by_archiving_query__CustomDimensions.getCustomDimension_day.xml
@@ -168,6 +168,48 @@
 				<segment>dimension1==site3+group5;actionUrl=$example.com%2Fpage%2F5%2F5</segment>
 				<url>example.com%2Fpage%2F5%2F5</url>
 			</row>
+			<row>
+				<label>Others</label>
+				<nb_visits>2</nb_visits>
+				<nb_uniq_visitors>2</nb_uniq_visitors>
+				<nb_hits>53</nb_hits>
+				<sum_time_network>0</sum_time_network>
+				<nb_hits_with_time_network>0</nb_hits_with_time_network>
+				<min_time_network>0</min_time_network>
+				<max_time_network>0</max_time_network>
+				<sum_time_server>0</sum_time_server>
+				<nb_hits_with_time_server>0</nb_hits_with_time_server>
+				<min_time_server>0</min_time_server>
+				<max_time_server>0</max_time_server>
+				<sum_time_transfer>0</sum_time_transfer>
+				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
+				<min_time_transfer>0</min_time_transfer>
+				<max_time_transfer>0</max_time_transfer>
+				<sum_time_dom_processing>0</sum_time_dom_processing>
+				<nb_hits_with_time_dom_processing>0</nb_hits_with_time_dom_processing>
+				<min_time_dom_processing>0</min_time_dom_processing>
+				<max_time_dom_processing>0</max_time_dom_processing>
+				<sum_time_dom_completion>0</sum_time_dom_completion>
+				<nb_hits_with_time_dom_completion>0</nb_hits_with_time_dom_completion>
+				<min_time_dom_completion>0</min_time_dom_completion>
+				<max_time_dom_completion>0</max_time_dom_completion>
+				<sum_time_on_load>0</sum_time_on_load>
+				<nb_hits_with_time_on_load>0</nb_hits_with_time_on_load>
+				<min_time_on_load>0</min_time_on_load>
+				<max_time_on_load>0</max_time_on_load>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth>0</min_bandwidth>
+				<max_bandwidth>0</max_bandwidth>
+				<sum_time_spent>0</sum_time_spent>
+				<bounce_count>0</bounce_count>
+				<exit_nb_visits>2</exit_nb_visits>
+				<avg_time_on_dimension>0</avg_time_on_dimension>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>100%</exit_rate>
+				<segment>dimension1==site3+group5;actionUrl=$__mtm_ranking_query_others__</segment>
+				<url>__mtm_ranking_query_others__</url>
+			</row>
 		</subtable>
 	</row>
 	<row>

--- a/plugins/CustomDimensions/tests/System/expected/test_ranking_limit_with_rollup_by_archiving_query_expanded__CustomDimensions.getCustomDimension_day.xml
+++ b/plugins/CustomDimensions/tests/System/expected/test_ranking_limit_with_rollup_by_archiving_query_expanded__CustomDimensions.getCustomDimension_day.xml
@@ -168,6 +168,48 @@
 				<segment>dimension1==site3+group5;actionUrl=$example.com%2Fpage%2F5%2F5</segment>
 				<url>example.com%2Fpage%2F5%2F5</url>
 			</row>
+			<row>
+				<label>Others</label>
+				<nb_visits>2</nb_visits>
+				<nb_uniq_visitors>2</nb_uniq_visitors>
+				<nb_hits>53</nb_hits>
+				<sum_time_network>0</sum_time_network>
+				<nb_hits_with_time_network>0</nb_hits_with_time_network>
+				<min_time_network>0</min_time_network>
+				<max_time_network>0</max_time_network>
+				<sum_time_server>0</sum_time_server>
+				<nb_hits_with_time_server>0</nb_hits_with_time_server>
+				<min_time_server>0</min_time_server>
+				<max_time_server>0</max_time_server>
+				<sum_time_transfer>0</sum_time_transfer>
+				<nb_hits_with_time_transfer>0</nb_hits_with_time_transfer>
+				<min_time_transfer>0</min_time_transfer>
+				<max_time_transfer>0</max_time_transfer>
+				<sum_time_dom_processing>0</sum_time_dom_processing>
+				<nb_hits_with_time_dom_processing>0</nb_hits_with_time_dom_processing>
+				<min_time_dom_processing>0</min_time_dom_processing>
+				<max_time_dom_processing>0</max_time_dom_processing>
+				<sum_time_dom_completion>0</sum_time_dom_completion>
+				<nb_hits_with_time_dom_completion>0</nb_hits_with_time_dom_completion>
+				<min_time_dom_completion>0</min_time_dom_completion>
+				<max_time_dom_completion>0</max_time_dom_completion>
+				<sum_time_on_load>0</sum_time_on_load>
+				<nb_hits_with_time_on_load>0</nb_hits_with_time_on_load>
+				<min_time_on_load>0</min_time_on_load>
+				<max_time_on_load>0</max_time_on_load>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth>0</min_bandwidth>
+				<max_bandwidth>0</max_bandwidth>
+				<sum_time_spent>0</sum_time_spent>
+				<bounce_count>0</bounce_count>
+				<exit_nb_visits>2</exit_nb_visits>
+				<avg_time_on_dimension>0</avg_time_on_dimension>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>100%</exit_rate>
+				<segment>dimension1==site3+group5;actionUrl=$__mtm_ranking_query_others__</segment>
+				<url>__mtm_ranking_query_others__</url>
+			</row>
 		</subtable>
 	</row>
 	<row>

--- a/tests/PHPUnit/System/RankingQueryTest.php
+++ b/tests/PHPUnit/System/RankingQueryTest.php
@@ -1,0 +1,235 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Tests\System;
+
+use Piwik\ArchiveProcessor\Parameters;
+use Piwik\DataAccess\LogAggregator;
+use Piwik\Period;
+use Piwik\RankingQuery;
+use Piwik\Segment;
+use Piwik\Site;
+use Piwik\Tests\Fixtures\ManyVisitsWithGeoIP;
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
+
+/**
+ * @group Core
+ * @group RankingQuery
+ */
+class RankingQueryTest extends SystemTestCase
+{
+    /**
+     * @var ManyVisitsWithGeoIP
+     */
+    public static $fixture = null; // initialized below class definition
+
+    /**
+     * @var LogAggregator
+     */
+    private $logAggregator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $site = new Site(self::$fixture->idSite);
+        $period = Period\Factory::build('month', self::$fixture->dateTime);
+        $segment = new Segment('', [$site->getId()]);
+        $params = new Parameters($site, $period, $segment);
+
+        $this->logAggregator = new LogAggregator($params);
+    }
+
+    /**
+     * Make sure the results are consistently structured across database vendors.
+     *
+     * We always expect the same order, with second-level results ordered by the given base query:
+     *
+     * 1. top-level rollup (both labels NULL)
+     * 2. first-level rollups (secondary label NULL)
+     * 3. first-level "Others"
+     * 4. second-level results
+     * 5. second-level "Others"
+     *
+     * @dataProvider getRollupResultStructureTestData
+     */
+    public function testRollupResultStructure(string $sortOrder, array $expectedResultSet): void
+    {
+        $select = '
+            log_visit.config_browser_engine AS config_browser_engine,
+            log_visit.custom_var_v1 AS custom_var_v1,
+            COUNT(log_visit.idvisit) AS nb_visits
+        ';
+
+        $where = '
+            log_visit.visit_last_action_time >= ?
+            AND log_visit.visit_last_action_time <= ?
+            AND log_visit.idsite IN (?)
+            AND custom_var_v1 IS NOT NULL
+        ';
+
+        $from = 'log_visit';
+        $groupBy = 'config_browser_engine, custom_var_v1';
+        $orderBy = "nb_visits $sortOrder, config_browser_engine, custom_var_v1";
+
+        $query = $this->logAggregator->generateQuery(
+            $select,
+            $from,
+            $where,
+            $groupBy,
+            $orderBy,
+            $limit = 0,
+            $offset = 0,
+            true
+        );
+
+        $rankingQuery = new RankingQuery(3);
+        $rankingQuery->addLabelColumn(['config_browser_engine', 'custom_var_v1']);
+        $rankingQuery->addColumn(['nb_visits'], 'sum');
+
+        $query['sql'] = $rankingQuery->generateRankingQuery($query['sql'], true);
+        $resultSet = $this->logAggregator->getDb()->query($query['sql'], $query['bind'])->fetchAll();
+
+        self::assertEquals($expectedResultSet, $resultSet);
+    }
+
+    public function getRollupResultStructureTestData(): iterable
+    {
+        yield 'nb_visits DESC' => [
+            'DESC',
+            [
+                [
+                    'config_browser_engine' => null,
+                    'custom_var_v1' => null,
+                    'nb_visits' => 30,
+                ],
+                [
+                    'config_browser_engine' => 'Gecko',
+                    'custom_var_v1' => null,
+                    'nb_visits' => 20,
+                ],
+                [
+                    'config_browser_engine' => 'Blink',
+                    'custom_var_v1' => null,
+                    'nb_visits' => 4,
+                ],
+                [
+                    'config_browser_engine' => 'WebKit',
+                    'custom_var_v1' => null,
+                    'nb_visits' => 4,
+                ],
+                [
+                    'config_browser_engine' => RankingQuery::LABEL_SUMMARY_ROW,
+                    'custom_var_v1' => null,
+                    'nb_visits' => 2,
+                ],
+                [
+                    'config_browser_engine' => 'Gecko',
+                    'custom_var_v1' => 'Cvar1 value is 1',
+                    'nb_visits' => 4,
+                ],
+                [
+                    'config_browser_engine' => 'Blink',
+                    'custom_var_v1' => 'Cvar1 value is 0',
+                    'nb_visits' => 3,
+                ],
+                [
+                    'config_browser_engine' => 'Gecko',
+                    'custom_var_v1' => 'Cvar1 value is 0',
+                    'nb_visits' => 2,
+                ],
+                [
+                    'config_browser_engine' => 'Blink',
+                    'custom_var_v1' => RankingQuery::LABEL_SUMMARY_ROW,
+                    'nb_visits' => 1,
+                ],
+                [
+                    'config_browser_engine' => 'Gecko',
+                    'custom_var_v1' => RankingQuery::LABEL_SUMMARY_ROW,
+                    'nb_visits' => 14,
+                ],
+                [
+                    'config_browser_engine' => 'Trident',
+                    'custom_var_v1' => RankingQuery::LABEL_SUMMARY_ROW,
+                    'nb_visits' => 2,
+                ],
+                [
+                    'config_browser_engine' => 'WebKit',
+                    'custom_var_v1' => RankingQuery::LABEL_SUMMARY_ROW,
+                    'nb_visits' => 4,
+                ],
+            ],
+        ];
+
+        yield 'nb_visits ASC' => [
+            'ASC',
+            [
+                [
+                    'config_browser_engine' => null,
+                    'custom_var_v1' => null,
+                    'nb_visits' => 30,
+                ],
+                [
+                    'config_browser_engine' => 'Trident',
+                    'custom_var_v1' => null,
+                    'nb_visits' => 2,
+                ],
+                [
+                    'config_browser_engine' => 'Blink',
+                    'custom_var_v1' => null,
+                    'nb_visits' => 4,
+                ],
+                [
+                    'config_browser_engine' => 'WebKit',
+                    'custom_var_v1' => null,
+                    'nb_visits' => 4,
+                ],
+                [
+                    'config_browser_engine' => RankingQuery::LABEL_SUMMARY_ROW,
+                    'custom_var_v1' => null,
+                    'nb_visits' => 20,
+                ],
+                [
+                    'config_browser_engine' => 'Blink',
+                    'custom_var_v1' => 'Cvar1 value is 3',
+                    'nb_visits' => 1,
+                ],
+                [
+                    'config_browser_engine' => 'Trident',
+                    'custom_var_v1' => 'Cvar1 value is 1',
+                    'nb_visits' => 1,
+                ],
+                [
+                    'config_browser_engine' => 'Trident',
+                    'custom_var_v1' => 'Cvar1 value is 2',
+                    'nb_visits' => 1,
+                ],
+                [
+                    'config_browser_engine' => 'Blink',
+                    'custom_var_v1' => RankingQuery::LABEL_SUMMARY_ROW,
+                    'nb_visits' => 3,
+                ],
+                [
+                    'config_browser_engine' => 'Gecko',
+                    'custom_var_v1' => RankingQuery::LABEL_SUMMARY_ROW,
+                    'nb_visits' => 20,
+                ],
+                [
+                    'config_browser_engine' => 'WebKit',
+                    'custom_var_v1' => RankingQuery::LABEL_SUMMARY_ROW,
+                    'nb_visits' => 4,
+                ],
+            ],
+        ];
+    }
+}
+
+RankingQueryTest::$fixture = new ManyVisitsWithGeoIP();

--- a/tests/PHPUnit/Unit/RankingQueryTest.php
+++ b/tests/PHPUnit/Unit/RankingQueryTest.php
@@ -12,12 +12,13 @@ namespace Piwik\Tests\Unit;
 use Piwik\Db\Schema;
 use Piwik\RankingQuery;
 
+/**
+ * @group Core
+ * @group RankingQuery
+ */
 class RankingQueryTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @group Core
-     */
-    public function testBasic()
+    public function testBasic(): void
     {
         $query = new RankingQuery();
         $query->setOthersLabel('Others');
@@ -82,10 +83,7 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
         $this->checkQuery($query, $innerQuery, $expected);
     }
 
-    /**
-     * @group Core
-     */
-    public function testBasicWithRollup()
+    public function testBasicWithRollup(): void
     {
         $query = new RankingQuery();
         $query->setOthersLabel('Others');
@@ -302,10 +300,7 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
         $this->checkQuery($query, $innerQuery, $expected, true);
     }
 
-    /**
-     * @group Core
-     */
-    public function testExcludeRows()
+    public function testExcludeRows(): void
     {
 
         $query = new RankingQuery(20);
@@ -373,10 +368,7 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
         $this->checkQuery($query, $innerQuery, $expected);
     }
 
-    /**
-     * @group Core
-     */
-    public function testPartitionResult()
+    public function testPartitionResult(): void
     {
         $query = new RankingQuery(1000);
         $query->setOthersLabel('Others');

--- a/tests/PHPUnit/Unit/RankingQueryTest.php
+++ b/tests/PHPUnit/Unit/RankingQueryTest.php
@@ -109,13 +109,13 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
                 CASE
                     WHEN counterRollup = 11 THEN 'Others'
                     WHEN counterRollup > 0 THEN `label`
+                    WHEN counter = 11 AND counterRollup = 0 THEN `label`
                     WHEN counter = 11 THEN 'Others'
                     ELSE `label`
                 END AS `label`,
                 CASE
-                    WHEN counterRollup = 11 THEN NULL 
-                    WHEN counterRollup > 0 THEN `url`
-                    WHEN counter = 11 THEN 'Others'
+                    WHEN `url` IS NULL THEN NULL
+                    WHEN counter = 11 AND counterRollup = 0 THEN 'Others'
                     ELSE `url`
                 END AS `url`,
                 `column`,
@@ -151,7 +151,19 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
                         ORDER BY `column`
                     ) actualQuery
             ) AS withCounter
-            GROUP BY counter, counterRollup
+            GROUP BY counter, counterRollup,
+                CASE
+                    WHEN counterRollup = 11 THEN 'Others'
+                    WHEN counterRollup > 0 THEN `label`
+                    WHEN counter = 11 AND counterRollup = 0 THEN `label`
+                    WHEN counter = 11 THEN 'Others'
+                    ELSE `label`
+                END,
+                CASE
+                    WHEN `url` IS NULL THEN NULL
+                    WHEN counter = 11 AND counterRollup = 0 THEN 'Others'
+                    ELSE `url`
+                END
         ";
 
         if (!Schema::getInstance()->supportsSortingInSubquery()) {
@@ -160,13 +172,13 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
                     CASE
                         WHEN counterRollup = 11 THEN 'Others'
                         WHEN counterRollup > 0 THEN `label`
+                        WHEN counter = 11 AND counterRollup = 0 THEN `label`
                         WHEN counter = 11 THEN 'Others'
                         ELSE `label`
                     END AS `label`,
                     CASE
-                        WHEN counterRollup = 11 THEN NULL
-                        WHEN counterRollup > 0 THEN `url`
-                        WHEN counter = 11 THEN 'Others'
+                        WHEN `url` IS NULL THEN NULL
+                        WHEN counter = 11 AND counterRollup = 0 THEN 'Others'
                         ELSE `url`
                     END AS `url`,
                     `column`,
@@ -203,7 +215,19 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
                             LIMIT 18446744073709551615
                         ) actualQuery
                 ) AS withCounter
-                GROUP BY counter, counterRollup
+                GROUP BY counter, counterRollup,
+                    CASE
+                        WHEN counterRollup = 11 THEN 'Others'
+                        WHEN counterRollup > 0 THEN `label`
+                        WHEN counter = 11 AND counterRollup = 0 THEN `label`
+                        WHEN counter = 11 THEN 'Others'
+                        ELSE `label`
+                    END,
+                    CASE
+                        WHEN `url` IS NULL THEN NULL
+                        WHEN counter = 11 AND counterRollup = 0 THEN 'Others'
+                        ELSE `url`
+                    END
                 ORDER BY counter, counterRollup
             ";
         }
@@ -214,13 +238,13 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
                     CASE
                         WHEN counterRollup = 11 THEN 'Others'
                         WHEN counterRollup > 0 THEN `label`
+                        WHEN counter = 11 AND counterRollup = 0 THEN `label`
                         WHEN counter = 11 THEN 'Others'
                         ELSE `label`
                     END AS `label`,
                     CASE
-                        WHEN counterRollup = 11 THEN NULL
-                        WHEN counterRollup > 0 THEN `url`
-                        WHEN counter = 11 THEN 'Others'
+                        WHEN `url` IS NULL THEN NULL
+                        WHEN counter = 11 AND counterRollup = 0 THEN 'Others'
                         ELSE `url`
                     END AS `url`,
                     `column`,
@@ -257,7 +281,19 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
                         ) actualQuery
                     ORDER BY `label` IS NULL, `url` IS NULL, `column`
                 ) AS withCounter
-                GROUP BY counter, counterRollup
+                GROUP BY counter, counterRollup,
+                    CASE
+                        WHEN counterRollup = 11 THEN 'Others'
+                        WHEN counterRollup > 0 THEN `label`
+                        WHEN counter = 11 AND counterRollup = 0 THEN `label`
+                        WHEN counter = 11 THEN 'Others'
+                        ELSE `label`
+                    END,
+                    CASE
+                        WHEN `url` IS NULL THEN NULL
+                        WHEN counter = 11 AND counterRollup = 0 THEN 'Others'
+                        ELSE `url`
+                    END
             ";
         }
 

--- a/tests/PHPUnit/Unit/RankingQueryTest.php
+++ b/tests/PHPUnit/Unit/RankingQueryTest.php
@@ -164,6 +164,7 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
                     WHEN counter = 11 AND counterRollup = 0 THEN 'Others'
                     ELSE `url`
                 END
+            ORDER BY counter, counterRollup
         ";
 
         if (!Schema::getInstance()->supportsSortingInSubquery()) {
@@ -294,6 +295,7 @@ class RankingQueryTest extends \PHPUnit\Framework\TestCase
                         WHEN counter = 11 AND counterRollup = 0 THEN 'Others'
                         ELSE `url`
                     END
+                ORDER BY counter, counterRollup
             ";
         }
 


### PR DESCRIPTION
### Description

Rollup Ranking queries have an issue in generating the correct rollup rows for the first dimension, e.g. a rollup for the labels `custom_dimension` and `url` might not receive the expected `url == __mtm_ranking_query_others__` results upon exceeding the ranking limits.

At the same time the result order was not completely fixed across database vendors/versions. This meant a double iteration was required to safely build the report tables.

This PR attempts to fix both issues by modifying the rollup queries. Non-rollup queries should not be affected.

Requirement for https://github.com/matomo-org/matomo/pull/23863.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
