### PR TITLE
Add max-height to materialize-textarea (#19901)

### DIFF
--- a/plugins/Morpheus/stylesheets/general/_forms.less
+++ b/plugins/Morpheus/stylesheets/general/_forms.less
@@ -231,4 +231,6 @@ abbr[title] {
 
 textarea.materialize-textarea {
   min-height: 100px;
+  max-height: 500px;
+  overflow-y: auto !important;
 }


### PR DESCRIPTION
This PR adds a max-height and overflow-y: auto to the materialize-textarea class. This prevents settings textareas (like Global filtered/ignored IPs) from growing excessively large and breaking the UI layout when they contain many items. Fixes #19901.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules