### PR TITLE
Segment - Allow to remove 'All Visits' from comparisons

### DIFF
--- a/plugins/SegmentEditor/javascripts/Segmentation.js
+++ b/plugins/SegmentEditor/javascripts/Segmentation.js
@@ -476,7 +476,7 @@ Segmentation = (function($) {
                   return false;
                 }
                 const comparisonService = window.CoreHome.ComparisonsStoreInstance;
-                const segmentDefinition = $button.closest('li').data('definition');
+                const segmentDefinition = $button.closest('li').data('definition') ?? '';
                 if ($button.attr('data-state') === 'active') {
                   comparisonService.removeSegmentComparisonByDefinition(segmentDefinition);
                 } else {

--- a/plugins/SegmentEditor/tests/UI/SegmentSelectorCompare_spec.js
+++ b/plugins/SegmentEditor/tests/UI/SegmentSelectorCompare_spec.js
@@ -9,6 +9,19 @@
 
 describe('SegmentComparison', () => {
   var generalParams = 'idSite=1&period=year&date=2012-08-09';
+  async function clickCompareButton(selector) {
+    await page.click('.segmentationContainer .title');
+    await page.waitForSelector(selector);
+    await page.evaluate((buttonSelector) => {
+      const button = document.querySelector(buttonSelector);
+      if (!button) {
+        throw new Error(`Compare button not found for selector: ${buttonSelector}`);
+      }
+      button.click();
+    }, selector);
+    await page.waitForTimeout(150);
+  }
+
   it('should not allow comparing segments more than the limit set', async function() {
     const configLimit = 2;
     const maxSegments = configLimit + 1;
@@ -50,14 +63,14 @@ describe('SegmentComparison', () => {
       await page.waitForTimeout(100);
     }
 
-    // We want to click all the segments so that we can check that it stops at the limit
-    for (let i=0; i<liElemLength; i++) {
-      await page.click('.segmentationContainer .title');
-      await page.waitForTimeout(100);
-      const elements = await page.$$('.segmentListContainer .segmentList li button.compareSegment');
-      if (!elements[i]) break;
-      await elements[i].click();
-      await page.waitForTimeout(100);
+    // We want to click all the segments so that we can check that it stops at the limit.
+    // Use DOM-level click because Materialize dropdown transitions can make Puppeteer
+    // consider the element temporarily non-clickable even though it exists in the panel.
+    for (let i = 0; i < liElemLength; i++) {
+      const selector = `.segmentListContainer .segmentList li:nth-child(${i + 1}) .compareSegment`;
+      const hasButton = await page.$(selector);
+      if (!hasButton) break;
+      await clickCompareButton(selector);
     }
 
     // We check that the number of segments compared is now equal to the limit we set
@@ -66,5 +79,45 @@ describe('SegmentComparison', () => {
       (nodes) => nodes.length,
     );
     expect(comparedCount).to.equal(maxSegments);
+  });
+
+  it("should remove 'All Visits' from comparisons when clicking its compare button", async function () {
+    testEnvironment.overrideConfig('General', 'data_comparison_segment_limit', 5);
+    await testEnvironment.save();
+
+    const dashUrl = '?module=CoreHome&action=index&' + generalParams + '#?' + generalParams + '&category=Dashboard_Dashboard&subcategory=1';
+    await page.goto('about:blank');
+    await page.waitForNetworkIdle();
+    await page.goto(dashUrl);
+    await page.waitForNetworkIdle();
+    await page.waitForSelector('.segmentationContainer');
+
+    await page.click('.segmentationContainer .title');
+    await page.waitForSelector('.segmentListContainer .segmentList li[data-idsegment]');
+
+    const segmentIds = await page.$$eval(
+      '.segmentListContainer .segmentList li[data-idsegment]',
+      (items) => items
+        .map((item) => item.getAttribute('data-idsegment'))
+        .filter((id) => !!id)
+        .slice(0, 2),
+    );
+    expect(segmentIds.length).to.equal(2);
+
+    for (const id of segmentIds) {
+      await clickCompareButton(`.segmentListContainer .segmentList li[data-idsegment="${id}"] .compareSegment`);
+    }
+
+    await page.waitForFunction(() => (
+      document.querySelectorAll('.segmentListContainer .segmentList li.comparedSegment').length >= 3
+    ));
+
+    const allVisitsCompareSelector = '.segmentListContainer .segmentList li[data-idsegment=""] .compareSegment';
+    await clickCompareButton(allVisitsCompareSelector);
+
+    await page.waitForFunction(() => {
+      const allVisitsRow = document.querySelector('.segmentListContainer .segmentList li[data-idsegment=""]');
+      return !!allVisitsRow && !allVisitsRow.classList.contains('comparedSegment');
+    });
   });
 });


### PR DESCRIPTION
### Description

Fix Segment comparison toggle for All Visits by handling empty segment definitions in native JS event flow, and stabilize related UI compare tests against Materialize dropdown transition timing.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
