### PR TITLE
remove some more segments for CNIL

### DIFF
--- a/plugins/API/tests/System/expected/test_ApiTest_compliancePolicyEnforced__API.getSegmentsMetadata.xml
+++ b/plugins/API/tests/System/expected/test_ApiTest_compliancePolicyEnforced__API.getSegmentsMetadata.xml
@@ -76,14 +76,6 @@
 		<segment>visitDuration</segment>
 	</row>
 	<row>
-		<type>metric</type>
-		<category>Visitors</category>
-		<name>Visitor IP</name>
-		<segment>visitIp</segment>
-		<acceptedValues>13.54.122.1. Select IP ranges with notation: &lt;code&gt;visitIp&gt;13.54.122.0;visitIp&lt;13.54.122.255&lt;/code&gt;</acceptedValues>
-		<permission>1</permission>
-	</row>
-	<row>
 		<type>dimension</type>
 		<category>Visitors</category>
 		<name>AI Agent Name</name>
@@ -159,13 +151,6 @@
 		<name>Profilable</name>
 		<segment>profilable</segment>
 		<acceptedValues>1 for profilable (eg cookies were used), 0 for not profilable (eg no cookies were used)</acceptedValues>
-	</row>
-	<row>
-		<type>dimension</type>
-		<category>Visitors</category>
-		<name>Site time — hour (time of last action)</name>
-		<segment>visitServerHour</segment>
-		<acceptedValues>0, 1, 2, 3, ..., 20, 21, 22, 23</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>

--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -454,12 +454,14 @@ class CoreHome extends \Piwik\Plugin
             }
             if ($limitSegmentsSettingEnabled) {
                 $list->remove('General_Visitors', 'userId');
+                $list->remove('General_Visitors', 'visitIp');
                 $list->remove('General_Visitors', 'visitId');
                 $list->remove('General_Visitors', 'visitorId');
                 $list->remove('General_Visitors', 'fingerprint');
                 $list->remove('Referrers_Referrers', 'campaignId');
                 $list->remove('General_Actions', 'actionServerHour');
                 $list->remove('General_Actions', 'actionServerMinute');
+                $list->remove('General_Visitors', 'visitServerHour');
                 $list->remove('General_Visitors', 'visitEndServerMinute');
                 $list->remove('General_Visitors', 'visitEndServerSecond');
                 $list->remove('General_Visitors', 'visitStartServerHour');


### PR DESCRIPTION
### Description

Adds `visitServerHour` and `visitIp` to the list of segments to be removed when CNIL is enabled.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
