### PR TITLE
Fix pagination Next button visible when all data fits on one page

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1034,12 +1034,13 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         var $next = $('.dataTableNext', domElem);
 
         // Display the next link if the total Rows is greater than the current end row
+        // and filter_limit is a positive number (not "show all")
         $next.each(function () {
             var offsetEnd = Number(self.param.filter_offset)
                 + Number(self.param.filter_limit);
             var totalRows = Number(self.param.totalRows);
             if (self.param.keep_summary_row == 1) --totalRows;
-            if (offsetEnd < totalRows) {
+            if (offsetEnd < totalRows && Number(self.param.filter_limit) > 0) {
                 $(this).css('visibility', 'visible');
             }
         });


### PR DESCRIPTION
### Description

Fixes an issue where the "Next" pagination button was incorrectly visible when all data fits on a single page in DataTable reports (e.g., Behaviour > Pages).

#### Problem
When the total number of rows is less than or equal to the page limit, the Next button should be hidden since there is no next page. However, the button remained visible and clickable.
Additionally, clicking the Next button in this state caused incorrect pagination values to be displayed (e.g., showing "0–124 of 124" or "-1–124 of 124").


<img width="806" height="325" alt="image" src="https://github.com/user-attachments/assets/fd572a94-5128-43d4-80ee-698d58c43dad" />
<img width="756" height="262" alt="image" src="https://github.com/user-attachments/assets/3342b4f4-7599-4e26-97f5-25b46774cc5c" />
<img width="775" height="267" alt="image" src="https://github.com/user-attachments/assets/bbf7e9c1-9d8e-4762-83c7-fc1a4c797b8c" />

#### Root cause
When `filter_limit` is `-1` (show all rows), the condition `offsetEnd < totalRows` was evaluated as:
- `offsetEnd = filter_offset + filter_limit = 0 + (-1) = -1`
- `-1 < totalRows` is always `true` when there is any data

#### Fix
  Added a check for `filter_limit > 0` to ensure the Next button is only shown when there's
  actually a next page to navigate to.
### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
