### PR TITLE
Hide segmented visits log for empty page action values

### DIFF
--- a/plugins/Actions/DataTable/Filter/Actions.php
+++ b/plugins/Actions/DataTable/Filter/Actions.php
@@ -89,14 +89,16 @@ class Actions extends BaseFilter
                             $row->setMetadata('segment', 'pageTitle=^' . urlencode(urlencode(trim($label))));
                         } else {
                             if (trim($label) == $notDefinedTitle) {
-                                $row->setMetadata('segmentValue', '');
+                                // segmenting by an "empty" value is currently broken for actions, so we do not set a segment value to hide row actions like segmented visit log
+                                $row->setMetadata('segment', null);
                             } else {
                                 $row->setMetadata('segmentValue', urlencode(trim($label)));
                             }
                         }
                     } elseif ($this->actionType == Action::TYPE_PAGE_URL && $urlPrefix) { // folder for older data w/ no folder URL metadata
                         if ($label === $notDefinedUrl) {
-                            $row->setMetadata('segmentValue', '');
+                            // segmenting by an "empty" value is currently broken for actions, so we do not set a segment value to hide row actions like segmented visit log
+                            $row->setMetadata('segment', null);
                         } else {
                             $row->setMetadata('segment', 'pageUrl=^' . urlencode(urlencode($urlPrefix . '/' . $label)));
                         }

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageTitles_month.xml
@@ -19,7 +19,7 @@
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
-		<segment>pageTitle==</segment>
+		<segment />
 	</row>
 	<row>
 		<label> 301/URL = http://example.hello.com/Topic/hw43061</label>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageTitles_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageTitles_range.xml
@@ -39,7 +39,7 @@
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
-		<segment>pageTitle==</segment>
+		<segment />
 	</row>
 	<row>
 		<label> Liberate Web Analytics - Analytics - Piwik</label>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
@@ -237,7 +237,7 @@
 		</result>
 		<result prettyDate="Monday, January 4, 2010">
 			<row>
-				<segment>pageTitle==</segment>
+				<segment />
 			</row>
 		</result>
 		<result prettyDate="Tuesday, January 5, 2010">

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
@@ -251,7 +251,7 @@
 		<result prettyDate="Monday, January 4, 2010">
 			<row>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result prettyDate="Tuesday, January 5, 2010">
@@ -265,7 +265,7 @@
 			</row>
 			<row>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result prettyDate="Wednesday, January 6, 2010">
@@ -279,7 +279,7 @@
 			</row>
 			<row>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result prettyDate="Thursday, January 7, 2010">
@@ -293,7 +293,7 @@
 			</row>
 			<row>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result prettyDate="Friday, January 8, 2010">
@@ -307,7 +307,7 @@
 			</row>
 			<row>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result prettyDate="Saturday, January 9, 2010">
@@ -321,7 +321,7 @@
 			</row>
 			<row>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 	</reportMetadata>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_day.xml
@@ -67,7 +67,7 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
-				<segment>pageTitle==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2010-01-05">
@@ -773,7 +773,7 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
-				<segment>pageTitle==</segment>
+				<segment />
 			</row>
 			<row>
 				<label> Website 2 page view</label>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_month.xml
@@ -219,7 +219,7 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
-				<segment>pageTitle==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2010-02" />
@@ -270,7 +270,7 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
-				<segment>pageTitle==</segment>
+				<segment />
 			</row>
 			<row>
 				<label> Website 2 page view</label>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_week.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_week.xml
@@ -221,7 +221,7 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
-				<segment>pageTitle==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2010-01-11,2010-01-17">
@@ -403,7 +403,7 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
-				<segment>pageTitle==</segment>
+				<segment />
 			</row>
 			<row>
 				<label> Website 2 page view</label>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_year.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageTitles_year.xml
@@ -219,7 +219,7 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
-				<segment>pageTitle==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2011" />
@@ -270,7 +270,7 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
-				<segment>pageTitle==</segment>
+				<segment />
 			</row>
 			<row>
 				<label> Website 2 page view</label>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_day.xml
@@ -118,7 +118,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2010-01-05">
@@ -253,7 +253,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2010-01-06">
@@ -388,7 +388,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2010-01-07">
@@ -523,7 +523,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2010-01-08">
@@ -658,7 +658,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2010-01-09">
@@ -793,7 +793,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 	</result>
@@ -889,7 +889,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2010-01-05" />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_month.xml
@@ -91,7 +91,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 			<row>
 				<label>/thankyou</label>
@@ -285,7 +285,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2010-02" />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_week.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_week.xml
@@ -142,7 +142,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 			<row>
 				<label>/index.htm</label>
@@ -368,7 +368,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2010-01-18,2010-01-24" />
@@ -468,7 +468,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2010-01-11,2010-01-17" />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_year.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_year.xml
@@ -91,7 +91,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 			<row>
 				<label>/thankyou</label>
@@ -285,7 +285,7 @@
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url />
-				<segment>pageUrl==</segment>
+				<segment />
 			</row>
 		</result>
 		<result date="2011" />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_day.xml
@@ -66,7 +66,7 @@
 			<avg_time_on_page>0</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
-			<segment>pageTitle==</segment>
+			<segment />
 		</row>
 	</result>
 	<result date="2010-01-05">

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_month.xml
@@ -218,7 +218,7 @@
 			<avg_time_on_page>0</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
-			<segment>pageTitle==</segment>
+			<segment />
 		</row>
 	</result>
 	<result date="2010-02" />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_week.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_week.xml
@@ -220,7 +220,7 @@
 			<avg_time_on_page>0</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
-			<segment>pageTitle==</segment>
+			<segment />
 		</row>
 	</result>
 	<result date="2010-01-11,2010-01-17">

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_year.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageTitles_year.xml
@@ -218,7 +218,7 @@
 			<avg_time_on_page>0</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
-			<segment>pageTitle==</segment>
+			<segment />
 		</row>
 	</result>
 	<result date="2011" />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_day.xml
@@ -117,7 +117,7 @@
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
 			<url />
-			<segment>pageUrl==</segment>
+			<segment />
 		</row>
 	</result>
 	<result date="2010-01-05">
@@ -252,7 +252,7 @@
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
 			<url />
-			<segment>pageUrl==</segment>
+			<segment />
 		</row>
 	</result>
 	<result date="2010-01-06">
@@ -387,7 +387,7 @@
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
 			<url />
-			<segment>pageUrl==</segment>
+			<segment />
 		</row>
 	</result>
 	<result date="2010-01-07">
@@ -522,7 +522,7 @@
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
 			<url />
-			<segment>pageUrl==</segment>
+			<segment />
 		</row>
 	</result>
 	<result date="2010-01-08">
@@ -657,7 +657,7 @@
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
 			<url />
-			<segment>pageUrl==</segment>
+			<segment />
 		</row>
 	</result>
 	<result date="2010-01-09">
@@ -792,7 +792,7 @@
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
 			<url />
-			<segment>pageUrl==</segment>
+			<segment />
 		</row>
 	</result>
 </results>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_month.xml
@@ -90,7 +90,7 @@
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
 			<url />
-			<segment>pageUrl==</segment>
+			<segment />
 		</row>
 		<row>
 			<label>/thankyou</label>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_week.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_week.xml
@@ -141,7 +141,7 @@
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
 			<url />
-			<segment>pageUrl==</segment>
+			<segment />
 		</row>
 		<row>
 			<label>/index.htm</label>
@@ -367,7 +367,7 @@
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
 			<url />
-			<segment>pageUrl==</segment>
+			<segment />
 		</row>
 	</result>
 	<result date="2010-01-18,2010-01-24" />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_year.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_year.xml
@@ -90,7 +90,7 @@
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>0%</exit_rate>
 			<url />
-			<segment>pageUrl==</segment>
+			<segment />
 		</row>
 		<row>
 			<label>/thankyou</label>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata_pageTitleZeroString__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata_pageTitleZeroString__Actions.getPageTitles_day.xml
@@ -15,6 +15,6 @@
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
-		<segment>pageTitle==</segment>
+		<segment />
 	</row>
 </result>


### PR DESCRIPTION
### Description

Segment for action without a value (e.g. Page URL not defined, Page Name not defined) currently do not work due to our database structure. Therefor the segmented visits log is always empty.

Not setting the `segmentValue` in the API prevents the row action icon to appear.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
