### PR TITLE
Remove invalid throws notations

### DIFF
--- a/core/QuickForm2.php
+++ b/core/QuickForm2.php
@@ -10,15 +10,13 @@
 namespace Piwik;
 
 use HTML_QuickForm2;
-use HTML_QuickForm2_InvalidArgumentException;
 use HTML_QuickForm2_Node;
-use HTML_QuickForm2_NotFoundException;
 use HTML_QuickForm2_Renderer;
 
 /**
  * Manages forms displayed in Twig
  *
- * For an example, @see Piwik\Plugins\Login\FormLogin
+ * For an example, @see \Piwik\Plugins\Login\FormLogin
  *
  * @see                 HTML_QuickForm2, libs/HTML/QuickForm2.php
  * @link https://pear.php.net/package/HTML_QuickForm2/
@@ -64,8 +62,6 @@ abstract class QuickForm2 extends HTML_QuickForm2
      * @param    mixed $attributes Element attributes
      * @param    array $data Element-specific data
      * @return   HTML_QuickForm2_Node     Added element
-     * @throws   HTML_QuickForm2_InvalidArgumentException
-     * @throws   HTML_QuickForm2_NotFoundException
      */
     public function addElement(
         $elementOrType,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1621,11 +1621,6 @@ parameters:
 			path: core/QuickForm2.php
 
 		-
-			message: "#^PHPDoc tag @throws with type HTML_QuickForm2_InvalidArgumentException\\|HTML_QuickForm2_NotFoundException is not subtype of Throwable$#"
-			count: 1
-			path: core/QuickForm2.php
-
-		-
 			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
 			count: 1
 			path: core/RankingQuery.php


### PR DESCRIPTION
### Description



### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
