### PR TITLE
TestRunner: add --skip-screenshots option to accelerate local UI test

### DIFF
--- a/plugins/TestRunner/Commands/TestsRunUI.php
+++ b/plugins/TestRunner/Commands/TestsRunUI.php
@@ -33,6 +33,7 @@ class TestsRunUI extends ConsoleCommand
         $this->addRequiredValueOption('plugin', null, "Execute all tests for a plugin.");
         $this->addNoValueOption('core', null, "Execute only tests for Piwik core & core plugins.");
         $this->addNoValueOption('skip-delete-assets', null, "Skip deleting of merged assets (will speed up a test run, but not by a lot).");
+        $this->addNoValueOption('skip-screenshots', null, 'Run UI tests without image diff assertions (local functional debugging).');
         $this->addNoValueOption('screenshot-repo', null, "For tests");
         $this->addNoValueOption('store-in-ui-tests-repo', null, "For tests");
         $this->addNoValueOption('debug', null, "Enables node inspector");
@@ -58,6 +59,7 @@ class TestsRunUI extends ConsoleCommand
         $storeInUiTestsRepo = $input->getOption('store-in-ui-tests-repo');
         $screenshotRepo = $input->getOption('screenshot-repo');
         $debug = $input->getOption('debug');
+        $skipScreenshotComparison = $input->getOption('skip-screenshots');
         $matomoDomain = $input->getOption('matomo-domain');
         $enableLogging = $input->getOption('enable-logging');
         $timeout = $input->getOption('timeout');
@@ -113,6 +115,10 @@ class TestsRunUI extends ConsoleCommand
 
         if ($debug) {
             $additionalOptions[] = "--inspect";
+        }
+
+        if ($skipScreenshotComparison) {
+            $options[] = '--skip-screenshots';
         }
 
         if ($enableLogging) {

--- a/tests/lib/screenshot-testing/support/chai-extras.js
+++ b/tests/lib/screenshot-testing/support/chai-extras.js
@@ -60,6 +60,11 @@ module.exports = function makeChaiImageAssert(comparisonCommand = 'compare') {
             chai.assert.instanceOf(imageBuffer, Buffer);
             fs.writeFileSync(processedPath, imageBuffer);
 
+            if (options['skip-screenshots']) {
+                performAutomaticPageChecks();
+                return;
+            }
+
             try {
                 if (!fs.isFile(expectedPath)) {
                     app.appendMissingExpected(imageName);

--- a/tests/lib/screenshot-testing/support/chai-extras.js
+++ b/tests/lib/screenshot-testing/support/chai-extras.js
@@ -61,6 +61,7 @@ module.exports = function makeChaiImageAssert(comparisonCommand = 'compare') {
             fs.writeFileSync(processedPath, imageBuffer);
 
             if (options['skip-screenshots']) {
+                console.log(`    ~ [skip-screenshots] no image comparison for ${imageName}`);
                 performAutomaticPageChecks();
                 return;
             }


### PR DESCRIPTION
### Description

This PR introduces a new UI test runner flag: --skip-screenshots.

When enabled, UI tests still execute normally (fixtures, navigation, interactions, API calls, waits, JS/runtime checks), but screenshot diff assertions are skipped.

#### Why this is valuable

  - Screenshot comparison is often unreliable locally because rendering depends on OS-level differences (for example, font rendering).
  - Makes local debugging faster when visual diffs are not the focus, or when investigating logic/regression issues.
  - Unblocks development in environments missing image tooling.
  
#### How it looks

<img width="736" height="346" alt="Screenshot 2026-02-28 at 22 08 21" src="https://github.com/user-attachments/assets/36ed88ef-85a5-4322-8b0c-cab12d5f431a" />


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
