### PR TITLE
Correctly filter shared segments by available site access for user

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4694,11 +4694,6 @@ parameters:
 			path: plugins/ScheduledReports/ScheduledReports.php
 
 		-
-			message: "#^Parameter \\#2 \\$idSites of class Piwik\\\\Segment constructor expects array, int\\|null given\\.$#"
-			count: 1
-			path: plugins/SegmentEditor/API.php
-
-		-
 			message: "#^Parameter \\#1 \\$ids of static method Piwik\\\\Site\\:\\:getIdSitesFromIdSitesString\\(\\) expects array\\|string, int\\<min, \\-2\\>\\|int\\<0, max\\> given\\.$#"
 			count: 1
 			path: plugins/SegmentEditor/SegmentEditor.php

--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\SegmentEditor;
 
 use Exception;
 use Piwik\ArchiveProcessor\Rules;
+use Piwik\Access;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\CronArchive\SegmentArchiving;
@@ -420,6 +421,8 @@ class API extends \Piwik\Plugin\API
         if (empty($segment)) {
             return null;
         }
+        $this->checkUserHasViewAccessToSegmentSite($segment);
+
         try {
             if (!$segment['enable_all_users']) {
                 Piwik::checkUserHasSuperUserAccessOrIsTheUser($segment['login']);
@@ -462,6 +465,10 @@ class API extends \Piwik\Plugin\API
             }
         }
 
+        if (empty($idSite)) {
+            $segments = $this->filterSegmentsWithoutSiteAccess($segments);
+        }
+
         $segments = $this->filterSegmentsWithDisabledElements($segments, $idSite);
         $segments = $this->sortSegmentsCreatedByUserFirst($segments);
 
@@ -486,6 +493,36 @@ class API extends \Piwik\Plugin\API
             }
         }
         return $segments;
+    }
+
+    private function filterSegmentsWithoutSiteAccess(array $segments): array
+    {
+        if (Piwik::hasUserSuperUserAccess()) {
+            return $segments;
+        }
+
+        $idSitesWithViewAccess = Access::getInstance()->getSitesIdWithAtLeastViewAccess();
+
+        foreach ($segments as $key => $segment) {
+            $segmentSiteId = (int) $segment['enable_only_idsite'];
+            if ($segmentSiteId !== 0 && !in_array($segmentSiteId, $idSitesWithViewAccess, true)) {
+                unset($segments[$key]);
+            }
+        }
+
+        return $segments;
+    }
+
+    private function checkUserHasViewAccessToSegmentSite(array $segment): void
+    {
+        if (Piwik::hasUserSuperUserAccess()) {
+            return;
+        }
+
+        $segmentSiteId = (int) $segment['enable_only_idsite'];
+        if ($segmentSiteId !== 0) {
+            Piwik::checkUserHasViewAccess($segmentSiteId);
+        }
     }
 
     /**

--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -39,6 +39,9 @@ class API extends \Piwik\Plugin\API
      */
     private $segmentArchiving;
 
+    /**
+     * @var string
+     */
     private $processNewSegmentsFrom;
 
     protected $autoSanitizeInputParams = false;
@@ -59,7 +62,7 @@ class API extends \Piwik\Plugin\API
         $definition = str_replace("&", '%26', $definition);
 
         try {
-            $segment = new Segment($definition, $idSite);
+            $segment = new Segment($definition, $idSite ? [$idSite] : []);
             $segment->getHash();
         } catch (Exception $e) {
             throw new Exception("The specified segment is invalid: " . $e->getMessage());
@@ -85,22 +88,15 @@ class API extends \Piwik\Plugin\API
         return $enabledAllUsers;
     }
 
-    protected function checkIdSite($idSite): ?int
+    protected function checkIdSite(?int $idSite): void
     {
         if (empty($idSite)) {
             if (!Piwik::hasUserSuperUserAccess()) {
                 throw new Exception($this->getMessageCannotEditSegmentCreatedBySuperUser());
             }
-
-            return null;
         } else {
-            if (!is_numeric($idSite)) {
-                throw new Exception("idSite should be a numeric value");
-            }
-
             Piwik::checkUserHasViewAccess($idSite);
         }
-        return (int) $idSite;
     }
 
     protected function checkAutoArchive(bool $autoArchive, ?int $idSite): bool
@@ -169,13 +165,20 @@ class API extends \Piwik\Plugin\API
             return false;
         }
 
-        $requiredAccess = Config::getInstance()->General['adding_segment_requires_access'];
+        if (Piwik::hasUserSuperUserAccess()) {
+            return true; // super user can always edit
+        }
+
+        if (empty($idSite)) {
+            return false; // only super user can add a segment without a site
+        }
+
+        $requiredAccess = Config\GeneralConfig::getConfigValue('adding_segment_requires_access', $idSite);
 
         $authorized =
             ($requiredAccess == 'view' && Piwik::isUserHasViewAccess($idSite)) ||
             ($requiredAccess == 'admin' && Piwik::isUserHasAdminAccess($idSite)) ||
-            ($requiredAccess == 'write' && Piwik::isUserHasWriteAccess($idSite)) ||
-            ($requiredAccess == 'superuser' && Piwik::hasUserSuperUserAccess())
+            ($requiredAccess == 'write' && Piwik::isUserHasWriteAccess($idSite))
         ;
 
         return $authorized;
@@ -234,7 +237,7 @@ class API extends \Piwik\Plugin\API
      * @param int $idSegment The ID of the stored segment to modify.
      * @param string $name The new name of the segment.
      * @param string $definition The new definition of the segment.
-     * @param int|string|null $idSite If supplied, associates the stored segment with as single site.
+     * @param int|null $idSite If supplied, associates the stored segment with as single site.
      * @param bool $autoArchive Whether to automatically archive data with the segment or not.
      * @param bool $enabledAllUsers Whether the stored segment is viewable by all users or just the one that created it.
      */
@@ -242,14 +245,14 @@ class API extends \Piwik\Plugin\API
         int $idSegment,
         string $name,
         string $definition,
-        $idSite = null,
+        ?int $idSite = null,
         bool $autoArchive = false,
         bool $enabledAllUsers = false
     ): void {
         $segment = $this->getSegmentOrFail($idSegment);
         $this->checkUserCanEditOrDeleteSegment($segment);
 
-        $idSite = $this->checkIdSite($idSite);
+        $this->checkIdSite($idSite);
         $name = Common::sanitizeInputValue($name);
         $this->checkSegmentName($name);
         $definition = Common::sanitizeInputValue($definition);
@@ -304,7 +307,7 @@ class API extends \Piwik\Plugin\API
      *
      * @param string $name The new name of the segment.
      * @param string $definition The new definition of the segment.
-     * @param null|string|int $idSite If supplied, associates the stored segment with as single site.
+     * @param null|int $idSite If supplied, associates the stored segment with as single site.
      * @param bool $autoArchive Whether to automatically archive data with the segment or not.
      * @param bool $enabledAllUsers Whether the stored segment is viewable by all users or just the one that created it.
      *
@@ -313,11 +316,11 @@ class API extends \Piwik\Plugin\API
     public function add(
         string $name,
         string $definition,
-        $idSite = null,
+        ?int $idSite = null,
         bool $autoArchive = false,
         bool $enabledAllUsers = false
     ): int {
-        $idSite = $this->checkIdSite($idSite);
+        $this->checkIdSite($idSite);
         $this->checkUserCanAddNewSegment($idSite);
         $name = Common::sanitizeInputValue($name);
         $this->checkSegmentName($name);
@@ -441,10 +444,10 @@ class API extends \Piwik\Plugin\API
     /**
      * Returns all stored segments.
      *
-     * @param null|string|int $idSite Whether to return stored segments for a specific idSite, or all of them. If supplied, must be a valid site ID.
+     * @param null|int $idSite Whether to return stored segments for a specific idSite, or all of them. If supplied, must be a valid site ID.
      * @return array
      */
-    public function getAll($idSite = null): array
+    public function getAll(?int $idSite = null): array
     {
         if (!empty($idSite)) {
             Piwik::checkUserHasViewAccess($idSite);
@@ -478,12 +481,12 @@ class API extends \Piwik\Plugin\API
     /**
      * Filter out any segments which cannot be initialized due to disable plugins or features
      *
-     * @param array $segments
-     * @param null|string|int $idSite
+     * @param array<array> $segments
+     * @param null|int $idSite
      *
-     * @return array
+     * @return array<array>
      */
-    private function filterSegmentsWithDisabledElements(array $segments, $idSite = null): array
+    private function filterSegmentsWithDisabledElements(array $segments, ?int $idSite = null): array
     {
         $idSites = empty($idSite) ? [] : [$idSite];
 
@@ -495,6 +498,10 @@ class API extends \Piwik\Plugin\API
         return $segments;
     }
 
+    /**
+     * @param array<array> $segments
+     * @return array<array>
+     */
     private function filterSegmentsWithoutSiteAccess(array $segments): array
     {
         if (Piwik::hasUserSuperUserAccess()) {
@@ -532,8 +539,8 @@ class API extends \Piwik\Plugin\API
      *  2) segments created by the super user that were shared with all users
      *  3) segments created by other users (which are visible to all super users)
      *
-     * @param array $segments
-     * @return array
+     * @param array<array> $segments
+     * @return array<array>
      */
     private function sortSegmentsCreatedByUserFirst(array $segments): array
     {

--- a/plugins/SegmentEditor/tests/Integration/ApiTest.php
+++ b/plugins/SegmentEditor/tests/Integration/ApiTest.php
@@ -96,6 +96,44 @@ class ApiTest extends IntegrationTestCase
         $this->assertSame($expectedOrder, $segmentNames);
     }
 
+    public function testGetAllFiltersSegmentsForSitesWithoutAccess()
+    {
+        $this->createAdminUser();
+        $this->createSegments();
+
+        FakeAccess::clearAccess($superUser = false, $idSitesAdmin = [], $idSitesView = [1], $userName = 'myUserLogin');
+
+        $expectedOrder = [
+            // 1) my segments
+            'segment 1',
+            'segment 3',
+            'segment 7',
+
+            // 2) segments created by a super user that were shared with all users
+            'segment 5',
+            'segment 9',
+        ];
+
+        $segments     = $this->api->getAll();
+        $segmentNames = $this->getNamesFromSegments($segments);
+        $this->assertSame($expectedOrder, $segmentNames);
+    }
+
+    public function testGetThrowsWhenSegmentSiteIsNotAccessible()
+    {
+        $this->createAdminUser();
+        $this->setSuperUser();
+
+        $idSegment = $this->api->add('segment access check', 'countryCode==fr', $idSite = 2, $autoArchive = false, $enableAllUsers = true);
+
+        FakeAccess::clearAccess($superUser = false, $idSitesAdmin = [], $idSitesView = [1], $userName = 'myUserLogin');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasViewAccess Fake exception');
+
+        $this->api->get($idSegment);
+    }
+
     public function testGetAllForAllWebsitesReturnsSortedSegmentsAsSuperUser()
     {
         $this->createAdminUser();

--- a/plugins/SegmentEditor/tests/Integration/ApiTest.php
+++ b/plugins/SegmentEditor/tests/Integration/ApiTest.php
@@ -134,6 +134,106 @@ class ApiTest extends IntegrationTestCase
         $this->api->get($idSegment);
     }
 
+    /**
+     * @dataProvider requiredAccessProvider
+     */
+    public function testIsUserCanAddNewSegmentReturnsTrueWithRequiredAccess(string $requiredAccess): void
+    {
+        $this->withAddingSegmentAccess($requiredAccess, function () use ($requiredAccess) {
+            FakeAccess::$identity  = 'normalUser';
+            FakeAccess::$superUser = false;
+            $this->setAccessForRequiredAccess($requiredAccess, [1], [1]);
+
+            $this->assertTrue($this->api->isUserCanAddNewSegment(1));
+        });
+    }
+
+    /**
+     * @dataProvider requiredAccessProvider
+     */
+    public function testIsUserCanAddNewSegmentReturnsFalseWithoutRequiredAccess(string $requiredAccess): void
+    {
+        $this->withAddingSegmentAccess($requiredAccess, function () use ($requiredAccess) {
+            FakeAccess::$identity  = 'normalUser';
+            FakeAccess::$superUser = false;
+            $this->setAccessForRequiredAccess($requiredAccess, [2], [2]);
+
+            $this->assertFalse($this->api->isUserCanAddNewSegment(1));
+        });
+    }
+
+    /**
+     * @dataProvider requiredAccessProvider
+     */
+    public function testIsUserCanAddNewSegmentReturnsFalseWhenUserHasNoSiteAccess(string $requiredAccess): void
+    {
+        $this->withAddingSegmentAccess($requiredAccess, function () {
+            FakeAccess::$identity  = 'normalUser';
+            FakeAccess::$superUser = false;
+            FakeAccess::$idSitesView = [];
+            FakeAccess::$idSitesWrite = [];
+            FakeAccess::$idSitesAdmin = [];
+
+            $this->assertFalse($this->api->isUserCanAddNewSegment(1));
+        });
+    }
+
+    /**
+     * @dataProvider requiredAccessProvider
+     */
+    public function testIsUserCanAddNewSegmentReturnsFalseForAllSitesWhenNotSuperUser(string $requiredAccess): void
+    {
+        $this->withAddingSegmentAccess($requiredAccess, function () use ($requiredAccess) {
+            FakeAccess::$identity  = 'normalUser';
+            FakeAccess::$superUser = false;
+            $this->setAccessForRequiredAccess($requiredAccess, [1], [1]);
+
+            $this->assertFalse($this->api->isUserCanAddNewSegment(null));
+        });
+    }
+
+    public function testIsUserCanAddNewSegmentReturnsFalseForAnonymousUser(): void
+    {
+        $this->withAddingSegmentAccess('view', function () {
+            FakeAccess::$identity  = 'anonymous';
+            FakeAccess::$superUser = false;
+            FakeAccess::$idSitesView = [1];
+
+            $this->assertFalse($this->api->isUserCanAddNewSegment(1));
+        });
+    }
+
+    public function testIsUserCanAddNewSegmentReturnsTrueForAllSitesForSuperUser(): void
+    {
+        $this->withAddingSegmentAccess('view', function () {
+            FakeAccess::$identity  = 'superUserLogin';
+            FakeAccess::$superUser = true;
+
+            $this->assertTrue($this->api->isUserCanAddNewSegment(null));
+        });
+    }
+
+    public function testIsUserCanAddNewSegmentReturnsFalseWhenSuperUserRequired(): void
+    {
+        $this->withAddingSegmentAccess('superuser', function () {
+            FakeAccess::$identity  = 'normalUser';
+            FakeAccess::$superUser = false;
+            FakeAccess::$idSitesView = [1];
+
+            $this->assertFalse($this->api->isUserCanAddNewSegment(1));
+        });
+    }
+
+    public function testIsUserCanAddNewSegmentReturnsTrueForSuperUser(): void
+    {
+        $this->withAddingSegmentAccess('superuser', function () {
+            FakeAccess::$identity  = 'superUserLogin';
+            FakeAccess::$superUser = true;
+
+            $this->assertTrue($this->api->isUserCanAddNewSegment(1));
+        });
+    }
+
     public function testGetAllForAllWebsitesReturnsSortedSegmentsAsSuperUser()
     {
         $this->createAdminUser();

--- a/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61b1bd46d50275eb3951c60291a68d627aa41ef72187e86f5f72564a87039c16
-size 5073372
+oid sha256:b469c0f6ec944bbcf602d51d1c96d0deb139fec66da8afc9484c54d01855bd65
+size 5074821


### PR DESCRIPTION
### Description

Currently a user might be able to receive shared segment details for sites without access.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
