### PR TITLE
Add bulk request limits for API.getBulkRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This is the Developer Changelog for Matomo platform developers. All changes in o
 
 The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)** lets you see more details about any Matomo release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
+## Matomo 5.8.0
+
+### New config.ini.php settings
+* `API_bulk_request_limit` sets the maximum number of URLs allowed in `API.getBulkRequest` for authenticated users (-1 disables the limit).
+
+### HTTP API
+* `API.getBulkRequest` now enforces request limits (10 for anonymous users without view access, 50 for anonymous users with view access, or the lower configured limit if `API_bulk_request_limit` is set).
+
 ## Matomo 5.7.0
 
 ### Breaking Changes

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -355,6 +355,9 @@ datatable_row_limits = "5,10,25,50,100,250,500,-1"
 ; if set to -1, a click on 'Export as' will export all rows independently of the current '# Rows to display'.
 API_datatable_default_limit = 100
 
+; Maximum number of URLs allowed in API.getBulkRequest for authenticated users (-1 disables the limit)
+API_bulk_request_limit = -1
+
 ; When period=range, below the datatables, when user clicks on "export", the data will be aggregate of the range.
 ; Here you can specify the comma separated list of formats for which the data will be exported aggregated by day
 ; (ie. there will be a new "date" column). For example set to: "rss,tsv,csv"

--- a/lang/en.json
+++ b/lang/en.json
@@ -308,6 +308,7 @@
         "Matches": "Matches",
         "MatomoIsACollaborativeProjectYouCanContributeAndDonateNextRelease": "%1$sMatomo%2$s, formerly known as Piwik, is a collaborative project brought to you by the %7$sMatomo team%8$s members as well as many other contributors around the globe. <br/> If you're a fan of Matomo, you can help: find out %3$sHow to participate in Matomo%4$s, or %5$sdonate now%6$s to help fund the next great Matomo release!",
         "MaximumNumberOfPeriodsComparedIs": "The maximum number of periods that can be compared simultaneously is %s.",
+        "MaximumNumberOfBulkRequestUrlsIs": "The maximum number of URLs that can be requested in a bulk request is %s.",
         "MaximumNumberOfSegmentsComparedIs": "The maximum number of segments that can be compared simultaneously is %s.",
         "Measurable": "Measurable",
         "MeasurableId": "Measurable ID",

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -21,6 +21,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\DataTable;
 use Piwik\DataTable\Filter\ColumnDelete;
 use Piwik\Date;
+use Piwik\Http\BadRequestException;
 use Piwik\IP;
 use Piwik\Period;
 use Piwik\Piwik;
@@ -516,6 +517,11 @@ class API extends \Piwik\Plugin\API
             return [];
         }
 
+        $limit = $this->getBulkRequestLimit();
+        if ($limit > -1 && count($urls) > $limit) {
+            throw new BadRequestException(Piwik::translate('General_MaximumNumberOfBulkRequestUrlsIs', [$limit]));
+        }
+
         $request = \Piwik\Request::fromRequest();
         $queryParameters = $request->getParameters();
         unset($queryParameters['urls']);
@@ -540,6 +546,22 @@ class API extends \Piwik\Plugin\API
             $result[] = json_decode($req->process(), true);
         }
         return $result;
+    }
+
+    private function getBulkRequestLimit(): int
+    {
+        $configLimit = Config::getInstance()->General['API_bulk_request_limit'] ?? -1;
+        $configLimit = (int)$configLimit;
+
+        if (Piwik::isUserIsAnonymous()) {
+            $defaultLimit = Piwik::isUserHasSomeViewAccess() ? 50 : 10;
+            if ($configLimit > -1) {
+                return min($defaultLimit, $configLimit);
+            }
+            return $defaultLimit;
+        }
+
+        return $configLimit;
     }
 
     /**

--- a/plugins/API/tests/Integration/APITest.php
+++ b/plugins/API/tests/Integration/APITest.php
@@ -11,15 +11,20 @@ namespace Piwik\Plugins\API\tests\Integration;
 
 use Piwik\Access;
 use Piwik\API\Request;
+use Piwik\Config;
 use Piwik\Container\StaticContainer;
+use Piwik\Date;
+use Piwik\Http\BadRequestException;
 use Piwik\Piwik;
 use Piwik\Plugins\API\API;
+use Piwik\Plugins\UsersManager\Model as UsersManagerModel;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 /**
  * @group API
  * @group APITest
+ * @group APITestBulkRequest
  * @group Plugins
  */
 class APITest extends IntegrationTestCase
@@ -30,6 +35,12 @@ class APITest extends IntegrationTestCase
     private $api;
 
     private $hasSuperUserAccess = false;
+
+    private $bulkRequestLimitBackup;
+
+    private $anonymousAccessBackup;
+
+    private $createdAnonymousUser = false;
 
     public function setUp(): void
     {
@@ -43,11 +54,33 @@ class APITest extends IntegrationTestCase
             Fixture::createWebsite('2012-01-01 00:00:00');
         }
 
+        $this->bulkRequestLimitBackup = Config::getInstance()->General['API_bulk_request_limit'] ?? null;
+
         $this->makeSureTestRunsInContextOfAnonymousUser();
     }
 
     public function tearDown(): void
     {
+        if ($this->anonymousAccessBackup !== null) {
+            $model = new UsersManagerModel();
+            $model->deleteUserAccess('anonymous', [1]);
+            if ($this->anonymousAccessBackup !== 'noaccess') {
+                $model->addUserAccess('anonymous', $this->anonymousAccessBackup, [1]);
+            }
+            $this->setAnonymousContext();
+            $this->anonymousAccessBackup = null;
+        }
+
+        if ($this->createdAnonymousUser) {
+            $model = new UsersManagerModel();
+            $model->deleteUser('anonymous');
+            $this->createdAnonymousUser = false;
+        }
+
+        if ($this->bulkRequestLimitBackup !== null) {
+            Config::getInstance()->General['API_bulk_request_limit'] = $this->bulkRequestLimitBackup;
+        }
+
         Access::getInstance()->hasSuperUserAccess($this->hasSuperUserAccess);
         parent::tearDown();
     }
@@ -72,6 +105,74 @@ class APITest extends IntegrationTestCase
         $this->assertResponseIsSuccess($response[4]);
     }
 
+    public function testGetBulkRequestLimitForAnonymousWithoutViewAccess()
+    {
+        Config::getInstance()->General['API_bulk_request_limit'] = -1;
+
+        $response = $this->api->getBulkRequest($this->makeBulkUrls(10));
+        $this->assertCount(10, $response);
+
+        $this->expectException(BadRequestException::class);
+        $this->api->getBulkRequest($this->makeBulkUrls(11));
+    }
+
+    public function testGetBulkRequestLimitForAnonymousWithViewAccess()
+    {
+        Config::getInstance()->General['API_bulk_request_limit'] = -1;
+
+        $this->setAnonymousAccessForSite(1, 'view');
+
+        try {
+            $response = $this->api->getBulkRequest($this->makeBulkUrls(50));
+            $this->assertCount(50, $response);
+
+            $this->expectException(BadRequestException::class);
+            $this->api->getBulkRequest($this->makeBulkUrls(51));
+        } finally {
+            $this->restoreAnonymousAccessForSite(1);
+        }
+    }
+
+    public function testGetBulkRequestLimitForAuthenticatedUsers()
+    {
+        $this->setSuperUserContext();
+        Config::getInstance()->General['API_bulk_request_limit'] = 3;
+
+        try {
+            $response = $this->api->getBulkRequest($this->makeBulkUrls(3));
+            $this->assertCount(3, $response);
+
+            $this->expectException(BadRequestException::class);
+            $this->api->getBulkRequest($this->makeBulkUrls(4));
+        } finally {
+            $this->setAnonymousContext();
+        }
+    }
+
+    public function testGetBulkRequestLimitForAnonymousUsesLowerConfiguredLimit()
+    {
+        Config::getInstance()->General['API_bulk_request_limit'] = 2;
+
+        $response = $this->api->getBulkRequest($this->makeBulkUrls(2));
+        $this->assertCount(2, $response);
+
+        $this->expectException(BadRequestException::class);
+        $this->api->getBulkRequest($this->makeBulkUrls(3));
+    }
+
+    public function testGetBulkRequestLimitIsDisabledForAuthenticatedUsersWhenConfigIsMinusOne()
+    {
+        $this->setSuperUserContext();
+        Config::getInstance()->General['API_bulk_request_limit'] = -1;
+
+        try {
+            $response = $this->api->getBulkRequest($this->makeBulkUrls(12));
+            $this->assertCount(12, $response);
+        } finally {
+            $this->setAnonymousContext();
+        }
+    }
+
     private function assertResponseIsPermissionError($response)
     {
         $this->assertSame('error', $response['result']);
@@ -83,6 +184,11 @@ class APITest extends IntegrationTestCase
         $this->assertArrayNotHasKey('result', $response);
     }
 
+    private function makeBulkUrls(int $count): array
+    {
+        return array_fill(0, $count, 'method%3dAPI.getMatomoVersion');
+    }
+
     private function makeSureTestRunsInContextOfAnonymousUser()
     {
         Piwik::postEvent('Request.initAuthenticationObject');
@@ -92,5 +198,60 @@ class APITest extends IntegrationTestCase
         $access->setSuperUserAccess(false);
         $access->reloadAccess(StaticContainer::get('Piwik\Auth'));
         Request::reloadAuthUsingTokenAuth(array('token_auth' => 'anonymous'));
+    }
+
+    private function setAnonymousContext(): void
+    {
+        Piwik::postEvent('Request.initAuthenticationObject');
+
+        $access = Access::getInstance();
+        $access->setSuperUserAccess(false);
+        $access->reloadAccess(StaticContainer::get('Piwik\Auth'));
+        Request::reloadAuthUsingTokenAuth(['token_auth' => 'anonymous']);
+    }
+
+    private function setSuperUserContext(): void
+    {
+        Piwik::postEvent('Request.initAuthenticationObject');
+
+        $access = Access::getInstance();
+        $access->setSuperUserAccess(true);
+        $access->reloadAccess(StaticContainer::get('Piwik\Auth'));
+        Request::reloadAuthUsingTokenAuth(['token_auth' => Fixture::getTokenAuth()]);
+    }
+
+    private function setAnonymousAccessForSite(int $idSite, string $access): void
+    {
+        $model = new UsersManagerModel();
+        if (!$model->userExists('anonymous')) {
+            $model->addUser('anonymous', 'not_a_hash', 'anonymous@example.com', Date::now()->getDatetime());
+            $this->createdAnonymousUser = true;
+        }
+
+        if ($this->anonymousAccessBackup === null) {
+            $usersAccess                 = $model->getUsersAccessFromSite($idSite);
+            $this->anonymousAccessBackup = $usersAccess['anonymous'] ?? 'noaccess';
+        }
+
+        $model->deleteUserAccess('anonymous', [$idSite]);
+        if ($access !== 'noaccess') {
+            $model->addUserAccess('anonymous', $access, [$idSite]);
+        }
+        $this->setAnonymousContext();
+    }
+
+    private function restoreAnonymousAccessForSite(int $idSite): void
+    {
+        if ($this->anonymousAccessBackup === null) {
+            return;
+        }
+
+        $model = new UsersManagerModel();
+        $model->deleteUserAccess('anonymous', [$idSite]);
+        if ($this->anonymousAccessBackup !== 'noaccess') {
+            $model->addUserAccess('anonymous', $this->anonymousAccessBackup, [$idSite]);
+        }
+        $this->setAnonymousContext();
+        $this->anonymousAccessBackup = null;
     }
 }

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd9f1c191d119dd0e6d9f5d08c03c81c5b93fb043b9f48dabbcb17759c09dc99
-size 5222833
+oid sha256:fa70c84425b60746aac6a2695418e4ff448a26f3ec91327d153d5ac0381ffcf3
+size 5231403


### PR DESCRIPTION
### Description

  - Add per-user limits for API.getBulkRequest (anonymous no-access: 10, anonymous with view access: 50, configurable for authenticated users via new `API_bulk_request_limit` config).
  - Enforce lower configured limit for anonymous users when `API_bulk_request_limit` is set.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
