### PR TITLE
Remove superfluous return type annotations in commentary

### DIFF
--- a/core/API/ApiRenderer.php
+++ b/core/API/ApiRenderer.php
@@ -126,7 +126,6 @@ abstract class ApiRenderer
 
     /**
      * @param array  $request
-     * @return ApiRenderer
      * @throws Exception
      */
     public static function factory(string $format, array $request): ApiRenderer

--- a/core/Access/CapabilitiesProvider.php
+++ b/core/Access/CapabilitiesProvider.php
@@ -76,7 +76,6 @@ class CapabilitiesProvider
     }
 
     /**
-     * @return Capability|null
      * @throws Exception
      */
     public function getCapability(string $capabilityId): ?Capability
@@ -104,7 +103,6 @@ class CapabilitiesProvider
     }
 
     /**
-     * @return bool
      * @throws Exception
      */
     public function isValidCapability(string $capabilityId): bool

--- a/core/Archive/ArchivePurger.php
+++ b/core/Archive/ArchivePurger.php
@@ -205,7 +205,6 @@ class ArchivePurger
 
     /**
      * @param array $deletedSegments List of segments whose archives should be purged
-     * @return int
      */
     public function purgeDeletedSegmentArchives(Date $dateStart, array $deletedSegments): int
     {
@@ -221,7 +220,6 @@ class ArchivePurger
      * Purge all numeric and blob archives with the given IDs from the database.
      * @param array $idArchivesToDelete
      * @param string $reason
-     * @return int
      */
     protected function purge(array $idArchivesToDelete, Date $dateStart, $reason): int
     {

--- a/core/ArchiveProcessor/Record.php
+++ b/core/ArchiveProcessor/Record.php
@@ -194,7 +194,6 @@ class Record
 
     /**
      * @param array|null $columnToRenameAfterAggregation
-     * @return Record
      */
     public function setColumnToRenameAfterAggregation(?array $columnToRenameAfterAggregation): Record
     {
@@ -212,7 +211,6 @@ class Record
 
     /**
      * @param array|null $blobColumnAggregationOps
-     * @return Record
      */
     public function setBlobColumnAggregationOps(?array $blobColumnAggregationOps): Record
     {

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -71,7 +71,6 @@ abstract class RecordBuilder
      * Uses the protected `aggregate()` function to build records by aggregating log table data directly, then
      * inserts them as archive data.
      *
-     * @return void
      */
     public function buildFromLogs(ArchiveProcessor $archiveProcessor): void
     {
@@ -127,7 +126,6 @@ abstract class RecordBuilder
      * Builds records for non-day periods by aggregating day records together, then inserts
      * them as archive data.
      *
-     * @return void
      */
     public function buildForNonDayPeriod(ArchiveProcessor $archiveProcessor): void
     {
@@ -327,7 +325,6 @@ abstract class RecordBuilder
      * Returns an extra hint for LogAggregator to add to log aggregation SQL. Can be overridden if you'd
      * like the origin hint to have more information.
      *
-     * @return string
      */
     public function getQueryOriginHint(): string
     {
@@ -343,7 +340,6 @@ abstract class RecordBuilder
      * @param ArchiveProcessor $archiveProcessor Archiving parameters, like idSite, can influence the list of
      *                                           all records a RecordBuilder produces, so it is required here.
      * @param string[] $requestedReports The list of requested reports to check for.
-     * @return bool
      */
     public function isBuilderForAtLeastOneOf(ArchiveProcessor $archiveProcessor, array $requestedReports): bool
     {

--- a/core/AssetManager.php
+++ b/core/AssetManager.php
@@ -139,7 +139,6 @@ class AssetManager extends Singleton
     /**
      * Return JS file inclusion directive(s) using the markup <script>
      *
-     * @return string
      */
     public function getJsInclusionDirective(bool $deferJS = false): string
     {
@@ -375,7 +374,6 @@ class AssetManager extends Singleton
     /**
      * Return individual JS file inclusion directive(s) using the markup <script>
      *
-     * @return string
      */
     protected function getIndividualCoreAndNonCoreJsIncludes(): string
     {
@@ -387,7 +385,6 @@ class AssetManager extends Singleton
 
     /**
      * @param UIAssetFetcher $assetFetcher
-     * @return string
      */
     protected function getIndividualJsIncludesFromAssetFetcher($assetFetcher): string
     {

--- a/core/Changes/Model.php
+++ b/core/Changes/Model.php
@@ -135,7 +135,6 @@ class Model
      *
      * @param int|null $newerThanId     Only count new changes as having a key > than this sequential key
      *
-     * @return int
      */
     public function doChangesExist(?int $newerThanId = null): int
     {
@@ -164,7 +163,6 @@ class Model
      *
      * @param int|null $newerThanId     Only count new changes as having a key > than this sequential key
      *
-     * @return int
      */
     public function getNewChangesCount(?int $newerThanId = null): int
     {

--- a/core/Changes/UserChanges.php
+++ b/core/Changes/UserChanges.php
@@ -55,7 +55,6 @@ class UserChanges
     /**
      * Return the key of the last viewed change for the user, if any
      *
-     * @return int
      */
     private function getIdchangeLastViewed(): ?int
     {
@@ -93,7 +92,6 @@ class UserChanges
     /**
      * Record all changes as read
      *
-     * @return void
      * @throws \Piwik\Tracker\Db\DbException
      */
     public function markChangesAsRead(): void

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -415,7 +415,6 @@ class CliMulti
      * Several of the regular supportsAsync requirements may be obsolete after
      * a complete switch has been done.
      *
-     * @return bool
      */
     public function supportsAsyncSymfony(): bool
     {

--- a/core/Concurrency/Lock.php
+++ b/core/Concurrency/Lock.php
@@ -51,7 +51,6 @@ class Lock
      *
      * @todo remove in Matomo 6.0
      * @deprecated use {@link reacquireLock()} instead.
-     * @return bool
      */
     public function reexpireLock(): bool
     {
@@ -61,7 +60,6 @@ class Lock
     /**
      * Reacquires the current lock. The TTL will be extended if 1/4 of the TTL already passed by.
      *
-     * @return bool
      */
     public function reacquireLock(): bool
     {
@@ -150,7 +148,6 @@ class Lock
     /**
      * Return if the acquired lock is currently locked
      *
-     * @return bool
      */
     public function isLocked(): bool
     {
@@ -164,7 +161,6 @@ class Lock
     /**
      * Releases the acquired lock
      *
-     * @return void
      */
     public function unlock(): void
     {
@@ -179,7 +175,6 @@ class Lock
      *
      * @deprecated use {@link extendLock()} instead.
      * @todo remove in Matomo 6.0
-     * @return bool
      */
     public function expireLock($ttlInSeconds): bool
     {

--- a/core/Config.php
+++ b/core/Config.php
@@ -480,7 +480,6 @@ class Config
     /**
      * Sanity check a config file by checking contents
      *
-     * @return bool
      */
     public function sanityCheck(string $localPath, string $expectedContent, bool $notify = false): bool
     {

--- a/core/Config/SectionConfig.php
+++ b/core/Config/SectionConfig.php
@@ -21,7 +21,6 @@ abstract class SectionConfig
      * @param string $name Setting name
      * @param mixed $value Value
      *
-     * @return void
      */
     public static function setConfigValue(string $name, $value): void
     {

--- a/core/Container/ContainerFactory.php
+++ b/core/Container/ContainerFactory.php
@@ -56,7 +56,6 @@ class ContainerFactory
     /**
      * @link https://php-di.org/doc/container-configuration.html
      * @throws \Exception
-     * @return Container
      */
     public function create(): Container
     {
@@ -168,7 +167,6 @@ class ContainerFactory
     /**
      * This method is required for Matomo Cloud to allow for custom sorting of plugin order
      *
-     * @return bool
      */
     private function shouldSortPlugins(): bool
     {

--- a/core/DataAccess/ArchiveTableCreator.php
+++ b/core/DataAccess/ArchiveTableCreator.php
@@ -103,7 +103,6 @@ class ArchiveTableCreator
      * If no type is specified, blob table is returned when both blob and numeric are found for the same year_month.
      *
      * @param string|null $type The type of archive table to return. Either `self::NUMERIC_TABLE` or `self::BLOB_TABLE`.
-     * @return string|null
      */
     public static function getLatestArchiveTableInstalled(?string $type = null, bool $forceReload = false): ?string
     {

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -1042,7 +1042,6 @@ class Model
      * Otherwise the invalidation will be reset
      *
      * @param array $idinvalidations
-     * @return int
      * @throws \Zend_Db_Statement_Exception
      */
     public function releaseInProgressInvalidations(array $idinvalidations): int

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -2226,7 +2226,6 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
 
     /**
      * @param int $offset
-     * @return bool
      */
     public function offsetExists($offset): bool
     {
@@ -2237,7 +2236,6 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
 
     /**
      * @param int $offset
-     * @return Row
      */
     public function offsetGet($offset): Row
     {
@@ -2247,7 +2245,6 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
     /**
      * @param int $offset
      * @param Row $value
-     * @return void
      */
     public function offsetSet($offset, $value): void
     {
@@ -2256,7 +2253,6 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
 
     /**
      * @param int $offset
-     * @return void
      * @throws Exception
      */
     public function offsetUnset($offset): void
@@ -2268,7 +2264,6 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      * @param string|int|null $label
      * @param array $columns
      * @param array<string, string>|null $aggregationOps
-     * @return Row
      * @throws Exception
      */
     public function sumRowWithLabel($label, array $columns, ?array $aggregationOps = null): Row

--- a/core/DataTable/Renderer.php
+++ b/core/DataTable/Renderer.php
@@ -96,7 +96,6 @@ abstract class Renderer extends BaseFactory
     /**
      * Returns whether to render subtables or not
      *
-     * @return bool
      */
     protected function isRenderSubtables(): bool
     {
@@ -120,7 +119,6 @@ abstract class Renderer extends BaseFactory
 
     /**
      * @see render()
-     * @return string
      */
     public function __toString(): string
     {

--- a/core/DataTable/Renderer/Console.php
+++ b/core/DataTable/Renderer/Console.php
@@ -27,7 +27,6 @@ class Console extends Renderer
     /**
      * Computes the dataTable output and returns the string/binary
      *
-     * @return string
      */
     public function render(): string
     {
@@ -49,7 +48,6 @@ class Console extends Renderer
      *
      * @param DataTable\Map $map data tables to render
      * @param string $prefix prefix to output before table data
-     * @return string
      */
     protected function renderDataTableMap(DataTable\Map $map, string $prefix): string
     {
@@ -68,7 +66,6 @@ class Console extends Renderer
      *
      * @param array|DataTable|DataTable\Map $table data table to render
      * @param string $prefix prefix to output before table data
-     * @return string
      */
     protected function renderTable($table, string $prefix = ''): string
     {

--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -62,7 +62,6 @@ class Csv extends Renderer
     /**
      * Computes the dataTable output and returns the string/binary
      *
-     * @return string
      */
     public function render(): string
     {
@@ -100,7 +99,6 @@ class Csv extends Renderer
      *
      * @param DataTable|array $table
      * @param array $allColumns
-     * @return string
      */
     protected function renderTable($table, array &$allColumns = []): string
     {
@@ -121,7 +119,6 @@ class Csv extends Renderer
      * Computes the output of the given data table array
      *
      * @param array $allColumns
-     * @return string
      */
     protected function renderDataTableMap(DataTable\Map $table, array &$allColumns = []): string
     {
@@ -154,7 +151,6 @@ class Csv extends Renderer
      *
      * @param DataTable|Simple $table
      * @param array $allColumns
-     * @return string
      */
     protected function renderDataTable($table, array &$allColumns = []): string
     {
@@ -181,7 +177,6 @@ class Csv extends Renderer
      * Returns the CSV header line for a set of metrics. Will translate columns if desired.
      *
      * @param array $columnMetrics
-     * @return string
      */
     private function getHeaderLine(array $columnMetrics): string
     {
@@ -354,7 +349,6 @@ class Csv extends Renderer
     /**
      * @param array $allColumns
      * @param array $csv
-     * @return string
      */
     private function buildCsvString(array $allColumns, array $csv): string
     {

--- a/core/DataTable/Renderer/Html.php
+++ b/core/DataTable/Renderer/Html.php
@@ -38,7 +38,6 @@ class Html extends Renderer
     /**
      * Computes the dataTable output and returns the string/binary
      *
-     * @return string
      */
     public function render(): string
     {
@@ -53,7 +52,6 @@ class Html extends Renderer
      * Computes the output for the given data table
      *
      * @param DataTableInterface|array $table
-     * @return string
      */
     protected function renderTable($table): string
     {
@@ -154,7 +152,6 @@ class Html extends Renderer
     /**
      * Computes the output for the table structure array
      *
-     * @return string
      */
     protected function renderDataTable(): string
     {

--- a/core/DataTable/Renderer/Json.php
+++ b/core/DataTable/Renderer/Json.php
@@ -23,7 +23,6 @@ class Json extends Renderer
     /**
      * Computes the dataTable output and returns the string/binary
      *
-     * @return string
      */
     public function render(): string
     {

--- a/core/DataTable/Renderer/Rss.php
+++ b/core/DataTable/Renderer/Rss.php
@@ -28,7 +28,6 @@ class Rss extends Renderer
     /**
      * Computes the dataTable output and returns the string/binary
      *
-     * @return string
      */
     public function render(): string
     {
@@ -39,7 +38,6 @@ class Rss extends Renderer
      * Computes the output for the given data table
      *
      * @param DataTable|DataTable\Map $table
-     * @return string
      * @throws Exception
      */
     protected function renderTable($table): string
@@ -96,7 +94,6 @@ class Rss extends Renderer
     /**
      * Returns the RSS file footer
      *
-     * @return string
      */
     protected function getRssFooter(): string
     {
@@ -106,7 +103,6 @@ class Rss extends Renderer
     /**
      * Returns the RSS file header
      *
-     * @return string
      */
     protected function getRssHeader(): string
     {

--- a/core/DataTable/Renderer/Tsv.php
+++ b/core/DataTable/Renderer/Tsv.php
@@ -30,7 +30,6 @@ class Tsv extends Csv
     /**
      * Computes the dataTable output and returns the string/binary
      *
-     * @return string
      */
     public function render(): string
     {

--- a/core/DataTable/Renderer/Xml.php
+++ b/core/DataTable/Renderer/Xml.php
@@ -29,7 +29,6 @@ class Xml extends Renderer
     /**
      * Computes the dataTable output and returns the string/binary
      *
-     * @return string
      */
     public function render(): string
     {
@@ -40,7 +39,6 @@ class Xml extends Renderer
      * Computes the output for the given data table
      *
      * @param DataTable|DataTable\Map $table
-     * @return string
      * @throws Exception
      */
     protected function renderTable($table, bool $returnOnlyDataTableXml = false, string $prefixLines = ''): string
@@ -109,7 +107,6 @@ class Xml extends Renderer
      *
      * @param array $array The array to render.
      * @param string $prefixLines The string to prefix each line in the output.
-     * @return string
      */
     private function renderArray(array $array, string $prefixLines): string
     {
@@ -195,7 +192,6 @@ class Xml extends Renderer
      * Computes the output for the given data table array
      *
      * @param array $array
-     * @return string
      */
     protected function renderDataTableMap(Map $table, array $array, string $prefixLines = ''): string
     {
@@ -321,7 +317,6 @@ class Xml extends Renderer
      * Computes the output for the given data array
      *
      * @param array $array
-     * @return string
      */
     protected function renderDataTable($array, string $prefixLine = ''): string
     {
@@ -395,7 +390,6 @@ class Xml extends Renderer
      * Computes the output for the given data array (representing a simple data table)
      *
      * @param $array
-     * @return string
      */
     protected function renderDataTableSimple($array, string $prefixLine = ''): string
     {
@@ -429,7 +423,6 @@ class Xml extends Renderer
     /**
      * Returns true if a string is a valid XML tag name, false if otherwise.
      *
-     * @return bool
      */
     private static function isValidXmlTagName(string $str): bool
     {

--- a/core/Db/Schema.php
+++ b/core/Db/Schema.php
@@ -32,7 +32,6 @@ class Schema extends Singleton
      * Get schema class name
      *
      * @param string $schemaName
-     * @return string
      */
     private static function getSchemaClassName($schemaName): string
     {
@@ -51,7 +50,6 @@ class Schema extends Singleton
     /**
      * Return the default port for the provided database schema
      *
-     * @return int
      */
     public static function getDefaultPortForSchema(string $schemaName): int
     {
@@ -77,7 +75,6 @@ class Schema extends Singleton
     /**
      * Returns an instance that subclasses Schema
      *
-     * @return SchemaInterface
      */
     private function getSchema(): SchemaInterface
     {
@@ -90,7 +87,6 @@ class Schema extends Singleton
 
     /**
      * Unset schema instance
-     * @return void
      */
     public function unsetSchema(): void
     {
@@ -100,7 +96,6 @@ class Schema extends Singleton
     /**
      * Returns the default collation for a charset.
      *
-     * @return string
      */
     public function getDefaultCollationForCharset(string $charset): string
     {
@@ -110,7 +105,6 @@ class Schema extends Singleton
     /**
      * Get the table options to use for a CREATE TABLE statement.
      *
-     * @return string
      */
     public function getTableCreateOptions(): string
     {
@@ -256,7 +250,6 @@ class Schema extends Singleton
      *
      * @param string $sql  query to add hint to
      * @param float $limit  time limit in seconds
-     * @return string
      */
     public function addMaxExecutionTimeHintToQuery(string $sql, float $limit): string
     {
@@ -266,7 +259,6 @@ class Schema extends Singleton
     /**
      * Returns if the schema support complex column updates
      *
-     * @return bool
      */
     public function supportsComplexColumnUpdates(): bool
     {
@@ -276,7 +268,6 @@ class Schema extends Singleton
     /**
      * Returns if the schema supports `OPTIMIZE TABLE` statements for innodb tables
      *
-     * @return bool
      */
     public function isOptimizeInnoDBSupported(): bool
     {
@@ -292,7 +283,6 @@ class Schema extends Singleton
      * @param string|array $tables The name of the table to optimize or an array of tables to optimize.
      *                             Table names must be prefixed (see {@link Piwik\Common::prefixTable()}).
      * @param bool $force If true, the `OPTIMIZE TABLE` query will be run even if InnoDB tables are being used.
-     * @return bool
      */
     public function optimizeTables(array $tables, bool $force = false): bool
     {
@@ -303,7 +293,6 @@ class Schema extends Singleton
      * Returns if the database engine can provide a rollup ranking query result
      * without needing additional sorting.
      *
-     * @return bool
      */
     public function supportsRankingRollupWithoutExtraSorting(): bool
     {
@@ -313,7 +302,6 @@ class Schema extends Singleton
     /**
      * Returns if the database engine is able to use sorted subqueries
      *
-     * @return bool
      */
     public function supportsSortingInSubquery(): bool
     {
@@ -351,7 +339,6 @@ class Schema extends Singleton
 
     /**
      * Returns the minimum supported version of the currently used database server
-     * @return string
      */
     public function getMinimumSupportedVersion(): string
     {

--- a/core/Db/Schema/Mariadb.php
+++ b/core/Db/Schema/Mariadb.php
@@ -28,7 +28,6 @@ class Mariadb extends Mysql
      *
      * @param string $sql  query to add hint to
      * @param float $limit  time limit in seconds
-     * @return string
      */
     public function addMaxExecutionTimeHintToQuery(string $sql, float $limit): string
     {

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -689,7 +689,6 @@ class Mysql implements SchemaInterface
      *
      * @param string $sql  query to add hint to
      * @param float $limit  time limit in seconds
-     * @return string
      */
     public function addMaxExecutionTimeHintToQuery(string $sql, float $limit): string
     {
@@ -715,7 +714,6 @@ class Mysql implements SchemaInterface
      * (can happen for alias charsets like "utf8").
      *
      *
-     * @return string
      * @throws Exception
      */
     public function getDefaultCollationForCharset(string $charset): string

--- a/core/Db/Schema/Tidb.php
+++ b/core/Db/Schema/Tidb.php
@@ -23,7 +23,6 @@ class Tidb extends Mysql
      * TiDB performs a sanity check before performing e.g. ALTER TABLE statements. If any of the used columns does not
      * exist before the query fails. This also happens if the column would be added in the same query.
      *
-     * @return bool
      */
     public function supportsComplexColumnUpdates(): bool
     {

--- a/core/Db/SchemaInterface.php
+++ b/core/Db/SchemaInterface.php
@@ -127,7 +127,6 @@ interface SchemaInterface
      *
      * @param string $sql  query to add hint to
      * @param float $limit  time limit in seconds
-     * @return string
      */
     public function addMaxExecutionTimeHintToQuery(string $sql, float $limit): string;
 
@@ -136,7 +135,6 @@ interface SchemaInterface
      * Some database engines are performing sanity checks for table updates. Those might include checking if all columns used
      * already exist. In such a case queries like this might fail: `ALTER TABLE t ADD COLUMN b, ADD INDEX i (b)`
      *
-     * @return bool
      */
     public function supportsComplexColumnUpdates(): bool;
 
@@ -144,28 +142,24 @@ interface SchemaInterface
      * Returns the default collation for a charset used by this database engine.
      *
      *
-     * @return string
      */
     public function getDefaultCollationForCharset(string $charset): string;
 
     /**
      * Return the default port used by this database engine
      *
-     * @return int
      */
     public function getDefaultPort(): int;
 
     /**
      * Return the table options to use for a CREATE TABLE statement.
      *
-     * @return string
      */
     public function getTableCreateOptions(): string;
 
     /**
      * Returns if performing on `OPTIMIZE TABLE` is supported for InnoDb tables
      *
-     * @return bool
      */
     public function isOptimizeInnoDBSupported(): bool;
 
@@ -178,7 +172,6 @@ interface SchemaInterface
      * @param array $tables The name of the table to optimize or an array of tables to optimize.
      *                      Table names must be prefixed (see {@link Piwik\Common::prefixTable()}).
      * @param bool $force If true, the `OPTIMIZE TABLE` query will be run even if InnoDB tables are being used.
-     * @return bool
      */
     public function optimizeTables(array $tables, bool $force = false): bool;
 
@@ -186,32 +179,27 @@ interface SchemaInterface
      * Returns if the database engine can provide a rollup ranking query result
      * without needing additional sorting.
      *
-     * @return bool
      */
     public function supportsRankingRollupWithoutExtraSorting(): bool;
 
     /**
      * Returns if the database engine is able to use sorted subqueries
      *
-     * @return bool
      */
     public function supportsSortingInSubquery(): bool;
 
     /**
      * Returns the version of the database server
-     * @return string
      */
     public function getVersion(): string;
 
     /**
      * Returns if the used database version has reached its EOL
-     * @return bool
      */
     public function hasReachedEOL(): bool;
 
     /**
      * Returns the minimum supported version set for the schema
-     * @return string
      */
     public function getMinimumSupportedVersion(): string;
 }

--- a/core/DbHelper.php
+++ b/core/DbHelper.php
@@ -208,7 +208,6 @@ class DbHelper
      *
      * Returns utf8mb4 if supported, with fallback to utf8
      *
-     * @return string
      * @throws Tracker\Db\DbException
      */
     public static function getDefaultCharset(): string
@@ -238,7 +237,6 @@ class DbHelper
      * Returns the default collation for a charset.
      *
      *
-     * @return string
      * @throws Exception
      */
     public static function getDefaultCollationForCharset(string $charset): string
@@ -304,7 +302,6 @@ class DbHelper
      *
      * @param string $sql  query to add hint to
      * @param float $limit  time limit in seconds
-     * @return string
      */
     public static function addMaxExecutionTimeHintToQuery(string $sql, float $limit): string
     {

--- a/core/FileIntegrity.php
+++ b/core/FileIntegrity.php
@@ -65,7 +65,6 @@ class FileIntegrity
     /**
      * Include the manifest
      *
-     * @return void
      */
     private static function loadManifest(): void
     {

--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -570,7 +570,6 @@ class Filesystem
     /**
      * Check if the filesystem is case sensitive by writing a temporary file
      *
-     * @return bool
      */
     public static function isFileSystemCaseInsensitive(): bool
     {

--- a/core/Period/Range.php
+++ b/core/Period/Range.php
@@ -599,7 +599,6 @@ class Range extends Period
      * automatically lower the end date to the date returned by this method.
      * The max supported timestamp is always set to end of the current year plus 10 years.
      *
-     * @return int
      * @api
      */
     public static function getMaxAllowedEndTimestamp(): int

--- a/core/Plugin/ConsoleCommand.php
+++ b/core/Plugin/ConsoleCommand.php
@@ -54,7 +54,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
      * Sends the given message(s) as success message(s) to the output interface (surrounded by empty lines)
      *
      * @param string|string[] $messages
-     * @return void
      */
     public function writeSuccessMessage($messages): void
     {
@@ -75,7 +74,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
      * Sends the given message(s) as error message(s) to the output interface (surrounded by empty lines)
      *
      * @param string|string[] $messages
-     * @return void
      */
     public function writeErrorMessage($messages): void
     {
@@ -96,7 +94,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
      * Sends the given messages as comment message to the output interface (surrounded by empty lines)
      *
      * @param string|string[] $messages
-     * @return void
      */
     public function writeComment($messages): void
     {
@@ -116,7 +113,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
     /**
      * Checks if all input options that are marked as requires-value were provided
      *
-     * @return void
      * @throws \InvalidArgumentException
      */
     protected function checkAllRequiredOptionsAreNotEmpty(): void
@@ -146,7 +142,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
     /**
      * Method is final to make it impossible to overwrite it in plugin commands
      *
-     * @return int
      */
     final public function run(InputInterface $input, OutputInterface $output): int
     {
@@ -359,7 +354,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
      *
      * @see parent::interact()
      *
-     * @return void
      */
     protected function doInteract(): void
     {
@@ -382,7 +376,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
      *
      * @see parent::initialize()
      *
-     * @return void
      */
     protected function doInitialize(): void
     {
@@ -418,7 +411,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
      *
      * @see QuestionHelper
      *
-     * @return bool
      */
     protected function askForConfirmation(string $question, bool $default = true, string $trueAnswerRegex = '/^y/i'): bool
     {
@@ -471,7 +463,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
      *
      * @see ProgressBar
      *
-     * @return ProgressBar
      */
     protected function initProgressBar(int $numChangesToPerform = 0): ProgressBar
     {
@@ -482,7 +473,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
     /**
      * Starts a previously initialized progress bar
      *
-     * @return void
      */
     protected function startProgressBar(int $numChangesToPerform = 0): void
     {
@@ -492,7 +482,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
     /**
      * Advances the previously initialized progress bar
      *
-     * @return void
      */
     protected function advanceProgressBar(int $step = 1): void
     {
@@ -506,7 +495,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
     /**
      * Finished the initialized progress bar
      *
-     * @return void
      */
     protected function finishProgressBar(): void
     {
@@ -539,7 +527,6 @@ class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterfac
      * Runs a certain command
      *
      * @param array  $arguments
-     * @return int
      * @throws \Symfony\Component\Console\Exception\ExceptionInterface
      */
     protected function runCommand(string $command, array $arguments, bool $hideOutput = false): int

--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -837,7 +837,6 @@ abstract class Controller
     /**
      * Set the template variables to show the what's new popup if appropriate
      *
-     * @return void
      */
     protected function showWhatIsNew(View $view): void
     {

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -517,7 +517,6 @@ class Manager
     /**
      * Returns the plugin directory path relative to Matomo's root directory.
      *
-     * @return string
      */
     public static function getRelativePluginDirectory(string $pluginName): string
     {
@@ -787,7 +786,6 @@ class Manager
      *
      * If no theme is enabled, the **Morpheus** plugin is returned (this is the base and default theme).
      *
-     * @return Plugin|null
      * @api
      */
     public function getThemeEnabled(): ?Plugin

--- a/core/Plugin/Metric.php
+++ b/core/Plugin/Metric.php
@@ -92,7 +92,6 @@ abstract class Metric
      *
      * See {@link \Piwik\Columns\Dimension} for the list of available semantic types.
      *
-     * @return string|null
      */
     public function getSemanticType(): ?string
     {

--- a/core/Plugin/ReleaseChannels.php
+++ b/core/Plugin/ReleaseChannels.php
@@ -90,7 +90,6 @@ class ReleaseChannels
 
     /**
      * @param string $releaseChannelId
-     * @return ?ReleaseChannel
      */
     private function factory($releaseChannelId): ?ReleaseChannel
     {

--- a/core/Plugin/Report.php
+++ b/core/Plugin/Report.php
@@ -1143,7 +1143,6 @@ class Report
      * Returns the name of the column/metadata that uniquely identifies rows in this report. See
      * {@link self::$rowIdentifier} for more information.
      *
-     * @return string
      */
     public function getRowIdentifier(): string
     {

--- a/core/Plugin/SettingsProvider.php
+++ b/core/Plugin/SettingsProvider.php
@@ -41,7 +41,6 @@ class SettingsProvider
     /**
      *
      * Get user settings implemented by a specific plugin (if implemented by this plugin).
-     * @return SystemSettings|null
      */
     public function getSystemSettings(string $pluginName): ?SystemSettings
     {
@@ -60,7 +59,6 @@ class SettingsProvider
 
     /**
      * Get user settings implemented by a specific plugin (if implemented by this plugin).
-     * @return UserSettings|null
      */
     public function getUserSettings(string $pluginName): ?UserSettings
     {

--- a/core/Policy/PolicyManager.php
+++ b/core/Policy/PolicyManager.php
@@ -210,7 +210,6 @@ class PolicyManager
     /**
      * Return setting type from a given Setting instance, including subclasses
      *
-     * @return string|null
      */
     public static function getSettingTypeFromSettingClass(Setting $setting): ?string
     {

--- a/core/ReportRenderer/Pdf.php
+++ b/core/ReportRenderer/Pdf.php
@@ -575,7 +575,6 @@ class Pdf extends ReportRenderer
     /**
      * Gets the row height for a label. This will be the total height including wrapping
      * but still having a maximum height
-     * @return float
      */
     private function getLabelRowHeight(string $text): float
     {
@@ -597,7 +596,6 @@ class Pdf extends ReportRenderer
     /**
      * @param false|string $url
      * @param array<string, mixed> $rowMetadata
-     * @return void
      */
     private function renderLabelLinkAndLogo(
         $url,
@@ -660,7 +658,6 @@ class Pdf extends ReportRenderer
     /**
      * This is only useful when label row is 3 lines,
      * we needed to make max row bigger so that it can be centered vertically better
-     * @return float
      */
     private function getLabelRowMaxHeight(float $rowHeight): float
     {
@@ -672,7 +669,6 @@ class Pdf extends ReportRenderer
 
     /**
      * Sets initial label width based on column count and content heuristics.
-     * @return void
      */
     private function setInitialLabelWidth(int $columnsCount): void
     {
@@ -814,7 +810,6 @@ class Pdf extends ReportRenderer
     /**
      * This function will try to show all values for selected metric columns.
      * Will adjust other column widths to accommodate this
-     * @return void
      */
     private function adjustMetricColumnWidthsToContent(): void
     {
@@ -833,7 +828,6 @@ class Pdf extends ReportRenderer
     /**
      * This function will try to adjust column width based on the content.
      * This will try to make other columns smaller to accommodate this
-     * @return void
      */
     private function adjustMetricColumnWidthToContent(string $columnId): void
     {
@@ -909,7 +903,6 @@ class Pdf extends ReportRenderer
 
     /**
      * Computes maximum column width for a given metric column
-     * @return float
      */
     private function getMaxFormattedColumnWidth(string $columnId): float
     {
@@ -1019,7 +1012,6 @@ class Pdf extends ReportRenderer
     /**
      * Will check if label column could use a shorter width.
      * This is done so that we can fit more metrics in the same row for data table with no label that is too long
-     * @return bool
      */
     private function shouldUseShortLabelWidth(): bool
     {
@@ -1127,7 +1119,6 @@ class Pdf extends ReportRenderer
     /**
      * Will initialize table column widths,
      * this will include adjusting label and revenue columns
-     * @return void
      */
     private function initializeTableColumnWidths(): void
     {
@@ -1293,7 +1284,6 @@ class Pdf extends ReportRenderer
      * Prints a message
      *
      * @param string $message
-     * @return void
      */
     private function paintMessage($message): void
     {

--- a/core/Request.php
+++ b/core/Request.php
@@ -129,7 +129,6 @@ class Request
      * If no default is provided and the requested parameter either can't be found or is not of type integer an
      * exception will be thrown
      *
-     * @return int
      * @throws InvalidArgumentException
      */
     public function getIntegerParameter(string $name, ?int $default = null): int
@@ -152,7 +151,6 @@ class Request
      * If no default is provided and the requested parameter either can't be found or is not of type float an
      * exception will be thrown
      *
-     * @return float
      * @throws InvalidArgumentException
      */
     public function getFloatParameter(string $name, ?float $default = null): float
@@ -183,7 +181,6 @@ class Request
      * If no default is provided and the requested parameter either can't be found or is not of type string an
      * exception will be thrown
      *
-     * @return string
      * @throws InvalidArgumentException
      */
     public function getStringParameter(string $name, ?string $default = null): string
@@ -210,7 +207,6 @@ class Request
      * true: true, 'true', '1', 1
      * false: false, 'false', '0', 0
      *
-     * @return bool
      * @throws InvalidArgumentException
      */
     public function getBoolParameter(string $name, ?bool $default = null): bool

--- a/core/Request/AuthenticationToken.php
+++ b/core/Request/AuthenticationToken.php
@@ -35,7 +35,6 @@ class AuthenticationToken
 
     /**
      * @param array<string, mixed>|null $request
-     * @return string
      */
     public function getAuthToken(?array $request = null): string
     {

--- a/core/Scheduler/Task.php
+++ b/core/Scheduler/Task.php
@@ -205,7 +205,6 @@ class Task
      * Returns the TTL for this task.
      * See {@link self::$ttlInSeconds}
      *
-     * @return int
      */
     public function getTTL(): int
     {

--- a/core/Scheduler/Timetable.php
+++ b/core/Scheduler/Timetable.php
@@ -220,7 +220,6 @@ class Timetable
      * Return the current number of retries for a task
      *
      *
-     * @return int
      */
     public function getRetryCount(string $taskName): int
     {

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -185,7 +185,6 @@ class Segment
      * Checks if the provided segmentCondition is valid and available for the given idSites
      *
      * @params array $idSites
-     * @return bool
      * @api since Matomo 5.3.0
      */
     public static function isAvailable(string $segmentCondition, array $idSites): bool

--- a/core/Session/SaveHandler/DbTable.php
+++ b/core/Session/SaveHandler/DbTable.php
@@ -61,7 +61,6 @@ class DbTable implements \SessionHandlerInterface
      *
      * @param string $save_path
      * @param string $name
-     * @return boolean
      */
     public function open($save_path, $name): bool
     {
@@ -73,7 +72,6 @@ class DbTable implements \SessionHandlerInterface
     /**
      * Close Session - free resources
      *
-     * @return boolean
      */
     public function close(): bool
     {
@@ -138,7 +136,6 @@ class DbTable implements \SessionHandlerInterface
      *
      * @param string $id
      * @param mixed $data
-     * @return boolean
      */
     public function write($id, $data): bool
     {
@@ -165,7 +162,6 @@ class DbTable implements \SessionHandlerInterface
      * given session id
      *
      * @param string $id
-     * @return boolean
      */
     public function destroy($id): bool
     {

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -27,7 +27,6 @@ class SettingsPiwik
      *
      * NOTE: Keep this salt secret! Never output anywhere or share it etc.
      *
-     * @return string|null
      */
     public static function getSalt(): ?string
     {
@@ -163,7 +162,6 @@ class SettingsPiwik
     /**
      * Number of websites to show in the Website selector
      *
-     * @return int
      */
     public static function getWebsitesCountToDisplay(): int
     {
@@ -254,7 +252,6 @@ class SettingsPiwik
      * Check if outgoing internet connections are enabled
      * This is often disable in an intranet environment
      *
-     * @return bool
      */
     public static function isInternetEnabled(): bool
     {
@@ -265,7 +262,6 @@ class SettingsPiwik
      * Detect whether user has enabled auto updates. Please note this config is a bit misleading. It is currently
      * actually used for 2 things: To disable making any connections back to Piwik, and to actually disable the auto
      * update of core and plugins.
-     * @return bool
      */
     public static function isAutoUpdateEnabled(): bool
     {
@@ -283,7 +279,6 @@ class SettingsPiwik
      * as it would be installed only on one server instead of all of them. Also if a user has disabled automatic updates
      * we cannot perform any automatic updates.
      *
-     * @return bool
      */
     public static function isAutoUpdatePossible(): bool
     {
@@ -294,7 +289,6 @@ class SettingsPiwik
      * Returns `true` if Piwik is running on more than one server. For example in a load balanced environment. In this
      * case we should not make changes to the config and not install a plugin via the UI as it would be only executed
      * on one server.
-     * @return bool
      */
     public static function isMultiServerEnvironment(): bool
     {
@@ -306,7 +300,6 @@ class SettingsPiwik
     /**
      * Returns `true` if segmentation is allowed for this user, `false` if otherwise.
      *
-     * @return bool
      * @api
      */
     public static function isSegmentationEnabled(): bool
@@ -322,7 +315,6 @@ class SettingsPiwik
      * INI config options. By default, unique visitors are processed only for day/week/month periods.
      *
      * @param string $periodLabel `"day"`, `"week"`, `"month"`, `"year"` or `"range"`
-     * @return bool
      * @api
      */
     public static function isUniqueVisitorsEnabled(string $periodLabel): bool
@@ -345,7 +337,6 @@ class SettingsPiwik
 
     /**
      * If Piwik uses per-domain config file, make sure CustomLogo is unique
-     * @return string
      * @throws \Piwik\Exception\DI\DependencyException
      * @throws \Piwik\Exception\DI\NotFoundException
      * @throws Exception
@@ -364,7 +355,6 @@ class SettingsPiwik
      * or if the Piwik server is "offline",
      * this will return false..
      *
-     * @return void
      * @throws Exception
      */
     public static function checkPiwikServerWorking(string $piwikServerUrl, bool $acceptInvalidSSLCertificates = false): void
@@ -412,7 +402,6 @@ class SettingsPiwik
      * Returns true if Piwik is deployed using git
      * FAQ: https://piwik.org/faq/how-to-install/faq_18271/
      *
-     * @return bool
      */
     public static function isGitDeployment(): bool
     {
@@ -439,7 +428,6 @@ class SettingsPiwik
     }
 
     /**
-     * @return string
      * @throws Exception
      */
     protected static function rewritePathAppendPiwikInstanceId(string $pathToRewrite, string $leadingPathToAppendHostnameTo): string
@@ -503,7 +491,6 @@ class SettingsPiwik
     /**
      * Note: this config settig is also checked in the InterSites plugin
      *
-     * @return bool
      */
     public static function isSameFingerprintAcrossWebsites(): bool
     {

--- a/core/SiteContentDetector.php
+++ b/core/SiteContentDetector.php
@@ -84,7 +84,6 @@ class SiteContentDetector
     /**
      * Returns the site content detection object with the provided id, or null if it can't be found
      *
-     * @return SiteContentDetectionAbstract|null
      */
     public function getSiteContentDetectionById(string $id): ?SiteContentDetectionAbstract
     {
@@ -110,7 +109,6 @@ class SiteContentDetector
     /**
      * Reset the detections
      *
-     * @return void
      */
     private function resetDetections(): void
     {
@@ -139,7 +137,6 @@ class SiteContentDetector
      * @param ?array      $siteResponse  String containing the site data to search, if blank then data will be retrieved
      *                                   from the current request site via an http request
      * @param int         $timeOut       How long to wait for the site to response, defaults to 5 seconds
-     * @return void
      */
     public function detectContent(
         array $detectContent = [],
@@ -202,7 +199,6 @@ class SiteContentDetector
      *
      * Note: self::detectContent needs to be called before.
      *
-     * @return bool
      */
     public function wasDetected(string $detectionClassId): bool
     {
@@ -240,7 +236,6 @@ class SiteContentDetector
      * @param array $detectContent
      * @param array $cache
      *
-     * @return bool
      */
     private function checkCacheHasRequiredProperties(array $detectContent, array $cache): bool
     {
@@ -281,7 +276,6 @@ class SiteContentDetector
      * Save data to the cache
      *
      *
-     * @return void
      */
     private function saveToCache(string $cacheKey, int $cacheLife): void
     {
@@ -318,7 +312,6 @@ class SiteContentDetector
      *
      * @param array $detectContent    Array of detection types used to filter the checks that are run
      *
-     * @return void
      */
     private function detectionChecks(array $detectContent): void
     {

--- a/core/Tracker/Settings.php
+++ b/core/Tracker/Settings.php
@@ -138,7 +138,6 @@ class Settings // TODO: merge w/ visitor recognizer or make it it's own service.
      * @param $ip
      * @param $browserLang
      * @param $fingerprintHash
-     * @return string
      */
     protected function getConfigHash(
         Request $request,

--- a/core/Tracker/Visit/VisitProperties.php
+++ b/core/Tracker/Visit/VisitProperties.php
@@ -65,7 +65,6 @@ class VisitProperties
      * @param string $name The property name.
      * @param mixed $value The property value.
      *
-     * @return void
      */
     public function setProperty($name, $value): void
     {
@@ -75,7 +74,6 @@ class VisitProperties
     /**
      * Unsets all visit properties.
      *
-     * @return void
      */
     public function clearProperties(): void
     {
@@ -87,7 +85,6 @@ class VisitProperties
      *
      * @param array $properties
      *
-     * @return void
      */
     public function setProperties(array $properties): void
     {
@@ -101,7 +98,6 @@ class VisitProperties
      *
      * @param mixed $value
      *
-     * @return void
      */
     public function initializeProperty(string $name, $value): void
     {

--- a/core/Tracker/VisitExcluded.php
+++ b/core/Tracker/VisitExcluded.php
@@ -356,7 +356,6 @@ class VisitExcluded
      * are also supported.
      *
      * @internal param string $this ->userAgent The user agent string.
-     * @return bool
      */
     protected function isUserAgentExcluded(): bool
     {

--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -110,7 +110,6 @@ class Translator
      * Converts the given list of items into a listing (e.g. One, Two, and Three)
      *
      * @param array       $items
-     * @return string
      */
     public function createAndListing(array $items, ?string $language = null): string
     {
@@ -121,7 +120,6 @@ class Translator
      * Converts the given list of items into a or listing (e.g. One, Two, or Three)
      *
      * @param array       $items
-     * @return string
      */
     public function createOrListing(array $items, ?string $language = null): string
     {
@@ -131,7 +129,6 @@ class Translator
     /**
      * @param string      $listType type of the list (LIST_TYPE_AND or LIST_TYPE_OR)
      * @param array       $items
-     * @return string
      */
     private function createListing(string $listType, array $items, ?string $language = null): string
     {
@@ -218,7 +215,6 @@ class Translator
     /**
      * Decodes all entities in the given string except of &gt; and &lt;
      *
-     * @return string
      */
     private function decodeEntitiesSafeForHTML(string $text): string
     {

--- a/core/UpdateCheck.php
+++ b/core/UpdateCheck.php
@@ -102,7 +102,6 @@ class UpdateCheck
     /**
      * Returns whether the last update check was flagged as having failed or not.
      *
-     * @return bool
      */
     public static function hasLastCheckFailed(): bool
     {

--- a/core/UpdateCheck/ReleaseChannel.php
+++ b/core/UpdateCheck/ReleaseChannel.php
@@ -81,7 +81,6 @@ abstract class ReleaseChannel
 
     /**
      * If the channel should be possible to be enabled in the system settings.
-     * @return bool
      */
     public function isSelectableInSettings(): bool
     {

--- a/core/UrlHelper.php
+++ b/core/UrlHelper.php
@@ -368,7 +368,6 @@ class UrlHelper
      *
      * @param array  $additionalParamsToAdd
      *
-     * @return string
      */
     private static function addAdditionalParameters(string $query, array $additionalParamsToAdd): string
     {

--- a/core/ViewDataTable/Config.php
+++ b/core/ViewDataTable/Config.php
@@ -766,7 +766,6 @@ class Config
      * @template T of array<string, string>
      * @param T $dimensions
      * @param key-of<T> $defaultDimension
-     * @return void
      */
     public function setSecondaryDimensions(array $dimensions, string $defaultDimension): void
     {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -36,4 +36,5 @@
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment" />
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation" />
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation" />
 </ruleset>

--- a/plugins/API/Filter/DataComparisonFilter.php
+++ b/plugins/API/Filter/DataComparisonFilter.php
@@ -601,7 +601,6 @@ class DataComparisonFilter
      *
      * @see \Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines::render()
      *
-     * @return bool
      * @throws \Exception
      */
     private function shouldIncludeTrendValues(): bool

--- a/plugins/API/Renderer/Original.php
+++ b/plugins/API/Renderer/Original.php
@@ -87,7 +87,6 @@ class Original extends ApiRenderer
     /**
      * Returns true if the user requested to serialize the output data (&serialize=1 in the request)
      *
-     * @return bool
      */
     private function shouldSerialize(): bool
     {

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -222,7 +222,6 @@ class ArchivingHelper
      * @param array $row        The array of goals metric data to add to the action table row
      * @param bool  $isPages    True if page view goals metrics should be used, else entry goal metrics
      *
-     * @return bool
      * @throws \Exception
      */
     private static function updateActionsTableRowWithGoals(array $row, bool $isPages): bool

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -536,7 +536,6 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
      * Add goals data for each combination of url / title and pageviews / entries
      *
      *
-     * @return void
      */
     protected function archiveDayActionsGoals(ArchiveProcessor $archiveProcessor, int $rankingQueryLimit): void
     {

--- a/plugins/Annotations/API.php
+++ b/plugins/Annotations/API.php
@@ -359,7 +359,6 @@ class API extends \Piwik\Plugin\API
     /**
      * Throws an exception if the given $idSite does not exist.
      *
-     * @return void
      * @throws UnexpectedWebsiteFoundException
      */
     private function checkSiteExists(int $idSite): void

--- a/plugins/Annotations/Annotations.php
+++ b/plugins/Annotations/Annotations.php
@@ -105,7 +105,6 @@ class Annotations extends \Piwik\Plugin
      * created the note in question.
      *
      * @param array $annotation The annotation.
-     * @return bool
      */
     public static function canUserModifyOrDelete(array $annotation): bool
     {

--- a/plugins/Annotations/Controller.php
+++ b/plugins/Annotations/Controller.php
@@ -229,7 +229,6 @@ class Controller extends \Piwik\Plugin\Controller
      * Returns true if the current user can add notes for a specific site.
      *
      * @param int $idSite The site to add notes to.
-     * @return bool
      */
     public static function canUserAddNotesFor(int $idSite): bool
     {

--- a/plugins/BotTracking/RecordBuilders/AIChatbotReports.php
+++ b/plugins/BotTracking/RecordBuilders/AIChatbotReports.php
@@ -146,7 +146,6 @@ class AIChatbotReports extends RecordBuilder
     /**
      * @param array<string, DataTable> $tables
      * @param array<string, int> $visits
-     * @return void
      */
     private function populateChatbotTableForActionType(array $tables, int $actionType, LogAggregator $logAggregator, array $visits): void
     {

--- a/plugins/BotTracking/Tracker/BotRequestProcessor.php
+++ b/plugins/BotTracking/Tracker/BotRequestProcessor.php
@@ -112,7 +112,6 @@ class BotRequestProcessor extends \Piwik\Tracker\BotRequestProcessor
     /**
      * Get or create action ID for the URL
      *
-     * @return int|null
      */
     private function getActionId(Request $request): ?int
     {

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -426,7 +426,6 @@ class API extends \Piwik\Plugin\API
      * Show the JavaScript opt out code
      *
      *
-     * @return string
      *
      * @internal
      */
@@ -457,7 +456,6 @@ class API extends \Piwik\Plugin\API
      * Show the self-contained JavaScript opt out code
      *
      *
-     * @return string
      *
      * @internal
      */

--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -269,7 +269,6 @@ class Controller extends ControllerAdmin
     /**
      * Shows the Javascript opt out
      *
-     * @return string
      * @throws Exception
      */
     public function optOutJS(): string

--- a/plugins/CoreAdminHome/CustomLogo.php
+++ b/plugins/CoreAdminHome/CustomLogo.php
@@ -292,7 +292,6 @@ class CustomLogo
     /**
      * Publish logo and small logo from tmp folder to user folder
      *
-     * @return bool
      */
     public function publishUserLogo(): bool
     {
@@ -326,7 +325,6 @@ class CustomLogo
     /**
      * Publish favicon from tmp folder to user folder
      *
-     * @return bool
      */
     public function publishUserFavicon(): bool
     {
@@ -354,7 +352,6 @@ class CustomLogo
     /**
      * Remove any uploaded logos from tmp and user folders
      *
-     * @return void
      */
     public function removeLogos(): void
     {
@@ -365,7 +362,6 @@ class CustomLogo
     /**
      * Remove publicly accessible logos and favicons from the misc/user folder
      *
-     * @return void
      */
     public function removePublishedLogos(): void
     {
@@ -381,7 +377,6 @@ class CustomLogo
     /**
      * Remove all uploaded logos and favicons from the temp folder
      *
-     * @return void
      */
     public function removeLogosFromTempFolder(): void
     {
@@ -394,7 +389,6 @@ class CustomLogo
      * @param $uploadFieldName
      * @param $targetHeight
      * @param $path
-     * @return bool
      */
     private function uploadImage($uploadFieldName, $targetHeight, $path): bool
     {
@@ -457,7 +451,6 @@ class CustomLogo
     /**
      * If tmp logo exists, return it as base64 encoded string for preview in branding settings
      *
-     * @return string|null
      */
     public function getTempUserLogoBase64(): ?string
     {
@@ -473,7 +466,6 @@ class CustomLogo
     /**
      * If tmp favicon exists, return it as base64 encoded string for preview in branding settings
      *
-     * @return string|null
      */
     public function getTempUserFaviconBase64(): ?string
     {

--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -183,7 +183,6 @@ class OptOutManager
      * Return the HTML code to be added to pages for the JavaScript opt-out
      *
      *
-     * @return string
      */
     public function getOptOutJSEmbedCode(
         string $matomoUrl,
@@ -217,7 +216,6 @@ class OptOutManager
      * Return the HTML code to be added to pages for the self-contained opt-out
      *
      *
-     * @return string
      */
     public function getOptOutSelfContainedEmbedCode(
         string $backgroundColor,
@@ -286,7 +284,6 @@ HTML;
      *     cookiePath (default blank)         Use this path for consent cookies
      *     cookieDomain (default blank)       Use this domain for consent cookies
      *
-     * @return string
      */
     public function getOptOutJS(): string
     {
@@ -406,7 +403,6 @@ JS;
     /**
      * Return the shared opt-out JavaScript (used by self-contained and tracker versions)
      *
-     * @return string
      */
     private function getOptOutCommonJS(): string
     {
@@ -645,7 +641,6 @@ JS;
      * Provide a CSS style sheet based on the chosen opt out style options
      *
      *
-     * @return string
      * @throws \Exception
      */
     private function optOutStyling(

--- a/plugins/CoreHome/DataTableRowAction/RowEvolution.php
+++ b/plugins/CoreHome/DataTableRowAction/RowEvolution.php
@@ -504,7 +504,6 @@ class RowEvolution
 
     /**
      * @param string|int|float $value
-     * @return int
      */
     private function getFractionDigits($value): int
     {

--- a/plugins/CoreHome/EntityDuplicator/DuplicateRequestResponse.php
+++ b/plugins/CoreHome/EntityDuplicator/DuplicateRequestResponse.php
@@ -86,7 +86,6 @@ class DuplicateRequestResponse
 
     /**
      * @param array $additionalData
-     * @return void
      */
     public function setAdditionalData(array $additionalData): void
     {
@@ -166,7 +165,6 @@ class DuplicateRequestResponse
      *   idSite but also since it doesn't need to be provided if the only destination site is the source site (idSite).
      * @param array|null $additionalData Optional array of additional data relating to the entity being copied.
      *
-     * @return void
      */
     public function setRequestDataForEvent(
         string $entityTypeTranslation,

--- a/plugins/CorePluginsAdmin/API.php
+++ b/plugins/CorePluginsAdmin/API.php
@@ -135,7 +135,6 @@ class API extends \Piwik\Plugin\API
 
     /**
      * @internal
-     * @return int
      */
     public function getNumberOfPluginUpdates(): int
     {

--- a/plugins/CorePluginsAdmin/CorePluginsAdmin.php
+++ b/plugins/CorePluginsAdmin/CorePluginsAdmin.php
@@ -58,7 +58,6 @@ class CorePluginsAdmin extends Plugin
     /**
      * Retrieve an instantiated ChangesModel object
      *
-     * @return ChangesModel
      */
     private function getChangesModel(): ChangesModel
     {

--- a/plugins/CoreVisualizations/Visualizations/EvolutionPeriodSelector.php
+++ b/plugins/CoreVisualizations/Visualizations/EvolutionPeriodSelector.php
@@ -92,7 +92,6 @@ class EvolutionPeriodSelector
      * allow it.
      *
      * @param $comparisonPeriods
-     * @return string
      */
     public function getHighestPeriodInCommon(Period $originalPeriod, $comparisonPeriods): string
     {

--- a/plugins/DevicesDetection/DevicesDetection.php
+++ b/plugins/DevicesDetection/DevicesDetection.php
@@ -72,7 +72,6 @@ class DevicesDetection extends \Piwik\Plugin
     /**
      * Check if compliance policy disables device model detection
      *
-     * @return bool
      * @throws \Piwik\Exception\DI\DependencyException
      * @throws \Piwik\Exception\DI\NotFoundException
      */

--- a/plugins/Diagnostics/Commands/ArchivingStatus.php
+++ b/plugins/Diagnostics/Commands/ArchivingStatus.php
@@ -102,7 +102,6 @@ class ArchivingStatus extends ConsoleCommand
      *
      * @param mixed     $output
      *
-     * @return void
      */
     private function outputSectionHeader($output, string $title): void
     {

--- a/plugins/Diagnostics/Commands/UnexpectedFiles.php
+++ b/plugins/Diagnostics/Commands/UnexpectedFiles.php
@@ -35,7 +35,6 @@ class UnexpectedFiles extends ConsoleCommand
     /**
      * Execute the command
      *
-     * @return int
      */
     protected function doExecute(): int
     {
@@ -76,7 +75,6 @@ class UnexpectedFiles extends ConsoleCommand
      * Handle unexpected files command options
      *
      *
-     * @return int
      */
     private function runUnexpectedFiles(bool $delete = false): int
     {
@@ -125,7 +123,6 @@ class UnexpectedFiles extends ConsoleCommand
     /**
      * Interact with the user to confirm the deletion
      *
-     * @return bool
      */
     private function askForDeleteConfirmation(): bool
     {

--- a/plugins/ExampleAPI/API.php
+++ b/plugins/ExampleAPI/API.php
@@ -34,7 +34,6 @@ class API extends \Piwik\Plugin\API
 
     /**
      * Get Matomo version
-     * @return string
      */
     public function getMatomoVersion(): string
     {
@@ -44,7 +43,6 @@ class API extends \Piwik\Plugin\API
 
     /**
      * Get Answer to Life
-     * @return int
      */
     public function getAnswerToLife(): int
     {
@@ -70,7 +68,6 @@ class API extends \Piwik\Plugin\API
      * when the API function is called. You can also use default values
      * as shown in this example.
      *
-     * @return float
      */
     public function getSum(float $a = 0, float $b = 0): float
     {
@@ -104,7 +101,6 @@ class API extends \Piwik\Plugin\API
      * This data table will be converted to all available formats
      * when requested in the API request.
      *
-     * @return DataTable
      */
     public function getCompetitionDatatable(): DataTable
     {
@@ -126,7 +122,6 @@ class API extends \Piwik\Plugin\API
     /**
      * Get more information on the Answer to Life...
      *
-     * @return string
      */
     public function getMoreInformationAnswerToLife(): string
     {

--- a/plugins/ExamplePlugin/API.php
+++ b/plugins/ExamplePlugin/API.php
@@ -30,7 +30,6 @@ class API extends \Piwik\Plugin\API
      * /index.php?module=API&method=ExamplePlugin.getAnswerToLife&truth=0
      *
      *
-     * @return int
      */
     public function getAnswerToLife(bool $truth = true): int
     {
@@ -44,7 +43,6 @@ class API extends \Piwik\Plugin\API
     /**
      * Another example method that returns a data table.
      * @param string $idSite  (might be a number, or the string all)
-     * @return DataTable
      */
     public function getExampleReport(string $idSite, string $period, string $date, ?string $segment = null): DataTable
     {
@@ -61,7 +59,6 @@ class API extends \Piwik\Plugin\API
     /**
      * Returns the example metric we archive in Archiver.php.
      * @param string $idSite (might be a number, or the string all)
-     * @return DataTable\DataTableInterface
      */
     public function getExampleArchivedMetric(string $idSite, string $period, string $date, ?string $segment = null): DataTable\DataTableInterface
     {

--- a/plugins/FeatureFlags/FeatureFlagManager.php
+++ b/plugins/FeatureFlags/FeatureFlagManager.php
@@ -33,7 +33,6 @@ class FeatureFlagManager
 
     /**
      * @param string $featureFlag The ::class name of a class that implements FeatureFlagInterface
-     * @return bool
      */
     public function isFeatureActive(string $featureFlag): bool
     {
@@ -57,7 +56,6 @@ class FeatureFlagManager
     }
 
     /**
-     * @return void
      * @internal
      */
     public static function deleteFeatureFlag(string $featureFlagName): void

--- a/plugins/FeatureFlags/FeatureFlagStorageInterface.php
+++ b/plugins/FeatureFlags/FeatureFlagStorageInterface.php
@@ -17,19 +17,16 @@ interface FeatureFlagStorageInterface
      * If the flag isn't set for the particular storage context then will return null
      *
      *
-     * @return bool|null
      */
     public function isFeatureActive(FeatureFlagInterface $feature): ?bool;
 
     /**
      * @internal
-     * @return void
      */
     public function disableFeatureFlag(FeatureFlagInterface $feature): void;
 
     /**
      * @internal
-     * @return void
      */
     public function enableFeatureFlag(FeatureFlagInterface $feature): void;
 
@@ -37,7 +34,6 @@ interface FeatureFlagStorageInterface
      * Delete a feature flag even if it doesn't exist in code as a class
      *
      * @internal
-     * @return void
      */
     public function deleteFeatureFlag(string $featureName): void;
 }

--- a/plugins/FeatureFlags/Storage/ConfigFeatureFlagStorage.php
+++ b/plugins/FeatureFlags/Storage/ConfigFeatureFlagStorage.php
@@ -35,7 +35,6 @@ class ConfigFeatureFlagStorage implements FeatureFlagStorageInterface
 
     /**
      * @internal
-     * @return bool|null
      */
     public function isFeatureActive(FeatureFlagInterface $feature): ?bool
     {
@@ -58,7 +57,6 @@ class ConfigFeatureFlagStorage implements FeatureFlagStorageInterface
 
     /**
      * @internal
-     * @return void
      */
     public function disableFeatureFlag(FeatureFlagInterface $feature): void
     {
@@ -72,7 +70,6 @@ class ConfigFeatureFlagStorage implements FeatureFlagStorageInterface
 
     /**
      * @internal
-     * @return void
      */
     public function enableFeatureFlag(FeatureFlagInterface $feature): void
     {
@@ -86,7 +83,6 @@ class ConfigFeatureFlagStorage implements FeatureFlagStorageInterface
 
     /**
      * @internal
-     * @return void
      */
     public function deleteFeatureFlag(string $featureName): void
     {

--- a/plugins/GeoIp2/LocationProvider/GeoIp2.php
+++ b/plugins/GeoIp2/LocationProvider/GeoIp2.php
@@ -251,7 +251,6 @@ abstract class GeoIp2 extends LocationProvider
     /**
      * GeoIP2 providers can be used for location-based security checks
      *
-     * @return bool
      */
     public function canBeUsedForLocationBasedSecurityChecks(): bool
     {

--- a/plugins/Goals/Commands/CalculateConversionPages.php
+++ b/plugins/Goals/Commands/CalculateConversionPages.php
@@ -106,7 +106,6 @@ class CalculateConversionPages extends ConsoleCommand
      * Static method to calculate conversion for today and yesterday, for all sites and goals.
      * Called by the migration updater
      *
-     * @return void
      */
     public static function calculateYesterdayAndToday(): void
     {
@@ -161,7 +160,6 @@ class CalculateConversionPages extends ConsoleCommand
     /**
      * Validate the sites parameter
      *
-     * @return string|null
      */
     private function getSitesToCalculate(): ?string
     {
@@ -187,7 +185,6 @@ class CalculateConversionPages extends ConsoleCommand
     /**
      * Validate the goals parameter
      *
-     * @return string|null
      */
     private function getGoalsToCalculate(): ?string
     {

--- a/plugins/Goals/Model.php
+++ b/plugins/Goals/Model.php
@@ -115,7 +115,6 @@ class Model
      * Checks if an active idgoal exists for the site
      *
      *
-     * @return bool
      */
     public function doesGoalExist(int $idGoal, int $idSite): bool
     {

--- a/plugins/Goals/tests/System/CalculateConversionPagesCommandTest.php
+++ b/plugins/Goals/tests/System/CalculateConversionPagesCommandTest.php
@@ -69,7 +69,6 @@ class CalculateConversionPagesCommandTest extends ConsoleCommandTestCase
      * Set all pageviews before value to null
      *
      * @throws \Exception
-     * @return void
      */
     private function unsetPageviewsBefore(): void
     {
@@ -83,7 +82,6 @@ class CalculateConversionPagesCommandTest extends ConsoleCommandTestCase
      * Check that the log_conversion.pageviews_before column was correctly calculated
      *
      *
-     * @return void
      * @throws \Exception
      */
     public function checkPageviewsBeforeValid(?string $onlyToDate = null): void

--- a/plugins/JsTrackerInstallCheck/NonceOption/JsTrackerInstallCheckOption.php
+++ b/plugins/JsTrackerInstallCheck/NonceOption/JsTrackerInstallCheckOption.php
@@ -119,7 +119,6 @@ class JsTrackerInstallCheckOption
     /**
      * Create a new nonce for the site/URL combination. This checks if a
      *
-     * @return string
      */
     public function createNewNonce(int $idSite, string $url): string
     {
@@ -158,7 +157,6 @@ class JsTrackerInstallCheckOption
      * Update the string JSON stored in the option table to track installation checks.
      *
      * @param array $nonceMap
-     * @return void
      */
     protected function setNonceOption(int $idSite, array $nonceMap): void
     {
@@ -169,7 +167,6 @@ class JsTrackerInstallCheckOption
      * Update the time associated with a specific nonce. This is mainly for when a nonce already exists for the
      * site and requested URL. This allows us to bump the time so that we can reuse the nonce for the second test.
      *
-     * @return bool
      */
     protected function updateNonceTime(int $idSite, string $nonce, int $time): bool
     {
@@ -186,7 +183,6 @@ class JsTrackerInstallCheckOption
 
     /**
      * @param array $nonceMap
-     * @return string
      */
     protected function searchNonceMapForUrl(array $nonceMap, string $url): string
     {

--- a/plugins/JsTrackerInstallCheck/tests/Unit/JsTrackerInstallCheckOptionTest.php
+++ b/plugins/JsTrackerInstallCheck/tests/Unit/JsTrackerInstallCheckOptionTest.php
@@ -286,7 +286,6 @@ class JsTrackerInstallCheckOptionTest extends TestCase
     /**
      * Helper method for checking if the nonce is successful
      *
-     * @return bool
      */
     protected function isNonceSuccessFul(int $idSite, string $nonce): bool
     {

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -355,7 +355,6 @@ class API extends \Piwik\Plugin\API
      * If no action was performed in this timeframe an empty string is returned
      *
      * @param int|string $idSite
-     * @return string
      * @throws Exception
      */
     public function getMostRecentVisitsDateTime($idSite, ?string $period = null, ?string $date = null): string

--- a/plugins/Live/Live.php
+++ b/plugins/Live/Live.php
@@ -103,7 +103,6 @@ class Live extends \Piwik\Plugin
      * Returns whether visits log is enabled (for the given site)
      *
      * @param null|int|array $idSite
-     * @return bool
      */
     public static function isVisitorLogEnabled($idSite = null): bool
     {
@@ -152,7 +151,6 @@ class Live extends \Piwik\Plugin
      * Returns whether visitor profile is enabled (for the given site)
      *
      * @param null|int|array $idSite
-     * @return bool
      */
     public static function isVisitorProfileEnabled($idSite = null): bool
     {

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -174,7 +174,6 @@ class Model
      * @param $idSite
      * @param $period
      * @param $date
-     * @return string
      * @throws Exception
      */
     public function getMostRecentVisitsDateTime($idSite, $period = null, $date = null): string

--- a/plugins/Marketplace/API.php
+++ b/plugins/Marketplace/API.php
@@ -76,7 +76,6 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
-     * @return bool
      * @throws Service\Exception If the marketplace request failed
      *
      * @internal
@@ -169,7 +168,6 @@ class API extends \Piwik\Plugin\API
 
     /**
      *
-     * @return bool
      *
      * @unsanitized
      * @internal
@@ -199,7 +197,6 @@ class API extends \Piwik\Plugin\API
 
     /**
      *
-     * @return bool
      * @throws Service\Exception If the marketplace request failed
      *
      * @internal

--- a/plugins/Marketplace/Api/Client.php
+++ b/plugins/Marketplace/Api/Client.php
@@ -338,7 +338,6 @@ class Client
     /**
      * Return the api.matomo.org URL with the correct protocol prefix
      *
-     * @return string|null
      */
     public static function getApiServiceUrl(): ?string
     {

--- a/plugins/Marketplace/PluginTrial/Notification.php
+++ b/plugins/Marketplace/PluginTrial/Notification.php
@@ -40,7 +40,6 @@ class Notification
     /**
      * Dismisses the notification for the current user
      *
-     * @return void
      */
     public function setNotificationDismissed(): void
     {
@@ -51,7 +50,6 @@ class Notification
     /**
      * Creates a plugin trial notification for the current user if needed
      *
-     * @return void
      * @throws Exception
      */
     public function createNotificationIfNeeded(): void
@@ -82,7 +80,6 @@ class Notification
     /**
      * Removes a notification from current users session
      *
-     * @return void
      */
     public function removeFromSession(): void
     {

--- a/plugins/Marketplace/PluginTrial/Request.php
+++ b/plugins/Marketplace/PluginTrial/Request.php
@@ -40,7 +40,6 @@ class Request
     /**
      * Creates a trial request and sends a mail to all super users
      *
-     * @return void
      */
     public function create(string $pluginDisplayName = ''): void
     {
@@ -56,7 +55,6 @@ class Request
     /**
      * Cancels a trial request
      *
-     * @return void
      */
     public function cancel(): void
     {
@@ -71,7 +69,6 @@ class Request
     /**
      * Returns if a plugin was already requested
      *
-     * @return bool
      */
     public function wasRequested(): bool
     {
@@ -81,7 +78,6 @@ class Request
     /**
      * Send notification email to all super users
      *
-     * @return void
      */
     private function sendEmailToSuperUsers(): void
     {

--- a/plugins/Marketplace/PluginTrial/Service.php
+++ b/plugins/Marketplace/PluginTrial/Service.php
@@ -23,7 +23,6 @@ final class Service
     /**
      * Creates a trial request (and sends a mail to all super users)
      *
-     * @return void
      */
     public function request(string $pluginName, string $pluginDisplayName): void
     {
@@ -39,7 +38,6 @@ final class Service
     /**
      * Returns if a plugin was already requested
      *
-     * @return bool
      */
     public function wasRequested(string $pluginName): bool
     {
@@ -54,7 +52,6 @@ final class Service
     /**
      * Creates notifications for all available plugin trial requests if any
      *
-     * @return void
      * @throws Exception
      */
     public function createNotificationsIfNeeded(): void
@@ -77,7 +74,6 @@ final class Service
      * Dismisses a plugin trial notification for the current (super) user if the provided notification id matches a
      * plugin trial request.
      *
-     * @return void
      * @throws Exception
      */
     public function dismissNotification(string $notificationId): void
@@ -114,7 +110,6 @@ final class Service
     /**
      * Cancels a plugin trial request
      *
-     * @return void
      * @throws Exception
      */
     public function cancelRequest(string $pluginName): void

--- a/plugins/Marketplace/PluginTrial/Storage.php
+++ b/plugins/Marketplace/PluginTrial/Storage.php
@@ -36,7 +36,6 @@ class Storage
     /**
      * Creates a trial request for the current user
      *
-     * @return void
      */
     public function setRequested(string $pluginDisplayName = ''): void
     {
@@ -52,7 +51,6 @@ class Storage
     /**
      * Returns if a plugin was already requested
      *
-     * @return bool
      */
     public function wasRequested(): bool
     {
@@ -73,7 +71,6 @@ class Storage
     /**
      * Dismisses the trial request for the current user
      *
-     * @return void
      */
     public function setNotificationDismissed(): void
     {
@@ -84,7 +81,6 @@ class Storage
     /**
      * Returns the display name for the plugin stored when requesting the trial
      *
-     * @return string
      */
     public function getDisplayName(): string
     {
@@ -94,7 +90,6 @@ class Storage
     /**
      * Returns if the current user has dismissed the trial request
      *
-     * @return bool
      */
     public function isNotificationDismissed(): bool
     {
@@ -104,7 +99,6 @@ class Storage
     /**
      * Removes the trial request from storage
      *
-     * @return void
      */
     public function clearStorage(): void
     {

--- a/plugins/Marketplace/Plugins.php
+++ b/plugins/Marketplace/Plugins.php
@@ -388,7 +388,6 @@ class Plugins
      * Find the cheapest shop variant, and if none is found specified, return the first variant.
      *
      * @param $plugin
-     * @return void
      */
     private function addPriceFrom(&$plugin): void
     {
@@ -416,7 +415,6 @@ class Plugins
      * cover image), we use Matomo image for Matomo plugins and a generic cover image otherwise.
      *
      * @param $plugin
-     * @return void
      */
     private function addPluginCoverImage(&$plugin): void
     {
@@ -443,7 +441,6 @@ class Plugins
      * Add prettified number of downloads to plugin info to shorten large numbers to 1k or 1m format.
      *
      * @param $plugin
-     * @return void
      */
     private function prettifyNumberOfDownloads(&$plugin): void
     {

--- a/plugins/MobileMessaging/API.php
+++ b/plugins/MobileMessaging/API.php
@@ -65,7 +65,6 @@ class API extends \Piwik\Plugin\API
      *
      * @param string $provider SMS API provider
      * @param array $credentials array with data like API Key or username
-     * @return void
      */
     public function setSMSAPICredential(string $provider, array $credentials = []): void
     {
@@ -85,7 +84,6 @@ class API extends \Piwik\Plugin\API
     /**
      * Adds a phone number for the current user
      *
-     * @return void
      */
     public function addPhoneNumber(string $phoneNumber): void
     {
@@ -122,7 +120,6 @@ class API extends \Piwik\Plugin\API
     /**
      * Requests a new verification code for the given phone number
      *
-     * @return void
      */
     public function resendVerificationCode(string $phoneNumber): void
     {
@@ -215,7 +212,6 @@ class API extends \Piwik\Plugin\API
      * remove phone number
      *
      *
-     * @return void
      */
     public function removePhoneNumber(string $phoneNumber): void
     {
@@ -260,7 +256,6 @@ class API extends \Piwik\Plugin\API
     /**
      * delete the SMS API credential
      *
-     * @return void
      */
     public function deleteSMSAPICredential(): void
     {
@@ -277,7 +272,6 @@ class API extends \Piwik\Plugin\API
      * Specify if normal users can manage their own SMS API credential
      *
      * @param bool $delegatedManagement false if SMS API credential only manageable by super admin, true otherwise
-     * @return void
      */
     public function setDelegatedManagement(bool $delegatedManagement): void
     {

--- a/plugins/MobileMessaging/Model.php
+++ b/plugins/MobileMessaging/Model.php
@@ -85,7 +85,6 @@ class Model
     /**
      * Tries to verify the given phone number with the given verification code
      *
-     * @return bool
      */
     public function verifyPhoneNumber(string $login, string $phoneNumber, string $verificationCode): bool
     {
@@ -126,7 +125,6 @@ class Model
     /**
      * Adds a new phone number to the user, which needs to be verified with the provided code first
      *
-     * @return void
      */
     public function addPhoneNumber(string $login, string $phoneNumber, string $verificationCode): void
     {
@@ -146,7 +144,6 @@ class Model
     /**
      * Removes a phone number
      *
-     * @return void
      */
     public function removePhoneNumber(string $login, string $phoneNumber): void
     {

--- a/plugins/Monolog/Processor/ExceptionToTextProcessor.php
+++ b/plugins/Monolog/Processor/ExceptionToTextProcessor.php
@@ -94,7 +94,6 @@ class ExceptionToTextProcessor
 
     /**
      * @param \Throwable|array{message: ?string, backtrace: ?string} $exception
-     * @return string
      */
     public static function getMessageAndWholeBacktrace($exception, ?bool $shouldPrintBacktrace = null): string
     {

--- a/plugins/MultiSites/API.php
+++ b/plugins/MultiSites/API.php
@@ -98,7 +98,6 @@ class API extends \Piwik\Plugin\API
      * @param bool $enhanced When true, return additional goal & ecommerce metrics
      * @param null|string $pattern If specified, only the website which names (or site ID) match the pattern will be returned using SitesManager.getPatternMatchSites
      * @param string|array<string> $showColumns If specified, only the requested columns will be fetched
-     * @return DataTableInterface
      */
     public function getAll(
         string $period,
@@ -206,7 +205,6 @@ class API extends \Piwik\Plugin\API
      * @param null|string $_restrictSitesToLogin Hack used to enforce we restrict the returned data to the specified username
      *                                        Only used when a scheduled task is running
      * @param bool $enhanced When true, return additional goal & ecommerce metrics
-     * @return DataTableInterface
      */
     public function getOne(
         int $idSite,

--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -957,7 +957,6 @@ class PrivacyManager extends Plugin
     /**
      * Returns if cookie less tracking is forced
      *
-     * @return bool
      */
     public static function isCookieLessTrackingForced(): bool
     {

--- a/plugins/PrivacyManager/tests/Fixtures/FewVisitsAnonymizedFixture.php
+++ b/plugins/PrivacyManager/tests/Fixtures/FewVisitsAnonymizedFixture.php
@@ -66,7 +66,6 @@ class FewVisitsAnonymizedFixture extends Fixture
     /**
      * Returns a pre-configured MatomoTracker
      *
-     * @return MatomoTracker
      * @throws \Exception
      */
     private static function prepareTracker(int $idSite, string $dateTime, string $urlPath = '', string $ip = ''): MatomoTracker

--- a/plugins/ProfessionalServices/API.php
+++ b/plugins/ProfessionalServices/API.php
@@ -30,7 +30,6 @@ class API extends \Piwik\Plugin\API
      *
      * @internal
      *
-     * @return bool
      * @throws \Piwik\NoAccessException
      */
     public function dismissWidget(): bool

--- a/plugins/Referrers/AIAssistant.php
+++ b/plugins/Referrers/AIAssistant.php
@@ -142,7 +142,6 @@ class AIAssistant extends Singleton
      *
      * @param string $url The URL to check.
      * @param string|null $aiAssistantName The name of the AI assistant to check for, or false to check for any.
-     * @return bool
      */
     public function isAIAssistantUrl(string $url, ?string $aiAssistantName = null): bool
     {

--- a/plugins/Referrers/Columns/Base.php
+++ b/plugins/Referrers/Columns/Base.php
@@ -381,7 +381,6 @@ abstract class Base extends VisitDimension
 
     /**
      * AI detection
-     * @return bool
      */
     protected function detectReferrerAIAssistant(): bool
     {
@@ -504,7 +503,6 @@ abstract class Base extends VisitDimension
      * Check if campaign parameters were directly provided in tracking request.
      * This might e.g. be the case when using image tracking
      *
-     * @return void
      */
     protected function detectReferrerCampaignFromTrackerParams(Request $request): void
     {

--- a/plugins/Resolution/Resolution.php
+++ b/plugins/Resolution/Resolution.php
@@ -32,7 +32,6 @@ class Resolution extends \Piwik\Plugin
     /**
      * Check if compliance policy disables screen resolution detection
      *
-     * @return bool
      * @throws \Piwik\Exception\DI\DependencyException
      * @throws \Piwik\Exception\DI\NotFoundException
      */

--- a/plugins/SegmentEditor/SegmentEditor.php
+++ b/plugins/SegmentEditor/SegmentEditor.php
@@ -353,7 +353,6 @@ class SegmentEditor extends \Piwik\Plugin
     /**
      * Returns whether create realtime segments is enabled or not.
      *
-     * @return bool
      */
     public static function isCreateRealtimeSegmentsEnabled(): bool
     {

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -1416,7 +1416,6 @@ class API extends \Piwik\Plugin\API
      *  - custom
      * @param string|null $queryParamsToExclude (Optional) Comma separated list of query parameters to exclude when $exclusionType is 'custom'.
      *                                         Ignored if $exclusionType is not 'custom'.
-     * @return void
      * @throws Exception
      */
     public function setGlobalQueryParamExclusion(string $exclusionType, ?string $queryParamsToExclude = null): void
@@ -1451,7 +1450,6 @@ class API extends \Piwik\Plugin\API
      * Gets the exclusion type, if the option is not present in the store then it infers the type based on if there are
      * custom exclusions already defined.
      *
-     * @return string
      */
     public function getExclusionTypeForQueryParams(?int $idSite = null): string
     {

--- a/plugins/SitesManager/SiteContentDetection/ConsentManagerDetectionAbstract.php
+++ b/plugins/SitesManager/SiteContentDetection/ConsentManagerDetectionAbstract.php
@@ -20,7 +20,6 @@ abstract class ConsentManagerDetectionAbstract extends SiteContentDetectionAbstr
      * Returns if the consent manager was already connected to Matomo
      *
      * @param array<string,string>|null $headers
-     * @return bool
      */
     abstract public function checkIsConnected(?string $data = null, ?array $headers = null): bool;
 }

--- a/plugins/SitesManager/SiteContentDetection/SiteContentDetectionAbstract.php
+++ b/plugins/SitesManager/SiteContentDetection/SiteContentDetectionAbstract.php
@@ -28,7 +28,6 @@ abstract class SiteContentDetectionAbstract
     /**
      * Returns the ID of the current detection. Automatically built from the class name (without namespace)
      *
-     * @return string
      */
     public static function getId(): string
     {
@@ -39,14 +38,12 @@ abstract class SiteContentDetectionAbstract
     /**
      * Returns the Name of this detection (e.g. name of CMS, Framework, ...)
      *
-     * @return string
      */
     abstract public static function getName(): string;
 
     /**
      * Returns the location of the icon of this detection
      *
-     * @return string
      */
     public static function getIcon(): string
     {
@@ -57,14 +54,12 @@ abstract class SiteContentDetectionAbstract
      * Returns the content type this detection provides
      * May be one of TYPE_TRACKER, TYPE_CMS, TYPE_JS_FRAMEWORK, TYPE_CONSENT_MANAGER
      *
-     * @return int
      */
     abstract public static function getContentType(): int;
 
     /**
      * Returns the URL to the instruction FAQ on how to integrate Matomo (if applicable)
      *
-     * @return string|null
      */
     public static function getInstructionUrl(): ?string
     {
@@ -74,7 +69,6 @@ abstract class SiteContentDetectionAbstract
     /**
      * Returns the priority the tab should be displayed with.
      *
-     * @return int
      */
     public static function getPriority(): int
     {
@@ -85,14 +79,12 @@ abstract class SiteContentDetectionAbstract
      * Returns if the current detection succeeded for the provided site content or not.
      *
      * @param array<string,string>|null $headers
-     * @return bool
      */
     abstract public function isDetected(?string $data = null, ?array $headers = null): bool;
 
     /**
      * Returns the content that should be rendered into a new Tab on the no data page
      *
-     * @return string
      */
     public function renderInstructionsTab(SiteContentDetector $detector): string
     {
@@ -102,7 +94,6 @@ abstract class SiteContentDetectionAbstract
     /**
      * Returns the content that should be displayed in the Others tab on the no data page
      *
-     * @return string
      */
     public function renderOthersInstruction(SiteContentDetector $detector): string
     {
@@ -112,7 +103,6 @@ abstract class SiteContentDetectionAbstract
     /**
      * Returns if the method should be recommended. Returns true if the method was detected
      *
-     * @return bool
      */
     public function isRecommended(SiteContentDetector $detector): bool
     {

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -717,7 +717,6 @@ class API extends \Piwik\Plugin\API
      * @param $period
      * @param $date
      *
-     * @return bool
      */
     public function isPeriodAllowed($idSite, $period, $date): bool
     {

--- a/plugins/Transitions/Transitions.php
+++ b/plugins/Transitions/Transitions.php
@@ -79,7 +79,6 @@ class Transitions extends \Piwik\Plugin
      *
      * @param $idSite
      *
-     * @return string
      */
     public static function getPeriodAllowedConfig($idSite): string
     {

--- a/plugins/UserCountry/LocationProvider.php
+++ b/plugins/UserCountry/LocationProvider.php
@@ -184,7 +184,6 @@ abstract class LocationProvider
     /**
      * Returns a message that should be shown as diagnostics warning if provider is used
      *
-     * @return null|string
      */
     public function getUsageWarning(): ?string
     {
@@ -562,7 +561,6 @@ abstract class LocationProvider
      * Returns true if the location provider can be used for security checks based
      * on location, such as determining the current country where the user logs in from.
      *
-     * @return bool
      */
     public function canBeUsedForLocationBasedSecurityChecks(): bool
     {

--- a/plugins/UsersManager/TokenNotifications/TokenNotificationProviderInterface.php
+++ b/plugins/UsersManager/TokenNotifications/TokenNotificationProviderInterface.php
@@ -22,7 +22,6 @@ interface TokenNotificationProviderInterface
     /**
      * Sets information that a notification for a given token has been dispatched
      *
-     * @return void
      */
     public function setTokenNotificationDispatched(string $tokenId): void;
 }

--- a/plugins/UsersManager/UserNotifications/UserNotificationProviderInterface.php
+++ b/plugins/UsersManager/UserNotifications/UserNotificationProviderInterface.php
@@ -23,7 +23,6 @@ interface UserNotificationProviderInterface
      * Sets information that a notification for a set of users has been dispatched
      *
      * @param array $users
-     * @return void
      */
     public function setUserNotificationDispatched(array $users): void;
 }

--- a/tests/PHPUnit/Framework/Constraint/HttpResponseText.php
+++ b/tests/PHPUnit/Framework/Constraint/HttpResponseText.php
@@ -48,7 +48,6 @@ class HttpResponseText extends \PHPUnit\Framework\Constraint\Constraint
      * constraint is met, FALSE otherwise.
      *
      * @param mixed $other Value or object to evaluate.
-     * @return bool
      */
     public function matches($other): bool
     {
@@ -60,7 +59,6 @@ class HttpResponseText extends \PHPUnit\Framework\Constraint\Constraint
     /**
      * Returns a string representation of the constraint.
      *
-     * @return string
      */
     public function toString(): string
     {

--- a/tests/PHPUnit/Framework/Constraint/ResponseCode.php
+++ b/tests/PHPUnit/Framework/Constraint/ResponseCode.php
@@ -31,7 +31,6 @@ class ResponseCode extends \PHPUnit\Framework\Constraint\Constraint
      * constraint is met, FALSE otherwise.
      *
      * @param mixed $other Value or object to evaluate.
-     * @return bool
      */
     public function matches($other): bool
     {
@@ -56,7 +55,6 @@ class ResponseCode extends \PHPUnit\Framework\Constraint\Constraint
     /**
      * Returns a string representation of the constraint.
      *
-     * @return string
      */
     public function toString(): string
     {

--- a/tests/PHPUnit/Integration/Segment/SegmentUnavailableTest.php
+++ b/tests/PHPUnit/Integration/Segment/SegmentUnavailableTest.php
@@ -121,7 +121,6 @@ class SegmentUnavailableTest extends IntegrationTestCase
      * Disable the visitorlog feature
      *
      *
-     * @return void
      * @throws \Exception
      */
     private function disableVisitorProfile(bool $status): void
@@ -137,7 +136,6 @@ class SegmentUnavailableTest extends IntegrationTestCase
     /**
      * Flush the caches that contain cached segment data
      *
-     * @return void
      */
     private function flushCaches(): void
     {
@@ -150,7 +148,6 @@ class SegmentUnavailableTest extends IntegrationTestCase
      * Check if a segment is available
      *
      *
-     * @return void
      */
     private function checkSegmentAvailable(string $definition, string $name, bool $shouldBeEnabled): void
     {

--- a/tests/PHPUnit/Integration/Tracker/Config/ThirdPartyCookiesTest.php
+++ b/tests/PHPUnit/Integration/Tracker/Config/ThirdPartyCookiesTest.php
@@ -18,7 +18,6 @@ class ThirdPartyCookiesTest extends IntegrationTestCase
 {
     /**
      * @dataProvider dataGetValueNoIdSite
-     * @return void
      */
     public function testGetValueReturnsCorrectValueWhenNoIdSiteProvided(
         bool $instanceWideSettingValue,
@@ -69,7 +68,6 @@ class ThirdPartyCookiesTest extends IntegrationTestCase
 
     /**
      * @dataProvider dataGetValueIdSite
-     * @return void
      */
     public function testGetValueReturnsCorrectValueWhenIdSiteProvided(
         int $idSite,
@@ -123,7 +121,6 @@ class ThirdPartyCookiesTest extends IntegrationTestCase
 
     /**
      * @dataProvider dataIsCompliant
-     * @return void
      */
     public function testIsCompliant(
         string $policy,

--- a/tests/PHPUnit/Unit/Db/Adapter/MysqliTest.php
+++ b/tests/PHPUnit/Unit/Db/Adapter/MysqliTest.php
@@ -42,7 +42,6 @@ class MysqliTest extends TestCase
 
     /**
      * This will 'mock' the Schema class to return a specific minimum version.
-     * @return Schema
      */
     private function createMockSchema(string $minimumVersion): Schema
     {

--- a/tests/PHPUnit/Unit/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/PHPUnit/Unit/Db/Adapter/Pdo/MysqlTest.php
@@ -42,7 +42,6 @@ class MysqlTest extends TestCase
 
     /**
      * This will 'mock' the Schema class to return a specific minimum version.
-     * @return Schema
      */
     private function createMockSchema(string $minimumVersion): Schema
     {


### PR DESCRIPTION
### Description

Enables PHPCS rule `SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation` and applies all required changes using phpcbf

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
