### PR TITLE
Implement flat-first archiving for Action reports to improve limiting and memory consumption

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -624,6 +624,8 @@ datatable_archiving_maximum_rows_subtable_custom_dimensions = 1000
 
 ; maximum number of rows for any of the Actions tables (pages, downloads, outlinks)
 datatable_archiving_maximum_rows_actions = 500
+; maximum number of rows used when aggregating flat page/title actions for non-day periods before rebuilding hierarchy
+datatable_archiving_maximum_rows_actions_flat_non_day = 50000
 ; maximum number of rows for pages in categories (sub pages, when clicking on the + for a page category)
 ; note: should not exceed the display limit in Piwik\Actions\Controller::ACTIONS_REPORT_ROWS_DISPLAY
 ; because each subdirectory doesn't have paging at the bottom, so all data should be displayed if possible.

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -624,8 +624,9 @@ datatable_archiving_maximum_rows_subtable_custom_dimensions = 1000
 
 ; maximum number of rows for any of the Actions tables (pages, downloads, outlinks)
 datatable_archiving_maximum_rows_actions = 500
-; maximum number of rows used when aggregating flat page/title actions for non-day periods before rebuilding hierarchy
-datatable_archiving_maximum_rows_actions_flat_non_day = 50000
+; maximum number of rows used when archiving flat page/title actions before rebuilding hierarchy
+; if set to 0, legacy hierarchical-only Actions archiving is used
+datatable_archiving_maximum_rows_actions_flat = 0
 ; maximum number of rows for pages in categories (sub pages, when clicking on the + for a page category)
 ; note: should not exceed the display limit in Piwik\Actions\Controller::ACTIONS_REPORT_ROWS_DISPLAY
 ; because each subdirectory doesn't have paging at the bottom, so all data should be displayed if possible.

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -11,6 +11,7 @@ namespace Piwik;
 
 use Exception;
 use Piwik\Archive\DataTableFactory;
+use Piwik\ArchiveProcessor\BlobTableAggregator;
 use Piwik\ArchiveProcessor\Parameters;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\Container\StaticContainer;
@@ -390,25 +391,12 @@ class ArchiveProcessor
 
     protected function getAggregatedDataTableMapFromBlobs(\Iterator $dataTableBlobs, $columnsAggregationOperation, $columnsToRenameAfterAggregation, $name)
     {
-        // maps period & subtable ID in database to the Row instance in $result that subtable should be added to when encountered
-        // [$row['date1'].','.$row['date2']][$tableId] = $row in $result
-        /** @var Row[][] */
-        $tableIdToResultRowMapping = [];
-
-        $result = new DataTable();
-
-        if (!empty($columnsAggregationOperation)) {
-            $result->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnsAggregationOperation);
-        }
-
-        foreach ($dataTableBlobs as $archiveDataRow) {
-            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
-            $tableId = $archiveDataRow['name'] == $name ? null : $this->getSubtableIdFromBlobName($archiveDataRow['name']);
-
-            $blobTable = DataTable::fromSerializedArray($archiveDataRow['value']);
-
-            // see https://github.com/piwik/piwik/issues/4377
-            $blobTable->filter(function ($table) use ($columnsToRenameAfterAggregation) {
+        [$result, $hasRows] = BlobTableAggregator::aggregateBlobRows(
+            $dataTableBlobs,
+            $name,
+            $columnsAggregationOperation,
+            function (DataTable $table) use ($columnsToRenameAfterAggregation): void {
+                // see https://github.com/piwik/piwik/issues/4377
                 if ($this->areColumnsNotAlreadyRenamed($table)) {
                     /**
                      * This makes archiving and range dates a lot faster. Imagine we archive a week, then we will
@@ -420,12 +408,9 @@ class ArchiveProcessor
                      */
                     $this->renameColumnsAfterAggregation($table, $columnsToRenameAfterAggregation);
                 }
-            });
-
-            $tableToAddTo = null;
-            if ($tableId === null) {
-                $tableToAddTo = $result;
-            } elseif (empty($tableIdToResultRowMapping[$period][$tableId])) { // sanity check
+            },
+            null,
+            function (string $period, int $tableId): void {
                 StaticContainer::get(LoggerInterface::class)->info(
                     'Unexpected state when aggregating DataTable, unknown period/table ID combination encountered: {period} - {tableId}.'
                     . ' This either means the SQL to order blobs is behaving incorrectly or the blob data is corrupt in some way.',
@@ -434,50 +419,11 @@ class ArchiveProcessor
                         'tableId' => $tableId,
                     ]
                 );
-                continue;
-            } else {
-                $rowToAddTo = $tableIdToResultRowMapping[$period][$tableId];
-
-                if (!$rowToAddTo->getIdSubDataTable()) {
-                    $newTable = new DataTable();
-                    $newTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnsAggregationOperation);
-                    $rowToAddTo->setSubtable($newTable);
-                }
-
-                $tableToAddTo = $rowToAddTo->getSubtable();
             }
-
-            $tableToAddTo->addDataTable($blobTable);
-
-            // add subtable IDs for $blobTableRow to $tableIdToResultRowMapping
-            foreach ($blobTable->getRows() as $blobTableRow) {
-                $label = $blobTableRow->getColumn('label');
-                $subtableId = $blobTableRow->getIdSubDataTable();
-                if (empty($subtableId)) {
-                    continue;
-                }
-
-                $rowToAddTo = $tableToAddTo->getRowFromLabel($label);
-                $tableIdToResultRowMapping[$period][$subtableId] = $rowToAddTo;
-            }
-
-            Common::destroy($blobTable);
-            unset($blobTable);
-        }
+        );
+        unset($hasRows);
 
         return $result;
-    }
-
-    private function getSubtableIdFromBlobName($recordName)
-    {
-        $parts = explode('_', $recordName);
-        $id = end($parts);
-
-        if (is_numeric($id)) {
-            return $id;
-        }
-
-        return null;
     }
 
     /**

--- a/core/ArchiveProcessor/BlobTableAggregator.php
+++ b/core/ArchiveProcessor/BlobTableAggregator.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\ArchiveProcessor;
+
+use Piwik\Common;
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+
+/**
+ * Internal helper for aggregating blob rows into a DataTable.
+ *
+ * @internal
+ */
+final class BlobTableAggregator
+{
+    /**
+     * @param iterable<array{name: string, date1: string, date2: string, value: string}> $archiveDataRows
+     * @param callable(DataTable):void $renameColumnsCallback
+     * @param callable(array{name: string, date1: string, date2: string, value: string}):bool|null $shouldIncludeRow
+     * @param callable(string, int):void|null $onMissingParentTable
+     * @return array{0: DataTable, 1: bool}
+     */
+    public static function aggregateBlobRows(
+        iterable $archiveDataRows,
+        string $recordName,
+        ?array $columnsAggregationOperation,
+        callable $renameColumnsCallback,
+        ?callable $shouldIncludeRow = null,
+        ?callable $onMissingParentTable = null
+    ): array {
+        // maps period & subtable ID in database to the Row instance in $result that subtable should be added to
+        // [$row['date1'].','.$row['date2']][$tableId] = $row in $result
+        $tableIdToResultRowMapping = [];
+        $result = new DataTable();
+        $hasRows = false;
+
+        if (!empty($columnsAggregationOperation)) {
+            $result->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnsAggregationOperation);
+        }
+
+        foreach ($archiveDataRows as $archiveDataRow) {
+            if ($shouldIncludeRow !== null && !$shouldIncludeRow($archiveDataRow)) {
+                continue;
+            }
+
+            $hasRows = true;
+            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
+            $tableId = $archiveDataRow['name'] === $recordName
+                ? null
+                : self::parseSubtableIdFromBlobName($archiveDataRow['name']);
+
+            $blobTable = DataTable::fromSerializedArray($archiveDataRow['value']);
+            $blobTable->filter(function (DataTable $table) use ($renameColumnsCallback) {
+                $renameColumnsCallback($table);
+            });
+
+            if ($tableId === null) {
+                $tableToAddTo = $result;
+            } elseif (empty($tableIdToResultRowMapping[$period][$tableId])) {
+                if ($onMissingParentTable !== null) {
+                    $onMissingParentTable($period, $tableId);
+                }
+                Common::destroy($blobTable);
+                continue;
+            } else {
+                $rowToAddTo = $tableIdToResultRowMapping[$period][$tableId];
+                if (!$rowToAddTo->getIdSubDataTable()) {
+                    $newTable = new DataTable();
+                    if (!empty($columnsAggregationOperation)) {
+                        $newTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnsAggregationOperation);
+                    }
+                    $rowToAddTo->setSubtable($newTable);
+                }
+
+                $tableToAddTo = $rowToAddTo->getSubtable();
+            }
+
+            $tableToAddTo->addDataTable($blobTable);
+
+            foreach ($blobTable->getRows() as $blobTableRow) {
+                $label = $blobTableRow->getColumn('label');
+                $subtableId = $blobTableRow->getIdSubDataTable();
+                if (empty($subtableId)) {
+                    continue;
+                }
+
+                $rowToAddTo = $tableToAddTo->getRowFromLabel($label);
+                if ($rowToAddTo instanceof Row) {
+                    $tableIdToResultRowMapping[$period][$subtableId] = $rowToAddTo;
+                }
+            }
+
+            Common::destroy($blobTable);
+        }
+
+        return [$result, $hasRows];
+    }
+
+    public static function parseSubtableIdFromBlobName(string $recordName): ?int
+    {
+        $parts = explode('_', $recordName);
+        $id = end($parts);
+
+        if (!is_numeric($id)) {
+            return null;
+        }
+
+        return (int) $id;
+    }
+}

--- a/core/ArchiveProcessor/Record.php
+++ b/core/ArchiveProcessor/Record.php
@@ -252,6 +252,21 @@ class Record
         return $this->multiplePeriodTransform;
     }
 
+    /**
+     * Marks this blob record as being derived from a flat blob record during non-day aggregation.
+     *
+     * Use this when day archives store a flat representation and non-day archives should rebuild
+     * hierarchy from it. The flat record must be present in getRecordMetadata().
+     *
+     * @param string $flatRecordName Name of the flat blob record to aggregate first.
+     * @param callable $flatToHierarchyPathCallback Callback used when rebuilding hierarchy.
+     *                                              Signature: function (Row $flatRow, ArchiveProcessor $archiveProcessor, Record $hierarchicalRecord): ?array
+     *                                              Return value is the path of labels to map the flat row into the hierarchy.
+     * @param callable|null $legacyHierarchyToFlatReducerCallback Optional callback that can merge legacy hierarchical
+     *                                                            aggregates into the flat table when some periods do not
+     *                                                            have the flat record yet.
+     *                                                            Signature: function (DataTable $legacyHierarchy, DataTable $flatTable, ArchiveProcessor $archiveProcessor, Record $hierarchicalRecord): void
+     */
     public function setBuiltFromFlatRecord(
         string $flatRecordName,
         callable $flatToHierarchyPathCallback,
@@ -277,11 +292,17 @@ class Record
         return $this->builtFromFlatRecord;
     }
 
+    /**
+     * @see setBuiltFromFlatRecord()
+     */
     public function getFlatToHierarchyPathCallback(): ?callable
     {
         return $this->flatToHierarchyPathCallback;
     }
 
+    /**
+     * @see setBuiltFromFlatRecord()
+     */
     public function getLegacyHierarchyToFlatReducerCallback(): ?callable
     {
         return $this->legacyHierarchyToFlatReducerCallback;

--- a/core/ArchiveProcessor/Record.php
+++ b/core/ArchiveProcessor/Record.php
@@ -78,6 +78,21 @@ class Record
      */
     private $multiplePeriodTransform = null;
 
+    /**
+     * @var string|null
+     */
+    private $builtFromFlatRecord = null;
+
+    /**
+     * @var callable|null
+     */
+    private $flatToHierarchyPathCallback = null;
+
+    /**
+     * @var callable|null
+     */
+    private $legacyHierarchyToFlatReducerCallback = null;
+
     public static function make($type, $name)
     {
         $record = new Record();
@@ -235,5 +250,40 @@ class Record
     public function getMultiplePeriodTransform(): ?callable
     {
         return $this->multiplePeriodTransform;
+    }
+
+    public function setBuiltFromFlatRecord(
+        string $flatRecordName,
+        callable $flatToHierarchyPathCallback,
+        ?callable $legacyHierarchyToFlatReducerCallback = null
+    ): Record {
+        if ($this->type !== self::TYPE_BLOB) {
+            throw new \InvalidArgumentException('setBuiltFromFlatRecord() can only be used with blob records.');
+        }
+
+        if (!preg_match('/^[a-zA-Z0-9_-]+$/', $flatRecordName)) {
+            throw new \InvalidArgumentException('Invalid flat record name: ' . $flatRecordName);
+        }
+
+        $this->builtFromFlatRecord = $flatRecordName;
+        $this->flatToHierarchyPathCallback = $flatToHierarchyPathCallback;
+        $this->legacyHierarchyToFlatReducerCallback = $legacyHierarchyToFlatReducerCallback;
+
+        return $this;
+    }
+
+    public function getBuiltFromFlatRecord(): ?string
+    {
+        return $this->builtFromFlatRecord;
+    }
+
+    public function getFlatToHierarchyPathCallback(): ?callable
+    {
+        return $this->flatToHierarchyPathCallback;
+    }
+
+    public function getLegacyHierarchyToFlatReducerCallback(): ?callable
+    {
+        return $this->legacyHierarchyToFlatReducerCallback;
     }
 }

--- a/core/ArchiveProcessor/Record.php
+++ b/core/ArchiveProcessor/Record.php
@@ -266,6 +266,7 @@ class Record
      *                                                            aggregates into the flat table when some periods do not
      *                                                            have the flat record yet.
      *                                                            Signature: function (DataTable $legacyHierarchy, DataTable $flatTable, ArchiveProcessor $archiveProcessor, Record $hierarchicalRecord): void
+     *                                                            The callback is invoked once per legacy source period hierarchy table.
      */
     public function setBuiltFromFlatRecord(
         string $flatRecordName,

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -9,9 +9,11 @@
 
 namespace Piwik\ArchiveProcessor;
 
+use Piwik\Archive;
 use Piwik\ArchiveProcessor;
 use Piwik\Common;
 use Piwik\DataTable;
+use Piwik\DataTable\Row;
 use Piwik\Piwik;
 
 /**
@@ -142,6 +144,10 @@ abstract class RecordBuilder
         $blobRecords = array_filter($recordsBuilt, function (Record $r) {
             return $r->getType() == Record::TYPE_BLOB;
         });
+        $blobRecordsByName = [];
+        foreach ($blobRecords as $blobRecord) {
+            $blobRecordsByName[$blobRecord->getName()] = $blobRecord;
+        }
 
         $aggregatedCounts = [];
 
@@ -167,6 +173,7 @@ abstract class RecordBuilder
             }
         }
 
+        $processedFlatRecords = [];
         foreach ($blobRecords as $record) {
             if (
                 !empty($requestedReports)
@@ -176,11 +183,29 @@ abstract class RecordBuilder
                 continue;
             }
 
+            if (isset($processedFlatRecords[$record->getName()])) {
+                continue;
+            }
+
             $maxRowsInTable = $record->getMaxRowsInTable() ?? $this->maxRowsInTable;
             $maxRowsInSubtable = $record->getMaxRowsInSubtable() ?? $this->maxRowsInSubtable;
             $columnToSortByBeforeTruncation = $record->getColumnToSortByBeforeTruncation() ?? $this->columnToSortByBeforeTruncation;
             $columnToRenameAfterAggregation = $record->getColumnToRenameAfterAggregation() ?? $this->columnToRenameAfterAggregation;
             $columnAggregationOps = $record->getBlobColumnAggregationOps() ?? $this->columnAggregationOps;
+
+            if (
+                $this->aggregateBuiltFromFlatRecordForNonDay(
+                    $archiveProcessor,
+                    $record,
+                    $blobRecordsByName,
+                    $columnAggregationOps,
+                    $columnToRenameAfterAggregation,
+                    $columnToSortByBeforeTruncation,
+                    $processedFlatRecords
+                )
+            ) {
+                continue;
+            }
 
             // only do recursive row counts if there is a numeric record that depends on it
             $countRecursiveRows = $countLeafRows = [];
@@ -264,6 +289,301 @@ abstract class RecordBuilder
                 $archiveProcessor->insertNumericRecords($recordCountMetricValues);
             }
         }
+    }
+
+    protected function aggregateBuiltFromFlatRecordForNonDay(
+        ArchiveProcessor $archiveProcessor,
+        Record $hierarchicalRecord,
+        array $blobRecordsByName,
+        ?array $columnAggregationOps,
+        ?array $columnToRenameAfterAggregation,
+        ?string $columnToSortByBeforeTruncation,
+        array &$processedFlatRecords
+    ): bool {
+        $flatRecordName = $hierarchicalRecord->getBuiltFromFlatRecord();
+        if (empty($flatRecordName)) {
+            return false;
+        }
+
+        $flatToHierarchyPathCallback = $hierarchicalRecord->getFlatToHierarchyPathCallback();
+        if (!is_callable($flatToHierarchyPathCallback)) {
+            return false;
+        }
+
+        $flatRecord = $blobRecordsByName[$flatRecordName] ?? null;
+        if (empty($flatRecord)) {
+            return false;
+        }
+
+        $flatColumnAggregationOps = $flatRecord->getBlobColumnAggregationOps() ?? $this->columnAggregationOps;
+        $flatColumnToRenameAfterAggregation = $flatRecord->getColumnToRenameAfterAggregation() ?? $this->columnToRenameAfterAggregation;
+        $flatColumnToSortByBeforeTruncation = $flatRecord->getColumnToSortByBeforeTruncation() ?? $this->columnToSortByBeforeTruncation;
+        $flatMaxRowsInTable = $flatRecord->getMaxRowsInTable() ?? $this->maxRowsInTable;
+
+        $periodsWithFlatRecord = $this->getPeriodsWithRootBlob($archiveProcessor, $flatRecordName);
+        $allSubperiodKeys = $this->getAllSubperiodKeys($archiveProcessor);
+        $periodsWithoutFlatRecord = array_diff_key($allSubperiodKeys, $periodsWithFlatRecord);
+
+        [$flatTable, $hasFlatSourceData] = $this->aggregateDataTableFromBlobs(
+            $archiveProcessor,
+            $flatRecordName,
+            $flatColumnAggregationOps,
+            $flatColumnToRenameAfterAggregation,
+            $periodsWithFlatRecord
+        );
+
+        $hasLegacyFallbackData = false;
+        $legacyReducerCallback = $hierarchicalRecord->getLegacyHierarchyToFlatReducerCallback();
+        if (!empty($periodsWithoutFlatRecord) && is_callable($legacyReducerCallback)) {
+            [$legacyHierarchicalTable, $hasLegacyFallbackData] = $this->aggregateDataTableFromBlobs(
+                $archiveProcessor,
+                $hierarchicalRecord->getName(),
+                $columnAggregationOps,
+                $columnToRenameAfterAggregation,
+                $periodsWithoutFlatRecord
+            );
+
+            if ($hasLegacyFallbackData) {
+                call_user_func($legacyReducerCallback, $legacyHierarchicalTable, $flatTable, $archiveProcessor, $hierarchicalRecord);
+            }
+            Common::destroy($legacyHierarchicalTable);
+        }
+
+        if (!$hasFlatSourceData && !$hasLegacyFallbackData) {
+            Common::destroy($flatTable);
+            return false;
+        }
+
+        $flatSerialized = $flatTable->getSerialized(
+            $flatMaxRowsInTable,
+            null,
+            $flatColumnToSortByBeforeTruncation
+        );
+        $archiveProcessor->insertBlobRecord($flatRecordName, $flatSerialized);
+        $processedFlatRecords[$flatRecordName] = true;
+
+        $hierarchicalTable = $this->buildHierarchicalTableFromFlatTable(
+            $flatTable,
+            $columnAggregationOps,
+            $flatToHierarchyPathCallback,
+            $archiveProcessor,
+            $hierarchicalRecord
+        );
+
+        $this->beforeInsertBuiltFromFlatHierarchyRecord($archiveProcessor, $hierarchicalRecord, $hierarchicalTable, $flatTable);
+
+        $hierarchicalSerialized = $hierarchicalTable->getSerialized(
+            null,
+            null,
+            $columnToSortByBeforeTruncation
+        );
+        $archiveProcessor->insertBlobRecord($hierarchicalRecord->getName(), $hierarchicalSerialized);
+
+        Common::destroy($hierarchicalTable);
+        Common::destroy($flatTable);
+
+        return true;
+    }
+
+    protected function beforeInsertBuiltFromFlatHierarchyRecord(
+        ArchiveProcessor $archiveProcessor,
+        Record $hierarchicalRecord,
+        DataTable $hierarchicalTable,
+        DataTable $flatTable
+    ): void {
+    }
+
+    protected function buildHierarchicalTableFromFlatTable(
+        DataTable $flatTable,
+        ?array $columnAggregationOps,
+        callable $flatToHierarchyPathCallback,
+        ArchiveProcessor $archiveProcessor,
+        Record $hierarchicalRecord
+    ): DataTable {
+        $hierarchicalTable = new DataTable();
+        if (!empty($columnAggregationOps)) {
+            $hierarchicalTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnAggregationOps);
+        }
+
+        foreach ($flatTable->getRows() as $flatRow) {
+            if ($flatRow->isSummaryRow()) {
+                if ($this->isSummaryRowEmpty($flatRow)) {
+                    continue;
+                }
+
+                $summaryRow = $hierarchicalTable->getRowFromId(DataTable::ID_SUMMARY_ROW);
+                if ($summaryRow === false) {
+                    $summaryRow = clone $flatRow;
+                    $summaryRow->setIsSummaryRow();
+                    $hierarchicalTable->addSummaryRow($summaryRow);
+                    continue;
+                }
+
+                $this->sumRowIntoDestination($flatRow, $summaryRow, $columnAggregationOps);
+                continue;
+            }
+
+            $path = call_user_func($flatToHierarchyPathCallback, $flatRow, $archiveProcessor, $hierarchicalRecord);
+            if (!is_array($path) || empty($path)) {
+                continue;
+            }
+
+            [$destinationRow, $level] = $hierarchicalTable->walkPath($path, [], 0);
+            if (!$destinationRow instanceof Row) {
+                continue;
+            }
+
+            $this->sumRowIntoDestination($flatRow, $destinationRow, $columnAggregationOps);
+        }
+
+        return $hierarchicalTable;
+    }
+
+    protected function sumRowIntoDestination(Row $source, Row $destination, ?array $columnAggregationOps): void
+    {
+        $sourceCopy = clone $source;
+        $destination->sumRow($sourceCopy, true, $columnAggregationOps ?? []);
+    }
+
+    protected function isSummaryRowEmpty(Row $summaryRow): bool
+    {
+        foreach ($summaryRow->getColumns() as $name => $value) {
+            if ($name === 'label') {
+                continue;
+            }
+
+            if (is_array($value)) {
+                if (!empty($value)) {
+                    return false;
+                }
+                continue;
+            }
+
+            if (!empty($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function aggregateDataTableFromBlobs(
+        ArchiveProcessor $archiveProcessor,
+        string $recordName,
+        ?array $columnsAggregationOperation,
+        ?array $columnsToRenameAfterAggregation,
+        ?array $periodsToInclude = null
+    ): array {
+        $tableIdToResultRowMapping = [];
+        $result = new DataTable();
+
+        if (!empty($columnsAggregationOperation)) {
+            $result->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnsAggregationOperation);
+        }
+
+        $hasRows = false;
+        foreach ($this->querySingleBlobRows($archiveProcessor, $recordName) as $archiveDataRow) {
+            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
+            if ($periodsToInclude !== null && !isset($periodsToInclude[$period])) {
+                continue;
+            }
+
+            $hasRows = true;
+            $tableId = $archiveDataRow['name'] == $recordName ? null : $this->getSubtableIdFromBlobName($archiveDataRow['name']);
+
+            $blobTable = DataTable::fromSerializedArray($archiveDataRow['value']);
+            $blobTable->filter(function (DataTable $table) use ($archiveProcessor, $columnsToRenameAfterAggregation) {
+                $archiveProcessor->renameColumnsAfterAggregation($table, $columnsToRenameAfterAggregation);
+            });
+
+            if ($tableId === null) {
+                $tableToAddTo = $result;
+            } elseif (!empty($tableIdToResultRowMapping[$period][$tableId])) {
+                $rowToAddTo = $tableIdToResultRowMapping[$period][$tableId];
+                if (!$rowToAddTo->getIdSubDataTable()) {
+                    $newTable = new DataTable();
+                    if (!empty($columnsAggregationOperation)) {
+                        $newTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnsAggregationOperation);
+                    }
+                    $rowToAddTo->setSubtable($newTable);
+                }
+
+                $tableToAddTo = $rowToAddTo->getSubtable();
+            } else {
+                Common::destroy($blobTable);
+                continue;
+            }
+
+            $tableToAddTo->addDataTable($blobTable);
+
+            foreach ($blobTable->getRows() as $blobTableRow) {
+                $label = $blobTableRow->getColumn('label');
+                $subtableId = $blobTableRow->getIdSubDataTable();
+                if (empty($subtableId)) {
+                    continue;
+                }
+
+                $rowToAddTo = $tableToAddTo->getRowFromLabel($label);
+                if ($rowToAddTo instanceof Row) {
+                    $tableIdToResultRowMapping[$period][$subtableId] = $rowToAddTo;
+                }
+            }
+
+            Common::destroy($blobTable);
+        }
+
+        return [$result, $hasRows];
+    }
+
+    protected function getPeriodsWithRootBlob(ArchiveProcessor $archiveProcessor, string $recordName): array
+    {
+        $result = [];
+        foreach ($this->querySingleBlobRows($archiveProcessor, $recordName) as $archiveDataRow) {
+            if ($archiveDataRow['name'] !== $recordName) {
+                continue;
+            }
+
+            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
+            $result[$period] = true;
+        }
+
+        return $result;
+    }
+
+    protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable
+    {
+        $archive = Archive::factory(
+            $archiveProcessor->getParams()->getSegment(),
+            $archiveProcessor->getParams()->getPeriod()->getSubperiods(),
+            [$archiveProcessor->getParams()->getSite()->getId()]
+        );
+        if (!method_exists($archive, 'querySingleBlob')) {
+            return [];
+        }
+
+        return $archive->querySingleBlob($recordName);
+    }
+
+    protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
+    {
+        $result = [];
+        foreach ($archiveProcessor->getParams()->getPeriod()->getSubperiods() as $period) {
+            $result[$period->getDateStart()->toString() . ',' . $period->getDateEnd()->toString()] = true;
+        }
+
+        return $result;
+    }
+
+    protected function getSubtableIdFromBlobName(string $recordName): ?int
+    {
+        $parts = explode('_', $recordName);
+        $id = end($parts);
+
+        if (!is_numeric($id)) {
+            return null;
+        }
+
+        return (int) $id;
     }
 
     /**

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -378,6 +378,7 @@ abstract class RecordBuilder
             $flatColumnToSortByBeforeTruncation
         );
         $archiveProcessor->insertBlobRecord($flatRecordName, $flatSerialized);
+        unset($flatSerialized);
         $processedFlatRecords[$flatRecordName] = true;
 
         $hierarchicalTable = $this->buildHierarchicalTableFromFlatTableAndConsumeRows(
@@ -396,6 +397,7 @@ abstract class RecordBuilder
             $columnToSortByBeforeTruncation
         );
         $archiveProcessor->insertBlobRecord($hierarchicalRecord->getName(), $hierarchicalSerialized);
+        unset($hierarchicalSerialized);
 
         Common::destroy($hierarchicalTable);
         Common::destroy($flatTable);

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -160,10 +160,14 @@ abstract class RecordBuilder
                 continue;
             }
 
+            // If the flat record is requested directly, also force aggregation of the corresponding
+            // hierarchical record so the API can still read the expected hierarchical blob.
             if (!in_array($record->getName(), $requestedReports)) {
                 $requestedReports[] = $record->getName();
             }
 
+            // We are about to rebuild this record from flat data, so treat it as not-found and
+            // make sure it is re-aggregated even if a previous archive row exists.
             $indexInFoundRecords = array_search($record->getName(), $foundRequestedReports);
             if ($indexInFoundRecords !== false) {
                 unset($foundRequestedReports[$indexInFoundRecords]);
@@ -404,6 +408,13 @@ abstract class RecordBuilder
         return true;
     }
 
+    /**
+     * Hook executed after the hierarchy table has been rebuilt from the flat table and before
+     * the hierarchical blob record is serialized and inserted.
+     *
+     * Intended for plugin-specific finalization (for example, metadata or column cleanup) when
+     * using setBuiltFromFlatRecord().
+     */
     protected function beforeInsertBuiltFromFlatHierarchyRecord(
         ArchiveProcessor $archiveProcessor,
         Record $hierarchicalRecord,

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -382,7 +382,7 @@ abstract class RecordBuilder
         $archiveProcessor->insertBlobRecord($flatRecordName, $flatSerialized);
         $processedFlatRecords[$flatRecordName] = true;
 
-        $hierarchicalTable = $this->buildHierarchicalTableFromFlatTable(
+        $hierarchicalTable = $this->buildHierarchicalTableFromFlatTableAndConsumeRows(
             $flatTable,
             $columnAggregationOps,
             function (Row $flatRow) use ($flatToHierarchyPathCallback, $archiveProcessor, $hierarchicalRecord) {
@@ -410,7 +410,8 @@ abstract class RecordBuilder
      * the hierarchical blob record is serialized and inserted.
      *
      * Intended for plugin-specific finalization (for example, metadata or column cleanup) when
-     * using setBuiltFromFlatRecord().
+     * using setBuiltFromFlatRecord(). The flat table has already been serialized at this point
+     * and may have been fully consumed while rebuilding the hierarchy.
      */
     protected function beforeInsertBuiltFromFlatHierarchyRecord(
         ArchiveProcessor $archiveProcessor,
@@ -461,6 +462,47 @@ abstract class RecordBuilder
 
             $this->sumRowIntoDestination($flatRow, $destinationRow, $columnAggregationOps);
         }
+
+        return $hierarchicalTable;
+    }
+
+    protected function buildHierarchicalTableFromFlatTableAndConsumeRows(
+        DataTable $flatTable,
+        ?array $columnAggregationOps,
+        callable $flatToHierarchyPathCallback,
+        array $defaultHierarchyRowColumns = []
+    ): DataTable {
+        $hierarchicalTable = new DataTable();
+        if (!empty($columnAggregationOps)) {
+            $hierarchicalTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnAggregationOps);
+        }
+
+        while (($flatRow = $flatTable->shiftRow()) instanceof Row) {
+            $path = call_user_func($flatToHierarchyPathCallback, $flatRow);
+            if (is_array($path) && !empty($path)) {
+                [$destinationRow, $level] = $hierarchicalTable->walkPath($path, $defaultHierarchyRowColumns, 0);
+                if ($destinationRow instanceof Row) {
+                    $this->sumRowIntoDestination($flatRow, $destinationRow, $columnAggregationOps);
+                }
+            }
+
+            Common::destroy($flatRow);
+        }
+
+        $summaryRow = $flatTable->getSummaryRow();
+        if ($summaryRow instanceof Row && !$this->isSummaryRowEmpty($summaryRow)) {
+            $destinationSummaryRow = $hierarchicalTable->getRowFromId(DataTable::ID_SUMMARY_ROW);
+            if ($destinationSummaryRow === false) {
+                $destinationSummaryRow = clone $summaryRow;
+                $destinationSummaryRow->setIsSummaryRow();
+                $hierarchicalTable->addSummaryRow($destinationSummaryRow);
+            } else {
+                $this->sumRowIntoDestination($summaryRow, $destinationSummaryRow, $columnAggregationOps);
+            }
+        }
+
+        $flatTable->deleteRow(DataTable::ID_SUMMARY_ROW);
+        Common::destroy($summaryRow);
 
         return $hierarchicalTable;
     }

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -365,9 +365,9 @@ abstract class RecordBuilder
         $hierarchicalTable = $this->buildHierarchicalTableFromFlatTable(
             $flatTable,
             $columnAggregationOps,
-            $flatToHierarchyPathCallback,
-            $archiveProcessor,
-            $hierarchicalRecord
+            function (Row $flatRow) use ($flatToHierarchyPathCallback, $archiveProcessor, $hierarchicalRecord) {
+                return call_user_func($flatToHierarchyPathCallback, $flatRow, $archiveProcessor, $hierarchicalRecord);
+            }
         );
 
         $this->beforeInsertBuiltFromFlatHierarchyRecord($archiveProcessor, $hierarchicalRecord, $hierarchicalTable, $flatTable);
@@ -397,8 +397,7 @@ abstract class RecordBuilder
         DataTable $flatTable,
         ?array $columnAggregationOps,
         callable $flatToHierarchyPathCallback,
-        ArchiveProcessor $archiveProcessor,
-        Record $hierarchicalRecord
+        array $defaultHierarchyRowColumns = []
     ): DataTable {
         $hierarchicalTable = new DataTable();
         if (!empty($columnAggregationOps)) {
@@ -423,12 +422,12 @@ abstract class RecordBuilder
                 continue;
             }
 
-            $path = call_user_func($flatToHierarchyPathCallback, $flatRow, $archiveProcessor, $hierarchicalRecord);
+            $path = call_user_func($flatToHierarchyPathCallback, $flatRow);
             if (!is_array($path) || empty($path)) {
                 continue;
             }
 
-            [$destinationRow, $level] = $hierarchicalTable->walkPath($path, [], 0);
+            [$destinationRow, $level] = $hierarchicalTable->walkPath($path, $defaultHierarchyRowColumns, 0);
             if (!$destinationRow instanceof Row) {
                 continue;
             }
@@ -442,6 +441,23 @@ abstract class RecordBuilder
     protected function sumRowIntoDestination(Row $source, Row $destination, ?array $columnAggregationOps): void
     {
         $sourceCopy = clone $source;
+
+        // Preserve original column representation (eg "0.0620" strings) when
+        // destination does not have a value yet. This keeps day flat-first
+        // output consistent with legacy day archiving.
+        foreach ($sourceCopy->getColumns() as $columnName => $columnValue) {
+            if ($columnName === 'label') {
+                continue;
+            }
+
+            if ($destination->getColumn($columnName) !== false) {
+                continue;
+            }
+
+            $destination->setColumn($columnName, $columnValue);
+            $sourceCopy->deleteColumn($columnName);
+        }
+
         $destination->sumRow($sourceCopy, true, $columnAggregationOps ?? []);
     }
 

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -625,32 +625,6 @@ abstract class RecordBuilder
         return true;
     }
 
-    protected function aggregateDataTableFromBlobs(
-        ArchiveProcessor $archiveProcessor,
-        string $recordName,
-        ?array $columnsAggregationOperation,
-        ?array $columnsToRenameAfterAggregation,
-        ?array $periodsToInclude = null
-    ): array {
-        [$result, $hasRows] = BlobTableAggregator::aggregateBlobRows(
-            $this->querySingleBlobRows($archiveProcessor, $recordName),
-            $recordName,
-            $columnsAggregationOperation,
-            function (DataTable $table) use ($archiveProcessor, $columnsToRenameAfterAggregation): void {
-                $archiveProcessor->renameColumnsAfterAggregation($table, $columnsToRenameAfterAggregation);
-            },
-            function (array $archiveDataRow) use ($periodsToInclude): bool {
-                if ($periodsToInclude === null) {
-                    return true;
-                }
-                $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
-                return isset($periodsToInclude[$period]);
-            }
-        );
-
-        return [$result, $hasRows];
-    }
-
     /**
      * Aggregates a root blob record while discovering periods that contain the root record in a single pass.
      *
@@ -683,21 +657,6 @@ abstract class RecordBuilder
         );
 
         return [$result, $hasRows, $periodsWithRootRecord];
-    }
-
-    protected function getPeriodsWithRootBlob(ArchiveProcessor $archiveProcessor, string $recordName): array
-    {
-        $result = [];
-        foreach ($this->querySingleBlobRows($archiveProcessor, $recordName) as $archiveDataRow) {
-            if ($archiveDataRow['name'] !== $recordName) {
-                continue;
-            }
-
-            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
-            $result[$period] = true;
-        }
-
-        return $result;
     }
 
     protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -513,63 +513,21 @@ abstract class RecordBuilder
         ?array $columnsToRenameAfterAggregation,
         ?array $periodsToInclude = null
     ): array {
-        $tableIdToResultRowMapping = [];
-        $result = new DataTable();
-
-        if (!empty($columnsAggregationOperation)) {
-            $result->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnsAggregationOperation);
-        }
-
-        $hasRows = false;
-        foreach ($this->querySingleBlobRows($archiveProcessor, $recordName) as $archiveDataRow) {
-            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
-            if ($periodsToInclude !== null && !isset($periodsToInclude[$period])) {
-                continue;
-            }
-
-            $hasRows = true;
-            $tableId = $archiveDataRow['name'] == $recordName ? null : $this->getSubtableIdFromBlobName($archiveDataRow['name']);
-
-            $blobTable = DataTable::fromSerializedArray($archiveDataRow['value']);
-            $blobTable->filter(function (DataTable $table) use ($archiveProcessor, $columnsToRenameAfterAggregation) {
+        [$result, $hasRows] = BlobTableAggregator::aggregateBlobRows(
+            $this->querySingleBlobRows($archiveProcessor, $recordName),
+            $recordName,
+            $columnsAggregationOperation,
+            function (DataTable $table) use ($archiveProcessor, $columnsToRenameAfterAggregation): void {
                 $archiveProcessor->renameColumnsAfterAggregation($table, $columnsToRenameAfterAggregation);
-            });
-
-            if ($tableId === null) {
-                $tableToAddTo = $result;
-            } elseif (!empty($tableIdToResultRowMapping[$period][$tableId])) {
-                $rowToAddTo = $tableIdToResultRowMapping[$period][$tableId];
-                if (!$rowToAddTo->getIdSubDataTable()) {
-                    $newTable = new DataTable();
-                    if (!empty($columnsAggregationOperation)) {
-                        $newTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnsAggregationOperation);
-                    }
-                    $rowToAddTo->setSubtable($newTable);
+            },
+            function (array $archiveDataRow) use ($periodsToInclude): bool {
+                if ($periodsToInclude === null) {
+                    return true;
                 }
-
-                $tableToAddTo = $rowToAddTo->getSubtable();
-            } else {
-                Common::destroy($blobTable);
-                continue;
+                $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
+                return isset($periodsToInclude[$period]);
             }
-
-            $tableToAddTo->addDataTable($blobTable);
-
-            foreach ($blobTable->getRows() as $blobTableRow) {
-                $label = $blobTableRow->getColumn('label');
-                $subtableId = $blobTableRow->getIdSubDataTable();
-                if (empty($subtableId)) {
-                    continue;
-                }
-
-                $rowToAddTo = $tableToAddTo->getRowFromLabel($label);
-                if ($rowToAddTo instanceof Row) {
-                    $tableIdToResultRowMapping[$period][$subtableId] = $rowToAddTo;
-                }
-            }
-
-            Common::destroy($blobTable);
-        }
+        );
 
         return [$result, $hasRows];
     }
@@ -611,18 +569,6 @@ abstract class RecordBuilder
         }
 
         return $result;
-    }
-
-    protected function getSubtableIdFromBlobName(string $recordName): ?int
-    {
-        $parts = explode('_', $recordName);
-        $id = end($parts);
-
-        if (!is_numeric($id)) {
-            return null;
-        }
-
-        return (int) $id;
     }
 
     /**

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -468,13 +468,6 @@ abstract class RecordBuilder
                 continue;
             }
 
-            if (is_array($value)) {
-                if (!empty($value)) {
-                    return false;
-                }
-                continue;
-            }
-
             if (!empty($value)) {
                 return false;
             }

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -343,17 +343,14 @@ abstract class RecordBuilder
         $flatColumnToSortByBeforeTruncation = $flatRecord->getColumnToSortByBeforeTruncation() ?? $this->columnToSortByBeforeTruncation;
         $flatMaxRowsInTable = $flatRecord->getMaxRowsInTable() ?? $this->maxRowsInTable;
 
-        $periodsWithFlatRecord = $this->getPeriodsWithRootBlob($archiveProcessor, $flatRecordName);
-        $allSubperiodKeys = $this->getAllSubperiodKeys($archiveProcessor);
-        $periodsWithoutFlatRecord = array_diff_key($allSubperiodKeys, $periodsWithFlatRecord);
-
-        [$flatTable, $hasFlatSourceData] = $this->aggregateDataTableFromBlobs(
+        [$flatTable, $hasFlatSourceData, $periodsWithFlatRecord] = $this->aggregateRootDataTableFromBlobs(
             $archiveProcessor,
             $flatRecordName,
             $flatColumnAggregationOps,
-            $flatColumnToRenameAfterAggregation,
-            $periodsWithFlatRecord
+            $flatColumnToRenameAfterAggregation
         );
+        $allSubperiodKeys = $this->getAllSubperiodKeys($archiveProcessor);
+        $periodsWithoutFlatRecord = array_diff_key($allSubperiodKeys, $periodsWithFlatRecord);
 
         $hasLegacyFallbackData = false;
         $legacyReducerCallback = $hierarchicalRecord->getLegacyHierarchyToFlatReducerCallback();
@@ -530,6 +527,40 @@ abstract class RecordBuilder
         );
 
         return [$result, $hasRows];
+    }
+
+    /**
+     * Aggregates a root blob record while discovering periods that contain the root record in a single pass.
+     *
+     * @return array{0: DataTable, 1: bool, 2: array<string, bool>}
+     */
+    protected function aggregateRootDataTableFromBlobs(
+        ArchiveProcessor $archiveProcessor,
+        string $recordName,
+        ?array $columnsAggregationOperation,
+        ?array $columnsToRenameAfterAggregation
+    ): array {
+        $periodsWithRootRecord = [];
+
+        [$result, $hasRows] = BlobTableAggregator::aggregateBlobRows(
+            $this->querySingleBlobRows($archiveProcessor, $recordName),
+            $recordName,
+            $columnsAggregationOperation,
+            function (DataTable $table) use ($archiveProcessor, $columnsToRenameAfterAggregation): void {
+                $archiveProcessor->renameColumnsAfterAggregation($table, $columnsToRenameAfterAggregation);
+            },
+            function (array $archiveDataRow) use (&$periodsWithRootRecord, $recordName): bool {
+                $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
+                if ($archiveDataRow['name'] === $recordName) {
+                    $periodsWithRootRecord[$period] = true;
+                    return true;
+                }
+
+                return isset($periodsWithRootRecord[$period]);
+            }
+        );
+
+        return [$result, $hasRows, $periodsWithRootRecord];
     }
 
     protected function getPeriodsWithRootBlob(ArchiveProcessor $archiveProcessor, string $recordName): array

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -151,6 +151,25 @@ abstract class RecordBuilder
 
         $aggregatedCounts = [];
 
+        foreach ($blobRecords as $record) {
+            $flatRecordName = $record->getBuiltFromFlatRecord();
+            if (
+                empty($flatRecordName)
+                || !in_array($flatRecordName, $requestedReports)
+            ) {
+                continue;
+            }
+
+            if (!in_array($record->getName(), $requestedReports)) {
+                $requestedReports[] = $record->getName();
+            }
+
+            $indexInFoundRecords = array_search($record->getName(), $foundRequestedReports);
+            if ($indexInFoundRecords !== false) {
+                unset($foundRequestedReports[$indexInFoundRecords]);
+            }
+        }
+
         // make sure if there are requested numeric records that depend on blob records, that the blob records will be archived first
         foreach ($numericRecords as $record) {
             if (

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -355,18 +355,16 @@ abstract class RecordBuilder
         $hasLegacyFallbackData = false;
         $legacyReducerCallback = $hierarchicalRecord->getLegacyHierarchyToFlatReducerCallback();
         if (!empty($periodsWithoutFlatRecord) && is_callable($legacyReducerCallback)) {
-            [$legacyHierarchicalTable, $hasLegacyFallbackData] = $this->aggregateDataTableFromBlobs(
+            $hasLegacyFallbackData = $this->aggregateLegacyHierarchyPeriodsIntoFlatTable(
                 $archiveProcessor,
                 $hierarchicalRecord->getName(),
+                $flatTable,
+                $legacyReducerCallback,
+                $hierarchicalRecord,
                 $columnAggregationOps,
                 $columnToRenameAfterAggregation,
                 $periodsWithoutFlatRecord
             );
-
-            if ($hasLegacyFallbackData) {
-                call_user_func($legacyReducerCallback, $legacyHierarchicalTable, $flatTable, $archiveProcessor, $hierarchicalRecord);
-            }
-            Common::destroy($legacyHierarchicalTable);
         }
 
         if (!$hasFlatSourceData && !$hasLegacyFallbackData) {
@@ -403,6 +401,88 @@ abstract class RecordBuilder
         Common::destroy($flatTable);
 
         return true;
+    }
+
+    protected function aggregateLegacyHierarchyPeriodsIntoFlatTable(
+        ArchiveProcessor $archiveProcessor,
+        string $recordName,
+        DataTable $flatTable,
+        callable $legacyReducerCallback,
+        Record $hierarchicalRecord,
+        ?array $columnsAggregationOperation,
+        ?array $columnsToRenameAfterAggregation,
+        ?array $periodsToInclude
+    ): bool {
+        $currentPeriod = null;
+        $currentPeriodRows = [];
+        $hasRows = false;
+
+        foreach ($this->querySingleBlobRows($archiveProcessor, $recordName) as $archiveDataRow) {
+            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
+            if ($periodsToInclude !== null && !isset($periodsToInclude[$period])) {
+                continue;
+            }
+
+            if ($currentPeriod !== null && $period !== $currentPeriod) {
+                $hasRows = $this->reduceLegacyHierarchyPeriodRowsIntoFlatTable(
+                    $currentPeriodRows,
+                    $recordName,
+                    $flatTable,
+                    $legacyReducerCallback,
+                    $archiveProcessor,
+                    $hierarchicalRecord,
+                    $columnsAggregationOperation,
+                    $columnsToRenameAfterAggregation
+                ) || $hasRows;
+                $currentPeriodRows = [];
+            }
+
+            $currentPeriod = $period;
+            $currentPeriodRows[] = $archiveDataRow;
+        }
+
+        if (!empty($currentPeriodRows)) {
+            $hasRows = $this->reduceLegacyHierarchyPeriodRowsIntoFlatTable(
+                $currentPeriodRows,
+                $recordName,
+                $flatTable,
+                $legacyReducerCallback,
+                $archiveProcessor,
+                $hierarchicalRecord,
+                $columnsAggregationOperation,
+                $columnsToRenameAfterAggregation
+            ) || $hasRows;
+        }
+
+        return $hasRows;
+    }
+
+    protected function reduceLegacyHierarchyPeriodRowsIntoFlatTable(
+        array $periodRows,
+        string $recordName,
+        DataTable $flatTable,
+        callable $legacyReducerCallback,
+        ArchiveProcessor $archiveProcessor,
+        Record $hierarchicalRecord,
+        ?array $columnsAggregationOperation,
+        ?array $columnsToRenameAfterAggregation
+    ): bool {
+        [$legacyHierarchicalTable, $hasRows] = BlobTableAggregator::aggregateBlobRows(
+            $periodRows,
+            $recordName,
+            $columnsAggregationOperation,
+            function (DataTable $table) use ($archiveProcessor, $columnsToRenameAfterAggregation): void {
+                $archiveProcessor->renameColumnsAfterAggregation($table, $columnsToRenameAfterAggregation);
+            }
+        );
+
+        if ($hasRows) {
+            call_user_func($legacyReducerCallback, $legacyHierarchicalTable, $flatTable, $archiveProcessor, $hierarchicalRecord);
+        }
+
+        Common::destroy($legacyHierarchicalTable);
+
+        return $hasRows;
     }
 
     /**

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -966,6 +966,30 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
     }
 
     /**
+     * Removes and returns the first non-summary row in this table.
+     *
+     * @return Row|null
+     */
+    public function shiftRow()
+    {
+        if (empty($this->rows)) {
+            return null;
+        }
+
+        reset($this->rows);
+        $rowId = key($this->rows);
+
+        if (!isset($this->rows[$rowId])) {
+            return null;
+        }
+
+        $row = $this->rows[$rowId];
+        unset($this->rows[$rowId]);
+
+        return $row;
+    }
+
+    /**
      * @return int
      * @ignore
      */

--- a/plugins/Actions/API.php
+++ b/plugins/Actions/API.php
@@ -125,9 +125,10 @@ class API extends \Piwik\Plugin\API
 
         if ($flat) {
             $dataTable->filter(function (DataTable $dataTable) {
+                $notDefinedUrl = ArchivingHelper::getUnknownActionName(Action::TYPE_PAGE_URL);
                 foreach ($dataTable->getRows() as $row) {
                     $label = (string)$row->getColumn('label');
-                    if (substr($label, 0, 1) !== '/' && $label != Piwik::translate('General_NotDefined', Piwik::translate('Actions_ColumnPageURL'))) {
+                    if (substr($label, 0, 1) !== '/' && $label !== $notDefinedUrl) {
                         $row->setColumn('label', '/' . $label);
                     }
                 }

--- a/plugins/Actions/Archiver.php
+++ b/plugins/Actions/Archiver.php
@@ -21,6 +21,8 @@ class Archiver extends \Piwik\Plugin\Archiver
     public const SITE_SEARCH_RECORD_NAME = 'Actions_sitesearch';
     public const SITE_SEARCH_CATEGORY_RECORD_NAME = 'Actions_SiteSearchCategories';
     public const PAGE_URLS_RECORD_NAME = 'Actions_actions_url';
+    public const PAGE_URLS_FLAT_RECORD_NAME = 'Actions_actions_url_flat';
+    public const PAGE_TITLES_FLAT_RECORD_NAME = 'Actions_actions_flat';
 
     public const METRIC_PAGEVIEWS_RECORD_NAME = 'Actions_nb_pageviews';
     public const METRIC_UNIQ_PAGEVIEWS_RECORD_NAME = 'Actions_nb_uniq_pageviews';

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -704,7 +704,28 @@ class ArchivingHelper
 
     public static function mergeHierarchicalActionsTableIntoFlatTable(DataTable $hierarchicalTable, DataTable $flatTable): void
     {
-        self::appendHierarchicalRowsToFlatTable($hierarchicalTable, [], $flatTable);
+        self::appendHierarchicalRowsToFlatTable(
+            $hierarchicalTable,
+            [],
+            $flatTable,
+            [self::class, 'buildFlatRowLabel']
+        );
+    }
+
+    public static function mergeHierarchicalActionsTableIntoBestEffortFlatTable(
+        DataTable $hierarchicalTable,
+        DataTable $flatTable,
+        int $actionType
+    ): void {
+        self::appendHierarchicalRowsToFlatTable(
+            $hierarchicalTable,
+            [],
+            $flatTable,
+            function (array $path) use ($actionType): string {
+                return self::buildBestEffortActionLabelFromPath($path, $actionType);
+            },
+            false
+        );
     }
 
     private static function getFlatActionRow($actionName, $actionType, $urlPrefix, DataTable $table): Row
@@ -757,8 +778,13 @@ class ArchivingHelper
         return implode($delimiter, $segments);
     }
 
-    private static function appendHierarchicalRowsToFlatTable(DataTable $sourceTable, array $path, DataTable $flatTable): void
-    {
+    private static function appendHierarchicalRowsToFlatTable(
+        DataTable $sourceTable,
+        array $path,
+        DataTable $flatTable,
+        callable $flatLabelBuilder,
+        bool $useDefaultFlatRowColumns = true
+    ): void {
         foreach ($sourceTable->getRowsWithoutSummaryRow() as $row) {
             $label = $row->getColumn('label');
             if (!is_string($label) || $label === '') {
@@ -770,15 +796,26 @@ class ArchivingHelper
 
             $subtable = $row->getSubtable();
             if ($subtable) {
-                self::appendHierarchicalRowsToFlatTable($subtable, $currentPath, $flatTable);
+                self::appendHierarchicalRowsToFlatTable(
+                    $subtable,
+                    $currentPath,
+                    $flatTable,
+                    $flatLabelBuilder,
+                    $useDefaultFlatRowColumns
+                );
                 continue;
             }
 
-            $flatLabel = self::buildFlatRowLabel($currentPath);
+            $flatLabel = call_user_func($flatLabelBuilder, $currentPath);
             $flatRow = $flatTable->getRowFromLabel($flatLabel);
             if ($flatRow === false) {
+                $columns = array('label' => $flatLabel);
+                if ($useDefaultFlatRowColumns) {
+                    $columns += self::getDefaultFlatRowColumns();
+                }
+
                 $flatRow = new Row(array(
-                    Row::COLUMNS => array('label' => $flatLabel) + self::getDefaultFlatRowColumns(),
+                    Row::COLUMNS => $columns,
                 ));
                 $flatRow->setMetadata(self::ACTION_FLAT_PATH_METADATA_NAME, $currentPath);
                 $flatTable->addRow($flatRow);
@@ -841,13 +878,6 @@ class ArchivingHelper
     {
         foreach ($row->getColumns() as $name => $value) {
             if ($name === 'label') {
-                continue;
-            }
-
-            if (is_array($value)) {
-                if (!empty($value)) {
-                    return false;
-                }
                 continue;
             }
 

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -31,6 +31,9 @@ use Zend_Db_Statement;
 class ArchivingHelper
 {
     public const OTHERS_ROW_KEY = '';
+    public const ACTION_TABLE_MODE_HIERARCHICAL = 'hierarchical';
+    public const ACTION_TABLE_MODE_FLAT = 'flat';
+    public const ACTION_FLAT_PATH_METADATA_NAME = 'flat_action_path';
 
     /**
      * Ideally this should use the DataArray object instead of custom data structure
@@ -40,7 +43,7 @@ class ArchivingHelper
      * @param array $actionsTablesByType
      * @return int
      */
-    public static function updateActionsTableWithRowQuery($query, $fieldQueried, $actionsTablesByType, $metricsConfig)
+    public static function updateActionsTableWithRowQuery($query, $fieldQueried, $actionsTablesByType, $metricsConfig, array $tableModesByType = [])
     {
         $rowsProcessed = 0;
         while ($row = $query->fetch()) {
@@ -95,7 +98,8 @@ class ArchivingHelper
                     continue;
                 }
 
-                $actionRow = self::getActionRow($actionName, $actionType, $urlPrefix, $actionsTablesByType);
+                $tableMode = $tableModesByType[$actionType] ?? self::ACTION_TABLE_MODE_HIERARCHICAL;
+                $actionRow = self::getActionRow($actionName, $actionType, $urlPrefix, $actionsTablesByType, $tableMode);
 
                 self::setCachedActionRow($idaction, $actionType, $actionRow);
             } else {
@@ -473,6 +477,7 @@ class ArchivingHelper
     public static $maximumRowsInDataTableLevelZero;
     public static $maximumRowsInSubDataTable;
     public static $maximumRowsInDataTableSiteSearch;
+    public static $maximumRowsInDataTableFlatNonDay;
     public static $columnToSortByBeforeTruncation;
 
     protected static $actionUrlCategoryDelimiter = null;
@@ -497,6 +502,7 @@ class ArchivingHelper
         self::$maximumRowsInDataTableLevelZero = Config::getInstance()->General['datatable_archiving_maximum_rows_actions'];
         self::$maximumRowsInSubDataTable = Config::getInstance()->General['datatable_archiving_maximum_rows_subtable_actions'];
         self::$maximumRowsInDataTableSiteSearch = Config::getInstance()->General['datatable_archiving_maximum_rows_site_search'];
+        self::$maximumRowsInDataTableFlatNonDay = Config::getInstance()->General['datatable_archiving_maximum_rows_actions_flat_non_day'];
 
         DataTable::setMaximumDepthLevelAllowedAtLeast(self::getSubCategoryLevelLimit() + 1);
     }
@@ -535,8 +541,13 @@ class ArchivingHelper
      * @param array $actionsTablesByType
      * @return DataTable\Row
      */
-    public static function getActionRow($actionName, $actionType, $urlPrefix, $actionsTablesByType)
-    {
+    public static function getActionRow(
+        $actionName,
+        $actionType,
+        $urlPrefix,
+        $actionsTablesByType,
+        string $tableMode = self::ACTION_TABLE_MODE_HIERARCHICAL
+    ) {
         // we work on the root table of the given TYPE (either ACTION_URL or DOWNLOAD or OUTLINK etc.)
         /* @var DataTable $currentTable */
         $currentTable = $actionsTablesByType[$actionType];
@@ -554,6 +565,10 @@ class ArchivingHelper
             return $summaryRow;
         }
 
+        if ($tableMode === self::ACTION_TABLE_MODE_FLAT) {
+            return self::getFlatActionRow($actionName, $actionType, $urlPrefix, $currentTable);
+        }
+
         // go to the level of the subcategory
         $actionExplodedNames = self::getActionExplodedNames($actionName, $actionType, $urlPrefix);
         list($row, $level) = $currentTable->walkPath(
@@ -563,6 +578,105 @@ class ArchivingHelper
         );
 
         return $row;
+    }
+
+    public static function buildHierarchicalActionsTableFromFlatTable(DataTable $flatTable): DataTable
+    {
+        $table = new DataTable();
+        $table->setMaximumAllowedRows(self::$maximumRowsInDataTableLevelZero);
+        $table->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
+
+        foreach ($flatTable->getRows() as $flatRow) {
+            if ($flatRow->isSummaryRow()) {
+                if (self::isRowEmptyOfMetrics($flatRow)) {
+                    continue;
+                }
+
+                $summaryRow = self::createSummaryRow();
+                self::mergeRowIntoDestination($flatRow, $summaryRow);
+                $table->addSummaryRow($summaryRow);
+                continue;
+            }
+
+            $actionPath = $flatRow->getMetadata(self::ACTION_FLAT_PATH_METADATA_NAME);
+            if (empty($actionPath) || !is_array($actionPath)) {
+                continue;
+            }
+
+            [$hierarchyRow, $level] = $table->walkPath(
+                $actionPath,
+                self::getDefaultRowColumns(),
+                self::$maximumRowsInSubDataTable
+            );
+
+            if ($hierarchyRow === false) {
+                continue;
+            }
+
+            self::mergeRowIntoDestination($flatRow, $hierarchyRow);
+        }
+
+        return $table;
+    }
+
+    private static function getFlatActionRow($actionName, $actionType, $urlPrefix, DataTable $table): Row
+    {
+        $actionExplodedNames = self::getActionExplodedNames($actionName, $actionType, $urlPrefix);
+        $flatLabel = self::buildFlatRowLabel($actionExplodedNames);
+
+        $row = $table->getRowFromLabel($flatLabel);
+        if ($row !== false) {
+            return $row;
+        }
+
+        $row = new Row(array(
+            Row::COLUMNS => array('label' => $flatLabel) + self::getDefaultRowColumns(),
+        ));
+        $row->setMetadata(self::ACTION_FLAT_PATH_METADATA_NAME, $actionExplodedNames);
+        $table->addRow($row);
+
+        return $row;
+    }
+
+    private static function buildFlatRowLabel(array $actionPath): string
+    {
+        $encodedPath = json_encode($actionPath);
+        if ($encodedPath === false) {
+            return implode("\n", $actionPath);
+        }
+
+        return $encodedPath;
+    }
+
+    private static function mergeRowIntoDestination(Row $source, Row $destination): void
+    {
+        $sourceCopy = clone $source;
+        $sourceCopy->deleteMetadata(self::ACTION_FLAT_PATH_METADATA_NAME);
+
+        $aggregationOps = Metrics::getColumnsAggregationOperation();
+        $destination->sumRow($sourceCopy, $enableCopyMetadata = true, $aggregationOps);
+    }
+
+    private static function isRowEmptyOfMetrics(Row $row): bool
+    {
+        foreach ($row->getColumns() as $name => $value) {
+            if ($name === 'label') {
+                continue;
+            }
+
+            if (is_array($value)) {
+                if (!empty($value)) {
+                    return false;
+                }
+                continue;
+            }
+
+            if (!empty($value)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -291,29 +291,10 @@ class ArchivingHelper
         }
 
         if (!$isPages) {
-            $nbEntrances = $actionRow->getColumn(PiwikMetrics::INDEX_PAGE_ENTRY_NB_VISITS);
-            $conversions = $row[PiwikMetrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY];
-            if ($nbEntrances !== false && is_numeric($nbEntrances) && $nbEntrances > 0) {
-                // Calculate conversion entry rate
-                if (isset($row[PiwikMetrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY])) {
-                    $row[PiwikMetrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY_RATE] = Piwik::getQuotientSafe(
-                        $conversions,
-                        $nbEntrances,
-                        GoalManager::REVENUE_PRECISION + 1
-                    );
-                }
-
-                // Calculate revenue per entry
-                if (isset($row[PiwikMetrics::INDEX_GOAL_REVENUE_ENTRY])) {
-                    $row[PiwikMetrics::INDEX_GOAL_REVENUE_PER_ENTRY] = (float) Piwik::getQuotientSafe(
-                        $row[PiwikMetrics::INDEX_GOAL_REVENUE_ENTRY],
-                        $nbEntrances,
-                        GoalManager::REVENUE_PRECISION + 1
-                    );
-
-                    $row[PiwikMetrics::INDEX_GOAL_REVENUE_ENTRY] = (float) $row[PiwikMetrics::INDEX_GOAL_REVENUE_ENTRY];
-                }
-            }
+            self::normalizeEntryGoalMetricsForEntrances(
+                $row,
+                $actionRow->getColumn(PiwikMetrics::INDEX_PAGE_ENTRY_NB_VISITS)
+            );
         }
 
         // Get goals column
@@ -331,23 +312,162 @@ class ArchivingHelper
         foreach ($possibleMetrics as $metricKey => $columnName) {
             if (isset($row[$metricKey])) {
                 // Add metric
-                if (!isset($goalsColumn[$row['idgoal']][$metricKey])) {
-                    $goalsColumn[$row['idgoal']][$metricKey] = $row[$metricKey];
-                } else {
-                    if ($metricKey == PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE) {
-                        if ($goalsColumn[$row['idgoal']][$metricKey] < $row[$metricKey]) {
-                            $goalsColumn[$row['idgoal']][$metricKey] = $row[$metricKey];
-                        }
-                    } else {
-                        $goalsColumn[$row['idgoal']][$metricKey] += $row[$metricKey];
-                    }
-                }
+                self::mergeGoalMetric($goalsColumn[$row['idgoal']], $metricKey, $row[$metricKey]);
 
                 // Write goals column back to datatable
                 $actionRow->setColumn(PiwikMetrics::INDEX_GOALS, $goalsColumn);
             }
         }
         return true;
+    }
+
+    public static function normalizeFlatGoalsMetricsForHierarchy(array $flatPageTablesByType): void
+    {
+        foreach ($flatPageTablesByType as $dataTable) {
+            if (!$dataTable instanceof DataTable) {
+                continue;
+            }
+
+            $rowsByPath = [];
+            foreach ($dataTable->getRowsWithoutSummaryRow() as $row) {
+                $path = $row->getMetadata(self::ACTION_FLAT_PATH_METADATA_NAME);
+                if (!is_array($path) || empty($path)) {
+                    continue;
+                }
+
+                $pathKey = self::getFlatPathKey($path);
+                $rowsByPath[$pathKey][] = $row;
+            }
+
+            foreach ($rowsByPath as $rows) {
+                self::normalizeFlatGoalsMetricsForHierarchyPathRows($rows);
+            }
+        }
+    }
+
+    private static function normalizeFlatGoalsMetricsForHierarchyPathRows(array $rows): void
+    {
+        $entryVisitsTotal = 0.0;
+        $maxPagesBeforeByGoal = [];
+
+        foreach ($rows as $row) {
+            $entryVisits = $row->getColumn(PiwikMetrics::INDEX_PAGE_ENTRY_NB_VISITS);
+            if (is_numeric($entryVisits)) {
+                $entryVisitsTotal += (float) $entryVisits;
+            }
+
+            $goals = $row->getColumn(PiwikMetrics::INDEX_GOALS);
+            if (!is_array($goals)) {
+                continue;
+            }
+
+            foreach ($goals as $goalId => $goalMetrics) {
+                if (!is_array($goalMetrics)) {
+                    continue;
+                }
+
+                $pagesBefore = $goalMetrics[PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE] ?? null;
+                if (!is_numeric($pagesBefore)) {
+                    continue;
+                }
+
+                if (
+                    !isset($maxPagesBeforeByGoal[$goalId])
+                    || $maxPagesBeforeByGoal[$goalId]['value'] < (float) $pagesBefore
+                ) {
+                    $maxPagesBeforeByGoal[$goalId] = [
+                        'row' => $row,
+                        'value' => (float) $pagesBefore,
+                    ];
+                }
+            }
+        }
+
+        foreach ($rows as $row) {
+            $goals = $row->getColumn(PiwikMetrics::INDEX_GOALS);
+            if (!is_array($goals)) {
+                continue;
+            }
+
+            foreach ($goals as &$goalMetrics) {
+                if (!is_array($goalMetrics)) {
+                    continue;
+                }
+
+                if (isset($goalMetrics[PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE])) {
+                    $goalMetrics[PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE] = 0;
+                }
+
+                self::normalizeEntryGoalMetricsForEntrances($goalMetrics, $entryVisitsTotal);
+            }
+            unset($goalMetrics);
+
+            $row[PiwikMetrics::INDEX_GOALS] = $goals;
+        }
+
+        foreach ($maxPagesBeforeByGoal as $goalId => $maxValue) {
+            /** @var Row $maxRow */
+            $maxRow = $maxValue['row'];
+            $goals = $maxRow->getColumn(PiwikMetrics::INDEX_GOALS);
+            if (!is_array($goals) || !isset($goals[$goalId]) || !is_array($goals[$goalId])) {
+                continue;
+            }
+
+            $goals[$goalId][PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE] = $maxValue['value'];
+            $maxRow[PiwikMetrics::INDEX_GOALS] = $goals;
+        }
+    }
+
+    private static function normalizeEntryGoalMetricsForEntrances(array &$goalMetrics, $nbEntrances): void
+    {
+        if (!is_numeric($nbEntrances) || $nbEntrances <= 0) {
+            return;
+        }
+
+        if (isset($goalMetrics[PiwikMetrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY])) {
+            $goalMetrics[PiwikMetrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY_RATE] = Piwik::getQuotientSafe(
+                $goalMetrics[PiwikMetrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY],
+                $nbEntrances,
+                GoalManager::REVENUE_PRECISION + 1
+            );
+        }
+
+        if (isset($goalMetrics[PiwikMetrics::INDEX_GOAL_REVENUE_ENTRY])) {
+            $goalMetrics[PiwikMetrics::INDEX_GOAL_REVENUE_PER_ENTRY] = (float) Piwik::getQuotientSafe(
+                $goalMetrics[PiwikMetrics::INDEX_GOAL_REVENUE_ENTRY],
+                $nbEntrances,
+                GoalManager::REVENUE_PRECISION + 1
+            );
+
+            $goalMetrics[PiwikMetrics::INDEX_GOAL_REVENUE_ENTRY] = (float) $goalMetrics[PiwikMetrics::INDEX_GOAL_REVENUE_ENTRY];
+        }
+    }
+
+    private static function mergeGoalMetric(array &$goalMetrics, int $metricKey, $value): void
+    {
+        if (!isset($goalMetrics[$metricKey])) {
+            $goalMetrics[$metricKey] = $value;
+            return;
+        }
+
+        if ($metricKey == PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE) {
+            if ($goalMetrics[$metricKey] < $value) {
+                $goalMetrics[$metricKey] = $value;
+            }
+            return;
+        }
+
+        $goalMetrics[$metricKey] += $value;
+    }
+
+    private static function getFlatPathKey(array $path): string
+    {
+        $pathKey = json_encode($path);
+        if ($pathKey === false) {
+            return implode("\n", $path);
+        }
+
+        return $pathKey;
     }
 
     public static function removeEmptyColumns($dataTable)

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -477,7 +477,7 @@ class ArchivingHelper
     public static $maximumRowsInDataTableLevelZero;
     public static $maximumRowsInSubDataTable;
     public static $maximumRowsInDataTableSiteSearch;
-    public static $maximumRowsInDataTableFlatNonDay;
+    public static $maximumRowsInDataTableFlat;
     public static $columnToSortByBeforeTruncation;
 
     protected static $actionUrlCategoryDelimiter = null;
@@ -502,7 +502,7 @@ class ArchivingHelper
         self::$maximumRowsInDataTableLevelZero = Config::getInstance()->General['datatable_archiving_maximum_rows_actions'];
         self::$maximumRowsInSubDataTable = Config::getInstance()->General['datatable_archiving_maximum_rows_subtable_actions'];
         self::$maximumRowsInDataTableSiteSearch = Config::getInstance()->General['datatable_archiving_maximum_rows_site_search'];
-        self::$maximumRowsInDataTableFlatNonDay = Config::getInstance()->General['datatable_archiving_maximum_rows_actions_flat_non_day'];
+        self::$maximumRowsInDataTableFlat = Config::getInstance()->General['datatable_archiving_maximum_rows_actions_flat'] ?? 0;
 
         DataTable::setMaximumDepthLevelAllowedAtLeast(self::getSubCategoryLevelLimit() + 1);
     }
@@ -583,8 +583,15 @@ class ArchivingHelper
     public static function buildHierarchicalActionsTableFromFlatTable(DataTable $flatTable): DataTable
     {
         $table = new DataTable();
-        $table->setMaximumAllowedRows(self::$maximumRowsInDataTableLevelZero);
+        $maxRowsInHierarchy = self::$maximumRowsInDataTableFlat > 0
+            ? self::$maximumRowsInDataTableFlat
+            : self::$maximumRowsInDataTableLevelZero;
+        $table->setMaximumAllowedRows($maxRowsInHierarchy);
         $table->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
+
+        $maxRowsInHierarchySubtable = self::$maximumRowsInDataTableFlat > 0
+            ? self::$maximumRowsInDataTableFlat
+            : self::$maximumRowsInSubDataTable;
 
         foreach ($flatTable->getRows() as $flatRow) {
             if ($flatRow->isSummaryRow()) {
@@ -606,7 +613,7 @@ class ArchivingHelper
             [$hierarchyRow, $level] = $table->walkPath(
                 $actionPath,
                 self::getDefaultRowColumns(),
-                self::$maximumRowsInSubDataTable
+                $maxRowsInHierarchySubtable
             );
 
             if ($hierarchyRow === false) {
@@ -617,6 +624,11 @@ class ArchivingHelper
         }
 
         return $table;
+    }
+
+    public static function mergeHierarchicalActionsTableIntoFlatTable(DataTable $hierarchicalTable, DataTable $flatTable): void
+    {
+        self::appendHierarchicalRowsToFlatTable($hierarchicalTable, [], $flatTable);
     }
 
     private static function getFlatActionRow($actionName, $actionType, $urlPrefix, DataTable $table): Row
@@ -636,6 +648,50 @@ class ArchivingHelper
         $table->addRow($row);
 
         return $row;
+    }
+
+    private static function appendHierarchicalRowsToFlatTable(DataTable $sourceTable, array $path, DataTable $flatTable): void
+    {
+        foreach ($sourceTable->getRowsWithoutSummaryRow() as $row) {
+            $label = $row->getColumn('label');
+            if (!is_string($label) || $label === '') {
+                continue;
+            }
+
+            $currentPath = $path;
+            $currentPath[] = $label;
+
+            $subtable = $row->getSubtable();
+            if ($subtable) {
+                self::appendHierarchicalRowsToFlatTable($subtable, $currentPath, $flatTable);
+                continue;
+            }
+
+            $flatLabel = self::buildFlatRowLabel($currentPath);
+            $flatRow = $flatTable->getRowFromLabel($flatLabel);
+            if ($flatRow === false) {
+                $flatRow = new Row(array(
+                    Row::COLUMNS => array('label' => $flatLabel) + self::getDefaultRowColumns(),
+                ));
+                $flatRow->setMetadata(self::ACTION_FLAT_PATH_METADATA_NAME, $currentPath);
+                $flatTable->addRow($flatRow);
+            }
+            self::mergeRowIntoDestination($row, $flatRow);
+        }
+
+        $summaryRow = $sourceTable->getRowFromId(DataTable::ID_SUMMARY_ROW);
+        if ($summaryRow !== false) {
+            if (self::isRowEmptyOfMetrics($summaryRow)) {
+                return;
+            }
+
+            $globalSummary = $flatTable->getRowFromId(DataTable::ID_SUMMARY_ROW);
+            if ($globalSummary === false) {
+                $globalSummary = self::createSummaryRow();
+                $flatTable->addSummaryRow($globalSummary);
+            }
+            self::mergeRowIntoDestination($summaryRow, $globalSummary);
+        }
     }
 
     private static function buildFlatRowLabel(array $actionPath): string

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -702,49 +702,6 @@ class ArchivingHelper
         return $row;
     }
 
-    public static function buildHierarchicalActionsTableFromFlatTable(DataTable $flatTable): DataTable
-    {
-        $table = new DataTable();
-        // Flat source table is already limited. Do not apply extra hierarchy limits.
-        $table->setMaximumAllowedRows(0);
-        $table->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
-
-        $hierarchyDefaultColumns = self::getDefaultRowColumns();
-
-        foreach ($flatTable->getRows() as $flatRow) {
-            if ($flatRow->isSummaryRow()) {
-                if (self::isRowEmptyOfMetrics($flatRow)) {
-                    continue;
-                }
-
-                $summaryRow = clone $flatRow;
-                $summaryRow->setIsSummaryRow();
-                $summaryRow->deleteMetadata(self::ACTION_FLAT_PATH_METADATA_NAME);
-                $table->addSummaryRow($summaryRow);
-                continue;
-            }
-
-            $actionPath = $flatRow->getMetadata(self::ACTION_FLAT_PATH_METADATA_NAME);
-            if (empty($actionPath) || !is_array($actionPath)) {
-                continue;
-            }
-
-            [$hierarchyRow, $level] = $table->walkPath(
-                $actionPath,
-                $hierarchyDefaultColumns,
-                0
-            );
-
-            if ($hierarchyRow === false) {
-                continue;
-            }
-
-            self::mergeRowIntoDestination($flatRow, $hierarchyRow);
-        }
-
-        return $table;
-    }
-
     public static function mergeHierarchicalActionsTableIntoFlatTable(DataTable $hierarchicalTable, DataTable $flatTable): void
     {
         self::appendHierarchicalRowsToFlatTable($hierarchicalTable, [], $flatTable);

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -634,7 +634,7 @@ class ArchivingHelper
     private static function getFlatActionRow($actionName, $actionType, $urlPrefix, DataTable $table): Row
     {
         $actionExplodedNames = self::getActionExplodedNames($actionName, $actionType, $urlPrefix);
-        $flatLabel = self::buildFlatRowLabel($actionExplodedNames);
+        $flatLabel = self::buildFlatActionLabelFromActionName($actionName, $actionType, $urlPrefix);
 
         $row = $table->getRowFromLabel($flatLabel);
         if ($row !== false) {
@@ -648,6 +648,37 @@ class ArchivingHelper
         $table->addRow($row);
 
         return $row;
+    }
+
+    public static function buildBestEffortActionLabelFromPath(array $actionPath, int $actionType): string
+    {
+        if (empty($actionPath)) {
+            return '';
+        }
+
+        $segments = array_values($actionPath);
+        $lastIndex = count($segments) - 1;
+        $lastSegment = (string) $segments[$lastIndex];
+
+        if ($actionType === Action::TYPE_PAGE_URL) {
+            if (strpos($lastSegment, '/') === 0) {
+                $lastSegment = substr($lastSegment, 1);
+            }
+            $segments[$lastIndex] = $lastSegment;
+            $delimiter = self::$actionUrlCategoryDelimiter;
+        } else {
+            if (strpos($lastSegment, ' ') === 0) {
+                $lastSegment = substr($lastSegment, 1);
+            }
+            $segments[$lastIndex] = $lastSegment;
+            $delimiter = self::$actionTitleCategoryDelimiter;
+        }
+
+        if ($delimiter === '') {
+            return implode('', $segments);
+        }
+
+        return implode($delimiter, $segments);
     }
 
     private static function appendHierarchicalRowsToFlatTable(DataTable $sourceTable, array $path, DataTable $flatTable): void
@@ -702,6 +733,23 @@ class ArchivingHelper
         }
 
         return $encodedPath;
+    }
+
+    private static function buildFlatActionLabelFromActionName($actionName, $actionType, $urlPrefix): string
+    {
+        if (!is_string($actionName)) {
+            return (string) $actionName;
+        }
+
+        if (
+            $actionType === Action::TYPE_PAGE_URL
+            && $actionName !== ''
+            && $actionName !== RankingQuery::LABEL_SUMMARY_ROW
+        ) {
+            return PageUrl::reconstructNormalizedUrl($actionName, $urlPrefix);
+        }
+
+        return $actionName;
     }
 
     private static function mergeRowIntoDestination(Row $source, Row $destination): void

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -705,15 +705,10 @@ class ArchivingHelper
     public static function buildHierarchicalActionsTableFromFlatTable(DataTable $flatTable): DataTable
     {
         $table = new DataTable();
-        $maxRowsInHierarchy = self::$maximumRowsInDataTableFlat > 0
-            ? self::$maximumRowsInDataTableFlat
-            : self::$maximumRowsInDataTableLevelZero;
-        $table->setMaximumAllowedRows($maxRowsInHierarchy);
+        // Flat source table is already limited. Do not apply extra hierarchy limits.
+        $table->setMaximumAllowedRows(0);
         $table->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
 
-        $maxRowsInHierarchySubtable = self::$maximumRowsInDataTableFlat > 0
-            ? self::$maximumRowsInDataTableFlat
-            : self::$maximumRowsInSubDataTable;
         $hierarchyDefaultColumns = self::getDefaultRowColumns();
 
         foreach ($flatTable->getRows() as $flatRow) {
@@ -737,7 +732,7 @@ class ArchivingHelper
             [$hierarchyRow, $level] = $table->walkPath(
                 $actionPath,
                 $hierarchyDefaultColumns,
-                $maxRowsInHierarchySubtable
+                0
             );
 
             if ($hierarchyRow === false) {

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -330,18 +330,17 @@ class ArchivingHelper
                 continue;
             }
 
-            $rowsByPath = [];
+            $rowsByLabel = [];
             foreach ($dataTable->getRowsWithoutSummaryRow() as $row) {
-                $path = $row->getMetadata(self::ACTION_FLAT_PATH_METADATA_NAME);
-                if (!is_array($path) || empty($path)) {
+                $label = $row->getColumn('label');
+                if (!is_string($label) || $label === '') {
                     continue;
                 }
 
-                $pathKey = self::getFlatPathKey($path);
-                $rowsByPath[$pathKey][] = $row;
+                $rowsByLabel[$label][] = $row;
             }
 
-            foreach ($rowsByPath as $rows) {
+            foreach ($rowsByLabel as $rows) {
                 self::normalizeFlatGoalsMetricsForHierarchyPathRows($rows);
             }
         }
@@ -460,16 +459,6 @@ class ArchivingHelper
         }
 
         $goalMetrics[$metricKey] += $value;
-    }
-
-    private static function getFlatPathKey(array $path): string
-    {
-        $pathKey = json_encode($path);
-        if ($pathKey === false) {
-            return implode("\n", $path);
-        }
-
-        return $pathKey;
     }
 
     public static function removeEmptyColumns($dataTable)
@@ -732,7 +721,6 @@ class ArchivingHelper
 
     private static function getFlatActionRow($actionName, $actionType, $urlPrefix, DataTable $table): Row
     {
-        $actionExplodedNames = self::getActionExplodedNames($actionName, $actionType, $urlPrefix);
         $flatLabel = self::buildFlatActionLabelFromActionName($actionName, $actionType, $urlPrefix);
 
         $row = $table->getRowFromLabel($flatLabel);
@@ -743,7 +731,6 @@ class ArchivingHelper
         $row = new Row(array(
             Row::COLUMNS => array('label' => $flatLabel) + self::getDefaultFlatRowColumns(),
         ));
-        $row->setMetadata(self::ACTION_FLAT_PATH_METADATA_NAME, $actionExplodedNames);
         $table->addRow($row);
 
         return $row;
@@ -774,10 +761,25 @@ class ArchivingHelper
         }
 
         if ($delimiter === '') {
-            return implode('', $segments);
+            $label = implode('', $segments);
+        } else {
+            $label = implode($delimiter, $segments);
         }
 
-        return implode($delimiter, $segments);
+        if (
+            $actionType === Action::TYPE_PAGE_URL
+            && $label !== self::getUnknownActionName(Action::TYPE_PAGE_URL)
+            && substr($label, 0, 1) !== '/'
+        ) {
+            return '/' . $label;
+        }
+
+        return $label;
+    }
+
+    public static function removePageUrlLeafMarkerFromFlatLabel(string $label): string
+    {
+        return ltrim($label, self::URL_ACTION_LEAF_MARKER);
     }
 
     private static function appendHierarchicalRowsToFlatTable(
@@ -819,7 +821,6 @@ class ArchivingHelper
                 $flatRow = new Row(array(
                     Row::COLUMNS => $columns,
                 ));
-                $flatRow->setMetadata(self::ACTION_FLAT_PATH_METADATA_NAME, $currentPath);
                 $flatTable->addRow($flatRow);
             }
             self::mergeRowIntoDestination($row, $flatRow);
@@ -856,12 +857,14 @@ class ArchivingHelper
             return (string) $actionName;
         }
 
+        $actionType = (int) $actionType;
+
         if (
-            $actionType === Action::TYPE_PAGE_URL
-            && $actionName !== ''
+            ($actionType === Action::TYPE_PAGE_URL || $actionType === Action::TYPE_PAGE_TITLE)
             && $actionName !== RankingQuery::LABEL_SUMMARY_ROW
         ) {
-            return PageUrl::reconstructNormalizedUrl($actionName, $urlPrefix);
+            $actionPath = self::getActionExplodedNames($actionName, $actionType, $urlPrefix);
+            return self::buildBestEffortActionLabelFromPath($actionPath, $actionType);
         }
 
         return $actionName;
@@ -874,6 +877,11 @@ class ArchivingHelper
 
         $aggregationOps = Metrics::getColumnsAggregationOperation();
         $destination->sumRow($sourceCopy, $enableCopyMetadata = true, $aggregationOps);
+
+        $metadataValue = $sourceCopy->getMetadata('url');
+        if ($metadataValue !== false) {
+            $destination->setMetadata('url', $metadataValue);
+        }
     }
 
     private static function isRowEmptyOfMetrics(Row $row): bool

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -731,9 +731,10 @@ class ArchivingHelper
         $row = new Row(array(
             Row::COLUMNS => array('label' => $flatLabel) + self::getDefaultFlatRowColumns(),
         ));
-        $table->addRow($row);
 
-        return $row;
+        // when the table is full, addRow() aggregates the row into the summary row and
+        // returns the summary row instead, so metrics of truncated actions accumulate there
+        return $table->addRow($row);
     }
 
     public static function buildBestEffortActionLabelFromPath(array $actionPath, int $actionType): string

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -1149,7 +1149,7 @@ class ArchivingHelper
     public static function setFolderPathMetadata(DataTable $dataTable, $isUrl, $prefix = '')
     {
         $configGeneral = Config::getInstance()->General;
-        $separator = $isUrl ? '/' : $configGeneral['action_title_category_delimiter'];
+        $separator = $isUrl ? $configGeneral['action_url_category_delimiter'] : $configGeneral['action_title_category_delimiter'];
         $metadataName = $isUrl ? 'folder_url_start' : 'page_title_path';
 
         foreach ($dataTable->getRows() as $row) {

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -503,6 +503,8 @@ class ArchivingHelper
         self::$maximumRowsInSubDataTable = Config::getInstance()->General['datatable_archiving_maximum_rows_subtable_actions'];
         self::$maximumRowsInDataTableSiteSearch = Config::getInstance()->General['datatable_archiving_maximum_rows_site_search'];
         self::$maximumRowsInDataTableFlat = Config::getInstance()->General['datatable_archiving_maximum_rows_actions_flat'] ?? 0;
+        self::$defaultActionNameWhenNotDefined = null;
+        self::$defaultActionUrlWhenNotDefined = null;
 
         DataTable::setMaximumDepthLevelAllowedAtLeast(self::getSubCategoryLevelLimit() + 1);
     }
@@ -592,6 +594,7 @@ class ArchivingHelper
         $maxRowsInHierarchySubtable = self::$maximumRowsInDataTableFlat > 0
             ? self::$maximumRowsInDataTableFlat
             : self::$maximumRowsInSubDataTable;
+        $hierarchyDefaultColumns = self::getDefaultRowColumns();
 
         foreach ($flatTable->getRows() as $flatRow) {
             if ($flatRow->isSummaryRow()) {
@@ -599,8 +602,9 @@ class ArchivingHelper
                     continue;
                 }
 
-                $summaryRow = self::createSummaryRow();
-                self::mergeRowIntoDestination($flatRow, $summaryRow);
+                $summaryRow = clone $flatRow;
+                $summaryRow->setIsSummaryRow();
+                $summaryRow->deleteMetadata(self::ACTION_FLAT_PATH_METADATA_NAME);
                 $table->addSummaryRow($summaryRow);
                 continue;
             }
@@ -612,7 +616,7 @@ class ArchivingHelper
 
             [$hierarchyRow, $level] = $table->walkPath(
                 $actionPath,
-                self::getDefaultRowColumns(),
+                $hierarchyDefaultColumns,
                 $maxRowsInHierarchySubtable
             );
 
@@ -642,7 +646,7 @@ class ArchivingHelper
         }
 
         $row = new Row(array(
-            Row::COLUMNS => array('label' => $flatLabel) + self::getDefaultRowColumns(),
+            Row::COLUMNS => array('label' => $flatLabel) + self::getDefaultFlatRowColumns(),
         ));
         $row->setMetadata(self::ACTION_FLAT_PATH_METADATA_NAME, $actionExplodedNames);
         $table->addRow($row);
@@ -702,7 +706,7 @@ class ArchivingHelper
             $flatRow = $flatTable->getRowFromLabel($flatLabel);
             if ($flatRow === false) {
                 $flatRow = new Row(array(
-                    Row::COLUMNS => array('label' => $flatLabel) + self::getDefaultRowColumns(),
+                    Row::COLUMNS => array('label' => $flatLabel) + self::getDefaultFlatRowColumns(),
                 ));
                 $flatRow->setMetadata(self::ACTION_FLAT_PATH_METADATA_NAME, $currentPath);
                 $flatTable->addRow($flatRow);
@@ -944,6 +948,13 @@ class ArchivingHelper
     {
         return array(PiwikMetrics::INDEX_NB_VISITS           => 0,
                      PiwikMetrics::INDEX_NB_UNIQ_VISITORS    => 0,
+                     PiwikMetrics::INDEX_PAGE_NB_HITS        => 0,
+                     PiwikMetrics::INDEX_PAGE_SUM_TIME_SPENT => 0);
+    }
+
+    private static function getDefaultFlatRowColumns()
+    {
+        return array(PiwikMetrics::INDEX_NB_VISITS           => 0,
                      PiwikMetrics::INDEX_PAGE_NB_HITS        => 0,
                      PiwikMetrics::INDEX_PAGE_SUM_TIME_SPENT => 0);
     }

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -34,6 +34,8 @@ class ArchivingHelper
     public const ACTION_TABLE_MODE_HIERARCHICAL = 'hierarchical';
     public const ACTION_TABLE_MODE_FLAT = 'flat';
     public const ACTION_FLAT_PATH_METADATA_NAME = 'flat_action_path';
+    private const URL_ACTION_LEAF_MARKER = '/';
+    private const TITLE_ACTION_LEAF_MARKER = ' ';
 
     /**
      * Ideally this should use the DataArray object instead of custom data structure
@@ -758,14 +760,14 @@ class ArchivingHelper
         $lastSegment = (string) $segments[$lastIndex];
 
         if ($actionType === Action::TYPE_PAGE_URL) {
-            if (strpos($lastSegment, '/') === 0) {
-                $lastSegment = substr($lastSegment, 1);
+            if (strpos($lastSegment, self::URL_ACTION_LEAF_MARKER) === 0) {
+                $lastSegment = substr($lastSegment, strlen(self::URL_ACTION_LEAF_MARKER));
             }
             $segments[$lastIndex] = $lastSegment;
             $delimiter = self::$actionUrlCategoryDelimiter;
         } else {
-            if (strpos($lastSegment, ' ') === 0) {
-                $lastSegment = substr($lastSegment, 1);
+            if (strpos($lastSegment, self::TITLE_ACTION_LEAF_MARKER) === 0) {
+                $lastSegment = substr($lastSegment, strlen(self::TITLE_ACTION_LEAF_MARKER));
             }
             $segments[$lastIndex] = $lastSegment;
             $delimiter = self::$actionTitleCategoryDelimiter;
@@ -952,7 +954,7 @@ class ArchivingHelper
             if ($name === '' || $name === false || $name === null || trim($name) === '') {
                 $name = self::getUnknownActionName($type);
             }
-            return array(' ' . trim($name));
+            return array(self::TITLE_ACTION_LEAF_MARKER . trim($name));
         }
 
         $name = self::parseNameFromPageUrl($name, $type, $urlPrefix);
@@ -974,9 +976,9 @@ class ArchivingHelper
         // so that if a page has the same name as a category
         // we don't merge both entries
         if ($type != Action::TYPE_PAGE_TITLE) {
-            $lastPageName = '/' . $lastPageName;
+            $lastPageName = self::URL_ACTION_LEAF_MARKER . $lastPageName;
         } else {
-            $lastPageName = ' ' . $lastPageName;
+            $lastPageName = self::TITLE_ACTION_LEAF_MARKER . $lastPageName;
         }
         $split[count($split) - 1] = $lastPageName;
         return array_values($split);

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -100,24 +100,32 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         return $records;
     }
 
-    public function flatRowToUrlHierarchyPath(Row $flatRow, ArchiveProcessor $archiveProcessor, Record $record): ?array
+    public function flatRowToUrlHierarchyPath(Row $flatRow): ?array
     {
         return $this->flatRowToHierarchyPath($flatRow, Action::TYPE_PAGE_URL);
     }
 
-    public function flatRowToTitleHierarchyPath(Row $flatRow, ArchiveProcessor $archiveProcessor, Record $record): ?array
+    public function flatRowToTitleHierarchyPath(Row $flatRow): ?array
     {
         return $this->flatRowToHierarchyPath($flatRow, Action::TYPE_PAGE_TITLE);
     }
 
     public function reduceLegacyUrlHierarchyIntoFlatTable(DataTable $legacyHierarchy, DataTable $flatTable, ArchiveProcessor $archiveProcessor, Record $record): void
     {
-        $this->reduceLegacyHierarchyIntoFlatTable($legacyHierarchy, $flatTable, Action::TYPE_PAGE_URL);
+        ArchivingHelper::mergeHierarchicalActionsTableIntoBestEffortFlatTable(
+            $legacyHierarchy,
+            $flatTable,
+            Action::TYPE_PAGE_URL
+        );
     }
 
     public function reduceLegacyTitleHierarchyIntoFlatTable(DataTable $legacyHierarchy, DataTable $flatTable, ArchiveProcessor $archiveProcessor, Record $record): void
     {
-        $this->reduceLegacyHierarchyIntoFlatTable($legacyHierarchy, $flatTable, Action::TYPE_PAGE_TITLE);
+        ArchivingHelper::mergeHierarchicalActionsTableIntoBestEffortFlatTable(
+            $legacyHierarchy,
+            $flatTable,
+            Action::TYPE_PAGE_TITLE
+        );
     }
 
     protected function aggregate(ArchiveProcessor $archiveProcessor): array
@@ -170,15 +178,11 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
         $tablesByType[Action::TYPE_PAGE_URL] = $this->buildDayHierarchicalTableFromFlatTable(
             $flatPageTablesByType[Action::TYPE_PAGE_URL],
-            Archiver::PAGE_URLS_RECORD_NAME,
-            [$this, 'flatRowToUrlHierarchyPath'],
-            $archiveProcessor
+            [$this, 'flatRowToUrlHierarchyPath']
         );
         $tablesByType[Action::TYPE_PAGE_TITLE] = $this->buildDayHierarchicalTableFromFlatTable(
             $flatPageTablesByType[Action::TYPE_PAGE_TITLE],
-            Archiver::PAGE_TITLES_RECORD_NAME,
-            [$this, 'flatRowToTitleHierarchyPath'],
-            $archiveProcessor
+            [$this, 'flatRowToTitleHierarchyPath']
         );
         $this->finalizeBuiltFromFlatHierarchyTable(
             $archiveProcessor,
@@ -284,11 +288,6 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         return ArchivingHelper::getActionExplodedNames($label, $actionType);
     }
 
-    private function reduceLegacyHierarchyIntoFlatTable(DataTable $legacyHierarchy, DataTable $flatTable, int $actionType): void
-    {
-        $this->appendLegacyHierarchyRowsToFlatTable($legacyHierarchy, [], $flatTable, $actionType);
-    }
-
     private function removeFlatPathMetadataFromDataTable(DataTable $dataTable): void
     {
         $summaryRow = $dataTable->getRowFromId(DataTable::ID_SUMMARY_ROW);
@@ -325,52 +324,6 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($hierarchicalTable);
     }
 
-    private function appendLegacyHierarchyRowsToFlatTable(DataTable $sourceTable, array $path, DataTable $flatTable, int $actionType): void
-    {
-        foreach ($sourceTable->getRowsWithoutSummaryRow() as $row) {
-            $label = $row->getColumn('label');
-            if (!is_string($label) || $label === '') {
-                continue;
-            }
-
-            $currentPath = $path;
-            $currentPath[] = $label;
-
-            $subtable = $row->getSubtable();
-            if ($subtable) {
-                $this->appendLegacyHierarchyRowsToFlatTable($subtable, $currentPath, $flatTable, $actionType);
-                continue;
-            }
-
-            $flatLabel = ArchivingHelper::buildBestEffortActionLabelFromPath($currentPath, $actionType);
-            $flatRow = $flatTable->getRowFromLabel($flatLabel);
-            if ($flatRow === false) {
-                $flatRow = new Row([
-                    Row::COLUMNS => ['label' => $flatLabel],
-                ]);
-                $flatRow->setMetadata(ArchivingHelper::ACTION_FLAT_PATH_METADATA_NAME, $currentPath);
-                $flatTable->addRow($flatRow);
-            }
-
-            $flatRow->sumRow(clone $row, true, Metrics::getColumnsAggregationOperation());
-        }
-
-        $summaryRow = $sourceTable->getRowFromId(DataTable::ID_SUMMARY_ROW);
-        if ($summaryRow === false) {
-            return;
-        }
-
-        $globalSummary = $flatTable->getRowFromId(DataTable::ID_SUMMARY_ROW);
-        if ($globalSummary === false) {
-            $globalSummary = clone $summaryRow;
-            $globalSummary->setIsSummaryRow();
-            $flatTable->addSummaryRow($globalSummary);
-            return;
-        }
-
-        $globalSummary->sumRow(clone $summaryRow, true, Metrics::getColumnsAggregationOperation());
-    }
-
     private function isFlatArchivingEnabled(): bool
     {
         ArchivingHelper::reloadConfig();
@@ -392,18 +345,12 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
     private function buildDayHierarchicalTableFromFlatTable(
         DataTable $flatTable,
-        string $hierarchicalRecordName,
-        callable $flatToHierarchyPathCallback,
-        ArchiveProcessor $archiveProcessor
+        callable $flatToHierarchyPathCallback
     ): DataTable {
-        $hierarchicalRecord = Record::make(Record::TYPE_BLOB, $hierarchicalRecordName);
-
         return $this->buildHierarchicalTableFromFlatTable(
             $flatTable,
             Metrics::getColumnsAggregationOperation(),
-            function (Row $flatRow) use ($flatToHierarchyPathCallback, $archiveProcessor, $hierarchicalRecord) {
-                return call_user_func($flatToHierarchyPathCallback, $flatRow, $archiveProcessor, $hierarchicalRecord);
-            },
+            $flatToHierarchyPathCallback,
             $this->getDefaultHierarchyRowColumns()
         );
     }

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -10,11 +10,9 @@
 namespace Piwik\Plugins\Actions\RecordBuilders;
 
 use Piwik\API\Request;
-use Piwik\Archive;
 use Piwik\ArchiveProcessor;
 use Piwik\ArchiveProcessor\Record;
 use Piwik\Cache;
-use Piwik\Common;
 use Piwik\Config\GeneralConfig;
 use Piwik\DataAccess\LogAggregator;
 use Piwik\DataTable;
@@ -29,16 +27,6 @@ use Piwik\Tracker\GoalManager;
 
 class ActionReports extends ArchiveProcessor\RecordBuilder
 {
-    private const PAGE_HIERARCHICAL_TO_FLAT_RECORD = [
-        Archiver::PAGE_URLS_RECORD_NAME => Archiver::PAGE_URLS_FLAT_RECORD_NAME,
-        Archiver::PAGE_TITLES_RECORD_NAME => Archiver::PAGE_TITLES_FLAT_RECORD_NAME,
-    ];
-
-    private const PAGE_HIERARCHICAL_TO_ACTION_TYPE = [
-        Archiver::PAGE_URLS_RECORD_NAME => Action::TYPE_PAGE_URL,
-        Archiver::PAGE_TITLES_RECORD_NAME => Action::TYPE_PAGE_TITLE,
-    ];
-
     public function __construct()
     {
         ArchivingHelper::reloadConfig();
@@ -54,14 +42,30 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
     public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
     {
+        $pageUrlsRecord = Record::make(Record::TYPE_BLOB, Archiver::PAGE_URLS_RECORD_NAME)
+            ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation());
+        $pageTitlesRecord = Record::make(Record::TYPE_BLOB, Archiver::PAGE_TITLES_RECORD_NAME)
+            ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation());
+
+        if ($this->isFlatArchivingEnabled()) {
+            $pageUrlsRecord->setBuiltFromFlatRecord(
+                Archiver::PAGE_URLS_FLAT_RECORD_NAME,
+                [$this, 'flatRowToUrlHierarchyPath'],
+                [$this, 'reduceLegacyUrlHierarchyIntoFlatTable']
+            );
+            $pageTitlesRecord->setBuiltFromFlatRecord(
+                Archiver::PAGE_TITLES_FLAT_RECORD_NAME,
+                [$this, 'flatRowToTitleHierarchyPath'],
+                [$this, 'reduceLegacyTitleHierarchyIntoFlatTable']
+            );
+        }
+
         $records = [
             Record::make(Record::TYPE_BLOB, Archiver::SITE_SEARCH_RECORD_NAME)
                 ->setMaxRowsInTable(ArchivingHelper::$maximumRowsInDataTableSiteSearch),
 
-            Record::make(Record::TYPE_BLOB, Archiver::PAGE_URLS_RECORD_NAME)
-                ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation()),
-            Record::make(Record::TYPE_BLOB, Archiver::PAGE_TITLES_RECORD_NAME)
-                ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation()),
+            $pageUrlsRecord,
+            $pageTitlesRecord,
 
             Record::make(Record::TYPE_BLOB, Archiver::DOWNLOADS_RECORD_NAME),
             Record::make(Record::TYPE_BLOB, Archiver::OUTLINKS_RECORD_NAME),
@@ -92,6 +96,26 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         }
 
         return $records;
+    }
+
+    public function flatRowToUrlHierarchyPath(Row $flatRow, ArchiveProcessor $archiveProcessor, Record $record): ?array
+    {
+        return $this->flatRowToHierarchyPath($flatRow, Action::TYPE_PAGE_URL);
+    }
+
+    public function flatRowToTitleHierarchyPath(Row $flatRow, ArchiveProcessor $archiveProcessor, Record $record): ?array
+    {
+        return $this->flatRowToHierarchyPath($flatRow, Action::TYPE_PAGE_TITLE);
+    }
+
+    public function reduceLegacyUrlHierarchyIntoFlatTable(DataTable $legacyHierarchy, DataTable $flatTable, ArchiveProcessor $archiveProcessor, Record $record): void
+    {
+        $this->reduceLegacyHierarchyIntoFlatTable($legacyHierarchy, $flatTable, Action::TYPE_PAGE_URL);
+    }
+
+    public function reduceLegacyTitleHierarchyIntoFlatTable(DataTable $legacyHierarchy, DataTable $flatTable, ArchiveProcessor $archiveProcessor, Record $record): void
+    {
+        $this->reduceLegacyHierarchyIntoFlatTable($legacyHierarchy, $flatTable, Action::TYPE_PAGE_TITLE);
     }
 
     protected function aggregate(ArchiveProcessor $archiveProcessor): array
@@ -212,254 +236,25 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
     public function buildForNonDayPeriod(ArchiveProcessor $archiveProcessor): void
     {
-        if (!$this->isFlatArchivingEnabled()) {
-            parent::buildForNonDayPeriod($archiveProcessor);
-            return;
-        }
-
-        if (!$this->isEnabled($archiveProcessor)) {
-            return;
-        }
-
-        $requestedReports = $archiveProcessor->getParams()->getArchiveOnlyReportAsArray();
-        $foundRequestedReports = $archiveProcessor->getParams()->getFoundRequestedReports();
-
-        $recordsBuilt = $this->getRecordMetadata($archiveProcessor);
-
-        $numericRecords = array_filter($recordsBuilt, function (Record $r) {
-            return $r->getType() == Record::TYPE_NUMERIC;
-        });
-        $blobRecords = array_filter($recordsBuilt, function (Record $r) {
-            return $r->getType() == Record::TYPE_BLOB;
-        });
-
-        $aggregatedCounts = [];
-
-        foreach ($numericRecords as $record) {
-            if (
-                empty($record->getCountOfRecordName())
-                || !in_array($record->getName(), $requestedReports)
-            ) {
-                continue;
-            }
-
-            $dependentRecordName = $record->getCountOfRecordName();
-            if (!in_array($dependentRecordName, $requestedReports)) {
-                $requestedReports[] = $dependentRecordName;
-            }
-
-            $indexInFoundRecords = array_search($dependentRecordName, $foundRequestedReports);
-            if ($indexInFoundRecords !== false) {
-                unset($foundRequestedReports[$indexInFoundRecords]);
-            }
-        }
-
-        $processedFlatPageRecords = [];
-        foreach ($blobRecords as $record) {
-            if (
-                !empty($requestedReports)
-                && (!in_array($record->getName(), $requestedReports)
-                    || in_array($record->getName(), $foundRequestedReports))
-            ) {
-                continue;
-            }
-
-            $recordName = $record->getName();
-            $maxRowsInTable = $record->getMaxRowsInTable() ?? $this->maxRowsInTable;
-            $maxRowsInSubtable = $record->getMaxRowsInSubtable() ?? $this->maxRowsInSubtable;
-            $columnToSortByBeforeTruncation = $record->getColumnToSortByBeforeTruncation();
-            if (empty($columnToSortByBeforeTruncation)) {
-                $columnToSortByBeforeTruncation = $this->columnToSortByBeforeTruncation;
-            }
-            $columnToRenameAfterAggregation = $record->getColumnToRenameAfterAggregation() ?? $this->columnToRenameAfterAggregation;
-            $columnAggregationOps = $record->getBlobColumnAggregationOps() ?? $this->columnAggregationOps;
-
-            if (isset(self::PAGE_HIERARCHICAL_TO_FLAT_RECORD[$recordName])) {
-                $flatRecordName = self::PAGE_HIERARCHICAL_TO_FLAT_RECORD[$recordName];
-                $processedFlatPageRecords[$flatRecordName] = true;
-
-                $usedFlatPath = $this->aggregatePageRecordFlatFirstForNonDay(
-                    $archiveProcessor,
-                    $recordName,
-                    $flatRecordName,
-                    $columnAggregationOps,
-                    $columnToRenameAfterAggregation,
-                    $maxRowsInTable,
-                    $maxRowsInSubtable,
-                    $columnToSortByBeforeTruncation
-                );
-
-                if (!$usedFlatPath) {
-                    $archiveProcessor->aggregateDataTableRecords(
-                        $recordName,
-                        $maxRowsInTable,
-                        $maxRowsInSubtable,
-                        $columnToSortByBeforeTruncation,
-                        $columnAggregationOps,
-                        $columnToRenameAfterAggregation
-                    );
-                }
-
-                continue;
-            }
-
-            $hierarchicalRecordName = $this->getHierarchicalRecordNameForFlat($recordName);
-            if ($hierarchicalRecordName !== null) {
-                if (isset($processedFlatPageRecords[$recordName])) {
-                    continue;
-                }
-
-                $this->aggregateAndInsertFlatRecordForNonDay(
-                    $archiveProcessor,
-                    $recordName,
-                    $columnAggregationOps,
-                    $columnToRenameAfterAggregation
-                );
-                continue;
-            }
-
-            $countRecursiveRows = $countLeafRows = [];
-            foreach ($numericRecords as $numeric) {
-                if (
-                    $numeric->getCountOfRecordName() == $record->getName()
-                ) {
-                    if ($numeric->getCountOfRecordNameIsRecursive()) {
-                        $countRecursiveRows[] = $numeric->getCountOfRecordName();
-                    }
-                    if ($numeric->getCountOfRecordNameIsForLeafs()) {
-                        $countLeafRows[] = $numeric->getCountOfRecordName();
-                    }
-                }
-            }
-
-            $counts = $archiveProcessor->aggregateDataTableRecords(
-                $record->getName(),
-                $maxRowsInTable,
-                $maxRowsInSubtable,
-                $columnToSortByBeforeTruncation,
-                $columnAggregationOps,
-                $columnToRenameAfterAggregation,
-                $countRecursiveRows,
-                $countLeafRows
-            );
-
-            $aggregatedCounts = array_merge($aggregatedCounts, $counts);
-        }
-
-        if (!empty($numericRecords)) {
-            $autoAggregateMetrics = array_filter($numericRecords, function (Record $r) {
-                return empty($r->getCountOfRecordName());
-            });
-            $autoAggregateMetrics = array_map(function (Record $r) {
-                return $r->getName();
-            }, $autoAggregateMetrics);
-
-            if (!empty($requestedReports)) {
-                $autoAggregateMetrics = array_filter($autoAggregateMetrics, function ($name) use ($requestedReports, $foundRequestedReports) {
-                    return in_array($name, $requestedReports) && !in_array($name, $foundRequestedReports);
-                });
-            }
-
-            $autoAggregateMetrics = array_values($autoAggregateMetrics);
-
-            if (!empty($autoAggregateMetrics)) {
-                $archiveProcessor->aggregateNumericMetrics($autoAggregateMetrics, $this->columnAggregationOps);
-            }
-
-            $recordCountMetricValues = [];
-
-            $recordCountMetrics = array_filter($numericRecords, function (Record $r) {
-                return !empty($r->getCountOfRecordName());
-            });
-            foreach ($recordCountMetrics as $record) {
-                $dependentRecordName = $record->getCountOfRecordName();
-                if (empty($aggregatedCounts[$dependentRecordName])) {
-                    continue;
-                }
-
-                $count = $aggregatedCounts[$dependentRecordName];
-
-                if ($record->getCountOfRecordNameIsForLeafs()) {
-                    $recordCountMetricValues[$record->getName()] = $count['leafs'];
-                } elseif ($record->getCountOfRecordNameIsRecursive()) {
-                    $recordCountMetricValues[$record->getName()] = $count['recursive'];
-                } else {
-                    $recordCountMetricValues[$record->getName()] = $count['level0'];
-                }
-
-                $transform = $record->getMultiplePeriodTransform();
-                if (!empty($transform)) {
-                    $recordCountMetricValues[$record->getName()] = $transform($recordCountMetricValues[$record->getName()], $count);
-                }
-            }
-
-            if (!empty($recordCountMetricValues)) {
-                $archiveProcessor->insertNumericRecords($recordCountMetricValues);
-            }
-        }
+        parent::buildForNonDayPeriod($archiveProcessor);
     }
 
-    private function aggregatePageRecordFlatFirstForNonDay(
+    protected function beforeInsertBuiltFromFlatHierarchyRecord(
         ArchiveProcessor $archiveProcessor,
-        string $hierarchicalRecordName,
-        string $flatRecordName,
-        ?array $columnAggregationOps,
-        ?array $columnToRenameAfterAggregation,
-        ?int $maxRowsInTable,
-        ?int $maxRowsInSubtable,
-        ?string $columnToSortByBeforeTruncation
-    ): bool {
-        $periodsWithFlatRecord = $this->getPeriodsWithRootBlob($archiveProcessor, $flatRecordName);
-        $allSubperiodKeys = $this->getAllSubperiodKeys($archiveProcessor);
-        $periodsWithoutFlatRecord = array_diff_key($allSubperiodKeys, $periodsWithFlatRecord);
-
-        [$flatTable, $hasFlatSourceData] = $this->aggregateDataTableFromBlobs(
-            $archiveProcessor,
-            $flatRecordName,
-            $columnAggregationOps,
-            $columnToRenameAfterAggregation,
-            $periodsWithFlatRecord
-        );
-
-        $hierarchicalTableFallback = new DataTable();
-        if (!empty($columnAggregationOps)) {
-            $hierarchicalTableFallback->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnAggregationOps);
+        Record $hierarchicalRecord,
+        DataTable $hierarchicalTable,
+        DataTable $flatTable
+    ): void {
+        $recordName = $hierarchicalRecord->getName();
+        if (
+            $recordName !== Archiver::PAGE_URLS_RECORD_NAME
+            && $recordName !== Archiver::PAGE_TITLES_RECORD_NAME
+        ) {
+            return;
         }
 
-        $hasHierarchicalFallbackData = false;
-        if (!empty($periodsWithoutFlatRecord)) {
-            [$hierarchicalTableFallback, $hasHierarchicalFallbackData] = $this->aggregateDataTableFromBlobs(
-                $archiveProcessor,
-                $hierarchicalRecordName,
-                $columnAggregationOps,
-                $columnToRenameAfterAggregation,
-                $periodsWithoutFlatRecord
-            );
-        }
-
-        if ($hasHierarchicalFallbackData) {
-            ArchivingHelper::mergeHierarchicalActionsTableIntoFlatTable($hierarchicalTableFallback, $flatTable);
-        }
-
-        Common::destroy($hierarchicalTableFallback);
-
-        if (!$hasFlatSourceData && !$hasHierarchicalFallbackData) {
-            Common::destroy($flatTable);
-            return false;
-        }
-
-        $flatSerialized = $flatTable->getSerialized(
-            ArchivingHelper::$maximumRowsInDataTableFlat,
-            null,
-            $columnToSortByBeforeTruncation
-        );
-        $archiveProcessor->insertBlobRecord($flatRecordName, $flatSerialized);
-
-        $actionType = self::PAGE_HIERARCHICAL_TO_ACTION_TYPE[$hierarchicalRecordName];
-        $hierarchicalTable = ArchivingHelper::buildHierarchicalActionsTableFromFlatTable($flatTable);
         $hierarchicalTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
-
-        if ($actionType === Action::TYPE_PAGE_URL) {
+        if ($recordName === Archiver::PAGE_URLS_RECORD_NAME) {
             $prefix = $archiveProcessor->getParams()->getSite()->getMainUrl();
             $prefix = rtrim($prefix, '/') . '/';
             ArchivingHelper::setFolderPathMetadata($hierarchicalTable, $isUrl = true, $prefix);
@@ -468,151 +263,72 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         }
 
         ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($hierarchicalTable);
-
-        $hierarchicalSerialized = $hierarchicalTable->getSerialized(
-            null,
-            null,
-            $columnToSortByBeforeTruncation
-        );
-        $archiveProcessor->insertBlobRecord($hierarchicalRecordName, $hierarchicalSerialized);
-
-        Common::destroy($hierarchicalTable);
-        Common::destroy($flatTable);
-
-        return true;
     }
 
-    private function aggregateAndInsertFlatRecordForNonDay(
-        ArchiveProcessor $archiveProcessor,
-        string $flatRecordName,
-        ?array $columnAggregationOps,
-        ?array $columnToRenameAfterAggregation
-    ): void {
-        [$flatTable, $hasFlatSourceData] = $this->aggregateDataTableFromBlobs(
-            $archiveProcessor,
-            $flatRecordName,
-            $columnAggregationOps,
-            $columnToRenameAfterAggregation
-        );
+    private function flatRowToHierarchyPath(Row $flatRow, int $actionType): ?array
+    {
+        $path = $flatRow->getMetadata(ArchivingHelper::ACTION_FLAT_PATH_METADATA_NAME);
+        if (is_array($path) && !empty($path)) {
+            return $path;
+        }
 
-        if (!$hasFlatSourceData) {
-            Common::destroy($flatTable);
+        $label = $flatRow->getColumn('label');
+        if (!is_string($label) || $label === '') {
+            return null;
+        }
+
+        return ArchivingHelper::getActionExplodedNames($label, $actionType);
+    }
+
+    private function reduceLegacyHierarchyIntoFlatTable(DataTable $legacyHierarchy, DataTable $flatTable, int $actionType): void
+    {
+        $this->appendLegacyHierarchyRowsToFlatTable($legacyHierarchy, [], $flatTable, $actionType);
+    }
+
+    private function appendLegacyHierarchyRowsToFlatTable(DataTable $sourceTable, array $path, DataTable $flatTable, int $actionType): void
+    {
+        foreach ($sourceTable->getRowsWithoutSummaryRow() as $row) {
+            $label = $row->getColumn('label');
+            if (!is_string($label) || $label === '') {
+                continue;
+            }
+
+            $currentPath = $path;
+            $currentPath[] = $label;
+
+            $subtable = $row->getSubtable();
+            if ($subtable) {
+                $this->appendLegacyHierarchyRowsToFlatTable($subtable, $currentPath, $flatTable, $actionType);
+                continue;
+            }
+
+            $flatLabel = ArchivingHelper::buildBestEffortActionLabelFromPath($currentPath, $actionType);
+            $flatRow = $flatTable->getRowFromLabel($flatLabel);
+            if ($flatRow === false) {
+                $flatRow = new Row([
+                    Row::COLUMNS => ['label' => $flatLabel],
+                ]);
+                $flatRow->setMetadata(ArchivingHelper::ACTION_FLAT_PATH_METADATA_NAME, $currentPath);
+                $flatTable->addRow($flatRow);
+            }
+
+            $flatRow->sumRow(clone $row, true, Metrics::getColumnsAggregationOperation());
+        }
+
+        $summaryRow = $sourceTable->getRowFromId(DataTable::ID_SUMMARY_ROW);
+        if ($summaryRow === false) {
             return;
         }
 
-        $flatSerialized = $flatTable->getSerialized(
-            ArchivingHelper::$maximumRowsInDataTableFlat,
-            null,
-            $this->columnToSortByBeforeTruncation
-        );
-        $archiveProcessor->insertBlobRecord($flatRecordName, $flatSerialized);
-
-        Common::destroy($flatTable);
-    }
-
-    private function aggregateDataTableFromBlobs(
-        ArchiveProcessor $archiveProcessor,
-        string $recordName,
-        ?array $columnsAggregationOperation,
-        ?array $columnsToRenameAfterAggregation,
-        ?array $periodsToInclude = null
-    ): array {
-        $tableIdToResultRowMapping = [];
-        $result = new DataTable();
-
-        if (!empty($columnsAggregationOperation)) {
-            $result->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnsAggregationOperation);
+        $globalSummary = $flatTable->getRowFromId(DataTable::ID_SUMMARY_ROW);
+        if ($globalSummary === false) {
+            $globalSummary = clone $summaryRow;
+            $globalSummary->setIsSummaryRow();
+            $flatTable->addSummaryRow($globalSummary);
+            return;
         }
 
-        $hasRows = false;
-        foreach ($this->querySingleBlobRows($archiveProcessor, $recordName) as $archiveDataRow) {
-            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
-            if ($periodsToInclude !== null && !isset($periodsToInclude[$period])) {
-                continue;
-            }
-
-            $hasRows = true;
-            $tableId = $archiveDataRow['name'] == $recordName ? null : $this->getSubtableIdFromBlobName($archiveDataRow['name']);
-
-            $blobTable = DataTable::fromSerializedArray($archiveDataRow['value']);
-            $blobTable->filter(function (DataTable $table) use ($archiveProcessor, $columnsToRenameAfterAggregation) {
-                $archiveProcessor->renameColumnsAfterAggregation($table, $columnsToRenameAfterAggregation);
-            });
-
-            if ($tableId === null) {
-                $tableToAddTo = $result;
-            } elseif (!empty($tableIdToResultRowMapping[$period][$tableId])) {
-                $rowToAddTo = $tableIdToResultRowMapping[$period][$tableId];
-                if (!$rowToAddTo->getIdSubDataTable()) {
-                    $newTable = new DataTable();
-                    $newTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnsAggregationOperation);
-                    $rowToAddTo->setSubtable($newTable);
-                }
-
-                $tableToAddTo = $rowToAddTo->getSubtable();
-            } else {
-                Common::destroy($blobTable);
-                continue;
-            }
-
-            $tableToAddTo->addDataTable($blobTable);
-
-            foreach ($blobTable->getRows() as $blobTableRow) {
-                $label = $blobTableRow->getColumn('label');
-                $subtableId = $blobTableRow->getIdSubDataTable();
-                if (empty($subtableId)) {
-                    continue;
-                }
-
-                $rowToAddTo = $tableToAddTo->getRowFromLabel($label);
-                if ($rowToAddTo instanceof Row) {
-                    $tableIdToResultRowMapping[$period][$subtableId] = $rowToAddTo;
-                }
-            }
-
-            Common::destroy($blobTable);
-        }
-
-        return [$result, $hasRows];
-    }
-
-    private function getPeriodsWithRootBlob(ArchiveProcessor $archiveProcessor, string $recordName): array
-    {
-        $result = [];
-        foreach ($this->querySingleBlobRows($archiveProcessor, $recordName) as $archiveDataRow) {
-            if ($archiveDataRow['name'] !== $recordName) {
-                continue;
-            }
-
-            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
-            $result[$period] = true;
-        }
-
-        return $result;
-    }
-
-    protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable
-    {
-        $archive = Archive::factory(
-            $archiveProcessor->getParams()->getSegment(),
-            $archiveProcessor->getParams()->getPeriod()->getSubperiods(),
-            [$archiveProcessor->getParams()->getSite()->getId()]
-        );
-        if (!method_exists($archive, 'querySingleBlob')) {
-            return [];
-        }
-
-        return $archive->querySingleBlob($recordName);
-    }
-
-    private function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
-    {
-        $result = [];
-        foreach ($archiveProcessor->getParams()->getPeriod()->getSubperiods() as $period) {
-            $result[$period->getDateStart()->toString() . ',' . $period->getDateEnd()->toString()] = true;
-        }
-
-        return $result;
+        $globalSummary->sumRow(clone $summaryRow, true, Metrics::getColumnsAggregationOperation());
     }
 
     private function isFlatArchivingEnabled(): bool
@@ -695,28 +411,6 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             Archiver::METRIC_DOWNLOADS_RECORD_NAME => $nbDownloads,
             Archiver::METRIC_UNIQ_DOWNLOADS_RECORD_NAME => $nbUniqDownloads,
         ];
-    }
-
-    private function getSubtableIdFromBlobName(string $recordName): ?int
-    {
-        $parts = explode('_', $recordName);
-        $id = end($parts);
-
-        if (!is_numeric($id)) {
-            return null;
-        }
-
-        return (int) $id;
-    }
-
-    private function getHierarchicalRecordNameForFlat(string $flatRecordName): ?string
-    {
-        $hierarchicalRecordName = array_search($flatRecordName, self::PAGE_HIERARCHICAL_TO_FLAT_RECORD, true);
-        if ($hierarchicalRecordName === false) {
-            return null;
-        }
-
-        return $hierarchicalRecordName;
     }
 
     protected function deleteUnusedColumnsFromKeywordsDataTable(DataTable $dataTable): void

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -21,7 +21,6 @@ use Piwik\Metrics as PiwikMetrics;
 use Piwik\Plugins\Actions\Archiver;
 use Piwik\Plugins\Actions\ArchivingHelper;
 use Piwik\Plugins\Actions\Metrics;
-use Piwik\Piwik;
 use Piwik\RankingQuery;
 use Piwik\Tracker\Action;
 use Piwik\Tracker\GoalManager;
@@ -163,7 +162,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         $this->archiveDayExitActions($archiveProcessor->getLogAggregator(), $dayTablesByType, $rankingQueryLimit, $tableModesByType);
         $this->archiveDayActionsTime($archiveProcessor->getLogAggregator(), $dayTablesByType, $rankingQueryLimit, $tableModesByType);
         $this->archiveDayActionsGoals($archiveProcessor, $rankingQueryLimit);
-        $this->normalizeFlatGoalsMetricsForHierarchy($flatPageTablesByType);
+        ArchivingHelper::normalizeFlatGoalsMetricsForHierarchy($flatPageTablesByType);
 
         ArchivingHelper::clearActionsCache();
 
@@ -355,122 +354,6 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
     {
         ArchivingHelper::reloadConfig();
         return ArchivingHelper::$maximumRowsInDataTableFlat > 0;
-    }
-
-    private function normalizeFlatGoalsMetricsForHierarchy(array $flatPageTablesByType): void
-    {
-        foreach ($flatPageTablesByType as $dataTable) {
-            if (!$dataTable instanceof DataTable) {
-                continue;
-            }
-
-            $rowsByPath = [];
-            foreach ($dataTable->getRowsWithoutSummaryRow() as $row) {
-                $path = $row->getMetadata(ArchivingHelper::ACTION_FLAT_PATH_METADATA_NAME);
-                if (!is_array($path) || empty($path)) {
-                    continue;
-                }
-
-                $pathKey = json_encode($path);
-                if ($pathKey === false) {
-                    $pathKey = implode("\n", $path);
-                }
-                $rowsByPath[$pathKey][] = $row;
-            }
-
-            foreach ($rowsByPath as $rows) {
-                $this->normalizeFlatGoalsMetricsForHierarchyPathRows($rows);
-            }
-        }
-    }
-
-    private function normalizeFlatGoalsMetricsForHierarchyPathRows(array $rows): void
-    {
-        $entryVisitsTotal = 0.0;
-        $maxPagesBeforeByGoal = [];
-
-        foreach ($rows as $row) {
-            $entryVisits = $row->getColumn(PiwikMetrics::INDEX_PAGE_ENTRY_NB_VISITS);
-            if (is_numeric($entryVisits)) {
-                $entryVisitsTotal += (float) $entryVisits;
-            }
-
-            $goals = $row->getColumn(PiwikMetrics::INDEX_GOALS);
-            if (!is_array($goals)) {
-                continue;
-            }
-
-            foreach ($goals as $goalId => $goalMetrics) {
-                if (!is_array($goalMetrics)) {
-                    continue;
-                }
-
-                $pagesBefore = $goalMetrics[PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE] ?? null;
-                if (!is_numeric($pagesBefore)) {
-                    continue;
-                }
-
-                if (
-                    !isset($maxPagesBeforeByGoal[$goalId])
-                    || $maxPagesBeforeByGoal[$goalId]['value'] < (float) $pagesBefore
-                ) {
-                    $maxPagesBeforeByGoal[$goalId] = [
-                        'row' => $row,
-                        'value' => (float) $pagesBefore,
-                    ];
-                }
-            }
-        }
-
-        foreach ($rows as $row) {
-            $goals = $row->getColumn(PiwikMetrics::INDEX_GOALS);
-            if (!is_array($goals)) {
-                continue;
-            }
-
-            foreach ($goals as $goalId => &$goalMetrics) {
-                if (!is_array($goalMetrics)) {
-                    continue;
-                }
-
-                if (isset($goalMetrics[PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE])) {
-                    $goalMetrics[PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE] = 0;
-                }
-
-                if ($entryVisitsTotal > 0.0) {
-                    if (isset($goalMetrics[PiwikMetrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY])) {
-                        $goalMetrics[PiwikMetrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY_RATE] = Piwik::getQuotientSafe(
-                            $goalMetrics[PiwikMetrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY],
-                            $entryVisitsTotal,
-                            GoalManager::REVENUE_PRECISION + 1
-                        );
-                    }
-
-                    if (isset($goalMetrics[PiwikMetrics::INDEX_GOAL_REVENUE_ENTRY])) {
-                        $goalMetrics[PiwikMetrics::INDEX_GOAL_REVENUE_PER_ENTRY] = (float) Piwik::getQuotientSafe(
-                            $goalMetrics[PiwikMetrics::INDEX_GOAL_REVENUE_ENTRY],
-                            $entryVisitsTotal,
-                            GoalManager::REVENUE_PRECISION + 1
-                        );
-                    }
-                }
-            }
-            unset($goalMetrics);
-
-            $row[PiwikMetrics::INDEX_GOALS] = $goals;
-        }
-
-        foreach ($maxPagesBeforeByGoal as $goalId => $maxValue) {
-            /** @var Row $maxRow */
-            $maxRow = $maxValue['row'];
-            $goals = $maxRow->getColumn(PiwikMetrics::INDEX_GOALS);
-            if (!is_array($goals) || !isset($goals[$goalId]) || !is_array($goals[$goalId])) {
-                continue;
-            }
-
-            $goals[$goalId][PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE] = $maxValue['value'];
-            $maxRow[PiwikMetrics::INDEX_GOALS] = $goals;
-        }
     }
 
     private function aggregateLegacyHierarchical(ArchiveProcessor $archiveProcessor): array

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -48,16 +48,18 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation());
 
         if ($this->isFlatArchivingEnabled()) {
-            $pageUrlsRecord->setBuiltFromFlatRecord(
+            $this->setHierarchyBuiltFromFlatRecord(
+                $pageUrlsRecord,
                 Archiver::PAGE_URLS_FLAT_RECORD_NAME,
                 [$this, 'flatRowToUrlHierarchyPath'],
                 [$this, 'reduceLegacyUrlHierarchyIntoFlatTable']
-            )->setMaxRowsInTable(0)->setMaxRowsInSubtable(0);
-            $pageTitlesRecord->setBuiltFromFlatRecord(
+            );
+            $this->setHierarchyBuiltFromFlatRecord(
+                $pageTitlesRecord,
                 Archiver::PAGE_TITLES_FLAT_RECORD_NAME,
                 [$this, 'flatRowToTitleHierarchyPath'],
                 [$this, 'reduceLegacyTitleHierarchyIntoFlatTable']
-            )->setMaxRowsInTable(0)->setMaxRowsInSubtable(0);
+            );
         }
 
         $records = [
@@ -166,14 +168,20 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
         ArchivingHelper::clearActionsCache();
 
-        $tablesByType[Action::TYPE_PAGE_URL] = ArchivingHelper::buildHierarchicalActionsTableFromFlatTable(
-            $flatPageTablesByType[Action::TYPE_PAGE_URL]
+        $tablesByType[Action::TYPE_PAGE_URL] = $this->buildDayHierarchicalTableFromFlatTable(
+            $flatPageTablesByType[Action::TYPE_PAGE_URL],
+            Archiver::PAGE_URLS_RECORD_NAME,
+            [$this, 'flatRowToUrlHierarchyPath'],
+            $archiveProcessor
         );
-        $tablesByType[Action::TYPE_PAGE_TITLE] = ArchivingHelper::buildHierarchicalActionsTableFromFlatTable(
-            $flatPageTablesByType[Action::TYPE_PAGE_TITLE]
+        $tablesByType[Action::TYPE_PAGE_TITLE] = $this->buildDayHierarchicalTableFromFlatTable(
+            $flatPageTablesByType[Action::TYPE_PAGE_TITLE],
+            Archiver::PAGE_TITLES_RECORD_NAME,
+            [$this, 'flatRowToTitleHierarchyPath'],
+            $archiveProcessor
         );
-        $tablesByType[Action::TYPE_PAGE_URL]->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
-        $tablesByType[Action::TYPE_PAGE_TITLE]->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
+        $this->removeFlatPathMetadataFromDataTable($tablesByType[Action::TYPE_PAGE_URL]);
+        $this->removeFlatPathMetadataFromDataTable($tablesByType[Action::TYPE_PAGE_TITLE]);
 
         $prefix = $archiveProcessor->getParams()->getSite()->getMainUrl();
         $prefix = rtrim($prefix, '/') . '/';
@@ -233,11 +241,6 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             Archiver::METRIC_DOWNLOADS_RECORD_NAME => $nbDownloads,
             Archiver::METRIC_UNIQ_DOWNLOADS_RECORD_NAME => $nbUniqDownloads,
         ];
-    }
-
-    public function buildForNonDayPeriod(ArchiveProcessor $archiveProcessor): void
-    {
-        parent::buildForNonDayPeriod($archiveProcessor);
     }
 
     protected function beforeInsertBuiltFromFlatHierarchyRecord(
@@ -354,6 +357,47 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
     {
         ArchivingHelper::reloadConfig();
         return ArchivingHelper::$maximumRowsInDataTableFlat > 0;
+    }
+
+    private function setHierarchyBuiltFromFlatRecord(
+        Record $record,
+        string $flatRecordName,
+        callable $flatToHierarchyPathCallback,
+        callable $legacyHierarchyToFlatReducer
+    ): void {
+        $record->setBuiltFromFlatRecord(
+            $flatRecordName,
+            $flatToHierarchyPathCallback,
+            $legacyHierarchyToFlatReducer
+        )->setMaxRowsInTable(0)->setMaxRowsInSubtable(0);
+    }
+
+    private function buildDayHierarchicalTableFromFlatTable(
+        DataTable $flatTable,
+        string $hierarchicalRecordName,
+        callable $flatToHierarchyPathCallback,
+        ArchiveProcessor $archiveProcessor
+    ): DataTable {
+        $hierarchicalRecord = Record::make(Record::TYPE_BLOB, $hierarchicalRecordName);
+
+        return $this->buildHierarchicalTableFromFlatTable(
+            $flatTable,
+            Metrics::getColumnsAggregationOperation(),
+            function (Row $flatRow) use ($flatToHierarchyPathCallback, $archiveProcessor, $hierarchicalRecord) {
+                return call_user_func($flatToHierarchyPathCallback, $flatRow, $archiveProcessor, $hierarchicalRecord);
+            },
+            $this->getDefaultHierarchyRowColumns()
+        );
+    }
+
+    private function getDefaultHierarchyRowColumns(): array
+    {
+        return [
+            PiwikMetrics::INDEX_NB_VISITS => 0,
+            PiwikMetrics::INDEX_NB_UNIQ_VISITORS => 0,
+            PiwikMetrics::INDEX_PAGE_NB_HITS => 0,
+            PiwikMetrics::INDEX_PAGE_SUM_TIME_SPENT => 0,
+        ];
     }
 
     private function aggregateLegacyHierarchical(ArchiveProcessor $archiveProcessor): array

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -209,7 +209,9 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($dataTable);
         }
         foreach ($flatPageTablesByType as $flatDataTable) {
-            ArchivingHelper::removeEmptyColumns($flatDataTable);
+            // also removes unique visitor columns from the summary row, as those cannot
+            // be summed and would otherwise be aggregated into non-day periods
+            ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($flatDataTable);
         }
 
         $nbSearches = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_PAGE_NB_HITS));

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -52,12 +52,12 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
                 Archiver::PAGE_URLS_FLAT_RECORD_NAME,
                 [$this, 'flatRowToUrlHierarchyPath'],
                 [$this, 'reduceLegacyUrlHierarchyIntoFlatTable']
-            );
+            )->setMaxRowsInTable(0)->setMaxRowsInSubtable(0);
             $pageTitlesRecord->setBuiltFromFlatRecord(
                 Archiver::PAGE_TITLES_FLAT_RECORD_NAME,
                 [$this, 'flatRowToTitleHierarchyPath'],
                 [$this, 'reduceLegacyTitleHierarchyIntoFlatTable']
-            );
+            )->setMaxRowsInTable(0)->setMaxRowsInSubtable(0);
         }
 
         $records = [

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -180,19 +180,28 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             [$this, 'flatRowToTitleHierarchyPath'],
             $archiveProcessor
         );
-        $this->removeFlatPathMetadataFromDataTable($tablesByType[Action::TYPE_PAGE_URL]);
-        $this->removeFlatPathMetadataFromDataTable($tablesByType[Action::TYPE_PAGE_TITLE]);
-
-        $prefix = $archiveProcessor->getParams()->getSite()->getMainUrl();
-        $prefix = rtrim($prefix, '/') . '/';
-        ArchivingHelper::setFolderPathMetadata($tablesByType[Action::TYPE_PAGE_URL], $isUrl = true, $prefix);
-
-        ArchivingHelper::setFolderPathMetadata($tablesByType[Action::TYPE_PAGE_TITLE], $isUrl = false);
+        $this->finalizeBuiltFromFlatHierarchyTable(
+            $archiveProcessor,
+            $tablesByType[Action::TYPE_PAGE_URL],
+            Archiver::PAGE_URLS_RECORD_NAME
+        );
+        $this->finalizeBuiltFromFlatHierarchyTable(
+            $archiveProcessor,
+            $tablesByType[Action::TYPE_PAGE_TITLE],
+            Archiver::PAGE_TITLES_RECORD_NAME
+        );
 
         $dataTable = $tablesByType[Action::TYPE_SITE_SEARCH];
         $this->deleteUnusedColumnsFromKeywordsDataTable($dataTable);
 
-        foreach ($tablesByType as $dataTable) {
+        foreach ($tablesByType as $actionType => $dataTable) {
+            if (
+                $actionType === Action::TYPE_PAGE_URL
+                || $actionType === Action::TYPE_PAGE_TITLE
+            ) {
+                continue;
+            }
+
             ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($dataTable);
         }
         foreach ($flatPageTablesByType as $flatDataTable) {
@@ -257,17 +266,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             return;
         }
 
-        $hierarchicalTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
-        if ($recordName === Archiver::PAGE_URLS_RECORD_NAME) {
-            $prefix = $archiveProcessor->getParams()->getSite()->getMainUrl();
-            $prefix = rtrim($prefix, '/') . '/';
-            ArchivingHelper::setFolderPathMetadata($hierarchicalTable, $isUrl = true, $prefix);
-        } else {
-            ArchivingHelper::setFolderPathMetadata($hierarchicalTable, $isUrl = false);
-        }
-
-        $this->removeFlatPathMetadataFromDataTable($hierarchicalTable);
-        ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($hierarchicalTable);
+        $this->finalizeBuiltFromFlatHierarchyTable($archiveProcessor, $hierarchicalTable, $recordName);
     }
 
     private function flatRowToHierarchyPath(Row $flatRow, int $actionType): ?array
@@ -305,6 +304,25 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
                 $this->removeFlatPathMetadataFromDataTable($subtable);
             }
         }
+    }
+
+    private function finalizeBuiltFromFlatHierarchyTable(
+        ArchiveProcessor $archiveProcessor,
+        DataTable $hierarchicalTable,
+        string $recordName
+    ): void {
+        $hierarchicalTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
+
+        if ($recordName === Archiver::PAGE_URLS_RECORD_NAME) {
+            $prefix = $archiveProcessor->getParams()->getSite()->getMainUrl();
+            $prefix = rtrim($prefix, '/') . '/';
+            ArchivingHelper::setFolderPathMetadata($hierarchicalTable, $isUrl = true, $prefix);
+        } elseif ($recordName === Archiver::PAGE_TITLES_RECORD_NAME) {
+            ArchivingHelper::setFolderPathMetadata($hierarchicalTable, $isUrl = false);
+        }
+
+        $this->removeFlatPathMetadataFromDataTable($hierarchicalTable);
+        ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($hierarchicalTable);
     }
 
     private function appendLegacyHierarchyRowsToFlatTable(DataTable $sourceTable, array $path, DataTable $flatTable, int $actionType): void

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -525,16 +525,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         }
 
         $hasRows = false;
-        $archive = Archive::factory(
-            $archiveProcessor->getParams()->getSegment(),
-            $archiveProcessor->getParams()->getPeriod()->getSubperiods(),
-            [$archiveProcessor->getParams()->getSite()->getId()]
-        );
-        if (!method_exists($archive, 'querySingleBlob')) {
-            return [$result, false];
-        }
-
-        foreach ($archive->querySingleBlob($recordName) as $archiveDataRow) {
+        foreach ($this->querySingleBlobRows($archiveProcessor, $recordName) as $archiveDataRow) {
             $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
             if ($periodsToInclude !== null && !isset($periodsToInclude[$period])) {
                 continue;
@@ -588,16 +579,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
     private function getPeriodsWithRootBlob(ArchiveProcessor $archiveProcessor, string $recordName): array
     {
         $result = [];
-        $archive = Archive::factory(
-            $archiveProcessor->getParams()->getSegment(),
-            $archiveProcessor->getParams()->getPeriod()->getSubperiods(),
-            [$archiveProcessor->getParams()->getSite()->getId()]
-        );
-        if (!method_exists($archive, 'querySingleBlob')) {
-            return $result;
-        }
-
-        foreach ($archive->querySingleBlob($recordName) as $archiveDataRow) {
+        foreach ($this->querySingleBlobRows($archiveProcessor, $recordName) as $archiveDataRow) {
             if ($archiveDataRow['name'] !== $recordName) {
                 continue;
             }
@@ -607,6 +589,20 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         }
 
         return $result;
+    }
+
+    protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable
+    {
+        $archive = Archive::factory(
+            $archiveProcessor->getParams()->getSegment(),
+            $archiveProcessor->getParams()->getPeriod()->getSubperiods(),
+            [$archiveProcessor->getParams()->getSite()->getId()]
+        );
+        if (!method_exists($archive, 'querySingleBlob')) {
+            return [];
+        }
+
+        return $archive->querySingleBlob($recordName);
     }
 
     private function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -21,6 +21,7 @@ use Piwik\Metrics as PiwikMetrics;
 use Piwik\Plugins\Actions\Archiver;
 use Piwik\Plugins\Actions\ArchivingHelper;
 use Piwik\Plugins\Actions\Metrics;
+use Piwik\Piwik;
 use Piwik\RankingQuery;
 use Piwik\Tracker\Action;
 use Piwik\Tracker\GoalManager;
@@ -162,6 +163,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         $this->archiveDayExitActions($archiveProcessor->getLogAggregator(), $dayTablesByType, $rankingQueryLimit, $tableModesByType);
         $this->archiveDayActionsTime($archiveProcessor->getLogAggregator(), $dayTablesByType, $rankingQueryLimit, $tableModesByType);
         $this->archiveDayActionsGoals($archiveProcessor, $rankingQueryLimit);
+        $this->normalizeFlatGoalsMetricsForHierarchy($flatPageTablesByType);
 
         ArchivingHelper::clearActionsCache();
 
@@ -262,6 +264,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             ArchivingHelper::setFolderPathMetadata($hierarchicalTable, $isUrl = false);
         }
 
+        $this->removeFlatPathMetadataFromDataTable($hierarchicalTable);
         ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($hierarchicalTable);
     }
 
@@ -283,6 +286,23 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
     private function reduceLegacyHierarchyIntoFlatTable(DataTable $legacyHierarchy, DataTable $flatTable, int $actionType): void
     {
         $this->appendLegacyHierarchyRowsToFlatTable($legacyHierarchy, [], $flatTable, $actionType);
+    }
+
+    private function removeFlatPathMetadataFromDataTable(DataTable $dataTable): void
+    {
+        $summaryRow = $dataTable->getRowFromId(DataTable::ID_SUMMARY_ROW);
+        if ($summaryRow instanceof Row) {
+            $summaryRow->deleteMetadata(ArchivingHelper::ACTION_FLAT_PATH_METADATA_NAME);
+        }
+
+        foreach ($dataTable->getRows() as $row) {
+            $row->deleteMetadata(ArchivingHelper::ACTION_FLAT_PATH_METADATA_NAME);
+
+            $subtable = $row->getSubtable();
+            if ($subtable instanceof DataTable) {
+                $this->removeFlatPathMetadataFromDataTable($subtable);
+            }
+        }
     }
 
     private function appendLegacyHierarchyRowsToFlatTable(DataTable $sourceTable, array $path, DataTable $flatTable, int $actionType): void
@@ -335,6 +355,122 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
     {
         ArchivingHelper::reloadConfig();
         return ArchivingHelper::$maximumRowsInDataTableFlat > 0;
+    }
+
+    private function normalizeFlatGoalsMetricsForHierarchy(array $flatPageTablesByType): void
+    {
+        foreach ($flatPageTablesByType as $dataTable) {
+            if (!$dataTable instanceof DataTable) {
+                continue;
+            }
+
+            $rowsByPath = [];
+            foreach ($dataTable->getRowsWithoutSummaryRow() as $row) {
+                $path = $row->getMetadata(ArchivingHelper::ACTION_FLAT_PATH_METADATA_NAME);
+                if (!is_array($path) || empty($path)) {
+                    continue;
+                }
+
+                $pathKey = json_encode($path);
+                if ($pathKey === false) {
+                    $pathKey = implode("\n", $path);
+                }
+                $rowsByPath[$pathKey][] = $row;
+            }
+
+            foreach ($rowsByPath as $rows) {
+                $this->normalizeFlatGoalsMetricsForHierarchyPathRows($rows);
+            }
+        }
+    }
+
+    private function normalizeFlatGoalsMetricsForHierarchyPathRows(array $rows): void
+    {
+        $entryVisitsTotal = 0.0;
+        $maxPagesBeforeByGoal = [];
+
+        foreach ($rows as $row) {
+            $entryVisits = $row->getColumn(PiwikMetrics::INDEX_PAGE_ENTRY_NB_VISITS);
+            if (is_numeric($entryVisits)) {
+                $entryVisitsTotal += (float) $entryVisits;
+            }
+
+            $goals = $row->getColumn(PiwikMetrics::INDEX_GOALS);
+            if (!is_array($goals)) {
+                continue;
+            }
+
+            foreach ($goals as $goalId => $goalMetrics) {
+                if (!is_array($goalMetrics)) {
+                    continue;
+                }
+
+                $pagesBefore = $goalMetrics[PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE] ?? null;
+                if (!is_numeric($pagesBefore)) {
+                    continue;
+                }
+
+                if (
+                    !isset($maxPagesBeforeByGoal[$goalId])
+                    || $maxPagesBeforeByGoal[$goalId]['value'] < (float) $pagesBefore
+                ) {
+                    $maxPagesBeforeByGoal[$goalId] = [
+                        'row' => $row,
+                        'value' => (float) $pagesBefore,
+                    ];
+                }
+            }
+        }
+
+        foreach ($rows as $row) {
+            $goals = $row->getColumn(PiwikMetrics::INDEX_GOALS);
+            if (!is_array($goals)) {
+                continue;
+            }
+
+            foreach ($goals as $goalId => &$goalMetrics) {
+                if (!is_array($goalMetrics)) {
+                    continue;
+                }
+
+                if (isset($goalMetrics[PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE])) {
+                    $goalMetrics[PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE] = 0;
+                }
+
+                if ($entryVisitsTotal > 0.0) {
+                    if (isset($goalMetrics[PiwikMetrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY])) {
+                        $goalMetrics[PiwikMetrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY_RATE] = Piwik::getQuotientSafe(
+                            $goalMetrics[PiwikMetrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY],
+                            $entryVisitsTotal,
+                            GoalManager::REVENUE_PRECISION + 1
+                        );
+                    }
+
+                    if (isset($goalMetrics[PiwikMetrics::INDEX_GOAL_REVENUE_ENTRY])) {
+                        $goalMetrics[PiwikMetrics::INDEX_GOAL_REVENUE_PER_ENTRY] = (float) Piwik::getQuotientSafe(
+                            $goalMetrics[PiwikMetrics::INDEX_GOAL_REVENUE_ENTRY],
+                            $entryVisitsTotal,
+                            GoalManager::REVENUE_PRECISION + 1
+                        );
+                    }
+                }
+            }
+            unset($goalMetrics);
+
+            $row[PiwikMetrics::INDEX_GOALS] = $goals;
+        }
+
+        foreach ($maxPagesBeforeByGoal as $goalId => $maxValue) {
+            /** @var Row $maxRow */
+            $maxRow = $maxValue['row'];
+            $goals = $maxRow->getColumn(PiwikMetrics::INDEX_GOALS);
+            if (!is_array($goals) || !isset($goals[$goalId]) || !is_array($goals[$goalId])) {
+                continue;
+            }
+
+            $goals[$goalId][PiwikMetrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE] = $maxValue['value'];
+            $maxRow[PiwikMetrics::INDEX_GOALS] = $goals;
+        }
     }
 
     private function aggregateLegacyHierarchical(ArchiveProcessor $archiveProcessor): array

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -54,7 +54,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
     public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
     {
-        return [
+        $records = [
             Record::make(Record::TYPE_BLOB, Archiver::SITE_SEARCH_RECORD_NAME)
                 ->setMaxRowsInTable(ArchivingHelper::$maximumRowsInDataTableSiteSearch),
 
@@ -62,12 +62,6 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
                 ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation()),
             Record::make(Record::TYPE_BLOB, Archiver::PAGE_TITLES_RECORD_NAME)
                 ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation()),
-            Record::make(Record::TYPE_BLOB, Archiver::PAGE_URLS_FLAT_RECORD_NAME)
-                ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation())
-                ->setMaxRowsInTable(ArchivingHelper::getRankingQueryLimit()),
-            Record::make(Record::TYPE_BLOB, Archiver::PAGE_TITLES_FLAT_RECORD_NAME)
-                ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation())
-                ->setMaxRowsInTable(ArchivingHelper::getRankingQueryLimit()),
 
             Record::make(Record::TYPE_BLOB, Archiver::DOWNLOADS_RECORD_NAME),
             Record::make(Record::TYPE_BLOB, Archiver::OUTLINKS_RECORD_NAME),
@@ -87,10 +81,25 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             Record::make(Record::TYPE_NUMERIC, Archiver::METRIC_DOWNLOADS_RECORD_NAME),
             Record::make(Record::TYPE_NUMERIC, Archiver::METRIC_UNIQ_DOWNLOADS_RECORD_NAME),
         ];
+
+        if ($this->isFlatArchivingEnabled()) {
+            $records[] = Record::make(Record::TYPE_BLOB, Archiver::PAGE_URLS_FLAT_RECORD_NAME)
+                ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation())
+                ->setMaxRowsInTable(ArchivingHelper::$maximumRowsInDataTableFlat);
+            $records[] = Record::make(Record::TYPE_BLOB, Archiver::PAGE_TITLES_FLAT_RECORD_NAME)
+                ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation())
+                ->setMaxRowsInTable(ArchivingHelper::$maximumRowsInDataTableFlat);
+        }
+
+        return $records;
     }
 
     protected function aggregate(ArchiveProcessor $archiveProcessor): array
     {
+        if (!$this->isFlatArchivingEnabled()) {
+            return $this->aggregateLegacyHierarchical($archiveProcessor);
+        }
+
         $rankingQueryLimit = ArchivingHelper::getRankingQueryLimit();
         ArchivingHelper::reloadConfig();
 
@@ -203,6 +212,11 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
     public function buildForNonDayPeriod(ArchiveProcessor $archiveProcessor): void
     {
+        if (!$this->isFlatArchivingEnabled()) {
+            parent::buildForNonDayPeriod($archiveProcessor);
+            return;
+        }
+
         if (!$this->isEnabled($archiveProcessor)) {
             return;
         }
@@ -395,20 +409,47 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         ?int $maxRowsInSubtable,
         ?string $columnToSortByBeforeTruncation
     ): bool {
+        $periodsWithFlatRecord = $this->getPeriodsWithRootBlob($archiveProcessor, $flatRecordName);
+        $allSubperiodKeys = $this->getAllSubperiodKeys($archiveProcessor);
+        $periodsWithoutFlatRecord = array_diff_key($allSubperiodKeys, $periodsWithFlatRecord);
+
         [$flatTable, $hasFlatSourceData] = $this->aggregateDataTableFromBlobs(
             $archiveProcessor,
             $flatRecordName,
             $columnAggregationOps,
-            $columnToRenameAfterAggregation
+            $columnToRenameAfterAggregation,
+            $periodsWithFlatRecord
         );
 
-        if (!$hasFlatSourceData) {
+        $hierarchicalTableFallback = new DataTable();
+        if (!empty($columnAggregationOps)) {
+            $hierarchicalTableFallback->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnAggregationOps);
+        }
+
+        $hasHierarchicalFallbackData = false;
+        if (!empty($periodsWithoutFlatRecord)) {
+            [$hierarchicalTableFallback, $hasHierarchicalFallbackData] = $this->aggregateDataTableFromBlobs(
+                $archiveProcessor,
+                $hierarchicalRecordName,
+                $columnAggregationOps,
+                $columnToRenameAfterAggregation,
+                $periodsWithoutFlatRecord
+            );
+        }
+
+        if ($hasHierarchicalFallbackData) {
+            ArchivingHelper::mergeHierarchicalActionsTableIntoFlatTable($hierarchicalTableFallback, $flatTable);
+        }
+
+        Common::destroy($hierarchicalTableFallback);
+
+        if (!$hasFlatSourceData && !$hasHierarchicalFallbackData) {
             Common::destroy($flatTable);
             return false;
         }
 
         $flatSerialized = $flatTable->getSerialized(
-            ArchivingHelper::$maximumRowsInDataTableFlatNonDay,
+            ArchivingHelper::$maximumRowsInDataTableFlat,
             null,
             $columnToSortByBeforeTruncation
         );
@@ -429,8 +470,8 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($hierarchicalTable);
 
         $hierarchicalSerialized = $hierarchicalTable->getSerialized(
-            ArchivingHelper::$maximumRowsInDataTableFlatNonDay,
-            ArchivingHelper::$maximumRowsInDataTableFlatNonDay,
+            null,
+            null,
             $columnToSortByBeforeTruncation
         );
         $archiveProcessor->insertBlobRecord($hierarchicalRecordName, $hierarchicalSerialized);
@@ -460,7 +501,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         }
 
         $flatSerialized = $flatTable->getSerialized(
-            ArchivingHelper::$maximumRowsInDataTableFlatNonDay,
+            ArchivingHelper::$maximumRowsInDataTableFlat,
             null,
             $this->columnToSortByBeforeTruncation
         );
@@ -473,7 +514,8 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         ArchiveProcessor $archiveProcessor,
         string $recordName,
         ?array $columnsAggregationOperation,
-        ?array $columnsToRenameAfterAggregation
+        ?array $columnsToRenameAfterAggregation,
+        ?array $periodsToInclude = null
     ): array {
         $tableIdToResultRowMapping = [];
         $result = new DataTable();
@@ -493,8 +535,12 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         }
 
         foreach ($archive->querySingleBlob($recordName) as $archiveDataRow) {
-            $hasRows = true;
             $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
+            if ($periodsToInclude !== null && !isset($periodsToInclude[$period])) {
+                continue;
+            }
+
+            $hasRows = true;
             $tableId = $archiveDataRow['name'] == $recordName ? null : $this->getSubtableIdFromBlobName($archiveDataRow['name']);
 
             $blobTable = DataTable::fromSerializedArray($archiveDataRow['value']);
@@ -537,6 +583,122 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         }
 
         return [$result, $hasRows];
+    }
+
+    private function getPeriodsWithRootBlob(ArchiveProcessor $archiveProcessor, string $recordName): array
+    {
+        $result = [];
+        $archive = Archive::factory(
+            $archiveProcessor->getParams()->getSegment(),
+            $archiveProcessor->getParams()->getPeriod()->getSubperiods(),
+            [$archiveProcessor->getParams()->getSite()->getId()]
+        );
+        if (!method_exists($archive, 'querySingleBlob')) {
+            return $result;
+        }
+
+        foreach ($archive->querySingleBlob($recordName) as $archiveDataRow) {
+            if ($archiveDataRow['name'] !== $recordName) {
+                continue;
+            }
+
+            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
+            $result[$period] = true;
+        }
+
+        return $result;
+    }
+
+    private function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
+    {
+        $result = [];
+        foreach ($archiveProcessor->getParams()->getPeriod()->getSubperiods() as $period) {
+            $result[$period->getDateStart()->toString() . ',' . $period->getDateEnd()->toString()] = true;
+        }
+
+        return $result;
+    }
+
+    private function isFlatArchivingEnabled(): bool
+    {
+        ArchivingHelper::reloadConfig();
+        return ArchivingHelper::$maximumRowsInDataTableFlat > 0;
+    }
+
+    private function aggregateLegacyHierarchical(ArchiveProcessor $archiveProcessor): array
+    {
+        $rankingQueryLimit = ArchivingHelper::getRankingQueryLimit();
+        ArchivingHelper::reloadConfig();
+
+        $tablesByType = $this->makeReportTables();
+
+        $this->archiveDayActions(
+            $archiveProcessor,
+            $rankingQueryLimit,
+            $tablesByType,
+            array_diff(array_keys($tablesByType), [Action::TYPE_SITE_SEARCH]),
+            true
+        );
+
+        if ($archiveProcessor->getParams()->getSite()->isSiteSearchEnabled()) {
+            $rankingQueryLimitSiteSearch = max($rankingQueryLimit, ArchivingHelper::$maximumRowsInDataTableSiteSearch);
+            $this->archiveDayActions($archiveProcessor, $rankingQueryLimitSiteSearch, $tablesByType, [Action::TYPE_SITE_SEARCH], false);
+        }
+
+        $this->archiveDayEntryActions($archiveProcessor->getLogAggregator(), $tablesByType, $rankingQueryLimit);
+        $this->archiveDayExitActions($archiveProcessor->getLogAggregator(), $tablesByType, $rankingQueryLimit);
+        $this->archiveDayActionsTime($archiveProcessor->getLogAggregator(), $tablesByType, $rankingQueryLimit);
+        $this->archiveDayActionsGoals($archiveProcessor, $rankingQueryLimit);
+
+        ArchivingHelper::clearActionsCache();
+
+        $prefix = $archiveProcessor->getParams()->getSite()->getMainUrl();
+        $prefix = rtrim($prefix, '/') . '/';
+        ArchivingHelper::setFolderPathMetadata($tablesByType[Action::TYPE_PAGE_URL], $isUrl = true, $prefix);
+        ArchivingHelper::setFolderPathMetadata($tablesByType[Action::TYPE_PAGE_TITLE], $isUrl = false);
+
+        $dataTable = $tablesByType[Action::TYPE_SITE_SEARCH];
+        $this->deleteUnusedColumnsFromKeywordsDataTable($dataTable);
+
+        foreach ($tablesByType as $dataTable) {
+            ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($dataTable);
+        }
+
+        $nbSearches = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_PAGE_NB_HITS));
+        $nbKeywords = $dataTable->getRowsCount();
+
+        $dataTable = $tablesByType[Action::TYPE_OUTLINK];
+        $nbOutlinks = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_PAGE_NB_HITS));
+        $nbUniqOutlinks = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_NB_VISITS));
+
+        $dataTable = $tablesByType[Action::TYPE_PAGE_URL];
+        $nbPageviews = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_PAGE_NB_HITS));
+        $nbUniqPageviews = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_NB_VISITS));
+        $nbSumTimeGeneration = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_PAGE_SUM_TIME_GENERATION));
+        $nbHitsWithTimeGeneration = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_PAGE_NB_HITS_WITH_TIME_GENERATION));
+
+        $dataTable = $tablesByType[Action::TYPE_DOWNLOAD];
+        $nbDownloads = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_PAGE_NB_HITS));
+        $nbUniqDownloads = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_NB_VISITS));
+
+        return [
+            Archiver::PAGE_URLS_RECORD_NAME => $tablesByType[Action::TYPE_PAGE_URL],
+            Archiver::PAGE_TITLES_RECORD_NAME => $tablesByType[Action::TYPE_PAGE_TITLE],
+            Archiver::DOWNLOADS_RECORD_NAME => $tablesByType[Action::TYPE_DOWNLOAD],
+            Archiver::OUTLINKS_RECORD_NAME => $tablesByType[Action::TYPE_OUTLINK],
+            Archiver::SITE_SEARCH_RECORD_NAME => $tablesByType[Action::TYPE_SITE_SEARCH],
+
+            Archiver::METRIC_SEARCHES_RECORD_NAME => $nbSearches,
+            Archiver::METRIC_KEYWORDS_RECORD_NAME => $nbKeywords,
+            Archiver::METRIC_OUTLINKS_RECORD_NAME => $nbOutlinks,
+            Archiver::METRIC_UNIQ_OUTLINKS_RECORD_NAME => $nbUniqOutlinks,
+            Archiver::METRIC_PAGEVIEWS_RECORD_NAME => $nbPageviews,
+            Archiver::METRIC_UNIQ_PAGEVIEWS_RECORD_NAME => $nbUniqPageviews,
+            Archiver::METRIC_SUM_TIME_RECORD_NAME => $nbSumTimeGeneration,
+            Archiver::METRIC_HITS_TIMED_RECORD_NAME => $nbHitsWithTimeGeneration,
+            Archiver::METRIC_DOWNLOADS_RECORD_NAME => $nbDownloads,
+            Archiver::METRIC_UNIQ_DOWNLOADS_RECORD_NAME => $nbUniqDownloads,
+        ];
     }
 
     private function getSubtableIdFromBlobName(string $recordName): ?int
@@ -604,7 +766,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
     private function makeFlatPageTables(): array
     {
         $tables = [];
-        $maxRowsInFlatTable = ArchivingHelper::getRankingQueryLimit() + 1;
+        $maxRowsInFlatTable = ArchivingHelper::$maximumRowsInDataTableFlat;
         foreach ([Action::TYPE_PAGE_URL, Action::TYPE_PAGE_TITLE] as $type) {
             $table = new DataTable();
             $table->setMaximumAllowedRows($maxRowsInFlatTable);

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -275,14 +275,20 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
     private function flatRowToHierarchyPath(Row $flatRow, int $actionType): ?array
     {
-        $path = $flatRow->getMetadata(ArchivingHelper::ACTION_FLAT_PATH_METADATA_NAME);
-        if (is_array($path) && !empty($path)) {
-            return $path;
-        }
-
         $label = $flatRow->getColumn('label');
         if (!is_string($label) || $label === '') {
             return null;
+        }
+
+        if ($actionType === Action::TYPE_PAGE_URL) {
+            if ($label === ArchivingHelper::getUnknownActionName(Action::TYPE_PAGE_URL)) {
+                return [$label];
+            }
+
+            return ArchivingHelper::getActionExplodedNames(
+                ArchivingHelper::removePageUrlLeafMarkerFromFlatLabel($label),
+                $actionType
+            );
         }
 
         return ArchivingHelper::getActionExplodedNames($label, $actionType);

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -10,12 +10,15 @@
 namespace Piwik\Plugins\Actions\RecordBuilders;
 
 use Piwik\API\Request;
+use Piwik\Archive;
 use Piwik\ArchiveProcessor;
 use Piwik\ArchiveProcessor\Record;
 use Piwik\Cache;
+use Piwik\Common;
 use Piwik\Config\GeneralConfig;
 use Piwik\DataAccess\LogAggregator;
 use Piwik\DataTable;
+use Piwik\DataTable\Row;
 use Piwik\Metrics as PiwikMetrics;
 use Piwik\Plugins\Actions\Archiver;
 use Piwik\Plugins\Actions\ArchivingHelper;
@@ -26,6 +29,16 @@ use Piwik\Tracker\GoalManager;
 
 class ActionReports extends ArchiveProcessor\RecordBuilder
 {
+    private const PAGE_HIERARCHICAL_TO_FLAT_RECORD = [
+        Archiver::PAGE_URLS_RECORD_NAME => Archiver::PAGE_URLS_FLAT_RECORD_NAME,
+        Archiver::PAGE_TITLES_RECORD_NAME => Archiver::PAGE_TITLES_FLAT_RECORD_NAME,
+    ];
+
+    private const PAGE_HIERARCHICAL_TO_ACTION_TYPE = [
+        Archiver::PAGE_URLS_RECORD_NAME => Action::TYPE_PAGE_URL,
+        Archiver::PAGE_TITLES_RECORD_NAME => Action::TYPE_PAGE_TITLE,
+    ];
+
     public function __construct()
     {
         ArchivingHelper::reloadConfig();
@@ -49,6 +62,12 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
                 ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation()),
             Record::make(Record::TYPE_BLOB, Archiver::PAGE_TITLES_RECORD_NAME)
                 ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation()),
+            Record::make(Record::TYPE_BLOB, Archiver::PAGE_URLS_FLAT_RECORD_NAME)
+                ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation())
+                ->setMaxRowsInTable(ArchivingHelper::getRankingQueryLimit()),
+            Record::make(Record::TYPE_BLOB, Archiver::PAGE_TITLES_FLAT_RECORD_NAME)
+                ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation())
+                ->setMaxRowsInTable(ArchivingHelper::getRankingQueryLimit()),
 
             Record::make(Record::TYPE_BLOB, Archiver::DOWNLOADS_RECORD_NAME),
             Record::make(Record::TYPE_BLOB, Archiver::OUTLINKS_RECORD_NAME),
@@ -76,26 +95,51 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         ArchivingHelper::reloadConfig();
 
         $tablesByType = $this->makeReportTables();
+        $flatPageTablesByType = $this->makeFlatPageTables();
+        $tableModesByType = [
+            Action::TYPE_PAGE_URL => ArchivingHelper::ACTION_TABLE_MODE_FLAT,
+            Action::TYPE_PAGE_TITLE => ArchivingHelper::ACTION_TABLE_MODE_FLAT,
+        ];
+        $dayTablesByType = $tablesByType;
+        $dayTablesByType[Action::TYPE_PAGE_URL] = $flatPageTablesByType[Action::TYPE_PAGE_URL];
+        $dayTablesByType[Action::TYPE_PAGE_TITLE] = $flatPageTablesByType[Action::TYPE_PAGE_TITLE];
 
         $this->archiveDayActions(
             $archiveProcessor,
             $rankingQueryLimit,
-            $tablesByType,
-            array_diff(array_keys($tablesByType), [Action::TYPE_SITE_SEARCH]),
-            true
+            $dayTablesByType,
+            array_diff(array_keys($dayTablesByType), [Action::TYPE_SITE_SEARCH]),
+            true,
+            $tableModesByType
         );
 
         if ($archiveProcessor->getParams()->getSite()->isSiteSearchEnabled()) {
             $rankingQueryLimitSiteSearch = max($rankingQueryLimit, ArchivingHelper::$maximumRowsInDataTableSiteSearch);
-            $this->archiveDayActions($archiveProcessor, $rankingQueryLimitSiteSearch, $tablesByType, [Action::TYPE_SITE_SEARCH], false);
+            $this->archiveDayActions(
+                $archiveProcessor,
+                $rankingQueryLimitSiteSearch,
+                $dayTablesByType,
+                [Action::TYPE_SITE_SEARCH],
+                false,
+                $tableModesByType
+            );
         }
 
-        $this->archiveDayEntryActions($archiveProcessor->getLogAggregator(), $tablesByType, $rankingQueryLimit);
-        $this->archiveDayExitActions($archiveProcessor->getLogAggregator(), $tablesByType, $rankingQueryLimit);
-        $this->archiveDayActionsTime($archiveProcessor->getLogAggregator(), $tablesByType, $rankingQueryLimit);
+        $this->archiveDayEntryActions($archiveProcessor->getLogAggregator(), $dayTablesByType, $rankingQueryLimit, $tableModesByType);
+        $this->archiveDayExitActions($archiveProcessor->getLogAggregator(), $dayTablesByType, $rankingQueryLimit, $tableModesByType);
+        $this->archiveDayActionsTime($archiveProcessor->getLogAggregator(), $dayTablesByType, $rankingQueryLimit, $tableModesByType);
         $this->archiveDayActionsGoals($archiveProcessor, $rankingQueryLimit);
 
         ArchivingHelper::clearActionsCache();
+
+        $tablesByType[Action::TYPE_PAGE_URL] = ArchivingHelper::buildHierarchicalActionsTableFromFlatTable(
+            $flatPageTablesByType[Action::TYPE_PAGE_URL]
+        );
+        $tablesByType[Action::TYPE_PAGE_TITLE] = ArchivingHelper::buildHierarchicalActionsTableFromFlatTable(
+            $flatPageTablesByType[Action::TYPE_PAGE_TITLE]
+        );
+        $tablesByType[Action::TYPE_PAGE_URL]->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
+        $tablesByType[Action::TYPE_PAGE_TITLE]->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
 
         $prefix = $archiveProcessor->getParams()->getSite()->getMainUrl();
         $prefix = rtrim($prefix, '/') . '/';
@@ -109,6 +153,9 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         foreach ($tablesByType as $dataTable) {
             ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($dataTable);
         }
+        foreach ($flatPageTablesByType as $flatDataTable) {
+            ArchivingHelper::removeEmptyColumns($flatDataTable);
+        }
 
         $nbSearches = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_PAGE_NB_HITS));
         $nbKeywords = $dataTable->getRowsCount();
@@ -117,7 +164,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         $nbOutlinks = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_PAGE_NB_HITS));
         $nbUniqOutlinks = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_NB_VISITS));
 
-        $dataTable = $tablesByType[Action::TYPE_PAGE_URL];
+        $dataTable = $flatPageTablesByType[Action::TYPE_PAGE_URL];
         $nbPageviews = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_PAGE_NB_HITS));
         $nbUniqPageviews = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_NB_VISITS));
         $nbSumTimeGeneration = array_sum($dataTable->getColumn(PiwikMetrics::INDEX_PAGE_SUM_TIME_GENERATION));
@@ -129,6 +176,8 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
         return [
             // blob records
+            Archiver::PAGE_URLS_FLAT_RECORD_NAME => $flatPageTablesByType[Action::TYPE_PAGE_URL],
+            Archiver::PAGE_TITLES_FLAT_RECORD_NAME => $flatPageTablesByType[Action::TYPE_PAGE_TITLE],
             Archiver::PAGE_URLS_RECORD_NAME => $tablesByType[Action::TYPE_PAGE_URL],
             Archiver::PAGE_TITLES_RECORD_NAME => $tablesByType[Action::TYPE_PAGE_TITLE],
             Archiver::DOWNLOADS_RECORD_NAME => $tablesByType[Action::TYPE_DOWNLOAD],
@@ -150,6 +199,366 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             Archiver::METRIC_DOWNLOADS_RECORD_NAME => $nbDownloads,
             Archiver::METRIC_UNIQ_DOWNLOADS_RECORD_NAME => $nbUniqDownloads,
         ];
+    }
+
+    public function buildForNonDayPeriod(ArchiveProcessor $archiveProcessor): void
+    {
+        if (!$this->isEnabled($archiveProcessor)) {
+            return;
+        }
+
+        $requestedReports = $archiveProcessor->getParams()->getArchiveOnlyReportAsArray();
+        $foundRequestedReports = $archiveProcessor->getParams()->getFoundRequestedReports();
+
+        $recordsBuilt = $this->getRecordMetadata($archiveProcessor);
+
+        $numericRecords = array_filter($recordsBuilt, function (Record $r) {
+            return $r->getType() == Record::TYPE_NUMERIC;
+        });
+        $blobRecords = array_filter($recordsBuilt, function (Record $r) {
+            return $r->getType() == Record::TYPE_BLOB;
+        });
+
+        $aggregatedCounts = [];
+
+        foreach ($numericRecords as $record) {
+            if (
+                empty($record->getCountOfRecordName())
+                || !in_array($record->getName(), $requestedReports)
+            ) {
+                continue;
+            }
+
+            $dependentRecordName = $record->getCountOfRecordName();
+            if (!in_array($dependentRecordName, $requestedReports)) {
+                $requestedReports[] = $dependentRecordName;
+            }
+
+            $indexInFoundRecords = array_search($dependentRecordName, $foundRequestedReports);
+            if ($indexInFoundRecords !== false) {
+                unset($foundRequestedReports[$indexInFoundRecords]);
+            }
+        }
+
+        $processedFlatPageRecords = [];
+        foreach ($blobRecords as $record) {
+            if (
+                !empty($requestedReports)
+                && (!in_array($record->getName(), $requestedReports)
+                    || in_array($record->getName(), $foundRequestedReports))
+            ) {
+                continue;
+            }
+
+            $recordName = $record->getName();
+            $maxRowsInTable = $record->getMaxRowsInTable() ?? $this->maxRowsInTable;
+            $maxRowsInSubtable = $record->getMaxRowsInSubtable() ?? $this->maxRowsInSubtable;
+            $columnToSortByBeforeTruncation = $record->getColumnToSortByBeforeTruncation();
+            if (empty($columnToSortByBeforeTruncation)) {
+                $columnToSortByBeforeTruncation = $this->columnToSortByBeforeTruncation;
+            }
+            $columnToRenameAfterAggregation = $record->getColumnToRenameAfterAggregation() ?? $this->columnToRenameAfterAggregation;
+            $columnAggregationOps = $record->getBlobColumnAggregationOps() ?? $this->columnAggregationOps;
+
+            if (isset(self::PAGE_HIERARCHICAL_TO_FLAT_RECORD[$recordName])) {
+                $flatRecordName = self::PAGE_HIERARCHICAL_TO_FLAT_RECORD[$recordName];
+                $processedFlatPageRecords[$flatRecordName] = true;
+
+                $usedFlatPath = $this->aggregatePageRecordFlatFirstForNonDay(
+                    $archiveProcessor,
+                    $recordName,
+                    $flatRecordName,
+                    $columnAggregationOps,
+                    $columnToRenameAfterAggregation,
+                    $maxRowsInTable,
+                    $maxRowsInSubtable,
+                    $columnToSortByBeforeTruncation
+                );
+
+                if (!$usedFlatPath) {
+                    $archiveProcessor->aggregateDataTableRecords(
+                        $recordName,
+                        $maxRowsInTable,
+                        $maxRowsInSubtable,
+                        $columnToSortByBeforeTruncation,
+                        $columnAggregationOps,
+                        $columnToRenameAfterAggregation
+                    );
+                }
+
+                continue;
+            }
+
+            $hierarchicalRecordName = $this->getHierarchicalRecordNameForFlat($recordName);
+            if ($hierarchicalRecordName !== null) {
+                if (isset($processedFlatPageRecords[$recordName])) {
+                    continue;
+                }
+
+                $this->aggregateAndInsertFlatRecordForNonDay(
+                    $archiveProcessor,
+                    $recordName,
+                    $columnAggregationOps,
+                    $columnToRenameAfterAggregation
+                );
+                continue;
+            }
+
+            $countRecursiveRows = $countLeafRows = [];
+            foreach ($numericRecords as $numeric) {
+                if (
+                    $numeric->getCountOfRecordName() == $record->getName()
+                ) {
+                    if ($numeric->getCountOfRecordNameIsRecursive()) {
+                        $countRecursiveRows[] = $numeric->getCountOfRecordName();
+                    }
+                    if ($numeric->getCountOfRecordNameIsForLeafs()) {
+                        $countLeafRows[] = $numeric->getCountOfRecordName();
+                    }
+                }
+            }
+
+            $counts = $archiveProcessor->aggregateDataTableRecords(
+                $record->getName(),
+                $maxRowsInTable,
+                $maxRowsInSubtable,
+                $columnToSortByBeforeTruncation,
+                $columnAggregationOps,
+                $columnToRenameAfterAggregation,
+                $countRecursiveRows,
+                $countLeafRows
+            );
+
+            $aggregatedCounts = array_merge($aggregatedCounts, $counts);
+        }
+
+        if (!empty($numericRecords)) {
+            $autoAggregateMetrics = array_filter($numericRecords, function (Record $r) {
+                return empty($r->getCountOfRecordName());
+            });
+            $autoAggregateMetrics = array_map(function (Record $r) {
+                return $r->getName();
+            }, $autoAggregateMetrics);
+
+            if (!empty($requestedReports)) {
+                $autoAggregateMetrics = array_filter($autoAggregateMetrics, function ($name) use ($requestedReports, $foundRequestedReports) {
+                    return in_array($name, $requestedReports) && !in_array($name, $foundRequestedReports);
+                });
+            }
+
+            $autoAggregateMetrics = array_values($autoAggregateMetrics);
+
+            if (!empty($autoAggregateMetrics)) {
+                $archiveProcessor->aggregateNumericMetrics($autoAggregateMetrics, $this->columnAggregationOps);
+            }
+
+            $recordCountMetricValues = [];
+
+            $recordCountMetrics = array_filter($numericRecords, function (Record $r) {
+                return !empty($r->getCountOfRecordName());
+            });
+            foreach ($recordCountMetrics as $record) {
+                $dependentRecordName = $record->getCountOfRecordName();
+                if (empty($aggregatedCounts[$dependentRecordName])) {
+                    continue;
+                }
+
+                $count = $aggregatedCounts[$dependentRecordName];
+
+                if ($record->getCountOfRecordNameIsForLeafs()) {
+                    $recordCountMetricValues[$record->getName()] = $count['leafs'];
+                } elseif ($record->getCountOfRecordNameIsRecursive()) {
+                    $recordCountMetricValues[$record->getName()] = $count['recursive'];
+                } else {
+                    $recordCountMetricValues[$record->getName()] = $count['level0'];
+                }
+
+                $transform = $record->getMultiplePeriodTransform();
+                if (!empty($transform)) {
+                    $recordCountMetricValues[$record->getName()] = $transform($recordCountMetricValues[$record->getName()], $count);
+                }
+            }
+
+            if (!empty($recordCountMetricValues)) {
+                $archiveProcessor->insertNumericRecords($recordCountMetricValues);
+            }
+        }
+    }
+
+    private function aggregatePageRecordFlatFirstForNonDay(
+        ArchiveProcessor $archiveProcessor,
+        string $hierarchicalRecordName,
+        string $flatRecordName,
+        ?array $columnAggregationOps,
+        ?array $columnToRenameAfterAggregation,
+        ?int $maxRowsInTable,
+        ?int $maxRowsInSubtable,
+        ?string $columnToSortByBeforeTruncation
+    ): bool {
+        [$flatTable, $hasFlatSourceData] = $this->aggregateDataTableFromBlobs(
+            $archiveProcessor,
+            $flatRecordName,
+            $columnAggregationOps,
+            $columnToRenameAfterAggregation
+        );
+
+        if (!$hasFlatSourceData) {
+            Common::destroy($flatTable);
+            return false;
+        }
+
+        $flatSerialized = $flatTable->getSerialized(
+            ArchivingHelper::$maximumRowsInDataTableFlatNonDay,
+            null,
+            $columnToSortByBeforeTruncation
+        );
+        $archiveProcessor->insertBlobRecord($flatRecordName, $flatSerialized);
+
+        $actionType = self::PAGE_HIERARCHICAL_TO_ACTION_TYPE[$hierarchicalRecordName];
+        $hierarchicalTable = ArchivingHelper::buildHierarchicalActionsTableFromFlatTable($flatTable);
+        $hierarchicalTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
+
+        if ($actionType === Action::TYPE_PAGE_URL) {
+            $prefix = $archiveProcessor->getParams()->getSite()->getMainUrl();
+            $prefix = rtrim($prefix, '/') . '/';
+            ArchivingHelper::setFolderPathMetadata($hierarchicalTable, $isUrl = true, $prefix);
+        } else {
+            ArchivingHelper::setFolderPathMetadata($hierarchicalTable, $isUrl = false);
+        }
+
+        ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($hierarchicalTable);
+
+        $hierarchicalSerialized = $hierarchicalTable->getSerialized(
+            ArchivingHelper::$maximumRowsInDataTableFlatNonDay,
+            ArchivingHelper::$maximumRowsInDataTableFlatNonDay,
+            $columnToSortByBeforeTruncation
+        );
+        $archiveProcessor->insertBlobRecord($hierarchicalRecordName, $hierarchicalSerialized);
+
+        Common::destroy($hierarchicalTable);
+        Common::destroy($flatTable);
+
+        return true;
+    }
+
+    private function aggregateAndInsertFlatRecordForNonDay(
+        ArchiveProcessor $archiveProcessor,
+        string $flatRecordName,
+        ?array $columnAggregationOps,
+        ?array $columnToRenameAfterAggregation
+    ): void {
+        [$flatTable, $hasFlatSourceData] = $this->aggregateDataTableFromBlobs(
+            $archiveProcessor,
+            $flatRecordName,
+            $columnAggregationOps,
+            $columnToRenameAfterAggregation
+        );
+
+        if (!$hasFlatSourceData) {
+            Common::destroy($flatTable);
+            return;
+        }
+
+        $flatSerialized = $flatTable->getSerialized(
+            ArchivingHelper::$maximumRowsInDataTableFlatNonDay,
+            null,
+            $this->columnToSortByBeforeTruncation
+        );
+        $archiveProcessor->insertBlobRecord($flatRecordName, $flatSerialized);
+
+        Common::destroy($flatTable);
+    }
+
+    private function aggregateDataTableFromBlobs(
+        ArchiveProcessor $archiveProcessor,
+        string $recordName,
+        ?array $columnsAggregationOperation,
+        ?array $columnsToRenameAfterAggregation
+    ): array {
+        $tableIdToResultRowMapping = [];
+        $result = new DataTable();
+
+        if (!empty($columnsAggregationOperation)) {
+            $result->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnsAggregationOperation);
+        }
+
+        $hasRows = false;
+        $archive = Archive::factory(
+            $archiveProcessor->getParams()->getSegment(),
+            $archiveProcessor->getParams()->getPeriod()->getSubperiods(),
+            [$archiveProcessor->getParams()->getSite()->getId()]
+        );
+        if (!method_exists($archive, 'querySingleBlob')) {
+            return [$result, false];
+        }
+
+        foreach ($archive->querySingleBlob($recordName) as $archiveDataRow) {
+            $hasRows = true;
+            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
+            $tableId = $archiveDataRow['name'] == $recordName ? null : $this->getSubtableIdFromBlobName($archiveDataRow['name']);
+
+            $blobTable = DataTable::fromSerializedArray($archiveDataRow['value']);
+            $blobTable->filter(function (DataTable $table) use ($archiveProcessor, $columnsToRenameAfterAggregation) {
+                $archiveProcessor->renameColumnsAfterAggregation($table, $columnsToRenameAfterAggregation);
+            });
+
+            if ($tableId === null) {
+                $tableToAddTo = $result;
+            } elseif (!empty($tableIdToResultRowMapping[$period][$tableId])) {
+                $rowToAddTo = $tableIdToResultRowMapping[$period][$tableId];
+                if (!$rowToAddTo->getIdSubDataTable()) {
+                    $newTable = new DataTable();
+                    $newTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $columnsAggregationOperation);
+                    $rowToAddTo->setSubtable($newTable);
+                }
+
+                $tableToAddTo = $rowToAddTo->getSubtable();
+            } else {
+                Common::destroy($blobTable);
+                continue;
+            }
+
+            $tableToAddTo->addDataTable($blobTable);
+
+            foreach ($blobTable->getRows() as $blobTableRow) {
+                $label = $blobTableRow->getColumn('label');
+                $subtableId = $blobTableRow->getIdSubDataTable();
+                if (empty($subtableId)) {
+                    continue;
+                }
+
+                $rowToAddTo = $tableToAddTo->getRowFromLabel($label);
+                if ($rowToAddTo instanceof Row) {
+                    $tableIdToResultRowMapping[$period][$subtableId] = $rowToAddTo;
+                }
+            }
+
+            Common::destroy($blobTable);
+        }
+
+        return [$result, $hasRows];
+    }
+
+    private function getSubtableIdFromBlobName(string $recordName): ?int
+    {
+        $parts = explode('_', $recordName);
+        $id = end($parts);
+
+        if (!is_numeric($id)) {
+            return null;
+        }
+
+        return (int) $id;
+    }
+
+    private function getHierarchicalRecordNameForFlat(string $flatRecordName): ?string
+    {
+        $hierarchicalRecordName = array_search($flatRecordName, self::PAGE_HIERARCHICAL_TO_FLAT_RECORD, true);
+        if ($hierarchicalRecordName === false) {
+            return null;
+        }
+
+        return $hierarchicalRecordName;
     }
 
     protected function deleteUnusedColumnsFromKeywordsDataTable(DataTable $dataTable): void
@@ -192,12 +601,27 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         return $result;
     }
 
+    private function makeFlatPageTables(): array
+    {
+        $tables = [];
+        $maxRowsInFlatTable = ArchivingHelper::getRankingQueryLimit() + 1;
+        foreach ([Action::TYPE_PAGE_URL, Action::TYPE_PAGE_TITLE] as $type) {
+            $table = new DataTable();
+            $table->setMaximumAllowedRows($maxRowsInFlatTable);
+            $table->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, Metrics::getColumnsAggregationOperation());
+            $tables[$type] = $table;
+        }
+
+        return $tables;
+    }
+
     protected function archiveDayActions(
         ArchiveProcessor $archiveProcessor,
         int $rankingQueryLimit,
         array $actionsTablesByType,
         $actionTypes,
-        bool $includePageNotDefined
+        bool $includePageNotDefined,
+        array $tableModesByType = []
     ): void {
         $logAggregator = $archiveProcessor->getLogAggregator();
 
@@ -256,14 +680,38 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             $this->updateQuerySelectFromForSiteSearch($select, $from);
         }
 
-        $this->archiveDayQueryProcess($logAggregator, $actionsTablesByType, $select, $from, $where, $groupBy, $orderBy, "idaction_name", $rankingQuery, $metricsConfig);
-        $this->archiveDayQueryProcess($logAggregator, $actionsTablesByType, $select, $from, $where, $groupBy, $orderBy, "idaction_url", $rankingQuery, $metricsConfig);
+        $this->archiveDayQueryProcess(
+            $logAggregator,
+            $actionsTablesByType,
+            $select,
+            $from,
+            $where,
+            $groupBy,
+            $orderBy,
+            "idaction_name",
+            $rankingQuery,
+            $metricsConfig,
+            $tableModesByType
+        );
+        $this->archiveDayQueryProcess(
+            $logAggregator,
+            $actionsTablesByType,
+            $select,
+            $from,
+            $where,
+            $groupBy,
+            $orderBy,
+            "idaction_url",
+            $rankingQuery,
+            $metricsConfig,
+            $tableModesByType
+        );
     }
 
     /**
      * Entry actions for Page URLs and Page names
      */
-    protected function archiveDayEntryActions(LogAggregator $logAggregator, array $actionsTablesByType, int $rankingQueryLimit)
+    protected function archiveDayEntryActions(LogAggregator $logAggregator, array $actionsTablesByType, int $rankingQueryLimit, array $tableModesByType = [])
     {
         $rankingQuery = false;
         if ($rankingQueryLimit > 0) {
@@ -312,7 +760,9 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             $groupBy,
             $orderBy,
             "visit_entry_idaction_url",
-            $rankingQuery
+            $rankingQuery,
+            [],
+            $tableModesByType
         );
 
         $this->archiveDayQueryProcess(
@@ -324,14 +774,16 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             $groupBy,
             $orderBy,
             "visit_entry_idaction_name",
-            $rankingQuery
+            $rankingQuery,
+            [],
+            $tableModesByType
         );
     }
 
     /**
      * Exit actions
      */
-    protected function archiveDayExitActions(LogAggregator $logAggregator, array $actionsTablesByType, int $rankingQueryLimit)
+    protected function archiveDayExitActions(LogAggregator $logAggregator, array $actionsTablesByType, int $rankingQueryLimit, array $tableModesByType = [])
     {
         $rankingQuery = false;
         if ($rankingQueryLimit > 0) {
@@ -374,7 +826,9 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             $groupBy,
             $orderBy,
             "visit_exit_idaction_url",
-            $rankingQuery
+            $rankingQuery,
+            [],
+            $tableModesByType
         );
 
         $this->archiveDayQueryProcess(
@@ -386,7 +840,9 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             $groupBy,
             $orderBy,
             "visit_exit_idaction_name",
-            $rankingQuery
+            $rankingQuery,
+            [],
+            $tableModesByType
         );
 
         return array($rankingQuery, $extraSelects, $from, $orderBy, $select, $where, $groupBy);
@@ -395,7 +851,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
     /**
      * Time per action
      */
-    protected function archiveDayActionsTime(LogAggregator $logAggregator, array $actionsTablesByType, int $rankingQueryLimit)
+    protected function archiveDayActionsTime(LogAggregator $logAggregator, array $actionsTablesByType, int $rankingQueryLimit, array $tableModesByType = [])
     {
         $rankingQuery = false;
         if ($rankingQueryLimit > 0) {
@@ -438,7 +894,9 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             $groupBy,
             $orderBy,
             "idaction_url_ref",
-            $rankingQuery
+            $rankingQuery,
+            [],
+            $tableModesByType
         );
 
         $this->archiveDayQueryProcess(
@@ -450,7 +908,9 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
             $groupBy,
             $orderBy,
             "idaction_name_ref",
-            $rankingQuery
+            $rankingQuery,
+            [],
+            $tableModesByType
         );
     }
 
@@ -464,7 +924,8 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
         $orderBy,
         string $sprintfField,
         ?RankingQuery $rankingQuery = null,
-        array $metricsConfig = array()
+        array $metricsConfig = array(),
+        array $tableModesByType = []
     ): void {
         $select = sprintf($select, $sprintfField);
 
@@ -481,7 +942,13 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
         // get result
         $resultSet = $logAggregator->getDb()->query($querySql, $query['bind']);
-        ArchivingHelper::updateActionsTableWithRowQuery($resultSet, $sprintfField, $actionsTablesByType, $metricsConfig);
+        ArchivingHelper::updateActionsTableWithRowQuery(
+            $resultSet,
+            $sprintfField,
+            $actionsTablesByType,
+            $metricsConfig,
+            $tableModesByType
+        );
     }
 
     protected function updateQuerySelectFromForSiteSearch(string &$select, array &$from): void

--- a/plugins/Actions/tests/System/MixedArchivingAggregationTest.php
+++ b/plugins/Actions/tests/System/MixedArchivingAggregationTest.php
@@ -1,0 +1,214 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Actions\tests\System;
+
+use Piwik\Archive;
+use Piwik\Common;
+use Piwik\Config;
+use Piwik\DataTable;
+use Piwik\Db;
+use Piwik\Metrics;
+use Piwik\Plugins\Actions\Archiver;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Actions
+ * @group Plugins
+ */
+class MixedArchivingAggregationTest extends IntegrationTestCase
+{
+    public function testWeekAggregationCombinesLegacyAndFlatDaysAndMergesOthers()
+    {
+        $idSite = Fixture::createWebsite('2026-01-01 00:00:00');
+
+        $this->trackUrlHits($idSite, '2026-01-06', [
+            '/a' => 9,
+            '/b' => 6,
+            '/c' => 3,
+        ]);
+        $this->trackUrlHits($idSite, '2026-01-07', [
+            '/a' => 5,
+            '/b' => 2,
+            '/d' => 4,
+        ]);
+
+        $config = Config::getInstance();
+        $configKeys = [
+            'datatable_archiving_maximum_rows_actions_flat',
+            'datatable_archiving_maximum_rows_actions',
+            'datatable_archiving_maximum_rows_subtable_actions',
+            'archiving_ranking_query_row_limit',
+        ];
+        $configBackup = $this->backupGeneralConfig($configKeys);
+
+        try {
+            // phase 1: archive legacy day (hierarchical only) with subtable truncation
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 0;
+            $config->General['datatable_archiving_maximum_rows_actions'] = 1;
+            $config->General['datatable_archiving_maximum_rows_subtable_actions'] = 2;
+            $config->General['archiving_ranking_query_row_limit'] = 1;
+            $legacyDayArchive = Archive::build($idSite, 'day', '2026-01-06');
+            $legacyDayHierarchical = $legacyDayArchive->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+            $legacyDaySummaryHits = $this->sumSummaryHitsRecursively($legacyDayHierarchical);
+
+            // phase 2: archive flat day with low ranking query limit to force day-level "Others"
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50;
+            $config->General['archiving_ranking_query_row_limit'] = 1;
+            $flatDayArchive = Archive::build($idSite, 'day', '2026-01-07');
+            $flatDayArchive->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+            $flatDayFlat = $flatDayArchive->getDataTable(Archiver::PAGE_URLS_FLAT_RECORD_NAME);
+            $flatDaySummaryHits = $this->getSummaryHits($flatDayFlat);
+
+            // phase 3: aggregate week with higher flat limit to avoid additional week truncation
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50;
+            $config->General['archiving_ranking_query_row_limit'] = 100000;
+            $archive = Archive::build($idSite, 'week', '2026-01-07');
+            $weekFlat = $archive->getDataTable(Archiver::PAGE_URLS_FLAT_RECORD_NAME);
+            $weekHierarchical = $archive->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        $this->assertDayArchiveRecordNames(
+            $idSite,
+            '2026-01-06',
+            [Archiver::PAGE_URLS_RECORD_NAME],
+            [Archiver::PAGE_URLS_FLAT_RECORD_NAME]
+        );
+        $this->assertDayArchiveRecordNames(
+            $idSite,
+            '2026-01-07',
+            [Archiver::PAGE_URLS_RECORD_NAME, Archiver::PAGE_URLS_FLAT_RECORD_NAME],
+            []
+        );
+
+        $this->assertGreaterThan(0, $legacyDaySummaryHits);
+        $this->assertGreaterThan(0, $flatDaySummaryHits);
+
+        $weekSummaryRow = $weekFlat->getRowFromId(DataTable::ID_SUMMARY_ROW);
+        $this->assertNotFalse($weekSummaryRow);
+        $weekSummaryHits = (int) $weekSummaryRow->getColumn(Metrics::INDEX_PAGE_NB_HITS);
+        $this->assertSame($legacyDaySummaryHits + $flatDaySummaryHits, $weekSummaryHits);
+
+        $nonSummaryHits = $this->sumHitsWithoutSummary($weekFlat);
+        $this->assertSame(29, $nonSummaryHits + $weekSummaryHits);
+
+        $weekHierarchicalSummary = $weekHierarchical->getRowFromId(DataTable::ID_SUMMARY_ROW);
+        $this->assertNotFalse($weekHierarchicalSummary);
+        $this->assertSame($weekSummaryHits, (int) $weekHierarchicalSummary->getColumn(Metrics::INDEX_PAGE_NB_HITS));
+    }
+
+    protected static function configureFixture($fixture)
+    {
+        parent::configureFixture($fixture);
+        $fixture->createSuperUser = true;
+    }
+
+    private function trackUrlHits(int $idSite, string $day, array $urlHits): void
+    {
+        $tracker = Fixture::getTracker($idSite, $day . ' 00:00:01');
+        $second = 1;
+
+        foreach ($urlHits as $path => $hits) {
+            for ($i = 0; $i < $hits; ++$i) {
+                $tracker->setForceVisitDateTime($day . sprintf(' 00:00:%02d', $second));
+                $tracker->setUrl('http://example.org' . $path);
+                Fixture::checkResponse($tracker->doTrackPageView('title ' . $path));
+                ++$second;
+            }
+        }
+    }
+
+    private function backupGeneralConfig(array $configKeys): array
+    {
+        $config = Config::getInstance();
+        $backup = [];
+        foreach ($configKeys as $key) {
+            $exists = array_key_exists($key, $config->General);
+            $backup[$key] = [
+                'exists' => $exists,
+                'value' => $exists ? $config->General[$key] : null,
+            ];
+        }
+
+        return $backup;
+    }
+
+    private function restoreGeneralConfig(array $configBackup): void
+    {
+        $config = Config::getInstance();
+        foreach ($configBackup as $key => $state) {
+            if (!empty($state['exists'])) {
+                $config->General[$key] = $state['value'];
+            } else {
+                unset($config->General[$key]);
+            }
+        }
+    }
+
+    private function assertDayArchiveRecordNames(int $idSite, string $day, array $expectedPresent, array $expectedAbsent): void
+    {
+        $table = Common::prefixTable('archive_blob_2026_01');
+        $names = Db::fetchAll(
+            "SELECT DISTINCT name
+             FROM $table
+             WHERE idsite = ?
+               AND period = 1
+               AND date1 = ?
+               AND date2 = ?
+               AND name IN (?, ?)",
+            [$idSite, $day, $day, Archiver::PAGE_URLS_RECORD_NAME, Archiver::PAGE_URLS_FLAT_RECORD_NAME]
+        );
+        $names = array_column($names, 'name');
+
+        foreach ($expectedPresent as $name) {
+            $this->assertContains($name, $names);
+        }
+        foreach ($expectedAbsent as $name) {
+            $this->assertNotContains($name, $names);
+        }
+    }
+
+    private function getSummaryHits(DataTable $table): int
+    {
+        $summaryRow = $table->getRowFromId(DataTable::ID_SUMMARY_ROW);
+        if ($summaryRow === false) {
+            return 0;
+        }
+
+        return (int) $summaryRow->getColumn(Metrics::INDEX_PAGE_NB_HITS);
+    }
+
+    private function sumSummaryHitsRecursively(DataTable $table): int
+    {
+        $sum = $this->getSummaryHits($table);
+        foreach ($table->getRowsWithoutSummaryRow() as $row) {
+            /** @var Row $row */
+            $subtable = $row->getSubtable();
+            if ($subtable instanceof DataTable) {
+                $sum += $this->sumSummaryHitsRecursively($subtable);
+            }
+        }
+
+        return $sum;
+    }
+
+    private function sumHitsWithoutSummary(DataTable $table): int
+    {
+        $sum = 0;
+        foreach ($table->getRowsWithoutSummaryRow() as $row) {
+            /** @var Row $row */
+            $sum += (int) $row->getColumn(Metrics::INDEX_PAGE_NB_HITS);
+        }
+
+        return $sum;
+    }
+}

--- a/plugins/Actions/tests/System/MixedArchivingAggregationTest.php
+++ b/plugins/Actions/tests/System/MixedArchivingAggregationTest.php
@@ -167,6 +167,54 @@ class MixedArchivingAggregationTest extends IntegrationTestCase
         );
     }
 
+    public function testDayFlatAndHierarchyStayInParityWhenHostsDifferButPathsMatch()
+    {
+        $idSite = Fixture::createWebsite('2026-02-10 00:00:00');
+
+        $tracker = Fixture::getTracker($idSite, '2026-02-10 00:00:01');
+        $tracker->setUrl('http://EXAMPLE.org/shared/path#');
+        Fixture::checkResponse($tracker->doTrackPageView('first'));
+
+        $tracker->setForceVisitDateTime('2026-02-10 00:00:02');
+        $tracker->setUrl('https://other.example/shared/path');
+        Fixture::checkResponse($tracker->doTrackPageView('second'));
+
+        $config = Config::getInstance();
+        $configKeys = [
+            'datatable_archiving_maximum_rows_actions_flat',
+            'datatable_archiving_maximum_rows_actions',
+            'datatable_archiving_maximum_rows_subtable_actions',
+            'archiving_ranking_query_row_limit',
+        ];
+        $configBackup = $this->backupGeneralConfig($configKeys);
+
+        try {
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50;
+            $config->General['datatable_archiving_maximum_rows_actions'] = 50000;
+            $config->General['datatable_archiving_maximum_rows_subtable_actions'] = 50000;
+            $config->General['archiving_ranking_query_row_limit'] = 100000;
+
+            $archive = Archive::build($idSite, 'day', '2026-02-10');
+            $flatUrls = $archive->getDataTable(Archiver::PAGE_URLS_FLAT_RECORD_NAME);
+            $hierarchicalUrls = $archive->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        $flatExport = $this->exportFlatTableValues($flatUrls);
+        $hierarchicalExport = $this->exportHierarchyTableValues($hierarchicalUrls);
+
+        $this->assertCount(1, $flatExport['rows']);
+        $this->assertArrayHasKey('/shared/path', $flatExport['rows']);
+        $flatUrlRow = $flatUrls->getRowFromLabel('/shared/path');
+        $this->assertNotFalse($flatUrlRow);
+        $this->assertNotFalse($flatUrlRow->getMetadata('url'));
+        $this->assertCount(1, $hierarchicalExport['rows']);
+        $hierarchicalRows = array_values($hierarchicalExport['rows']);
+        $this->assertCount(1, $hierarchicalRows);
+        $this->assertSame(2, $hierarchicalRows[0][Metrics::INDEX_PAGE_NB_HITS]);
+    }
+
     protected static function configureFixture($fixture)
     {
         parent::configureFixture($fixture);

--- a/plugins/Actions/tests/System/MixedArchivingAggregationTest.php
+++ b/plugins/Actions/tests/System/MixedArchivingAggregationTest.php
@@ -16,6 +16,7 @@ use Piwik\DataTable;
 use Piwik\Db;
 use Piwik\Metrics;
 use Piwik\Plugins\Actions\Archiver;
+use Piwik\Plugins\Actions\ArchivingHelper;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -104,6 +105,66 @@ class MixedArchivingAggregationTest extends IntegrationTestCase
         $weekHierarchicalSummary = $weekHierarchical->getRowFromId(DataTable::ID_SUMMARY_ROW);
         $this->assertNotFalse($weekHierarchicalSummary);
         $this->assertSame($weekSummaryHits, (int) $weekHierarchicalSummary->getColumn(Metrics::INDEX_PAGE_NB_HITS));
+    }
+
+    public function testWeekAggregationParityBetweenLegacyAndFlatFirst()
+    {
+        $legacySiteId = Fixture::createWebsite('2026-02-01 00:00:00');
+        $flatSiteId = Fixture::createWebsite('2026-02-01 00:00:00');
+
+        $hitsByDay = [
+            '2026-02-02' => [
+                '/shop/shoes/nike' => 5,
+                '/shop/shoes/adidas' => 3,
+                '/about' => 2,
+            ],
+            '2026-02-03' => [
+                '/shop/shoes/nike' => 4,
+                '/blog/article-1' => 3,
+                '/contact' => 1,
+            ],
+        ];
+
+        foreach ($hitsByDay as $day => $urlHits) {
+            $this->trackUrlHits($legacySiteId, $day, $urlHits);
+            $this->trackUrlHits($flatSiteId, $day, $urlHits);
+        }
+
+        $config = Config::getInstance();
+        $configKeys = [
+            'datatable_archiving_maximum_rows_actions_flat',
+            'datatable_archiving_maximum_rows_actions',
+            'datatable_archiving_maximum_rows_subtable_actions',
+            'archiving_ranking_query_row_limit',
+        ];
+        $configBackup = $this->backupGeneralConfig($configKeys);
+
+        try {
+            $config->General['datatable_archiving_maximum_rows_actions'] = 50000;
+            $config->General['datatable_archiving_maximum_rows_subtable_actions'] = 50000;
+            $config->General['archiving_ranking_query_row_limit'] = 100000;
+
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 0;
+            $legacyWeekArchive = Archive::build($legacySiteId, 'week', '2026-02-03');
+            $legacyWeekUrls = $legacyWeekArchive->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+            $legacyWeekTitles = $legacyWeekArchive->getDataTable(Archiver::PAGE_TITLES_RECORD_NAME);
+
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50000;
+            $flatWeekArchive = Archive::build($flatSiteId, 'week', '2026-02-03');
+            $flatWeekUrls = $flatWeekArchive->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+            $flatWeekTitles = $flatWeekArchive->getDataTable(Archiver::PAGE_TITLES_RECORD_NAME);
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        $this->assertSame(
+            $this->exportHierarchyTableValues($legacyWeekUrls),
+            $this->exportHierarchyTableValues($flatWeekUrls)
+        );
+        $this->assertSame(
+            $this->exportHierarchyTableValues($legacyWeekTitles),
+            $this->exportHierarchyTableValues($flatWeekTitles)
+        );
     }
 
     protected static function configureFixture($fixture)
@@ -210,5 +271,43 @@ class MixedArchivingAggregationTest extends IntegrationTestCase
         }
 
         return $sum;
+    }
+
+    private function exportHierarchyTableValues(DataTable $hierarchicalTable): array
+    {
+        $flattened = new DataTable();
+        ArchivingHelper::mergeHierarchicalActionsTableIntoFlatTable($hierarchicalTable, $flattened);
+
+        return $this->exportFlatTableValues($flattened);
+    }
+
+    private function exportFlatTableValues(DataTable $flatTable): array
+    {
+        $rows = [];
+        foreach ($flatTable->getRowsWithoutSummaryRow() as $row) {
+            $label = $row->getColumn('label');
+            if (!is_string($label)) {
+                continue;
+            }
+
+            $columns = $row->getColumns();
+            unset($columns['label']);
+            ksort($columns);
+            $rows[$label] = $columns;
+        }
+        ksort($rows);
+
+        $summaryColumns = [];
+        $summaryRow = $flatTable->getRowFromId(DataTable::ID_SUMMARY_ROW);
+        if ($summaryRow !== false) {
+            $summaryColumns = $summaryRow->getColumns();
+            unset($summaryColumns['label']);
+            ksort($summaryColumns);
+        }
+
+        return [
+            'rows' => $rows,
+            'summary' => $summaryColumns,
+        ];
     }
 }

--- a/plugins/Actions/tests/Unit/ActionReportsTest.php
+++ b/plugins/Actions/tests/Unit/ActionReportsTest.php
@@ -74,7 +74,7 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
             $flatRecordName = Archiver::PAGE_URLS_FLAT_RECORD_NAME;
             $hierarchicalRecordName = Archiver::PAGE_URLS_RECORD_NAME;
 
-            $flatPeriodTable = $this->createFlatSerializedTable(['flat-a'], 4);
+            $flatPeriodTable = $this->createFlatSerializedTable('flat-a', ['flat-a'], 4);
             $hierarchicalPeriodTable = $this->createHierarchicalSerializedTable('legacy-b', 6, 2);
 
             $rowsByRecordName = [
@@ -135,11 +135,11 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
             $flatResult = DataTable::fromSerializedArray(
                 $this->getRootBlobFromInsertedRecord($insertedBlobs[$flatRecordName], $flatRecordName)
             );
-            $flatRowA = $flatResult->getRowFromLabel(json_encode(['flat-a']));
+            $flatRowA = $flatResult->getRowFromLabel('flat-a');
             $this->assertNotFalse($flatRowA);
             $this->assertSame(4, $flatRowA->getColumn('nb_hits'));
 
-            $flatRowB = $flatResult->getRowFromLabel(json_encode(['legacy-b']));
+            $flatRowB = $flatResult->getRowFromLabel('legacy-b');
             $this->assertNotFalse($flatRowB);
             $this->assertSame(6, $flatRowB->getColumn('nb_hits'));
 
@@ -308,10 +308,10 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
         };
     }
 
-    private function createFlatSerializedTable(array $actionPath, int $nbHits): string
+    private function createFlatSerializedTable(string $label, array $actionPath, int $nbHits): string
     {
         $flat = new DataTable();
-        $flatRow = new Row([Row::COLUMNS => ['label' => json_encode($actionPath), 'nb_hits' => $nbHits]]);
+        $flatRow = new Row([Row::COLUMNS => ['label' => $label, 'nb_hits' => $nbHits]]);
         $flatRow->setMetadata(ArchivingHelper::ACTION_FLAT_PATH_METADATA_NAME, $actionPath);
         $flat->addRow($flatRow);
 

--- a/plugins/Actions/tests/Unit/ActionReportsTest.php
+++ b/plugins/Actions/tests/Unit/ActionReportsTest.php
@@ -10,8 +10,10 @@
 namespace Piwik\Plugins\Actions\tests\Unit;
 
 use Piwik\ArchiveProcessor;
+use Piwik\Config;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
+use Piwik\Date;
 use Piwik\Plugins\Actions\Archiver;
 use Piwik\Plugins\Actions\ArchivingHelper;
 use Piwik\Plugins\Actions\RecordBuilders\ActionReports;
@@ -24,10 +26,7 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetRecordMetadataDoesNotIncludeFlatRecordsWhenFlatLimitIsZero()
     {
-        $previousFlatLimit = ArchivingHelper::$maximumRowsInDataTableFlat;
-        try {
-            ArchivingHelper::$maximumRowsInDataTableFlat = 0;
-
+        $this->withFlatLimit(0, function () {
             $recordBuilder = new ActionReports();
             $records = $recordBuilder->getRecordMetadata($this->createMock(ArchiveProcessor::class));
             $recordNames = array_map(function ($record) {
@@ -36,9 +35,133 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
 
             $this->assertNotContains(Archiver::PAGE_URLS_FLAT_RECORD_NAME, $recordNames);
             $this->assertNotContains(Archiver::PAGE_TITLES_FLAT_RECORD_NAME, $recordNames);
-        } finally {
-            ArchivingHelper::$maximumRowsInDataTableFlat = $previousFlatLimit;
-        }
+        });
+    }
+
+    public function testBuildForNonDayPeriodUsesLegacyPathWhenFlatArchivingDisabled()
+    {
+        $this->withFlatLimit(0, function () {
+            $params = $this->createParams(
+                [Archiver::PAGE_URLS_RECORD_NAME],
+                [],
+                ['2026-01-01']
+            );
+            $archiveProcessor = $this->getMockBuilder(ArchiveProcessor::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['getParams', 'aggregateDataTableRecords', 'aggregateNumericMetrics', 'insertNumericRecords'])
+                ->getMock();
+            $archiveProcessor->method('getParams')->willReturn($params);
+            $archiveProcessor->expects($this->never())->method('aggregateNumericMetrics');
+            $archiveProcessor->expects($this->never())->method('insertNumericRecords');
+
+            $aggregatedRecordNames = [];
+            $archiveProcessor->expects($this->once())->method('aggregateDataTableRecords')
+                ->willReturnCallback(function (...$args) use (&$aggregatedRecordNames) {
+                    $aggregatedRecordNames[] = $args[0];
+                    return [];
+                });
+
+            $recordBuilder = new ActionReports();
+            $recordBuilder->buildForNonDayPeriod($archiveProcessor);
+
+            $this->assertSame([Archiver::PAGE_URLS_RECORD_NAME], $aggregatedRecordNames);
+        });
+    }
+
+    public function testBuildForNonDayPeriodFlatFirstAggregatesMixedFlatAndHierarchicalSources()
+    {
+        $this->withFlatLimit(50000, function () {
+            $flatRecordName = Archiver::PAGE_URLS_FLAT_RECORD_NAME;
+            $hierarchicalRecordName = Archiver::PAGE_URLS_RECORD_NAME;
+
+            $flatPeriodTable = $this->createFlatSerializedTable(['flat-a'], 4);
+            $hierarchicalPeriodTable = $this->createHierarchicalSerializedTable('legacy-b', 6, 2);
+
+            $rowsByRecordName = [
+                $flatRecordName => [[
+                    'date1' => '2026-01-01',
+                    'date2' => '2026-01-01',
+                    'name' => $flatRecordName,
+                    'value' => $flatPeriodTable,
+                ]],
+                $hierarchicalRecordName => [[
+                    'date1' => '2026-01-02',
+                    'date2' => '2026-01-02',
+                    'name' => $hierarchicalRecordName,
+                    'value' => $hierarchicalPeriodTable,
+                ]],
+            ];
+
+            $recordBuilder = new class ($rowsByRecordName) extends ActionReports {
+                private $rowsByRecordName;
+
+                public function __construct(array $rowsByRecordName)
+                {
+                    $this->rowsByRecordName = $rowsByRecordName;
+                    parent::__construct();
+                }
+
+                protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable
+                {
+                    return $this->rowsByRecordName[$recordName] ?? [];
+                }
+            };
+
+            $params = $this->createParams(
+                [Archiver::PAGE_URLS_RECORD_NAME],
+                [],
+                ['2026-01-01', '2026-01-02']
+            );
+            $archiveProcessor = $this->getMockBuilder(ArchiveProcessor::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['getParams', 'insertBlobRecord', 'aggregateDataTableRecords', 'aggregateNumericMetrics', 'insertNumericRecords'])
+                ->getMock();
+            $archiveProcessor->method('getParams')->willReturn($params);
+            $archiveProcessor->expects($this->never())->method('aggregateDataTableRecords');
+            $archiveProcessor->expects($this->never())->method('aggregateNumericMetrics');
+            $archiveProcessor->expects($this->never())->method('insertNumericRecords');
+
+            $insertedBlobs = [];
+            $archiveProcessor->method('insertBlobRecord')->willReturnCallback(function ($recordName, $blobValue) use (&$insertedBlobs) {
+                $insertedBlobs[$recordName] = $blobValue;
+            });
+
+            $recordBuilder->buildForNonDayPeriod($archiveProcessor);
+
+            $this->assertArrayHasKey($flatRecordName, $insertedBlobs);
+            $this->assertArrayHasKey($hierarchicalRecordName, $insertedBlobs);
+            $this->assertArrayNotHasKey(Archiver::PAGE_TITLES_RECORD_NAME, $insertedBlobs);
+
+            $flatResult = DataTable::fromSerializedArray(
+                $this->getRootBlobFromInsertedRecord($insertedBlobs[$flatRecordName], $flatRecordName)
+            );
+            $flatRowA = $flatResult->getRowFromLabel(json_encode(['flat-a']));
+            $this->assertNotFalse($flatRowA);
+            $this->assertSame(4, $flatRowA->getColumn('nb_hits'));
+
+            $flatRowB = $flatResult->getRowFromLabel(json_encode(['legacy-b']));
+            $this->assertNotFalse($flatRowB);
+            $this->assertSame(6, $flatRowB->getColumn('nb_hits'));
+
+            $flatSummary = $flatResult->getRowFromId(DataTable::ID_SUMMARY_ROW);
+            $this->assertNotFalse($flatSummary);
+            $this->assertSame(2, $flatSummary->getColumn('nb_hits'));
+
+            $hierarchicalResult = DataTable::fromSerializedArray(
+                $this->getRootBlobFromInsertedRecord($insertedBlobs[$hierarchicalRecordName], $hierarchicalRecordName)
+            );
+            $hierarchicalRowA = $hierarchicalResult->getRowFromLabel('flat-a');
+            $this->assertNotFalse($hierarchicalRowA);
+            $this->assertSame(4, $hierarchicalRowA->getColumn('nb_hits'));
+
+            $hierarchicalRowB = $hierarchicalResult->getRowFromLabel('legacy-b');
+            $this->assertNotFalse($hierarchicalRowB);
+            $this->assertSame(6, $hierarchicalRowB->getColumn('nb_hits'));
+
+            $hierarchicalSummary = $hierarchicalResult->getRowFromId(DataTable::ID_SUMMARY_ROW);
+            $this->assertNotFalse($hierarchicalSummary);
+            $this->assertSame(2, $hierarchicalSummary->getColumn('nb_hits'));
+        });
     }
 
     public function testMergeHierarchicalActionsTableIntoFlatTableMovesNestedOthersToGlobalOthers()
@@ -72,5 +195,158 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
         $rebuiltSummary = $rebuilt->getRowFromId(DataTable::ID_SUMMARY_ROW);
         $this->assertNotFalse($rebuiltSummary);
         $this->assertSame(12, $rebuiltSummary->getColumn('nb_hits'));
+    }
+
+    private function withFlatLimit(int $flatLimit, callable $callback): void
+    {
+        $config = Config::getInstance();
+        $hadPreviousFlatLimit = array_key_exists('datatable_archiving_maximum_rows_actions_flat', $config->General);
+        $previousFlatLimit = $hadPreviousFlatLimit ? $config->General['datatable_archiving_maximum_rows_actions_flat'] : null;
+
+        $config->General['datatable_archiving_maximum_rows_actions_flat'] = $flatLimit;
+        ArchivingHelper::reloadConfig();
+
+        try {
+            $callback();
+        } finally {
+            if ($hadPreviousFlatLimit) {
+                $config->General['datatable_archiving_maximum_rows_actions_flat'] = $previousFlatLimit;
+            } else {
+                unset($config->General['datatable_archiving_maximum_rows_actions_flat']);
+            }
+            ArchivingHelper::reloadConfig();
+        }
+    }
+
+    private function createParams(array $requestedReports, array $foundRequestedReports, array $dates): object
+    {
+        $subperiods = array_map(function ($date) {
+            return new class ($date) {
+                private $date;
+
+                public function __construct(string $date)
+                {
+                    $this->date = $date;
+                }
+
+                public function getDateStart(): Date
+                {
+                    return Date::factory($this->date);
+                }
+
+                public function getDateEnd(): Date
+                {
+                    return Date::factory($this->date);
+                }
+            };
+        }, $dates);
+
+        $period = new class ($subperiods) {
+            private $subperiods;
+
+            public function __construct(array $subperiods)
+            {
+                $this->subperiods = $subperiods;
+            }
+
+            public function getSubperiods(): array
+            {
+                return $this->subperiods;
+            }
+        };
+
+        $site = new class {
+            public function getId(): int
+            {
+                return 1;
+            }
+
+            public function getMainUrl(): string
+            {
+                return 'https://example.test/';
+            }
+        };
+
+        return new class ($requestedReports, $foundRequestedReports, $period, $site) {
+            private $requestedReports;
+            private $foundRequestedReports;
+            private $period;
+            private $site;
+
+            public function __construct(array $requestedReports, array $foundRequestedReports, object $period, object $site)
+            {
+                $this->requestedReports = $requestedReports;
+                $this->foundRequestedReports = $foundRequestedReports;
+                $this->period = $period;
+                $this->site = $site;
+            }
+
+            public function getArchiveOnlyReportAsArray(): array
+            {
+                return $this->requestedReports;
+            }
+
+            public function getFoundRequestedReports(): array
+            {
+                return $this->foundRequestedReports;
+            }
+
+            public function getPeriod(): object
+            {
+                return $this->period;
+            }
+
+            public function getSite(): object
+            {
+                return $this->site;
+            }
+
+            public function getSegment()
+            {
+                return null;
+            }
+        };
+    }
+
+    private function createFlatSerializedTable(array $actionPath, int $nbHits): string
+    {
+        $flat = new DataTable();
+        $flatRow = new Row([Row::COLUMNS => ['label' => json_encode($actionPath), 'nb_hits' => $nbHits]]);
+        $flatRow->setMetadata(ArchivingHelper::ACTION_FLAT_PATH_METADATA_NAME, $actionPath);
+        $flat->addRow($flatRow);
+
+        return $this->getRootSerializedBlob($flat);
+    }
+
+    private function createHierarchicalSerializedTable(string $label, int $nbHits, int $summaryHits): string
+    {
+        $table = new DataTable();
+        $table->addRow(new Row([Row::COLUMNS => ['label' => $label, 'nb_hits' => $nbHits]]));
+        $table->addSummaryRow(new Row([Row::COLUMNS => ['label' => DataTable::LABEL_SUMMARY_ROW, 'nb_hits' => $summaryHits]]));
+
+        return $this->getRootSerializedBlob($table);
+    }
+
+    private function getRootSerializedBlob(DataTable $table): string
+    {
+        $serialized = $table->getSerialized(null, null, null);
+        if (!is_array($serialized)) {
+            return $serialized;
+        }
+
+        return (string) reset($serialized);
+    }
+
+    private function getRootBlobFromInsertedRecord($blobValue, string $recordName): string
+    {
+        if (!is_array($blobValue)) {
+            return $blobValue;
+        }
+
+        if (!empty($blobValue[$recordName])) {
+            return $blobValue[$recordName];
+        }
+
+        return (string) reset($blobValue);
     }
 }

--- a/plugins/Actions/tests/Unit/ActionReportsTest.php
+++ b/plugins/Actions/tests/Unit/ActionReportsTest.php
@@ -17,6 +17,8 @@ use Piwik\Date;
 use Piwik\Plugins\Actions\Archiver;
 use Piwik\Plugins\Actions\ArchivingHelper;
 use Piwik\Plugins\Actions\RecordBuilders\ActionReports;
+use Piwik\Tracker\Action;
+use Piwik\Tracker\PageUrl;
 
 /**
  * @group Actions
@@ -74,8 +76,8 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
             $flatRecordName = Archiver::PAGE_URLS_FLAT_RECORD_NAME;
             $hierarchicalRecordName = Archiver::PAGE_URLS_RECORD_NAME;
 
-            $flatPeriodTable = $this->createFlatSerializedTable('flat-a', ['flat-a'], 4);
-            $hierarchicalPeriodTable = $this->createHierarchicalSerializedTable('legacy-b', 6, 2);
+            $flatPeriodTable = $this->createFlatSerializedTable('/flat-a', ['/flat-a'], 4);
+            $hierarchicalPeriodTable = $this->createHierarchicalSerializedTable('/legacy-b', 6, 2);
 
             $rowsByRecordName = [
                 $flatRecordName => [[
@@ -135,11 +137,11 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
             $flatResult = DataTable::fromSerializedArray(
                 $this->getRootBlobFromInsertedRecord($insertedBlobs[$flatRecordName], $flatRecordName)
             );
-            $flatRowA = $flatResult->getRowFromLabel('flat-a');
+            $flatRowA = $flatResult->getRowFromLabel('/flat-a');
             $this->assertNotFalse($flatRowA);
             $this->assertSame(4, $flatRowA->getColumn('nb_hits'));
 
-            $flatRowB = $flatResult->getRowFromLabel('legacy-b');
+            $flatRowB = $flatResult->getRowFromLabel('/legacy-b');
             $this->assertNotFalse($flatRowB);
             $this->assertSame(6, $flatRowB->getColumn('nb_hits'));
 
@@ -150,11 +152,11 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
             $hierarchicalResult = DataTable::fromSerializedArray(
                 $this->getRootBlobFromInsertedRecord($insertedBlobs[$hierarchicalRecordName], $hierarchicalRecordName)
             );
-            $hierarchicalRowA = $hierarchicalResult->getRowFromLabel('flat-a');
+            $hierarchicalRowA = $hierarchicalResult->getRowFromLabel('/flat-a');
             $this->assertNotFalse($hierarchicalRowA);
             $this->assertSame(4, $hierarchicalRowA->getColumn('nb_hits'));
 
-            $hierarchicalRowB = $hierarchicalResult->getRowFromLabel('legacy-b');
+            $hierarchicalRowB = $hierarchicalResult->getRowFromLabel('/legacy-b');
             $this->assertNotFalse($hierarchicalRowB);
             $this->assertSame(6, $hierarchicalRowB->getColumn('nb_hits'));
 
@@ -170,8 +172,8 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
             $flatRecordName = Archiver::PAGE_URLS_FLAT_RECORD_NAME;
             $hierarchicalRecordName = Archiver::PAGE_URLS_RECORD_NAME;
 
-            $flatPeriodTable = $this->createFlatSerializedTable('flat-a', ['flat-a'], 4);
-            $hierarchicalPeriodTable = $this->createHierarchicalSerializedTable('legacy-b', 6, 2);
+            $flatPeriodTable = $this->createFlatSerializedTable('/flat-a', ['/flat-a'], 4);
+            $hierarchicalPeriodTable = $this->createHierarchicalSerializedTable('/legacy-b', 6, 2);
 
             $rowsByRecordName = [
                 $flatRecordName => [[
@@ -230,11 +232,11 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
             $flatResult = DataTable::fromSerializedArray(
                 $this->getRootBlobFromInsertedRecord($insertedBlobs[$flatRecordName], $flatRecordName)
             );
-            $flatRowA = $flatResult->getRowFromLabel('flat-a');
+            $flatRowA = $flatResult->getRowFromLabel('/flat-a');
             $this->assertNotFalse($flatRowA);
             $this->assertSame(4, $flatRowA->getColumn('nb_hits'));
 
-            $flatRowB = $flatResult->getRowFromLabel('legacy-b');
+            $flatRowB = $flatResult->getRowFromLabel('/legacy-b');
             $this->assertNotFalse($flatRowB);
             $this->assertSame(6, $flatRowB->getColumn('nb_hits'));
 
@@ -291,6 +293,186 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(12, $rebuiltSummary->getColumn('nb_hits'));
     }
 
+    public function testPageUrlFlatRowsDeduplicateUsingNormalizedUrl()
+    {
+        $table = new DataTable();
+
+        $firstRow = $this->invokeGetFlatActionRow(
+            'EXAMPLE.org/shared/path#',
+            Action::TYPE_PAGE_URL,
+            PageUrl::$urlPrefixMap['http://'],
+            $table
+        );
+        $secondRow = $this->invokeGetFlatActionRow(
+            'example.org/shared/path',
+            Action::TYPE_PAGE_URL,
+            PageUrl::$urlPrefixMap['http://'],
+            $table
+        );
+
+        $this->assertSame($firstRow, $secondRow);
+        $this->assertSame('/shared/path', $firstRow->getColumn('label'));
+        $this->assertSame(1, $table->getRowsCount());
+        $this->assertFalse($firstRow->getMetadata(ArchivingHelper::ACTION_FLAT_PATH_METADATA_NAME));
+    }
+
+    public function testPageUrlFlatRowsUseUrlPrefixToBuildCanonicalPathLabel()
+    {
+        $table = new DataTable();
+
+        $row = $this->invokeGetFlatActionRow(
+            'example.org/page',
+            Action::TYPE_PAGE_URL,
+            PageUrl::$urlPrefixMap['http://www.'],
+            $table
+        );
+
+        $this->assertSame('/page', $row->getColumn('label'));
+        $this->assertSame(1, $table->getRowsCount());
+    }
+
+    public function testPageUrlFlatRowsTreatStringActionTypeAsPageUrl()
+    {
+        $table = new DataTable();
+
+        $row = $this->invokeGetFlatActionRow(
+            'example.org/page',
+            '1',
+            PageUrl::$urlPrefixMap['http://www.'],
+            $table
+        );
+
+        $this->assertSame('/page', $row->getColumn('label'));
+        $this->assertSame(1, $table->getRowsCount());
+    }
+
+    public function testMergingFlatRowsUsesLastUrlMetadata()
+    {
+        $destination = new Row([
+            Row::COLUMNS => ['label' => '/page', 'nb_hits' => 1],
+        ]);
+        $destination->setMetadata('url', 'http://example.org/first');
+
+        $source = new Row([
+            Row::COLUMNS => ['label' => '/page', 'nb_hits' => 1],
+        ]);
+        $source->setMetadata('url', 'http://example.org/last');
+
+        $method = new \ReflectionMethod(ArchivingHelper::class, 'mergeRowIntoDestination');
+        $method->setAccessible(true);
+        $method->invoke(null, $source, $destination);
+
+        $this->assertSame('http://example.org/last', $destination->getMetadata('url'));
+    }
+
+    public function testUnknownPageUrlFlatLabelRebuildsWithoutLeadingSlash()
+    {
+        $flatRow = new Row([
+            Row::COLUMNS => [
+                'label' => ArchivingHelper::getUnknownActionName(Action::TYPE_PAGE_URL),
+                'nb_hits' => 1,
+            ],
+        ]);
+
+        $recordBuilder = new ActionReports();
+        $method = new \ReflectionMethod(ActionReports::class, 'flatRowToHierarchyPath');
+        $method->setAccessible(true);
+        $path = $method->invoke($recordBuilder, $flatRow, Action::TYPE_PAGE_URL);
+
+        $this->assertSame([ArchivingHelper::getUnknownActionName(Action::TYPE_PAGE_URL)], $path);
+    }
+
+    public function testPageUrlFlatLabelRebuildPreservesTrailingIndexAtLevelLimit()
+    {
+        $this->withActionCategoryLevelLimit(10, function () {
+            $flatRow = new Row([
+                Row::COLUMNS => [
+                    'label' => '/this/is/not/the/page/i/am/looking/for/index',
+                    'nb_hits' => 1,
+                ],
+            ]);
+
+            $recordBuilder = new ActionReports();
+            $method = new \ReflectionMethod(ActionReports::class, 'flatRowToHierarchyPath');
+            $method->setAccessible(true);
+            $path = $method->invoke($recordBuilder, $flatRow, Action::TYPE_PAGE_URL);
+
+            $this->assertSame(
+                ['this', 'is', 'not', 'the', 'page', 'i', 'am', 'looking', 'for', '/index'],
+                $path
+            );
+        });
+    }
+
+    public function testHierarchyBuiltFromCanonicalFlatUrlLabelMatchesFlatRowCount()
+    {
+        $flat = new DataTable();
+
+        $firstRow = new Row([Row::COLUMNS => ['label' => '/shared/path', 'nb_hits' => 4]]);
+        $flat->addRow($firstRow);
+
+        $recordBuilder = new class extends ActionReports {
+            public function buildUrlHierarchyFromFlatForTest(DataTable $flat): DataTable
+            {
+                return $this->buildHierarchicalTableFromFlatTable(
+                    $flat,
+                    null,
+                    [$this, 'flatRowToUrlHierarchyPath']
+                );
+            }
+        };
+
+        $rebuilt = $recordBuilder->buildUrlHierarchyFromFlatForTest($flat);
+
+        $this->assertSame(1, $flat->getRowsCount());
+        $this->assertSame(1, $rebuilt->getRowsCount());
+
+        $parentRow = $rebuilt->getRows()[0] ?? null;
+        $this->assertInstanceOf(Row::class, $parentRow);
+        $this->assertSame('shared', $parentRow->getColumn('label'));
+
+        $leafTable = $parentRow->getSubtable();
+        $this->assertInstanceOf(DataTable::class, $leafTable);
+
+        $leafRow = $leafTable->getRows()[0] ?? null;
+        $this->assertInstanceOf(Row::class, $leafRow);
+        $this->assertSame('/path', $leafRow->getColumn('label'));
+        $this->assertSame(4, $leafRow->getColumn('nb_hits'));
+    }
+
+    public function testPageTitleFlatLabelCanBeRebuiltIntoTheSameHierarchy()
+    {
+        $this->withTitleDelimiter(' / ', function () {
+            $flat = new DataTable();
+            $flat->addRow(new Row([Row::COLUMNS => ['label' => 'Parent / Child', 'nb_hits' => 3]]));
+
+            $recordBuilder = new class extends ActionReports {
+                public function buildTitleHierarchyFromFlatForTest(DataTable $flat): DataTable
+                {
+                    return $this->buildHierarchicalTableFromFlatTable(
+                        $flat,
+                        null,
+                        [$this, 'flatRowToTitleHierarchyPath']
+                    );
+                }
+            };
+
+            $rebuilt = $recordBuilder->buildTitleHierarchyFromFlatForTest($flat);
+
+            $parentRow = $rebuilt->getRows()[0] ?? null;
+            $this->assertInstanceOf(Row::class, $parentRow);
+            $this->assertSame('Parent', $parentRow->getColumn('label'));
+
+            $leafTable = $parentRow->getSubtable();
+            $this->assertInstanceOf(DataTable::class, $leafTable);
+
+            $leafRow = $leafTable->getRows()[0] ?? null;
+            $this->assertInstanceOf(Row::class, $leafRow);
+            $this->assertSame(' Child', $leafRow->getColumn('label'));
+            $this->assertSame(3, $leafRow->getColumn('nb_hits'));
+        });
+    }
+
     private function withFlatLimit(int $flatLimit, callable $callback): void
     {
         $config = Config::getInstance();
@@ -307,6 +489,48 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
                 $config->General['datatable_archiving_maximum_rows_actions_flat'] = $previousFlatLimit;
             } else {
                 unset($config->General['datatable_archiving_maximum_rows_actions_flat']);
+            }
+            ArchivingHelper::reloadConfig();
+        }
+    }
+
+    private function withTitleDelimiter(string $titleDelimiter, callable $callback): void
+    {
+        $config = Config::getInstance();
+        $hadPreviousDelimiter = array_key_exists('action_title_category_delimiter', $config->General);
+        $previousDelimiter = $hadPreviousDelimiter ? $config->General['action_title_category_delimiter'] : null;
+
+        $config->General['action_title_category_delimiter'] = $titleDelimiter;
+        ArchivingHelper::reloadConfig();
+
+        try {
+            $callback();
+        } finally {
+            if ($hadPreviousDelimiter) {
+                $config->General['action_title_category_delimiter'] = $previousDelimiter;
+            } else {
+                unset($config->General['action_title_category_delimiter']);
+            }
+            ArchivingHelper::reloadConfig();
+        }
+    }
+
+    private function withActionCategoryLevelLimit(int $levelLimit, callable $callback): void
+    {
+        $config = Config::getInstance();
+        $hadPreviousLimit = array_key_exists('action_category_level_limit', $config->General);
+        $previousLimit = $hadPreviousLimit ? $config->General['action_category_level_limit'] : null;
+
+        $config->General['action_category_level_limit'] = $levelLimit;
+        ArchivingHelper::reloadConfig();
+
+        try {
+            $callback();
+        } finally {
+            if ($hadPreviousLimit) {
+                $config->General['action_category_level_limit'] = $previousLimit;
+            } else {
+                unset($config->General['action_category_level_limit']);
             }
             ArchivingHelper::reloadConfig();
         }
@@ -442,5 +666,13 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
         }
 
         return (string) reset($blobValue);
+    }
+
+    private function invokeGetFlatActionRow(string $actionName, int $actionType, int $urlPrefix, DataTable $table): Row
+    {
+        $reflection = new \ReflectionMethod(ArchivingHelper::class, 'getFlatActionRow');
+        $reflection->setAccessible(true);
+
+        return $reflection->invoke(null, $actionName, $actionType, $urlPrefix, $table);
     }
 }

--- a/plugins/Actions/tests/Unit/ActionReportsTest.php
+++ b/plugins/Actions/tests/Unit/ActionReportsTest.php
@@ -191,7 +191,21 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
         $this->assertNotFalse($flatRowB);
         $this->assertSame(2, $flatRowB->getColumn('nb_hits'));
 
-        $rebuilt = ArchivingHelper::buildHierarchicalActionsTableFromFlatTable($flat);
+        $recordBuilder = new class extends ActionReports {
+            public function buildHierarchyFromFlatForTest(DataTable $flat): DataTable
+            {
+                return $this->buildHierarchicalTableFromFlatTable(
+                    $flat,
+                    null,
+                    function (Row $flatRow) {
+                        $path = $flatRow->getMetadata(ArchivingHelper::ACTION_FLAT_PATH_METADATA_NAME);
+                        return is_array($path) && !empty($path) ? $path : null;
+                    }
+                );
+            }
+        };
+
+        $rebuilt = $recordBuilder->buildHierarchyFromFlatForTest($flat);
         $rebuiltSummary = $rebuilt->getRowFromId(DataTable::ID_SUMMARY_ROW);
         $this->assertNotFalse($rebuiltSummary);
         $this->assertSame(12, $rebuiltSummary->getColumn('nb_hits'));

--- a/plugins/Actions/tests/Unit/ActionReportsTest.php
+++ b/plugins/Actions/tests/Unit/ActionReportsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Actions\tests\Unit;
+
+use Piwik\ArchiveProcessor;
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+use Piwik\Plugins\Actions\Archiver;
+use Piwik\Plugins\Actions\ArchivingHelper;
+use Piwik\Plugins\Actions\RecordBuilders\ActionReports;
+
+/**
+ * @group Actions
+ * @group Plugins
+ */
+class ActionReportsTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetRecordMetadataDoesNotIncludeFlatRecordsWhenFlatLimitIsZero()
+    {
+        $previousFlatLimit = ArchivingHelper::$maximumRowsInDataTableFlat;
+        try {
+            ArchivingHelper::$maximumRowsInDataTableFlat = 0;
+
+            $recordBuilder = new ActionReports();
+            $records = $recordBuilder->getRecordMetadata($this->createMock(ArchiveProcessor::class));
+            $recordNames = array_map(function ($record) {
+                return $record->getName();
+            }, $records);
+
+            $this->assertNotContains(Archiver::PAGE_URLS_FLAT_RECORD_NAME, $recordNames);
+            $this->assertNotContains(Archiver::PAGE_TITLES_FLAT_RECORD_NAME, $recordNames);
+        } finally {
+            ArchivingHelper::$maximumRowsInDataTableFlat = $previousFlatLimit;
+        }
+    }
+
+    public function testMergeHierarchicalActionsTableIntoFlatTableMovesNestedOthersToGlobalOthers()
+    {
+        $hierarchical = new DataTable();
+        $rootA = $hierarchical->addRow(new Row([Row::COLUMNS => ['label' => 'a', 'nb_hits' => 8]]));
+        $rootB = $hierarchical->addRow(new Row([Row::COLUMNS => ['label' => 'b', 'nb_hits' => 2]]));
+        $hierarchical->addSummaryRow(new Row([Row::COLUMNS => ['label' => DataTable::LABEL_SUMMARY_ROW, 'nb_hits' => 7]]));
+
+        $subtableA = new DataTable();
+        $subtableA->addRow(new Row([Row::COLUMNS => ['label' => '/x', 'nb_hits' => 3]]));
+        $subtableA->addSummaryRow(new Row([Row::COLUMNS => ['label' => DataTable::LABEL_SUMMARY_ROW, 'nb_hits' => 5]]));
+        $rootA->setSubtable($subtableA);
+
+        $flat = new DataTable();
+        ArchivingHelper::mergeHierarchicalActionsTableIntoFlatTable($hierarchical, $flat);
+
+        $flatSummary = $flat->getRowFromId(DataTable::ID_SUMMARY_ROW);
+        $this->assertNotFalse($flatSummary);
+        $this->assertSame(12, $flatSummary->getColumn('nb_hits'));
+
+        $flatRowA = $flat->getRowFromLabel(json_encode(['a', '/x']));
+        $this->assertNotFalse($flatRowA);
+        $this->assertSame(3, $flatRowA->getColumn('nb_hits'));
+
+        $flatRowB = $flat->getRowFromLabel(json_encode(['b']));
+        $this->assertNotFalse($flatRowB);
+        $this->assertSame(2, $flatRowB->getColumn('nb_hits'));
+
+        $rebuilt = ArchivingHelper::buildHierarchicalActionsTableFromFlatTable($flat);
+        $rebuiltSummary = $rebuilt->getRowFromId(DataTable::ID_SUMMARY_ROW);
+        $this->assertNotFalse($rebuiltSummary);
+        $this->assertSame(12, $rebuiltSummary->getColumn('nb_hits'));
+    }
+}

--- a/plugins/Actions/tests/Unit/ActionReportsTest.php
+++ b/plugins/Actions/tests/Unit/ActionReportsTest.php
@@ -164,6 +164,86 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
         });
     }
 
+    public function testBuildForNonDayPeriodFlatFirstAggregatesMixedSourcesWhenOnlyFlatRecordIsRequested()
+    {
+        $this->withFlatLimit(50000, function () {
+            $flatRecordName = Archiver::PAGE_URLS_FLAT_RECORD_NAME;
+            $hierarchicalRecordName = Archiver::PAGE_URLS_RECORD_NAME;
+
+            $flatPeriodTable = $this->createFlatSerializedTable('flat-a', ['flat-a'], 4);
+            $hierarchicalPeriodTable = $this->createHierarchicalSerializedTable('legacy-b', 6, 2);
+
+            $rowsByRecordName = [
+                $flatRecordName => [[
+                    'date1' => '2026-01-01',
+                    'date2' => '2026-01-01',
+                    'name' => $flatRecordName,
+                    'value' => $flatPeriodTable,
+                ]],
+                $hierarchicalRecordName => [[
+                    'date1' => '2026-01-02',
+                    'date2' => '2026-01-02',
+                    'name' => $hierarchicalRecordName,
+                    'value' => $hierarchicalPeriodTable,
+                ]],
+            ];
+
+            $recordBuilder = new class ($rowsByRecordName) extends ActionReports {
+                private $rowsByRecordName;
+
+                public function __construct(array $rowsByRecordName)
+                {
+                    $this->rowsByRecordName = $rowsByRecordName;
+                    parent::__construct();
+                }
+
+                protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable
+                {
+                    return $this->rowsByRecordName[$recordName] ?? [];
+                }
+            };
+
+            $params = $this->createParams(
+                [Archiver::PAGE_URLS_FLAT_RECORD_NAME],
+                [Archiver::PAGE_URLS_RECORD_NAME],
+                ['2026-01-01', '2026-01-02']
+            );
+            $archiveProcessor = $this->getMockBuilder(ArchiveProcessor::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['getParams', 'insertBlobRecord', 'aggregateDataTableRecords', 'aggregateNumericMetrics', 'insertNumericRecords'])
+                ->getMock();
+            $archiveProcessor->method('getParams')->willReturn($params);
+            $archiveProcessor->expects($this->never())->method('aggregateDataTableRecords');
+            $archiveProcessor->expects($this->never())->method('aggregateNumericMetrics');
+            $archiveProcessor->expects($this->never())->method('insertNumericRecords');
+
+            $insertedBlobs = [];
+            $archiveProcessor->method('insertBlobRecord')->willReturnCallback(function ($recordName, $blobValue) use (&$insertedBlobs) {
+                $insertedBlobs[$recordName] = $blobValue;
+            });
+
+            $recordBuilder->buildForNonDayPeriod($archiveProcessor);
+
+            $this->assertArrayHasKey($flatRecordName, $insertedBlobs);
+            $this->assertArrayHasKey($hierarchicalRecordName, $insertedBlobs);
+
+            $flatResult = DataTable::fromSerializedArray(
+                $this->getRootBlobFromInsertedRecord($insertedBlobs[$flatRecordName], $flatRecordName)
+            );
+            $flatRowA = $flatResult->getRowFromLabel('flat-a');
+            $this->assertNotFalse($flatRowA);
+            $this->assertSame(4, $flatRowA->getColumn('nb_hits'));
+
+            $flatRowB = $flatResult->getRowFromLabel('legacy-b');
+            $this->assertNotFalse($flatRowB);
+            $this->assertSame(6, $flatRowB->getColumn('nb_hits'));
+
+            $flatSummary = $flatResult->getRowFromId(DataTable::ID_SUMMARY_ROW);
+            $this->assertNotFalse($flatSummary);
+            $this->assertSame(2, $flatSummary->getColumn('nb_hits'));
+        });
+    }
+
     public function testMergeHierarchicalActionsTableIntoFlatTableMovesNestedOthersToGlobalOthers()
     {
         $hierarchical = new DataTable();

--- a/tests/PHPUnit/System/BlobReportLimitingTest.php
+++ b/tests/PHPUnit/System/BlobReportLimitingTest.php
@@ -308,7 +308,6 @@ class BlobReportLimitingTest extends SystemTestCase
             $params['testSuffix'] = '';
         }
         $params['testSuffix'] .= '_flatFirst';
-        $params['xmlFieldsToRemove'] = ['url', 'segment'];
 
         $this->runApiTests($api, $params);
     }
@@ -325,7 +324,6 @@ class BlobReportLimitingTest extends SystemTestCase
             $params['testSuffix'] = '';
         }
         $params['testSuffix'] .= '_flatFirst_flattened';
-        $params['xmlFieldsToRemove'] = ['url', 'segment'];
 
         // keep flattened assertions focused on day archives
         $params['periods'] = ['day'];
@@ -353,7 +351,6 @@ class BlobReportLimitingTest extends SystemTestCase
                 $params['testSuffix'] = '';
             }
             $params['testSuffix'] .= '_flatFirst_rankingQuery';
-            $params['xmlFieldsToRemove'] = ['url', 'segment'];
 
             $this->runApiTests($apiToCall, $params);
         }

--- a/tests/PHPUnit/System/BlobReportLimitingTest.php
+++ b/tests/PHPUnit/System/BlobReportLimitingTest.php
@@ -103,8 +103,11 @@ class BlobReportLimitingTest extends SystemTestCase
                         'idDimension' => self::$fixture->actionCustomDimensionId,
                     ],
                     'testSuffix'             => "dimension_" . self::$fixture->actionCustomDimensionId,
-                    // ranking query doesn't guarantee order if the main metric values are the same so the label/segment can randomly change.
-                    // in this test, we only care to check that the result is being limited/aggregated correctly, so we can remove these
+                    // ranking query doesn't guarantee order if the main metric
+                    // values are the same so the label/segment can randomly
+                    // change. in this test, we only care to check that the
+                    // result is being limited/aggregated correctly, so we can
+                    // remove these
                     // when comparing.
                     'xmlFieldsToRemove'      => [
                         'label',
@@ -184,6 +187,28 @@ class BlobReportLimitingTest extends SystemTestCase
         ];
     }
 
+    public function getActionsApiForFlatFirstTesting()
+    {
+        return [
+            [
+                'Actions.getPageUrls',
+                [
+                    'idSite'  => self::$fixture->idSite,
+                    'date'    => self::$fixture->dateTime,
+                    'periods' => ['day', 'month'],
+                ],
+            ],
+            [
+                'Actions.getPageTitles',
+                [
+                    'idSite'  => self::$fixture->idSite,
+                    'date'    => self::$fixture->dateTime,
+                    'periods' => ['day', 'month'],
+                ],
+            ],
+        ];
+    }
+
     /**
      * @dataProvider getApiForTesting
      */
@@ -192,7 +217,11 @@ class BlobReportLimitingTest extends SystemTestCase
         self::setUpConfigOptions();
 
         // also perform some tests for month period, to ensure limiting of aggregated archives is correct
-        if (empty($params['testSuffix']) && $params['periods'] === 'day' && $params['date'] === self::$fixture->dateTime) {
+        if (
+            empty($params['testSuffix'])
+            && $params['periods'] === 'day'
+            && $params['date'] === self::$fixture->dateTime
+        ) {
             $params['periods'] = ['day', 'month'];
         }
 
@@ -247,6 +276,7 @@ class BlobReportLimitingTest extends SystemTestCase
         $generalConfig['datatable_archiving_maximum_rows_subtable_referrers']         = 500;
         $generalConfig['datatable_archiving_maximum_rows_actions']                    = 500;
         $generalConfig['datatable_archiving_maximum_rows_subtable_actions']           = 500;
+        $generalConfig['datatable_archiving_maximum_rows_actions_flat']               = 0;
         $generalConfig['datatable_archiving_maximum_rows_standard']                   = 500;
         $generalConfig['datatable_archiving_maximum_rows_custom_dimensions']          = 500;
         $generalConfig['datatable_archiving_maximum_rows_subtable_custom_dimensions'] = 500;
@@ -266,6 +296,69 @@ class BlobReportLimitingTest extends SystemTestCase
         }
     }
 
+    /**
+     * @dataProvider getActionsApiForFlatFirstTesting
+     */
+    public function testActionsApiWithFlatFirst($api, $params)
+    {
+        self::setUpConfigOptionsFlatFirst();
+        self::deleteArchiveTables();
+
+        if (empty($params['testSuffix'])) {
+            $params['testSuffix'] = '';
+        }
+        $params['testSuffix'] .= '_flatFirst';
+        $params['xmlFieldsToRemove'] = ['url', 'segment'];
+
+        $this->runApiTests($api, $params);
+    }
+
+    /**
+     * @dataProvider getActionsApiForFlatFirstTesting
+     */
+    public function testActionsApiWithFlatFirstFlattening($api, $params)
+    {
+        self::setUpConfigOptionsFlatFirst();
+        self::deleteArchiveTables();
+
+        if (empty($params['testSuffix'])) {
+            $params['testSuffix'] = '';
+        }
+        $params['testSuffix'] .= '_flatFirst_flattened';
+        $params['xmlFieldsToRemove'] = ['url', 'segment'];
+
+        // keep flattened assertions focused on day archives
+        $params['periods'] = ['day'];
+        if (empty($params['otherRequestParameters'])) {
+            $params['otherRequestParameters'] = [];
+        }
+        $params['otherRequestParameters']['flat'] = '1';
+
+        $this->runApiTests($api, $params);
+    }
+
+    public function testActionsApiWithFlatFirstRankingQuery()
+    {
+        self::setUpConfigOptionsFlatFirst();
+
+        self::deleteArchiveTables();
+        Config::getInstance()->General['archiving_ranking_query_row_limit'] = 3;
+        ArchivingHelper::reloadConfig();
+
+        foreach ($this->getActionsApiForFlatFirstTesting() as $pair) {
+            [$apiToCall, $params] = $pair;
+
+            $params['periods'] = ['day'];
+            if (empty($params['testSuffix'])) {
+                $params['testSuffix'] = '';
+            }
+            $params['testSuffix'] .= '_flatFirst_rankingQuery';
+            $params['xmlFieldsToRemove'] = ['url', 'segment'];
+
+            $this->runApiTests($apiToCall, $params);
+        }
+    }
+
     public static function getOutputPrefix()
     {
         return 'reportLimiting';
@@ -280,6 +373,7 @@ class BlobReportLimitingTest extends SystemTestCase
         $generalConfig['datatable_archiving_maximum_rows_custom_dimensions']          = 3;
         $generalConfig['datatable_archiving_maximum_rows_subtable_custom_dimensions'] = 2;
         $generalConfig['datatable_archiving_maximum_rows_subtable_actions']           = 2;
+        $generalConfig['datatable_archiving_maximum_rows_actions_flat']               = 0;
         $generalConfig['datatable_archiving_maximum_rows_standard']                   = 3;
         $generalConfig['datatable_archiving_maximum_rows_userid_users']               = 3;
         $generalConfig['datatable_archiving_maximum_rows_events']                     = 3;
@@ -287,6 +381,12 @@ class BlobReportLimitingTest extends SystemTestCase
         $generalConfig['archiving_ranking_query_row_limit']                           = 50000;
         // Should be more than the datatable_archiving_maximum_rows_actions as code will take the max of these two
         $generalConfig['datatable_archiving_maximum_rows_site_search'] = 5;
+    }
+
+    protected static function setUpConfigOptionsFlatFirst()
+    {
+        self::setUpConfigOptions();
+        Config::getInstance()->General['datatable_archiving_maximum_rows_actions_flat'] = 4;
     }
 }
 

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageTitles_day.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label> title_8 / title_32</label>
+		<nb_visits>8</nb_visits>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		<segment>pageTitle==title_8%2B%252F%2Btitle_32</segment>
+	</row>
+	<row>
+		<label> title_8 / title_33</label>
+		<nb_visits>8</nb_visits>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		<segment>pageTitle==title_8%2B%252F%2Btitle_33</segment>
+	</row>
+	<row>
+		<label> title_8 / title_34</label>
+		<nb_visits>8</nb_visits>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_uniq_visitors>1</entry_nb_uniq_visitors>
+		<entry_nb_visits>1</entry_nb_visits>
+		<entry_nb_actions>2</entry_nb_actions>
+		<entry_sum_visit_length>1</entry_sum_visit_length>
+		<entry_bounce_count>0</entry_bounce_count>
+		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		<segment>pageTitle==title_8%2B%252F%2Btitle_34</segment>
+	</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageTitles_day.xml
@@ -62,4 +62,24 @@
 		<exit_rate>13%</exit_rate>
 		<segment>pageTitle==title_8%2B%252F%2Btitle_34</segment>
 	</row>
+	<row>
+		<label>Others</label>
+		<nb_visits>145</nb_visits>
+		<nb_hits>145</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>42</entry_nb_visits>
+		<entry_nb_actions>167</entry_nb_actions>
+		<entry_sum_visit_length>15</entry_sum_visit_length>
+		<entry_bounce_count>27</entry_bounce_count>
+		<exit_nb_visits>40</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>64%</bounce_rate>
+		<exit_rate>28%</exit_rate>
+	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageTitles_month.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label> bought book</label>
+		<nb_visits>25</nb_visits>
+		<nb_hits>25</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>25</entry_nb_visits>
+		<entry_nb_actions>25</entry_nb_actions>
+		<entry_sum_visit_length>0</entry_sum_visit_length>
+		<entry_bounce_count>25</entry_bounce_count>
+		<exit_nb_visits>25</exit_nb_visits>
+		<sum_daily_nb_uniq_visitors>25</sum_daily_nb_uniq_visitors>
+		<sum_daily_entry_nb_uniq_visitors>25</sum_daily_entry_nb_uniq_visitors>
+		<sum_daily_exit_nb_uniq_visitors>25</sum_daily_exit_nb_uniq_visitors>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>100%</bounce_rate>
+		<exit_rate>100%</exit_rate>
+		<segment>pageTitle==bought%2Bbook</segment>
+	</row>
+	<row>
+		<label> title_8 / title_32</label>
+		<nb_visits>8</nb_visits>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<exit_nb_visits>1</exit_nb_visits>
+		<sum_daily_nb_uniq_visitors>8</sum_daily_nb_uniq_visitors>
+		<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		<segment>pageTitle==title_8%2B%252F%2Btitle_32</segment>
+	</row>
+	<row>
+		<label> title_8 / title_33</label>
+		<nb_visits>8</nb_visits>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<exit_nb_visits>1</exit_nb_visits>
+		<sum_daily_nb_uniq_visitors>8</sum_daily_nb_uniq_visitors>
+		<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		<segment>pageTitle==title_8%2B%252F%2Btitle_33</segment>
+	</row>
+	<row>
+		<label>Others</label>
+		<nb_visits>14</nb_visits>
+		<nb_hits>14</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>7</entry_nb_visits>
+		<entry_nb_actions>8</entry_nb_actions>
+		<entry_sum_visit_length>1</entry_sum_visit_length>
+		<entry_bounce_count>6</entry_bounce_count>
+		<exit_nb_visits>7</exit_nb_visits>
+		<sum_daily_nb_uniq_visitors>14</sum_daily_nb_uniq_visitors>
+		<sum_daily_entry_nb_uniq_visitors>7</sum_daily_entry_nb_uniq_visitors>
+		<sum_daily_exit_nb_uniq_visitors>7</sum_daily_exit_nb_uniq_visitors>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>86%</bounce_rate>
+		<exit_rate>50%</exit_rate>
+	</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageTitles_month.xml
@@ -64,25 +64,25 @@
 	</row>
 	<row>
 		<label>Others</label>
-		<nb_visits>14</nb_visits>
-		<nb_hits>14</nb_hits>
+		<nb_visits>203</nb_visits>
+		<nb_hits>203</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
 		<max_bandwidth />
-		<entry_nb_visits>7</entry_nb_visits>
-		<entry_nb_actions>8</entry_nb_actions>
-		<entry_sum_visit_length>1</entry_sum_visit_length>
-		<entry_bounce_count>6</entry_bounce_count>
-		<exit_nb_visits>7</exit_nb_visits>
+		<entry_nb_visits>93</entry_nb_visits>
+		<entry_nb_actions>219</entry_nb_actions>
+		<entry_sum_visit_length>16</entry_sum_visit_length>
+		<entry_bounce_count>77</entry_bounce_count>
+		<exit_nb_visits>91</exit_nb_visits>
 		<sum_daily_nb_uniq_visitors>14</sum_daily_nb_uniq_visitors>
 		<sum_daily_entry_nb_uniq_visitors>7</sum_daily_entry_nb_uniq_visitors>
 		<sum_daily_exit_nb_uniq_visitors>7</sum_daily_exit_nb_uniq_visitors>
 		<avg_bandwidth>0</avg_bandwidth>
 		<avg_page_load_time>0</avg_page_load_time>
 		<avg_time_on_page>0</avg_time_on_page>
-		<bounce_rate>86%</bounce_rate>
-		<exit_rate>50%</exit_rate>
+		<bounce_rate>83%</bounce_rate>
+		<exit_rate>45%</exit_rate>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageUrls_day.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>8</label>
+		<nb_visits>24</nb_visits>
+		<nb_hits>24</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<exit_nb_visits>3</exit_nb_visits>
+		<entry_nb_visits>1</entry_nb_visits>
+		<entry_nb_actions>2</entry_nb_actions>
+		<entry_sum_visit_length>1</entry_sum_visit_length>
+		<entry_bounce_count>0</entry_bounce_count>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		
+		<subtable>
+			<row>
+				<label>/32</label>
+				<nb_visits>8</nb_visits>
+				<nb_uniq_visitors>8</nb_uniq_visitors>
+				<nb_hits>8</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>13%</exit_rate>
+				
+				
+			</row>
+			<row>
+				<label>/33</label>
+				<nb_visits>8</nb_visits>
+				<nb_uniq_visitors>8</nb_uniq_visitors>
+				<nb_hits>8</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>13%</exit_rate>
+				
+				
+			</row>
+			<row>
+				<label>/34</label>
+				<nb_visits>8</nb_visits>
+				<nb_uniq_visitors>8</nb_uniq_visitors>
+				<nb_hits>8</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<entry_nb_uniq_visitors>1</entry_nb_uniq_visitors>
+				<entry_nb_visits>1</entry_nb_visits>
+				<entry_nb_actions>2</entry_nb_actions>
+				<entry_sum_visit_length>1</entry_sum_visit_length>
+				<entry_bounce_count>0</entry_bounce_count>
+				<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>13%</exit_rate>
+				
+				
+			</row>
+		</subtable>
+	</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageUrls_day.xml
@@ -19,7 +19,7 @@
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>13%</exit_rate>
-		
+		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252F8</segment>
 		<subtable>
 			<row>
 				<label>/32</label>
@@ -36,8 +36,8 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>13%</exit_rate>
-				
-				
+				<url>http://piwik.net/8/32</url>
+				<segment>pageUrl==http%253A%252F%252Fpiwik.net%252F8%252F32</segment>
 			</row>
 			<row>
 				<label>/33</label>
@@ -54,8 +54,8 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>13%</exit_rate>
-				
-				
+				<url>http://piwik.net/8/33</url>
+				<segment>pageUrl==http%253A%252F%252Fpiwik.net%252F8%252F33</segment>
 			</row>
 			<row>
 				<label>/34</label>
@@ -77,9 +77,29 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>13%</exit_rate>
-				
-				
+				<url>http://piwik.net/8/34</url>
+				<segment>pageUrl==http%253A%252F%252Fpiwik.net%252F8%252F34</segment>
 			</row>
 		</subtable>
+	</row>
+	<row>
+		<label>Others</label>
+		<nb_visits>145</nb_visits>
+		<nb_hits>145</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>42</entry_nb_visits>
+		<entry_nb_actions>167</entry_nb_actions>
+		<entry_sum_visit_length>15</entry_sum_visit_length>
+		<entry_bounce_count>27</entry_bounce_count>
+		<exit_nb_visits>40</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>64%</bounce_rate>
+		<exit_rate>28%</exit_rate>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageUrls_month.xml
@@ -22,8 +22,8 @@
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>100%</bounce_rate>
 		<exit_rate>100%</exit_rate>
-		<url>http://matomo-archivetesting.ddev.site/</url>
-		<segment>pageUrl==http%253A%252F%252Fmatomo-archivetesting.ddev.site%252F</segment>
+		<url>http://example.com/piwik/</url>
+		<segment>pageUrl==http%253A%252F%252Flocalhost%252F</segment>
 	</row>
 	<row>
 		<label>8</label>
@@ -82,25 +82,25 @@
 	</row>
 	<row>
 		<label>Others</label>
-		<nb_visits>14</nb_visits>
-		<nb_hits>14</nb_hits>
+		<nb_visits>203</nb_visits>
+		<nb_hits>203</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
 		<max_bandwidth />
-		<entry_nb_visits>7</entry_nb_visits>
-		<entry_nb_actions>8</entry_nb_actions>
-		<entry_sum_visit_length>1</entry_sum_visit_length>
-		<entry_bounce_count>6</entry_bounce_count>
-		<exit_nb_visits>7</exit_nb_visits>
+		<entry_nb_visits>93</entry_nb_visits>
+		<entry_nb_actions>219</entry_nb_actions>
+		<entry_sum_visit_length>16</entry_sum_visit_length>
+		<entry_bounce_count>77</entry_bounce_count>
+		<exit_nb_visits>91</exit_nb_visits>
 		<sum_daily_nb_uniq_visitors>14</sum_daily_nb_uniq_visitors>
 		<sum_daily_entry_nb_uniq_visitors>7</sum_daily_entry_nb_uniq_visitors>
 		<sum_daily_exit_nb_uniq_visitors>7</sum_daily_exit_nb_uniq_visitors>
 		<avg_bandwidth>0</avg_bandwidth>
 		<avg_page_load_time>0</avg_page_load_time>
 		<avg_time_on_page>0</avg_time_on_page>
-		<bounce_rate>86%</bounce_rate>
-		<exit_rate>50%</exit_rate>
+		<bounce_rate>83%</bounce_rate>
+		<exit_rate>45%</exit_rate>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst__Actions.getPageUrls_month.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>/index</label>
+		<nb_visits>25</nb_visits>
+		<nb_hits>25</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>25</entry_nb_visits>
+		<entry_nb_actions>25</entry_nb_actions>
+		<entry_sum_visit_length>0</entry_sum_visit_length>
+		<entry_bounce_count>25</entry_bounce_count>
+		<exit_nb_visits>25</exit_nb_visits>
+		<sum_daily_nb_uniq_visitors>25</sum_daily_nb_uniq_visitors>
+		<sum_daily_entry_nb_uniq_visitors>25</sum_daily_entry_nb_uniq_visitors>
+		<sum_daily_exit_nb_uniq_visitors>25</sum_daily_exit_nb_uniq_visitors>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>100%</bounce_rate>
+		<exit_rate>100%</exit_rate>
+		<url>http://matomo-archivetesting.ddev.site/</url>
+		<segment>pageUrl==http%253A%252F%252Fmatomo-archivetesting.ddev.site%252F</segment>
+	</row>
+	<row>
+		<label>8</label>
+		<nb_visits>16</nb_visits>
+		<nb_hits>16</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<exit_nb_visits>2</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252F8</segment>
+		<subtable>
+			<row>
+				<label>/32</label>
+				<nb_visits>8</nb_visits>
+				<nb_hits>8</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<exit_nb_visits>1</exit_nb_visits>
+				<sum_daily_nb_uniq_visitors>8</sum_daily_nb_uniq_visitors>
+				<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>13%</exit_rate>
+				<url>http://piwik.net/8/32</url>
+				<segment>pageUrl==http%253A%252F%252Fpiwik.net%252F8%252F32</segment>
+			</row>
+			<row>
+				<label>/33</label>
+				<nb_visits>8</nb_visits>
+				<nb_hits>8</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<exit_nb_visits>1</exit_nb_visits>
+				<sum_daily_nb_uniq_visitors>8</sum_daily_nb_uniq_visitors>
+				<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>13%</exit_rate>
+				<url>http://piwik.net/8/33</url>
+				<segment>pageUrl==http%253A%252F%252Fpiwik.net%252F8%252F33</segment>
+			</row>
+		</subtable>
+	</row>
+	<row>
+		<label>Others</label>
+		<nb_visits>14</nb_visits>
+		<nb_hits>14</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>7</entry_nb_visits>
+		<entry_nb_actions>8</entry_nb_actions>
+		<entry_sum_visit_length>1</entry_sum_visit_length>
+		<entry_bounce_count>6</entry_bounce_count>
+		<exit_nb_visits>7</exit_nb_visits>
+		<sum_daily_nb_uniq_visitors>14</sum_daily_nb_uniq_visitors>
+		<sum_daily_entry_nb_uniq_visitors>7</sum_daily_entry_nb_uniq_visitors>
+		<sum_daily_exit_nb_uniq_visitors>7</sum_daily_exit_nb_uniq_visitors>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>86%</bounce_rate>
+		<exit_rate>50%</exit_rate>
+	</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_flattened__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_flattened__Actions.getPageTitles_day.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>title_8 / title_32</label>
+		<nb_visits>8</nb_visits>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		<Actions_PageTitle>title_8 / title_32</Actions_PageTitle>
+		<segment>pageTitle==title_8%2B%252F%2Btitle_32</segment>
+	</row>
+	<row>
+		<label>title_8 / title_33</label>
+		<nb_visits>8</nb_visits>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		<Actions_PageTitle>title_8 / title_33</Actions_PageTitle>
+		<segment>pageTitle==title_8%2B%252F%2Btitle_33</segment>
+	</row>
+	<row>
+		<label>title_8 / title_34</label>
+		<nb_visits>8</nb_visits>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_uniq_visitors>1</entry_nb_uniq_visitors>
+		<entry_nb_visits>1</entry_nb_visits>
+		<entry_nb_actions>2</entry_nb_actions>
+		<entry_sum_visit_length>1</entry_sum_visit_length>
+		<entry_bounce_count>0</entry_bounce_count>
+		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		<Actions_PageTitle>title_8 / title_34</Actions_PageTitle>
+		<segment>pageTitle==title_8%2B%252F%2Btitle_34</segment>
+	</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_flattened__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_flattened__Actions.getPageTitles_day.xml
@@ -1,6 +1,28 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>
+		<label>Others</label>
+		<nb_visits>145</nb_visits>
+		<nb_hits>145</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>42</entry_nb_visits>
+		<entry_nb_actions>167</entry_nb_actions>
+		<entry_sum_visit_length>15</entry_sum_visit_length>
+		<entry_bounce_count>27</entry_bounce_count>
+		<exit_nb_visits>40</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>64%</bounce_rate>
+		<exit_rate>28%</exit_rate>
+		<is_summary>1</is_summary>
+		<Actions_PageTitle>Others</Actions_PageTitle>
+	</row>
+	<row>
 		<label>title_8 / title_32</label>
 		<nb_visits>8</nb_visits>
 		<nb_uniq_visitors>8</nb_uniq_visitors>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_flattened__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_flattened__Actions.getPageUrls_day.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>/8/32</label>
+		<nb_visits>8</nb_visits>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		
+		<Actions_PageUrl>/8/32</Actions_PageUrl>
+		
+	</row>
+	<row>
+		<label>/8/33</label>
+		<nb_visits>8</nb_visits>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		
+		<Actions_PageUrl>/8/33</Actions_PageUrl>
+		
+	</row>
+	<row>
+		<label>/8/34</label>
+		<nb_visits>8</nb_visits>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_uniq_visitors>1</entry_nb_uniq_visitors>
+		<entry_nb_visits>1</entry_nb_visits>
+		<entry_nb_actions>2</entry_nb_actions>
+		<entry_sum_visit_length>1</entry_sum_visit_length>
+		<entry_bounce_count>0</entry_bounce_count>
+		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>13%</exit_rate>
+		
+		<Actions_PageUrl>/8/34</Actions_PageUrl>
+		
+	</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_flattened__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_flattened__Actions.getPageUrls_day.xml
@@ -1,6 +1,28 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>
+		<label>Others</label>
+		<nb_visits>145</nb_visits>
+		<nb_hits>145</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>42</entry_nb_visits>
+		<entry_nb_actions>167</entry_nb_actions>
+		<entry_sum_visit_length>15</entry_sum_visit_length>
+		<entry_bounce_count>27</entry_bounce_count>
+		<exit_nb_visits>40</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>64%</bounce_rate>
+		<exit_rate>28%</exit_rate>
+		<is_summary>1</is_summary>
+		<Actions_PageUrl>Others</Actions_PageUrl>
+	</row>
+	<row>
 		<label>/8/32</label>
 		<nb_visits>8</nb_visits>
 		<nb_uniq_visitors>8</nb_uniq_visitors>
@@ -17,9 +39,9 @@
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>13%</exit_rate>
-		
+		<url>http://piwik.net/8/32</url>
 		<Actions_PageUrl>/8/32</Actions_PageUrl>
-		
+		<segment>pageUrl==http%253A%252F%252Fpiwik.net%252F8%252F32</segment>
 	</row>
 	<row>
 		<label>/8/33</label>
@@ -38,9 +60,9 @@
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>13%</exit_rate>
-		
+		<url>http://piwik.net/8/33</url>
 		<Actions_PageUrl>/8/33</Actions_PageUrl>
-		
+		<segment>pageUrl==http%253A%252F%252Fpiwik.net%252F8%252F33</segment>
 	</row>
 	<row>
 		<label>/8/34</label>
@@ -64,8 +86,8 @@
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>13%</exit_rate>
-		
+		<url>http://piwik.net/8/34</url>
 		<Actions_PageUrl>/8/34</Actions_PageUrl>
-		
+		<segment>pageUrl==http%253A%252F%252Fpiwik.net%252F8%252F34</segment>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_rankingQuery__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_rankingQuery__Actions.getPageTitles_day.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label> title_8 / title_32</label>
+		<nb_visits>8</nb_visits>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>0%</exit_rate>
+		<segment>pageTitle==title_8%2B%252F%2Btitle_32</segment>
+	</row>
+	<row>
+		<label> title_8 / title_33</label>
+		<nb_visits>8</nb_visits>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>0%</exit_rate>
+		<segment>pageTitle==title_8%2B%252F%2Btitle_33</segment>
+	</row>
+	<row>
+		<label> title_8 / title_34</label>
+		<nb_visits>8</nb_visits>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_hits>8</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>0%</exit_rate>
+		<segment>pageTitle==title_8%2B%252F%2Btitle_34</segment>
+	</row>
+	<row>
+		<label>Others</label>
+		<nb_visits>137</nb_visits>
+		<nb_hits>137</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>36</entry_nb_visits>
+		<entry_nb_actions>108</entry_nb_actions>
+		<entry_sum_visit_length>12</entry_sum_visit_length>
+		<entry_bounce_count>24</entry_bounce_count>
+		<exit_nb_visits>29</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>67%</bounce_rate>
+		<exit_rate>21%</exit_rate>
+	</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_rankingQuery__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_rankingQuery__Actions.getPageTitles_day.xml
@@ -53,8 +53,8 @@
 	</row>
 	<row>
 		<label>Others</label>
-		<nb_visits>137</nb_visits>
-		<nb_hits>137</nb_hits>
+		<nb_visits>145</nb_visits>
+		<nb_hits>145</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
@@ -64,11 +64,11 @@
 		<entry_nb_actions>108</entry_nb_actions>
 		<entry_sum_visit_length>12</entry_sum_visit_length>
 		<entry_bounce_count>24</entry_bounce_count>
-		<exit_nb_visits>29</exit_nb_visits>
+		<exit_nb_visits>37</exit_nb_visits>
 		<avg_bandwidth>0</avg_bandwidth>
 		<avg_page_load_time>0</avg_page_load_time>
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>67%</bounce_rate>
-		<exit_rate>21%</exit_rate>
+		<exit_rate>26%</exit_rate>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_rankingQuery__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_rankingQuery__Actions.getPageUrls_day.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>8</label>
+		<nb_visits>24</nb_visits>
+		<nb_hits>24</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>0%</exit_rate>
+		
+		<subtable>
+			<row>
+				<label>/32</label>
+				<nb_visits>8</nb_visits>
+				<nb_uniq_visitors>8</nb_uniq_visitors>
+				<nb_hits>8</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>0%</exit_rate>
+				
+				
+			</row>
+			<row>
+				<label>/33</label>
+				<nb_visits>8</nb_visits>
+				<nb_uniq_visitors>8</nb_uniq_visitors>
+				<nb_hits>8</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>0%</exit_rate>
+				
+				
+			</row>
+			<row>
+				<label>/34</label>
+				<nb_visits>8</nb_visits>
+				<nb_uniq_visitors>8</nb_uniq_visitors>
+				<nb_hits>8</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>0%</exit_rate>
+				
+				
+			</row>
+		</subtable>
+	</row>
+	<row>
+		<label>Others</label>
+		<nb_visits>137</nb_visits>
+		<nb_hits>137</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>36</entry_nb_visits>
+		<entry_nb_actions>108</entry_nb_actions>
+		<entry_sum_visit_length>12</entry_sum_visit_length>
+		<entry_bounce_count>24</entry_bounce_count>
+		<exit_nb_visits>29</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_page_load_time>0</avg_page_load_time>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>67%</bounce_rate>
+		<exit_rate>21%</exit_rate>
+	</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_rankingQuery__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flatFirst_rankingQuery__Actions.getPageUrls_day.xml
@@ -14,7 +14,7 @@
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
-		
+		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252F8</segment>
 		<subtable>
 			<row>
 				<label>/32</label>
@@ -29,8 +29,8 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
-				
-				
+				<url>http://piwik.net/8/32</url>
+				<segment>pageUrl==http%253A%252F%252Fpiwik.net%252F8%252F32</segment>
 			</row>
 			<row>
 				<label>/33</label>
@@ -45,8 +45,8 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
-				
-				
+				<url>http://piwik.net/8/33</url>
+				<segment>pageUrl==http%253A%252F%252Fpiwik.net%252F8%252F33</segment>
 			</row>
 			<row>
 				<label>/34</label>
@@ -61,15 +61,15 @@
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
-				
-				
+				<url>http://piwik.net/8/34</url>
+				<segment>pageUrl==http%253A%252F%252Fpiwik.net%252F8%252F34</segment>
 			</row>
 		</subtable>
 	</row>
 	<row>
 		<label>Others</label>
-		<nb_visits>137</nb_visits>
-		<nb_hits>137</nb_hits>
+		<nb_visits>145</nb_visits>
+		<nb_hits>145</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
@@ -79,11 +79,11 @@
 		<entry_nb_actions>108</entry_nb_actions>
 		<entry_sum_visit_length>12</entry_sum_visit_length>
 		<entry_bounce_count>24</entry_bounce_count>
-		<exit_nb_visits>29</exit_nb_visits>
+		<exit_nb_visits>37</exit_nb_visits>
 		<avg_bandwidth>0</avg_bandwidth>
 		<avg_page_load_time>0</avg_page_load_time>
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>67%</bounce_rate>
-		<exit_rate>21%</exit_rate>
+		<exit_rate>26%</exit_rate>
 	</row>
 </result>

--- a/tests/PHPUnit/Unit/ArchiveProcessor/BlobTableAggregatorTest.php
+++ b/tests/PHPUnit/Unit/ArchiveProcessor/BlobTableAggregatorTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace PHPUnit\Unit\ArchiveProcessor;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\ArchiveProcessor\BlobTableAggregator;
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+
+class BlobTableAggregatorTest extends TestCase
+{
+    public function testParseSubtableIdFromBlobNameReturnsIntegerForNumericSuffix(): void
+    {
+        $this->assertSame(123, BlobTableAggregator::parseSubtableIdFromBlobName('Actions_actions_123'));
+        $this->assertNull(BlobTableAggregator::parseSubtableIdFromBlobName('Actions_actions_subtable'));
+    }
+
+    public function testAggregateBlobRowsRespectsRowFilter(): void
+    {
+        $rows = array_merge(
+            $this->makeArchiveDataRowsForPeriod('Test_record', '2020-01-01', $this->makeSimpleTable('page-a', 3)),
+            $this->makeArchiveDataRowsForPeriod('Test_record', '2020-01-02', $this->makeSimpleTable('page-b', 7))
+        );
+
+        [$result, $hasRows] = BlobTableAggregator::aggregateBlobRows(
+            $rows,
+            'Test_record',
+            null,
+            function (DataTable $table): void {
+            },
+            function (array $archiveDataRow): bool {
+                return $archiveDataRow['date1'] === '2020-01-01';
+            }
+        );
+
+        $this->assertTrue($hasRows);
+        $this->assertSame(1, $result->getRowsCount());
+        $row = $result->getRowFromLabel('page-a');
+        $this->assertInstanceOf(Row::class, $row);
+        $this->assertSame(3, $row->getColumn('nb_visits'));
+    }
+
+    public function testAggregateBlobRowsCallsMissingParentCallbackForOrphanedSubtable(): void
+    {
+        $rows = $this->makeArchiveDataRowsForPeriod(
+            'Test_record',
+            '2020-01-01',
+            $this->makeTableWithSubtable('parent', 'child', 5)
+        );
+        $rows[] = [
+            'name' => 'Test_record_999',
+            'date1' => '2020-01-02',
+            'date2' => '2020-01-02',
+            'value' => $rows[1]['value'],
+        ];
+
+        $missingParents = [];
+        [$result, $hasRows] = BlobTableAggregator::aggregateBlobRows(
+            $rows,
+            'Test_record',
+            null,
+            function (DataTable $table): void {
+            },
+            null,
+            function (string $period, int $tableId) use (&$missingParents): void {
+                $missingParents[] = [$period, $tableId];
+            }
+        );
+
+        $this->assertTrue($hasRows);
+        $this->assertContains(['2020-01-02,2020-01-02', 999], $missingParents);
+        $this->assertGreaterThan(0, $result->getRowsCount());
+        $rows = $result->getRows();
+        $row = reset($rows);
+        $this->assertInstanceOf(Row::class, $row);
+    }
+
+    private function makeSimpleTable(string $label, int $nbVisits): DataTable
+    {
+        $table = new DataTable();
+        $table->addRowFromSimpleArray(['label' => $label, 'nb_visits' => $nbVisits]);
+        return $table;
+    }
+
+    private function makeTableWithSubtable(string $parentLabel, string $childLabel, int $nbVisits): DataTable
+    {
+        $table = new DataTable();
+        $row = new Row([Row::COLUMNS => ['label' => $parentLabel, 'nb_visits' => $nbVisits]]);
+
+        $subtable = new DataTable();
+        $subtable->addRowFromSimpleArray(['label' => $childLabel, 'nb_visits' => $nbVisits]);
+        $row->setSubtable($subtable);
+
+        $table->addRow($row);
+        return $table;
+    }
+
+    /**
+     * @return array<int, array{name: string, date1: string, date2: string, value: string}>
+     */
+    private function makeArchiveDataRowsForPeriod(string $recordName, string $date, DataTable $table): array
+    {
+        $rows = [];
+        $serialized = $table->getSerialized();
+        $rootKey = array_key_first($serialized);
+
+        foreach ($serialized as $key => $value) {
+            $name = $key === $rootKey ? $recordName : $recordName . '_' . $key;
+            $rows[] = [
+                'name' => $name,
+                'date1' => $date,
+                'date2' => $date,
+                'value' => $value,
+            ];
+        }
+
+        return $rows;
+    }
+}

--- a/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
+++ b/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
@@ -721,6 +721,84 @@ class RecordBuilderTest extends TestCase
         $this->assertSame(['/flat-path', '/legacy-path'], $hierarchyLabels);
     }
 
+    public function testBuildForNonDayPeriodConsumesFlatTableBeforePreInsertHook(): void
+    {
+        $hookState = (object) ['flatRowsAtHook' => null, 'hierarchyLabelsAtHook' => []];
+
+        $recordBuilder = new class ($hookState) extends ArchiveProcessor\RecordBuilder {
+            private $hookState;
+
+            public function __construct(object $hookState)
+            {
+                parent::__construct();
+                $this->hookState = $hookState;
+            }
+
+            public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_hierarchy')
+                        ->setBuiltFromFlatRecord('TestPlugin_flat', function (Row $flatRow): ?array {
+                            $label = $flatRow->getColumn('label');
+                            if (!is_string($label) || $label === '') {
+                                return null;
+                            }
+
+                            return [$label];
+                        }),
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_flat'),
+                ];
+            }
+
+            protected function aggregate(ArchiveProcessor $archiveProcessor): array
+            {
+                return [];
+            }
+
+            protected function aggregateRootDataTableFromBlobs(
+                ArchiveProcessor $archiveProcessor,
+                string $recordName,
+                ?array $columnsAggregationOperation,
+                ?array $columnsToRenameAfterAggregation
+            ): array {
+                $table = new DataTable();
+                if ($recordName === 'TestPlugin_flat') {
+                    $table->addRowFromSimpleArray(['label' => '/flat-path-a', 'nb_visits' => 5]);
+                    $table->addRowFromSimpleArray(['label' => '/flat-path-b', 'nb_visits' => 3]);
+                    $table->addSummaryRow(new Row([Row::COLUMNS => ['label' => '-1', 'nb_visits' => 2]]));
+
+                    return [$table, true, ['2020-03-04,2020-03-04' => true]];
+                }
+
+                return [$table, false, []];
+            }
+
+            protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
+            {
+                return ['2020-03-04,2020-03-04' => true];
+            }
+
+            protected function beforeInsertBuiltFromFlatHierarchyRecord(
+                ArchiveProcessor $archiveProcessor,
+                Record $hierarchicalRecord,
+                DataTable $hierarchicalTable,
+                DataTable $flatTable
+            ): void {
+                $this->hookState->flatRowsAtHook = $flatTable->getRowsCount();
+                $this->hookState->hierarchyLabelsAtHook = $hierarchicalTable->getColumn('label');
+            }
+        };
+
+        $mockArchiveProcessor = $this->getMockArchiveProcessor('week', ['TestPlugin_flat']);
+        $recordBuilder->buildForNonDayPeriod($mockArchiveProcessor);
+
+        $this->assertSame(0, $hookState->flatRowsAtHook);
+        $this->assertSame(['/flat-path-a', '/flat-path-b', '-1'], $hookState->hierarchyLabelsAtHook);
+
+        $this->assertSame(['/flat-path-a', '/flat-path-b', '-1'], $this->getTopLevelLabelsOfInsertedBlobRecord('TestPlugin_flat'));
+        $this->assertSame(['/flat-path-a', '/flat-path-b', '-1'], $this->getTopLevelLabelsOfInsertedBlobRecord('TestPlugin_hierarchy'));
+    }
+
     public function testBuildForNonDayPeriodCorrectlyAggregatesMetricsForMetricsThatAreRowCountsOfRecords()
     {
         $recordBuilder = new class () extends ArchiveProcessor\RecordBuilder {

--- a/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
+++ b/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
@@ -521,9 +521,19 @@ class RecordBuilderTest extends TestCase
                 return [$table, false];
             }
 
-            protected function getPeriodsWithRootBlob(ArchiveProcessor $archiveProcessor, string $recordName): array
-            {
-                return ['2020-03-04,2020-03-04' => true];
+            protected function aggregateRootDataTableFromBlobs(
+                ArchiveProcessor $archiveProcessor,
+                string $recordName,
+                ?array $columnsAggregationOperation,
+                ?array $columnsToRenameAfterAggregation
+            ): array {
+                $table = new DataTable();
+                if ($recordName === 'TestPlugin_flat') {
+                    $table->addRowFromSimpleArray(['label' => '/flat-path', 'nb_visits' => 5]);
+                    return [$table, true, ['2020-03-04,2020-03-04' => true]];
+                }
+
+                return [$table, false, []];
             }
 
             protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
@@ -543,6 +553,76 @@ class RecordBuilderTest extends TestCase
 
         $this->assertSame(['/flat-path'], $flatLabels);
         $this->assertSame(['/flat-path'], $hierarchyLabels);
+    }
+
+    public function testBuildForNonDayPeriodBuiltFromFlatReadsFlatBlobRowsOnlyOnce(): void
+    {
+        $table = new DataTable();
+        $table->addRowFromSimpleArray(['label' => '/flat-path', 'nb_visits' => 5]);
+        $serialized = $table->getSerialized();
+        $rootBlob = reset($serialized);
+        $counter = (object) ['flatQueryCount' => 0];
+
+        $recordBuilder = new class ($counter, (string) $rootBlob) extends ArchiveProcessor\RecordBuilder {
+            private $counter;
+            private $flatRootBlob;
+
+            public function __construct(object $counter, string $flatRootBlob)
+            {
+                parent::__construct();
+                $this->counter = $counter;
+                $this->flatRootBlob = $flatRootBlob;
+            }
+
+            public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_hierarchy')
+                        ->setBuiltFromFlatRecord('TestPlugin_flat', function (Row $flatRow): ?array {
+                            $label = $flatRow->getColumn('label');
+                            if (!is_string($label) || $label === '') {
+                                return null;
+                            }
+
+                            return [$label];
+                        }),
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_flat'),
+                ];
+            }
+
+            protected function aggregate(ArchiveProcessor $archiveProcessor): array
+            {
+                return [];
+            }
+
+            protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable
+            {
+                if ($recordName !== 'TestPlugin_flat') {
+                    return [];
+                }
+
+                $this->counter->flatQueryCount++;
+
+                return [[
+                    'name' => 'TestPlugin_flat',
+                    'date1' => '2020-03-04',
+                    'date2' => '2020-03-04',
+                    'value' => $this->flatRootBlob,
+                ]];
+            }
+
+            protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
+            {
+                return ['2020-03-04,2020-03-04' => true];
+            }
+        };
+
+        $mockArchiveProcessor = $this->getMockArchiveProcessor('week', ['TestPlugin_hierarchy']);
+        $recordBuilder->buildForNonDayPeriod($mockArchiveProcessor);
+
+        $this->assertSame(1, $counter->flatQueryCount);
+        $this->assertArrayHasKey('TestPlugin_flat', $this->blobRecordsInserted);
+        $this->assertArrayHasKey('TestPlugin_hierarchy', $this->blobRecordsInserted);
     }
 
     public function testBuildForNonDayPeriodCanFallbackToLegacyHierarchyWhenFlatBlobMissingForSomeSubperiods()
@@ -601,9 +681,19 @@ class RecordBuilderTest extends TestCase
                 return [$table, false];
             }
 
-            protected function getPeriodsWithRootBlob(ArchiveProcessor $archiveProcessor, string $recordName): array
-            {
-                return ['2020-03-04,2020-03-04' => true];
+            protected function aggregateRootDataTableFromBlobs(
+                ArchiveProcessor $archiveProcessor,
+                string $recordName,
+                ?array $columnsAggregationOperation,
+                ?array $columnsToRenameAfterAggregation
+            ): array {
+                $table = new DataTable();
+                if ($recordName === 'TestPlugin_flat') {
+                    $table->addRowFromSimpleArray(['label' => '/flat-path', 'nb_visits' => 5]);
+                    return [$table, true, ['2020-03-04,2020-03-04' => true]];
+                }
+
+                return [$table, false, []];
             }
 
             protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array

--- a/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
+++ b/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
@@ -150,6 +150,7 @@ class RecordBuilderTest extends TestCase
         $recordBuilder = new class () extends ArchiveProcessor\RecordBuilder {
             public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
             {
+                // @phpstan-ignore-next-line intentionally returns invalid values to verify runtime filtering.
                 return [
                     0,
                     'def',
@@ -478,6 +479,156 @@ class RecordBuilderTest extends TestCase
 
         $this->assertEquals($expectedNumericRecords, $this->numericRecordsInserted);
         $this->assertEquals($expectedBlobRecords, $this->blobRecordsInserted);
+    }
+
+    public function testBuildForNonDayPeriodBuildsHierarchyFromFlatBlobWhenFlatBlobIsRequested()
+    {
+        $recordBuilder = new class () extends ArchiveProcessor\RecordBuilder {
+            public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_hierarchy')
+                        ->setBuiltFromFlatRecord('TestPlugin_flat', function (Row $flatRow): ?array {
+                            $label = $flatRow->getColumn('label');
+                            if (!is_string($label) || $label === '') {
+                                return null;
+                            }
+
+                            return [$label];
+                        }),
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_flat'),
+                ];
+            }
+
+            protected function aggregate(ArchiveProcessor $archiveProcessor): array
+            {
+                return [];
+            }
+
+            protected function aggregateDataTableFromBlobs(
+                ArchiveProcessor $archiveProcessor,
+                string $recordName,
+                ?array $columnsAggregationOperation,
+                ?array $columnsToRenameAfterAggregation,
+                ?array $periodsToInclude = null
+            ): array {
+                $table = new DataTable();
+                if ($recordName === 'TestPlugin_flat') {
+                    $table->addRowFromSimpleArray(['label' => '/flat-path', 'nb_visits' => 5]);
+                    return [$table, true];
+                }
+
+                return [$table, false];
+            }
+
+            protected function getPeriodsWithRootBlob(ArchiveProcessor $archiveProcessor, string $recordName): array
+            {
+                return ['2020-03-04,2020-03-04' => true];
+            }
+
+            protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
+            {
+                return ['2020-03-04,2020-03-04' => true];
+            }
+        };
+
+        $mockArchiveProcessor = $this->getMockArchiveProcessor('week', ['TestPlugin_flat']);
+        $recordBuilder->buildForNonDayPeriod($mockArchiveProcessor);
+
+        $this->assertArrayHasKey('TestPlugin_flat', $this->blobRecordsInserted);
+        $this->assertArrayHasKey('TestPlugin_hierarchy', $this->blobRecordsInserted);
+
+        $flatLabels = $this->getTopLevelLabelsOfInsertedBlobRecord('TestPlugin_flat');
+        $hierarchyLabels = $this->getTopLevelLabelsOfInsertedBlobRecord('TestPlugin_hierarchy');
+
+        $this->assertSame(['/flat-path'], $flatLabels);
+        $this->assertSame(['/flat-path'], $hierarchyLabels);
+    }
+
+    public function testBuildForNonDayPeriodCanFallbackToLegacyHierarchyWhenFlatBlobMissingForSomeSubperiods()
+    {
+        $recordBuilder = new class () extends ArchiveProcessor\RecordBuilder {
+            public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_hierarchy')
+                        ->setBuiltFromFlatRecord(
+                            'TestPlugin_flat',
+                            function (Row $flatRow): ?array {
+                                $label = $flatRow->getColumn('label');
+                                if (!is_string($label) || $label === '') {
+                                    return null;
+                                }
+
+                                return [$label];
+                            },
+                            function (DataTable $legacyHierarchy, DataTable $flatTable): void {
+                                foreach ($legacyHierarchy->getRows() as $legacyRow) {
+                                    $flatTable->addRowFromSimpleArray([
+                                        'label' => (string) $legacyRow->getColumn('label'),
+                                        'nb_visits' => $legacyRow->getColumn('nb_visits'),
+                                    ]);
+                                }
+                            }
+                        ),
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_flat'),
+                ];
+            }
+
+            protected function aggregate(ArchiveProcessor $archiveProcessor): array
+            {
+                return [];
+            }
+
+            protected function aggregateDataTableFromBlobs(
+                ArchiveProcessor $archiveProcessor,
+                string $recordName,
+                ?array $columnsAggregationOperation,
+                ?array $columnsToRenameAfterAggregation,
+                ?array $periodsToInclude = null
+            ): array {
+                $table = new DataTable();
+                if ($recordName === 'TestPlugin_flat') {
+                    $table->addRowFromSimpleArray(['label' => '/flat-path', 'nb_visits' => 5]);
+                    return [$table, true];
+                }
+
+                if ($recordName === 'TestPlugin_hierarchy') {
+                    $table->addRowFromSimpleArray(['label' => '/legacy-path', 'nb_visits' => 7]);
+                    return [$table, true];
+                }
+
+                return [$table, false];
+            }
+
+            protected function getPeriodsWithRootBlob(ArchiveProcessor $archiveProcessor, string $recordName): array
+            {
+                return ['2020-03-04,2020-03-04' => true];
+            }
+
+            protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    '2020-03-04,2020-03-04' => true,
+                    '2020-03-05,2020-03-05' => true,
+                ];
+            }
+        };
+
+        $mockArchiveProcessor = $this->getMockArchiveProcessor('week', ['TestPlugin_hierarchy']);
+        $recordBuilder->buildForNonDayPeriod($mockArchiveProcessor);
+
+        $this->assertArrayHasKey('TestPlugin_flat', $this->blobRecordsInserted);
+        $this->assertArrayHasKey('TestPlugin_hierarchy', $this->blobRecordsInserted);
+
+        $flatLabels = $this->getTopLevelLabelsOfInsertedBlobRecord('TestPlugin_flat');
+        $hierarchyLabels = $this->getTopLevelLabelsOfInsertedBlobRecord('TestPlugin_hierarchy');
+
+        sort($flatLabels);
+        sort($hierarchyLabels);
+
+        $this->assertSame(['/flat-path', '/legacy-path'], $flatLabels);
+        $this->assertSame(['/flat-path', '/legacy-path'], $hierarchyLabels);
     }
 
     public function testBuildForNonDayPeriodCorrectlyAggregatesMetricsForMetricsThatAreRowCountsOfRecords()
@@ -885,6 +1036,17 @@ class RecordBuilderTest extends TestCase
                 $this->test->blobRecordsInserted[$name] = $values;
             }
         };
+    }
+
+    private function getTopLevelLabelsOfInsertedBlobRecord(string $recordName): array
+    {
+        if (empty($this->blobRecordsInserted[$recordName][0])) {
+            return [];
+        }
+
+        return array_values(array_map(function (array $row): string {
+            return (string) ($row[Row::COLUMNS]['label'] ?? '');
+        }, $this->blobRecordsInserted[$recordName][0]));
     }
 
     public static function makeTestDataTable(): DataTable

--- a/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
+++ b/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
@@ -660,27 +660,6 @@ class RecordBuilderTest extends TestCase
                 return [];
             }
 
-            protected function aggregateDataTableFromBlobs(
-                ArchiveProcessor $archiveProcessor,
-                string $recordName,
-                ?array $columnsAggregationOperation,
-                ?array $columnsToRenameAfterAggregation,
-                ?array $periodsToInclude = null
-            ): array {
-                $table = new DataTable();
-                if ($recordName === 'TestPlugin_flat') {
-                    $table->addRowFromSimpleArray(['label' => '/flat-path', 'nb_visits' => 5]);
-                    return [$table, true];
-                }
-
-                if ($recordName === 'TestPlugin_hierarchy') {
-                    $table->addRowFromSimpleArray(['label' => '/legacy-path', 'nb_visits' => 7]);
-                    return [$table, true];
-                }
-
-                return [$table, false];
-            }
-
             protected function aggregateRootDataTableFromBlobs(
                 ArchiveProcessor $archiveProcessor,
                 string $recordName,
@@ -694,6 +673,23 @@ class RecordBuilderTest extends TestCase
                 }
 
                 return [$table, false, []];
+            }
+
+            protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable
+            {
+                if ($recordName !== 'TestPlugin_hierarchy') {
+                    return [];
+                }
+
+                $legacyTable = new DataTable();
+                $legacyTable->addRowFromSimpleArray(['label' => '/legacy-path', 'nb_visits' => 7]);
+
+                yield [
+                    'date1' => '2020-03-05',
+                    'date2' => '2020-03-05',
+                    'name' => 'TestPlugin_hierarchy',
+                    'value' => $legacyTable->getSerialized()[0],
+                ];
             }
 
             protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
@@ -797,6 +793,415 @@ class RecordBuilderTest extends TestCase
 
         $this->assertSame(['/flat-path-a', '/flat-path-b', '-1'], $this->getTopLevelLabelsOfInsertedBlobRecord('TestPlugin_flat'));
         $this->assertSame(['/flat-path-a', '/flat-path-b', '-1'], $this->getTopLevelLabelsOfInsertedBlobRecord('TestPlugin_hierarchy'));
+    }
+
+    public function testBuildForNonDayPeriodReducesLegacyFallbackPerPeriod(): void
+    {
+        $state = (object) ['reducerCalls' => []];
+
+        $recordBuilder = new class ($state) extends ArchiveProcessor\RecordBuilder {
+            private $state;
+
+            public function __construct(object $state)
+            {
+                parent::__construct();
+                $this->state = $state;
+            }
+
+            public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_hierarchy')
+                        ->setBuiltFromFlatRecord(
+                            'TestPlugin_flat',
+                            function (Row $flatRow): ?array {
+                                $label = $flatRow->getColumn('label');
+                                return is_string($label) && $label !== '' ? [$label] : null;
+                            },
+                            function (DataTable $legacyHierarchy, DataTable $flatTable) {
+                                $this->state->reducerCalls[] = $legacyHierarchy->getColumn('label');
+
+                                foreach ($legacyHierarchy->getRowsWithoutSummaryRow() as $row) {
+                                    $flatTable->addRow(clone $row);
+                                }
+                            }
+                        ),
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_flat'),
+                ];
+            }
+
+            protected function aggregate(ArchiveProcessor $archiveProcessor): array
+            {
+                return [];
+            }
+
+            protected function aggregateRootDataTableFromBlobs(
+                ArchiveProcessor $archiveProcessor,
+                string $recordName,
+                ?array $columnsAggregationOperation,
+                ?array $columnsToRenameAfterAggregation
+            ): array {
+                $table = new DataTable();
+                if ($recordName === 'TestPlugin_flat') {
+                    $table->addRowFromSimpleArray(['label' => '/flat-path', 'nb_visits' => 5]);
+                    return [$table, true, ['2020-03-04,2020-03-04' => true]];
+                }
+
+                return [$table, false, []];
+            }
+
+            protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable
+            {
+                if ($recordName !== 'TestPlugin_hierarchy') {
+                    return [];
+                }
+
+                $legacyTableA = new DataTable();
+                $legacyTableA->addRowFromSimpleArray(['label' => '/legacy-path-a', 'nb_visits' => 2]);
+
+                $legacyTableB = new DataTable();
+                $legacyTableB->addRowFromSimpleArray(['label' => '/legacy-path-b', 'nb_visits' => 3]);
+
+                yield [
+                    'date1' => '2020-03-05',
+                    'date2' => '2020-03-05',
+                    'name' => 'TestPlugin_hierarchy',
+                    'value' => $legacyTableA->getSerialized()[0],
+                ];
+
+                yield [
+                    'date1' => '2020-03-06',
+                    'date2' => '2020-03-06',
+                    'name' => 'TestPlugin_hierarchy',
+                    'value' => $legacyTableB->getSerialized()[0],
+                ];
+            }
+
+            protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    '2020-03-04,2020-03-04' => true,
+                    '2020-03-05,2020-03-05' => true,
+                    '2020-03-06,2020-03-06' => true,
+                ];
+            }
+        };
+
+        $mockArchiveProcessor = $this->getMockArchiveProcessor('week', ['TestPlugin_hierarchy']);
+        $recordBuilder->buildForNonDayPeriod($mockArchiveProcessor);
+
+        $this->assertSame([['/legacy-path-a'], ['/legacy-path-b']], $state->reducerCalls);
+
+        $flatLabels = $this->getTopLevelLabelsOfInsertedBlobRecord('TestPlugin_flat');
+        sort($flatLabels);
+        $this->assertSame(['/flat-path', '/legacy-path-a', '/legacy-path-b'], $flatLabels);
+
+        $hierarchyLabels = $this->getTopLevelLabelsOfInsertedBlobRecord('TestPlugin_hierarchy');
+        sort($hierarchyLabels);
+        $this->assertSame(['/flat-path', '/legacy-path-a', '/legacy-path-b'], $hierarchyLabels);
+    }
+
+    public function testBuildForNonDayPeriodPassesDeepLegacyHierarchyWithSubtablesToReducer(): void
+    {
+        $state = (object) ['receivedHierarchies' => []];
+
+        $recordBuilder = new class ($state) extends ArchiveProcessor\RecordBuilder {
+            private $state;
+
+            public function __construct(object $state)
+            {
+                parent::__construct();
+                $this->state = $state;
+            }
+
+            public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_hierarchy')
+                        ->setBuiltFromFlatRecord(
+                            'TestPlugin_flat',
+                            function (Row $flatRow): ?array {
+                                $label = $flatRow->getColumn('label');
+                                if (!is_string($label) || $label === '') {
+                                    return null;
+                                }
+                                return explode('/', ltrim($label, '/'));
+                            },
+                            function (DataTable $legacyHierarchy, DataTable $flatTable) {
+                                $this->state->receivedHierarchies[] = RecordBuilderTest::describeHierarchy($legacyHierarchy);
+                                RecordBuilderTest::flattenHierarchyIntoFlatTable($legacyHierarchy, $flatTable);
+                            }
+                        ),
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_flat'),
+                ];
+            }
+
+            protected function aggregate(ArchiveProcessor $archiveProcessor): array
+            {
+                return [];
+            }
+
+            protected function aggregateRootDataTableFromBlobs(
+                ArchiveProcessor $archiveProcessor,
+                string $recordName,
+                ?array $columnsAggregationOperation,
+                ?array $columnsToRenameAfterAggregation
+            ): array {
+                // No flat record for any period, so the legacy fallback must cover both days.
+                return [new DataTable(), false, []];
+            }
+
+            protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable
+            {
+                if ($recordName !== 'TestPlugin_hierarchy') {
+                    return [];
+                }
+
+                $deepTable = RecordBuilderTest::makeDeepHierarchyTable([
+                    '/products' => [
+                        'shoes' => 4,
+                        'shirts' => 1,
+                    ],
+                    '/about' => 9,
+                ]);
+
+                foreach (RecordBuilderTest::serializeToArchiveRows('TestPlugin_hierarchy', '2020-03-04', $deepTable) as $row) {
+                    yield $row;
+                }
+            }
+
+            protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
+            {
+                return ['2020-03-04,2020-03-04' => true];
+            }
+        };
+
+        $mockArchiveProcessor = $this->getMockArchiveProcessor('week', ['TestPlugin_hierarchy']);
+        $recordBuilder->buildForNonDayPeriod($mockArchiveProcessor);
+
+        // Reducer must have been called exactly once (single period) and must have received the parent
+        // rows with subtables attached, not a flattened table.
+        $this->assertCount(1, $state->receivedHierarchies);
+        $this->assertSame(
+            [
+                '/products' => ['shoes' => 4, 'shirts' => 1],
+                '/about' => 9,
+            ],
+            $state->receivedHierarchies[0]
+        );
+
+        $flatLabels = $this->getTopLevelLabelsOfInsertedBlobRecord('TestPlugin_flat');
+        sort($flatLabels);
+        $this->assertSame(['/about', '/products/shirts', '/products/shoes'], $flatLabels);
+
+        // The hierarchy blob must be rebuilt from the resulting flat table. Top-level labels come
+        // from the first segment returned by the flatRowToHierarchyPath callback (leading "/" stripped).
+        $hierarchyLabels = $this->getTopLevelLabelsOfInsertedBlobRecord('TestPlugin_hierarchy');
+        sort($hierarchyLabels);
+        $this->assertSame(['about', 'products'], $hierarchyLabels);
+    }
+
+    public function testBuildForNonDayPeriodMergesOverlappingDeepLegacyHierarchyPathsAcrossPeriods(): void
+    {
+        $state = (object) ['reducerCallCount' => 0];
+
+        $recordBuilder = new class ($state) extends ArchiveProcessor\RecordBuilder {
+            private $state;
+
+            public function __construct(object $state)
+            {
+                parent::__construct();
+                $this->state = $state;
+            }
+
+            public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_hierarchy')
+                        ->setBuiltFromFlatRecord(
+                            'TestPlugin_flat',
+                            function (Row $flatRow): ?array {
+                                $label = $flatRow->getColumn('label');
+                                if (!is_string($label) || $label === '') {
+                                    return null;
+                                }
+                                return explode('/', ltrim($label, '/'));
+                            },
+                            function (DataTable $legacyHierarchy, DataTable $flatTable) {
+                                $this->state->reducerCallCount++;
+                                RecordBuilderTest::flattenHierarchyIntoFlatTable($legacyHierarchy, $flatTable);
+                            }
+                        ),
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_flat'),
+                ];
+            }
+
+            protected function aggregate(ArchiveProcessor $archiveProcessor): array
+            {
+                return [];
+            }
+
+            protected function aggregateRootDataTableFromBlobs(
+                ArchiveProcessor $archiveProcessor,
+                string $recordName,
+                ?array $columnsAggregationOperation,
+                ?array $columnsToRenameAfterAggregation
+            ): array {
+                // No flat blobs for either period -> both periods fall through to the legacy deep hierarchy.
+                return [new DataTable(), false, []];
+            }
+
+            protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable
+            {
+                if ($recordName !== 'TestPlugin_hierarchy') {
+                    return [];
+                }
+
+                // Period A: /products/shoes=4, /products/shirts=1, /about=9
+                $periodA = RecordBuilderTest::makeDeepHierarchyTable([
+                    '/products' => [
+                        'shoes' => 4,
+                        'shirts' => 1,
+                    ],
+                    '/about' => 9,
+                ]);
+
+                // Period B: /products/shoes=2 (overlap), /products/hats=6, /about=3 (overlap)
+                $periodB = RecordBuilderTest::makeDeepHierarchyTable([
+                    '/products' => [
+                        'shoes' => 2,
+                        'hats' => 6,
+                    ],
+                    '/about' => 3,
+                ]);
+
+                foreach (RecordBuilderTest::serializeToArchiveRows('TestPlugin_hierarchy', '2020-03-05', $periodA) as $row) {
+                    yield $row;
+                }
+                foreach (RecordBuilderTest::serializeToArchiveRows('TestPlugin_hierarchy', '2020-03-06', $periodB) as $row) {
+                    yield $row;
+                }
+            }
+
+            protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    '2020-03-05,2020-03-05' => true,
+                    '2020-03-06,2020-03-06' => true,
+                ];
+            }
+        };
+
+        $mockArchiveProcessor = $this->getMockArchiveProcessor('week', ['TestPlugin_hierarchy']);
+        $recordBuilder->buildForNonDayPeriod($mockArchiveProcessor);
+
+        // One reducer call per period with legacy data.
+        $this->assertSame(2, $state->reducerCallCount);
+
+        $flatByLabel = $this->getFlatInsertedBlobMetric('TestPlugin_flat', 'nb_visits');
+        ksort($flatByLabel);
+
+        // Overlapping leaves must be summed across periods; non-overlapping leaves must appear once.
+        $this->assertSame(
+            [
+                '/about' => 12,                // 9 + 3
+                '/products/hats' => 6,         // period B only
+                '/products/shirts' => 1,       // period A only
+                '/products/shoes' => 6,        // 4 + 2
+            ],
+            $flatByLabel
+        );
+    }
+
+    public function testBuildForNonDayPeriodMixesFlatRecordWithDeepLegacyHierarchyFallback(): void
+    {
+        $recordBuilder = new class () extends ArchiveProcessor\RecordBuilder {
+            public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_hierarchy')
+                        ->setBuiltFromFlatRecord(
+                            'TestPlugin_flat',
+                            function (Row $flatRow): ?array {
+                                $label = $flatRow->getColumn('label');
+                                if (!is_string($label) || $label === '') {
+                                    return null;
+                                }
+                                return explode('/', ltrim($label, '/'));
+                            },
+                            function (DataTable $legacyHierarchy, DataTable $flatTable) {
+                                RecordBuilderTest::flattenHierarchyIntoFlatTable($legacyHierarchy, $flatTable);
+                            }
+                        ),
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_flat'),
+                ];
+            }
+
+            protected function aggregate(ArchiveProcessor $archiveProcessor): array
+            {
+                return [];
+            }
+
+            protected function aggregateRootDataTableFromBlobs(
+                ArchiveProcessor $archiveProcessor,
+                string $recordName,
+                ?array $columnsAggregationOperation,
+                ?array $columnsToRenameAfterAggregation
+            ): array {
+                $table = new DataTable();
+                if ($recordName === 'TestPlugin_flat') {
+                    // Period 03-04 already has a flat record with paths overlapping the legacy hierarchy.
+                    $table->addRowFromSimpleArray(['label' => '/products/shoes', 'nb_visits' => 10]);
+                    $table->addRowFromSimpleArray(['label' => '/contact', 'nb_visits' => 2]);
+                    return [$table, true, ['2020-03-04,2020-03-04' => true]];
+                }
+                return [$table, false, []];
+            }
+
+            protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable
+            {
+                if ($recordName !== 'TestPlugin_hierarchy') {
+                    return [];
+                }
+
+                // Only period 03-05 falls back to legacy deep hierarchy.
+                $legacyTable = RecordBuilderTest::makeDeepHierarchyTable([
+                    '/products' => [
+                        'shoes' => 4,
+                        'shirts' => 1,
+                    ],
+                    '/about' => 9,
+                ]);
+
+                foreach (RecordBuilderTest::serializeToArchiveRows('TestPlugin_hierarchy', '2020-03-05', $legacyTable) as $row) {
+                    yield $row;
+                }
+            }
+
+            protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    '2020-03-04,2020-03-04' => true,
+                    '2020-03-05,2020-03-05' => true,
+                ];
+            }
+        };
+
+        $mockArchiveProcessor = $this->getMockArchiveProcessor('week', ['TestPlugin_hierarchy']);
+        $recordBuilder->buildForNonDayPeriod($mockArchiveProcessor);
+
+        $flatByLabel = $this->getFlatInsertedBlobMetric('TestPlugin_flat', 'nb_visits');
+        ksort($flatByLabel);
+
+        $this->assertSame(
+            [
+                '/about' => 9,                 // from legacy hierarchy (period 03-05)
+                '/contact' => 2,               // from flat record (period 03-04)
+                '/products/shirts' => 1,       // from legacy hierarchy (period 03-05)
+                '/products/shoes' => 14,       // 10 (flat) + 4 (legacy) merged by label
+            ],
+            $flatByLabel
+        );
     }
 
     public function testBuildForNonDayPeriodCorrectlyAggregatesMetricsForMetricsThatAreRowCountsOfRecords()
@@ -1224,6 +1629,134 @@ class RecordBuilderTest extends TestCase
         $table->addRowFromSimpleArray(['label' => 'another thing', 'nb_visits' => 50]);
         $table->addRowFromSimpleArray(['label' => 'a third thing', 'nb_visits' => 20]);
         return $table;
+    }
+
+    /**
+     * Builds a two-level DataTable from a nested spec.
+     * Leaf entries are `label => nb_visits`; nested entries are `label => [childLabel => nb_visits, ...]`.
+     */
+    public static function makeDeepHierarchyTable(array $spec): DataTable
+    {
+        $table = new DataTable();
+        foreach ($spec as $label => $children) {
+            if (is_array($children)) {
+                $row = new Row([Row::COLUMNS => ['label' => $label]]);
+                $subtable = new DataTable();
+                foreach ($children as $childLabel => $nbVisits) {
+                    $subtable->addRowFromSimpleArray(['label' => $childLabel, 'nb_visits' => $nbVisits]);
+                }
+                $row->setSubtable($subtable);
+                $table->addRow($row);
+            } else {
+                $table->addRowFromSimpleArray(['label' => $label, 'nb_visits' => $children]);
+            }
+        }
+        return $table;
+    }
+
+    /**
+     * Serializes a DataTable (including subtables) into the archive-row shape expected by
+     * `querySingleBlobRows()` — root blob named $recordName (serialized key 0 per the DataTable
+     * spec), subtable blobs named $recordName_<id>. Root is yielded first so consumers can rely
+     * on parent-before-child ordering, mirroring how ArchiveSelector orders rows.
+     *
+     * @return iterable<array{name: string, date1: string, date2: string, value: string}>
+     */
+    public static function serializeToArchiveRows(string $recordName, string $date, DataTable $table): iterable
+    {
+        $serialized = $table->getSerialized();
+        ksort($serialized);
+        foreach ($serialized as $key => $value) {
+            yield [
+                'name' => $key === 0 ? $recordName : $recordName . '_' . $key,
+                'date1' => $date,
+                'date2' => $date,
+                'value' => $value,
+            ];
+        }
+    }
+
+    /**
+     * Serializes a DataTable hierarchy into a plain nested array (label => nb_visits or label => [child => nb_visits]).
+     * Used by tests to compare a hierarchy structure without depending on internal row IDs.
+     */
+    public static function describeHierarchy(DataTable $table): array
+    {
+        $result = [];
+        foreach ($table->getRowsWithoutSummaryRow() as $row) {
+            $label = $row->getColumn('label');
+            $subtable = $row->getSubtable();
+            if ($subtable instanceof DataTable) {
+                $children = [];
+                foreach ($subtable->getRowsWithoutSummaryRow() as $childRow) {
+                    $children[(string) $childRow->getColumn('label')] = $childRow->getColumn('nb_visits');
+                }
+                $result[(string) $label] = $children;
+            } else {
+                $result[(string) $label] = $row->getColumn('nb_visits');
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Walks a (possibly deep) hierarchy DataTable and merges every leaf into the flat table by its
+     * fully-qualified "/parent/child" path label, summing nb_visits when the same label is seen
+     * again. Mirrors the essential semantics used by the production Actions legacy-hierarchy reducer.
+     */
+    public static function flattenHierarchyIntoFlatTable(DataTable $hierarchy, DataTable $flatTable): void
+    {
+        $walker = function (DataTable $source, array $path) use (&$walker, $flatTable): void {
+            foreach ($source->getRowsWithoutSummaryRow() as $row) {
+                $label = (string) $row->getColumn('label');
+                $subtable = $row->getSubtable();
+                if ($subtable instanceof DataTable) {
+                    $walker($subtable, array_merge($path, [$label]));
+                    continue;
+                }
+
+                $segments = array_merge($path, [$label]);
+                $flatLabel = '/' . implode('/', array_map(static function (string $segment): string {
+                    return ltrim($segment, '/');
+                }, $segments));
+
+                $nbVisits = (int) $row->getColumn('nb_visits');
+                $existing = $flatTable->getRowFromLabel($flatLabel);
+                if ($existing === false) {
+                    $flatTable->addRow(new Row([Row::COLUMNS => [
+                        'label' => $flatLabel,
+                        'nb_visits' => $nbVisits,
+                    ]]));
+                } else {
+                    $existing->setColumn(
+                        'nb_visits',
+                        (int) $existing->getColumn('nb_visits') + $nbVisits
+                    );
+                }
+            }
+        };
+
+        $walker($hierarchy, []);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getFlatInsertedBlobMetric(string $recordName, string $metric): array
+    {
+        if (empty($this->blobRecordsInserted[$recordName][0])) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($this->blobRecordsInserted[$recordName][0] as $rowId => $row) {
+            if ($rowId === DataTable::ID_SUMMARY_ROW) {
+                continue;
+            }
+            $label = (string) ($row[Row::COLUMNS]['label'] ?? '');
+            $result[$label] = (int) ($row[Row::COLUMNS][$metric] ?? 0);
+        }
+        return $result;
     }
 
     public static function makeAggregatedTestDataTable(): DataTable

--- a/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
+++ b/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
@@ -505,22 +505,6 @@ class RecordBuilderTest extends TestCase
                 return [];
             }
 
-            protected function aggregateDataTableFromBlobs(
-                ArchiveProcessor $archiveProcessor,
-                string $recordName,
-                ?array $columnsAggregationOperation,
-                ?array $columnsToRenameAfterAggregation,
-                ?array $periodsToInclude = null
-            ): array {
-                $table = new DataTable();
-                if ($recordName === 'TestPlugin_flat') {
-                    $table->addRowFromSimpleArray(['label' => '/flat-path', 'nb_visits' => 5]);
-                    return [$table, true];
-                }
-
-                return [$table, false];
-            }
-
             protected function aggregateRootDataTableFromBlobs(
                 ArchiveProcessor $archiveProcessor,
                 string $recordName,

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ff38709d63e155e1e7a34335b9185b6e35cb87f6ee6bb7e0280fe5638c7268b
-size 5294358
+oid sha256:f6eacd21f4c29ead7106fb10068b5b75147508fc5baad1bf0d8dbd2ba1448417
+size 5307665


### PR DESCRIPTION
### Summary

This PR introduces flat-first archiving for Action reports, controlled by a new config flag:

- `datatable_archiving_maximum_rows_actions_flat`

### Enable / Disable

- Disabled (legacy behavior): flag is `0` or not set
    - Only hierarchical Action tables are archived (same as before).
- Enabled (new behavior): flag is `> 0`
    - A flat Action archive is built first and limited to this configured row count.
    - Hierarchical tables are then built from this already-limited flat data.

A useful initial value is `50000`, which matches the current query/report row limit.

### Archiving approach changes

With flat-first enabled:

1. Day Action archives build a flat limited table first.
2. The hierarchy is built from that flat table (instead of building hierarchy first and flattening later).
3. Higher periods (week/month/year) aggregate from flat archives.
4. For mixed historical data, if a period has no flat archive yet, existing hierarchical archives are flattened and
   merged so re-archiving everything is not required.

### Limits and `Others` behavior

- The main limit is now applied at the flat table level using `datatable_archiving_maximum_rows_actions_flat`.
- No additional hierarchical limiting is applied afterward (hierarchy is built from already-limited data).
- `Others` is determined during flat limiting, so behavior is more consistent and avoids extra secondary `Others` created
  by hierarchical re-limiting.

### Impact on memory and archiving time

For high-cardinality Action data (many distinct URLs, changing month-to-month), this reduces resource pressure by
avoiding repeated deep hierarchical merges during period aggregation.

- Memory: lower peak memory usage during aggregation.
- Archiving time: typically faster/more stable for larger periods.
- Tradeoff: additional flat archive data is stored, but bounded by the configured limit.

### Testing

The changes contain a couple of tests to proof that flat-first archiving in general works. However, all tests were run with flat-archiving enabled, to ensure no other tests regress unexpectedly. Most of those failures were fixed by applying unrelated fixes (see linked PRs). 
There is currently one mismatch in tests remaining. See https://github.com/matomo-org/matomo/actions/runs/23338988295

#### URL Metadata / Segment Mismatch Note

There is an existing inconsistency in how Matomo merges duplicate rows with the same label but different metadata (for
example URL rows where one variant has different segment metadata, empty segment metadata, or different include-depth
behavior like include2 vs include4).

With flat-first archiving, this can become more visible because row merging happens through a slightly different path
than pure legacy hierarchy aggregation. The underlying issue is not specific to flat-first itself: when multiple
candidate rows exist, metadata winner selection is not fully deterministic/explicit in all merge paths.

Practical impact:

- Metric totals can still be correct.
- Returned metadata fields (especially segment metadata for URL rows) may differ in edge cases depending on merge
  order/source.
- This is a pre-existing merge-policy gap and should be fixed separately by defining deterministic metadata precedence
  during row aggregation.


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
