### PR TITLE
Properly check idSite value when updating a segment

### DIFF
--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -261,6 +261,14 @@ class API extends \Piwik\Plugin\API
             throw new Exception('Changing value for enabledAllUsers is permitted to super users only.');
         }
 
+        if (
+            ((int)$segment['enable_only_idsite'] !== (int)$idSite)
+            && !((int)$segment['enable_only_idsite'] === 0 && !empty($idSite) && Piwik::hasUserSuperUserAccess()) // changing from global to local segment is allowed for superuser
+            && !((int)$segment['enable_only_idsite'] > 0 && empty($idSite) && Piwik::hasUserSuperUserAccess()) // changing from site specific to global segment is allowed for superuser
+        ) {
+            throw new Exception('Changing value for enable_only_idsite is permitted to super users only and only between global and site-specific segments.');
+        }
+
         $autoArchive     = $this->checkAutoArchive($autoArchive, $idSite);
 
         $bind = [

--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -261,12 +261,8 @@ class API extends \Piwik\Plugin\API
             throw new Exception('Changing value for enabledAllUsers is permitted to super users only.');
         }
 
-        if (
-            ((int)$segment['enable_only_idsite'] !== (int)$idSite)
-            && !((int)$segment['enable_only_idsite'] === 0 && !empty($idSite) && Piwik::hasUserSuperUserAccess()) // changing from global to local segment is allowed for superuser
-            && !((int)$segment['enable_only_idsite'] > 0 && empty($idSite) && Piwik::hasUserSuperUserAccess()) // changing from site specific to global segment is allowed for superuser
-        ) {
-            throw new Exception('Changing value for enable_only_idsite is permitted to super users only and only between global and site-specific segments.');
+        if ((int)$segment['enable_only_idsite'] !== (int)$idSite && !$this->isUserCanAddNewSegment($idSite)) {
+            throw new Exception('Changing value for enable_only_idsite requires permission to add segments for the target site.');
         }
 
         $autoArchive     = $this->checkAutoArchive($autoArchive, $idSite);

--- a/plugins/SegmentEditor/tests/Integration/ApiTest.php
+++ b/plugins/SegmentEditor/tests/Integration/ApiTest.php
@@ -249,7 +249,7 @@ class ApiTest extends IntegrationTestCase
     }
 
 
-    public function testUserCanNoLongerEditSegmentAfterSuperUserSharedItAccrossSites()
+    public function testUserCanNoLongerEditSegmentAfterSuperUserSharedItAcrossSites()
     {
         $segment = 'pageUrl=@%252F1';
         Fixture::createWebsite('2020-03-03 00:00:00');
@@ -298,13 +298,13 @@ class ApiTest extends IntegrationTestCase
         ]);
     }
 
-    public function testNormalUserCannotChangeSegmentScopeBetweenSites()
+    public function testNormalUserCannotChangeSegmentScopeBetweenSitesWhenNoPermissionForTargetSite()
     {
         $segment = 'pageUrl=@%252F1';
 
         FakeAccess::$identity    = 'normalUser';
         FakeAccess::$superUser   = false;
-        FakeAccess::$idSitesView = [1, 2];
+        FakeAccess::$idSitesView = [1];
 
         $idSegment = Request::processRequest('SegmentEditor.add', [
             'name'            => 'test segment',
@@ -315,7 +315,7 @@ class ApiTest extends IntegrationTestCase
         ]);
 
         self::expectException(\Exception::class);
-        self::expectExceptionMessage('Changing value for enable_only_idsite is permitted to super users only and only between global and site-specific segments.');
+        self::expectExceptionMessage('Changing value for enable_only_idsite requires permission to add segments for the target site.');
 
         Request::processRequest('SegmentEditor.update', [
             'idSegment'       => $idSegment,
@@ -327,7 +327,7 @@ class ApiTest extends IntegrationTestCase
         ]);
     }
 
-    public function testSuperUserCannotChangeSegmentScopeBetweenSites()
+    public function testUserCanChangeSegmentScopeBetweenSites()
     {
         $segment = 'pageUrl=@%252F1';
 
@@ -343,9 +343,6 @@ class ApiTest extends IntegrationTestCase
             'enabledAllUsers' => 0,
         ]);
 
-        self::expectException(\Exception::class);
-        self::expectExceptionMessage('Changing value for enable_only_idsite is permitted to super users only and only between global and site-specific segments.');
-
         Request::processRequest('SegmentEditor.update', [
             'idSegment'       => $idSegment,
             'name'            => 'test segment',
@@ -354,6 +351,9 @@ class ApiTest extends IntegrationTestCase
             'autoArchive'     => 0,
             'enabledAllUsers' => 0,
         ]);
+
+        $updatedSegment = $this->api->get($idSegment);
+        $this->assertSame(2, (int)$updatedSegment['enable_only_idsite']);
     }
 
     public function testSuperUserCanChangeSegmentScopeFromSiteToAllSites()

--- a/plugins/SegmentEditor/tests/Integration/ApiTest.php
+++ b/plugins/SegmentEditor/tests/Integration/ApiTest.php
@@ -298,6 +298,122 @@ class ApiTest extends IntegrationTestCase
         ]);
     }
 
+    public function testNormalUserCannotChangeSegmentScopeBetweenSites()
+    {
+        $segment = 'pageUrl=@%252F1';
+
+        FakeAccess::$identity    = 'normalUser';
+        FakeAccess::$superUser   = false;
+        FakeAccess::$idSitesView = [1, 2];
+
+        $idSegment = Request::processRequest('SegmentEditor.add', [
+            'name'            => 'test segment',
+            'definition'      => $segment,
+            'idSite'          => 1,
+            'autoArchive'     => 0,
+            'enabledAllUsers' => 0,
+        ]);
+
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('Changing value for enable_only_idsite is permitted to super users only and only between global and site-specific segments.');
+
+        Request::processRequest('SegmentEditor.update', [
+            'idSegment'       => $idSegment,
+            'name'            => 'test segment',
+            'definition'      => $segment,
+            'idSite'          => 2,
+            'autoArchive'     => 0,
+            'enabledAllUsers' => 0,
+        ]);
+    }
+
+    public function testSuperUserCannotChangeSegmentScopeBetweenSites()
+    {
+        $segment = 'pageUrl=@%252F1';
+
+        FakeAccess::$identity    = 'superUserLogin';
+        FakeAccess::$superUser   = true;
+        FakeAccess::$idSitesView = [1, 2];
+
+        $idSegment = Request::processRequest('SegmentEditor.add', [
+            'name'            => 'test segment',
+            'definition'      => $segment,
+            'idSite'          => 1,
+            'autoArchive'     => 0,
+            'enabledAllUsers' => 0,
+        ]);
+
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('Changing value for enable_only_idsite is permitted to super users only and only between global and site-specific segments.');
+
+        Request::processRequest('SegmentEditor.update', [
+            'idSegment'       => $idSegment,
+            'name'            => 'test segment',
+            'definition'      => $segment,
+            'idSite'          => 2,
+            'autoArchive'     => 0,
+            'enabledAllUsers' => 0,
+        ]);
+    }
+
+    public function testSuperUserCanChangeSegmentScopeFromSiteToAllSites()
+    {
+        $segment = 'pageUrl=@%252F1';
+
+        FakeAccess::$identity    = 'superUserLogin';
+        FakeAccess::$superUser   = true;
+        FakeAccess::$idSitesView = [1];
+
+        $idSegment = Request::processRequest('SegmentEditor.add', [
+            'name'            => 'test segment',
+            'definition'      => $segment,
+            'idSite'          => 1,
+            'autoArchive'     => 0,
+            'enabledAllUsers' => 0,
+        ]);
+
+        Request::processRequest('SegmentEditor.update', [
+            'idSegment'       => $idSegment,
+            'name'            => 'test segment',
+            'definition'      => $segment,
+            'idSite'          => 0,
+            'autoArchive'     => 0,
+            'enabledAllUsers' => 0,
+        ]);
+
+        $updatedSegment = $this->api->get($idSegment);
+        $this->assertSame(0, (int) $updatedSegment['enable_only_idsite']);
+    }
+
+    public function testSuperUserCanChangeSegmentScopeFromAllSitesToSite()
+    {
+        $segment = 'pageUrl=@%252F1';
+
+        FakeAccess::$identity    = 'superUserLogin';
+        FakeAccess::$superUser   = true;
+        FakeAccess::$idSitesView = [1];
+
+        $idSegment = Request::processRequest('SegmentEditor.add', [
+            'name'            => 'test segment',
+            'definition'      => $segment,
+            'idSite'          => 0,
+            'autoArchive'     => 0,
+            'enabledAllUsers' => 0,
+        ]);
+
+        Request::processRequest('SegmentEditor.update', [
+            'idSegment'       => $idSegment,
+            'name'            => 'test segment',
+            'definition'      => $segment,
+            'idSite'          => 1,
+            'autoArchive'     => 0,
+            'enabledAllUsers' => 0,
+        ]);
+
+        $updatedSegment = $this->api->get($idSegment);
+        $this->assertSame(1, (int) $updatedSegment['enable_only_idsite']);
+    }
+
 
     protected function setSuperUser($userName = 'superUserLogin')
     {

--- a/plugins/SegmentEditor/tests/Integration/ApiTest.php
+++ b/plugins/SegmentEditor/tests/Integration/ApiTest.php
@@ -50,7 +50,7 @@ class ApiTest extends IntegrationTestCase
         $this->createSegments();
         $this->setAdminUser();
 
-        $expectedOrder = array(
+        $expectedOrder = [
             // 1) my segments
             'segment 1',
             'segment 3',
@@ -62,9 +62,9 @@ class ApiTest extends IntegrationTestCase
 
             // 3) segments created by other users (which are visible to all super users)
             // not a super user, so can't see those
-        );
+        ];
 
-        $segments = $this->api->getAll($idSite = 1);
+        $segments     = $this->api->getAll($idSite = 1);
         $segmentNames = $this->getNamesFromSegments($segments);
         $this->assertSame($expectedOrder, $segmentNames);
     }
@@ -75,7 +75,7 @@ class ApiTest extends IntegrationTestCase
         $this->createSegments();
         $this->setAdminUser();
 
-        $expectedOrder = array(
+        $expectedOrder = [
             // 1) my segments
             'segment 1',
             'segment 2',
@@ -89,9 +89,9 @@ class ApiTest extends IntegrationTestCase
 
             // 3) segments created by other users (which are visible to all super users)
             // not a super user, so can't see those
-        );
+        ];
 
-        $segments = $this->api->getAll();
+        $segments     = $this->api->getAll();
         $segmentNames = $this->getNamesFromSegments($segments);
         $this->assertSame($expectedOrder, $segmentNames);
     }
@@ -102,7 +102,7 @@ class ApiTest extends IntegrationTestCase
         $this->createSegments();
         $this->setAnotherSuperUser();
 
-        $expectedOrder = array(
+        $expectedOrder = [
             // 1) my segments
             'segment 9',
 
@@ -117,9 +117,9 @@ class ApiTest extends IntegrationTestCase
             'segment 4',
             'segment 7',
             'segment 8',
-        );
+        ];
 
-        $segments = $this->api->getAll();
+        $segments     = $this->api->getAll();
         $segmentNames = $this->getNamesFromSegments($segments);
         $this->assertSame($expectedOrder, $segmentNames);
     }
@@ -130,7 +130,7 @@ class ApiTest extends IntegrationTestCase
         $this->createSegments();
         $this->setAnotherSuperUser();
 
-        $expectedOrder = array(
+        $expectedOrder = [
             // 1) my segments
             'segment 9',
 
@@ -143,9 +143,9 @@ class ApiTest extends IntegrationTestCase
             'segment 4',
             'segment 7',
             'segment 8',
-        );
+        ];
 
-        $segments = $this->api->getAll($idSite = 1);
+        $segments     = $this->api->getAll($idSite = 1);
         $segmentNames = $this->getNamesFromSegments($segments);
         $this->assertSame($expectedOrder, $segmentNames);
     }
@@ -186,41 +186,41 @@ class ApiTest extends IntegrationTestCase
 
         Config::getInstance()->General['enable_browser_archiving_triggering'] = 0;
 
-        FakeAccess::$identity = 'normalUser';
-        FakeAccess::$superUser = false;
+        FakeAccess::$identity    = 'normalUser';
+        FakeAccess::$superUser   = false;
         FakeAccess::$idSitesView = [1];
 
         $idSegment = Request::processRequest('SegmentEditor.add', [
-            'name' => 'test segment',
-            'definition' => $segment,
-            'idSite' => 1,
-            'autoArchive' => 1,
+            'name'            => 'test segment',
+            'definition'      => $segment,
+            'idSite'          => 1,
+            'autoArchive'     => 1,
             'enabledAllUsers' => 0,
         ]);
 
-        FakeAccess::$identity = 'superUserLogin';
-        FakeAccess::$superUser = true;
+        FakeAccess::$identity    = 'superUserLogin';
+        FakeAccess::$superUser   = true;
         FakeAccess::$idSitesView = [];
 
         Request::processRequest('SegmentEditor.update', [
-            'idSegment' => $idSegment,
-            'name' => 'test segment',
-            'definition' => $segment,
-            'idSite' => 1,
-            'autoArchive' => 1,
+            'idSegment'       => $idSegment,
+            'name'            => 'test segment',
+            'definition'      => $segment,
+            'idSite'          => 1,
+            'autoArchive'     => 1,
             'enabledAllUsers' => 1,
         ]);
 
-        FakeAccess::$identity = 'normalUser';
-        FakeAccess::$superUser = false;
+        FakeAccess::$identity    = 'normalUser';
+        FakeAccess::$superUser   = false;
         FakeAccess::$idSitesView = [1];
 
         Request::processRequest('SegmentEditor.update', [
-            'idSegment' => $idSegment,
-            'name' => 'new segment name',
-            'definition' => $segment,
-            'idSite' => 1,
-            'autoArchive' => 1,
+            'idSegment'       => $idSegment,
+            'name'            => 'new segment name',
+            'definition'      => $segment,
+            'idSite'          => 1,
+            'autoArchive'     => 1,
             'enabledAllUsers' => 1,
         ]);
     }
@@ -235,15 +235,15 @@ class ApiTest extends IntegrationTestCase
 
         Config::getInstance()->General['enable_browser_archiving_triggering'] = 0;
 
-        FakeAccess::$identity = 'normalUser';
-        FakeAccess::$superUser = false;
+        FakeAccess::$identity    = 'normalUser';
+        FakeAccess::$superUser   = false;
         FakeAccess::$idSitesView = [1];
 
         $idSegment = Request::processRequest('SegmentEditor.add', [
-            'name' => 'test segment',
-            'definition' => $segment,
-            'idSite' => 1,
-            'autoArchive' => 1,
+            'name'            => 'test segment',
+            'definition'      => $segment,
+            'idSite'          => 1,
+            'autoArchive'     => 1,
             'enabledAllUsers' => 1,
         ]);
     }
@@ -256,52 +256,6 @@ class ApiTest extends IntegrationTestCase
 
         Config::getInstance()->General['enable_browser_archiving_triggering'] = 0;
 
-        FakeAccess::$identity = 'normalUser';
-        FakeAccess::$superUser = false;
-        FakeAccess::$idSitesView = [1];
-
-        $idSegment = Request::processRequest('SegmentEditor.add', [
-            'name' => 'test segment',
-            'definition' => $segment,
-            'idSite' => 1,
-            'autoArchive' => 1,
-            'enabledAllUsers' => 0,
-        ]);
-
-        FakeAccess::$identity = 'superUserLogin';
-        FakeAccess::$superUser = true;
-        FakeAccess::$idSitesView = [];
-
-        Request::processRequest('SegmentEditor.update', [
-            'idSegment' => $idSegment,
-            'name' => 'test segment',
-            'definition' => $segment,
-            'idSite' => 0,
-            'autoArchive' => 1,
-            'enabledAllUsers' => 0,
-        ]);
-
-        self::expectException(\Exception::class);
-        self::expectExceptionMessage('SegmentEditor_UpdatingAllSitesSegmentPermittedToSuperUser');
-
-        FakeAccess::$identity = 'normalUser';
-        FakeAccess::$superUser = false;
-        FakeAccess::$idSitesView = [1];
-
-        Request::processRequest('SegmentEditor.update', [
-            'idSegment' => $idSegment,
-            'name' => 'new segment name',
-            'definition' => $segment,
-            'idSite' => 0,
-            'autoArchive' => 1,
-            'enabledAllUsers' => 0,
-        ]);
-    }
-
-    public function testNormalUserCannotChangeSegmentScopeBetweenSitesWhenNoPermissionForTargetSite()
-    {
-        $segment = 'pageUrl=@%252F1';
-
         FakeAccess::$identity    = 'normalUser';
         FakeAccess::$superUser   = false;
         FakeAccess::$idSitesView = [1];
@@ -310,53 +264,245 @@ class ApiTest extends IntegrationTestCase
             'name'            => 'test segment',
             'definition'      => $segment,
             'idSite'          => 1,
-            'autoArchive'     => 0,
+            'autoArchive'     => 1,
+            'enabledAllUsers' => 0,
+        ]);
+
+        FakeAccess::$identity    = 'superUserLogin';
+        FakeAccess::$superUser   = true;
+        FakeAccess::$idSitesView = [];
+
+        Request::processRequest('SegmentEditor.update', [
+            'idSegment'       => $idSegment,
+            'name'            => 'test segment',
+            'definition'      => $segment,
+            'idSite'          => 0,
+            'autoArchive'     => 1,
             'enabledAllUsers' => 0,
         ]);
 
         self::expectException(\Exception::class);
-        self::expectExceptionMessage('Changing value for enable_only_idsite requires permission to add segments for the target site.');
+        self::expectExceptionMessage('SegmentEditor_UpdatingAllSitesSegmentPermittedToSuperUser');
+
+        FakeAccess::$identity    = 'normalUser';
+        FakeAccess::$superUser   = false;
+        FakeAccess::$idSitesView = [1];
 
         Request::processRequest('SegmentEditor.update', [
             'idSegment'       => $idSegment,
-            'name'            => 'test segment',
+            'name'            => 'new segment name',
             'definition'      => $segment,
-            'idSite'          => 2,
-            'autoArchive'     => 0,
+            'idSite'          => 0,
+            'autoArchive'     => 1,
             'enabledAllUsers' => 0,
         ]);
     }
 
-    public function testUserCanChangeSegmentScopeBetweenSites()
+    /**
+     * @dataProvider requiredAccessProvider
+     */
+    public function testNormalUserCannotChangeSegmentScopeBetweenSitesWhenNoPermissionForTargetSite(string $requiredAccess): void
     {
         $segment = 'pageUrl=@%252F1';
 
-        FakeAccess::$identity    = 'superUserLogin';
-        FakeAccess::$superUser   = true;
-        FakeAccess::$idSitesView = [1, 2];
+        $this->withAddingSegmentAccess($requiredAccess, function () use ($segment, $requiredAccess) {
+            FakeAccess::$identity  = 'normalUser';
+            FakeAccess::$superUser = false;
+            $this->setAccessForRequiredAccess($requiredAccess, [1], [1, 2]);
 
-        $idSegment = Request::processRequest('SegmentEditor.add', [
-            'name'            => 'test segment',
-            'definition'      => $segment,
-            'idSite'          => 1,
-            'autoArchive'     => 0,
-            'enabledAllUsers' => 0,
-        ]);
+            $idSegment = Request::processRequest('SegmentEditor.add', [
+                'name'            => 'test segment',
+                'definition'      => $segment,
+                'idSite'          => 1,
+                'autoArchive'     => 0,
+                'enabledAllUsers' => 0,
+            ]);
 
-        Request::processRequest('SegmentEditor.update', [
-            'idSegment'       => $idSegment,
-            'name'            => 'test segment',
-            'definition'      => $segment,
-            'idSite'          => 2,
-            'autoArchive'     => 0,
-            'enabledAllUsers' => 0,
-        ]);
+            self::expectException(\Exception::class);
+            if ($requiredAccess !== 'view') {
+                self::expectExceptionMessage('Changing value for enable_only_idsite requires permission to add segments for the target site.');
+            }
 
-        $updatedSegment = $this->api->get($idSegment);
-        $this->assertSame(2, (int)$updatedSegment['enable_only_idsite']);
+            Request::processRequest('SegmentEditor.update', [
+                'idSegment'       => $idSegment,
+                'name'            => 'test segment',
+                'definition'      => $segment,
+                'idSite'          => 2,
+                'autoArchive'     => 0,
+                'enabledAllUsers' => 0,
+            ]);
+        });
     }
 
-    public function testSuperUserCanChangeSegmentScopeFromSiteToAllSites()
+    /**
+     * @dataProvider requiredAccessProvider
+     */
+    public function testUserCanChangeSegmentScopeBetweenSitesWithPermissionForTargetSite(string $requiredAccess): void
+    {
+        $segment = 'pageUrl=@%252F1';
+
+        $this->withAddingSegmentAccess($requiredAccess, function () use ($segment, $requiredAccess) {
+            FakeAccess::$identity  = 'normalUser';
+            FakeAccess::$superUser = false;
+            $this->setAccessForRequiredAccess($requiredAccess, [1, 2]);
+
+            $idSegment = Request::processRequest('SegmentEditor.add', [
+                'name'            => 'test segment',
+                'definition'      => $segment,
+                'idSite'          => 1,
+                'autoArchive'     => 0,
+                'enabledAllUsers' => 0,
+            ]);
+
+            Request::processRequest('SegmentEditor.update', [
+                'idSegment'       => $idSegment,
+                'name'            => 'test segment',
+                'definition'      => $segment,
+                'idSite'          => 2,
+                'autoArchive'     => 0,
+                'enabledAllUsers' => 0,
+            ]);
+
+            $updatedSegment = $this->api->get($idSegment);
+            $this->assertSame(2, (int)$updatedSegment['enable_only_idsite']);
+        });
+    }
+
+    public function testSuperUserCanChangeSegmentScopeBetweenSitesWithoutTargetSitePermission(): void
+    {
+        $segment = 'pageUrl=@%252F1';
+
+        $this->withAddingSegmentAccess('admin', function () use ($segment) {
+            FakeAccess::$identity    = 'superUserLogin';
+            FakeAccess::$superUser   = true;
+            FakeAccess::$idSitesView = [];
+
+            $idSegment = Request::processRequest('SegmentEditor.add', [
+                'name'            => 'test segment',
+                'definition'      => $segment,
+                'idSite'          => 1,
+                'autoArchive'     => 0,
+                'enabledAllUsers' => 0,
+            ]);
+
+            Request::processRequest('SegmentEditor.update', [
+                'idSegment'       => $idSegment,
+                'name'            => 'test segment',
+                'definition'      => $segment,
+                'idSite'          => 2,
+                'autoArchive'     => 0,
+                'enabledAllUsers' => 0,
+            ]);
+
+            $updatedSegment = $this->api->get($idSegment);
+            $this->assertSame(2, (int)$updatedSegment['enable_only_idsite']);
+        });
+    }
+
+    public function testUserCannotChangeSegmentScopeBetweenSitesWhenNotSegmentOwner(): void
+    {
+        $segment = 'pageUrl=@%252F1';
+
+        $this->withAddingSegmentAccess('view', function () use ($segment) {
+            FakeAccess::$identity    = 'segmentOwner';
+            FakeAccess::$superUser   = false;
+            FakeAccess::$idSitesView = [1, 2];
+
+            $idSegment = Request::processRequest('SegmentEditor.add', [
+                'name'            => 'test segment',
+                'definition'      => $segment,
+                'idSite'          => 1,
+                'autoArchive'     => 0,
+                'enabledAllUsers' => 0,
+            ]);
+
+            FakeAccess::$identity    = 'anotherUser';
+            FakeAccess::$superUser   = false;
+            FakeAccess::$idSitesView = [1, 2];
+
+            self::expectException(\Exception::class);
+            self::expectExceptionMessage('SegmentEditor_UpdatingForeignSegmentPermittedToSuperUser');
+
+            Request::processRequest('SegmentEditor.update', [
+                'idSegment'       => $idSegment,
+                'name'            => 'test segment',
+                'definition'      => $segment,
+                'idSite'          => 2,
+                'autoArchive'     => 0,
+                'enabledAllUsers' => 0,
+            ]);
+        });
+    }
+
+    public function testUserCannotChangeSegmentScopeFromSiteToAllSitesEvenWithPermissions(): void
+    {
+        $segment = 'pageUrl=@%252F1';
+
+        $this->withAddingSegmentAccess('admin', function () use ($segment) {
+            FakeAccess::$identity     = 'normalUser';
+            FakeAccess::$superUser    = false;
+            FakeAccess::$idSitesAdmin = [1];
+            FakeAccess::$idSitesView  = [1];
+
+            $idSegment = Request::processRequest('SegmentEditor.add', [
+                'name'            => 'test segment',
+                'definition'      => $segment,
+                'idSite'          => 1,
+                'autoArchive'     => 0,
+                'enabledAllUsers' => 0,
+            ]);
+
+            self::expectException(\Exception::class);
+            self::expectExceptionMessage('SegmentEditor_UpdatingForeignSegmentPermittedToSuperUser');
+
+            Request::processRequest('SegmentEditor.update', [
+                'idSegment'       => $idSegment,
+                'name'            => 'test segment',
+                'definition'      => $segment,
+                'idSite'          => 0,
+                'autoArchive'     => 0,
+                'enabledAllUsers' => 0,
+            ]);
+        });
+    }
+
+    public function testUserCannotChangeSegmentScopeFromAllSitesToSiteWhenSegmentOwnedBySuperUser(): void
+    {
+        $segment = 'pageUrl=@%252F1';
+
+        $this->withAddingSegmentAccess('admin', function () use ($segment) {
+            FakeAccess::$identity    = 'superUserLogin';
+            FakeAccess::$superUser   = true;
+            FakeAccess::$idSitesView = [];
+
+            $idSegment = Request::processRequest('SegmentEditor.add', [
+                'name'            => 'test segment',
+                'definition'      => $segment,
+                'idSite'          => 0,
+                'autoArchive'     => 0,
+                'enabledAllUsers' => 0,
+            ]);
+
+            FakeAccess::$identity     = 'normalUser';
+            FakeAccess::$superUser    = false;
+            FakeAccess::$idSitesAdmin = [1];
+            FakeAccess::$idSitesView  = [1];
+
+            self::expectException(\Exception::class);
+            self::expectExceptionMessage('SegmentEditor_UpdatingForeignSegmentPermittedToSuperUser');
+
+            Request::processRequest('SegmentEditor.update', [
+                'idSegment'       => $idSegment,
+                'name'            => 'test segment',
+                'definition'      => $segment,
+                'idSite'          => 1,
+                'autoArchive'     => 0,
+                'enabledAllUsers' => 0,
+            ]);
+        });
+    }
+
+    public function testSuperUserCanChangeSegmentScopeFromSiteToAllSites(): void
     {
         $segment = 'pageUrl=@%252F1';
 
@@ -382,10 +528,10 @@ class ApiTest extends IntegrationTestCase
         ]);
 
         $updatedSegment = $this->api->get($idSegment);
-        $this->assertSame(0, (int) $updatedSegment['enable_only_idsite']);
+        $this->assertSame(0, (int)$updatedSegment['enable_only_idsite']);
     }
 
-    public function testSuperUserCanChangeSegmentScopeFromAllSitesToSite()
+    public function testSuperUserCanChangeSegmentScopeFromAllSitesToSite(): void
     {
         $segment = 'pageUrl=@%252F1';
 
@@ -411,13 +557,13 @@ class ApiTest extends IntegrationTestCase
         ]);
 
         $updatedSegment = $this->api->get($idSegment);
-        $this->assertSame(1, (int) $updatedSegment['enable_only_idsite']);
+        $this->assertSame(1, (int)$updatedSegment['enable_only_idsite']);
     }
 
 
     protected function setSuperUser($userName = 'superUserLogin')
     {
-        FakeAccess::clearAccess($superUser = true, $idSitesAdmin = array(), $idSitesView = array(), $userName);
+        FakeAccess::clearAccess($superUser = true, $idSitesAdmin = [], $idSitesView = [], $userName);
     }
 
     protected function setAnotherSuperUser()
@@ -427,7 +573,7 @@ class ApiTest extends IntegrationTestCase
 
     protected function setAdminUser($userName = 'myUserLogin')
     {
-        FakeAccess::clearAccess($superUser = false, $idSitesAdmin = array(1,2), $idSitesView = array(1,2), $userName);
+        FakeAccess::clearAccess($superUser = false, $idSitesAdmin = [1, 2], $idSitesView = [1, 2], $userName);
     }
 
     protected function setAnotherAdminUser()
@@ -435,11 +581,51 @@ class ApiTest extends IntegrationTestCase
         $this->setAdminUser('anotherUserWithAdmin');
     }
 
+    public function requiredAccessProvider(): iterable
+    {
+        yield 'view access' => ['view'];
+        yield 'write access' => ['write'];
+        yield 'admin access' => ['admin'];
+    }
+
+    protected function setAccessForRequiredAccess(string $requiredAccess, array $sitesForRequiredAccess, array $viewSites = []): void
+    {
+        FakeAccess::$idSitesView  = $viewSites;
+        FakeAccess::$idSitesWrite = [];
+        FakeAccess::$idSitesAdmin = [];
+
+        switch ($requiredAccess) {
+            case 'view':
+                FakeAccess::$idSitesView = $sitesForRequiredAccess;
+                break;
+            case 'write':
+                FakeAccess::$idSitesWrite = $sitesForRequiredAccess;
+                break;
+            case 'admin':
+                FakeAccess::$idSitesAdmin = $sitesForRequiredAccess;
+                break;
+            default:
+                throw new \InvalidArgumentException('Unknown access level for segment permissions test.');
+        }
+    }
+
+    protected function withAddingSegmentAccess(string $accessLevel, callable $callback): void
+    {
+        $originalAccess                                                  = Config::getInstance()->General['adding_segment_requires_access'];
+        Config::getInstance()->General['adding_segment_requires_access'] = $accessLevel;
+
+        try {
+            $callback();
+        } finally {
+            Config::getInstance()->General['adding_segment_requires_access'] = $originalAccess;
+        }
+    }
+
     public function provideContainerConfig()
     {
-        return array(
+        return [
             'Piwik\Access' => new FakeAccess(),
-        );
+        ];
     }
 
     protected function createAdminUser()
@@ -453,7 +639,7 @@ class ApiTest extends IntegrationTestCase
      */
     protected function getNamesFromSegments($segments)
     {
-        $segmentNames = array();
+        $segmentNames = [];
         foreach ($segments as $segment) {
             $segmentNames[] = $segment['name'];
         }


### PR DESCRIPTION
### Description



### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
