### PR TITLE
Simplify tooltip handling in segment selector

### DIFF
--- a/plugins/SegmentEditor/javascripts/Segmentation.js
+++ b/plugins/SegmentEditor/javascripts/Segmentation.js
@@ -74,7 +74,7 @@ Segmentation = (function($) {
         segmentation.prototype.setTooltip = function (segmentDescription) {
           var title = _pk_translate('SegmentEditor_ChooseASegment') + '.';
           title += ' '+ _pk_translate('SegmentEditor_CurrentlySelectedSegment', [segmentDescription]);
-          addTooltip($('a.title', this.content), title);
+          $('a.title', this.content).attr('title', title);
         };
         // We will listen to changes in the Segment Comparison Store
         // so we can mark compared segments properly. This will now include deletion of compared segments.
@@ -111,10 +111,10 @@ Segmentation = (function($) {
               }
               if (comparedSegmentsLength >= limit) {
                 $compareButton.attr('data-state','disabled');
-                addTooltip($compareButton, _pk_translate('General_MaximumNumberOfSegmentsComparedIs', [limit]));
+                $compareButton.attr('title', _pk_translate('General_MaximumNumberOfSegmentsComparedIs', [limit]));
               } else {
                 $compareButton.attr('data-state','');
-                addTooltip($compareButton, _pk_translate('SegmentEditor_CompareThisSegment'));
+                $compareButton.attr('title', _pk_translate('SegmentEditor_CompareThisSegment'));
               }
             });
             return false;
@@ -697,7 +697,7 @@ Segmentation = (function($) {
         function updateStarSegmentTooltip($segment, segment) {
           const $starButton = $segment.find('.starSegment');
           const canEdit = getIsUserCanEditSegment(segment);
-          addTooltip($starButton, getStarSegmentTitle(segment, canEdit));
+          $starButton.attr('title', getStarSegmentTitle(segment, canEdit));
         }
 
         function updateStarredSegment($segment, segment, isError = false) {
@@ -710,15 +710,6 @@ Segmentation = (function($) {
           $segment.toggleClass('segmentStarAnimation', !isError);
           $segment.toggleClass('segmentStarErrorAnimation', isError);
         }
-
-        function addTooltip(element, title) {
-          $(element).attr('title', title).tooltip({
-            track: true,
-            show: { delay: 700, duration: 200 }, // default from Tooltips.js
-            hide: false,
-            content: title,
-          });
-        };
 
         function openEditFormGivenSegment(option) {
             var idsegment = option.attr("data-idsegment");
@@ -1015,8 +1006,10 @@ Segmentation = (function($) {
             var segmentIsSet = this.getSegment().length;
             toggleLoadingMessage(segmentIsSet);
 
-            self.target.find('[title]').each(function () {
-              addTooltip(this, this.getAttribute('title'));
+            $(self.target).tooltip({
+              track: true,
+              show: { delay: 700, duration: 200 }, // default from Tooltips.js
+              hide: false,
             });
         };
 


### PR DESCRIPTION
### Description

This avoids a tooltip recreation when tooltip content changes. Instead the tooltips are initialized once, and afterwards only the title attribute is updated - which is used for the tooltip.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
