### PR TITLE
Add scheduled Slack alert for preview release failures

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -184,3 +184,34 @@ jobs:
       RELEASE_PASSWORD: ${{ secrets.RELEASE_PASSWORD }}
       GPG_CERTIFICATE: ${{ secrets.GPG_CERTIFICATE }}
       GPG_CERTIFICATE_PASS: ${{ secrets.GPG_CERTIFICATE_PASS }}
+
+  notify_slack_on_failure:
+    runs-on: ubuntu-24.04
+    needs: [prepare_preview_version, run_matomo_tests, release_preview_version]
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CORE_ALERT_WEBHOOK_URL }}
+    if: |
+      always() &&
+      github.event_name == 'schedule' &&
+      (
+        needs.prepare_preview_version.result == 'failure' ||
+        needs.run_matomo_tests.result == 'failure' ||
+        needs.release_preview_version.result == 'failure'
+      )
+    steps:
+      - name: Notify Slack on failure
+        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          PAYLOAD=$(cat <<EOF
+          {"text":"*Preview build has failed for today!*\n<${RUN_URL}|The automated preview build> failed to run.\n*Impact:* Cloud might not get the latest build in the next deployment cycle, so customers may not receive the newest fixes.\nPlease investigate and re-run the build if this was flaky until it passes."}
+          EOF
+          )
+
+          curl --fail-with-body -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
+
+      - name: Skip Slack notification when webhook is missing
+        if: ${{ env.SLACK_WEBHOOK_URL == '' }}
+        run: |
+          echo "Info: SLACK_CORE_ALERT_WEBHOOK_URL is not configured. Skipping failure notification."


### PR DESCRIPTION
### Description

Add alerting for when preview builds fail and alert internal team.

Here is an example run where I forced the error: https://github.com/matomo-org/matomo/actions/runs/22417228389/job/64905878492


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
