### PR TITLE
Harden handling for IdSite param in API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ### HTTP API
 * `API.getBulkRequest` now enforces request limits (10 for anonymous users without view access, 50 for anonymous users with view access, or the lower configured limit if `API_bulk_request_limit` is set).
 
+## Matomo 5.7.1
+
+### Breaking Changes
+* HTTP APIs that accept `idSite` now validate it more strictly. Invalid values that were previously ignored can now trigger a 400 Bad Request, and some endpoints now enforce integer `idSite` parameters (e.g., non-numeric values may raise a TypeError).
+
 ## Matomo 5.7.0
 
 ### Breaking Changes

--- a/core/Access.php
+++ b/core/Access.php
@@ -641,7 +641,7 @@ class Access
             $idSites = $this->getSitesIdWithAtLeastViewAccess();
         }
 
-        $idSites = Site::getIdSitesFromIdSitesString($idSites);
+        $idSites = Site::getIdSitesFromIdSitesString($idSites, false, true);
 
         if (empty($idSites)) {
             throw new BadRequestException("The parameter 'idSite=' is missing from the request.");

--- a/core/Access.php
+++ b/core/Access.php
@@ -637,7 +637,7 @@ class Access
      */
     protected function getIdSites($idSites)
     {
-        if ($idSites === 'all') {
+        if ($idSites === 'all' || $idSites === ['all']) {
             $idSites = $this->getSitesIdWithAtLeastViewAccess();
         }
 

--- a/core/Site.php
+++ b/core/Site.php
@@ -444,10 +444,10 @@ class Site
         $validIds = [];
         foreach ($ids as $id) {
             $id = is_string($id) ? trim($id) : $id;
-            if (empty($id)) {
+            if (is_null($id) || $id === '') {
                 continue;
             }
-            if (is_numeric($id) && (int)$id > 0) {
+            if (is_numeric($id) && (string)$id === (string)(int)$id && (int)$id > 0) {
                 $validIds[] = (int)$id;
                 continue;
             }

--- a/core/Site.php
+++ b/core/Site.php
@@ -428,7 +428,7 @@ class Site
             return [];
         }
 
-        if ($ids === 'all') {
+        if ($ids === 'all' || $ids === ['all']) {
             return API::getInstance()->getSitesIdWithAtLeastViewAccess($_restrictSitesToLogin);
         }
 

--- a/core/Site.php
+++ b/core/Site.php
@@ -447,8 +447,8 @@ class Site
             if (empty($id)) {
                 continue;
             }
-            if (is_numeric($id) && $id > 0) {
-                $validIds[] = $id;
+            if (is_numeric($id) && (int)$id > 0) {
+                $validIds[] = (int)$id;
                 continue;
             }
             if ($throwOnInvalid) {
@@ -456,9 +456,7 @@ class Site
             }
         }
         $validIds = array_filter($validIds);
-        $validIds = array_unique($validIds);
-
-        return $validIds;
+        return array_unique($validIds);
     }
 
     /**

--- a/core/Site.php
+++ b/core/Site.php
@@ -11,6 +11,7 @@ namespace Piwik;
 
 use Exception;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
+use Piwik\Http\BadRequestException;
 use Piwik\Plugins\SitesManager\API;
 
 /**
@@ -418,9 +419,10 @@ class Site
      * @param string|array $ids Comma separated idSite list, eg, `'1,2,3,4'` or an array of IDs, eg,
      *                          `array(1, 2, 3, 4)`.
      * @param bool|string $_restrictSitesToLogin Implementation detail. Used only when running as a scheduled task.
+     * @param bool $throwOnInvalid If true, throw when an invalid id is supplied.
      * @return array<string>|array<int> An array of valid, unique integers.
      */
-    public static function getIdSitesFromIdSitesString($ids, $_restrictSitesToLogin = false)
+    public static function getIdSitesFromIdSitesString($ids, $_restrictSitesToLogin = false, bool $throwOnInvalid = false): array
     {
         if (empty($ids)) {
             return [];
@@ -431,16 +433,26 @@ class Site
         }
 
         if (is_bool($ids)) {
-            return array();
+            if ($throwOnInvalid) {
+                throw new BadRequestException("The parameter 'idSite=' contains an invalid value.");
+            }
+            return [];
         }
         if (!is_array($ids)) {
             $ids = explode(',', $ids);
         }
-        $validIds = array();
+        $validIds = [];
         foreach ($ids as $id) {
             $id = is_string($id) ? trim($id) : $id;
-            if (!empty($id) && is_numeric($id) && $id > 0) {
+            if (empty($id)) {
+                continue;
+            }
+            if (is_numeric($id) && $id > 0) {
                 $validIds[] = $id;
+                continue;
+            }
+            if ($throwOnInvalid) {
+                throw new BadRequestException("The parameter 'idSite=' contains an invalid value.");
             }
         }
         $validIds = array_filter($validIds);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3734,11 +3734,6 @@ parameters:
 			path: plugins/GeoIp2/LocationProvider/GeoIp2/ServerModule.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\Goals\\\\API\\:\\:getGoal\\(\\) should return array\\|null but return statement is missing\\.$#"
-			count: 1
-			path: plugins/Goals/API.php
-
-		-
 			message: "#^Parameter \\#1 \\$name of method Piwik\\\\DataTable\\\\Row\\:\\:deleteColumn\\(\\) expects string, int given\\.$#"
 			count: 1
 			path: plugins/Goals/API.php

--- a/plugins/AIAgents/API.php
+++ b/plugins/AIAgents/API.php
@@ -44,7 +44,7 @@ class API extends PluginAPI
 
         $columns = Piwik::getArrayFromApiParameter($columns);
 
-        if ($idSite === 'all' || count(Site::getIdSitesFromIdSitesString($idSite)) > 1) {
+        if ($idSite === 'all' || count(Site::getIdSitesFromIdSitesString($idSite, false, true)) > 1) {
             $resultSet = new DataTable\Map();
             $resultSet->setKeyName('idSite');
         } elseif (Period::isMultiplePeriod($date, $period)) {

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -175,7 +175,7 @@ class API extends \Piwik\Plugin\API
         if (empty($idSites)) {
             Piwik::checkUserHasSomeViewAccess();
         } else {
-            $idSites = Site::getIdSitesFromIdSitesString($idSites);
+            $idSites = Site::getIdSitesFromIdSitesString($idSites, false, true);
             Piwik::checkUserHasViewAccess($idSites);
         }
 

--- a/plugins/Annotations/API.php
+++ b/plugins/Annotations/API.php
@@ -221,7 +221,7 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $ids = array_map('intval', Site::getIdSitesFromIdSitesString($idSite));
+        $ids = array_map('intval', Site::getIdSitesFromIdSitesString($idSite, false, true));
         $model = new Model();
         $annotations = [];
         foreach ($ids as $id) {
@@ -275,7 +275,7 @@ class API extends \Piwik\Plugin\API
     ): array {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $siteIds = array_map('intval', Site::getIdSitesFromIdSitesString($idSite));
+        $siteIds = array_map('intval', Site::getIdSitesFromIdSitesString($idSite, false, true));
         if (empty($siteIds)) {
             return [];
         }

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -178,7 +178,7 @@ class API extends \Piwik\Plugin\API
         $cascadeDown = false,
         $_forceInvalidateNonexistent = false
     ) {
-        $idSites = Site::getIdSitesFromIdSitesString($idSites);
+        $idSites = Site::getIdSitesFromIdSitesString($idSites, false, true);
         if (empty($idSites)) {
             throw new Exception("Specify a value for &idSites= as a comma separated list of website IDs, for which your token_auth has 'admin' permission");
         }

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -246,9 +246,8 @@ class API extends \Piwik\Plugin\API
      * @param int $idSite
      * @param int $idFailure
      */
-    public function deleteTrackingFailure($idSite, $idFailure)
+    public function deleteTrackingFailure(int $idSite, $idFailure)
     {
-        $idSite = (int) $idSite;
         Piwik::checkUserHasAdminAccess($idSite);
 
         $this->trackingFailures->deleteTrackingFailure($idSite, $idFailure);
@@ -285,7 +284,7 @@ class API extends \Piwik\Plugin\API
      * @throws \Piwik\Exception\UnexpectedWebsiteFoundException
      * @internal
      */
-    public function archiveReports($idSite, $period, $date, $segment = false, $plugin = false, $report = false)
+    public function archiveReports(int $idSite, $period, $date, $segment = false, $plugin = false, $report = false)
     {
         if (\Piwik\API\Request::getRootApiRequestMethod() === 'CoreAdminHome.archiveReports') {
             Piwik::checkUserHasSuperUserAccess();

--- a/plugins/CustomDimensions/API.php
+++ b/plugins/CustomDimensions/API.php
@@ -48,7 +48,7 @@ class API extends \Piwik\Plugin\API
      * @return DataTable|DataTable\Map
      * @throws \Exception
      */
-    public function getCustomDimension($idDimension, $idSite, $period, $date, $segment = false, $expanded = false, $flat = false, $idSubtable = false)
+    public function getCustomDimension($idDimension, int $idSite, $period, $date, $segment = false, $expanded = false, $flat = false, $idSubtable = false)
     {
         Piwik::checkUserHasViewAccess($idSite);
 
@@ -96,7 +96,7 @@ class API extends \Piwik\Plugin\API
      * @return int Returns the ID of the configured dimension. Note that the same idDimension will be used for different websites.
      * @throws \Exception
      */
-    public function configureNewCustomDimension($idSite, $name, $scope, $active, $extractions = array(), $caseSensitive = true)
+    public function configureNewCustomDimension(int $idSite, $name, $scope, $active, $extractions = array(), $caseSensitive = true)
     {
         Piwik::checkUserHasWriteAccess($idSite);
 
@@ -150,7 +150,7 @@ class API extends \Piwik\Plugin\API
      * @param int|bool|null $caseSensitive  '0' if extractions should be applied case insensitive, '1' if extractions should be applied case sensitive, null to keep case sensitive unchanged
      * @throws \Exception
      */
-    public function configureExistingCustomDimension($idDimension, $idSite, $name, $active, $extractions = array(), $caseSensitive = null)
+    public function configureExistingCustomDimension($idDimension, int $idSite, $name, $active, $extractions = array(), $caseSensitive = null)
     {
         Piwik::checkUserHasWriteAccess($idSite);
 
@@ -185,7 +185,7 @@ class API extends \Piwik\Plugin\API
      * @param int $idSite
      * @return array
      */
-    public function getConfiguredCustomDimensions($idSite)
+    public function getConfiguredCustomDimensions(int $idSite)
     {
         Piwik::checkUserHasViewAccess($idSite);
 
@@ -198,7 +198,7 @@ class API extends \Piwik\Plugin\API
      * For convenience. Hidden to reduce API surface area.
      * @hide
      */
-    public function getConfiguredCustomDimensionsHavingScope($idSite, $scope)
+    public function getConfiguredCustomDimensionsHavingScope(int $idSite, $scope)
     {
         $result = $this->getConfiguredCustomDimensions($idSite);
         $result = array_filter($result, function ($row) use ($scope) {
@@ -236,7 +236,7 @@ class API extends \Piwik\Plugin\API
      * @param int $idSite
      * @return array
      */
-    public function getAvailableScopes($idSite)
+    public function getAvailableScopes(int $idSite)
     {
         Piwik::checkUserHasViewAccess($idSite);
 

--- a/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getGoal.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_abandonedCartWithoutConversions__Goals.getGoal.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<success message="ok" />
+	<error message="Please specify a value for 'idGoal'.
+ 
+ --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
 </result>

--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -99,7 +99,7 @@ class API extends \Piwik\Plugin\API
             // note: the reason this is secure is because the above cache is a static cache and cleared after each request
             // if we were to use a different cache that persists the result, this would not be secure because when a
             // result is in the cache, it would just return the result
-            $idSite = Site::getIdSitesFromIdSitesString($idSite);
+            $idSite = Site::getIdSitesFromIdSitesString($idSite, false, true);
 
             if (empty($idSite)) {
                 return [];

--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -61,11 +61,9 @@ class API extends \Piwik\Plugin\API
     /**
      * Return a single goal.
      *
-     * @param int $idSite
-     * @param int $idGoal
      * @return ?array An array of goal attributes.
      */
-    public function getGoal($idSite, $idGoal)
+    public function getGoal(int $idSite, int $idGoal): ?array
     {
         Piwik::checkUserHasViewAccess($idSite);
 
@@ -74,6 +72,8 @@ class API extends \Piwik\Plugin\API
         if (!empty($goal)) {
             return $this->formatGoal($goal);
         }
+
+        return null;
     }
 
     /**
@@ -171,7 +171,7 @@ class API extends \Piwik\Plugin\API
      * @return int ID of the new goal
      */
     public function addGoal(
-        $idSite,
+        int $idSite,
         $name,
         $matchAttribute,
         $pattern,
@@ -239,7 +239,7 @@ class API extends \Piwik\Plugin\API
      * @see addGoal() for parameters description
      */
     public function updateGoal(
-        $idSite,
+        int $idSite,
         $idGoal,
         $name,
         $matchAttribute,
@@ -359,7 +359,7 @@ class API extends \Piwik\Plugin\API
      *
      * @return void
      */
-    public function deleteGoal($idSite, $idGoal)
+    public function deleteGoal(int $idSite, $idGoal)
     {
         Piwik::checkUserHasWriteAccess($idSite);
 

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -158,7 +158,7 @@ class API extends \Piwik\Plugin\API
     public function getLastVisitsDetails($idSite, $period = false, $date = false, $segment = false, $countVisitorsToFetch = false, $minTimestamp = false, $flat = false, $doNotFetchActions = false, $enhanced = false)
     {
         Piwik::checkUserHasViewAccess($idSite);
-        $idSites = Site::getIdSitesFromIdSitesString($idSite);
+        $idSites = Site::getIdSitesFromIdSitesString($idSite, false, true);
         if (is_array($idSites) && count($idSites) === 1) {
             $idSites = array_shift($idSites);
         }

--- a/plugins/Overlay/API.php
+++ b/plugins/Overlay/API.php
@@ -25,7 +25,7 @@ class API extends \Piwik\Plugin\API
     /**
      * Get translation strings
      */
-    public function getTranslations($idSite)
+    public function getTranslations(int $idSite)
     {
         $translations = array(
             'oneClick'         => 'Overlay_OneClick',
@@ -44,7 +44,7 @@ class API extends \Piwik\Plugin\API
      * @deprecated use SitesManager.getExcludedQueryParameters instead
      * @todo Remove in Matomo 6
      */
-    public function getExcludedQueryParameters($idSite)
+    public function getExcludedQueryParameters(int $idSite)
     {
         return Request::processRequest('SitesManager.getExcludedQueryParameters');
     }
@@ -56,7 +56,7 @@ class API extends \Piwik\Plugin\API
      * Note: if you use this method via the regular API, the number of results will be limited.
      * Make sure, you set filter_limit=-1 in the request.
      */
-    public function getFollowingPages($url, $idSite, $period, $date, $segment = false)
+    public function getFollowingPages($url, int $idSite, $period, $date, $segment = false)
     {
         $url = PageUrl::excludeQueryParametersFromUrl($url, $idSite);
         // we don't unsanitize $url here. it will be done in the Transitions plugin.

--- a/plugins/Overlay/API.php
+++ b/plugins/Overlay/API.php
@@ -25,7 +25,7 @@ class API extends \Piwik\Plugin\API
     /**
      * Get translation strings
      */
-    public function getTranslations(int $idSite)
+    public function getTranslations()
     {
         $translations = array(
             'oneClick'         => 'Overlay_OneClick',

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -116,6 +116,10 @@ class API extends \Piwik\Plugin\API
          * are disabled.
          */
         foreach ($siteIds as $siteId) {
+            if (!Piwik::isUserHasViewAccess($siteId)) {
+                continue;
+            }
+
             $isVisitorProfileEnabled = Live::isVisitorProfileEnabled($siteId);
 
             if ($isVisitorProfileEnabled) {

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -107,7 +107,7 @@ class API extends \Piwik\Plugin\API
             return [];
         }
 
-        $siteIds = Site::getIdSitesFromIdSitesString($idSite);
+        $siteIds = Site::getIdSitesFromIdSitesString($idSite, false, true);
         $siteIdsWithVisitorLogsOrProfilesEnabled = [];
 
         /*
@@ -189,7 +189,7 @@ class API extends \Piwik\Plugin\API
         if ($idSites === 'all' || empty($idSites)) {
             $idSites = null; // all websites
         } else {
-            $idSites = Site::getIdSitesFromIdSitesString($idSites);
+            $idSites = Site::getIdSitesFromIdSitesString($idSites, false, true);
         }
         $requester = Piwik::getCurrentUserLogin();
         $this->logDataAnonymizations->scheduleEntry(

--- a/plugins/Referrers/API.php
+++ b/plugins/Referrers/API.php
@@ -192,7 +192,7 @@ class API extends \Piwik\Plugin\API
 
     private function checkSingleSite($idSite, string $method): void
     {
-        $idSites = Site::getIdSitesFromIdSitesString($idSite);
+        $idSites = Site::getIdSitesFromIdSitesString($idSite, false, true);
 
         if (count($idSites) > 1 || 'all' === $idSite) {
             throw new Exception("Referrers.$method with multiple sites is not supported (yet).");

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -295,7 +295,7 @@ class API extends \Piwik\Plugin\API
      * @param int $idSite
      * @return array
      */
-    public function getSiteFromId($idSite)
+    public function getSiteFromId(int $idSite)
     {
         Piwik::checkUserHasViewAccess($idSite);
 
@@ -322,7 +322,7 @@ class API extends \Piwik\Plugin\API
      * @param int $idSite
      * @return array list of URLs
      */
-    public function getSiteUrlsFromId($idSite)
+    public function getSiteUrlsFromId(int $idSite)
     {
         Piwik::checkUserHasViewAccess($idSite);
         return $this->getModel()->getSiteUrlsFromId($idSite);
@@ -404,7 +404,7 @@ class API extends \Piwik\Plugin\API
 
         if ($fetchAliasUrls) {
             foreach ($sites as &$site) {
-                $site['alias_urls'] = $this->getSiteUrlsFromId($site['idsite']);
+                $site['alias_urls'] = $this->getSiteUrlsFromId((int) $site['idsite']);
             }
         }
 
@@ -868,7 +868,7 @@ class API extends \Piwik\Plugin\API
         return $coreProperties;
     }
 
-    public function getSiteSettings($idSite)
+    public function getSiteSettings(int $idSite)
     {
         Piwik::checkUserHasAdminAccess($idSite);
 
@@ -1034,7 +1034,7 @@ class API extends \Piwik\Plugin\API
      * @param array|string $urls When calling API via HTTP specify multiple URLs via `&urls[]=http...&urls[]=http...`.
      * @return int the number of inserted URLs
      */
-    public function addSiteAliasUrls($idSite, $urls)
+    public function addSiteAliasUrls(int $idSite, $urls)
     {
         Piwik::checkUserHasAdminAccess($idSite);
 
@@ -1068,7 +1068,7 @@ class API extends \Piwik\Plugin\API
      *
      * @return int the number of inserted URLs
      */
-    public function setSiteAliasUrls($idSite, $urls = [])
+    public function setSiteAliasUrls(int $idSite, $urls = [])
     {
         Piwik::checkUserHasAdminAccess($idSite);
 
@@ -1235,7 +1235,7 @@ class API extends \Piwik\Plugin\API
      *
      * @return array list of urls/hosts
      */
-    public function getExcludedReferrers($idSite)
+    public function getExcludedReferrers(int $idSite)
     {
         Piwik::checkUserHasViewAccess($idSite);
 

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -1635,7 +1635,7 @@ class API extends \Piwik\Plugin\API
      */
     public function updateSiteCreatedTime($idSites, Date $minDate)
     {
-        $idSites = Site::getIdSitesFromIdSitesString($idSites);
+        $idSites = Site::getIdSitesFromIdSitesString($idSites, false, true);
         Piwik::checkUserHasAdminAccess($idSites);
 
         $minDateSql = $minDate->subDay(1)->getDatetime();

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -574,7 +574,7 @@ class ApiTest extends IntegrationTestCase
      */
     public function testGetSiteFromIdWithWrongIdThrowsException2()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(\TypeError::class);
         API::getInstance()->getSiteFromId("x1");
     }
 

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -723,7 +723,7 @@ class API extends \Piwik\Plugin\API
      *
      * @return bool
      */
-    public function isPeriodAllowed(int $idSite, $period, $date): bool
+    public function isPeriodAllowed($idSite, $period, $date): bool
     {
         $maxPeriodAllowed = Transitions::getPeriodAllowedConfig($idSite);
         if ($maxPeriodAllowed === 'all') {

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -36,12 +36,12 @@ use Piwik\Tracker\TableLogAction;
  */
 class API extends \Piwik\Plugin\API
 {
-    public function getTransitionsForPageTitle(string $pageTitle, $idSite, $period, $date, $segment = false, $limitBeforeGrouping = 0)
+    public function getTransitionsForPageTitle(string $pageTitle, int $idSite, $period, $date, $segment = false, $limitBeforeGrouping = 0)
     {
         return $this->getTransitionsForAction($pageTitle, 'title', $idSite, $period, $date, $segment, $limitBeforeGrouping);
     }
 
-    public function getTransitionsForPageUrl(string $pageUrl, $idSite, $period, $date, $segment = false, $limitBeforeGrouping = 0)
+    public function getTransitionsForPageUrl(string $pageUrl, int $idSite, $period, $date, $segment = false, $limitBeforeGrouping = 0)
     {
         return $this->getTransitionsForAction($pageUrl, 'url', $idSite, $period, $date, $segment, $limitBeforeGrouping);
     }
@@ -63,7 +63,7 @@ class API extends \Piwik\Plugin\API
     public function getTransitionsForAction(
         string $actionName,
         string $actionType,
-        $idSite,
+        int $idSite,
         $period,
         $date,
         $segment = false,
@@ -723,7 +723,7 @@ class API extends \Piwik\Plugin\API
      *
      * @return bool
      */
-    public function isPeriodAllowed($idSite, $period, $date): bool
+    public function isPeriodAllowed(int $idSite, $period, $date): bool
     {
         $maxPeriodAllowed = Transitions::getPeriodAllowedConfig($idSite);
         if ($maxPeriodAllowed === 'all') {

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -93,7 +93,7 @@ class API extends \Piwik\Plugin\API
         $period = Period\Factory::build($period, $date);
         $segment = new Segment(
             $segment,
-            $idSite,
+            [$idSite],
             $period->getDateTimeStart()->setTimezone($site->getTimezone()),
             $period->getDateTimeEnd()->setTimezone($site->getTimezone())
         );

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -353,7 +353,7 @@ class API extends \Piwik\Plugin\API
      *                                   Filtering by 'superuser' is only allowed for other superusers.
      * @return array
      */
-    public function getUsersPlusRole($idSite, $limit = null, $offset = 0, $filter_search = null, $filter_access = null, $filter_status = null)
+    public function getUsersPlusRole(int $idSite, $limit = null, $offset = 0, $filter_search = null, $filter_access = null, $filter_status = null)
     {
         if (Piwik::isUserIsAnonymous()) {
             // anonymous user should never see any results.
@@ -550,7 +550,7 @@ class API extends \Piwik\Plugin\API
      *                        ...
      *                    )
      */
-    public function getUsersAccessFromSite($idSite)
+    public function getUsersAccessFromSite(int $idSite)
     {
         Piwik::checkUserHasAdminAccess($idSite);
 
@@ -560,7 +560,7 @@ class API extends \Piwik\Plugin\API
         return $usersAccess;
     }
 
-    public function getUsersWithSiteAccess($idSite, $access)
+    public function getUsersWithSiteAccess(int $idSite, $access)
     {
         Piwik::checkUserHasAdminAccess($idSite);
         $this->checkAccessType($access);

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1373,7 +1373,7 @@ class API extends \Piwik\Plugin\API
             $idSites = \Piwik\Plugins\SitesManager\API::getInstance()->getSitesIdWithAdminAccess();
         } else {
             // in case the idSites is an integer we build an array
-            $idSites = Site::getIdSitesFromIdSitesString($idSites);
+            $idSites = Site::getIdSitesFromIdSitesString($idSites, false, true);
         }
 
         if (empty($idSites)) {

--- a/plugins/VisitFrequency/API.php
+++ b/plugins/VisitFrequency/API.php
@@ -48,7 +48,7 @@ class API extends \Piwik\Plugin\API
 
         $columns = Piwik::getArrayFromApiParameter($columns);
 
-        if ($idSite === 'all' || count(Site::getIdSitesFromIdSitesString($idSite)) > 1) {
+        if ($idSite === 'all' || count(Site::getIdSitesFromIdSitesString($idSite, false, true)) > 1) {
             $resultSet = new DataTable\Map();
             $resultSet->setKeyName('idSite');
         } elseif (Period::isMultiplePeriod($date, $period)) {

--- a/tests/PHPUnit/Integration/SiteTest.php
+++ b/tests/PHPUnit/Integration/SiteTest.php
@@ -102,7 +102,7 @@ class SiteTest extends IntegrationTestCase
     {
         yield "negative int value" => ['1,-1'];
         yield "zero value" => ['1,0'];
-        yield "boolean value" => true;
+        yield "boolean value" => [true];
         yield "float value" => ['1,2.5'];
         yield "string value" => ['1,foo'];
     }

--- a/tests/PHPUnit/Integration/SiteTest.php
+++ b/tests/PHPUnit/Integration/SiteTest.php
@@ -88,16 +88,23 @@ class SiteTest extends IntegrationTestCase
         $this->assertSame([1, 2], $result);
     }
 
-    public function testGetIdSitesFromIdSitesStringThrowsOnInvalidWhenStrict()
+    /**
+     * @dataProvider getInvalidIdSiteStrings
+     */
+    public function testGetIdSitesFromIdSitesStringThrowsOnInvalidWhenStrict($idSites)
     {
         $this->expectException(BadRequestException::class);
-        Site::getIdSitesFromIdSitesString('1,foo', false, true);
+        Site::getIdSitesFromIdSitesString($idSites, false, true);
     }
 
-    public function testGetIdSitesFromIdSitesStringThrowsOnBoolWhenStrict()
+
+    public function getInvalidIdSiteStrings(): iterable
     {
-        $this->expectException(BadRequestException::class);
-        Site::getIdSitesFromIdSitesString(true, false, true);
+        yield "negative int value" => ['1,-1'];
+        yield "zero value" => ['1,0'];
+        yield "boolean value" => true;
+        yield "float value" => ['1,2.5'];
+        yield "string value" => ['1,foo'];
     }
 
     private function makeSite($idSite)

--- a/tests/PHPUnit/Integration/SiteTest.php
+++ b/tests/PHPUnit/Integration/SiteTest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Tests\Integration;
 
+use Piwik\Http\BadRequestException;
 use Piwik\Piwik;
 use Piwik\Plugins\SitesManager\API;
 use Piwik\Site;
@@ -73,6 +74,30 @@ class SiteTest extends IntegrationTestCase
 
         $this->assertSame('Piwik test' . $this->siteAppendix, $site->getName());
         $this->assertSame(array(), Site::getSites()); // make sure data was not fetched again
+    }
+
+    public function testGetIdSitesFromIdSitesStringFiltersInvalidByDefault()
+    {
+        $result = Site::getIdSitesFromIdSitesString('1,foo,2,,0,-3');
+        $this->assertSame([1, 2], $result);
+    }
+
+    public function testGetIdSitesFromIdSitesStringAllowsValidIdsWhenStrict()
+    {
+        $result = Site::getIdSitesFromIdSitesString([1, '2'], false, true);
+        $this->assertSame([1, 2], $result);
+    }
+
+    public function testGetIdSitesFromIdSitesStringThrowsOnInvalidWhenStrict()
+    {
+        $this->expectException(BadRequestException::class);
+        Site::getIdSitesFromIdSitesString('1,foo', false, true);
+    }
+
+    public function testGetIdSitesFromIdSitesStringThrowsOnBoolWhenStrict()
+    {
+        $this->expectException(BadRequestException::class);
+        Site::getIdSitesFromIdSitesString(true, false, true);
     }
 
     private function makeSite($idSite)

--- a/tests/PHPUnit/System/VisitsInPastInvalidateOldReportsTest.php
+++ b/tests/PHPUnit/System/VisitsInPastInvalidateOldReportsTest.php
@@ -82,7 +82,7 @@ class VisitsInPastInvalidateOldReportsTest extends SystemTestCase
 
         // 1) Invalidate old reports for the 2 websites
         // Test invalidate 1 date only
-        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=4,5,6',1&dates=2010-01-03");
+        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=4,5,6&dates=2010-01-03");
         $this->assertApiResponseHasNoError($r->process());
 
         // Test invalidate comma separated dates

--- a/tests/PHPUnit/System/VisitsInPastInvalidateOldReportsTest.php
+++ b/tests/PHPUnit/System/VisitsInPastInvalidateOldReportsTest.php
@@ -82,7 +82,7 @@ class VisitsInPastInvalidateOldReportsTest extends SystemTestCase
 
         // 1) Invalidate old reports for the 2 websites
         // Test invalidate 1 date only
-        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=4,5,6,-1,s',1&dates=2010-01-03");
+        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=4,5,6',1&dates=2010-01-03");
         $this->assertApiResponseHasNoError($r->process());
 
         // Test invalidate comma separated dates

--- a/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:70be8474d7e951ebbd2f2c9d5c9387f938f0c2e4bf87ecae5c579ef60459973b
-size 5081865
+oid sha256:dcb8fb595d91f42748fef54cbad3749dfbde5760f23963c6044bbf7d1d6f091b
+size 5080887

--- a/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b469c0f6ec944bbcf602d51d1c96d0deb139fec66da8afc9484c54d01855bd65
-size 5074821
+oid sha256:70be8474d7e951ebbd2f2c9d5c9387f938f0c2e4bf87ecae5c579ef60459973b
+size 5081865


### PR DESCRIPTION
### Description

Hardened idSite handling across plugin APIs by enforcing strict parsing where multi‑site lists are used and tightening single‑site method signatures.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
