### PR TITLE
UI tests - RowEvolution - fix flaky test

### DIFF
--- a/tests/UI/specs/RowEvolution_spec.js
+++ b/tests/UI/specs/RowEvolution_spec.js
@@ -14,6 +14,10 @@ describe("RowEvolution", function () {
     const ecommerceItemReportWidgetized = "?module=Widgetize&action=iframe&moduleToWidgetize=Goals&actionToWidgetize=getItemsSku&idGoal=ecommerceAbandonedCart"
                                       + "&idSite=1&period=year&date=2012-02-09&viewDataTable=ecommerceAbandonedCart&filter_limit=-1";
 
+    const waitForRowEvolutionAnnotations = async () => {
+        await page.waitForFunction("$('.ui-dialog .evolution-annotations > span').length > 0");
+    };
+
     it('should load when icon clicked in ViewDataTable', async function() {
         await page.goto(viewDataTableUrl);
         await page.waitForSelector('tbody tr:first-child')
@@ -25,6 +29,7 @@ describe("RowEvolution", function () {
 
         await page.waitForSelector('.ui-dialog');
         await page.waitForNetworkIdle();
+        await waitForRowEvolutionAnnotations();
 
         const dialog = await page.$('.ui-dialog');
         expect(await dialog.screenshot()).to.matchImage('row_evolution');
@@ -118,7 +123,7 @@ describe("RowEvolution", function () {
 
         await page.waitForSelector('.ui-dialog', { visible: true });
         await page.waitForNetworkIdle();
-        await page.waitForTimeout(250); // wait till annotations are rendered
+        await waitForRowEvolutionAnnotations();
 
         const dialog = await page.$('.ui-dialog');
         expect(await dialog.screenshot()).to.matchImage('row_evolution_ecommerce_item');


### PR DESCRIPTION
### Description

The first RowEvolution screenshot is taken immediately after network idle, while another test already has a comment saying annotations render later. So we should wait to see the Annotations in the DOM.

#### Examples

From a failing CI:

**RowEvolution_row_evolution.png**

| Processed | Expected | Diff |
|---|---|---|
|  <img width="1050" height="788" alt="image" src="https://github.com/user-attachments/assets/f7a7aa4b-1665-4ed7-a7a2-98d910755526" /> | <img width="1050" height="809" alt="image" src="https://github.com/user-attachments/assets/fe9dd5c8-fffa-4fc8-82d9-e6fb06c77133" /> | <img width="1050" height="809" alt="image" src="https://github.com/user-attachments/assets/b11f2828-94e6-44c6-b3a3-e0237e67687f" /> |

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
