### PR TITLE
Make date dynamic in test

### DIFF
--- a/plugins/UsersManager/tests/System/ApiTest.php
+++ b/plugins/UsersManager/tests/System/ApiTest.php
@@ -175,14 +175,17 @@ class ApiTest extends SystemTestCase
     public function testCreateAppSpecificTokenAuthWithExpireDate()
     {
         $this->model->deleteAllTokensForUser('login1');
-        $token = $this->api->createAppSpecificTokenAuth('login1', 'password', 'test', '2026-01-02 03:04:05');
+
+        $expiryDate = (new \DateTime())->modify('+1 day');
+
+        $token = $this->api->createAppSpecificTokenAuth('login1', 'password', 'test', $expiryDate->format('Y-m-d H:i:s'));
         $this->assertMd5($token);
 
         $tokens = $this->model->getAllNonSystemTokensForLogin('login1');
         $this->assertEquals($this->model->hashTokenAuth($token), $tokens[0]['password']);
         $this->assertEquals('login1', $tokens[0]['login']);
         $this->assertEquals('test', $tokens[0]['description']);
-        $this->assertEquals('2026-01-02 03:04:05', $tokens[0]['date_expired']);
+        $this->assertEquals($expiryDate->format('Y-m-d H:i:s'), $tokens[0]['date_expired']);
     }
 
     public function testCreateAppSpecificTokenAuthWithExpireHours()


### PR DESCRIPTION
### Description

There was a hard date written in a test that just elapsed.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
