### PR TITLE
Refactor login/email normalization into shared UsersManager helper

### DIFF
--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -232,6 +232,7 @@ if (!class_exists('Piwik\Plugin')) {
          *                                                      'before'   => true // execute before callbacks w/o ordering
          *                                                  )
          *                   )
+         * @phpstan-return array<string, string|array{function: string, after?: bool, before?: bool}>
          * @since 2.15.0
          */
         public function registerEvents()

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4069,11 +4069,6 @@ parameters:
 			path: plugins/Login/Model.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\Login\\\\PasswordResetter\\:\\:getUserInformation\\(\\) should return array but returns null\\.$#"
-			count: 1
-			path: plugins/Login/PasswordResetter.php
-
-		-
 			message: "#^PHPDoc tag @var has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 171$#"
 			count: 1
 			path: plugins/Login/PasswordResetter.php
@@ -4081,11 +4076,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$password of method Piwik\\\\Plugins\\\\UsersManager\\\\UserUpdater\\:\\:updateUserWithoutCurrentPassword\\(\\) expects bool, string given\\.$#"
 			count: 1
-			path: plugins/Login/PasswordResetter.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between array and null will always evaluate to false\\.$#"
-			count: 2
 			path: plugins/Login/PasswordResetter.php
 
 		-

--- a/plugins/LanguagesManager/LanguagesHelper.php
+++ b/plugins/LanguagesManager/LanguagesHelper.php
@@ -10,8 +10,8 @@
 namespace Piwik\Plugins\LanguagesManager;
 
 use Piwik\Container\StaticContainer;
-use Piwik\Plugins\UsersManager\Model as UserModel;
 use Piwik\Plugins\LanguagesManager\Model as LangModel;
+use Piwik\Plugins\UsersManager\UserLoginHelper;
 use Piwik\Translation\Translator;
 
 /**
@@ -27,23 +27,9 @@ use Piwik\Translation\Translator;
  */
 class LanguagesHelper
 {
-    private static function getUserFromEmailOrLogin(string $emailOrLogin): ?array
-    {
-        $userModel = new UserModel();
-
-        $user = null;
-        if ($userModel->userExists($emailOrLogin)) {
-            $user = $userModel->getUser($emailOrLogin);
-        } elseif ($userModel->userEmailExists($emailOrLogin)) {
-            $user = $userModel->getUserByEmail($emailOrLogin);
-        }
-
-        return $user;
-    }
-
     public static function doWithUserLanguage(string $emailOrLogin, callable $callback)
     {
-        $user = self::getUserFromEmailOrLogin($emailOrLogin);
+        $user = UserLoginHelper::findUserByLoginOrEmail($emailOrLogin);
 
         if (!$user) {
             return $callback();

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -29,6 +29,7 @@ use Piwik\Plugins\Login\Security\BruteForceDetection;
 use Piwik\Plugins\PrivacyManager\SystemSettings;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
 use Piwik\Plugins\UsersManager\Model as UsersModel;
+use Piwik\Plugins\UsersManager\UserLoginHelper;
 use Piwik\Plugins\UsersManager\UsersManager;
 use Piwik\QuickForm2;
 use Piwik\Request;
@@ -169,7 +170,10 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             // validate if there is error message
             if ($messageNoAccess === "") {
                 $loginOrEmail = $form->getSubmitValue('form_login');
-                $login = $this->getLoginFromLoginOrEmail($loginOrEmail);
+                if (!is_string($loginOrEmail)) {
+                    $loginOrEmail = '';
+                }
+                $login = UserLoginHelper::normalizeLoginOrEmailToLogin($loginOrEmail);
 
                 $password = $form->getSubmitValue('form_password');
                 try {
@@ -193,19 +197,6 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         self::setHostValidationVariablesView($view);
 
         return $view->render();
-    }
-
-    private function getLoginFromLoginOrEmail($loginOrEmail)
-    {
-        $model = new UsersModel();
-        if (!$model->userExists($loginOrEmail)) {
-            $user = $model->getUserByEmail($loginOrEmail);
-            if (!empty($user)) {
-                return $user['login'];
-            }
-        }
-
-        return $loginOrEmail;
     }
 
     /**

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -21,6 +21,7 @@ use Piwik\NoAccessException;
 use Piwik\Piwik;
 use Piwik\Plugins\Login\Security\BruteForceDetection;
 use Piwik\Plugins\Login\Security\LoginFromDifferentCountryDetection;
+use Piwik\Plugins\UsersManager\UserLoginHelper;
 use Piwik\Session;
 use Piwik\SettingsServer;
 
@@ -202,7 +203,18 @@ class Login extends \Piwik\Plugin
      */
     public function beforeCreateAppSpecificTokenAuthCheckBruteForce(array $params): void
     {
-        $this->performBruteForceCheck($params['userLogin'] ?? '');
+        $userLogin = $params['userLogin'] ?? '';
+
+        if (!is_string($userLogin)) {
+            $userLogin = '';
+        }
+
+        $this->performBruteForceCheck($this->normalizeUserLogin($userLogin));
+    }
+
+    private function normalizeUserLogin(string $userLogin): string
+    {
+        return UserLoginHelper::normalizeLoginOrEmailToLogin($userLogin);
     }
 
     private function performBruteForceCheck(?string $login): void
@@ -266,8 +278,15 @@ class Login extends \Piwik\Plugin
         }
 
         // if this is a login request & form_rememberme was set, change the session cookie expire time before starting the session
-        if (\Piwik\Request::fromPost()->getBoolParameter('form_rememberme')) {
-            Session::rememberMe(GeneralConfig::getConfigValue('login_cookie_expire'));
+        if (\Piwik\Request::fromPost()->getBoolParameter('form_rememberme', false)) {
+            $loginCookieExpire = GeneralConfig::getConfigValue('login_cookie_expire');
+            if (!is_numeric($loginCookieExpire)) {
+                $loginCookieExpire = null;
+            } else {
+                $loginCookieExpire = (int) $loginCookieExpire;
+            }
+
+            Session::rememberMe($loginCookieExpire);
         }
     }
 
@@ -289,11 +308,13 @@ class Login extends \Piwik\Plugin
         $frontController = FrontController::getInstance();
 
         if (Common::isXmlHttpRequest()) {
-            echo $frontController->dispatch(Piwik::getLoginPluginName(), 'ajaxNoAccess', [$exception->getMessage()]);
+            $response = $frontController->dispatch(Piwik::getLoginPluginName(), 'ajaxNoAccess', [$exception->getMessage()]);
+            echo is_string($response) ? $response : '';
             return;
         }
 
-        echo $frontController->dispatch(Piwik::getLoginPluginName(), 'login', [$exception->getMessage()]);
+        $response = $frontController->dispatch(Piwik::getLoginPluginName(), 'login', [$exception->getMessage()]);
+        echo is_string($response) ? $response : '';
     }
 
     /**
@@ -334,7 +355,7 @@ class Login extends \Piwik\Plugin
             }
         }
 
-        return $login;
+        return $this->normalizeUserLogin($login);
     }
 
     /**

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -13,7 +13,7 @@ use Exception;
 use Piwik\API\Request;
 use Piwik\Request\AuthenticationToken;
 use Piwik\Common;
-use Piwik\Config;
+use Piwik\Config\GeneralConfig;
 use Piwik\Container\StaticContainer;
 use Piwik\FrontController;
 use Piwik\IP;
@@ -26,8 +26,19 @@ use Piwik\SettingsServer;
 
 class Login extends \Piwik\Plugin
 {
+    /**
+     * @var bool
+     */
     private $hasAddedFailedAttempt = false;
+
+    /**
+     * @var bool
+     */
     private $hasPerformedBruteForceCheck = false;
+
+    /**
+     * @var bool
+     */
     private $hasPerformedBruteForceCheckForUserPwdLogin = false;
 
     /**
@@ -35,7 +46,7 @@ class Login extends \Piwik\Plugin
      */
     public function registerEvents()
     {
-        $hooks = array(
+        $hooks = [
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
             'User.isNotAuthorized'             => 'noAccess',
             'API.Request.authenticate'         => 'apiRequestAuthenticate',
@@ -45,7 +56,7 @@ class Login extends \Piwik\Plugin
 
             // for brute force prevention of all tracking + reporting api requests
             'Request.initAuthenticationObject' => 'onInitAuthenticationObject',
-            'API.UsersManager.createAppSpecificTokenAuth' => 'beforeLoginCheckBruteForce', // doesn't require auth but can be used to authenticate
+            'API.UsersManager.createAppSpecificTokenAuth' => 'beforeCreateAppSpecificTokenAuthCheckBruteForce', // doesn't require auth but can be used to authenticate
 
             // for brute force prevention of all UI requests
             'Controller.Login.logme'           => 'beforeLoginCheckBruteForce',
@@ -67,7 +78,7 @@ class Login extends \Piwik\Plugin
 
             // for 'Login from a different country' notification
             'Login.authenticate.processSuccessfulSession.end' => 'checkLoginFromAnotherCountry',
-        );
+        ];
 
         $loginPlugin = Piwik::getLoginPluginName();
 
@@ -84,6 +95,10 @@ class Login extends \Piwik\Plugin
         return $hooks;
     }
 
+    /**
+     * @param string[] $translations
+     * @return void
+     */
     public function getClientSideTranslationKeys(&$translations)
     {
         $translations[] = 'Login_CurrentlyBlockedIPs';
@@ -93,11 +108,17 @@ class Login extends \Piwik\Plugin
         $translations[] = 'Login_IPsAlwaysBlocked';
     }
 
+    /**
+     * @return true
+     */
     public function isTrackerPlugin()
     {
         return true;
     }
 
+    /**
+     * @return void
+     */
     public function onInitAuthenticationObject()
     {
         if (SettingsServer::isTrackerApiRequest() || Request::isRootRequestApiRequest()) {
@@ -110,6 +131,9 @@ class Login extends \Piwik\Plugin
         }
     }
 
+    /**
+     * @return void
+     */
     public function onFailedLoginRecordAttempt()
     {
         // we're always making sure on any success or failed login to check if user is actually allowed to log in
@@ -130,6 +154,9 @@ class Login extends \Piwik\Plugin
         }
     }
 
+    /**
+     * @return void
+     */
     public function onFailedAPILogin()
     {
         $this->onFailedLoginRecordAttempt();
@@ -145,6 +172,10 @@ class Login extends \Piwik\Plugin
         }
     }
 
+    /**
+     * @param string $login
+     * @return void
+     */
     public function checkLoginFromAnotherCountry($login)
     {
         if ('anonymous' === $login) {
@@ -158,28 +189,46 @@ class Login extends \Piwik\Plugin
         }
     }
 
+    /**
+     * @return void
+     */
     public function beforeLoginCheckBruteForce()
     {
+        $this->performBruteForceCheck($this->getUsernameUsedInPasswordLogin());
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function beforeCreateAppSpecificTokenAuthCheckBruteForce(array $params): void
+    {
+        $this->performBruteForceCheck($params['userLogin'] ?? '');
+    }
+
+    private function performBruteForceCheck(?string $login): void
+    {
+        /** @var BruteForceDetection $bruteForce */
         $bruteForce = StaticContainer::get('Piwik\Plugins\Login\Security\BruteForceDetection');
-        if (!$this->hasPerformedBruteForceCheck && $bruteForce->isEnabled() && !$bruteForce->isAllowedToLogin(IP::getIpFromHeader())) {
+
+        if (!$bruteForce->isEnabled()) {
+            return;
+        }
+
+        if (!$this->hasPerformedBruteForceCheck && !$bruteForce->isAllowedToLogin(IP::getIpFromHeader())) {
             throw new Exception(Piwik::translate('Login_LoginNotAllowedBecauseBlocked'));
         }
 
         // for performance reasons we make sure to execute it only once per request
         $this->hasPerformedBruteForceCheck = true;
 
-        // now check that user login (from any ip) is not blocked
-        $login = $this->getUsernameUsedInPasswordLogin();
         if (
             empty($login)
-            || $login == 'anonymous'
+            || $login === 'anonymous'
         ) {
             return; // can't do the check if we don't know the login
         }
 
-        /** @var BruteForceDetection $bruteForce */
-        $bruteForce = StaticContainer::get('Piwik\Plugins\Login\Security\BruteForceDetection');
-        if (!$this->hasPerformedBruteForceCheckForUserPwdLogin && $bruteForce->isEnabled() && $bruteForce->isUserLoginBlocked($login)) {
+        if (!$this->hasPerformedBruteForceCheckForUserPwdLogin && $bruteForce->isUserLoginBlocked($login)) {
             $ex = new NoAccessException(Piwik::translate('Login_LoginNotAllowedBecauseUserLoginBlocked'), 403);
             throw $ex;
         }
@@ -187,18 +236,29 @@ class Login extends \Piwik\Plugin
         $this->hasPerformedBruteForceCheckForUserPwdLogin = true;
     }
 
+    /**
+     * @param string[] $jsFiles
+     * @return void
+     */
     public function getJsFiles(&$jsFiles)
     {
         $jsFiles[] = "plugins/Login/javascripts/login.js";
         $jsFiles[] = "plugins/Login/javascripts/bruteforcelog.js";
     }
 
+    /**
+     * @param string[] $stylesheetFiles
+     * @return void
+     */
     public function getStylesheetFiles(&$stylesheetFiles)
     {
         $stylesheetFiles[] = "plugins/Login/stylesheets/login.less";
         $stylesheetFiles[] = "plugins/Login/stylesheets/variables.less";
     }
 
+    /**
+     * @return void
+     */
     public function beforeSessionStart()
     {
         if (!$this->shouldHandleRememberMe()) {
@@ -206,13 +266,12 @@ class Login extends \Piwik\Plugin
         }
 
         // if this is a login request & form_rememberme was set, change the session cookie expire time before starting the session
-        $rememberMe = isset($_POST['form_rememberme']) ? $_POST['form_rememberme'] : null;
-        if ($rememberMe == '1') {
-            Session::rememberMe(Config::getInstance()->General['login_cookie_expire']);
+        if (\Piwik\Request::fromPost()->getBoolParameter('form_rememberme')) {
+            Session::rememberMe(GeneralConfig::getConfigValue('login_cookie_expire'));
         }
     }
 
-    private function shouldHandleRememberMe()
+    private function shouldHandleRememberMe(): bool
     {
         $module = Piwik::getModule();
         $action = Piwik::getAction();
@@ -222,22 +281,27 @@ class Login extends \Piwik\Plugin
     /**
      * Redirects to Login form with error message.
      * Listens to User.isNotAuthorized hook.
+     *
+     * @return void
      */
     public function noAccess(Exception $exception)
     {
         $frontController = FrontController::getInstance();
 
         if (Common::isXmlHttpRequest()) {
-            echo $frontController->dispatch(Piwik::getLoginPluginName(), 'ajaxNoAccess', array($exception->getMessage()));
+            echo $frontController->dispatch(Piwik::getLoginPluginName(), 'ajaxNoAccess', [$exception->getMessage()]);
             return;
         }
 
-        echo $frontController->dispatch(Piwik::getLoginPluginName(), 'login', array($exception->getMessage()));
+        echo $frontController->dispatch(Piwik::getLoginPluginName(), 'login', [$exception->getMessage()]);
     }
 
     /**
      * Set login name and authentication token for API request.
      * Listens to API.Request.authenticate hook.
+     *
+     * @param string $tokenAuth
+     * @return void
      */
     public function apiRequestAuthenticate(
         #[\SensitiveParameter]
@@ -251,16 +315,19 @@ class Login extends \Piwik\Plugin
         $auth->setTokenAuth($tokenAuth);
     }
 
+    /**
+     * @return bool
+     */
     protected static function isModuleIsAPI()
     {
         return Piwik::getModule() === 'API'
-                && (Piwik::getAction() == '' || Piwik::getAction() == 'index');
+            && (Piwik::getAction() == '' || Piwik::getAction() === 'index');
     }
 
-    private function getUsernameUsedInPasswordLogin()
+    private function getUsernameUsedInPasswordLogin(): string
     {
         $login = StaticContainer::get(\Piwik\Auth::class)->getLogin();
-        if (empty($login) || $login == 'anonymous') {
+        if (empty($login) || $login === 'anonymous') {
             $login = \Piwik\Request::fromRequest()->getStringParameter('form_login', '');
             if (Piwik::getAction() === 'logme') {
                 $login = \Piwik\Request::fromRequest()->getStringParameter('login', $login);
@@ -270,6 +337,9 @@ class Login extends \Piwik\Plugin
         return $login;
     }
 
+    /**
+     * @return void
+     */
     public function deactivate()
     {
         Session::destroyAllSessions();

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -21,6 +21,7 @@ use Piwik\Plugins\Login\Emails\PasswordResetEmail;
 use Piwik\Plugins\Login\Emails\PasswordResetCancelEmail;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\UsersManager\Model;
+use Piwik\Plugins\UsersManager\UserLoginHelper;
 use Piwik\Plugins\UsersManager\UsersManager;
 use Piwik\Plugins\UsersManager\UserUpdater;
 use Piwik\SettingsPiwik;
@@ -468,7 +469,7 @@ class PasswordResetter
      * Derived classes can override this method to provide custom user querying logic.
      *
      * @param string $loginOrMail user login or email address
-     * @return array `array("login" => '...', "email" => '...', "password" => '...')` or null, if user not found.
+     * @return array<string, mixed>|null `array("login" => '...', "email" => '...', "password" => '...')` or null, if user not found.
      */
     protected function getUserInformation($loginOrMail)
     {
@@ -478,14 +479,7 @@ class PasswordResetter
             return null;
         }
 
-        $user = null;
-
-        if ($userModel->userExists($loginOrMail)) {
-            $user = $userModel->getUser($loginOrMail);
-        } elseif ($userModel->userEmailExists($loginOrMail)) {
-            $user = $userModel->getUserByEmail($loginOrMail);
-        }
-        return $user;
+        return UserLoginHelper::findUserByLoginOrEmail($loginOrMail);
     }
 
     /**

--- a/plugins/Login/tests/Integration/CreateAppSpecificTokenAuthBruteForceTest.php
+++ b/plugins/Login/tests/Integration/CreateAppSpecificTokenAuthBruteForceTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Login\tests\Integration;
+
+use Piwik\API\Request;
+use Piwik\Container\StaticContainer;
+use Piwik\NoAccessException;
+use Piwik\Plugins\Login\Login as LoginPlugin;
+use Piwik\Plugins\Login\Security\BruteForceDetection;
+use Piwik\Plugins\Login\SystemSettings;
+use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Login
+ * @group Plugins
+ */
+class CreateAppSpecificTokenAuthBruteForceTest extends IntegrationTestCase
+{
+    /**
+     * @var BruteForceDetection
+     */
+    private $bruteForceDetection;
+
+    /**
+     * @var string
+     */
+    private $userLogin;
+
+    /**
+     * @var string
+     */
+    private $userEmail;
+
+    /**
+     * @var string
+     */
+    private $userPassword = 'someStrongPassword123!';
+
+    /**
+     * @var SystemSettings
+     */
+    private $settings;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private $post = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    private $request = [];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->post = $_POST;
+        $this->request = $_REQUEST;
+
+        $this->bruteForceDetection = StaticContainer::get(BruteForceDetection::class);
+        $this->settings = new SystemSettings();
+        $this->settings->maxFailedLoginsPerMinutes->setValue(1);
+        $this->bruteForceDetection->deleteAll();
+
+        $this->userLogin = 'blockeduser' . substr(md5(uniqid('', true)), 0, 8);
+        $this->userEmail = $this->userLogin . '@matomo.org';
+
+        UsersManagerAPI::getInstance()->addUser($this->userLogin, $this->userPassword, $this->userEmail);
+    }
+
+    public function tearDown(): void
+    {
+        $this->bruteForceDetection->deleteAll();
+        $_POST = $this->post;
+        $_REQUEST = $this->request;
+
+        parent::tearDown();
+    }
+
+    public function testCreateAppSpecificTokenAuthThrowsWhenUserLoginIsBlockedUsingLogin(): void
+    {
+        $this->blockLogin($this->userLogin);
+        $this->assertTrue($this->bruteForceDetection->isUserLoginBlocked($this->userLogin));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Login_LoginNotAllowedBecauseUserLoginBlocked');
+
+        Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
+            'userLogin' => $this->userLogin,
+            'passwordConfirmation' => $this->userPassword,
+            'description' => 'blocked login test',
+        ]);
+    }
+
+    public function testCreateAppSpecificTokenAuthThrowsWhenUserLoginIsBlockedUsingEmail(): void
+    {
+        $this->blockLogin($this->userLogin);
+        $this->assertTrue($this->bruteForceDetection->isUserLoginBlocked($this->userLogin));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Login_LoginNotAllowedBecauseUserLoginBlocked');
+
+        Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
+            'userLogin' => $this->userEmail,
+            'passwordConfirmation' => $this->userPassword,
+            'description' => 'blocked email test',
+        ]);
+    }
+
+    public function testCreateAppSpecificTokenAuthCreatesTokenUsingEmailWhenUserNotBlocked(): void
+    {
+        $token = Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
+            'userLogin' => $this->userEmail,
+            'passwordConfirmation' => $this->userPassword,
+            'description' => 'allowed email test',
+        ]);
+
+        $this->assertIsString($token);
+        $this->assertNotSame('', $token);
+    }
+
+    public function testBeforeLoginCheckBruteForceThrowsWhenUserLoginIsBlockedUsingEmailInFormLogin(): void
+    {
+        $this->blockLogin($this->userLogin);
+        $this->assertTrue($this->bruteForceDetection->isUserLoginBlocked($this->userLogin));
+
+        $_POST['form_login'] = $this->userEmail;
+        $_REQUEST['form_login'] = $this->userEmail;
+        StaticContainer::get(\Piwik\Auth::class)->setLogin('anonymous');
+
+        $this->expectException(NoAccessException::class);
+        $this->expectExceptionCode(403);
+
+        $plugin = new LoginPlugin();
+        $plugin->beforeLoginCheckBruteForce();
+    }
+
+    private function blockLogin(string $userLogin): void
+    {
+        $requiredAttempts = BruteForceDetection::OVERALL_LOGIN_LOCKOUT_THRESHOLD_MIN + 1;
+
+        for ($i = 1; $i <= $requiredAttempts; $i++) {
+            $this->bruteForceDetection->addFailedAttempt('10.0.0.' . $i, $userLogin);
+        }
+    }
+}

--- a/plugins/TwoFactorAuth/TwoFactorAuth.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuth.php
@@ -18,6 +18,7 @@ use Piwik\Piwik;
 use Piwik\Request\AuthenticationToken;
 use Piwik\Plugins\TwoFactorAuth\Dao\RecoveryCodeDao;
 use Piwik\Plugins\UsersManager\Model;
+use Piwik\Plugins\UsersManager\UserLoginHelper;
 use Piwik\Session;
 use Piwik\Session\SessionFingerprint;
 use Exception;
@@ -178,24 +179,6 @@ class TwoFactorAuth extends \Piwik\Plugin
         return !empty($user);
     }
 
-    private function getCanonicalLogin(string $userLoginOrEmail): ?string
-    {
-        $model = new Model();
-
-        if ($model->userExists($userLoginOrEmail)) {
-            return $userLoginOrEmail;
-        }
-
-        if ($model->userEmailExists($userLoginOrEmail)) {
-            $user = $model->getUserByEmail($userLoginOrEmail);
-            if (!empty($user['login'])) {
-                return $user['login'];
-            }
-        }
-
-        return null;
-    }
-
     public function onCreateAppSpecificTokenAuth($returnedValue, array $params): void
     {
         if (!SettingsPiwik::isMatomoInstalled()) {
@@ -203,7 +186,7 @@ class TwoFactorAuth extends \Piwik\Plugin
         }
 
         if (!empty($returnedValue) && !empty($params['parameters']['userLogin'])) {
-            $login = $this->getCanonicalLogin($params['parameters']['userLogin']);
+            $login = UserLoginHelper::findCanonicalLoginByLoginOrEmail($params['parameters']['userLogin']);
             $twoFa = $this->getTwoFa();
 
             if (!empty($login) && TwoFactorAuthentication::isUserUsingTwoFactorAuthentication($login) && $this->isValidTokenAuth($returnedValue)) {

--- a/plugins/UsersManager/UserLoginHelper.php
+++ b/plugins/UsersManager/UserLoginHelper.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager;
+
+class UserLoginHelper
+{
+    /**
+     * @return array<string, mixed>|null
+     */
+    public static function findUserByLoginOrEmail(string $loginOrEmail): ?array
+    {
+        $model = new Model();
+
+        if ($model->userExists($loginOrEmail)) {
+            return $model->getUser($loginOrEmail);
+        }
+
+        if ($model->userEmailExists($loginOrEmail)) {
+            $user = $model->getUserByEmail($loginOrEmail);
+            if (!empty($user)) {
+                return $user;
+            }
+        }
+
+        return null;
+    }
+
+    public static function findCanonicalLoginByLoginOrEmail(string $loginOrEmail): ?string
+    {
+        if (empty($loginOrEmail)) {
+            return null;
+        }
+
+        $model = new Model();
+        if ($model->userExists($loginOrEmail)) {
+            return $loginOrEmail;
+        }
+
+        if ($model->userEmailExists($loginOrEmail)) {
+            $user = $model->getUserByEmail($loginOrEmail);
+            if (!empty($user['login']) && is_string($user['login'])) {
+                return $user['login'];
+            }
+        }
+
+        return null;
+    }
+
+    public static function normalizeLoginOrEmailToLogin(string $loginOrEmail): string
+    {
+        $login = self::findCanonicalLoginByLoginOrEmail($loginOrEmail);
+        if (!empty($login)) {
+            return $login;
+        }
+
+        return $loginOrEmail;
+    }
+}

--- a/plugins/UsersManager/tests/Integration/UserLoginHelperTest.php
+++ b/plugins/UsersManager/tests/Integration/UserLoginHelperTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\tests\Integration;
+
+use Piwik\Plugins\UsersManager\API;
+use Piwik\Plugins\UsersManager\UserLoginHelper;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group UsersManager
+ * @group Plugins
+ */
+class UserLoginHelperTest extends IntegrationTestCase
+{
+    /**
+     * @var string
+     */
+    private $login;
+
+    /**
+     * @var string
+     */
+    private $email;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->login = 'helperuser' . substr(md5(uniqid('', true)), 0, 8);
+        $this->email = $this->login . '@matomo.org';
+
+        API::getInstance()->addUser($this->login, 'someStrongPassword123!', $this->email);
+    }
+
+    public function testFindUserByLoginOrEmailFindsByLoginAndEmail(): void
+    {
+        $byLogin = UserLoginHelper::findUserByLoginOrEmail($this->login);
+        $byEmail = UserLoginHelper::findUserByLoginOrEmail($this->email);
+
+        $this->assertNotEmpty($byLogin);
+        $this->assertNotEmpty($byEmail);
+        $this->assertSame($this->login, $byLogin['login']);
+        $this->assertSame($this->email, $byLogin['email']);
+        $this->assertSame($this->login, $byEmail['login']);
+        $this->assertSame($this->email, $byEmail['email']);
+    }
+
+    public function testFindCanonicalLoginByLoginOrEmailResolvesAndReturnsNullWhenNotFound(): void
+    {
+        $this->assertSame($this->login, UserLoginHelper::findCanonicalLoginByLoginOrEmail($this->login));
+        $this->assertSame($this->login, UserLoginHelper::findCanonicalLoginByLoginOrEmail($this->email));
+        $this->assertNull(UserLoginHelper::findCanonicalLoginByLoginOrEmail('does-not-exist@example.org'));
+    }
+
+    public function testNormalizeLoginOrEmailToLoginKeepsUnknownInputUnchanged(): void
+    {
+        $this->assertSame($this->login, UserLoginHelper::normalizeLoginOrEmailToLogin($this->login));
+        $this->assertSame($this->login, UserLoginHelper::normalizeLoginOrEmailToLogin($this->email));
+        $this->assertSame('does-not-exist@example.org', UserLoginHelper::normalizeLoginOrEmailToLogin('does-not-exist@example.org'));
+    }
+}


### PR DESCRIPTION
Deduplicates login-or-email resolution logic across plugins by introducing a shared utility and migrating existing call sites to it.

### What changed

  - Added new shared utility:
      - plugins/UsersManager/UserLoginHelper.php
      - Methods:
          - findUserByLoginOrEmail(string): ?array
          - findCanonicalLoginByLoginOrEmail(string): ?string
          - normalizeLoginOrEmailToLogin(string): string
  - Updated callers to use the shared helper:
      - plugins/Login/Login.php
      - plugins/Login/Controller.php
      - plugins/TwoFactorAuth/TwoFactorAuth.php
      - plugins/LanguagesManager/LanguagesHelper.php
      - plugins/Login/PasswordResetter.php

### Behavior and BC notes

  - Brute-force checks now consistently normalize email to canonical login
  - Removed several single-use private wrapper methods where no BC concerns exist.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
