### PR TITLE
Use request arrays instead of query strings for Request class

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -54,8 +54,15 @@ use Piwik\Log\LoggerInterface;
  *
  * **Basic Usage**
  *
- *     $request = new Request('method=UserLanguage.getLanguage&idSite=1&date=yesterday&period=week'
- *                          . '&format=xml&filter_limit=5&filter_offset=0')
+ *     $request = new Request([
+ *         'method' => 'UserLanguage.getLanguage',
+ *         'idSite' => 1,
+ *         'date' => 'yesterday',
+ *         'period' => 'week',
+ *         'format' => 'xml',
+ *         'filter_limit' => 5,
+ *         'filter_offset' => 0,
+ *     ])
  *     $result = $request->process();
  *     echo $result;
  *

--- a/core/ReportRenderer.php
+++ b/core/ReportRenderer.php
@@ -262,13 +262,22 @@ abstract class ReportRenderer extends BaseFactory
             $imageGraphUrl = $reportMetadata['imageGraphEvolutionUrl'];
         }
 
-        $requestGraph = $imageGraphUrl .
-            '&outputType=' . API::GRAPH_OUTPUT_PHP .
-            '&format=original&serialize=0' .
-            '&filter_truncate=' .
-            '&width=' . $width .
-            '&height=' . $height .
-            ($segment != null ? '&segment=' . urlencode($segment['definition']) : '');
+        $queryString = Url::getQueryStringFromUrl($imageGraphUrl);
+        if (!is_string($queryString) || $queryString === '') {
+            $queryString = $imageGraphUrl;
+        }
+
+        $requestGraph = UrlHelper::getArrayFromQueryString($queryString);
+        $requestGraph['outputType'] = API::GRAPH_OUTPUT_PHP;
+        $requestGraph['format'] = 'original';
+        $requestGraph['serialize'] = 0;
+        $requestGraph['filter_truncate'] = '';
+        $requestGraph['width'] = $width;
+        $requestGraph['height'] = $height;
+
+        if ($segment != null) {
+            $requestGraph['segment'] = urlencode($segment['definition']);
+        }
 
         $request = new Request($requestGraph);
 

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -756,26 +756,28 @@ class API extends \Piwik\Plugin\API
     private function getSuggestedValuesForSegmentName($idSite, $segment, $maxSuggestionsToReturn)
     {
         $startDate = Date::now()->subDay(self::$_autoSuggestLookBack)->toString();
-        $requestLastVisits = "method=Live.getLastVisitsDetails
-        &idSite=$idSite
-        &period=range
-        &date=$startDate,today
-        &format=original
-        &serialize=0
-        &flat=1";
+        $requestLastVisits = [
+            'method' => 'Live.getLastVisitsDetails',
+            'idSite' => $idSite,
+            'period' => 'range',
+            'date' => $startDate . ',today',
+            'format' => 'original',
+            'serialize' => 0,
+            'flat' => 1,
+        ];
 
         $segmentName = $segment['segment'];
 
         // Select non empty fields only
         // Note: this optimization has only a very minor impact
-        $requestLastVisits .= "&segment=$segmentName" . urlencode('!=');
+        $requestLastVisits['segment'] = $segmentName . urlencode('!=');
 
         // By default Live fetches all actions for all visitors, but we'd rather do this only when required
         if ($this->doesSegmentNeedActionsData($segmentName)) {
-            $requestLastVisits .= "&filter_limit=400";
+            $requestLastVisits['filter_limit'] = 400;
         } else {
-            $requestLastVisits .= "&doNotFetchActions=1";
-            $requestLastVisits .= "&filter_limit=800";
+            $requestLastVisits['doNotFetchActions'] = 1;
+            $requestLastVisits['filter_limit'] = 800;
         }
 
         $request = new Request($requestLastVisits);

--- a/plugins/API/Controller.php
+++ b/plugins/API/Controller.php
@@ -33,8 +33,6 @@ class Controller extends \Piwik\Plugin\Controller
         $format = Common::getRequestVar('format', false);
         $serialize = Common::getRequestVar('serialize', false);
 
-        $token = 'token_auth=' . $tokenAuth;
-
         // when calling the API through http, we limit the number of returned results
         if (!isset($_GET['filter_limit'])) {
             if (isset($_POST['filter_limit'])) {
@@ -44,7 +42,9 @@ class Controller extends \Piwik\Plugin\Controller
             }
         }
 
-        $request  = new Request($token);
+        $request  = new Request([
+            'token_auth' => $tokenAuth,
+        ]);
         $response = $request->process();
 
         if (is_array($response)) {

--- a/plugins/API/tests/System/AutoSuggestAPITest.php
+++ b/plugins/API/tests/System/AutoSuggestAPITest.php
@@ -170,12 +170,12 @@ class AutoSuggestAPITest extends SystemTestCase
     public function testAnotherApi($api, $params)
     {
         // Get the top segment value
-        $request = new Request(
-            'method=API.getSuggestedValuesForSegment'
-            . '&segmentName=' . $params['segmentToComplete']
-            . '&idSite=' . $params['idSite']
-            . '&format=json'
-        );
+        $request = new Request([
+            'method' => 'API.getSuggestedValuesForSegment',
+            'segmentName' => $params['segmentToComplete'],
+            'idSite' => $params['idSite'],
+            'format' => 'json',
+        ]);
         $response = json_decode($request->process(), true);
         $this->assertApiResponseHasNoError($response);
         $topSegmentValue = @$response[0];

--- a/plugins/API/tests/System/GetSegmentsMetadataAPITest.php
+++ b/plugins/API/tests/System/GetSegmentsMetadataAPITest.php
@@ -19,13 +19,13 @@ class GetSegmentsMetadataAPITest extends SystemTestCase
 {
     public function testItContainsVisitidByDefault()
     {
-        $request = new Request(
-            'method=API.getSegmentsMetadata'
-            . '&filter_limit=-1'
-            . '&_hideImplementationData=0'
-            . '&format=json'
-            . '&module=API'
-        );
+        $request = new Request([
+            'method' => 'API.getSegmentsMetadata',
+            'filter_limit' => -1,
+            '_hideImplementationData' => 0,
+            'format' => 'json',
+            'module' => 'API',
+        ]);
 
         $response = json_decode($request->process(), true);
 
@@ -49,13 +49,13 @@ class GetSegmentsMetadataAPITest extends SystemTestCase
         $systemSettings->disableVisitorProfile->setValue(1);
         $systemSettings->save();
 
-        $request = new Request(
-            'method=API.getSegmentsMetadata'
-            . '&filter_limit=-1'
-            . '&_hideImplementationData=0'
-            . '&format=json'
-            . '&module=API'
-        );
+        $request = new Request([
+            'method' => 'API.getSegmentsMetadata',
+            'filter_limit' => -1,
+            '_hideImplementationData' => 0,
+            'format' => 'json',
+            'module' => 'API',
+        ]);
 
         $response = json_decode($request->process(), true);
 

--- a/plugins/Annotations/tests/System/AnnotationsTest.php
+++ b/plugins/Annotations/tests/System/AnnotationsTest.php
@@ -364,7 +364,7 @@ class AnnotationsTest extends SystemTestCase
         FakeAccess::$idSitesAdmin = $hasAdminAccess ? array(self::$fixture->idSite1) : array();
         FakeAccess::$idSitesView = $hasViewAccess ? array(self::$fixture->idSite1) : array();
 
-        $request = new Request($request . '&format=original');
+        $request = new Request(Request::getRequestArrayFromString($request . '&format=original'));
         $request->process();
     }
 

--- a/plugins/Ecommerce/Controller.php
+++ b/plugins/Ecommerce/Controller.php
@@ -78,7 +78,12 @@ class Controller extends \Piwik\Plugins\Goals\Controller
      */
     protected function getMetricsForGoal($idGoal, $dataRow = null)
     {
-        $request = new Request("method=Goals.get&format=original&format_metrics=0&idGoal=$idGoal");
+        $request = new Request([
+            'method' => 'Goals.get',
+            'format' => 'original',
+            'format_metrics' => 0,
+            'idGoal' => $idGoal,
+        ]);
         $datatable = $request->process();
         $dataRow = $datatable->getFirstRow();
 

--- a/plugins/Goals/Controller.php
+++ b/plugins/Goals/Controller.php
@@ -346,22 +346,24 @@ class Controller extends \Piwik\Plugin\Controller
                 $idGoalToProcess = AddColumnsProcessedMetricsGoal::GOALS_FULL_TABLE;
             }
 
-            $requestString = "method=$apiMethod
-                               &format=original
-                               &format_metrics=0
-                               &filter_update_columns_when_show_all_goals=1
-                               &idGoal=$idGoalToProcess
-                               &filter_sort_order=desc
-                               &filter_sort_column=$columnNbConversions
-                               &showColumns=label,$columnNbConversions,$columnConversionRate" .
-                               // select a couple more in case some are not valid (ie. conversions==0 or they are "Keyword not defined")
-                               "&filter_limit=" . (self::COUNT_TOP_ROWS_TO_DISPLAY + 2);
+            $requestParams = [
+                'method'                                 => $apiMethod,
+                'format'                                 => 'original',
+                'format_metrics'                         => 0,
+                'filter_update_columns_when_show_all_goals' => 1,
+                'idGoal'                                 => $idGoalToProcess,
+                'filter_sort_order'                      => 'desc',
+                'filter_sort_column'                     => $columnNbConversions,
+                'showColumns'                            => "label,$columnNbConversions,$columnConversionRate",
+                // select a couple more in case some are not valid (ie. conversions==0 or they are "Keyword not defined")
+                'filter_limit'                           => self::COUNT_TOP_ROWS_TO_DISPLAY + 2,
+            ];
 
             if ($apiMethod == 'Actions.getEntryPageUrls') {
-                $requestString .= '&flat=1';
+                $requestParams['flat'] = 1;
             }
 
-            $request = new Request($requestString);
+            $request = new Request($requestParams);
 
             $datatable = $request->process();
             $formatter = new Formatter();
@@ -395,7 +397,11 @@ class Controller extends \Piwik\Plugin\Controller
     protected function getMetricsForGoal($idGoal, $dataRow = null)
     {
         if (!$dataRow) {
-            $request = new Request("method=Goals.get&format=original&idGoal=$idGoal");
+            $request = new Request([
+                'method' => 'Goals.get',
+                'format' => 'original',
+                'idGoal' => $idGoal,
+            ]);
             $datatable = $request->process();
             $dataRow = $datatable->getFirstRow();
         }

--- a/plugins/Live/Controller.php
+++ b/plugins/Live/Controller.php
@@ -105,7 +105,14 @@ class Controller extends \Piwik\Plugin\Controller
         $error = '';
         $visitors = new DataTable();
         try {
-            $api = new Request("method=Live.getLastVisitsDetails&idSite={$this->idSite}&filter_limit=10&format=original&serialize=0&disable_generic_filters=1");
+            $api = new Request([
+                'method' => 'Live.getLastVisitsDetails',
+                'idSite' => $this->idSite,
+                'filter_limit' => 10,
+                'format' => 'original',
+                'serialize' => 0,
+                'disable_generic_filters' => 1,
+            ]);
             $visitors = $api->process();
         } catch (\Exception $e) {
             $error = $e->getMessage();

--- a/plugins/PrivacyManager/tests/System/PurgeDataTest.php
+++ b/plugins/PrivacyManager/tests/System/PurgeDataTest.php
@@ -165,37 +165,40 @@ class PurgeDataTest extends SystemTestCase
 
     private function assertNumVisits($expectedNumVisits, $period)
     {
-        $url = 'method=VisitsSummary.getVisits'
-             . '&idSite=' . self::$fixture->idSite
-             . '&date=' . self::$fixture->dateTime
-             . '&period=' . $period
-             . '&format=original';
-        $api   = new Request($url);
+        $api   = new Request([
+            'method' => 'VisitsSummary.getVisits',
+            'idSite' => self::$fixture->idSite,
+            'date' => self::$fixture->dateTime,
+            'period' => $period,
+            'format' => 'original',
+        ]);
         $table = $api->process();
         $this->assertEquals($expectedNumVisits, $table->getFirstRow()->getColumn('nb_visits'));
     }
 
     private function assertHasOneDownload($period)
     {
-        $api   = new Request($this->getDownloadApiRequestUrl($period));
+        $api   = new Request($this->getDownloadApiRequestParams($period));
         $table = $api->process();
         $this->assertEquals(1, $table->getRowsCount(), $period . ' should have one download but has not');
     }
 
     private function assertHasNoDownload($period)
     {
-        $api   = new Request($this->getDownloadApiRequestUrl($period));
+        $api   = new Request($this->getDownloadApiRequestParams($period));
         $table = $api->process();
         $this->assertEquals(0, $table->getRowsCount(), $period . ' should not have a download but has one');
     }
 
-    private function getDownloadApiRequestUrl($period)
+    private function getDownloadApiRequestParams($period)
     {
-        return 'method=Actions.getDownloads'
-             . '&idSite=' . self::$fixture->idSite
-             . '&date=' . self::$fixture->dateTime
-             . '&period=' . $period
-             . '&format=original';
+        return [
+            'method' => 'Actions.getDownloads',
+            'idSite' => self::$fixture->idSite,
+            'date' => self::$fixture->dateTime,
+            'period' => $period,
+            'format' => 'original',
+        ];
     }
 
     private function purgeData($deleteReportsOlderThan, $reportPeriodsToKeep, $keepBasicMetrics, $keepSegmentReports = false)

--- a/plugins/UserCountryMap/Controller.php
+++ b/plugins/UserCountryMap/Controller.php
@@ -65,15 +65,16 @@ class Controller extends \Piwik\Plugin\Controller
         $view = new View('@UserCountryMap/visitorMap');
 
         // request visits summary
-        $request = new Request(
-            'method=VisitsSummary.get&format=json'
-            . '&idSite=' . $this->idSite
-            . '&period=' . $period
-            . '&date=' . $date
-            . '&segment=' . $segment
-            . '&token_auth=' . $token_auth
-            . '&filter_limit=-1'
-        );
+        $request = new Request([
+            'method' => 'VisitsSummary.get',
+            'format' => 'json',
+            'idSite' => $this->idSite,
+            'period' => $period,
+            'date' => $date,
+            'segment' => $segment,
+            'token_auth' => $token_auth,
+            'filter_limit' => -1,
+        ]);
         $config = [];
         $config['visitsSummary'] = json_decode($request->process(), true);
         $config['countryDataUrl'] = $this->report(
@@ -310,15 +311,17 @@ class Controller extends \Piwik\Plugin\Controller
         #[\SensitiveParameter]
         $token_auth
     ) {
-        $request = new Request(
-            'method=API.getMetadata&format=json'
-            . '&apiModule=UserCountry&apiAction=getCountry'
-            . '&idSite=' . $idSite
-            . '&period=' . $period
-            . '&date=' . $date
-            . '&token_auth=' . $token_auth
-            . '&filter_limit=-1'
-        );
+        $request = new Request([
+            'method' => 'API.getMetadata',
+            'format' => 'json',
+            'apiModule' => 'UserCountry',
+            'apiAction' => 'getCountry',
+            'idSite' => $idSite,
+            'period' => $period,
+            'date' => $date,
+            'token_auth' => $token_auth,
+            'filter_limit' => -1,
+        ]);
         $metaData = json_decode($request->process(), true);
 
         $metrics = [];

--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -58,10 +58,12 @@ class Response
 
     public static function loadFromApi($params, $requestUrl, $normalize = true)
     {
-        $testRequest = new Request($requestUrl);
+        $requestParams = Request::getRequestArrayFromString($requestUrl, null);
+
+        $testRequest = new Request($requestParams, []);
 
         // set the request as root request
-        Request::setIsRootRequestApiRequest(Request::getMethodIfApiRequest(Request::getRequestArrayFromString($requestUrl, null)));
+        Request::setIsRootRequestApiRequest(Request::getMethodIfApiRequest($requestParams));
 
         // Cast as string is important. For example when calling
         // with format=original, objects or php arrays can be returned.
@@ -229,7 +231,7 @@ class Response
     private function removeXmlElement($input, $xmlElement, $testNotSmallAfter = true)
     {
         // Only raise error if there was some data before
-        $testNotSmallAfter = strlen($input > 100) && $testNotSmallAfter;
+        $testNotSmallAfter = strlen($input) > 100 && $testNotSmallAfter;
 
         $oldInput = $input;
         $input = preg_replace('/(<' . $xmlElement . '>.+?<\/' . $xmlElement . '>)/s', '', $input);

--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -58,7 +58,7 @@ class Response
 
     public static function loadFromApi($params, $requestUrl, $normalize = true)
     {
-        $requestParams = Request::getRequestArrayFromString($requestUrl, null);
+        $requestParams = Request::getRequestArrayFromString($requestUrl);
 
         $testRequest = new Request($requestParams, []);
 

--- a/tests/PHPUnit/System/ArchiveInvalidationTest.php
+++ b/tests/PHPUnit/System/ArchiveInvalidationTest.php
@@ -357,9 +357,12 @@ class ArchiveInvalidationTest extends SystemTestCase
         $dateToInvalidate1 = new \DateTime(self::$fixture->dateTimeFirstDateWebsite1);
 
         $r = new Request(
-            "module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=" . self::$fixture->idSite1 . "&dates=" . $dateToInvalidate1->format(
-                'Y-m-d'
-            )
+            [
+                'module' => 'API',
+                'method' => 'CoreAdminHome.invalidateArchivedReports',
+                'idSites' => self::$fixture->idSite1,
+                'dates' => $dateToInvalidate1->format('Y-m-d'),
+            ]
         );
         $this->assertApiResponseHasNoError($r->process());
 
@@ -373,7 +376,14 @@ class ArchiveInvalidationTest extends SystemTestCase
         $dates = new \DateTime($dateTime);
         $dates = $dates->format('Y-m-d');
         $r     = new Request(
-            "module=API&method=CoreAdminHome.invalidateArchivedReports&period=$period&idSites=$idSite&dates=$dates&cascadeDown=" . (int)$cascadeDown
+            [
+                'module' => 'API',
+                'method' => 'CoreAdminHome.invalidateArchivedReports',
+                'period' => $period,
+                'idSites' => $idSite,
+                'dates' => $dates,
+                'cascadeDown' => (int)$cascadeDown,
+            ]
         );
         $this->assertApiResponseHasNoError($r->process());
     }

--- a/tests/PHPUnit/System/VisitsInPastInvalidateOldReportsTest.php
+++ b/tests/PHPUnit/System/VisitsInPastInvalidateOldReportsTest.php
@@ -82,20 +82,41 @@ class VisitsInPastInvalidateOldReportsTest extends SystemTestCase
 
         // 1) Invalidate old reports for the 2 websites
         // Test invalidate 1 date only
-        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=4,5,6&dates=2010-01-03");
+        $r = new Request([
+            'module' => 'API',
+            'method' => 'CoreAdminHome.invalidateArchivedReports',
+            'idSites' => '4,5,6',
+            'dates' => '2010-01-03',
+        ]);
         $this->assertApiResponseHasNoError($r->process());
 
         // Test invalidate comma separated dates
-        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=" . $idSite . "," . $idSite2 . "&dates=2010-01-06,2009-10-30");
+        $r = new Request([
+            'module' => 'API',
+            'method' => 'CoreAdminHome.invalidateArchivedReports',
+            'idSites' => $idSite . ',' . $idSite2,
+            'dates' => '2010-01-06,2009-10-30',
+        ]);
         $this->assertApiResponseHasNoError($r->process());
 
         // test invalidate date in the past
         // Format=original will re-throw exception
-        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=" . $idSite2 . "&dates=2009-06-29&format=original");
+        $r = new Request([
+            'module' => 'API',
+            'method' => 'CoreAdminHome.invalidateArchivedReports',
+            'idSites' => $idSite2,
+            'dates' => '2009-06-29',
+            'format' => 'original',
+        ]);
         $this->assertApiResponseHasNoError($r->process());
 
         // invalidate a date more recent to check the date is only updated when it's earlier than current
-        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=" . $idSite2 . "&dates=2010-03-03");
+        $r = new Request([
+            'module' => 'API',
+            'method' => 'CoreAdminHome.invalidateArchivedReports',
+            'idSites' => $idSite2,
+            'dates' => '2010-03-03',
+        ]);
         $this->assertApiResponseHasNoError($r->process());
 
 
@@ -103,7 +124,14 @@ class VisitsInPastInvalidateOldReportsTest extends SystemTestCase
         $idSiteNoAccess = 777;
         try {
             FakeAccess::clearAccess();
-            $request = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=" . $idSiteNoAccess . "&dates=2010-03-03&format=original&token_auth=" . self::$fixture::VIEW_USER_TOKEN);
+            $request = new Request([
+                'module' => 'API',
+                'method' => 'CoreAdminHome.invalidateArchivedReports',
+                'idSites' => $idSiteNoAccess,
+                'dates' => '2010-03-03',
+                'format' => 'original',
+                'token_auth' => self::$fixture::VIEW_USER_TOKEN,
+            ]);
             $request->process();
             $this->fail('Invalidating archived reports with invalid idSite worked, but shouldn\'t');
         } catch (\PHPUnit\Framework\Exception $e) {
@@ -116,7 +144,14 @@ class VisitsInPastInvalidateOldReportsTest extends SystemTestCase
         // test an invalidate period parameter
         try {
             $invalidPeriod = "day,month";
-            $request = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&period=$invalidPeriod&idSites=$idSite&dates=2010-03-03&format=original");
+            $request = new Request([
+                'module' => 'API',
+                'method' => 'CoreAdminHome.invalidateArchivedReports',
+                'period' => $invalidPeriod,
+                'idSites' => $idSite,
+                'dates' => '2010-03-03',
+                'format' => 'original',
+            ]);
             $request->process();
             $this->fail('Invalidating archived reports with an invalid period worked, but shouldn\'t');
         } catch (\PHPUnit\Framework\Exception $e) {


### PR DESCRIPTION
### Description

Manually building query strings is error prone

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
