### PR TITLE
change eventdispatcher to allow non-blocking exceptions

### DIFF
--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -10,6 +10,8 @@
 namespace Piwik;
 
 use Piwik\Container\StaticContainer;
+use Piwik\Log\LoggerInterface;
+use Throwable;
 
 /**
  * This class allows code to post events from anywhere in Piwik and for
@@ -141,11 +143,24 @@ class EventDispatcher
         // sort callbacks by their importance
         ksort($callbacks);
 
+        $firstException = null;
+
         // execute callbacks in order
         foreach ($callbacks as $callbackGroup) {
             foreach ($callbackGroup as $callback) {
-                call_user_func_array($callback, $params);
+                try {
+                    call_user_func_array($callback, $params);
+                } catch (Throwable $exception) {
+                    $this->logCallbackException($eventName, $callback, $exception);
+                    if ($firstException === null) {
+                        $firstException = $exception;
+                    }
+                }
             }
+        }
+
+        if ($firstException) {
+            throw $firstException;
         }
     }
 
@@ -215,5 +230,55 @@ class EventDispatcher
         }
 
         return array($pluginFunction, $callbackGroup);
+    }
+
+    /**
+     * @param callable|array|string $callback
+     */
+    private function logCallbackException($eventName, $callback, Throwable $exception)
+    {
+        try {
+            StaticContainer::get(LoggerInterface::class)->warning(
+                'Exception in event handler for {event}: {callback}. {exception}',
+                [
+                    'event' => $eventName,
+                    'callback' => $this->getCallbackName($callback),
+                    'exception' => $exception,
+                ]
+            );
+        } catch (Throwable $logException) {
+            // Ignore logging failures to avoid breaking event dispatch.
+        }
+    }
+
+    /**
+     * @param callable|array|string $callback
+     */
+    private function getCallbackName($callback)
+    {
+        if (is_string($callback)) {
+            return $callback;
+        }
+
+        if (is_array($callback)) {
+            $classOrObject = $callback[0] ?? '';
+            $method = $callback[1] ?? '';
+
+            if (is_object($classOrObject)) {
+                $classOrObject = get_class($classOrObject);
+            }
+
+            return $classOrObject . '::' . $method;
+        }
+
+        if ($callback instanceof \Closure) {
+            return 'Closure';
+        }
+
+        if (is_object($callback)) {
+            return get_class($callback);
+        }
+
+        return 'Unknown callback';
     }
 }

--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -151,10 +151,13 @@ class EventDispatcher
                 try {
                     call_user_func_array($callback, $params);
                 } catch (Throwable $exception) {
-                    $this->logCallbackException($eventName, $callback, $exception);
                     if ($firstException === null) {
                         $firstException = $exception;
+                        continue;
                     }
+
+                    // log only additional callback failures. the first one is rethrown below.
+                    $this->logCallbackException($eventName, $callback, $exception);
                 }
             }
         }

--- a/tests/PHPUnit/Unit/EventDispatcherTest.php
+++ b/tests/PHPUnit/Unit/EventDispatcherTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Piwik\EventDispatcher;
+use Piwik\Plugin\Manager;
+use RuntimeException;
+
+/**
+ * @group Core
+ * @group EventDispatcher
+ */
+class EventDispatcherTest extends TestCase
+{
+    /**
+     * @var MockObject&Manager
+     */
+    private $pluginManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pluginManager = $this->createMock(Manager::class);
+    }
+
+    public function testPostEventContinuesWhenAPluginHandlerThrowsAnException(): void
+    {
+        $failingPlugin = new class () {
+            public function registerEvents()
+            {
+                return ['Test.event' => 'onTestEvent'];
+            }
+
+            public function onTestEvent()
+            {
+                throw new RuntimeException('Failing plugin callback');
+            }
+        };
+
+        $healthyPlugin = new class () {
+            public $hasRun = false;
+
+            public function registerEvents()
+            {
+                return ['Test.event' => 'onTestEvent'];
+            }
+
+            public function onTestEvent()
+            {
+                $this->hasRun = true;
+            }
+        };
+
+        $this->pluginManager
+            ->method('getPluginsLoadedAndActivated')
+            ->willReturn([
+                'FailingPlugin' => $failingPlugin,
+                'HealthyPlugin' => $healthyPlugin,
+            ]);
+
+        $dispatcher = new EventDispatcher($this->pluginManager);
+        try {
+            $dispatcher->postEvent('Test.event', []);
+            self::fail('Expected an exception to be rethrown after event dispatch.');
+        } catch (RuntimeException $expected) {
+            self::assertSame('Failing plugin callback', $expected->getMessage());
+        }
+        self::assertTrue($healthyPlugin->hasRun);
+    }
+
+    public function testPostEventContinuesWhenAnExtraObserverThrowsAnException(): void
+    {
+        $this->pluginManager
+            ->method('getPluginsLoadedAndActivated')
+            ->willReturn([]);
+
+        $observerRun = false;
+        $dispatcher = new EventDispatcher($this->pluginManager);
+
+        $dispatcher->addObserver('Test.event', static function () {
+            throw new RuntimeException('Failing extra observer');
+        });
+
+        $dispatcher->addObserver('Test.event', static function () use (&$observerRun) {
+            $observerRun = true;
+        });
+
+        try {
+            $dispatcher->postEvent('Test.event', []);
+            self::fail('Expected an exception to be rethrown after event dispatch.');
+        } catch (RuntimeException $expected) {
+            self::assertSame('Failing extra observer', $expected->getMessage());
+        }
+        self::assertTrue($observerRun);
+    }
+}


### PR DESCRIPTION
### Description

Currently if an event handler for a particular event throws an exception, that will block the event dispatcher from executing any following event handlers for that particular event. This fix changes that, so event handler exceptions should now be non-blocking to other handlers. If an exception is thrown by a handler, that exception is preserved and re-thrown to preserve current behaviour around code which already handles exceptions thrown during event dispatching.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
