### PR TITLE
Add centralized conflict validation in AuthenticationToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 
 ## Matomo 5.8.0
 
+### Breaking Changes
+* API requests that provide conflicting authentication values for `token_auth` or `force_api_session` across request sources (for example GET and POST) now fail with `400 Bad Request` instead of applying precedence.
+
 ### New config.ini.php settings
 * `API_bulk_request_limit` sets the maximum number of URLs allowed in `API.getBulkRequest` for authenticated users (-1 disables the limit).
 

--- a/core/Request/AuthenticationToken.php
+++ b/core/Request/AuthenticationToken.php
@@ -9,6 +9,9 @@
 
 namespace Piwik\Request;
 
+use Piwik\API\Request as ApiRequest;
+use Piwik\Http\BadRequestException;
+use Piwik\Piwik;
 use Piwik\Request;
 use Piwik\SettingsServer;
 
@@ -17,12 +20,21 @@ use Piwik\SettingsServer;
  */
 class AuthenticationToken
 {
+    /** @var string */
     protected $authToken = '';
+    /** @var bool */
     protected $wasTokenProvidedSecurely = false;
+    /** @var bool */
     protected $isSessionToken = false;
+    /** @var bool */
+    protected $isConflictingAuthValidationDone = false;
+    /** @var bool */
+    protected $isJsonRequestBodyTokenLoaded = false;
+    /** @var string|null */
+    protected $jsonRequestBodyTokenAuth = null;
 
     /**
-     * @param array|null $request
+     * @param array<string, mixed>|null $request
      * @return string
      */
     public function getAuthToken(?array $request = null): string
@@ -56,13 +68,83 @@ class AuthenticationToken
 
     private function detectToken(): void
     {
+        $this->validateNoConflictingAuthParameters();
         $this->initTokenFromHeader() || $this->initTokenFromJsonRequestBody() || $this->initTokenFromPostRequest() || $this->initTokenFromGetRequest();
+    }
+
+    private function validateNoConflictingAuthParameters(): void
+    {
+        if ($this->isConflictingAuthValidationDone || $this->shouldSkipConflictingAuthValidation()) {
+            return;
+        }
+
+        $this->isConflictingAuthValidationDone = true;
+
+        $tokenAuthBySource = [];
+        $forceApiSessionBySource = [];
+
+        $headerTokenAuth = $this->getTokenAuthFromHeader();
+        if (!empty($headerTokenAuth)) {
+            $tokenAuthBySource['header'] = $headerTokenAuth;
+        }
+
+        $jsonTokenAuth = $this->getTokenAuthFromJsonRequestBody();
+        if (!empty($jsonTokenAuth)) {
+            $tokenAuthBySource['json'] = $jsonTokenAuth;
+        }
+
+        $post = Request::fromPost();
+        $postTokenAuth = $post->getStringParameter('token_auth', '');
+        if (!empty($postTokenAuth)) {
+            $tokenAuthBySource['post'] = $postTokenAuth;
+        }
+
+        if (array_key_exists('force_api_session', $_POST)) {
+            $forceApiSessionBySource['post'] = $post->getBoolParameter('force_api_session', false);
+        }
+
+        $get = Request::fromGet();
+        $getTokenAuth = $get->getStringParameter('token_auth', '');
+        if (!empty($getTokenAuth)) {
+            $tokenAuthBySource['get'] = $getTokenAuth;
+        }
+
+        if (array_key_exists('force_api_session', $_GET)) {
+            $forceApiSessionBySource['get'] = $get->getBoolParameter('force_api_session', false);
+        }
+
+        $this->throwIfValuesConflict($tokenAuthBySource);
+        $this->throwIfValuesConflict($forceApiSessionBySource);
+    }
+
+    private function shouldSkipConflictingAuthValidation(): bool
+    {
+        return ApiRequest::isRootRequestApiRequest() && !ApiRequest::isCurrentApiRequestTheRootApiRequest();
+    }
+
+    /**
+     * @param array<string, bool|string> $valuesBySource
+     */
+    private function throwIfValuesConflict(array $valuesBySource): void
+    {
+        if (count($valuesBySource) < 2) {
+            return;
+        }
+
+        $firstValue = array_shift($valuesBySource);
+        foreach ($valuesBySource as $value) {
+            if ($value !== $firstValue) {
+                throw new BadRequestException(Piwik::translate('General_ConflictingAuthenticationParametersProvided'));
+            }
+        }
     }
 
     private function initTokenFromHeader(): bool
     {
-        if (!empty($_SERVER['HTTP_AUTHORIZATION']) && strpos($_SERVER['HTTP_AUTHORIZATION'], 'Bearer ') === 0) {
-            $this->authToken = substr($_SERVER['HTTP_AUTHORIZATION'], 7);
+        $tokenAuth = $this->getTokenAuthFromHeader();
+
+        if ($tokenAuth !== null) {
+            $this->authToken = $tokenAuth;
             $this->wasTokenProvidedSecurely = true;
             return true;
         }
@@ -72,20 +154,11 @@ class AuthenticationToken
 
     private function initTokenFromJsonRequestBody(): bool
     {
-        // Token in JSON request body is only support for tracking requests
-        if (!SettingsServer::isTrackerApiRequest()) {
-            return false;
-        }
-
-        $requestBody = file_get_contents('php://input');
-        if (!empty($requestBody) && strpos($requestBody, '{') === 0) {
-            $jsonContent = json_decode($requestBody, true);
-
-            if (!empty($jsonContent['token_auth']) && is_string($jsonContent['token_auth'])) {
-                $this->authToken = $jsonContent['token_auth'];
-                $this->wasTokenProvidedSecurely = true;
-                return true;
-            }
+        $tokenAuth = $this->getTokenAuthFromJsonRequestBody();
+        if (!empty($tokenAuth)) {
+            $this->authToken = $tokenAuth;
+            $this->wasTokenProvidedSecurely = true;
+            return true;
         }
 
         return false;
@@ -119,5 +192,40 @@ class AuthenticationToken
         }
 
         return false;
+    }
+
+    private function getTokenAuthFromHeader(): ?string
+    {
+        if (!empty($_SERVER['HTTP_AUTHORIZATION']) && strpos($_SERVER['HTTP_AUTHORIZATION'], 'Bearer ') === 0) {
+            return substr($_SERVER['HTTP_AUTHORIZATION'], 7);
+        }
+
+        return null;
+    }
+
+    private function getTokenAuthFromJsonRequestBody(): ?string
+    {
+        if ($this->isJsonRequestBodyTokenLoaded) {
+            return $this->jsonRequestBodyTokenAuth;
+        }
+
+        $this->isJsonRequestBodyTokenLoaded = true;
+        $this->jsonRequestBodyTokenAuth = null;
+
+        // Token in JSON request body is only supported for tracking requests
+        if (!SettingsServer::isTrackerApiRequest()) {
+            return null;
+        }
+
+        $requestBody = file_get_contents('php://input');
+        if (!empty($requestBody) && strpos($requestBody, '{') === 0) {
+            $jsonContent = json_decode($requestBody, true);
+
+            if (is_array($jsonContent) && !empty($jsonContent['token_auth']) && is_string($jsonContent['token_auth'])) {
+                $this->jsonRequestBodyTokenAuth = $jsonContent['token_auth'];
+            }
+        }
+
+        return $this->jsonRequestBodyTokenAuth;
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -121,6 +121,7 @@
         "ComplianceCNILWarning": "<b>Compliance cannot be guaranteed with the use of third-party plugins.</b>",
         "ComplianceCNILUnknownSettingOptOutTitle": "Opt out",
         "ComplianceCNILUnknownSettingOptOutNotes": "Opt out must be manually set up and configured. %1$sLearn more%2$s",
+        "ConflictingAuthenticationParametersProvided": "Conflicting authentication parameters provided.",
         "ComputedMetricAverage": "Avg. %1$s per %2$s",
         "ComputedMetricAverageDocumentation": "Average value of \"%1$s\" per \"%2$s\".",
         "ComputedMetricAverageShortDocumentation": "Average value of \"%1$s\".",

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -11,7 +11,6 @@ namespace Piwik\Plugins\PrivacyManager;
 
 use Exception;
 use Piwik\API\Request;
-use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 use Piwik\Config as PiwikConfig;
@@ -24,6 +23,7 @@ use Piwik\Plugins\PrivacyManager\Model\DataSubjects;
 use Piwik\Plugins\PrivacyManager\Dao\LogDataAnonymizer;
 use Piwik\Plugins\PrivacyManager\Model\LogDataAnonymizations;
 use Piwik\Plugins\PrivacyManager\Validators\VisitsDataSubject;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Policy\CompliancePolicy;
 use Piwik\Policy\PolicyManager;
 use Piwik\Site;
@@ -587,7 +587,7 @@ class API extends \Piwik\Plugin\API
 
         Piwik::checkUserHasSuperUserAccess();
 
-        if (Common::getRequestVar('force_api_session', 0)) {
+        if (StaticContainer::get(AuthenticationToken::class)->isSessionToken()) {
             $this->confirmCurrentUserPassword($passwordConfirmation);
         }
 

--- a/plugins/PrivacyManager/tests/Integration/ApiTest.php
+++ b/plugins/PrivacyManager/tests/Integration/ApiTest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\PrivacyManager\tests\Integration;
 
+use Exception;
 use Piwik\Access;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
@@ -103,6 +104,55 @@ class ApiTest extends IntegrationTestCase
 
         $complianceStatus = $this->api->getComplianceStatus($this->siteId, $complianceType);
         $this->assertTrue($complianceStatus['complianceModeEnforced']);
+    }
+
+    public function testSetComplianceStatusDoesNotRequirePasswordWhenPostSessionFlagIsZeroEvenIfGetFlagIsOne(): void
+    {
+        $container = StaticContainer::getContainer();
+        $container->get(Config::class)->FeatureFlags = ['PrivacyCompliance_feature' => 'enabled'];
+
+        $_GET['force_api_session'] = 1;
+        $_POST['token_auth'] = 'postToken';
+        $_POST['force_api_session'] = 0;
+
+        try {
+            $result = $this->api->setComplianceStatus(
+                (string) $this->siteId,
+                'cnil_v1',
+                true
+            );
+
+            $this->assertTrue($result);
+        } finally {
+            unset($_GET['force_api_session']);
+            unset($_POST['token_auth']);
+            unset($_POST['force_api_session']);
+        }
+    }
+
+    public function testSetComplianceStatusRequiresPasswordWhenPostSessionFlagIsOneEvenIfGetFlagIsZero(): void
+    {
+        $container = StaticContainer::getContainer();
+        $container->get(Config::class)->FeatureFlags = ['PrivacyCompliance_feature' => 'enabled'];
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('UsersManager_ConfirmWithReAuthentication');
+
+        $_GET['force_api_session'] = 0;
+        $_POST['token_auth'] = 'postToken';
+        $_POST['force_api_session'] = 1;
+
+        try {
+            $this->api->setComplianceStatus(
+                (string) $this->siteId,
+                'cnil_v1',
+                true
+            );
+        } finally {
+            unset($_GET['force_api_session']);
+            unset($_POST['token_auth']);
+            unset($_POST['force_api_session']);
+        }
     }
 
     public function provideContainerConfig()

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -26,6 +26,7 @@ use Piwik\Measurable\Type\TypeManager;
 use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugin\SettingsProvider;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Plugins\CorePluginsAdmin\SettingsMetadata;
 use Piwik\Plugins\FeatureFlags\FeatureFlagManager;
 use Piwik\Plugins\PrivacyManager\FeatureFlags\PrivacyCompliance;
@@ -922,7 +923,7 @@ class API extends \Piwik\Plugin\API
         Piwik::checkUserHasSuperUserAccess();
         SitesManager::dieIfSitesAdminIsDisabled();
 
-        if (Common::getRequestVar('force_api_session', 0)) {
+        if (StaticContainer::get(AuthenticationToken::class)->isSessionToken()) {
             $this->confirmCurrentUserPassword($passwordConfirmation);
         }
 

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -1221,6 +1221,46 @@ class ApiTest extends IntegrationTestCase
         $this->assertHasSite($siteId2);
     }
 
+    public function testDeleteSiteDoesNotRequirePasswordWhenPostSessionFlagIsZeroEvenIfGetFlagIsOne()
+    {
+        $this->addSite();
+        $siteId1 = $this->addSite();
+
+        $_GET['force_api_session'] = 1;
+        $_POST['token_auth'] = 'postToken';
+        $_POST['force_api_session'] = 0;
+
+        try {
+            API::getInstance()->deleteSite($siteId1);
+            $this->assertHasNotSite($siteId1);
+        } finally {
+            unset($_GET['force_api_session']);
+            unset($_POST['token_auth']);
+            unset($_POST['force_api_session']);
+        }
+    }
+
+    public function testDeleteSiteRequiresPasswordWhenPostSessionFlagIsOneEvenIfGetFlagIsZero()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ConfirmWithReAuthentication');
+
+        $this->addSite();
+        $siteId1 = $this->addSite();
+
+        $_GET['force_api_session'] = 0;
+        $_POST['token_auth'] = 'postToken';
+        $_POST['force_api_session'] = 1;
+
+        try {
+            API::getInstance()->deleteSite($siteId1);
+        } finally {
+            unset($_GET['force_api_session']);
+            unset($_POST['token_auth']);
+            unset($_POST['force_api_session']);
+        }
+    }
+
     public function testDeleteShouldTriggerAnEventOnceSiteWasActuallyDeleted()
     {
         $called = 0;

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -1223,8 +1223,10 @@ class ApiTest extends IntegrationTestCase
 
     public function testDeleteSiteDoesNotRequirePasswordWhenPostSessionFlagIsZeroEvenIfGetFlagIsOne()
     {
-        $this->addSite();
-        $siteId1 = $this->addSite();
+        $siteId0 = API::getInstance()->addSite('website 1', ['http://piwik.net']);
+        $siteId1 = API::getInstance()->addSite('website 2', ['http://piwik.com/test/']);
+        self::assertIsInt($siteId0);
+        self::assertIsInt($siteId1);
 
         $_GET['force_api_session'] = 1;
         $_POST['token_auth'] = 'postToken';
@@ -1245,8 +1247,10 @@ class ApiTest extends IntegrationTestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('UsersManager_ConfirmWithReAuthentication');
 
-        $this->addSite();
-        $siteId1 = $this->addSite();
+        $siteId0 = API::getInstance()->addSite('website 1', ['http://piwik.net']);
+        $siteId1 = API::getInstance()->addSite('website 2', ['http://piwik.com/test/']);
+        self::assertIsInt($siteId0);
+        self::assertIsInt($siteId1);
 
         $_GET['force_api_session'] = 0;
         $_POST['token_auth'] = 'postToken';

--- a/plugins/TwoFactorAuth/TwoFactorAuth.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuth.php
@@ -15,6 +15,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\Exception\NoPrivilegesException;
 use Piwik\FrontController;
 use Piwik\Piwik;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Plugins\TwoFactorAuth\Dao\RecoveryCodeDao;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\Session;
@@ -248,7 +249,7 @@ class TwoFactorAuth extends \Piwik\Plugin
                 if (!Request::isRootRequestApiRequest()) {
                     $module = 'TwoFactorAuth';
                     $action = 'loginTwoFactorAuth';
-                } elseif (Common::getRequestVar('force_api_session', 0) == 1) {
+                } elseif (StaticContainer::get(AuthenticationToken::class)->isSessionToken()) {
                     // don't allow API requests with session auth if 2fa code hasn't been verified.
                     throw new Exception(Piwik::translate('General_YourSessionHasExpired'));
                 }

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -31,7 +31,7 @@ use Piwik\Plugins\UsersManager\Emails\UserInfoChangedEmail;
 use Piwik\Plugins\UsersManager\Repository\UserRepository;
 use Piwik\Plugins\UsersManager\Validators\AllowedEmailDomain;
 use Piwik\Plugins\UsersManager\Validators\Email;
-use Piwik\Request;
+use Piwik\Request\AuthenticationToken;
 use Piwik\SettingsPiwik;
 use Piwik\Site;
 use Piwik\Tracker\Cache;
@@ -753,7 +753,7 @@ class API extends \Piwik\Plugin\API
         UsersManager::dieIfUsersAdminIsDisabled();
 
         // check password confirmation only when using session auth
-        if (Common::getRequestVar('force_api_session', 0)) {
+        if (StaticContainer::get(AuthenticationToken::class)->isSessionToken()) {
             $this->confirmCurrentUserPassword($passwordConfirmation);
         }
 
@@ -802,7 +802,7 @@ class API extends \Piwik\Plugin\API
         UsersManager::dieIfUsersAdminIsDisabled();
 
         // check password confirmation only when using session auth
-        if (Common::getRequestVar('force_api_session', 0)) {
+        if (StaticContainer::get(AuthenticationToken::class)->isSessionToken()) {
             $this->confirmCurrentUserPassword($passwordConfirmation);
         }
 
@@ -1021,7 +1021,7 @@ class API extends \Piwik\Plugin\API
         UsersManager::dieIfUsersAdminIsDisabled();
         $this->checkUserIsNotAnonymous($userLogin);
 
-        if (Common::getRequestVar('force_api_session', 0)) {
+        if (StaticContainer::get(AuthenticationToken::class)->isSessionToken()) {
             $this->confirmCurrentUserPassword($passwordConfirmation);
         }
 
@@ -1145,7 +1145,11 @@ class API extends \Piwik\Plugin\API
         $idSites = $this->getIdSitesCheckAdminAccess($idSites);
 
         // check password confirmation only when using session auth and setting view access for anonymous user
-        if ($userLogin === 'anonymous' && Request::fromRequest()->getBoolParameter('force_api_session', false) && $access === 'view') {
+        if (
+            $userLogin === 'anonymous'
+            && StaticContainer::get(AuthenticationToken::class)->isSessionToken()
+            && $access === 'view'
+        ) {
             $this->confirmCurrentUserPassword($passwordConfirmation);
         }
 
@@ -1642,7 +1646,7 @@ class API extends \Piwik\Plugin\API
         Piwik::checkUserHasSomeAdminAccess();
 
         // check password confirmation only when using session auth
-        if (Common::getRequestVar('force_api_session', 0)) {
+        if (StaticContainer::get(AuthenticationToken::class)->isSessionToken()) {
             $this->confirmCurrentUserPassword($passwordConfirmation);
         }
 
@@ -1687,7 +1691,7 @@ class API extends \Piwik\Plugin\API
         Piwik::checkUserHasSomeAdminAccess();
 
         // check password confirmation only when using session auth
-        if (Common::getRequestVar('force_api_session', 0)) {
+        if (StaticContainer::get(AuthenticationToken::class)->isSessionToken()) {
             $this->confirmCurrentUserPassword($passwordConfirmation);
         }
 

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -1127,11 +1127,47 @@ class APITest extends IntegrationTestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('UsersManager_ConfirmWithReAuthentication');
 
+        $_GET['token_auth'] = 'anyToken';
         $_GET['force_api_session'] = 1;
         try {
             $this->api->setUserAccess('anonymous', 'view', [1]);
         } finally {
+            unset($_GET['token_auth']);
             unset($_GET['force_api_session']);
+        }
+    }
+
+    public function testAddUserDoesNotRequirePasswordWhenPostSessionFlagIsZeroEvenIfGetFlagIsOne()
+    {
+        $_GET['force_api_session'] = 1;
+        $_POST['token_auth'] = 'postToken';
+        $_POST['force_api_session'] = 0;
+
+        try {
+            $this->api->addUser('collisionUser', 'password', 'collision@example.com');
+            self::assertTrue($this->model->userExists('collisionUser'));
+        } finally {
+            unset($_GET['force_api_session']);
+            unset($_POST['token_auth']);
+            unset($_POST['force_api_session']);
+        }
+    }
+
+    public function testAddUserRequiresPasswordWhenPostSessionFlagIsOneEvenIfGetFlagIsZero()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ConfirmWithReAuthentication');
+
+        $_GET['force_api_session'] = 0;
+        $_POST['token_auth'] = 'postToken';
+        $_POST['force_api_session'] = 1;
+
+        try {
+            $this->api->addUser('collisionUser2', 'password', 'collision2@example.com');
+        } finally {
+            unset($_GET['force_api_session']);
+            unset($_POST['token_auth']);
+            unset($_POST['force_api_session']);
         }
     }
 

--- a/tests/PHPUnit/Integration/API/RequestTest.php
+++ b/tests/PHPUnit/Integration/API/RequestTest.php
@@ -12,8 +12,10 @@ namespace Piwik\Tests\Integration\API;
 use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\AuthResult;
+use Piwik\Cache;
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Piwik;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use ReflectionClass;
@@ -264,6 +266,57 @@ class RequestTest extends IntegrationTestCase
         Request::checkTokenAuthIsNotLimited('SomePlugin', 'someMethod');
     }
 
+    public function testProcessThrowsIfForceApiSessionConflictsBetweenGetAndPost()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(Piwik::translate('General_ConflictingAuthenticationParametersProvided'));
+
+        $_GET['force_api_session'] = 1;
+        $_POST['force_api_session'] = 0;
+
+        try {
+            $request = new Request(['method' => 'API.getPiwikVersion', 'format' => 'original']);
+            $request->process();
+        } finally {
+            unset($_GET['force_api_session']);
+            unset($_POST['force_api_session']);
+        }
+    }
+
+    public function testProcessThrowsIfTokenAuthConflictsBetweenGetAndPost()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(Piwik::translate('General_ConflictingAuthenticationParametersProvided'));
+
+        $_GET['token_auth'] = 'tokenGet';
+        $_POST['token_auth'] = 'tokenPost';
+
+        try {
+            $request = new Request(['method' => 'API.getPiwikVersion', 'format' => 'original']);
+            $request->process();
+        } finally {
+            unset($_GET['token_auth']);
+            unset($_POST['token_auth']);
+        }
+    }
+
+    public function testProcessDoesNotThrowConflictingForceApiSessionWhenNestedApiInvocation()
+    {
+        $_GET['force_api_session'] = 1;
+        $_POST['force_api_session'] = 0;
+        $this->setNestedApiInvocationCount(2);
+
+        try {
+            $request = new Request(['method' => 'API.getPiwikVersion', 'format' => 'original']);
+            $result = $request->process();
+            $this->assertNotEmpty($result);
+        } finally {
+            unset($_GET['force_api_session']);
+            unset($_POST['force_api_session']);
+            $this->setNestedApiInvocationCount(0);
+        }
+    }
+
     private function assertSameUserAsBeforeIsAuthenticated()
     {
         $this->assertEquals($this->userAuthToken, $this->access->getTokenAuth());
@@ -324,6 +377,20 @@ class RequestTest extends IntegrationTestCase
         $mock->reloadAccess($auth);
 
         return $mock;
+    }
+
+    private function setNestedApiInvocationCount(int $count): void
+    {
+        $reflection = new ReflectionClass(Request::class);
+        $reflectionProperty = $reflection->getProperty('nestedApiInvocationCount');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue(null, $count);
+
+        if ($count > 0) {
+            Request::setIsRootRequestApiRequest('API.getPiwikVersion');
+        } else {
+            Cache::getTransientCache()->delete('API.setIsRootRequestApiRequest');
+        }
     }
 
     public function provideContainerConfig()

--- a/tests/PHPUnit/Unit/Request/AuthenticationToken.php
+++ b/tests/PHPUnit/Unit/Request/AuthenticationToken.php
@@ -9,6 +9,8 @@
 
 namespace Piwik\Tests\Unit\Request;
 
+use Piwik\Cache;
+
 class AuthenticationToken extends \PHPUnit\Framework\TestCase
 {
     public function tearDown(): void
@@ -16,6 +18,8 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
         parent::tearDown();
         $_GET = $_POST = [];
         unset($_SERVER['HTTP_AUTHORIZATION']);
+        $this->setNestedApiInvocationCount(0);
+        Cache::getTransientCache()->delete('API.setIsRootRequestApiRequest');
     }
 
     /**
@@ -86,7 +90,7 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
         ];
 
         yield 'token in POST request overwrites GET token' => [
-            ['token_auth' => 'randomGetAccessToken'],
+            ['token_auth' => 'randomPostAccessToken'],
             ['token_auth' => 'randomPostAccessToken'],
             null,
             null,
@@ -96,7 +100,7 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
         ];
 
         yield 'token in POST request overwrites GET session token' => [
-            ['token_auth' => 'randomGetAccessToken', 'force_api_session' => 1],
+            ['token_auth' => 'randomPostAccessToken', 'force_api_session' => 1],
             ['token_auth' => 'randomPostAccessToken'],
             null,
             null,
@@ -106,7 +110,7 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
         ];
 
         yield 'token in header overwrites GET token' => [
-            ['token_auth' => 'randomGetAccessToken'],
+            ['token_auth' => 'randomHeaderAccessToken'],
             [],
             'Bearer randomHeaderAccessToken',
             null,
@@ -116,7 +120,7 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
         ];
 
         yield 'token in header overwrites GET session token' => [
-            ['token_auth' => 'randomGetAccessToken', 'force_api_session' => 1],
+            ['token_auth' => 'randomHeaderAccessToken', 'force_api_session' => 1],
             [],
             'Bearer randomHeaderAccessToken',
             null,
@@ -127,7 +131,7 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
 
         yield 'token in header overwrites POST token' => [
             [],
-            ['token_auth' => 'randomPostAccessToken'],
+            ['token_auth' => 'randomHeaderAccessToken'],
             'Bearer randomHeaderAccessToken',
             null,
             'randomHeaderAccessToken',
@@ -137,7 +141,7 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
 
         yield 'token in header overwrites POST session token' => [
             [],
-            ['token_auth' => 'randomPostAccessToken', 'force_api_session' => 1],
+            ['token_auth' => 'randomHeaderAccessToken', 'force_api_session' => 1],
             'Bearer randomHeaderAccessToken',
             null,
             'randomHeaderAccessToken',
@@ -146,8 +150,8 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
         ];
 
         yield 'token in header overwrites GET and POST token' => [
-            ['token_auth' => 'randomGetAccessToken'],
-            ['token_auth' => 'randomPostAccessToken'],
+            ['token_auth' => 'randomHeaderAccessToken'],
+            ['token_auth' => 'randomHeaderAccessToken'],
             'Bearer randomHeaderAccessToken',
             null,
             'randomHeaderAccessToken',
@@ -156,8 +160,8 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
         ];
 
         yield 'token in header overwrites GET session and POST token' => [
-            ['token_auth' => 'randomGetAccessToken', 'force_api_session' => 1],
-            ['token_auth' => 'randomPostAccessToken'],
+            ['token_auth' => 'randomHeaderAccessToken', 'force_api_session' => 1],
+            ['token_auth' => 'randomHeaderAccessToken'],
             'Bearer randomHeaderAccessToken',
             null,
             'randomHeaderAccessToken',
@@ -166,8 +170,8 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
         ];
 
         yield 'token in header overwrites GET and POST session token' => [
-            ['token_auth' => 'randomGetAccessToken'],
-            ['token_auth' => 'randomPostAccessToken', 'force_api_session' => 1],
+            ['token_auth' => 'randomHeaderAccessToken'],
+            ['token_auth' => 'randomHeaderAccessToken', 'force_api_session' => 1],
             'Bearer randomHeaderAccessToken',
             null,
             'randomHeaderAccessToken',
@@ -176,8 +180,8 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
         ];
 
         yield 'token in header overwrites GET session and POST session token' => [
-            ['token_auth' => 'randomGetAccessToken', 'force_api_session' => 1],
-            ['token_auth' => 'randomPostAccessToken', 'force_api_session' => 1],
+            ['token_auth' => 'randomHeaderAccessToken', 'force_api_session' => 1],
+            ['token_auth' => 'randomHeaderAccessToken', 'force_api_session' => 1],
             'Bearer randomHeaderAccessToken',
             null,
             'randomHeaderAccessToken',
@@ -195,5 +199,122 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
             false, // secure
             false, // no session token
         ];
+    }
+
+    /**
+     * @dataProvider provideConflictingAuthParametersData
+     */
+    public function testGetAuthenticationTokenThrowsOnConflictingAuthParameters(array $getParams, array $postParams, ?string $authorizationHeader)
+    {
+        $this->expectException(\Piwik\Http\BadRequestException::class);
+        $this->expectExceptionCode(400);
+
+        $_GET = $getParams;
+        $_POST = $postParams;
+        $_SERVER['HTTP_AUTHORIZATION'] = $authorizationHeader;
+
+        $token = new \Piwik\Request\AuthenticationToken();
+        $token->getAuthToken();
+    }
+
+    public function provideConflictingAuthParametersData(): iterable
+    {
+        yield 'conflicting token_auth between GET and POST' => [
+            ['token_auth' => 'randomGetAccessToken'],
+            ['token_auth' => 'randomPostAccessToken'],
+            null,
+        ];
+
+        yield 'conflicting token_auth between header and GET' => [
+            ['token_auth' => 'randomGetAccessToken'],
+            [],
+            'Bearer randomHeaderAccessToken',
+        ];
+
+        yield 'conflicting token_auth between header and POST' => [
+            [],
+            ['token_auth' => 'randomPostAccessToken'],
+            'Bearer randomHeaderAccessToken',
+        ];
+
+        yield 'conflicting token_auth between header and GET/POST' => [
+            ['token_auth' => 'sameRequestToken'],
+            ['token_auth' => 'sameRequestToken'],
+            'Bearer randomHeaderAccessToken',
+        ];
+
+        yield 'conflicting force_api_session without token_auth on both sources' => [
+            ['force_api_session' => 1],
+            ['force_api_session' => 0],
+            null,
+        ];
+
+        yield 'conflicting force_api_session when token_auth only provided in one source' => [
+            ['token_auth' => 'randomGetAccessToken', 'force_api_session' => 1],
+            ['force_api_session' => 0],
+            null,
+        ];
+    }
+
+    /**
+     * @dataProvider provideConflictingAuthParametersForNestedApiRequestData
+     */
+    public function testGetAuthenticationTokenDoesNotThrowOnConflictingAuthForNestedApiRequest(
+        array $getParams,
+        array $postParams,
+        ?string $authorizationHeader,
+        string $expectedToken,
+        bool $expectedSessionToken
+    ) {
+        $this->setNestedApiInvocationCount(2);
+
+        $_GET = $getParams;
+        $_POST = $postParams;
+        $_SERVER['HTTP_AUTHORIZATION'] = $authorizationHeader;
+
+        $token = new \Piwik\Request\AuthenticationToken();
+        self::assertEquals($expectedToken, $token->getAuthToken());
+        self::assertSame($expectedSessionToken, $token->isSessionToken());
+    }
+
+    public function provideConflictingAuthParametersForNestedApiRequestData(): iterable
+    {
+        yield 'conflicting token_auth and force_api_session between GET and POST' => [
+            ['token_auth' => 'randomGetAccessToken', 'force_api_session' => 1],
+            ['token_auth' => 'randomPostAccessToken', 'force_api_session' => 0],
+            null,
+            'randomPostAccessToken',
+            false,
+        ];
+
+        yield 'conflicting token_auth including header and conflicting force_api_session' => [
+            ['token_auth' => 'randomGetAccessToken', 'force_api_session' => 1],
+            ['token_auth' => 'randomPostAccessToken', 'force_api_session' => 0],
+            'Bearer randomHeaderAccessToken',
+            'randomHeaderAccessToken',
+            false,
+        ];
+
+        yield 'force_api_session conflict only keeps POST session state in nested requests' => [
+            ['token_auth' => 'sameToken', 'force_api_session' => 0],
+            ['token_auth' => 'sameToken', 'force_api_session' => 1],
+            null,
+            'sameToken',
+            true,
+        ];
+    }
+
+    private function setNestedApiInvocationCount(int $count): void
+    {
+        $reflectionClass = new \ReflectionClass(\Piwik\API\Request::class);
+        $reflectionProperty = $reflectionClass->getProperty('nestedApiInvocationCount');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue(null, $count);
+
+        if ($count > 0) {
+            \Piwik\API\Request::setIsRootRequestApiRequest('API.getPiwikVersion');
+        } else {
+            Cache::getTransientCache()->delete('API.setIsRootRequestApiRequest');
+        }
     }
 }


### PR DESCRIPTION
### Description



### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
