### PR TITLE
Preserve empty URL segment metadata handling without requiring URL prefix

### DIFF
--- a/plugins/Actions/DataTable/Filter/Actions.php
+++ b/plugins/Actions/DataTable/Filter/Actions.php
@@ -93,11 +93,11 @@ class Actions extends BaseFilter
                                 $row->setMetadata('segmentValue', urlencode(trim($label)));
                             }
                         }
-                    } elseif ($this->actionType == Action::TYPE_PAGE_URL && $urlPrefix) { // folder for older data w/ no folder URL metadata
+                    } elseif ($this->actionType == Action::TYPE_PAGE_URL) { // folder for older data w/ no folder URL metadata
                         if ($label === $notDefinedUrl) {
                             // segmenting by an "empty" value is currently broken for actions, so we do not set a segment value to hide row actions like segmented visit log
                             $row->setMetadata('segment', null);
-                        } else {
+                        } elseif ($urlPrefix) {
                             $row->setMetadata('segment', 'pageUrl=^' . urlencode(urlencode($urlPrefix . '/' . $label)));
                         }
                     }

--- a/plugins/Actions/tests/Unit/DataTableFilterActionsTest.php
+++ b/plugins/Actions/tests/Unit/DataTableFilterActionsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Actions\tests\Unit;
+
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+use Piwik\Plugins\Actions\ArchivingHelper;
+use Piwik\Plugins\Actions\DataTable\Filter\Actions as ActionsFilter;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tracker\Action;
+
+require_once PIWIK_INCLUDE_PATH . '/plugins/Actions/Actions.php';
+
+/**
+ * @group Actions
+ * @group DataTableFilterActionsTest
+ * @group Plugins
+ */
+class DataTableFilterActionsTest extends \PHPUnit\Framework\TestCase
+{
+    public function setUp(): void
+    {
+        Fixture::loadAllTranslations();
+    }
+
+    public function tearDown(): void
+    {
+        Fixture::resetTranslations();
+    }
+
+    public function testFilterSetsNullSegmentForUnknownPageUrlEvenWithoutSiteUrlPrefix()
+    {
+        ArchivingHelper::reloadConfig();
+
+        $table = new DataTable();
+        $notDefinedUrl = ArchivingHelper::getUnknownActionName(Action::TYPE_PAGE_URL);
+        $row = new Row([Row::COLUMNS => ['label' => $notDefinedUrl]]);
+        $table->addRow($row);
+
+        $filter = new ActionsFilter($table, Action::TYPE_PAGE_URL);
+        $filter->filter($table);
+
+        $allMetadata = $row->getMetadata();
+        $this->assertArrayHasKey('segment', $allMetadata);
+        $this->assertNull($allMetadata['segment']);
+    }
+}


### PR DESCRIPTION
### Description

In Actions DataTable filter, URL metadata handling was gated by `&& $urlPrefix`.
If prefix was missing, the branch did not run, so empty/not-defined URL rows did not get `segment = null` metadata.

Empty/not-defined URL rows should consistently avoid segment actions, independent of URL prefix availability.

refs #24191

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
