### PR TITLE
Improve vue:build with a retry detection on missing path

### DIFF
--- a/plugins/CoreVue/Commands/Build.php
+++ b/plugins/CoreVue/Commands/Build.php
@@ -294,12 +294,20 @@ class Build extends ConsoleCommand
 
     private function isTypeScriptRaceConditionInOutput(string $plugin, string $concattedOutput): bool
     {
+        // Console output can contain ANSI escape sequences; remove them first to make regex matching stable.
+        // Example:
+        //   "\x1b[41m ERROR \x1b[49m ... TS2307: Cannot find module ..."
+        // becomes:
+        //   " ERROR  ... TS2307: Cannot find module ..."
         $normalizedOutput = preg_replace('/\x1b\[[0-9;]*m/', '', $concattedOutput);
         if (empty($normalizedOutput)) {
             return false;
         }
 
-        // Match "ERROR in /path/to/file(12,34)" followed by TS2307 for that import.
+        // Match TS2307 blocks and capture:
+        // 1) the importer file path
+        // 2) the missing module path
+        // so we can verify whether the target actually exists on disk.
         $matches = [];
         preg_match_all(
             '/in\s+([^\n]+)\(\d+,\d+\)\s*\n\s*TS2307:\s+Cannot find module \'([^\']+)\' or its corresponding type declarations\./m',
@@ -313,6 +321,8 @@ class Build extends ConsoleCommand
             $missingModule = $match[2];
 
             if ($this->isRelativeImport($missingModule)) {
+                // Relative imports are resolved from the importer directory.
+                // If the path exists, this is likely a transient TS resolver race and should be retried.
                 $resolvedPath = dirname($importerFile) . DIRECTORY_SEPARATOR . $missingModule;
                 if (file_exists($resolvedPath)) {
                     return true;
@@ -320,6 +330,7 @@ class Build extends ConsoleCommand
                 continue;
             }
 
+            // Keep legacy behavior for non-relative plugin imports (e.g. "SomePluginComponent").
             $filePath = Manager::getPluginDirectory($plugin) . '/vue/src/' . $missingModule;
             if (file_exists($filePath)) {
                 return true;

--- a/plugins/CoreVue/Commands/Build.php
+++ b/plugins/CoreVue/Commands/Build.php
@@ -294,14 +294,44 @@ class Build extends ConsoleCommand
 
     private function isTypeScriptRaceConditionInOutput(string $plugin, string $concattedOutput): bool
     {
-        if (!preg_match('/^TS2307: Cannot find module \'([^\']+)\' or its corresponding type declarations./', $concattedOutput, $matches)) {
+        $normalizedOutput = preg_replace('/\x1b\[[0-9;]*m/', '', $concattedOutput);
+        if (empty($normalizedOutput)) {
             return false;
         }
 
-        $file = $matches[1];
-        $filePath = Manager::getPluginDirectory($plugin) . '/vue/src/' . $file;
-        $isTypeScriptCompilerBug = file_exists($filePath);
-        return $isTypeScriptCompilerBug;
+        // Match "ERROR in /path/to/file(12,34)" followed by TS2307 for that import.
+        $matches = [];
+        preg_match_all(
+            '/in\s+([^\n]+)\(\d+,\d+\)\s*\n\s*TS2307:\s+Cannot find module \'([^\']+)\' or its corresponding type declarations\./m',
+            $normalizedOutput,
+            $matches,
+            PREG_SET_ORDER
+        );
+
+        foreach ($matches as $match) {
+            $importerFile = trim($match[1]);
+            $missingModule = $match[2];
+
+            if ($this->isRelativeImport($missingModule)) {
+                $resolvedPath = dirname($importerFile) . DIRECTORY_SEPARATOR . $missingModule;
+                if (file_exists($resolvedPath)) {
+                    return true;
+                }
+                continue;
+            }
+
+            $filePath = Manager::getPluginDirectory($plugin) . '/vue/src/' . $missingModule;
+            if (file_exists($filePath)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isRelativeImport(string $importPath): bool
+    {
+        return strpos($importPath, './') === 0 || strpos($importPath, '../') === 0;
     }
 
     private function getAllPlugins(): array


### PR DESCRIPTION
### Description

`vue:build` is a bit flaky in CI and it's always the same error:

```
   error  in /home/runner/work/matomo/matomo/plugins/Installation/vue/src/SystemCheck/SystemCheck.vue.ts

  [tsl] ERROR in /home/runner/work/matomo/matomo/plugins/Installation/vue/src/SystemCheck/SystemCheck.vue(48,31)
        TS2307: Cannot find module './SystemCheckLegend.vue' or its corresponding type declarations.

   error  in /home/runner/work/matomo/matomo/plugins/Installation/vue/src/SystemCheck/SystemCheckSection.vue.ts

  [tsl] ERROR in /home/runner/work/matomo/matomo/plugins/Installation/vue/src/SystemCheck/SystemCheckSection.vue(86,29)
        TS2307: Cannot find module './DiagnosticTable.vue' or its corresponding type declarations.
```

This is certainly a compiler race/flakiness.

We can fixed it with a retry detection in Build.php:

  - Before, Matomo only detected TS2307 race for very limited patterns.
  - It missed relative-import TS2307 cases like your Installation ones.
  - Now it parses TS2307 with importer file context and correctly treats existing relative targets as transient, so `vue:build` retries automatically instead of failing CI immediately.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
