### PR TITLE
Update DDEV config to support v1.25.0 (Debian Trixie)

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -14,7 +14,7 @@ hooks:
         - exec: MYSQL_PWD=root mysql -uroot -e "GRANT ALL PRIVILEGES ON *.* to 'db'@'%'"
           service: db
         - exec-host: ddev matomo:init
-webimage_extra_packages: [build-essential, chromium, default-jre, fonts-dejavu, fonts-liberation, gconf-service, imagemagick, imagemagick-doc, libappindicator1, libasound2, libatk1.0-0, libcairo2, libdrm2, libgbm1, libgconf-2-4, libgdk-pixbuf2.0-0, libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libpangocairo-1.0-0, libx11-xcb1, libxcomposite1, libxcursor1, libxdamage1, libxfixes3, libxi6, libxrandr2, libxrender1, libxshmfence1, libxss1, libxtst6, ripgrep, ttf-mscorefonts-installer, xdg-utils]
+webimage_extra_packages: [build-essential, chromium, default-jre, fonts-dejavu, fonts-liberation, imagemagick, imagemagick-doc, libasound2, libatk1.0-0, libcairo2, libdrm2, libgbm1, libgdk-pixbuf-2.0-0, libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libpangocairo-1.0-0, libx11-xcb1, libxcomposite1, libxcursor1, libxdamage1, libxfixes3, libxi6, libxrandr2, libxrender1, libxshmfence1, libxss1, libxtst6, ripgrep, ttf-mscorefonts-installer, xdg-utils]
 use_dns_when_possible: true
 composer_version: "2"
 web_environment:


### PR DESCRIPTION
### Description

The recent [DDEV 1.25.0](https://ddev.com/blog/release-v1250/) release switch from Debian Bookworm to Debian Trixie.

In our base setup there are some packages that prevent starting with the new base image:

- longer available: `gconf-service`, `libgconf-2-4`
- renamed: `libgdk-pixbuf2.0-0 => libgdk-pixbuf-2.0-0`
- unused: `libappindicator1`

From some limited tests they seem to be safe to remove (or rename) for both a `1.24.10` base image, and the newer Trixie release.

Local switch can be done by pinning a base image:

```
# .ddev/config.local.yaml
webimage: ddev/ddev-webserver:v1.24.10
webimage: ddev/ddev-webserver:v1.25.0
```

And should then be visible in the PHPUnit runtime banner:

```
Runtime:       PHP 7.2.34-55+0~20250707.109+debian12~1.gbp140deb
Runtime:       PHP 7.2.34-59+0~20251218.111+debian13~1.gbp637f71
```

Only did some baseline tests with some PHPUnit and some UI tests. Both versions seemed to work just fine with the updated package list.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
