### PR TITLE
Force scroll to top to stop flaky test

### DIFF
--- a/plugins/UsersManager/tests/UI/UsersManager_spec.js
+++ b/plugins/UsersManager/tests/UI/UsersManager_spec.js
@@ -448,6 +448,7 @@ describe("UsersManager", function () {
         });
         await page.waitForNetworkIdle();
         await page.waitForTimeout(250); // animation
+        await page.evaluate(() => window.scrollTo(0, 0));
 
         expect(await page.screenshotSelector('.usersManager')).to.matchImage({
             imageName: 'permissions_bulk_access_set_all',


### PR DESCRIPTION
### Description

This test is a bit flaky, here are some runs below of it not being flaky anymore.

**Before change:**

https://builds-artifacts.matomo.org/matomo-org/matomo/5.x-dev/21834911632/

**After change:**

Run no1 https://github.com/matomo-org/matomo/actions/runs/21931573923/job/63336437610?pr=24075#step:3:1766
Run no2 https://github.com/matomo-org/matomo/actions/runs/21931573923/job/63339700051?pr=24075#step:3:1764
Run no3 https://github.com/matomo-org/matomo/actions/runs/21931573923/job/63347989618?pr=24075#step:3:1763

If it fails again after this PR I will just re-evaluate if we can change what its testing.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
