### PR TITLE
Improve Archive class code

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -36,7 +36,7 @@ use Piwik\Plugins\VisitFrequency;
  *
  * You can search for metrics (such as `nb_visits`) using the {@link getNumeric()} and
  * {@link getDataTableFromNumeric()} methods. You can search for
- * reports using the {@link getBlob()}, {@link getDataTable()} and {@link getDataTableExpanded()} methods.
+ * reports using the {@link getDataTable()} and {@link getDataTableExpanded()} methods.
  *
  * If you're creating an API that returns report data, you may want to use the
  * {@link createDataTableFromArchive()} helper function.
@@ -167,7 +167,7 @@ class Archive implements ArchiveQuery
     private $idarchiveStates = [];
 
     /**
-     * If set to true, the result of all get functions (ie, getNumeric, getBlob, etc.)
+     * If set to true, the result of all get functions (ie, getNumeric, getDataTable, etc.)
      * will be indexed by the site ID, even if we're only querying data for one site.
      *
      * @var bool
@@ -175,7 +175,7 @@ class Archive implements ArchiveQuery
     private $forceIndexedBySite;
 
     /**
-     * If set to true, the result of all get functions (ie, getNumeric, getBlob, etc.)
+     * If set to true, the result of all get functions (ie, getNumeric, getDataTable, etc.)
      * will be indexed by the period, even if we're only querying data for one period.
      *
      * @var bool
@@ -186,11 +186,6 @@ class Archive implements ArchiveQuery
      * @var Parameters
      */
     private $params;
-
-    /**
-     * @var \Matomo\Cache\Cache
-     */
-    private static $cache;
 
     /**
      * If true, this Archive instance will not launch the archiving process, even if the current request
@@ -229,8 +224,8 @@ class Archive implements ArchiveQuery
      * @param string $period 'day', `'week'`, `'month'`, `'year'` or `'range'`
      * @param Date|string $strDate 'YYYY-MM-DD', magic keywords (ie, 'today'; {@link Date::factory()}
      *                             or date range (ie, 'YYYY-MM-DD,YYYY-MM-DD').
-     * @param bool|false|string $segment Segment definition or false if no segment should be used. {@link Piwik\Segment}
-     * @param bool|false|string $_restrictSitesToLogin Used only when running as a scheduled task.
+     * @param string|null|false $segment Segment definition or false if no segment should be used. {@link Piwik\Segment}
+     * @param string|null|false $_restrictSitesToLogin Used only when running as a scheduled task.
      * @return ArchiveQuery
      */
     public static function build($idSites, $period, $strDate, $segment = false, $_restrictSitesToLogin = false)
@@ -282,6 +277,9 @@ class Archive implements ArchiveQuery
         );
     }
 
+    /**
+     * @return bool
+     */
     public static function shouldSkipArchiveIfSkippingSegmentArchiveForToday(Site $site, Period $period, Segment $segment)
     {
         $now = Date::factory('now', $site->getTimezone());
@@ -301,9 +299,9 @@ class Archive implements ArchiveQuery
      * The site ID index is always first, so if multiple sites & periods were requested, the result
      * will be indexed by site ID first, then period.
      *
-     * @param string|array $names One or more archive names, eg, `'nb_visits'`, `'Referrers_distinctKeywords'`,
+     * @param string|string[] $names One or more archive names, eg, `'nb_visits'`, `'Referrers_distinctKeywords'`,
      *                            etc.
-     * @return false|integer|array `false` if there is no data to return, a single numeric value if we're not querying
+     * @return float|array `false` if there is no data to return, a single numeric value if we're not querying
      *                             for multiple sites/periods, or an array if multiple sites, periods or names are
      *                             queried for.
      */
@@ -332,9 +330,11 @@ class Archive implements ArchiveQuery
      * Unlike other methods, this returns a DataCollection instance directly. Use it to directly access
      * and process blob data.
      *
-     * @param string|string[] $names One or more archive names, eg, `'nb_visits'`, `'Referrers_distinctKeywords'`,
-     *                            etc.
+     * @param string|string[] $names One or more archive names, eg, `'nb_visits'`, `'Referrers_distinctKeywords'`, etc.
+     * @param int|string|null $idSubtable
      * @return DataCollection the queried data.
+     *
+     * @deprecated remove with Matomo 6
      */
     public function getBlob($names, $idSubtable = null)
     {
@@ -390,6 +390,7 @@ class Archive implements ArchiveQuery
      *
      * This is the same as doing `$this->getDataTableFromNumeric()->mergeChildren()` but this way it is much faster.
      *
+     * @param string[] $names
      * @return DataTable|DataTable\Map
      *
      * @internal Currently only used by MultiSites.getAll plugin. Feel free to remove internal tag if needed somewhere
@@ -461,7 +462,7 @@ class Archive implements ArchiveQuery
     /**
      * Returns the given reports grouped by the plugin name that archives them.
      *
-     * @param array $archiveNames
+     * @param string[] $archiveNames
      * @return array `['MyPlugin' => ['MyPlugin_metric1', 'MyPlugin_report1'], ...]`
      */
     private function getRequestedPlugins($archiveNames)
@@ -498,7 +499,7 @@ class Archive implements ArchiveQuery
      * @param string $segment @see {@link build()}
      * @param bool $expanded If true, loads all subtables. See {@link getDataTableExpanded()}
      * @param bool $flat If true, loads all subtables and disabled all recursive filters.
-     * @param int|null|string $idSubtable See {@link getDataTableExpanded()}
+     * @param int|string|null|false $idSubtable See {@link getDataTableExpanded()}
      * @param int|null $depth See {@link getDataTableExpanded()}
      * @return DataTable|DataTable\Map
      */
@@ -544,8 +545,8 @@ class Archive implements ArchiveQuery
     /**
      * Queries archive tables for data and returns the result.
      * @param array|string $archiveNames
-     * @param $archiveDataType
-     * @param null|int $idSubtable
+     * @param 'blob'|'numeric' $archiveDataType
+     * @param null|int|string $idSubtable
      * @return Archive\DataCollection
      */
     protected function get($archiveNames, $archiveDataType, $idSubtable = null)
@@ -703,7 +704,7 @@ class Archive implements ArchiveQuery
      *
      * @param array $archiveNamesByPlugin @see getRequestedPlugins
      */
-    private function cacheArchiveIdsAfterLaunching($archiveNamesByPlugin)
+    private function cacheArchiveIdsAfterLaunching($archiveNamesByPlugin): void
     {
         foreach ($this->params->getPeriods() as $period) {
             $twoDaysAfterPeriod = $period->getDateEnd()->addDay(2);
@@ -758,7 +759,7 @@ class Archive implements ArchiveQuery
      *
      * @param array $plugins List of plugin names from which data is being requested.
      */
-    private function cacheArchiveIdsWithoutLaunching($plugins)
+    private function cacheArchiveIdsWithoutLaunching($plugins): void
     {
         [$idarchivesByReport, $idarchiveStatesByReport] = ArchiveSelector::getArchiveIdsAndStates(
             $this->params->getIdSites(),
@@ -799,9 +800,9 @@ class Archive implements ArchiveQuery
     /**
      * Returns the done string flag for a plugin using this instance's segment & periods.
      * @param string $plugin
-     * @return string
+     * @param array $idSites
      */
-    private function getDoneStringForPlugin($plugin, $idSites)
+    private function getDoneStringForPlugin($plugin, $idSites): string
     {
         $requestedReport = $this->getRequestedReport();
 
@@ -820,7 +821,7 @@ class Archive implements ArchiveQuery
         );
     }
 
-    private function getPeriodLabel()
+    private function getPeriodLabel(): string
     {
         $periods = $this->params->getPeriods();
         return reset($periods)->getLabel();
@@ -853,6 +854,10 @@ class Archive implements ArchiveQuery
         return $indices;
     }
 
+    /**
+     * @param string|int|float|false $value
+     * @return float|int
+     */
     private function formatNumericValue($value)
     {
         // If there is no dot, we return as is
@@ -881,7 +886,7 @@ class Archive implements ArchiveQuery
      * entries to the cache. If the archive is used again, SQL will be executed to
      * try and find the archive IDs even though we know there are none.
      */
-    private function initializeArchiveIdCache(string $doneFlag)
+    private function initializeArchiveIdCache(string $doneFlag): void
     {
         if (!isset($this->idarchives[$doneFlag])) {
             $this->idarchives[$doneFlag] = [];
@@ -899,6 +904,9 @@ class Archive implements ArchiveQuery
      * If the period isn't a range, then all plugins' archiving code is executed.
      * If the period is a range, then archiving code is executed individually for
      * each plugin.
+     *
+     * @param string $plugin
+     * @return string
      */
     private function getArchiveGroupOfPlugin($plugin)
     {
@@ -951,7 +959,7 @@ class Archive implements ArchiveQuery
         return $plugin;
     }
 
-    private function prepareArchive(array $archiveNamesByPlugin, Site $site, Period $period)
+    private function prepareArchive(array $archiveNamesByPlugin, Site $site, Period $period): void
     {
         $coreAdminHomeApi = API::getInstance();
 
@@ -999,7 +1007,11 @@ class Archive implements ArchiveQuery
         }
     }
 
-    private function getArchiveIdsAndStatesByMonth($doneFlags)
+    /**
+     * @param array $doneFlags
+     * @return array{0: array, 1: array}
+     */
+    private function getArchiveIdsAndStatesByMonth($doneFlags): array
     {
         // order idarchives by the table month they belong to
         $archiveIdsByMonth = [];
@@ -1032,13 +1044,17 @@ class Archive implements ArchiveQuery
     }
 
     /**
-     * @internal
+     * Only kept for BC
+     * @return void
+     * @deprecated Remove with Matomo 6
      */
     public static function clearStaticCache()
     {
-        self::$cache = null;
     }
 
+    /**
+     * @return void
+     */
     public function forceFetchingWithoutLaunchingArchiving()
     {
         $this->forceFetchingWithoutLaunchingArchiving = true;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -201,31 +201,6 @@ parameters:
 			path: core/Application/Kernel/PluginList.php
 
 		-
-			message: "#^Parameter \\#3 \\$idSubtable of method Piwik\\\\Archive\\:\\:get\\(\\) expects int\\|null, string given\\.$#"
-			count: 1
-			path: core/Archive.php
-
-		-
-			message: "#^Parameter \\#5 \\$plugin of method Piwik\\\\Plugins\\\\CoreAdminHome\\\\API\\:\\:archiveReports\\(\\) expects bool, \\(int\\|string\\) given\\.$#"
-			count: 1
-			path: core/Archive.php
-
-		-
-			message: "#^Static property Piwik\\\\Archive\\:\\:\\$cache \\(Matomo\\\\Cache\\\\Cache\\) does not accept null\\.$#"
-			count: 1
-			path: core/Archive.php
-
-		-
-			message: "#^Static property Piwik\\\\Archive\\:\\:\\$cache is never read, only written\\.$#"
-			count: 1
-			path: core/Archive.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between int\\|string\\|null and false will always evaluate to false\\.$#"
-			count: 1
-			path: core/Archive.php
-
-		-
 			message: "#^Method Piwik\\\\Archive\\\\ArchiveInvalidator\\:\\:getSegmentArchiving\\(\\) is unused\\.$#"
 			count: 1
 			path: core/Archive/ArchiveInvalidator.php
@@ -2815,16 +2790,6 @@ parameters:
 
 		-
 			message: "#^Left side of && is always true\\.$#"
-			count: 1
-			path: plugins/CoreAdminHome/API.php
-
-		-
-			message: "#^Parameter \\#1 \\$archiveOnlyReport of method Piwik\\\\ArchiveProcessor\\\\Parameters\\:\\:setArchiveOnlyReport\\(\\) expects array\\<string\\>\\|string, true given\\.$#"
-			count: 1
-			path: plugins/CoreAdminHome/API.php
-
-		-
-			message: "#^Parameter \\#1 \\$segmentCondition of class Piwik\\\\Segment constructor expects string, bool given\\.$#"
 			count: 1
 			path: plugins/CoreAdminHome/API.php
 

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -276,14 +276,12 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
-     * @param $idSite
-     * @param $period
-     * @param $date
-     * @param bool $segment
-     * @param bool $plugin
-     * @param bool $report
-     * @return mixed
-     * @throws \Piwik\Exception\UnexpectedWebsiteFoundException
+     * @param string $period
+     * @param string $date
+     * @param string|null|false $segment
+     * @param string|null|false $plugin
+     * @param string|string[]|null|false $report
+     * @return array
      * @internal
      */
     public function archiveReports(int $idSite, $period, $date, $segment = false, $plugin = false, $report = false)

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -11,7 +11,6 @@ namespace Piwik\Tests\Framework;
 
 use Piwik\Access;
 use Piwik\Application\Environment;
-use Piwik\Archive;
 use Piwik\ArchiveProcessor\PluginsArchiver;
 use Piwik\Auth;
 use Piwik\Auth\Password;
@@ -409,7 +408,6 @@ class Fixture extends \PHPUnit\Framework\Assert
         Common::$isCliMode = null;
         Common::$headersSentInTests = [];
         MockFileMethods::reset();
-        Archive::clearStaticCache();
         DataTableManager::getInstance()->deleteAll();
         Option::clearCache();
         Site::clearCache();


### PR DESCRIPTION
### Description

* Removes no longer used `$cache` property 
* marks `getBlob` and `clearStaticCache` as deprecated, so we do not forget to remove them with Matomo 6
  (Note: `getBlob` was already marked as deprecated in CHANGELOG, to be removed in 2015 🙈)
* adds a bunch missing type hints

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
