### PR TITLE
Gate proxy scheme headers behind config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
   - Missing plugins return 404
   - Deactivated plugins return 403
 
+### New config.ini.php settings
+* Proxy scheme headers (like `X-Forwarded-Proto`) are now configurable via `proxy_scheme_headers`.
+
 ### New Features
 
 * New event `PrivacyManager.deleteDataSubjectsForDeletedSites` to enable plugins to be GDPR compliant, when tracking visit unrelated data.

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -710,6 +710,18 @@ multi_server_environment = 0
 ; de facto standard (X-Forwarded-Host)
 ;proxy_host_headers[] = HTTP_X_FORWARDED_HOST
 
+; List of proxy headers for scheme (http/https) detection.
+; If unset, Matomo will ignore proxy scheme headers by default.
+;
+; de facto standard (X-Forwarded-Proto)
+;proxy_scheme_headers[] = HTTP_X_FORWARDED_PROTO
+;
+; alternative header (X-Forwarded-Scheme)
+;proxy_scheme_headers[] = HTTP_X_FORWARDED_SCHEME
+;
+; alternative header (X-Url-Scheme)
+;proxy_scheme_headers[] = HTTP_X_URL_SCHEME
+
 ; List of proxy IP addresses (or IP address ranges) to skip (if present in the above headers).
 ; Generally, only required if there's more than one proxy between the visitor and the backend web server.
 ;

--- a/core/ProxyHeaders.php
+++ b/core/ProxyHeaders.php
@@ -18,9 +18,9 @@ class ProxyHeaders
     /**
      * Get protocol information, with the exception of HTTPS
      *
-     * @return string protocol information
+     * @return ?string protocol information
      */
-    public static function getProtocolInformation()
+    public static function getProtocolInformation(): ?string
     {
         if (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443) {
             return 'SERVER_PORT=443';
@@ -44,12 +44,12 @@ class ProxyHeaders
     /**
      * Get headers present in the HTTP request
      *
-     * @param array $recognizedHeaders
-     * @return array HTTP headers
+     * @param string[] $recognizedHeaders
+     * @return string[] HTTP headers
      */
-    private static function getHeaders($recognizedHeaders)
+    private static function getHeaders(array $recognizedHeaders): array
     {
-        $headers = array();
+        $headers = [];
 
         foreach ($recognizedHeaders as $header) {
             if (isset($_SERVER[$header])) {
@@ -63,26 +63,40 @@ class ProxyHeaders
     /**
      * Detect proxy client headers
      *
-     * @return array Proxy client HTTP headers
+     * @return string[] Proxy client HTTP headers
      */
-    public static function getProxyClientHeaders()
+    public static function getProxyClientHeaders(): array
     {
-        return self::getHeaders(array(
-                                     'HTTP_CF_CONNECTING_IP',
-                                     'HTTP_CLIENT_IP',
-                                     'HTTP_X_FORWARDED_FOR',
-                                ));
+        return self::getHeaders([
+            'HTTP_CF_CONNECTING_IP',
+            'HTTP_CLIENT_IP',
+            'HTTP_X_FORWARDED_FOR',
+        ]);
     }
 
     /**
      * Detect proxy host headers
      *
-     * @return array Proxy host HTTP headers
+     * @return string[] Proxy host HTTP headers
      */
-    public static function getProxyHostHeaders()
+    public static function getProxyHostHeaders(): array
     {
-        return self::getHeaders(array(
-                                     'HTTP_X_FORWARDED_HOST',
-                                ));
+        return self::getHeaders([
+            'HTTP_X_FORWARDED_HOST',
+        ]);
+    }
+
+    /**
+     * Detect proxy scheme headers
+     *
+     * @return string[] Proxy scheme HTTP headers
+     */
+    public static function getProxySchemeHeaders(): array
+    {
+        return self::getHeaders([
+            'HTTP_X_FORWARDED_PROTO',
+            'HTTP_X_FORWARDED_SCHEME',
+            'HTTP_X_URL_SCHEME',
+        ]);
     }
 }

--- a/core/Updater/Migration/Config/Factory.php
+++ b/core/Updater/Migration/Config/Factory.php
@@ -36,7 +36,7 @@ class Factory
      *
      * @param string $section
      * @param string $key
-     * @param string $value
+     * @param scalar|scalar[] $value
      * @return Set
      */
     public function set($section, $key, $value)

--- a/core/Updater/Migration/Config/Set.php
+++ b/core/Updater/Migration/Config/Set.php
@@ -28,7 +28,7 @@ class Set extends Migration
     private $key;
 
     /**
-     * @var string
+     * @var scalar|scalar[]
      */
     private $value;
 
@@ -44,6 +44,12 @@ class Set extends Migration
     {
         $domain = Config::getLocalConfigPath() == Config::getDefaultLocalConfigPath() ? '' : Config::getHostname();
         $domainArg = !empty($domain) ? "--matomo-domain=\"$domain\" " : '';
+
+        if (is_array($this->value)) {
+            $assignment = sprintf('%s.%s=%s', $this->section, $this->key, json_encode($this->value));
+            $assignment = str_replace("'", "'\"'\"'", $assignment);
+            return sprintf("./console %sconfig:set '%s'", $domainArg, $assignment);
+        }
 
         return sprintf('./console %sconfig:set --section="%s" --key="%s" --value="%s"', $domainArg, $this->section, $this->key, $this->value);
     }

--- a/core/Updates/5.7.0-b3.php
+++ b/core/Updates/5.7.0-b3.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Config;
+use Piwik\Updates;
+use Piwik\Updater;
+
+class Updates_5_7_0_b3 extends Updates
+{
+    public function doUpdate(Updater $updater)
+    {
+        $config = Config::getInstance();
+        $generalLocal = $config->getFromLocalConfig('General');
+
+        if (!is_array($generalLocal)) {
+            return;
+        }
+
+        if (array_key_exists('proxy_scheme_headers', $generalLocal)) {
+            return;
+        }
+
+        $proxyKeys = [
+            'proxy_client_headers',
+            'proxy_host_headers',
+            'proxy_ips',
+            'proxy_uri_header',
+            'proxy_ip_read_last_in_list',
+        ];
+
+        $hasProxyConfig = false;
+        foreach ($proxyKeys as $key) {
+            if (array_key_exists($key, $generalLocal)) {
+                $hasProxyConfig = true;
+                break;
+            }
+        }
+
+        if (!$hasProxyConfig) {
+            return;
+        }
+
+        $general = $config->General;
+        $general['proxy_scheme_headers'] = [
+            'HTTP_X_FORWARDED_PROTO',
+            'HTTP_X_FORWARDED_SCHEME',
+            'HTTP_X_URL_SCHEME',
+        ];
+        $config->General = $general;
+        $config->forceSave();
+    }
+}

--- a/core/Updates/5.7.0-b3.php
+++ b/core/Updates/5.7.0-b3.php
@@ -10,22 +10,29 @@
 namespace Piwik\Updates;
 
 use Piwik\Config;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 use Piwik\Updates;
 use Piwik\Updater;
 
 class Updates_5_7_0_b3 extends Updates
 {
-    public function doUpdate(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         $config = Config::getInstance();
         $generalLocal = $config->getFromLocalConfig('General');
 
         if (!is_array($generalLocal)) {
-            return;
-        }
-
-        if (array_key_exists('proxy_scheme_headers', $generalLocal)) {
-            return;
+            return [];
         }
 
         $proxyKeys = [
@@ -44,17 +51,24 @@ class Updates_5_7_0_b3 extends Updates
             }
         }
 
-        if (!$hasProxyConfig) {
-            return;
+        if (
+            !$hasProxyConfig
+            || array_key_exists('proxy_scheme_headers', $generalLocal)
+        ) {
+            return [];
         }
 
-        $general = $config->General;
-        $general['proxy_scheme_headers'] = [
-            'HTTP_X_FORWARDED_PROTO',
-            'HTTP_X_FORWARDED_SCHEME',
-            'HTTP_X_URL_SCHEME',
+        return [
+            $this->migration->config->set('General', 'proxy_scheme_headers', [
+                'HTTP_X_FORWARDED_PROTO',
+                'HTTP_X_FORWARDED_SCHEME',
+                'HTTP_X_URL_SCHEME',
+            ]),
         ];
-        $config->General = $general;
-        $config->forceSave();
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Url.php
+++ b/core/Url.php
@@ -11,6 +11,7 @@ namespace Piwik;
 
 use Exception;
 use Matomo\Network\IPUtils;
+use Piwik\Config\GeneralConfig;
 
 /**
  * Provides URL related helper methods.
@@ -775,25 +776,22 @@ class Url
     /**
      * List of hosts that are never checked for validity.
      *
-     * @return array
+     * @return string[]
      */
-    private static function getAlwaysTrustedHosts()
+    private static function getAlwaysTrustedHosts(): array
     {
         return self::getLocalHostnames();
     }
 
     /**
-     * @return array
+     * @return string[]
      */
-    public static function getLocalHostnames()
+    public static function getLocalHostnames(): array
     {
         return ['localhost', '127.0.0.1', '::1', '[::1]', '[::]', '0000::1', '0177.0.0.1', '2130706433', '[0:0:0:0:0:ffff:127.0.0.1]'];
     }
 
-    /**
-     * @return bool
-     */
-    public static function isSecureConnectionAssumedByPiwikButNotForcedYet()
+    public static function isSecureConnectionAssumedByPiwikButNotForcedYet(): bool
     {
         $isSecureConnectionLikelyNotUsed = Url::isSecureConnectionLikelyNotUsed();
         $hasSessionCookieSecureFlag = ProxyHttp::isHttps();
@@ -804,41 +802,68 @@ class Url
                 && $isSecureConnectionAssumedByPiwikButNotForcedYet;
     }
 
-    /**
-     * @return string
-     */
-    protected static function getCurrentSchemeFromRequestHeader()
+    protected static function getCurrentSchemeFromRequestHeader(): string
     {
-        if (isset($_SERVER['HTTP_X_FORWARDED_SCHEME']) && strtolower($_SERVER['HTTP_X_FORWARDED_SCHEME']) === 'https') {
+        $proxySchemeHeaders = self::getProxySchemeHeadersFromConfig();
+        foreach ($proxySchemeHeaders as $header) {
+            if (empty($header) || !isset($_SERVER[$header])) {
+                continue;
+            }
+
+            $scheme = self::getSchemeFromHeaderValue($_SERVER[$header]);
+            if ($scheme !== null) {
+                return $scheme;
+            }
+        }
+
+        if (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true)) {
             return 'https';
         }
 
-        if (isset($_SERVER['HTTP_X_URL_SCHEME']) && strtolower($_SERVER['HTTP_X_URL_SCHEME']) === 'https') {
-            return 'https';
-        }
-
-        if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'http') {
-            return 'http';
-        }
-
-        if (
-            (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true))
-            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
-        ) {
-            return 'https';
-        }
         return 'http';
     }
 
-    protected static function isSecureConnectionLikelyNotUsed()
+    /**
+     * @return string[]
+     */
+    protected static function getProxySchemeHeadersFromConfig(): array
+    {
+        $proxySchemeHeaders = GeneralConfig::getConfigValue('proxy_scheme_headers');
+        if (empty($proxySchemeHeaders) || !is_array($proxySchemeHeaders)) {
+            return [];
+        }
+
+        return $proxySchemeHeaders;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function getSchemeFromHeaderValue($value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        $value = strtolower($value);
+        if ($value === 'http' || $value === 'https') {
+            return $value;
+        }
+
+        return null;
+    }
+
+    protected static function isSecureConnectionLikelyNotUsed(): bool
     {
         return  Url::getCurrentSchemeFromRequestHeader() == 'http';
     }
 
-    /**
-     * @return bool
-     */
-    protected static function isPiwikConfiguredToAssumeSecureConnection()
+    protected static function isPiwikConfiguredToAssumeSecureConnection(): bool
     {
         $assume_secure_protocol = @Config::getInstance()->General['assume_secure_protocol'];
         return (bool) $assume_secure_protocol;

--- a/core/Version.php
+++ b/core/Version.php
@@ -22,7 +22,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    public const VERSION = '5.7.0-b2';
+    public const VERSION = '5.7.0-b3';
 
     public const MAJOR_VERSION = 5;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1831,11 +1831,6 @@ parameters:
 			path: core/Profiler.php
 
 		-
-			message: "#^Method Piwik\\\\ProxyHeaders\\:\\:getProtocolInformation\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: core/ProxyHeaders.php
-
-		-
 			message: "#^Call to an undefined method HTML_QuickForm2_Renderer_Proxy\\:\\:toArray\\(\\)\\.$#"
 			count: 1
 			path: core/QuickForm2.php

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -593,6 +593,9 @@ class Controller extends ControllerAdmin
         if (count($headers = ProxyHeaders::getProxyHostHeaders()) > 0) {
             $config->General['proxy_host_headers'] = $headers;
         }
+        if (count($headers = ProxyHeaders::getProxySchemeHeaders()) > 0) {
+            $config->General['proxy_scheme_headers'] = $headers;
+        }
 
         if (Common::getRequestVar('clientProtocol', 'http', 'string') == 'https') {
             $protocol = 'https';

--- a/tests/PHPUnit/Unit/UrlTest.php
+++ b/tests/PHPUnit/Unit/UrlTest.php
@@ -108,6 +108,18 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
     }
 
+    public function testGetCurrentSchemeIgnoresProxyHeaderWhenNotConfigured2()
+    {
+        $_SERVER['HTTPS']                                      = 'on';
+        $_SERVER['HTTP_X_FORWARDED_PROTO']                     = 'http';
+        Config::getInstance()->General['proxy_scheme_headers'] = null;
+
+        $this->assertEquals('https', Url::getCurrentScheme());
+
+        unset($_SERVER['HTTPS']);
+        unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
+    }
+
     /**
      * @dataProvider getProtocol
      */
@@ -317,7 +329,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         ];
 
         foreach ($tests as $test) {
-            list($expected, $uri, $pathInfo) = $test;
+            [$expected, $uri, $pathInfo] = $test;
 
             $_SERVER['REQUEST_URI'] = $uri;
             $_SERVER['PATH_INFO'] = $pathInfo;

--- a/tests/PHPUnit/Unit/UrlTest.php
+++ b/tests/PHPUnit/Unit/UrlTest.php
@@ -90,10 +90,22 @@ class UrlTest extends \PHPUnit\Framework\TestCase
     {
         $_SERVER['HTTPS'] = 'on';
         $_SERVER['HTTP_X_FORWARDED_PROTO'] = $proto;
+        Config::getInstance()->General['proxy_scheme_headers'] = ['HTTP_X_FORWARDED_PROTO'];
         $this->assertEquals($proto, Url::getCurrentScheme());
 
         unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
         unset($_SERVER['HTTPS']);
+        Config::getInstance()->General['proxy_scheme_headers'] = null;
+    }
+
+    public function testGetCurrentSchemeIgnoresProxyHeaderWhenNotConfigured()
+    {
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+        Config::getInstance()->General['proxy_scheme_headers'] = null;
+
+        $this->assertEquals('http', Url::getCurrentScheme());
+
+        unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
     }
 
     /**
@@ -102,6 +114,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
     public function testGetCurrentSchemeShouldDetectSecureFromHttpsHeader()
     {
         $_SERVER['HTTPS'] = 'on';
+        Config::getInstance()->General['proxy_scheme_headers'] = null;
         $this->assertEquals('https', Url::getCurrentScheme());
 
         unset($_SERVER['HTTPS']);
@@ -112,6 +125,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetCurrentSchemeShouldBeHttpByDefault()
     {
+        Config::getInstance()->General['proxy_scheme_headers'] = null;
         $this->assertEquals('http', Url::getCurrentScheme());
     }
 


### PR DESCRIPTION
### Description

This change prevents spoofed scheme headers (like X-Forwarded-Proto) from bypassing force_ssl=1 by default. Matomo now ignores scheme-related proxy headers unless explicitly configured via proxy_scheme_headers. This aligns scheme detection with existing proxy header configuration patterns and avoids trusting unconfigured headers.

### What changed:

- Added proxy_scheme_headers[] config option in config/global.ini.php.
- Updated scheme detection in core/Url.php to only trust headers listed in proxy_scheme_headers.
- Added proxy scheme header detection in core/ProxyHeaders.php and install-time config wiring in plugins/Installation/Controller.php.
- Added update migration core/Updates/5.7.0-b2.php to auto-set proxy_scheme_headers when existing proxy config is already present, preserving current behavior behind proxies.
- Updated unit tests and changelog

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
