### PR TITLE
Improve type hinting in Http class and remove no longer needed PHP version check

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -11,6 +11,7 @@ namespace Piwik;
 
 use Composer\CaBundle\CaBundle;
 use Exception;
+use Piwik\Config\GeneralConfig;
 use Piwik\Container\StaticContainer;
 
 /**
@@ -43,11 +44,17 @@ class Http
         return $method;
     }
 
+    /**
+     * @return bool
+     */
     protected static function isSocketEnabled()
     {
         return function_exists('fsockopen');
     }
 
+    /**
+     * @return bool
+     */
     protected static function isCurlEnabled()
     {
         return function_exists('curl_init') && function_exists('curl_exec');
@@ -112,7 +119,7 @@ class Http
             $userAgent,
             $destinationPath,
             $file,
-            $followDepth,
+            $followDepth ?? 0,
             $acceptLanguage,
             $acceptInvalidSslCertificate = false,
             $byteRange,
@@ -127,6 +134,11 @@ class Http
         );
     }
 
+    /**
+     * @param string|null $destinationPath
+     * @return resource|null
+     * @throws Exception
+     */
     public static function ensureDestinationDirectoryExists($destinationPath)
     {
         if ($destinationPath) {
@@ -141,7 +153,7 @@ class Http
         return null;
     }
 
-    private static function convertWildcardToPattern($wildcardHost)
+    private static function convertWildcardToPattern(string $wildcardHost): string
     {
         $flexibleStart = $flexibleEnd = false;
         if (strpos($wildcardHost, '*.') === 0) {
@@ -168,16 +180,16 @@ class Http
     /**
      * Sends an HTTP request using the specified transport method.
      *
-     * @param string $method
+     * @param string|null $method
      * @param string $aUrl
      * @param int $timeout in seconds
      * @param string $userAgent
      * @param string $destinationPath
      * @param resource $file
      * @param int $followDepth
-     * @param bool|string $acceptLanguage Accept-language header
+     * @param string|false $acceptLanguage Accept-language header
      * @param bool $acceptInvalidSslCertificate Only used with $method == 'curl'. If set to true (NOT recommended!) the SSL certificate will not be checked
-     * @param array|bool $byteRange For Range: header. Should be two element array of bytes, eg, array(0, 1024)
+     * @param array|false $byteRange For Range: header. Should be two element array of bytes, eg, array(0, 1024)
      *                                                  Doesn't work w/ fopen method.
      * @param bool $getExtendedInfo True to return status code, headers & response, false if just response.
      * @param string $httpMethod The HTTP method to use. Defaults to `'GET'`.
@@ -223,7 +235,7 @@ class Http
             throw new Exception('Missing scheme in given url');
         }
 
-        $allowedProtocols = Config::getInstance()->General['allowed_outgoing_protocols'];
+        $allowedProtocols = GeneralConfig::getConfigValue('allowed_outgoing_protocols');
         $isAllowed = false;
 
         foreach (explode(',', $allowedProtocols) as $protocol) {
@@ -295,9 +307,11 @@ class Http
 
         [$proxyHost, $proxyPort, $proxyUser, $proxyPassword] = self::getProxyConfiguration($aUrl);
 
-        // other result data
+        /** @var int|null $status */
         $status  = null;
+        /** @var array<string, string> $headers */
         $headers = array();
+        /** @var string|null $response */
         $response = null;
 
         $httpAuthIsUsed = !empty($httpUsername) || !empty($httpPassword);
@@ -578,7 +592,7 @@ class Http
             // we create a stream_context (works in php >= 5.2.1)
             // we also set the socket_timeout (for php < 5.2.1)
             $default_socket_timeout = @ini_get('default_socket_timeout');
-            @ini_set('default_socket_timeout', $timeout);
+            @ini_set('default_socket_timeout', (string)$timeout);
 
             $ctx = null;
             if (function_exists('stream_context_create')) {
@@ -630,7 +644,7 @@ class Http
                     $http_response_header = http_get_last_response_headers();
                 }
             } else {
-                $response = @file_get_contents($aUrl, 0, $ctx);
+                $response = @file_get_contents($aUrl, false, $ctx);
 
                 if (function_exists('http_get_last_response_headers')) {
                     $http_response_header = http_get_last_response_headers();
@@ -846,7 +860,7 @@ class Http
         return http_build_query($params, '', '&');
     }
 
-    private static function buildHeadersForPost($requestBody)
+    private static function buildHeadersForPost(string $requestBody): string
     {
         $postHeader  = "Content-Type: application/x-www-form-urlencoded\r\n";
         $postHeader .= "Content-Length: " . strlen($requestBody) . "\r\n";
@@ -948,12 +962,13 @@ class Http
                 throw new Exception(Piwik::translate('General_DownloadFail_HttpRequestFail'));
             }
 
-            Option::set($downloadOption, $expectedFileSize);
+            Option::set($downloadOption, (string)$expectedFileSize);
         } else {
-            $expectedFileSize = (int)Option::get($downloadOption);
+            $expectedFileSize = Option::get($downloadOption);
             if ($expectedFileSize === false) { // sanity check
                 throw new Exception("Trying to continue a download that never started?! That's not supposed to happen...");
             }
+            $expectedFileSize = (int)$expectedFileSize;
         }
 
         // if existing file is already big enough, then fail so we don't accidentally overwrite
@@ -1012,10 +1027,8 @@ class Http
      */
     public static function configCurlCertificate(&$ch)
     {
-        $general = Config::getInstance()->General;
-        if (!empty($general['custom_cacert_pem'])) {
-            $cacertPath = $general['custom_cacert_pem'];
-        } else {
+        $cacertPath = GeneralConfig::getConfigValue('custom_cacert_pem');
+        if (empty($cacertPath)) {
             $cacertPath = CaBundle::getBundledCaBundlePath();
         }
         @curl_setopt($ch, CURLOPT_CAINFO, $cacertPath);
@@ -1073,7 +1086,7 @@ class Http
      * @param array $headers
      * @param string $line
      */
-    private static function parseHeaderLine(&$headers, $line)
+    private static function parseHeaderLine(&$headers, $line): void
     {
         $parts = explode(':', $line, 2);
         if (count($parts) == 1) {
@@ -1088,12 +1101,9 @@ class Http
          * With HTTP/2 Cloudflare is passing headers in lowercase (e.g. 'content-type' instead of 'Content-Type')
          * which breaks any code which uses the header data.
          */
-        if (version_compare(PHP_VERSION, '5.5.16', '>=')) {
-            // Passing a second arg to ucwords is not supported by older versions of PHP
-            $camelName = ucwords($name, '-');
-            if ($camelName !== $name) {
-                $headers[$camelName] = trim($value);
-            }
+        $camelName = ucwords($name, '-');
+        if ($camelName !== $name) {
+            $headers[$camelName] = trim($value);
         }
     }
 
@@ -1136,14 +1146,14 @@ class Http
      * Returns Proxy to use for connecting via HTTP to given URL
      *
      * @param string $url
-     * @return array
+     * @return array{0: string|null, 1: string|null, 2: string|null, 3: string|null}
      */
-    private static function getProxyConfiguration($url)
+    private static function getProxyConfiguration($url): array
     {
         $hostname = UrlHelper::getHostFromUrl($url);
 
         if (Url::isLocalHost($hostname)) {
-            return array(null, null, null, null);
+            return [null, null, null, null];
         }
 
         // proxy configuration
@@ -1158,7 +1168,7 @@ class Http
             $excludes = array_map('trim', $excludes);
             $excludes = array_filter($excludes);
             if (in_array($hostname, $excludes)) {
-                return array(null, null, null, null);
+                return [null, null, null, null];
             }
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1206,46 +1206,6 @@ parameters:
 			path: core/FrontController.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function trim expects string, null given\\.$#"
-			count: 1
-			path: core/Http.php
-
-		-
-			message: "#^Parameter \\#2 \\$newvalue of function ini_set expects string, int given\\.$#"
-			count: 1
-			path: core/Http.php
-
-		-
-			message: "#^Parameter \\#2 \\$use_include_path of function file_get_contents expects bool, int given\\.$#"
-			count: 1
-			path: core/Http.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int\\<min, \\-1\\>\\|int\\<1, max\\> given\\.$#"
-			count: 1
-			path: core/Http.php
-
-		-
-			message: "#^Result of \\|\\| is always false\\.$#"
-			count: 2
-			path: core/Http.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between null and null will always evaluate to false\\.$#"
-			count: 2
-			path: core/Http.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between int and false will always evaluate to false\\.$#"
-			count: 1
-			path: core/Http.php
-
-		-
-			message: "#^Variable \\$headers in empty\\(\\) always exists and is always falsy\\.$#"
-			count: 1
-			path: core/Http.php
-
-		-
 			message: "#^PHPDoc tag @var has invalid value \\(\\$controller Controller\\)\\: Unexpected token \"\\$controller\", expected type at offset 9$#"
 			count: 1
 			path: core/Http/ControllerResolver.php


### PR DESCRIPTION
### Description

* adds some more type hinting
* replace usage of `Config->General['name']` with `GeneralConfig::getConfigValue('name')`
* removed a left over PHP version check

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
