### PR TITLE
Integrate archiveReports with ArchiveMetrics timer

### DIFF
--- a/plugins/ArchivingMetrics/ArchivingMetrics.php
+++ b/plugins/ArchivingMetrics/ArchivingMetrics.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Piwik\Plugins\ArchivingMetrics;
 
+use Piwik\Period;
+use Piwik\Segment;
+
 class ArchivingMetrics extends \Piwik\Plugin
 {
     public function registerEvents()
@@ -21,7 +24,7 @@ class ArchivingMetrics extends \Piwik\Plugin
         ];
     }
 
-    public function onArchiveReportsStart(int $idSite, $period, $segment, string $plugin, bool $isArchivePhpTriggered): void
+    public function onArchiveReportsStart(int $idSite, Period $period, Segment $segment, string $plugin, bool $isArchivePhpTriggered): void
     {
         $timer = Timer::getInstance($isArchivePhpTriggered);
         $context = $this->buildContext($idSite, $period, $segment, $plugin);
@@ -29,10 +32,13 @@ class ArchivingMetrics extends \Piwik\Plugin
         $timer->start($context);
     }
 
+    /**
+     * @param int[] $idArchives
+     */
     public function onArchiveReportsComplete(
         int $idSite,
-        $period,
-        $segment,
+        Period $period,
+        Segment $segment,
         string $plugin,
         bool $isArchivePhpTriggered,
         array $idArchives,
@@ -44,7 +50,7 @@ class ArchivingMetrics extends \Piwik\Plugin
         $timer->complete($context, $idArchives, $wasCached);
     }
 
-    private function buildContext(int $idSite, $period, $segment, string $plugin): Context
+    private function buildContext(int $idSite, Period $period, Segment $segment, string $plugin): Context
     {
         return new Context($idSite, $period, $segment, $plugin);
     }

--- a/plugins/ArchivingMetrics/ArchivingMetrics.php
+++ b/plugins/ArchivingMetrics/ArchivingMetrics.php
@@ -13,5 +13,39 @@ namespace Piwik\Plugins\ArchivingMetrics;
 
 class ArchivingMetrics extends \Piwik\Plugin
 {
-    // Tracking is performed manually via Tracker from CoreAdminHome API; no events registered here.
+    public function registerEvents()
+    {
+        return [
+            'CoreAdminHome.archiveReports.start' => 'onArchiveReportsStart',
+            'CoreAdminHome.archiveReports.complete' => 'onArchiveReportsComplete',
+        ];
+    }
+
+    public function onArchiveReportsStart(int $idSite, $period, $segment, string $plugin, bool $isArchivePhpTriggered): void
+    {
+        $timer = Timer::getInstance($isArchivePhpTriggered);
+        $context = $this->buildContext($idSite, $period, $segment, $plugin);
+
+        $timer->start($context);
+    }
+
+    public function onArchiveReportsComplete(
+        int $idSite,
+        $period,
+        $segment,
+        string $plugin,
+        bool $isArchivePhpTriggered,
+        array $idArchives,
+        bool $wasCached
+    ): void {
+        $timer = Timer::getInstance($isArchivePhpTriggered);
+        $context = $this->buildContext($idSite, $period, $segment, $plugin);
+
+        $timer->complete($context, $idArchives, $wasCached);
+    }
+
+    private function buildContext(int $idSite, $period, $segment, string $plugin): Context
+    {
+        return new Context($idSite, $period, $segment, $plugin);
+    }
 }

--- a/plugins/ArchivingMetrics/ArchivingMetrics.php
+++ b/plugins/ArchivingMetrics/ArchivingMetrics.php
@@ -24,10 +24,17 @@ class ArchivingMetrics extends \Piwik\Plugin
         ];
     }
 
-    public function onArchiveReportsStart(int $idSite, Period $period, Segment $segment, string $plugin, bool $isArchivePhpTriggered): void
+    public function onArchiveReportsStart(
+        int $idSite,
+        Period $period,
+        Segment $segment,
+        string $plugin,
+        bool $isArchivePhpTriggered,
+        ?string $report = null
+    ): void
     {
         $timer = Timer::getInstance($isArchivePhpTriggered);
-        $context = $this->buildContext($idSite, $period, $segment, $plugin);
+        $context = $this->buildContext($idSite, $period, $segment, $plugin, $report);
 
         $timer->start($context);
     }
@@ -42,16 +49,17 @@ class ArchivingMetrics extends \Piwik\Plugin
         string $plugin,
         bool $isArchivePhpTriggered,
         array $idArchives,
-        bool $wasCached
+        bool $wasCached,
+        ?string $report = null
     ): void {
         $timer = Timer::getInstance($isArchivePhpTriggered);
-        $context = $this->buildContext($idSite, $period, $segment, $plugin);
+        $context = $this->buildContext($idSite, $period, $segment, $plugin, $report);
 
         $timer->complete($context, $idArchives, $wasCached);
     }
 
-    private function buildContext(int $idSite, Period $period, Segment $segment, string $plugin): Context
+    private function buildContext(int $idSite, Period $period, Segment $segment, string $plugin, ?string $report = null): Context
     {
-        return new Context($idSite, $period, $segment, $plugin);
+        return new Context($idSite, $period, $segment, $plugin, $report);
     }
 }

--- a/plugins/ArchivingMetrics/Timer.php
+++ b/plugins/ArchivingMetrics/Timer.php
@@ -69,6 +69,14 @@ final class Timer
         return self::$instance;
     }
 
+    /**
+     * @internal For tests only.
+     */
+    public static function resetInstanceForTests(): void
+    {
+        self::$instance = null;
+    }
+
     public function start(Context $context): void
     {
         if (false === $this->isApplicableForTiming($context)) {

--- a/plugins/ArchivingMetrics/Timer.php
+++ b/plugins/ArchivingMetrics/Timer.php
@@ -40,7 +40,7 @@ final class Timer
     private $runs = [];
 
     /**
-     * @var Timer
+     * @var ?Timer
      */
     private static $instance;
 

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -24,6 +24,8 @@ use Piwik\Date;
 use Piwik\Log\LoggerInterface;
 use Piwik\Period\Factory;
 use Piwik\Piwik;
+use Piwik\Plugins\ArchivingMetrics\Context;
+use Piwik\Plugins\ArchivingMetrics\Timer;
 use Piwik\Segment;
 use Piwik\Scheduler\Scheduler;
 use Piwik\SettingsServer;
@@ -299,19 +301,30 @@ class API extends \Piwik\Plugin\API
 
         $period = Factory::build($period, $date);
         $site = new Site($idSite);
+        $segmentObj = new Segment(
+            $segment,
+            [$idSite],
+            $period->getDateTimeStart()->setTimezone($site->getTimezone()),
+            $period->getDateTimeEnd()->setTimezone($site->getTimezone())
+        );
         $parameters = new ArchiveProcessor\Parameters(
             $site,
             $period,
-            new Segment(
-                $segment,
-                [$idSite],
-                $period->getDateTimeStart()->setTimezone($site->getTimezone()),
-                $period->getDateTimeEnd()->setTimezone($site->getTimezone())
-            )
+            $segmentObj
         );
         if ($report) {
             $parameters->setArchiveOnlyReport($report);
         }
+
+        $archivingMetricsTracker = Timer::getInstance($isArchivePhpTriggered);
+        $context = new Context(
+            $idSite,
+            $period,
+            $segmentObj,
+            (string) $plugin
+        );
+
+        $archivingMetricsTracker->start($context);
 
         // TODO: need to test case when there are multiple plugin archives w/ only some data each. does purging remove some that we need?
         $archiveLoader = new ArchiveProcessor\Loader($parameters, $invalidateBeforeArchiving);
@@ -323,6 +336,9 @@ class API extends \Piwik\Plugin\API
                 'nb_visits' => $result[1],
             ];
         }
+
+        $archivingMetricsTracker->complete($context, (array) $result['idarchives'], $archiveLoader->didReuseArchive());
+
         return $result;
     }
 

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -314,24 +314,22 @@ class API extends \Piwik\Plugin\API
             $parameters->setArchiveOnlyReport($report);
         }
 
-        $shouldRecordMetrics = !$report;
-        if ($shouldRecordMetrics) {
-            /**
-             * Triggered before a full archiveReports run starts.
-             *
-             * Usage example:
-             * Piwik::addAction('CoreAdminHome.archiveReports.start', function ($idSite, $period, $segment, $plugin, $isArchivePhpTriggered) { ... });
-             *
-             * @internal
-             */
-            Piwik::postEvent('CoreAdminHome.archiveReports.start', [
-                $idSite,
-                $period,
-                $segmentObj,
-                (string) $plugin,
-                $isArchivePhpTriggered,
-            ]);
-        }
+        /**
+         * Triggered before a full archiveReports run starts.
+         *
+         * Usage example:
+         * Piwik::addAction('CoreAdminHome.archiveReports.start', function ($idSite, $period, $segment, $plugin, $isArchivePhpTriggered) { ... });
+         *
+         * @internal
+         */
+        Piwik::postEvent('CoreAdminHome.archiveReports.start', [
+            $idSite,
+            $period,
+            $segmentObj,
+            (string) $plugin,
+            $isArchivePhpTriggered,
+            $report
+        ]);
 
         // TODO: need to test case when there are multiple plugin archives w/ only some data each. does purging remove some that we need?
         $archiveLoader = new ArchiveProcessor\Loader($parameters, $invalidateBeforeArchiving);
@@ -347,25 +345,24 @@ class API extends \Piwik\Plugin\API
         $idArchives = isset($result['idarchives']) ? (array) $result['idarchives'] : [];
         $wasCached = $archiveLoader->didReuseArchive();
 
-        if ($shouldRecordMetrics) {
-            /**
-             * Triggered after a full archiveReports run completes.
-             *
-             * Usage example:
-             * Piwik::addAction('CoreAdminHome.archiveReports.complete', function ($idSite, $period, $segment, $plugin, $isArchivePhpTriggered, $idArchives, $wasCached) { ... });
-             *
-             * @internal
-             */
-            Piwik::postEvent('CoreAdminHome.archiveReports.complete', [
-                $idSite,
-                $period,
-                $segmentObj,
-                (string) $plugin,
-                $isArchivePhpTriggered,
-                $idArchives,
-                $wasCached,
-            ]);
-        }
+        /**
+         * Triggered after a full archiveReports run completes.
+         *
+         * Usage example:
+         * Piwik::addAction('CoreAdminHome.archiveReports.complete', function ($idSite, $period, $segment, $plugin, $isArchivePhpTriggered, $idArchives, $wasCached, $report) { ... });
+         *
+         * @internal
+         */
+        Piwik::postEvent('CoreAdminHome.archiveReports.complete', [
+            $idSite,
+            $period,
+            $segmentObj,
+            (string) $plugin,
+            $isArchivePhpTriggered,
+            $idArchives,
+            $wasCached,
+            $report
+        ]);
 
         return $result;
     }

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -314,13 +314,24 @@ class API extends \Piwik\Plugin\API
             $parameters->setArchiveOnlyReport($report);
         }
 
-        Piwik::postEvent('CoreAdminHome.archiveReports.start', [
-            $idSite,
-            $period,
-            $segmentObj,
-            (string) $plugin,
-            $isArchivePhpTriggered,
-        ]);
+        $shouldRecordMetrics = !$report;
+        if ($shouldRecordMetrics) {
+            /**
+             * Triggered before a full archiveReports run starts.
+             *
+             * Usage example:
+             * Piwik::addAction('CoreAdminHome.archiveReports.start', function ($idSite, $period, $segment, $plugin, $isArchivePhpTriggered) { ... });
+             *
+             * @internal
+             */
+            Piwik::postEvent('CoreAdminHome.archiveReports.start', [
+                $idSite,
+                $period,
+                $segmentObj,
+                (string) $plugin,
+                $isArchivePhpTriggered,
+            ]);
+        }
 
         // TODO: need to test case when there are multiple plugin archives w/ only some data each. does purging remove some that we need?
         $archiveLoader = new ArchiveProcessor\Loader($parameters, $invalidateBeforeArchiving);
@@ -336,15 +347,25 @@ class API extends \Piwik\Plugin\API
         $idArchives = isset($result['idarchives']) ? (array) $result['idarchives'] : [];
         $wasCached = $archiveLoader->didReuseArchive();
 
-        Piwik::postEvent('CoreAdminHome.archiveReports.complete', [
-            $idSite,
-            $period,
-            $segmentObj,
-            (string) $plugin,
-            $isArchivePhpTriggered,
-            $idArchives,
-            $wasCached,
-        ]);
+        if ($shouldRecordMetrics) {
+            /**
+             * Triggered after a full archiveReports run completes.
+             *
+             * Usage example:
+             * Piwik::addAction('CoreAdminHome.archiveReports.complete', function ($idSite, $period, $segment, $plugin, $isArchivePhpTriggered, $idArchives, $wasCached) { ... });
+             *
+             * @internal
+             */
+            Piwik::postEvent('CoreAdminHome.archiveReports.complete', [
+                $idSite,
+                $period,
+                $segmentObj,
+                (string) $plugin,
+                $isArchivePhpTriggered,
+                $idArchives,
+                $wasCached,
+            ]);
+        }
 
         return $result;
     }

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -24,8 +24,6 @@ use Piwik\Date;
 use Piwik\Log\LoggerInterface;
 use Piwik\Period\Factory;
 use Piwik\Piwik;
-use Piwik\Plugins\ArchivingMetrics\Context;
-use Piwik\Plugins\ArchivingMetrics\Timer;
 use Piwik\Segment;
 use Piwik\Scheduler\Scheduler;
 use Piwik\SettingsServer;
@@ -316,15 +314,13 @@ class API extends \Piwik\Plugin\API
             $parameters->setArchiveOnlyReport($report);
         }
 
-        $archivingMetricsTracker = Timer::getInstance($isArchivePhpTriggered);
-        $context = new Context(
+        Piwik::postEvent('CoreAdminHome.archiveReports.start', [
             $idSite,
             $period,
             $segmentObj,
-            (string) $plugin
-        );
-
-        $archivingMetricsTracker->start($context);
+            (string) $plugin,
+            $isArchivePhpTriggered,
+        ]);
 
         // TODO: need to test case when there are multiple plugin archives w/ only some data each. does purging remove some that we need?
         $archiveLoader = new ArchiveProcessor\Loader($parameters, $invalidateBeforeArchiving);
@@ -337,7 +333,18 @@ class API extends \Piwik\Plugin\API
             ];
         }
 
-        $archivingMetricsTracker->complete($context, (array) $result['idarchives'], $archiveLoader->didReuseArchive());
+        $idArchives = isset($result['idarchives']) ? (array) $result['idarchives'] : [];
+        $wasCached = $archiveLoader->didReuseArchive();
+
+        Piwik::postEvent('CoreAdminHome.archiveReports.complete', [
+            $idSite,
+            $period,
+            $segmentObj,
+            (string) $plugin,
+            $isArchivePhpTriggered,
+            $idArchives,
+            $wasCached,
+        ]);
 
         return $result;
     }

--- a/plugins/CoreAdminHome/tests/Integration/ArchiveReportsMetricsTimerTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/ArchiveReportsMetricsTimerTest.php
@@ -23,6 +23,15 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class ArchiveReportsMetricsTimerTest extends IntegrationTestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        if (self::$fixture) {
+            self::$fixture->extraPluginsToLoad[] = 'ArchivingMetrics';
+        }
+
+        parent::setUpBeforeClass();
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/plugins/CoreAdminHome/tests/Integration/ArchiveReportsMetricsTimerTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/ArchiveReportsMetricsTimerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Integration;
+
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\Plugins\ArchivingMetrics\Timer;
+use Piwik\Plugins\CoreAdminHome\API as CoreAdminHomeAPI;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group CoreAdminHome
+ * @group CoreAdminHome_ArchiveReportsMetricsTimer
+ * @group Plugins
+ */
+class ArchiveReportsMetricsTimerTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resetTimerSingleton();
+        Db::query('DELETE FROM ' . Common::prefixTable('archiving_metrics'));
+    }
+
+    public function testArchiveReportsWritesMetricsOnceAndDoesNotWriteAgainWhenReusingDbArchive(): void
+    {
+        Fixture::createSuperUser(true);
+        $_GET['trigger'] = 'archivephp';
+
+        $idSite = Fixture::createWebsite('2024-01-01 00:00:00');
+
+        $t = Fixture::getTracker($idSite, '2024-01-01 12:00:00');
+        $t->setUrl('http://example.com/');
+        Fixture::checkResponse($t->doTrackPageView('test'));
+
+        CoreAdminHomeAPI::getInstance()->archiveReports($idSite, 'day', '2024-01-01');
+        $this->assertSame(1, $this->getMetricsCount(), 'Expected archiving_metrics to have 1 row after first archiveReports call.');
+
+        CoreAdminHomeAPI::getInstance()->archiveReports($idSite, 'day', '2024-01-01');
+        $this->assertSame(1, $this->getMetricsCount(), 'Expected archiving_metrics to still have 1 row after reusing the same DB archive.');
+    }
+
+    private function getMetricsCount(): int
+    {
+        return (int) Db::fetchOne('SELECT COUNT(*) FROM ' . Common::prefixTable('archiving_metrics'));
+    }
+
+    private function resetTimerSingleton(): void
+    {
+        $reflection = new \ReflectionClass(Timer::class);
+        $property = $reflection->getProperty('instance');
+        $property->setAccessible(true);
+        $property->setValue(null, null);
+    }
+}

--- a/plugins/CoreAdminHome/tests/Integration/ArchiveReportsMetricsTimerTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/ArchiveReportsMetricsTimerTest.php
@@ -7,6 +7,8 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
+declare(strict_types=1);
+
 namespace Piwik\Plugins\CoreAdminHome\tests\Integration;
 
 use Piwik\Common;

--- a/plugins/CoreAdminHome/tests/Integration/ArchiveReportsMetricsTimerTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/ArchiveReportsMetricsTimerTest.php
@@ -59,5 +59,4 @@ class ArchiveReportsMetricsTimerTest extends IntegrationTestCase
     {
         return (int) Db::fetchOne('SELECT COUNT(*) FROM ' . Common::prefixTable('archiving_metrics'));
     }
-
 }

--- a/plugins/CoreAdminHome/tests/Integration/ArchiveReportsMetricsTimerTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/ArchiveReportsMetricsTimerTest.php
@@ -25,9 +25,7 @@ class ArchiveReportsMetricsTimerTest extends IntegrationTestCase
 {
     public static function setUpBeforeClass(): void
     {
-        if (self::$fixture) {
-            self::$fixture->extraPluginsToLoad[] = 'ArchivingMetrics';
-        }
+        self::$fixture->extraPluginsToLoad[] = 'ArchivingMetrics';
 
         parent::setUpBeforeClass();
     }
@@ -36,8 +34,7 @@ class ArchiveReportsMetricsTimerTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->resetTimerSingleton();
-        Db::query('DELETE FROM ' . Common::prefixTable('archiving_metrics'));
+        Timer::resetInstanceForTests();
     }
 
     public function testArchiveReportsWritesMetricsOnceAndDoesNotWriteAgainWhenReusingDbArchive(): void
@@ -63,11 +60,4 @@ class ArchiveReportsMetricsTimerTest extends IntegrationTestCase
         return (int) Db::fetchOne('SELECT COUNT(*) FROM ' . Common::prefixTable('archiving_metrics'));
     }
 
-    private function resetTimerSingleton(): void
-    {
-        $reflection = new \ReflectionClass(Timer::class);
-        $property = $reflection->getProperty('instance');
-        $property->setAccessible(true);
-        $property->setValue(null, null);
-    }
 }

--- a/tests/PHPUnit/Integration/ArchiveProcessor/LoaderTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/LoaderTest.php
@@ -48,6 +48,44 @@ class LoaderTest extends IntegrationTestCase
         Fixture::createWebsite('2012-02-03 00:00:00');
     }
 
+    public function testDidReuseArchiveFlagIsOnlySetWhenReusingArchiveFromDb()
+    {
+        $oldGet = $_GET;
+        try {
+            Fixture::createSuperUser(true);
+            $_GET['trigger'] = 'archivephp';
+
+            $idSite = 1;
+            $dateTime = '2024-01-01 12:00:00';
+            $date = '2024-01-01';
+
+            $t = Fixture::getTracker($idSite, $dateTime);
+            $t->setUrl('http://example.com/');
+            Fixture::checkResponse($t->doTrackPageView('test'));
+
+            $periodObj = Factory::build('day', $date);
+
+            $params = new Parameters(new Site($idSite), $periodObj, new Segment('', [$idSite]));
+            $loader = new Loader($params);
+            $result = $loader->prepareArchive('VisitsSummary');
+
+            $this->assertFalse($loader->didReuseArchive(), 'Expected first archiving run to generate a new archive.');
+            $this->assertNotEmpty($result);
+            $this->assertNotEmpty($result[0]);
+
+            Cache::flushAll();
+
+            $params = new Parameters(new Site($idSite), $periodObj, new Segment('', [$idSite]));
+            $loader = new Loader($params);
+            $result = $loader->prepareArchive('VisitsSummary');
+
+            $this->assertTrue($loader->didReuseArchive(), 'Expected second archiving run to reuse the existing DB archive.');
+            $this->assertSame(1, (int) $result[0][0], 'Expected second archiving run to return the same archive ids.');
+        } finally {
+            $_GET = $oldGet;
+        }
+    }
+
     public function testPluginOnlyArchivingDoesNotRelaunchChildArchives()
     {
         $_GET['pluginOnly'] = 1;

--- a/tests/PHPUnit/Integration/ArchiveProcessor/LoaderTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/LoaderTest.php
@@ -51,39 +51,36 @@ class LoaderTest extends IntegrationTestCase
     public function testDidReuseArchiveFlagIsOnlySetWhenReusingArchiveFromDb()
     {
         $oldGet = $_GET;
-        try {
-            Fixture::createSuperUser(true);
-            $_GET['trigger'] = 'archivephp';
+        Fixture::createSuperUser(true);
+        $_GET['trigger'] = 'archivephp';
 
-            $idSite = 1;
-            $dateTime = '2024-01-01 12:00:00';
-            $date = '2024-01-01';
+        $idSite = 1;
+        $dateTime = '2024-01-01 12:00:00';
+        $date = '2024-01-01';
 
-            $t = Fixture::getTracker($idSite, $dateTime);
-            $t->setUrl('http://example.com/');
-            Fixture::checkResponse($t->doTrackPageView('test'));
+        $t = Fixture::getTracker($idSite, $dateTime);
+        $t->setUrl('http://example.com/');
+        Fixture::checkResponse($t->doTrackPageView('test'));
 
-            $periodObj = Factory::build('day', $date);
+        $periodObj = Factory::build('day', $date);
 
-            $params = new Parameters(new Site($idSite), $periodObj, new Segment('', [$idSite]));
-            $loader = new Loader($params);
-            $result = $loader->prepareArchive('VisitsSummary');
+        $params = new Parameters(new Site($idSite), $periodObj, new Segment('', [$idSite]));
+        $loader = new Loader($params);
+        $result = $loader->prepareArchive('VisitsSummary');
 
-            $this->assertFalse($loader->didReuseArchive(), 'Expected first archiving run to generate a new archive.');
-            $this->assertNotEmpty($result);
-            $this->assertNotEmpty($result[0]);
+        $this->assertFalse($loader->didReuseArchive(), 'Expected first archiving run to generate a new archive.');
+        $this->assertNotEmpty($result);
+        $this->assertNotEmpty($result[0]);
 
-            Cache::flushAll();
+        Cache::flushAll();
 
-            $params = new Parameters(new Site($idSite), $periodObj, new Segment('', [$idSite]));
-            $loader = new Loader($params);
-            $result = $loader->prepareArchive('VisitsSummary');
+        $params = new Parameters(new Site($idSite), $periodObj, new Segment('', [$idSite]));
+        $loader = new Loader($params);
+        $result = $loader->prepareArchive('VisitsSummary');
 
-            $this->assertTrue($loader->didReuseArchive(), 'Expected second archiving run to reuse the existing DB archive.');
-            $this->assertSame(1, (int) $result[0][0], 'Expected second archiving run to return the same archive ids.');
-        } finally {
-            $_GET = $oldGet;
-        }
+        $this->assertTrue($loader->didReuseArchive(), 'Expected second archiving run to reuse the existing DB archive.');
+        $this->assertSame(1, (int) $result[0][0], 'Expected second archiving run to return the same archive ids.');
+        $_GET = $oldGet;
     }
 
     public function testPluginOnlyArchivingDoesNotRelaunchChildArchives()


### PR DESCRIPTION
### Description

Integrates with this work https://github.com/matomo-org/matomo/pull/23902

Not every path is tested as the timer is tested in the other work.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
