### PR TITLE
Reactivate disabled UI test

### DIFF
--- a/plugins/SegmentEditor/tests/UI/SegmentSelectorEditor_spec.js
+++ b/plugins/SegmentEditor/tests/UI/SegmentSelectorEditor_spec.js
@@ -352,7 +352,7 @@ describe("SegmentSelectorEditorTest", function () {
         expect(await page.screenshotSelector(selectorsToCapture)).to.matchImage('enabled_create_realtime_segments_saved');
     });
 
-    it.skip('should not allow comparing segments more than the limit set', async function() {
+    it('should not allow comparing segments more than the limit set', async function() {
       const configLimit = 2;
       const maxSegments = configLimit + 1;
       testEnvironment.overrideConfig('General', 'data_comparison_segment_limit', configLimit);

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -108,6 +108,12 @@ PageRenderer.prototype.createPage = async function () {
     this.browserContext = await this.browser.createIncognitoBrowserContext();
     this.webpage = await this.browserContext.newPage();
 
+    if (this.activeRequestCount > 0) {
+      console.log('! activeRequestCount is ' + this.activeRequestCount + '. Resetting it as new browserContext has started.');
+      // unset active request count, to ensure unresolved requests from previous suites don't cause any issues
+      this.activeRequestCount = 0;
+    }
+
     PAGE_PROPERTIES_TO_PROXY.forEach((propertyName) => {
       Object.defineProperty(this, propertyName, {
         value: this.webpage[propertyName],


### PR DESCRIPTION
### Description



### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
