### PR TITLE
Normalize 4xx responses for invalid plugins/actions/assets and quiet their logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 
 ## Matomo 5.7.0
 
+### Breaking Changes
+
+* Client-side faults now map to consistent 4xx responses:
+  - Missing/invalid API params return 400
+  - Invalid actions return 404
+  - Missing chunks return 404
+  - Missing plugins return 404
+  - Deactivated plugins return 403
+
 ### New Features
 
 * New event `PrivacyManager.deleteDataSubjectsForDeletedSites` to enable plugins to be GDPR compliant, when tracking visit unrelated data.

--- a/core/API/Proxy.php
+++ b/core/API/Proxy.php
@@ -485,7 +485,7 @@ class Proxy
                     }
                 }
             } catch (Exception $e) {
-                throw new Exception(Piwik::translate('General_PleaseSpecifyValue', array($name)));
+                throw new BadRequestException(Piwik::translate('General_PleaseSpecifyValue', [$name]));
             }
             $finalParameters[$name] = $requestValue;
         }
@@ -541,7 +541,7 @@ class Proxy
                     $requestValue = $request->$method($name, $defaultValue);
                 }
             } catch (Exception $e) {
-                throw new Exception(Piwik::translate('General_PleaseSpecifyValue', [$name]));
+                throw new BadRequestException(Piwik::translate('General_PleaseSpecifyValue', [$name]));
             }
             $finalParameters[$name] = $requestValue;
         }

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -285,7 +285,7 @@ class Request
             });
         } catch (Exception $e) {
             if ($e instanceof HttpCodeException && $e->getCode() >= 400 && $e->getCode() < 500) {
-                StaticContainer::get(LoggerInterface::class)->debug('Uncaught exception in API: {exception}', [
+                StaticContainer::get(LoggerInterface::class)->debug('Uncaught client error in API: {exception}', [
                     'exception'            => $e,
                     'ignoreInScreenWriter' => true,
                 ]);

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -11,6 +11,7 @@ namespace Piwik\API;
 
 use Exception;
 use Piwik\Access;
+use Piwik\Http\HttpCodeException;
 use Piwik\Request\AuthenticationToken;
 use Piwik\Cache;
 use Piwik\Common;
@@ -283,10 +284,17 @@ class Request
                 return $response->getResponse($returnedValue, $module, $method);
             });
         } catch (Exception $e) {
-            StaticContainer::get(LoggerInterface::class)->error('Uncaught exception in API: {exception}', [
-                'exception' => $e,
-                'ignoreInScreenWriter' => true,
-            ]);
+            if ($e instanceof HttpCodeException && $e->getCode() >= 400 && $e->getCode() < 500) {
+                StaticContainer::get(LoggerInterface::class)->debug('Uncaught exception in API: {exception}', [
+                    'exception'            => $e,
+                    'ignoreInScreenWriter' => true,
+                ]);
+            } else {
+                StaticContainer::get(LoggerInterface::class)->error('Uncaught exception in API: {exception}', [
+                    'exception'            => $e,
+                    'ignoreInScreenWriter' => true,
+                ]);
+            }
 
             if (empty($response)) {
                 $response = new ResponseBuilder('console', $this->request);

--- a/core/AssetManager/UIAssetFetcher/PluginUmdAssetFetcher.php
+++ b/core/AssetManager/UIAssetFetcher/PluginUmdAssetFetcher.php
@@ -14,7 +14,7 @@ use Piwik\Cache;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Development;
-use Piwik\Http\BadRequestException;
+use Piwik\Exception\ThingNotFoundException;
 use Piwik\Plugin\Manager;
 
 class PluginUmdAssetFetcher extends UIAssetFetcher
@@ -203,7 +203,7 @@ class PluginUmdAssetFetcher extends UIAssetFetcher
             }
 
             if (!$foundChunk) {
-                throw new BadRequestException("Could not find chunk {$this->requestedChunk}", 404);
+                throw new ThingNotFoundException('Could not find chunk {$this->requestedChunk}');
             }
 
             foreach ($foundChunk->getFiles() as $file) {

--- a/core/AssetManager/UIAssetFetcher/PluginUmdAssetFetcher.php
+++ b/core/AssetManager/UIAssetFetcher/PluginUmdAssetFetcher.php
@@ -203,7 +203,7 @@ class PluginUmdAssetFetcher extends UIAssetFetcher
             }
 
             if (!$foundChunk) {
-                throw new BadRequestException("Could not find chunk {$this->requestedChunk}", 416);
+                throw new BadRequestException("Could not find chunk {$this->requestedChunk}", 404);
             }
 
             foreach ($foundChunk->getFiles() as $file) {

--- a/core/AssetManager/UIAssetFetcher/PluginUmdAssetFetcher.php
+++ b/core/AssetManager/UIAssetFetcher/PluginUmdAssetFetcher.php
@@ -14,6 +14,7 @@ use Piwik\Cache;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Development;
+use Piwik\Http\BadRequestException;
 use Piwik\Plugin\Manager;
 
 class PluginUmdAssetFetcher extends UIAssetFetcher
@@ -202,7 +203,7 @@ class PluginUmdAssetFetcher extends UIAssetFetcher
             }
 
             if (!$foundChunk) {
-                throw new \Exception("Could not find chunk {$this->requestedChunk}");
+                throw new BadRequestException("Could not find chunk {$this->requestedChunk}", 416);
             }
 
             foreach ($foundChunk->getFiles() as $file) {

--- a/core/Exception/NotSupportedBrowserException.php
+++ b/core/Exception/NotSupportedBrowserException.php
@@ -9,7 +9,9 @@
 
 namespace Piwik\Exception;
 
-class NotSupportedBrowserException extends \Piwik\Exception\Exception
+use Piwik\Http\HttpCodeException;
+
+class NotSupportedBrowserException extends \Piwik\Exception\Exception implements HttpCodeException
 {
     public function __construct($message)
     {

--- a/core/Exception/PluginNotFoundException.php
+++ b/core/Exception/PluginNotFoundException.php
@@ -14,10 +14,10 @@ use Piwik\Http\HttpCodeException;
 /**
  * Exception thrown when the requested plugin is not activated in the config file
  */
-class PluginDeactivatedException extends \Exception implements HttpCodeException
+class PluginNotFoundException extends \Exception implements HttpCodeException
 {
     public function __construct($module)
     {
-        parent::__construct("The plugin $module is not enabled. You can activate the plugin on Settings > Plugins page in Matomo.", 403);
+        parent::__construct("The plugin $module was not found.", 404);
     }
 }

--- a/core/Exception/ThingNotFoundException.php
+++ b/core/Exception/ThingNotFoundException.php
@@ -15,6 +15,6 @@ class ThingNotFoundException extends \Piwik\Exception\Exception implements HttpC
 {
     public function __construct($message, $previous = null)
     {
-        parent::__construct($message, 400, $previous);
+        parent::__construct($message, 404, $previous);
     }
 }

--- a/core/Exception/ThingNotFoundException.php
+++ b/core/Exception/ThingNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Exception;
+
+use Piwik\Http\HttpCodeException;
+
+class ThingNotFoundException extends \Piwik\Exception\Exception implements HttpCodeException
+{
+    public function __construct($message, $previous = null)
+    {
+        parent::__construct($message, 400, $previous);
+    }
+}

--- a/core/ExceptionHandler.php
+++ b/core/ExceptionHandler.php
@@ -16,6 +16,7 @@ use Piwik\API\ResponseBuilder;
 use Piwik\Container\ContainerDoesNotExistException;
 use Piwik\Container\StaticContainer;
 use Piwik\Exception\IRedirectException;
+use Piwik\Http\HttpCodeException;
 use Piwik\Plugins\CoreAdminHome\CustomLogo;
 use Piwik\Plugins\Monolog\Processor\ExceptionToTextProcessor;
 use Piwik\Log\LoggerInterface;
@@ -74,7 +75,7 @@ class ExceptionHandler
     {
         // Set an appropriate HTTP response code.
         switch (true) {
-            case ( ($exception instanceof \Piwik\Http\HttpCodeException || $exception instanceof \Piwik\Exception\NotSupportedBrowserException) && $exception->getCode() > 0):
+            case ($exception instanceof HttpCodeException && $exception->getCode() > 0):
                 // For these exception types, use the exception-provided error code.
                 http_response_code($exception->getCode());
                 break;
@@ -87,8 +88,8 @@ class ExceptionHandler
 
         // Log the error with an appropriate loglevel.
         switch (true) {
-            case ($exception instanceof \Piwik\Exception\NotSupportedBrowserException):
-                // These unsupported browsers are really a client-side problem, so log only at DEBUG level.
+            case ($exception instanceof HttpCodeException && $exception->getCode() > 400 && $exception->getCode() < 500):
+                // Do not log exception that results in 4xx HTTP status codes
                 self::logException($exception, Log::DEBUG);
                 break;
             default:
@@ -177,9 +178,8 @@ class ExceptionHandler
             }
         }
 
-        // Unsupported browser errors shouldn't be written to the web server log. At DEBUG logging level this error will
-        // be written to the application log instead
-        $writeErrorLog = !($ex instanceof \Piwik\Exception\NotSupportedBrowserException);
+        // Exceptions that should result in 4xx status code should not be logged
+        $writeErrorLog = !($ex instanceof HttpCodeException && $ex->getCode() >= 400 && $ex->getCode() < 500);
 
         $redirectUrl = null;
         $countdownToRedirect = null;

--- a/core/ExceptionHandler.php
+++ b/core/ExceptionHandler.php
@@ -88,8 +88,8 @@ class ExceptionHandler
 
         // Log the error with an appropriate loglevel.
         switch (true) {
-            case ($exception instanceof HttpCodeException && $exception->getCode() > 400 && $exception->getCode() < 500):
-                // Do not log exception that results in 4xx HTTP status codes
+            case ($exception instanceof HttpCodeException && $exception->getCode() >= 400 && $exception->getCode() < 500):
+                // Log exceptions, resulting in 4xx HTTP status code, only at debug level
                 self::logException($exception, Log::DEBUG);
                 break;
             default:

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -115,7 +115,7 @@ class FrontController extends Singleton
      */
     public static function generateSafeModeOutputFromException($e)
     {
-        if ($e instanceof HttpCodeException && in_array($e->getCode(), [403, 404])) {
+        if ($e instanceof HttpCodeException && $e->getCode() >= 400 && $e->getCode() < 500) {
             StaticContainer::get(LoggerInterface::class)->debug('Uncaught exception: {exception}', [
                 'exception'            => $e,
                 'ignoreInScreenWriter' => true,

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -27,7 +27,6 @@ use Piwik\Http\Router;
 use Piwik\Plugins\CoreAdminHome\CustomLogo;
 use Piwik\Session\SessionAuth;
 use Piwik\Session\SessionInitializer;
-use Piwik\SupportedBrowser;
 use Piwik\Log\LoggerInterface;
 
 /**
@@ -116,7 +115,7 @@ class FrontController extends Singleton
     public static function generateSafeModeOutputFromException($e)
     {
         if ($e instanceof HttpCodeException && $e->getCode() >= 400 && $e->getCode() < 500) {
-            StaticContainer::get(LoggerInterface::class)->debug('Uncaught exception: {exception}', [
+            StaticContainer::get(LoggerInterface::class)->debug('Uncaught client error: {exception}', [
                 'exception'            => $e,
                 'ignoreInScreenWriter' => true,
             ]);

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -11,6 +11,8 @@ namespace Piwik;
 
 use Exception;
 use Piwik\API\Request;
+use Piwik\Exception\PluginNotFoundException;
+use Piwik\Http\HttpCodeException;
 use Piwik\Request\AuthenticationToken;
 use Piwik\Config\GeneralConfig;
 use Piwik\Container\StaticContainer;
@@ -113,10 +115,17 @@ class FrontController extends Singleton
      */
     public static function generateSafeModeOutputFromException($e)
     {
-        StaticContainer::get(LoggerInterface::class)->error('Uncaught exception: {exception}', [
-            'exception' => $e,
-            'ignoreInScreenWriter' => true,
-        ]);
+        if ($e instanceof HttpCodeException && in_array($e->getCode(), [403, 404])) {
+            StaticContainer::get(LoggerInterface::class)->debug('Uncaught exception: {exception}', [
+                'exception'            => $e,
+                'ignoreInScreenWriter' => true,
+            ]);
+        } else {
+            StaticContainer::get(LoggerInterface::class)->error('Uncaught exception: {exception}', [
+                'exception'            => $e,
+                'ignoreInScreenWriter' => true,
+            ]);
+        }
 
         $error = array(
             'message' => $e->getMessage(),
@@ -496,6 +505,10 @@ class FrontController extends Singleton
 
         if (!SettingsPiwik::isInternetEnabled() && \Piwik\Plugin\Manager::getInstance()->doesPluginRequireInternetConnection($module)) {
             throw new PluginRequiresInternetException($module);
+        }
+
+        if (!\Piwik\Plugin\Manager::getInstance()->isPluginInFilesystem($module)) {
+            throw new PluginNotFoundException($module);
         }
 
         if (!\Piwik\Plugin\Manager::getInstance()->isPluginActivated($module)) {

--- a/core/Http/ControllerResolver.php
+++ b/core/Http/ControllerResolver.php
@@ -10,7 +10,7 @@
 namespace Piwik\Http;
 
 use DI\FactoryInterface;
-use Exception;
+use Piwik\Exception\ThingNotFoundException;
 use Piwik\Plugin\ReportsProvider;
 use Piwik\Plugin\WidgetsProvider;
 
@@ -41,7 +41,7 @@ class ControllerResolver
      * @param string $module
      * @param string|null $action
      * @param array $parameters
-     * @throws Exception Controller not found.
+     * @throws ThingNotFoundException Controller not found.
      * @return callable The controller is a PHP callable.
      */
     public function getController($module, $action, array &$parameters)
@@ -61,7 +61,7 @@ class ControllerResolver
             return $controller;
         }
 
-        throw new BadRequestException(sprintf("Action '%s' not found in the module '%s'", $action, $module), 404);
+        throw new ThingNotFoundException(sprintf("Action '%s' not found in the module '%s'", $action, $module));
     }
 
     private function createPluginController($module, $action)

--- a/core/Http/ControllerResolver.php
+++ b/core/Http/ControllerResolver.php
@@ -61,7 +61,7 @@ class ControllerResolver
             return $controller;
         }
 
-        throw new Exception(sprintf("Action '%s' not found in the module '%s'", $action, $module));
+        throw new BadRequestException(sprintf("Action '%s' not found in the module '%s'", $action, $module), 404);
     }
 
     private function createPluginController($module, $action)

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -19,6 +19,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\Development;
 use Piwik\EventDispatcher;
 use Piwik\Exception\PluginDeactivatedException;
+use Piwik\Exception\PluginNotFoundException;
 use Piwik\Filesystem;
 use Piwik\Log;
 use Piwik\Notification;
@@ -296,10 +297,13 @@ class Manager
      * Checks whether the given plugin is activated, if not triggers an exception.
      *
      * @param  string $pluginName
-     * @throws PluginDeactivatedException
+     * @throws PluginDeactivatedException|PluginNotFoundException
      */
-    public function checkIsPluginActivated($pluginName)
+    public function checkIsPluginActivated($pluginName): void
     {
+        if (!$this->isPluginInFilesystem($pluginName)) {
+            throw new PluginNotFoundException($pluginName);
+        }
         if (!$this->isPluginActivated($pluginName)) {
             throw new PluginDeactivatedException($pluginName);
         }
@@ -737,7 +741,7 @@ class Manager
         }
 
         if (!$this->isPluginInFilesystem($pluginName)) {
-            throw new \Exception("Plugin '$pluginName' cannot be found in the filesystem in plugins/ directory.");
+            throw new PluginNotFoundException("Plugin '$pluginName' cannot be found in the filesystem in plugins/ directory.");
         }
         $this->deactivateThemeIfTheme($pluginName);
 

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -741,7 +741,7 @@ class Manager
         }
 
         if (!$this->isPluginInFilesystem($pluginName)) {
-            throw new PluginNotFoundException("Plugin '$pluginName' cannot be found in the filesystem in plugins/ directory.");
+            throw new PluginNotFoundException($pluginName);
         }
         $this->deactivateThemeIfTheme($pluginName);
 

--- a/tests/PHPUnit/Integration/AssetManager/UIAssetFetcher/PluginUmdAssetFetcherTest.php
+++ b/tests/PHPUnit/Integration/AssetManager/UIAssetFetcher/PluginUmdAssetFetcherTest.php
@@ -12,8 +12,8 @@ namespace PHPUnit\Integration\AssetManager\UIAssetFetcher;
 use Piwik\AssetManager\UIAsset\OnDiskUIAsset;
 use Piwik\AssetManager\UIAssetFetcher\Chunk;
 use Piwik\AssetManager\UIAssetFetcher\PluginUmdAssetFetcher;
+use Piwik\Exception\ThingNotFoundException;
 use Piwik\Filesystem;
-use Piwik\Http\BadRequestException;
 use Piwik\Plugin\Manager;
 use Piwik\Tests\Framework\TestCase\UnitTestCase;
 
@@ -178,7 +178,7 @@ class PluginUmdAssetFetcherTest extends UnitTestCase
         $plugins = array_keys(self::TEST_PLUGIN_DEPENDENCIES);
         $instance = new PluginUmdAssetFetcher($plugins, null, 'does-not-exist', false);
 
-        $this->expectException(BadRequestException::class);
+        $this->expectException(ThingNotFoundException::class);
         $this->expectExceptionCode(404);
 
         $instance->getCatalog();

--- a/tests/PHPUnit/Integration/AssetManager/UIAssetFetcher/PluginUmdAssetFetcherTest.php
+++ b/tests/PHPUnit/Integration/AssetManager/UIAssetFetcher/PluginUmdAssetFetcherTest.php
@@ -13,6 +13,7 @@ use Piwik\AssetManager\UIAsset\OnDiskUIAsset;
 use Piwik\AssetManager\UIAssetFetcher\Chunk;
 use Piwik\AssetManager\UIAssetFetcher\PluginUmdAssetFetcher;
 use Piwik\Filesystem;
+use Piwik\Http\BadRequestException;
 use Piwik\Plugin\Manager;
 use Piwik\Tests\Framework\TestCase\UnitTestCase;
 
@@ -170,6 +171,17 @@ class PluginUmdAssetFetcherTest extends UnitTestCase
         ];
 
         $this->assertEquals($expectedChunkFiles, $actualChunkFiles);
+    }
+
+    public function testGetChunkFilesThrows404WhenChunkIsMissing()
+    {
+        $plugins = array_keys(self::TEST_PLUGIN_DEPENDENCIES);
+        $instance = new PluginUmdAssetFetcher($plugins, null, 'does-not-exist', false);
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionCode(404);
+
+        $instance->getCatalog();
     }
 
     public function testGetChunkFilesWhenLoadingUmdsIndividuallyAndNotAllPluginsActivated()

--- a/tests/PHPUnit/System/ResponseCodeTest.php
+++ b/tests/PHPUnit/System/ResponseCodeTest.php
@@ -101,6 +101,46 @@ class ResponseCodeTest extends SystemTestCase
         $this->assertEquals(200, $info['http_code']);
     }
 
+    public function testApiMissingRequiredParameterShouldReturn400()
+    {
+        [$response, $info] = $this->curl(
+            Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php?module=API&method=SitesManager.getSiteFromId',
+            ['token_auth' => Fixture::ADMIN_USER_TOKEN]
+        );
+
+        $this->assertEquals(400, $info['http_code']);
+        $this->assertStringContainsString('Please specify a value for \'idSite\'', $response);
+    }
+
+    public function testValidModuleInvalidActionShouldReturn404()
+    {
+        [$response, $info] = $this->curl(
+            Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php?module=CoreHome&action=doesNotExist'
+        );
+
+        $this->assertEquals(404, $info['http_code']);
+        $this->assertStringContainsString("Action &#039;doesNotExist&#039; not found in the module &#039;CoreHome&#039;", $response);
+    }
+
+    public function testMissingAssetChunkShouldReturn404()
+    {
+        [, $info] = $this->curl(
+            Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php?module=Proxy&action=getPluginUmdJs&plugin=NotAPlugin'
+        );
+
+        $this->assertEquals(404, $info['http_code']);
+    }
+
+    public function testMissingPluginShouldReturn404HttpStatus()
+    {
+        [$response, $info] = $this->curl(
+            Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php?module=NotAPlugin&action=index'
+        );
+
+        $this->assertEquals(404, $info['http_code']);
+        $this->assertStringContainsString('The plugin NotAPlugin was not found.', $response);
+    }
+
     private function curl($url, $postParams = [])
     {
         if (!function_exists('curl_init')) {


### PR DESCRIPTION
### Description

  - Map client-side faults to consistent 4xx responses: missing/invalid API params return 400, invalid actions return
    404, missing chunks return 404, missing plugins return 404, deactivated plugins return 403.
  - Silence noisy error logging for 4xx-only failures by tagging these paths as HttpCodeException and downgrading log
  - System/integration tests added for HTTP status expectations (400 missing param, 404 missing plugin, 404 invalid
    action, 404 missing asset chunk) and for plugin activation checks (404 missing plugin, 403 deactivated) plus missing
    chunk error in the asset fetcher.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
