### PR TITLE
Fix flaky ScheduledReport UI test

### DIFF
--- a/plugins/ScheduledReports/tests/UI/ScheduledReports_spec.js
+++ b/plugins/ScheduledReports/tests/UI/ScheduledReports_spec.js
@@ -145,8 +145,7 @@ describe("ScheduledReports", function () {
 
             expect(persistedOrder).to.deep.equal(expectedOrder);
             await page.waitForSelector('.selectedReportsWrapper', { visible: true });
-            const persistedSelectedReportsWrapper = await page.$('.selectedReportsWrapper');
-            expect(await persistedSelectedReportsWrapper.screenshot()).to.matchImage('reorder_persisted');
+            expect(await selectedReportsWrapper.screenshot()).to.matchImage('reorder_persisted');
         });
     });
 });

--- a/plugins/ScheduledReports/tests/UI/ScheduledReports_spec.js
+++ b/plugins/ScheduledReports/tests/UI/ScheduledReports_spec.js
@@ -90,6 +90,8 @@ describe("ScheduledReports", function () {
 
         it("should persist manually reordered selected reports when saving a report", async function () {
             await openReportForTesting();
+            const selectedReportsWrapper = await page.$('.selectedReportsWrapper');
+            expect(await selectedReportsWrapper.screenshot()).to.matchImage('before_reorder');
 
             const initialOrder = await page.$$eval(
               '.selectedReportsList li',
@@ -117,9 +119,23 @@ describe("ScheduledReports", function () {
                 }
             }, expectedOrder);
 
+            await page.evaluate((reportName) => {
+                const descriptionField = document.querySelector(
+                    'textarea[name="report_description"], input[name="report_description"]',
+                );
+                if (!descriptionField) {
+                    return;
+                }
+
+                descriptionField.value = reportName;
+                descriptionField.dispatchEvent(new Event('input', { bubbles: true }));
+                descriptionField.dispatchEvent(new Event('change', { bubbles: true }));
+            }, createdReportName);
+            await page.evaluate(() => new Promise((resolve) => {
+                requestAnimationFrame(() => requestAnimationFrame(resolve));
+            }));
             await page.click('.matomo-save-button .btn');
             await page.waitForNetworkIdle();
-            await page.waitForTimeout(500);
 
             await openReportForTesting();
             const persistedOrder = await page.$$eval(
@@ -128,9 +144,9 @@ describe("ScheduledReports", function () {
             );
 
             expect(persistedOrder).to.deep.equal(expectedOrder);
-
-            const selectedReportsWrapper = await page.$('.selectedReportsWrapper');
-            expect(await selectedReportsWrapper.screenshot()).to.matchImage('reorder_persisted');
+            await page.waitForSelector('.selectedReportsWrapper', { visible: true });
+            const persistedSelectedReportsWrapper = await page.$('.selectedReportsWrapper');
+            expect(await persistedSelectedReportsWrapper.screenshot()).to.matchImage('reorder_persisted');
         });
     });
 });

--- a/plugins/ScheduledReports/tests/UI/ScheduledReports_spec.js
+++ b/plugins/ScheduledReports/tests/UI/ScheduledReports_spec.js
@@ -62,6 +62,9 @@ describe("ScheduledReports", function () {
             await page.waitForSelector('#addEditReport', { visible: true });
             await page.waitForSelector('.selectedReportsList li', { visible: true });
         }
+        async function getReportsWrapper() {
+          return await page.$('.selectedReportsWrapper');
+        }
 
         it("should show selected reports when creating a new report", async function () {
             await page.goto(manageReportsUrl);
@@ -84,13 +87,13 @@ describe("ScheduledReports", function () {
                     selectedReportIds.push(uniqueId);
                 }
             }
-            const selectedReportsWrapper = await page.$('.selectedReportsWrapper');
+            const selectedReportsWrapper = await getReportsWrapper();
             expect(await selectedReportsWrapper.screenshot()).to.matchImage('selected_reports');
         });
 
         it("should persist manually reordered selected reports when saving a report", async function () {
             await openReportForTesting();
-            const selectedReportsWrapper = await page.$('.selectedReportsWrapper');
+            let selectedReportsWrapper = await getReportsWrapper();
             expect(await selectedReportsWrapper.screenshot()).to.matchImage('before_reorder');
 
             const initialOrder = await page.$$eval(
@@ -119,21 +122,15 @@ describe("ScheduledReports", function () {
                 }
             }, expectedOrder);
 
-            await page.evaluate((reportName) => {
-                const descriptionField = document.querySelector(
-                    'textarea[name="report_description"], input[name="report_description"]',
-                );
-                if (!descriptionField) {
-                    return;
-                }
-
-                descriptionField.value = reportName;
-                descriptionField.dispatchEvent(new Event('input', { bubbles: true }));
+            const descriptionSelector = 'textarea[name="report_description"], input[name="report_description"]';
+            await page.waitForSelector(descriptionSelector, { visible: true });
+            await page.click(descriptionSelector, { clickCount: 3 });
+            await page.keyboard.press('Backspace');
+            await page.type(descriptionSelector, createdReportName);
+            await page.keyboard.press('Tab');
+            await page.$eval(descriptionSelector, (descriptionField) => {
                 descriptionField.dispatchEvent(new Event('change', { bubbles: true }));
-            }, createdReportName);
-            await page.evaluate(() => new Promise((resolve) => {
-                requestAnimationFrame(() => requestAnimationFrame(resolve));
-            }));
+            });
             await page.click('.matomo-save-button .btn');
             await page.waitForNetworkIdle();
 
@@ -144,7 +141,7 @@ describe("ScheduledReports", function () {
             );
 
             expect(persistedOrder).to.deep.equal(expectedOrder);
-            await page.waitForSelector('.selectedReportsWrapper', { visible: true });
+            selectedReportsWrapper = await getReportsWrapper();
             expect(await selectedReportsWrapper.screenshot()).to.matchImage('reorder_persisted');
         });
     });

--- a/plugins/ScheduledReports/tests/UI/expected-screenshots/ManageScheduledReports_before_reorder.png
+++ b/plugins/ScheduledReports/tests/UI/expected-screenshots/ManageScheduledReports_before_reorder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:666968390c22665478dead63a4deeec1a7f2177f244df071abe8ccde71fdfb6e
+size 16910


### PR DESCRIPTION
### Description

I just noticed that we have this flaky test for Scheduled Reports that seem to happened often, but can be re-run and it works again
This is just to fix that and hopefully we don't see this popup unless an actual issue is found
### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
