### PR TITLE
UI tests - UserSettings - fix flaky test

### DIFF
--- a/plugins/UsersManager/tests/UI/UserSettings_spec.js
+++ b/plugins/UsersManager/tests/UI/UserSettings_spec.js
@@ -123,12 +123,16 @@ describe("UserSettings", function () {
         await page.click('#newsletterSignupCheckbox');
         await page.click('#newsletterSignupBtn input');
         await page.waitForNetworkIdle();
+        await page.waitForFunction(() => !$('#newsletterSignup').is(':visible'));
         expect(await page.screenshotSelector('.pageWrap')).to.matchImage('signup_success');
     });
 
     it('should not prompt user to subscribe to newsletter again', async function () {
         // Assumes previous test has clicked on the signup button - so we shouldn't see it this time
         await page.goto(userSettingsUrl);
+        const isNewsletterVisible = await page.evaluate(() => $('#newsletterSignup').is(':visible'));
+        expect(isNewsletterVisible, 'newsletter signup should stay hidden after signup').to.equal(false);
+
         expect(await page.screenshotSelector('.admin')).to.matchImage('already_signed_up');
     });
 


### PR DESCRIPTION
### Description

When the `subscribe to newsletter` test is too long or had a problem, the next test will be broken and could cause useless screenshot diff (the newsletter section is still there).

#### Examples

From a failing CI:

**SitesManager_search_no_result.png**

| Processed | Expected | Diff |
|---|---|---|
|  <img width="1092" height="2455" alt="image" src="https://github.com/user-attachments/assets/08b9929c-9738-406a-9b02-6c94f79cc5d3" /> | <img width="1092" height="2243" alt="image" src="https://github.com/user-attachments/assets/ea60dc46-fd4f-4344-b53a-906e76299fb7" /> | <img width="1092" height="2455" alt="image" src="https://github.com/user-attachments/assets/87abf6ac-dc45-4c10-b79a-b0df1e2db56f" /> |

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
