### PR TITLE
Fix Amazon CloudFront icon

### DIFF
--- a/plugins/BotTracking/tests/UI/expected-screenshots/BotTrackingSiteWithoutData_siteWithoutData.png
+++ b/plugins/BotTracking/tests/UI/expected-screenshots/BotTrackingSiteWithoutData_siteWithoutData.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7749909b73a56bdae80137045512570d0e33e6a685de5ce9fafe544742005a99
-size 105744
+oid sha256:e77c3177e4c768b268fa1b26136a118dbde6ec1ce9b40ca85aebc7d3a2e107b2
+size 104664

--- a/plugins/SitesManager/SiteContentDetection/AmazonCloudFront.php
+++ b/plugins/SitesManager/SiteContentDetection/AmazonCloudFront.php
@@ -18,7 +18,7 @@ class AmazonCloudFront extends SiteContentDetectionAbstract
 
     public static function getIcon(): string
     {
-        return './plugins/Morpheus/icons/src/brand/Amazon.png';
+        return './plugins/Morpheus/icons/dist/brand/Amazon.png';
     }
 
     public static function getContentType(): int


### PR DESCRIPTION
### Description

The icon used to represent Amazon CloudFront was by accident picked to be the "Morpheus source" instead of the "Morpheus distribution". Looks great locally and in CI, but is missing from the release package :(

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
