### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -157,16 +157,16 @@
         },
         {
             "name": "davaxi/sparkline",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/davaxi/Sparkline.git",
-                "reference": "7b1a978ec8c4d5f9eb9aa7b1af2efbc0130c6484"
+                "reference": "096dc8b68c95f1173e42177ed3e2d4ccb40c3fd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/davaxi/Sparkline/zipball/7b1a978ec8c4d5f9eb9aa7b1af2efbc0130c6484",
-                "reference": "7b1a978ec8c4d5f9eb9aa7b1af2efbc0130c6484",
+                "url": "https://api.github.com/repos/davaxi/Sparkline/zipball/096dc8b68c95f1173e42177ed3e2d4ccb40c3fd1",
+                "reference": "096dc8b68c95f1173e42177ed3e2d4ccb40c3fd1",
                 "shasum": ""
             },
             "require": {
@@ -208,7 +208,7 @@
                 "issues": "https://github.com/davaxi/Sparkline/issues",
                 "source": "https://github.com/davaxi/Sparkline/releases"
             },
-            "time": "2022-03-11T13:07:09+00:00"
+            "time": "2025-12-29T09:55:02+00:00"
         },
         {
             "name": "geoip2/geoip2",
@@ -611,21 +611,21 @@
         },
         {
             "name": "matomo/matomo-php-tracker",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/matomo-php-tracker.git",
-                "reference": "949259d7ffc833ae37bdec14394d13748ebccb64"
+                "reference": "9462dc6eb718c711545ea1b0f590b9ae892a4212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/matomo-php-tracker/zipball/949259d7ffc833ae37bdec14394d13748ebccb64",
-                "reference": "949259d7ffc833ae37bdec14394d13748ebccb64",
+                "url": "https://api.github.com/repos/matomo-org/matomo-php-tracker/zipball/9462dc6eb718c711545ea1b0f590b9ae892a4212",
+                "reference": "9462dc6eb718c711545ea1b0f590b9ae892a4212",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1 || ~8.2 || ~8.3 || ~8.4 || ~8.5"
             },
             "require-dev": {
                 "phpunit/phpunit": "^8.5 || ^9.3 || ^10.1"
@@ -663,7 +663,7 @@
                 "issues": "https://github.com/matomo-org/matomo-php-tracker/issues",
                 "source": "https://github.com/matomo-org/matomo-php-tracker"
             },
-            "time": "2024-10-09T08:10:30+00:00"
+            "time": "2025-12-20T18:55:41+00:00"
         },
         {
             "name": "matomo/network",
@@ -738,12 +738,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/searchengine-and-social-list.git",
-                "reference": "e1ed80f93287b9c3e389242b37bff9140c738874"
+                "reference": "743a0faff8185340c6db38f3b7f1c13cf168cc5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/searchengine-and-social-list/zipball/e1ed80f93287b9c3e389242b37bff9140c738874",
-                "reference": "e1ed80f93287b9c3e389242b37bff9140c738874",
+                "url": "https://api.github.com/repos/matomo-org/searchengine-and-social-list/zipball/743a0faff8185340c6db38f3b7f1c13cf168cc5b",
+                "reference": "743a0faff8185340c6db38f3b7f1c13cf168cc5b",
                 "shasum": ""
             },
             "replace": {
@@ -760,7 +760,7 @@
                 "issues": "https://github.com/matomo-org/searchengine-and-social-list/issues",
                 "source": "https://github.com/matomo-org/searchengine-and-social-list/tree/master"
             },
-            "time": "2025-11-10T14:58:06+00:00"
+            "time": "2025-12-15T20:05:07+00:00"
         },
         {
             "name": "maxmind-db/reader",
@@ -1205,16 +1205,16 @@
         },
         {
             "name": "pear/pear-core-minimal",
-            "version": "v1.10.16",
+            "version": "v1.10.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/pear-core-minimal.git",
-                "reference": "c0f51b45f50683bf5bbf558036854ebc9b54d033"
+                "reference": "c7b55789d01de0ce090d289b73f1bbd6a2f113b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/pear-core-minimal/zipball/c0f51b45f50683bf5bbf558036854ebc9b54d033",
-                "reference": "c0f51b45f50683bf5bbf558036854ebc9b54d033",
+                "url": "https://api.github.com/repos/pear/pear-core-minimal/zipball/c7b55789d01de0ce090d289b73f1bbd6a2f113b1",
+                "reference": "c7b55789d01de0ce090d289b73f1bbd6a2f113b1",
                 "shasum": ""
             },
             "require": {
@@ -1250,7 +1250,7 @@
                 "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=PEAR",
                 "source": "https://github.com/pear/pear-core-minimal"
             },
-            "time": "2024-11-24T22:27:58+00:00"
+            "time": "2025-12-14T20:37:07+00:00"
         },
         {
             "name": "pear/pear_exception",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
                                                      Updating dependencies
Lock file operations: 0 installs, 4 updates, 0 removals
  - Upgrading davaxi/sparkline (2.2.0 => 2.3.0)
  - Upgrading matomo/matomo-php-tracker (3.3.2 => 3.4.0)
  - Upgrading matomo/searchengine-and-social-list (dev-master e1ed80f => dev-master 743a0fa)
  - Upgrading pear/pear-core-minimal (v1.10.16 => v1.10.17)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 4 updates, 0 removals
  - Downloading davaxi/sparkline (2.3.0)
  - Downloading pear/pear-core-minimal (v1.10.17)
  - Downloading matomo/matomo-php-tracker (3.4.0)
  - Downloading matomo/searchengine-and-social-list (dev-master 743a0fa)
  - Upgrading davaxi/sparkline (2.2.0 => 2.3.0): Extracting archive
  - Upgrading pear/pear-core-minimal (v1.10.16 => v1.10.17): Extracting archive
  - Upgrading matomo/matomo-php-tracker (3.3.2 => 3.4.0): Extracting archive
  - Upgrading matomo/searchengine-and-social-list (dev-master e1ed80f => dev-master 743a0fa): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
54 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.
```
