### PR TITLE
Fix possible problem with handling idsite=all in API.getSuggestedValuesForSegment

### DIFF
--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -598,7 +598,6 @@ class API extends \Piwik\Plugin\API
         $suggestedValuesCallbackRequiresTable = false;
 
         if (!empty($segment['suggestedValuesApi']) && is_string($segment['suggestedValuesApi']) && !Rules::isBrowserTriggerEnabled()) {
-            $now = Date::now()->setTimezone(Site::getTimezoneFor($idSite));
             if ($idSite === 'all') {
                 $now = Date::now()->setTimezone(\Piwik\Plugins\SitesManager\API::getInstance()->getDefaultTimezone());
             } else {

--- a/plugins/API/tests/Integration/APITest.php
+++ b/plugins/API/tests/Integration/APITest.php
@@ -11,10 +11,12 @@ namespace Piwik\Plugins\API\tests\Integration;
 
 use Piwik\Access;
 use Piwik\API\Request;
+use Piwik\ArchiveProcessor\Rules;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Http\BadRequestException;
+use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugins\API\API;
 use Piwik\Plugins\UsersManager\Model as UsersManagerModel;
@@ -169,6 +171,33 @@ class APITest extends IntegrationTestCase
             $response = $this->api->getBulkRequest($this->makeBulkUrls(12));
             $this->assertCount(12, $response);
         } finally {
+            $this->setAnonymousContext();
+        }
+    }
+
+    public function testGetSuggestedValuesForSegmentSupportsAllIdSiteWhenBrowserArchivingDisabled()
+    {
+        $this->setSuperUserContext();
+        $previousBrowserArchivingSetting = Option::get(Rules::OPTION_BROWSER_TRIGGER_ARCHIVING);
+
+        try {
+            Option::set(Rules::OPTION_BROWSER_TRIGGER_ARCHIVING, 0);
+
+            try {
+                $result = $this->api->getSuggestedValuesForSegment('pageTitle', 'all');
+                $this->assertIsArray($result);
+            } catch (\Throwable $e) {
+                $this->assertNotInstanceOf(\TypeError::class, $e);
+                $this->assertStringNotContainsString('SitesManager::getSiteFromId', $e->getMessage());
+                $this->assertStringNotContainsString('must be of the type int', $e->getMessage());
+            }
+        } finally {
+            if ($previousBrowserArchivingSetting === false) {
+                Option::delete(Rules::OPTION_BROWSER_TRIGGER_ARCHIVING);
+            } else {
+                Option::set(Rules::OPTION_BROWSER_TRIGGER_ARCHIVING, $previousBrowserArchivingSetting);
+            }
+
             $this->setAnonymousContext();
         }
     }


### PR DESCRIPTION
 ### Title

  Fix autosuggest failures when idSite=all after SitesManager.getSiteFromId(int) typing

  ### Problem

  After SitesManager.getSiteFromId was tightened to int, some requests still reached site-specific code paths with idSite='all'.

  A concrete case is Segment Editor autosuggest (API.getSuggestedValuesForSegment), which can be triggered from all-sites context in the UI. In that flow, 'all' could reach timezone/site resolution logic and indirectly hit getSiteFromId(int) with a non-int value, causing errors.

### Root cause

API.getSuggestedValuesForSegment (browser-archiving-disabled branch) performed a timezone lookup that could call Site::getTimezoneFor($idSite) before safely handling 'all'. Site::getTimezoneFor itself assumed a concrete site id.

### Fix

  1. Hardened autosuggest timezone resolution
      - In plugins/API/API.php, getSuggestedValuesForSegment() now branches on $idSite first:
      - idSite === 'all' -> use SitesManager::getDefaultTimezone()
      - otherwise -> use Site::getTimezoneFor($idSite)


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
