### PR TITLE
Add action to check that a given PR has a valid milestone assigned

### DIFF
--- a/.github/workflows/pr-milestone.yml
+++ b/.github/workflows/pr-milestone.yml
@@ -1,0 +1,35 @@
+name: PR milestone check
+on:
+  pull_request:
+    types:
+      - opened
+      - milestoned
+      - demilestoned
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  milestone:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Ensure PR has an open milestone
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setFailed("This workflow only runs on pull_request events.");
+              return;
+            }
+
+            const milestone = pr.milestone;
+            if (!milestone) {
+              core.setFailed("PR must have a milestone assigned.");
+              return;
+            }
+
+            if (milestone.state !== "open") {
+              core.setFailed(`PR milestone "${milestone.title}" is ${milestone.state}.`);
+            }


### PR DESCRIPTION
### Description

Add GH action on the following events:

- PR created
- Milestone added
- Milestone removed

That verifies a milestone is set for the PR **and** the milestone isn't closed.

Once this is merged and had a few runs I will make it a merge requirement.

**Milestone is closed**

<img width="835" height="437" alt="Screenshot 2026-01-15 at 12 53 31 PM" src="https://github.com/user-attachments/assets/2215ae34-f41a-4184-b54c-f41e47bd7a0a" />


**Milestone not set**

<img width="840" height="501" alt="Screenshot 2026-01-15 at 12 44 37 PM" src="https://github.com/user-attachments/assets/38b2addc-dbff-44ff-8ebe-4416efad3ecb" />



### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
