### PR TITLE
UI tests - CustomDimensions - prevent flaky test

### DIFF
--- a/plugins/CustomDimensions/tests/UI/CustomDimensions_spec.js
+++ b/plugins/CustomDimensions/tests/UI/CustomDimensions_spec.js
@@ -60,6 +60,16 @@ describe("CustomDimensions", function () {
         await page.waitForNetworkIdle();
     }
 
+    async function waitForRowEvolutionPopover()
+    {
+        await page.waitForFunction('$(".ui-dialog:visible .rowevolution").length > 0');
+        await page.waitForFunction(
+            '$(".ui-dialog:visible .rowevolution table.metrics tr").length > 0'
+            + ' && $(".ui-dialog:visible .rowevolution .jqplot-target").length > 0'
+        );
+        await page.waitForTimeout(250);
+    }
+
     before(function () {
         testEnvironment.pluginsToLoad = ['CustomDimensions'];
         testEnvironment.save();
@@ -252,6 +262,7 @@ describe("CustomDimensions", function () {
         await captureSelector('report_actions_rowevolution', popupSelector, async function () {
             await page.goto(reportUrlDimension3);
             await triggerRowAction('en', 'actionRowEvolution');
+            await waitForRowEvolutionPopover();
         });
     });
 
@@ -269,6 +280,7 @@ describe("CustomDimensions", function () {
     it('should be able to show row evolution for subtable', async function () {
         await captureSelector('report_action_subtable_rowevolution', popupSelector, async function () {
             await triggerRowAction('en_US', 'actionRowEvolution');
+            await waitForRowEvolutionPopover();
         });
     });
 


### PR DESCRIPTION
### Description

The current `CustomDimensions_report_action_subtable_rowevolution.png` row-evolution popup capture only waits for network idle. So the fix is to wait for the row-evolution dialog content, not just the XHR, before taking the screenshot.

You can relaunch this test only thanks to [this action](https://github.com/matomo-org/matomo/actions/runs/22908377677)

#### Examples

From a failing CI:

**RowEvolution_row_evolution.png**

| Processed | Expected | Diff |
|---|---|---|
|  <img width="1050" height="821" alt="CustomDimensions_report_action_subtable_rowevolution-processed" src="https://github.com/user-attachments/assets/060ce6fb-c58c-49da-ac15-a6e11f1d18f9" /> | <img width="1050" height="842" alt="CustomDimensions_report_action_subtable_rowevolution-expected" src="https://github.com/user-attachments/assets/e98a34a6-bc91-4c32-93ae-3ffd4b789c02" /> | <img width="1050" height="842" alt="CustomDimensions_report_action_subtable_rowevolution-diff" src="https://github.com/user-attachments/assets/3e9a7e7c-c550-4f19-afe6-e6920e95b96e" /> |


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
