### PR TITLE
UI tests - UserManager - fix flaky test

### DIFF
--- a/plugins/UsersManager/tests/UI/UsersManager_spec.js
+++ b/plugins/UsersManager/tests/UI/UsersManager_spec.js
@@ -450,7 +450,7 @@ describe("UsersManager", function () {
         await page.waitForTimeout(250); // animation
         await page.evaluate(() => window.scrollTo(0, 0));
 
-        expect(await page.screenshotSelector('.usersManager')).to.matchImage({
+        expect(await page.screenshotSelector('.user-permissions')).to.matchImage({
             imageName: 'permissions_bulk_access_set_all',
             comparisonThreshold: 0.0015
         });

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_bulk_access_set_all.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_bulk_access_set_all.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:597d155e015b4fa16feebf10a7b05b6c1057e82a62c09979d0874f8a53479cda
-size 78972
+oid sha256:140aafa18580ea2eb9455b20b28a133932bdeec04fca2192153988e92111de8e
+size 65220


### PR DESCRIPTION
### Description

Several tests from the User Permission UI Tests are flaky, because of page scroll.
I try to solve it by only screenshot the user permission form and avoid difference from scroll state.

#### Examples

From a failing CI:

**UsersManager_permissions_bulk_access_set_all.png**

| Processed | Expected |
|---|---|
|  <img width="1092" height="1104" alt="image" src="https://github.com/user-attachments/assets/4d9d58fe-75b5-4ba0-b8e8-8b0bfc1d2b6f" /> | <img width="1092" height="1104" alt="image" src="https://github.com/user-attachments/assets/f0773b47-839c-4c7c-b98d-5d30b8add5e4" /> |

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
