### PR TITLE
Properly handle missing action types in VisitorDetails classes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2889,11 +2889,6 @@ parameters:
 			path: plugins/Contents/RecordBuilders/ContentRecords.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\Contents\\\\VisitorDetails\\:\\:renderAction\\(\\) should return string but empty return statement found\\.$#"
-			count: 1
-			path: plugins/Contents/VisitorDetails.php
-
-		-
 			message: "#^Left side of && is always true\\.$#"
 			count: 1
 			path: plugins/CoreAdminHome/API.php
@@ -3574,11 +3569,6 @@ parameters:
 			path: plugins/Events/Columns/TotalEvents.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\Events\\\\VisitorDetails\\:\\:renderAction\\(\\) should return string but empty return statement found\\.$#"
-			count: 1
-			path: plugins/Events/VisitorDetails.php
-
-		-
 			message: "#^Parameter \\#3 \\$escapeComment of static method Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\DiagnosticResult\\:\\:informationalResult\\(\\) expects bool, string given\\.$#"
 			count: 1
 			path: plugins/ExamplePlugin/Diagnostic/ExampleCheck.php
@@ -4011,11 +4001,6 @@ parameters:
 		-
 			message: "#^Method Piwik\\\\Plugins\\\\Live\\\\VisitorDetails\\:\\:getAdditionalUrlsForSite\\(\\) should return array\\<int, array\\<string\\>\\> but returns array\\<string\\>\\.$#"
 			count: 1
-			path: plugins/Live/VisitorDetails.php
-
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Live\\\\VisitorDetails\\:\\:renderAction\\(\\) should return string but empty return statement found\\.$#"
-			count: 3
 			path: plugins/Live/VisitorDetails.php
 
 		-

--- a/plugins/Actions/VisitorDetails.php
+++ b/plugins/Actions/VisitorDetails.php
@@ -119,11 +119,19 @@ class VisitorDetails extends VisitorDetailsAbstract
             Action::TYPE_DOWNLOAD,
         );
 
+        if (empty($action['type'])) {
+            return !empty($action['eventType']);
+        }
+
         return in_array($action['type'], $actionTypesToHandle) || !empty($action['eventType']);
     }
 
     private function isPageView($action)
     {
+        if (empty($action['type'])) {
+            return false;
+        }
+
         $pageViewTypes = array(
             Action::TYPE_PAGE_URL,
             Action::TYPE_PAGE_TITLE,
@@ -134,9 +142,14 @@ class VisitorDetails extends VisitorDetailsAbstract
 
     public function extendActionDetails(&$action, $nextAction, $visitorDetails)
     {
+        $actionType = '';
+        if (!empty($action['type'])) {
+            $actionType = $action['type'];
+        }
+
         $formatter = new Formatter();
 
-        if ($action['type'] == Action::TYPE_SITE_SEARCH) {
+        if ($actionType == Action::TYPE_SITE_SEARCH) {
             // Handle Site Search
             $action['siteSearchKeyword'] = $action['pageTitle'];
             $action['siteSearchCategory'] = $action['search_cat'];
@@ -189,7 +202,7 @@ class VisitorDetails extends VisitorDetailsAbstract
             }
         }
 
-        switch ($action['type']) {
+        switch ($actionType) {
             case 'goal':
                 $action['icon'] = 'plugins/Morpheus/images/goal.png';
                 $action['iconSVG'] = 'plugins/Morpheus/images/goal.svg';
@@ -201,9 +214,9 @@ class VisitorDetails extends VisitorDetailsAbstract
                 break;
             case Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER:
             case Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_CART:
-                $action['icon'] = 'plugins/Morpheus/images/' . $action['type'] . '.png';
-                $action['iconSVG'] = 'plugins/Morpheus/images/' . $action['type'] . '.svg';
-                if ($action['type'] == Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER) {
+                $action['icon'] = 'plugins/Morpheus/images/' . $actionType . '.png';
+                $action['iconSVG'] = 'plugins/Morpheus/images/' . $actionType . '.svg';
+                if ($actionType == Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER) {
                     $action['title'] = Piwik::translate('CoreHome_VisitStatusOrdered') . ' (' . $action['orderId'] . ')';
                 } else {
                     $action['title'] = Piwik::translate('Goals_AbandonedCart');
@@ -411,7 +424,7 @@ class VisitorDetails extends VisitorDetailsAbstract
      */
     private function handleIfDownloadAction($action, &$profile)
     {
-        if ($action['type'] != 'download') {
+        if (empty($action['type']) || $action['type'] != 'download') {
             return;
         }
         $profile['totalDownloads']++;
@@ -422,7 +435,7 @@ class VisitorDetails extends VisitorDetailsAbstract
      */
     private function handleIfOutlinkAction($action, &$profile)
     {
-        if ($action['type'] != 'outlink') {
+        if (empty($action['type']) || $action['type'] != 'outlink') {
             return;
         }
         $profile['totalOutlinks']++;
@@ -433,7 +446,7 @@ class VisitorDetails extends VisitorDetailsAbstract
      */
     private function handleIfPageViewAction($action, &$profile)
     {
-        if ($action['type'] != 'action') {
+        if (empty($action['type']) || $action['type'] != 'action') {
             return;
         }
         $profile['totalPageViews']++;

--- a/plugins/Contents/VisitorDetails.php
+++ b/plugins/Contents/VisitorDetails.php
@@ -17,7 +17,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 {
     public function extendActionDetails(&$action, $nextAction, $visitorDetails)
     {
-        if ($action['type'] != Action::TYPE_CONTENT) {
+        if (empty($action['type']) || $action['type'] != Action::TYPE_CONTENT) {
             unset($action['contentName']);
             unset($action['contentPiece']);
             unset($action['contentTarget']);
@@ -27,7 +27,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 
     public function renderAction($action, $previousAction, $visitorDetails)
     {
-        if ($action['type'] != Action::TYPE_CONTENT) {
+        if (empty($action['type']) || $action['type'] != Action::TYPE_CONTENT) {
             return;
         }
 
@@ -41,7 +41,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 
     public function renderActionTooltip($action, $visitInfo)
     {
-        if ($action['type'] != Action::TYPE_CONTENT) {
+        if (empty($action['type']) || $action['type'] != Action::TYPE_CONTENT) {
             return [];
         }
 

--- a/plugins/Contents/VisitorDetails.php
+++ b/plugins/Contents/VisitorDetails.php
@@ -28,7 +28,7 @@ class VisitorDetails extends VisitorDetailsAbstract
     public function renderAction($action, $previousAction, $visitorDetails)
     {
         if (empty($action['type']) || $action['type'] != Action::TYPE_CONTENT) {
-            return;
+            return '';
         }
 
         $view                 = new View('@Contents/_actionContent.twig');

--- a/plugins/Events/VisitorDetails.php
+++ b/plugins/Events/VisitorDetails.php
@@ -60,7 +60,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 
     public function renderAction($action, $previousAction, $visitorDetails)
     {
-        if ($action['type'] != 'event') {
+        if (empty($action['type']) || $action['type'] != 'event') {
             return;
         }
 
@@ -80,7 +80,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 
     public function handleProfileAction($action, &$profile)
     {
-        if ($action['type'] != 'event') {
+        if (empty($action['type']) || $action['type'] != 'event') {
             return;
         }
         $profile['totalEvents']++;

--- a/plugins/Events/VisitorDetails.php
+++ b/plugins/Events/VisitorDetails.php
@@ -61,7 +61,7 @@ class VisitorDetails extends VisitorDetailsAbstract
     public function renderAction($action, $previousAction, $visitorDetails)
     {
         if (empty($action['type']) || $action['type'] != 'event') {
-            return;
+            return '';
         }
 
         $view                 = new View('@Events/_actionEvent.twig');

--- a/plugins/Goals/VisitorDetails.php
+++ b/plugins/Goals/VisitorDetails.php
@@ -123,7 +123,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 
     public function handleProfileAction($action, &$profile)
     {
-        if ($action['type'] != 'goal') {
+        if (empty($action['type']) || $action['type'] != 'goal') {
             return;
         }
 

--- a/plugins/Live/VisitorDetails.php
+++ b/plugins/Live/VisitorDetails.php
@@ -77,7 +77,7 @@ class VisitorDetails extends VisitorDetailsAbstract
     public function renderAction($action, $previousAction, $visitorDetails)
     {
         if (empty($action['type'])) {
-            return;
+            return '';
         }
 
         switch ($action['type']) {
@@ -87,7 +87,7 @@ class VisitorDetails extends VisitorDetailsAbstract
                 break;
             case 'goal':
                 if (empty($action['goalName'])) {
-                    return; // goal deleted
+                    return ''; // goal deleted
                 }
                 $template = '@Live/_actionGoal.twig';
                 break;
@@ -100,7 +100,7 @@ class VisitorDetails extends VisitorDetailsAbstract
         }
 
         if (empty($template)) {
-            return;
+            return '';
         }
 
         if (isset($action['type']) && in_array($action['type'], ['outlink', 'download']) && isset($action['url'])) {

--- a/plugins/Referrers/VisitorDetails.php
+++ b/plugins/Referrers/VisitorDetails.php
@@ -42,7 +42,11 @@ class VisitorDetails extends VisitorDetailsAbstract
 
     public function renderActionTooltip($action, $visitInfo)
     {
-        if (($action['type'] !== 'goal' && $action['type'] !== 'ecommerceOrder') || empty($action['referrerType'])) {
+        if (
+            empty($action['type'])
+            || ($action['type'] !== 'goal' && $action['type'] !== 'ecommerceOrder')
+            || empty($action['referrerType'])
+        ) {
             return [];
         }
 


### PR DESCRIPTION
### Description

Some plugins might provide action that do not specify a type. While that might be unexpected it currently causes Matomo to emit a lot of warning, as access to the type property isn't handled well. This PR ensures that existence of the array key checked before accessing it.

fixes #24109, fixes #21185, fixes #20652

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
