### PR TITLE
Support token_auth with higher access for configurable Module.Action endpoints

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -95,6 +95,20 @@ return [
      */
     'DocumentationGenerator.customParameters' => [],
 
+    /**
+     * A list of exact (case-sensitive) `Module.Action` pairs where token_auths with write/admin
+     * access are allowed for non-API requests.
+     *
+     * Plugins can register actions in their `config/config.php`:
+     *
+     * return [
+     *     'token_auth.write_admin_allowed_module_actions' => \Piwik\DI::add(['MyPlugin.myAction']),
+     * ];
+     *
+     * @internal
+     */
+    'token_auth.write_admin_allowed_module_actions' => [],
+
     \Piwik\Log\Logger::class => Piwik\DI::create(\Piwik\Log\NullLogger::class),
     \Piwik\Log\LoggerInterface::class => Piwik\DI::create(\Piwik\Log\NullLogger::class),
 

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -15,7 +15,7 @@ use Piwik\Http\HttpCodeException;
 use Piwik\Request\AuthenticationToken;
 use Piwik\Cache;
 use Piwik\Common;
-use Piwik\Config;
+use Piwik\Config\GeneralConfig;
 use Piwik\Container\StaticContainer;
 use Piwik\Context;
 use Piwik\DataTable;
@@ -508,10 +508,19 @@ class Request
             throw $ex;
         }
 
-        $allowWriteAmin = Config::getInstance()->General['enable_framed_allow_write_admin_token_auth'] == 1;
+        $allowWriteAdminModuleActionConfig = StaticContainer::get('token_auth.write_admin_allowed_module_actions');
+
+        if (!is_array($allowWriteAdminModuleActionConfig)) {
+            $allowWriteAdminModuleActionConfig = [];
+        }
+
+        $allowWriteAdmin = GeneralConfig::getConfigValue('enable_framed_allow_write_admin_token_auth') == 1;
+        $allowWriteAdminModuleAction = in_array($module . '.' . $action, $allowWriteAdminModuleActionConfig, true);
+
         if (
             Piwik::isUserHasSomeWriteAccess()
-            && !$allowWriteAmin
+            && !$allowWriteAdmin
+            && !$allowWriteAdminModuleAction
         ) {
             // we allow UI authentication/ embedding widgets / reports etc only for users that have only view
             // access. it's mostly there to get users to use auth tokens of view users when embedding reports
@@ -519,7 +528,8 @@ class Request
             // token_auth is also fine in CLI mode as eg doAsSuperUser might be used etc
             //
             // NOTE: this does not apply if the [General] enable_framed_allow_write_admin_token_auth INI
-            // option is set.
+            // option is set, or if the current module/action is allowlisted in the
+            // token_auth.write_admin_allowed_module_actions DI entry.
             $ex = new \Piwik\Exception\Exception(Piwik::translate(
                 'Widgetize_ViewAccessRequired',
                 [Url::getExternalLinkTag('https://matomo.org/faq/troubleshooting/faq_147/') . 'https://matomo.org/faq/troubleshooting/faq_147/</a>']

--- a/tests/PHPUnit/Integration/API/RequestTest.php
+++ b/tests/PHPUnit/Integration/API/RequestTest.php
@@ -15,6 +15,7 @@ use Piwik\AuthResult;
 use Piwik\Cache;
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -234,6 +235,95 @@ class RequestTest extends IntegrationTestCase
         Request::checkTokenAuthIsNotLimited('SomePlugin', 'someMethod');
     }
 
+    public function testCheckTokenAuthIsNotLimitedAllowsWriteTokenAuthIfModuleActionConfigSet()
+    {
+        Config::getInstance()->General['enable_framed_allow_write_admin_token_auth'] = 0;
+        $this->setAllowedModuleActions(['SomePlugin.someMethod']);
+
+        $this->idSitesAccess['view'] = [];
+        $this->idSitesAccess['write'] = [1];
+        $this->access->reloadAccess($this->auth);
+        $this->access->setSuperUserAccess(false);
+        $this->assertFalse($this->access->hasSuperUserAccess());
+        $this->assertTrue($this->access->isUserHasSomeWriteAccess());
+
+        Common::$isCliMode = false;
+
+        Request::checkTokenAuthIsNotLimited('SomePlugin', 'someMethod');
+    }
+
+    public function testCheckTokenAuthIsNotLimitedAllowsAdminTokenAuthIfModuleActionConfigSet()
+    {
+        Config::getInstance()->General['enable_framed_allow_write_admin_token_auth'] = 0;
+        $this->setAllowedModuleActions(['SomePlugin.someMethod']);
+
+        $this->idSitesAccess['view'] = [];
+        $this->idSitesAccess['admin'] = [1];
+        $this->access->reloadAccess($this->auth);
+        $this->access->setSuperUserAccess(false);
+        $this->assertFalse($this->access->hasSuperUserAccess());
+        $this->assertTrue($this->access->isUserHasSomeAdminAccess());
+
+        Common::$isCliMode = false;
+
+        Request::checkTokenAuthIsNotLimited('SomePlugin', 'someMethod');
+    }
+
+    public function testCheckTokenAuthIsNotLimitedDoesNotAllowWriteTokenAuthIfModuleActionConfigCaseDoesNotMatch()
+    {
+        Config::getInstance()->General['enable_framed_allow_write_admin_token_auth'] = 0;
+        $this->setAllowedModuleActions(['someplugin.someMethod']);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Widgetize_ViewAccessRequired');
+
+        $this->idSitesAccess['view'] = [];
+        $this->idSitesAccess['write'] = [1];
+        $this->access->reloadAccess($this->auth);
+        $this->access->setSuperUserAccess(false);
+        $this->assertFalse($this->access->hasSuperUserAccess());
+        $this->assertTrue($this->access->isUserHasSomeWriteAccess());
+
+        Common::$isCliMode = false;
+
+        Request::checkTokenAuthIsNotLimited('SomePlugin', 'someMethod');
+    }
+
+    public function testCheckTokenAuthIsNotLimitedAllowsWriteTokenAuthIfCurrentModuleActionIsInMultipleConfiguredValues()
+    {
+        Config::getInstance()->General['enable_framed_allow_write_admin_token_auth'] = 0;
+        $this->setAllowedModuleActions([
+            'OtherPlugin.otherMethod',
+            'SomePlugin.someMethod',
+            'ThirdPlugin.thirdMethod',
+        ]);
+
+        $this->idSitesAccess['view'] = [];
+        $this->idSitesAccess['write'] = [1];
+        $this->access->reloadAccess($this->auth);
+        $this->access->setSuperUserAccess(false);
+        $this->assertFalse($this->access->hasSuperUserAccess());
+        $this->assertTrue($this->access->isUserHasSomeWriteAccess());
+
+        Common::$isCliMode = false;
+
+        Request::checkTokenAuthIsNotLimited('SomePlugin', 'someMethod');
+    }
+
+    public function testCheckTokenAuthIsNotLimitedDoesNotAllowSuperUserTokenAuthIfModuleActionConfigSet()
+    {
+        Config::getInstance()->General['enable_framed_allow_write_admin_token_auth'] = 0;
+        $this->setAllowedModuleActions(['SomePlugin.someMethod']);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Widgetize_TooHighAccessLevel');
+
+        Common::$isCliMode = false;
+        $this->access->setSuperUserAccess(true);
+
+        Request::checkTokenAuthIsNotLimited('SomePlugin', 'someMethod');
+    }
+
     public function testCheckTokenAuthIsNotLimitedAllowsViewTokenAuthIfConfigSet()
     {
         Config::getInstance()->General['enable_framed_allow_write_admin_token_auth'] = 1;
@@ -377,6 +467,11 @@ class RequestTest extends IntegrationTestCase
         $mock->reloadAccess($auth);
 
         return $mock;
+    }
+
+    private function setAllowedModuleActions(array $moduleActions): void
+    {
+        StaticContainer::getContainer()->set('token_auth.write_admin_allowed_module_actions', $moduleActions);
     }
 
     private function setNestedApiInvocationCount(int $count): void


### PR DESCRIPTION
### Description

Requesting a non-API endpoint in Matomo using a regular `token_auth` is, by default, only allowed with a "view only" access backed account. For higher privileges required activating `enable_framed_allow_write_admin_token_auth`:

https://github.com/matomo-org/matomo/blob/5634dff0c1a394559612b6808a6eb13402ec9032/config/global.ini.php#L553-L558

This is a global setting, for everything, and cannot be limited to certain plugins if one wants to keep the risk low.

This PR adds a new DI option for plugins to use, supporting an allowlist of `Module.Action` endpoints to be accessible by `token_auth`. Might need some future improvements to adjust the error message, as that always hints at the widgetization/embedding, but might be useful for any controller that needs token authentication and does not fit in the API layer.

_It still keeps the super user access guard in place. Only write/admin level tokens are possible._

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
