### PR TITLE
Make the countryName segment case-insensitive

### DIFF
--- a/plugins/UserCountry/Columns/Country.php
+++ b/plugins/UserCountry/Columns/Country.php
@@ -55,7 +55,11 @@ class Country extends Base
         });
 
         $segment->setSqlFilterValue(function ($val) use ($countryList) {
-            $result   = array_search($val, $countryList);
+            $countryList = array_map(function ($countryName) {
+                return mb_strtolower($countryName);
+            }, $countryList);
+            $result = array_search(mb_strtolower($val), $countryList);
+
             if ($result === false) {
                 $result = 'UNK';
             }

--- a/plugins/UserCountry/tests/Unit/UserCountryTest.php
+++ b/plugins/UserCountry/tests/Unit/UserCountryTest.php
@@ -9,14 +9,32 @@
 
 namespace Piwik\Plugins\UserCountry\tests\Unit;
 
+use Piwik\Columns\DimensionSegmentFactory;
 use Piwik\Container\StaticContainer;
 use Piwik\Intl\Data\Provider\RegionDataProvider;
+use Piwik\Plugins\UserCountry\Columns\Country;
+use Piwik\Segment\SegmentsList;
+use Piwik\Tests\Framework\Fixture;
 
 require_once PIWIK_INCLUDE_PATH . '/plugins/UserCountry/UserCountry.php';
 require_once PIWIK_INCLUDE_PATH . '/plugins/UserCountry/functions.php';
 
 class UserCountryTest extends \PHPUnit\Framework\TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::loadAllTranslations();
+    }
+
+    public function tearDown(): void
+    {
+        Fixture::resetTranslations();
+
+        parent::tearDown();
+    }
+
     /**
      * @group Plugins
      */
@@ -68,5 +86,24 @@ class UserCountryTest extends \PHPUnit\Framework\TestCase
             // test country
             $this->assertArrayHasKey($country, $countries, $filename);
         }
+    }
+
+    /**
+     * @group Plugins
+     */
+    public function testCountryNameSegmentMatchesCaseInsensitively()
+    {
+        $country = new Country();
+        $segmentsList = new SegmentsList();
+
+        $country->configureSegments($segmentsList, new DimensionSegmentFactory($country));
+
+        $segment = $segmentsList->getSegment('countryName');
+
+        $this->assertNotNull($segment);
+        $this->assertSame('ca', $segment->getSqlFilterValue()('Canada'));
+        $this->assertSame('ca', $segment->getSqlFilterValue()('canada'));
+        $this->assertSame('ca', $segment->getSqlFilterValue()('CANADA'));
+        $this->assertSame('UNK', $segment->getSqlFilterValue()('NotACountry'));
     }
 }


### PR DESCRIPTION
### Description

fixes #21062

Updates countryName segment filter to treat 'Canada', 'canada', and 'CANADA' the same, so countryName searches can use any combination of upper and lowercase.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
