### PR TITLE
Use null-coalescing for blob archive limits in RecordBuilder::insertBlobRecord

### DIFF
--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -291,9 +291,9 @@ abstract class RecordBuilder
         ?string $columnToSortByBeforeTruncation
     ): void {
         $serialized = $record->getSerialized(
-            $maxRowsInTable ?: $this->maxRowsInTable,
-            $maxRowsInSubtable ?: $this->maxRowsInSubtable,
-            $columnToSortByBeforeTruncation ?: $this->columnToSortByBeforeTruncation
+            $maxRowsInTable ?? $this->maxRowsInTable,
+            $maxRowsInSubtable ?? $this->maxRowsInSubtable,
+            $columnToSortByBeforeTruncation ?? $this->columnToSortByBeforeTruncation
         );
         $archiveProcessor->insertBlobRecord($recordName, $serialized);
         unset($serialized);

--- a/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
+++ b/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
@@ -211,6 +211,45 @@ class RecordBuilderTest extends TestCase
         $this->assertEquals($expectedBlobRecords, $this->blobRecordsInserted);
     }
 
+    public function testBuildFromLogsUsesZeroRecordSpecificLimitInsteadOfDefaultLimit(): void
+    {
+        $recordBuilder = new class (2, null, 'nb_visits') extends ArchiveProcessor\RecordBuilder {
+            public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    Record::make(Record::TYPE_NUMERIC, 'TestPlugin_myMetric'),
+                    Record::make(Record::TYPE_BLOB, 'TestPlugin_myReport')
+                        ->setMaxRowsInTable(0),
+                ];
+            }
+
+            protected function aggregate(ArchiveProcessor $archiveProcessor): array
+            {
+                return [
+                    'TestPlugin_myMetric' => 30,
+                    'TestPlugin_myReport' => RecordBuilderTest::makeTestDataTable(),
+                ];
+            }
+        };
+
+        $mockArchiveProcessor = $this->getMockArchiveProcessor();
+        $recordBuilder->buildFromLogs($mockArchiveProcessor);
+
+        $expectedNumericRecords = ['TestPlugin_myMetric' => 30];
+        $expectedBlobRecords = [
+            'TestPlugin_myReport' => [
+                [
+                    [Row::COLUMNS => ['label' => 'the thing', 'nb_visits' => 40], Row::METADATA => [], Row::DATATABLE_ASSOCIATED => null],
+                    [Row::COLUMNS => ['label' => 'another thing', 'nb_visits' => 50], Row::METADATA => [], Row::DATATABLE_ASSOCIATED => null],
+                    [Row::COLUMNS => ['label' => 'a third thing', 'nb_visits' => 20], Row::METADATA => [], Row::DATATABLE_ASSOCIATED => null],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedNumericRecords, $this->numericRecordsInserted);
+        $this->assertEquals($expectedBlobRecords, $this->blobRecordsInserted);
+    }
+
     public function testBuildForNonDayPeriodDoesNothingIfRecordBuilderNotEnabled()
     {
         $recordBuilder = new class () extends ArchiveProcessor\RecordBuilder {


### PR DESCRIPTION
### Description


RecordBuilder::insertBlobRecord() used ?: when applying record-specific limits.
This treats 0 as falsy and falls back to default limits, so explicit 0 values (= no limit) are ignored.

### Why this is correct

null means “use default”.
0 is a valid explicit config value and must be preserved.

### Impact

- Fixes incorrect fallback behavior for explicit 0 (no limit).

refs #24191

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
