### PR TITLE
Remove reviewers from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,10 @@ updates:
     schedule:
       interval: "monthly"
     labels:
-      - "Needs Review"
       - "github_actions"
     commit-message:
       prefix: "[GitHub Actions] "
     open-pull-requests-limit: 10
-    reviewers:
-      - "matomo-org/core-reviewers"
     pull-request-branch-name:
       separator: "-"
 
@@ -21,7 +18,6 @@ updates:
       interval: "weekly"
       day: "sunday"
     labels:
-      - "Needs Review"
       - "submodules"
     groups:
       all-submodules:
@@ -29,8 +25,6 @@ updates:
          - "*"
     commit-message:
       prefix: "[Submodules] "
-    reviewers:
-      - "matomo-org/core-reviewers"
     pull-request-branch-name:
       separator: "-" 
 
@@ -40,7 +34,6 @@ updates:
       interval: "weekly"
       day: "sunday"
     labels:
-      - "Needs Review"
       - "dependencies"
     groups:
       all-dependencies:
@@ -48,8 +41,6 @@ updates:
           - "*"
     commit-message:
       prefix: "[NPM] "
-    reviewers:
-      - "matomo-org/core-reviewers"
     pull-request-branch-name:
       separator: "-"
     ignore:
@@ -62,7 +53,6 @@ updates:
     schedule:
       interval: "monthly"
     labels:
-      - "Needs Review"
       - "dependencies"
       - "c: Tests & QA"
     groups:
@@ -71,8 +61,6 @@ updates:
          - "*"
     commit-message:
       prefix: "[NPM UI Tests] "
-    reviewers:
-      - "matomo-org/core-reviewers"
     pull-request-branch-name:
       separator: "-"    
     versioning-strategy: lockfile-only


### PR DESCRIPTION
### Description

reviewers configuration has been removed:

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
