### PR TITLE
UI tests - OneClickLastForcedUpdate - fix broken test

### DIFF
--- a/tests/UI/expected-screenshots/OneClickLastForcedUpdate_update_success.png
+++ b/tests/UI/expected-screenshots/OneClickLastForcedUpdate_update_success.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:081c15bc164eddde27b8ff42a2b32c767d994b8ba4c8f0ff57ed752afde595a1
-size 80629
+oid sha256:5e2ee82c2f846a72efa66bb646c8bf175dc692bd3aaf59d95b5a4a7f35ee7815
+size 80630

--- a/tests/UI/specs/OneClickLastForcedUpdate_spec.js
+++ b/tests/UI/specs/OneClickLastForcedUpdate_spec.js
@@ -68,6 +68,14 @@ describe("OneClickLastForcedUpdate", function () {
         await page.click('#updateUsingHttp');
         await page.waitForNetworkIdle();
         await page.waitForSelector('.content');
+
+        // redact specific version changes
+        page.evaluate(() => {
+          const updateLog = $('.row code').html();
+          const redacted = updateLog.replace(/\bv?\d+(?:\.\d+){1,}\b/gi, 'x.x.x');
+          $('.row code').text(redacted);
+        });
+
         expect(await page.screenshot({ fullPage: true })).to.matchImage('update_success');
     });
 


### PR DESCRIPTION
### Description

Redacts the version number from the Matomo update log, so the test stop from failing every time the TreemapVisualization plugin is updated.

#### Example

From a failing CI:

**OneClickLastForcedUpdate_update_success.png**

| Processed | Expected |
|---|---|
|  <img width="1350" height="933" alt="image" src="https://github.com/user-attachments/assets/585a2731-e901-4625-bdc9-c65b973edb92" /> | <img width="1350" height="933" alt="image" src="https://github.com/user-attachments/assets/96674563-6ef8-4b64-90f6-60b6ce535294" /> |


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
