### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -706,12 +706,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/referrer-spam-list.git",
-                "reference": "09bc14923ebac69c00fb928f9a8a5a8563f861a6"
+                "reference": "3e30189a3243690ee523bb434644029160c1e4d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/09bc14923ebac69c00fb928f9a8a5a8563f861a6",
-                "reference": "09bc14923ebac69c00fb928f9a8a5a8563f861a6",
+                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/3e30189a3243690ee523bb434644029160c1e4d7",
+                "reference": "3e30189a3243690ee523bb434644029160c1e4d7",
                 "shasum": ""
             },
             "replace": {
@@ -729,7 +729,7 @@
                 "issues": "https://github.com/matomo-org/referrer-spam-list/issues",
                 "source": "https://github.com/matomo-org/referrer-spam-list/tree/master"
             },
-            "time": "2025-12-02T03:59:19+00:00"
+            "time": "2026-02-09T20:17:13+00:00"
         },
         {
             "name": "matomo/searchengine-and-social-list",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
                                                      Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading matomo/referrer-spam-list (dev-master 09bc149 => dev-master 3e30189)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downloading matomo/referrer-spam-list (dev-master 3e30189)
  - Upgrading matomo/referrer-spam-list (dev-master 09bc149 => dev-master 3e30189): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
54 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.
```
