### PR TITLE
Removes tenth chunk of superfluous commentary

### DIFF
--- a/plugins/JsTrackerInstallCheck/JsTrackerInstallCheck.php
+++ b/plugins/JsTrackerInstallCheck/JsTrackerInstallCheck.php
@@ -70,7 +70,6 @@ class JsTrackerInstallCheck extends \Piwik\Plugin
      * result for the site will be returned. This is determined by whether there's only one previous nonce or if the URL
      * matches the main URL of the site.
      *
-     * @param int $idSite
      * @param string $nonce The unique nonce used to identify the test requests. Optionally can be left empty if simply
      * wanting to check if the site has been successfully tested.
      * @return bool Indicating whether the nonce check was marked as successful
@@ -111,7 +110,6 @@ class JsTrackerInstallCheck extends \Piwik\Plugin
      * Initiate a test whether the JS tracking code has been successfully installed for a site. It generates a nonce and
      * stores it in the option table so that it can be accessed later during the Tracker.isExcludedVisit event.
      *
-     * @param int $idSite
      * @param string $url Optional URL to append the nonce to. If not provided, it uses the main URL of the site
      * @return array containing the URL constructed using the main URL for the site and the newly created nonce as a
      * query parameter.

--- a/plugins/JsTrackerInstallCheck/NonceOption/JsTrackerInstallCheckOption.php
+++ b/plugins/JsTrackerInstallCheck/NonceOption/JsTrackerInstallCheckOption.php
@@ -18,7 +18,6 @@ class JsTrackerInstallCheckOption
     /**
      * Look up a specific nonce for a site. If none exists, an empty array is returned.
      *
-     * @param int $idSite
      * @param string $nonce A MD5 hash to uniquely identify an installation test request
      * @return array The data associated with a specific nonce for a site.
      * E.g. ['time' => 1692920000, 'url' => 'https://some-test-site.local', 'isSuccessful' => true]
@@ -33,8 +32,6 @@ class JsTrackerInstallCheckOption
     /**
      * Find the nonce for a specific site and URL. If none exists, an empty array is returned.
      *
-     * @param int $idSite
-     * @param string $url
      * @return array Collection containing the nonce and it's associated data.
      * E.g. ['some_nonce' => ['time' => 1692920000, 'url' => 'https://some-test-site.local', 'isSuccessful' => true]]
      */
@@ -51,7 +48,6 @@ class JsTrackerInstallCheckOption
      * Get the current list of nonces for a site, excluding expired ones. Optionally filter by URL. There should only be
      * one nonce per URL.
      *
-     * @param int $idSite
      * @param string $url Optionally filter the results to only be the nonce associated with the provided URL
      * @return array Associative array where the nonces are the keys and the value is an array with the nonce data.
      * E.g. ['some_nonce' => ['time' => 1692920000, 'url' => 'https://some-test-site.local', 'isSuccessful' => true]]
@@ -83,7 +79,6 @@ class JsTrackerInstallCheckOption
      * won't filter out expired nonces like getCurrentNonceMap, so this should only be used when looking for past test
      * results.
      *
-     * @param int $idSite
      * @return array Collection of nonces used for a specific site and their associated data.
      * E.g. ['some_nonce' => ['time' => 1692920000, 'url' => 'https://some-test-site.local', 'isSuccessful' => true]]
      */
@@ -106,8 +101,6 @@ class JsTrackerInstallCheckOption
     /**
      * Update a nonce to indicate that the test was successful.
      *
-     * @param int $idSite
-     * @param string $nonce
      * @return bool Indicates whether the update was successful. The main reason it might fail is if the nonce isn't found
      */
     public function markNonceAsSuccessFul(int $idSite, string $nonce): bool
@@ -126,8 +119,6 @@ class JsTrackerInstallCheckOption
     /**
      * Create a new nonce for the site/URL combination. This checks if a
      *
-     * @param int $idSite
-     * @param string $url
      * @return string
      */
     public function createNewNonce(int $idSite, string $url): string
@@ -156,7 +147,6 @@ class JsTrackerInstallCheckOption
     /**
      * Get the string JSON stored in the option table to track installation checks.
      *
-     * @param int $idSite
      * @return string JSON list of nonces and the data associated with each
      */
     protected function getNonceOption(int $idSite): string
@@ -167,7 +157,6 @@ class JsTrackerInstallCheckOption
     /**
      * Update the string JSON stored in the option table to track installation checks.
      *
-     * @param int $idSite
      * @param array $nonceMap
      * @return void
      */
@@ -180,9 +169,6 @@ class JsTrackerInstallCheckOption
      * Update the time associated with a specific nonce. This is mainly for when a nonce already exists for the
      * site and requested URL. This allows us to bump the time so that we can reuse the nonce for the second test.
      *
-     * @param int $idSite
-     * @param string $nonce
-     * @param int $time
      * @return bool
      */
     protected function updateNonceTime(int $idSite, string $nonce, int $time): bool
@@ -200,7 +186,6 @@ class JsTrackerInstallCheckOption
 
     /**
      * @param array $nonceMap
-     * @param string $url
      * @return string
      */
     protected function searchNonceMapForUrl(array $nonceMap, string $url): string

--- a/plugins/JsTrackerInstallCheck/tests/Unit/JsTrackerInstallCheckOptionTest.php
+++ b/plugins/JsTrackerInstallCheck/tests/Unit/JsTrackerInstallCheckOptionTest.php
@@ -257,7 +257,6 @@ class JsTrackerInstallCheckOptionTest extends TestCase
     /**
      * Helper method for checking the test nonces
      *
-     * @param int $idSite
      * @return array
      */
     protected function getTestOptionArray(int $idSite): array
@@ -275,8 +274,6 @@ class JsTrackerInstallCheckOptionTest extends TestCase
     /**
      * Helper method for checking the test nonce
      *
-     * @param int $idSite
-     * @param string $nonce
      * @return array
      */
     protected function getTestNonceArray(int $idSite, string $nonce): array
@@ -289,8 +286,6 @@ class JsTrackerInstallCheckOptionTest extends TestCase
     /**
      * Helper method for checking if the nonce is successful
      *
-     * @param int $idSite
-     * @param string $nonce
      * @return bool
      */
     protected function isNonceSuccessFul(int $idSite, string $nonce): bool

--- a/plugins/LanguagesManager/TranslationWriter/Writer.php
+++ b/plugins/LanguagesManager/TranslationWriter/Writer.php
@@ -285,7 +285,6 @@ class Writer
     /**
      * Adds an validator to check before saving
      *
-     * @param ValidateAbstract $validator
      */
     public function addValidator(ValidateAbstract $validator)
     {
@@ -353,9 +352,6 @@ class Writer
         return $this->filteredData;
     }
 
-    /**
-     * @param FilterAbstract $filter
-     */
     public function addFilter(FilterAbstract $filter)
     {
         $this->filters[] = $filter;

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -355,8 +355,6 @@ class API extends \Piwik\Plugin\API
      * If no action was performed in this timeframe an empty string is returned
      *
      * @param int|string $idSite
-     * @param string|null $period
-     * @param string|null $date
      * @return string
      * @throws Exception
      */
@@ -371,7 +369,6 @@ class API extends \Piwik\Plugin\API
     /**
      * For an array of visits, query the list of pages for this visit
      * as well as make the data human readable
-     * @param DataTable $dataTable
      * @param bool $flat whether to flatten the array (eg. 'customVariables' names/values will appear in the root array rather than in 'customVariables' key
      * @param bool $doNotFetchActions If set to true, we only fetch visit info and not actions (much faster)
      * @param bool $filterNow If true, the visitors will be cleaned immediately

--- a/plugins/Live/VisitorProfile.php
+++ b/plugins/Live/VisitorProfile.php
@@ -27,7 +27,6 @@ class VisitorProfile
     }
 
     /**
-     * @param DataTable $visits
      * @param $visitorId
      * @param $segment
      * @param $numLastVisits
@@ -76,7 +75,6 @@ class VisitorProfile
     }
 
     /**
-     * @param DataTable $visits
      * @param           $visitorId
      * @param           $segment
      */

--- a/plugins/Login/PasswordVerifier.php
+++ b/plugins/Login/PasswordVerifier.php
@@ -87,7 +87,6 @@ class PasswordVerifier
     }
 
     /**
-     * @param Date $now
      * @ignore
      * tests only
      */

--- a/plugins/Marketplace/API.php
+++ b/plugins/Marketplace/API.php
@@ -168,7 +168,6 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
-     * @param string $pluginName
      *
      * @return bool
      *
@@ -199,7 +198,6 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
-     * @param string $pluginName
      *
      * @return bool
      * @throws Service\Exception If the marketplace request failed

--- a/plugins/Marketplace/Emails/RequestTrialNotificationEmail.php
+++ b/plugins/Marketplace/Emails/RequestTrialNotificationEmail.php
@@ -49,9 +49,6 @@ class RequestTrialNotificationEmail extends Mail
         $this->setUpEmail();
     }
 
-    /**
-     * @return string
-     */
     protected function getDefaultSubject(): string
     {
         return Piwik::translate(
@@ -62,9 +59,6 @@ class RequestTrialNotificationEmail extends Mail
         );
     }
 
-    /**
-     * @return View
-     */
     protected function getDefaultBodyView(): View
     {
         $piwikUrl = SettingsPiwik::getPiwikUrl();

--- a/plugins/Marketplace/PluginTrial/Request.php
+++ b/plugins/Marketplace/PluginTrial/Request.php
@@ -40,7 +40,6 @@ class Request
     /**
      * Creates a trial request and sends a mail to all super users
      *
-     * @param string $pluginDisplayName
      * @return void
      */
     public function create(string $pluginDisplayName = ''): void

--- a/plugins/Marketplace/PluginTrial/Service.php
+++ b/plugins/Marketplace/PluginTrial/Service.php
@@ -23,8 +23,6 @@ final class Service
     /**
      * Creates a trial request (and sends a mail to all super users)
      *
-     * @param string $pluginName
-     * @param string $pluginDisplayName
      * @return void
      */
     public function request(string $pluginName, string $pluginDisplayName): void
@@ -41,7 +39,6 @@ final class Service
     /**
      * Returns if a plugin was already requested
      *
-     * @param string $pluginName
      * @return bool
      */
     public function wasRequested(string $pluginName): bool
@@ -80,7 +77,6 @@ final class Service
      * Dismisses a plugin trial notification for the current (super) user if the provided notification id matches a
      * plugin trial request.
      *
-     * @param string $notificationId
      * @return void
      * @throws Exception
      */
@@ -118,7 +114,6 @@ final class Service
     /**
      * Cancels a plugin trial request
      *
-     * @param string $pluginName
      * @return void
      * @throws Exception
      */

--- a/plugins/Marketplace/PluginTrial/Storage.php
+++ b/plugins/Marketplace/PluginTrial/Storage.php
@@ -36,7 +36,6 @@ class Storage
     /**
      * Creates a trial request for the current user
      *
-     * @param string $pluginDisplayName
      * @return void
      */
     public function setRequested(string $pluginDisplayName = ''): void

--- a/plugins/MobileMessaging/API.php
+++ b/plugins/MobileMessaging/API.php
@@ -85,7 +85,6 @@ class API extends \Piwik\Plugin\API
     /**
      * Adds a phone number for the current user
      *
-     * @param string $phoneNumber
      * @return void
      */
     public function addPhoneNumber(string $phoneNumber): void
@@ -123,7 +122,6 @@ class API extends \Piwik\Plugin\API
     /**
      * Requests a new verification code for the given phone number
      *
-     * @param string $phoneNumber
      * @return void
      */
     public function resendVerificationCode(string $phoneNumber): void
@@ -216,7 +214,6 @@ class API extends \Piwik\Plugin\API
     /**
      * remove phone number
      *
-     * @param string $phoneNumber
      *
      * @return void
      */
@@ -248,8 +245,6 @@ class API extends \Piwik\Plugin\API
     /**
      * Verify a phone number
      *
-     * @param string $phoneNumber
-     * @param string $verificationCode
      *
      * @return bool true if verification was successful, false otherwise
      */

--- a/plugins/MobileMessaging/Model.php
+++ b/plugins/MobileMessaging/Model.php
@@ -18,9 +18,6 @@ class Model
     /**
      * send a SMS
      *
-     * @param string $content
-     * @param string $phoneNumber
-     * @param string $from
      * @return bool true
      */
     public function sendSMS(string $content, string $phoneNumber, string $from): bool
@@ -42,7 +39,6 @@ class Model
     /**
      * get activated phone number list
      *
-     * @param string $login
      * @return array $phoneNumber
      */
     public function getActivatedPhoneNumbers(string $login): array
@@ -53,8 +49,6 @@ class Model
     /**
      * Returns the list of phone numbers with their verification data
      *
-     * @param string $login
-     * @param bool $onlyVerified
      * @return array
      */
     public function getPhoneNumbers(string $login, bool $onlyVerified = true): array
@@ -91,9 +85,6 @@ class Model
     /**
      * Tries to verify the given phone number with the given verification code
      *
-     * @param string $login
-     * @param string $phoneNumber
-     * @param string $verificationCode
      * @return bool
      */
     public function verifyPhoneNumber(string $login, string $phoneNumber, string $verificationCode): bool
@@ -135,9 +126,6 @@ class Model
     /**
      * Adds a new phone number to the user, which needs to be verified with the provided code first
      *
-     * @param string $login
-     * @param string $phoneNumber
-     * @param string $verificationCode
      * @return void
      */
     public function addPhoneNumber(string $login, string $phoneNumber, string $verificationCode): void
@@ -158,8 +146,6 @@ class Model
     /**
      * Removes a phone number
      *
-     * @param string $login
-     * @param string $phoneNumber
      * @return void
      */
     public function removePhoneNumber(string $login, string $phoneNumber): void

--- a/plugins/Monolog/Processor/ExceptionToTextProcessor.php
+++ b/plugins/Monolog/Processor/ExceptionToTextProcessor.php
@@ -94,7 +94,6 @@ class ExceptionToTextProcessor
 
     /**
      * @param \Throwable|array{message: ?string, backtrace: ?string} $exception
-     * @param bool|null $shouldPrintBacktrace
      * @return string
      */
     public static function getMessageAndWholeBacktrace($exception, ?bool $shouldPrintBacktrace = null): string

--- a/plugins/MultiSites/API.php
+++ b/plugins/MultiSites/API.php
@@ -155,8 +155,6 @@ class API extends \Piwik\Plugin\API
     /**
      * Fetches the list of sites which names match the string pattern
      *
-     * @param ?string $pattern
-     * @param ?string $_restrictSitesToLogin
      * @return array<int>
      */
     private function getSitesIdFromPattern(?string $pattern, ?string $_restrictSitesToLogin): array
@@ -239,11 +237,6 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
-     * @param null|string  $period
-     * @param null|string  $date
-     * @param null|string $segment
-     * @param string       $pattern
-     * @param int          $filter_limit
      * @return array<string,mixed>
      * @throws Exception
      */
@@ -567,7 +560,6 @@ class API extends \Piwik\Plugin\API
      * Sets the total visits, actions & revenue for a DataTable returned by
      * $this->buildDataTable.
      *
-     * @param DataTableInterface $dataTable
      * @param array<string,string> $apiMetrics Metrics info.
      */
     private function setMetricsTotalsMetadata(DataTableInterface $dataTable, array $apiMetrics): void

--- a/plugins/MultiSites/Dashboard.php
+++ b/plugins/MultiSites/Dashboard.php
@@ -40,11 +40,6 @@ class Dashboard
         'ai_chatbots_requests', 'previous_ai_chatbots_requests',
     ];
 
-    /**
-     * @param string $period
-     * @param string $date
-     * @param string|null $segment
-     */
     public function __construct(string $period, string $date, ?string $segment)
     {
         if (Period::isMultiplePeriod($date, $period)) {
@@ -310,7 +305,6 @@ class Dashboard
      *
      * in a sorted order
      *
-     * @param DataTable $table
      * @param array $request
      */
     private function makeSitesFlatAndApplyGenericFilters(DataTable $table, array $request): void

--- a/plugins/MultiSites/DataTable/Filter/NestedSitesLimiter.php
+++ b/plugins/MultiSites/DataTable/Filter/NestedSitesLimiter.php
@@ -121,9 +121,6 @@ class NestedSitesLimiter extends BaseFilter
         }
     }
 
-    /**
-     * @param null|Row $lastGroupFromPreviousPage
-     */
     private function prependGroupIfFirstSiteBelongsToAGroupButGroupIsMissingInRows(?Row $lastGroupFromPreviousPage): void
     {
         if ($lastGroupFromPreviousPage && !empty($this->rows)) {

--- a/plugins/PrivacyManager/Config.php
+++ b/plugins/PrivacyManager/Config.php
@@ -122,8 +122,6 @@ class Config
      * If PrivacyCompliance is enabled and specific settings are requested, return their value, otherwise
      * return a provided option value
      *
-     * @param string $name
-     * @param int|null $idSite
      * @param false|string $optionValue
      * @return int|mixed|null
      * @throws DependencyException
@@ -151,8 +149,6 @@ class Config
      * Get a value from the option table, with a potential compliance policy override and a fallback value
      * if there's no option stored for the given name yet
      *
-     * @param string $name
-     * @param bool $allowPolicyComplianceOverride
      * @return mixed
      * @throws DependencyException
      * @throws NotFoundException

--- a/plugins/PrivacyManager/IPAnonymizer.php
+++ b/plugins/PrivacyManager/IPAnonymizer.php
@@ -20,7 +20,6 @@ class IPAnonymizer
     /**
      * Internal function to mask portions of the visitor IP address
      *
-     * @param IP $ip
      * @param int $maskLength Number of octets to reset
      * @return IP
      */

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -208,7 +208,6 @@ class DataSubjects
 
     /**
      * @param LogTable[] $logTables
-     * @param callable $generateWhere
      * @throws \Zend_Db_Statement_Exception
      */
     private function deleteLogDataFrom($logTables, callable $generateWhere)

--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -535,7 +535,6 @@ class PrivacyManager extends Plugin
     /**
      * Customize the Installation "default settings" form.
      *
-     * @param FormDefaultSettings $form
      */
     public function installationFormInit(FormDefaultSettings $form)
     {
@@ -558,7 +557,6 @@ class PrivacyManager extends Plugin
     /**
      * Process the Installation "default settings" form submission
      *
-     * @param FormDefaultSettings $form
      */
     public function installationFormSubmit(FormDefaultSettings $form)
     {

--- a/plugins/PrivacyManager/tests/Fixtures/FewVisitsAnonymizedFixture.php
+++ b/plugins/PrivacyManager/tests/Fixtures/FewVisitsAnonymizedFixture.php
@@ -66,10 +66,6 @@ class FewVisitsAnonymizedFixture extends Fixture
     /**
      * Returns a pre-configured MatomoTracker
      *
-     * @param int $idSite
-     * @param string $dateTime
-     * @param string $urlPath
-     * @param string $ip
      * @return MatomoTracker
      * @throws \Exception
      */


### PR DESCRIPTION
### Description

This changes were adjusted automatically using PHPCBF

refs https://github.com/matomo-org/matomo/pull/24118

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
