### PR TITLE
Add robust fallback for goal conversion totals in `CalculateConversionPageRate`

### DIFF
--- a/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
+++ b/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
@@ -147,12 +147,12 @@ class CalculateConversionPageRate extends BaseFilter
                     continue;
                 }
 
-                $entryConversions = $goalsColumn[$idGoal][Metrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY] ?? null;
-                if (!is_numeric($entryConversions)) {
+                $conversions = $goalsColumn[$idGoal][Metrics::INDEX_GOAL_NB_CONVERSIONS] ?? null;
+                if (!is_numeric($conversions)) {
                     continue;
                 }
 
-                $goalTotals[$idGoal] = ($goalTotals[$idGoal] ?? 0) + (float) $entryConversions;
+                $goalTotals[$idGoal] = ($goalTotals[$idGoal] ?? 0) + (float) $conversions;
             }
         }
 

--- a/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
+++ b/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\Goals\DataTable\Filter;
 
 use Piwik\Plugins\Goals\Archiver as GoalsArchiver;
 use Piwik\Archive;
+use Piwik\Context;
 use Piwik\DataTable\BaseFilter;
 use Piwik\DataTable;
 use Piwik\Metrics;
@@ -45,6 +46,17 @@ class CalculateConversionPageRate extends BaseFilter
 
         // Get the total top-level conversions for the goals in the table
         $goalTotals = $this->getGoalTotalConversions($table, $goals);
+        $fallbackGoalTotals = $this->getGoalTotalConversionsFromTable($table, $goals);
+        foreach ($goals as $idGoal) {
+            if (
+                (!isset($goalTotals[$idGoal]) || (float) $goalTotals[$idGoal] <= 0.0)
+                && isset($fallbackGoalTotals[$idGoal])
+                && (float) $fallbackGoalTotals[$idGoal] > 0.0
+            ) {
+                $goalTotals[$idGoal] = (float) $fallbackGoalTotals[$idGoal];
+            }
+        }
+
         if (count($goalTotals) === 0) {
             return;
         }
@@ -97,19 +109,50 @@ class CalculateConversionPageRate extends BaseFilter
         $date = $period->getDateStart()->toString();
         $date = ($periodName === 'range' ? $date . ',' . $period->getDateEnd()->toString() : $date);
         $segment = $table->getMetadata('segment');
-        $archive = Archive::build($idSite, $periodName, $date, $segment);
-
         $names = [];
         foreach ($goalIds as $idGoal => $g) {
             $names[$idGoal] = GoalsArchiver::getRecordName('nb_conversions', $idGoal);
         }
 
-        $sum = $archive->getNumeric($names);
+        $sum = Context::executeWithQueryParameters(['requestedReport' => ''], function () use ($idSite, $periodName, $date, $segment, $names) {
+            $archive = Archive::build($idSite, $periodName, $date, $segment);
+            return $archive->getNumeric($names);
+        });
         foreach ($names as $idGoal => $name) {
             if (is_array($sum) && array_key_exists($name, $sum) && is_numeric($sum[$name])) {
                 $goalTotals[$idGoal] = $sum[$name];
             } elseif (is_numeric($sum)) {
                 $goalTotals[$idGoal] = $sum;
+            }
+        }
+
+        return $goalTotals;
+    }
+
+    private function getGoalTotalConversionsFromTable(DataTable $table, array $goalIds): array
+    {
+        $goalTotals = [];
+        if (empty($goalIds)) {
+            return $goalTotals;
+        }
+
+        foreach ($table->getRows() as $row) {
+            $goalsColumn = $row[Metrics::INDEX_GOALS] ?? null;
+            if (!is_array($goalsColumn)) {
+                continue;
+            }
+
+            foreach ($goalIds as $idGoal) {
+                if (!isset($goalsColumn[$idGoal]) || !is_array($goalsColumn[$idGoal])) {
+                    continue;
+                }
+
+                $entryConversions = $goalsColumn[$idGoal][Metrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY] ?? null;
+                if (!is_numeric($entryConversions)) {
+                    continue;
+                }
+
+                $goalTotals[$idGoal] = ($goalTotals[$idGoal] ?? 0) + (float) $entryConversions;
             }
         }
 

--- a/plugins/Goals/tests/System/TrackGoalsPagesTest.php
+++ b/plugins/Goals/tests/System/TrackGoalsPagesTest.php
@@ -87,6 +87,19 @@ class TrackGoalsPagesTest extends SystemTestCase
                     'apiAction' => 'getPageTitles',
                 ],
             ]],
+            ['API.getProcessedReport', [
+                'idSite' => self::$fixture->idSite,
+                'date' => self::$fixture->dateTime,
+                'period' => 'day',
+                'testSuffix' => 'showGoalsMetricsPageReportWithRequestedReport',
+                'otherRequestParameters' => [
+                    'filter_update_columns_when_show_all_goals' => '1',
+                    'filter_show_goal_columns_process_goals' => '1',
+                    'apiModule' => 'Actions',
+                    'apiAction' => 'getPageTitles',
+                    'requestedReport' => 'Goals.get',
+                ],
+            ]],
         ];
     }
 

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pagesshowGoalsMetricsPageReportWithRequestedReport__API.getProcessedReport_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pagesshowGoalsMetricsPageReportWithRequestedReport__API.getProcessedReport_day.xml
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<website>Piwik test</website>
+	<prettyDate>Monday, January 5, 2009</prettyDate>
+	<metadata>
+		<category>Behaviour</category>
+		<subcategory>Page titles</subcategory>
+		<name>Page titles</name>
+		<module>Actions</module>
+		<action>getPageTitles</action>
+		<dimension>Page Title</dimension>
+		<documentation>This report contains information about the titles of the pages that have been visited. &lt;br /&gt; The page title is the HTML &lt;title&gt; Tag that most browsers show in their window title.</documentation>
+		<metrics>
+			<nb_hits>Pageviews</nb_hits>
+			<nb_visits>Unique Pageviews</nb_visits>
+		</metrics>
+		<metricsDocumentation>
+			<nb_hits>The number of times this page was visited.</nb_hits>
+			<nb_visits>The number of visits that included this page. If a page was viewed multiple times during one visit, it is only counted once.</nb_visits>
+			<avg_time_on_page>The average amount of time visitors spent on this page (only the page, not the entire website).</avg_time_on_page>
+			<bounce_rate>The percentage of visits that started on this page and left the website straight away.</bounce_rate>
+			<exit_rate>The percentage of visits that left the website after viewing this page.</exit_rate>
+		</metricsDocumentation>
+		<processedMetrics>
+			<avg_time_on_page>Avg. time on page</avg_time_on_page>
+			<bounce_rate>Bounce Rate</bounce_rate>
+			<exit_rate>Exit rate</exit_rate>
+			<avg_time_generation>Avg. generation time</avg_time_generation>
+		</processedMetrics>
+		<metricTypes>
+			<nb_hits>number</nb_hits>
+			<nb_visits>number</nb_visits>
+			<avg_time_on_page>duration_s</avg_time_on_page>
+			<bounce_rate>percent</bounce_rate>
+			<exit_rate>percent</exit_rate>
+			<avg_time_generation>duration_s</avg_time_generation>
+		</metricTypes>
+		<actionToLoadSubTables>getPageTitles</actionToLoadSubTables>
+		<relatedReports>
+			<row>
+				<name>Entry page titles</name>
+				<module>Actions</module>
+				<action>getEntryPageTitles</action>
+			</row>
+			<row>
+				<name>Exit page titles</name>
+				<module>Actions</module>
+				<action>getExitPageTitles</action>
+			</row>
+		</relatedReports>
+		<metricsGoal>
+			<nb_conversions>Conversions</nb_conversions>
+			<conversion_rate>Conversion Rate</conversion_rate>
+			<nb_conversions_attrib>Conversions</nb_conversions_attrib>
+			<revenue_attrib>Revenue</revenue_attrib>
+		</metricsGoal>
+		<processedMetricsGoal>
+			<revenue_per_visit>Revenue per Visit</revenue_per_visit>
+			<nb_conversions_page_rate>Viewed before conversion rate</nb_conversions_page_rate>
+		</processedMetricsGoal>
+		<metricTypesGoal>
+			<revenue_per_visit>money</revenue_per_visit>
+			<nb_conversions>number</nb_conversions>
+			<conversion_rate>percent</conversion_rate>
+			<nb_conversions_attrib>number</nb_conversions_attrib>
+			<revenue_attrib>money</revenue_attrib>
+			<nb_conversions_page_rate>percent</nb_conversions_page_rate>
+		</metricTypesGoal>
+		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getPageTitles&amp;period=day&amp;date=2009-01-05</imageGraphUrl>
+		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getPageTitles&amp;period=day&amp;date=2008-12-07,2009-01-05</imageGraphEvolutionUrl>
+		<uniqueId>Actions_getPageTitles</uniqueId>
+	</metadata>
+	<columns>
+		<label>Page Title</label>
+		<nb_hits>Pageviews</nb_hits>
+		<nb_visits>Unique Pageviews</nb_visits>
+		<avg_time_on_page>Avg. time on page</avg_time_on_page>
+		<bounce_rate>Bounce Rate</bounce_rate>
+		<exit_rate>Exit rate</exit_rate>
+	</columns>
+	<reportData>
+		<row>
+			<label> Page A - index.html</label>
+			<nb_visits>4</nb_visits>
+			<nb_hits>5</nb_hits>
+			<bounce_rate>0%</bounce_rate>
+			<goal_1_conversion_rate>75%</goal_1_conversion_rate>
+			<goal_1_nb_conversions>3</goal_1_nb_conversions>
+			<goal_1_revenue_per_visit>$7.50</goal_1_revenue_per_visit>
+			<goal_1_revenue>$30</goal_1_revenue>
+			<goal_1_nb_conversions_attrib>1.0833</goal_1_nb_conversions_attrib>
+			<goal_1_revenue_attrib>$10.83</goal_1_revenue_attrib>
+			<goal_1_nb_conversions_page_rate>100%</goal_1_nb_conversions_page_rate>
+			<goal_2_conversion_rate>50%</goal_2_conversion_rate>
+			<goal_2_nb_conversions>2</goal_2_nb_conversions>
+			<goal_2_revenue_per_visit>$5</goal_2_revenue_per_visit>
+			<goal_2_revenue>$20</goal_2_revenue>
+			<goal_2_nb_conversions_attrib>0.4</goal_2_nb_conversions_attrib>
+			<goal_2_revenue_attrib>$4</goal_2_revenue_attrib>
+			<goal_2_nb_conversions_page_rate>100%</goal_2_nb_conversions_page_rate>
+			<avg_time_on_page>00:06:00</avg_time_on_page>
+			<exit_rate>0%</exit_rate>
+		</row>
+		<row>
+			<label> Page C</label>
+			<nb_visits>3</nb_visits>
+			<nb_hits>4</nb_hits>
+			<bounce_rate>0%</bounce_rate>
+			<goal_1_conversion_rate>100%</goal_1_conversion_rate>
+			<goal_1_nb_conversions>3</goal_1_nb_conversions>
+			<goal_1_revenue_per_visit>$10</goal_1_revenue_per_visit>
+			<goal_1_revenue>$30</goal_1_revenue>
+			<goal_1_nb_conversions_attrib>1.0833</goal_1_nb_conversions_attrib>
+			<goal_1_revenue_attrib>$10.83</goal_1_revenue_attrib>
+			<goal_1_nb_conversions_page_rate>100%</goal_1_nb_conversions_page_rate>
+			<goal_2_conversion_rate>66.67%</goal_2_conversion_rate>
+			<goal_2_nb_conversions>2</goal_2_nb_conversions>
+			<goal_2_revenue_per_visit>$6.67</goal_2_revenue_per_visit>
+			<goal_2_revenue>$20</goal_2_revenue>
+			<goal_2_nb_conversions_attrib>0.4</goal_2_nb_conversions_attrib>
+			<goal_2_revenue_attrib>$4</goal_2_revenue_attrib>
+			<goal_2_nb_conversions_page_rate>100%</goal_2_nb_conversions_page_rate>
+			<avg_time_on_page>00:01:30</avg_time_on_page>
+			<exit_rate>100%</exit_rate>
+		</row>
+		<row>
+			<label> Page B</label>
+			<nb_visits>2</nb_visits>
+			<nb_hits>2</nb_hits>
+			<bounce_rate>0%</bounce_rate>
+			<goal_1_conversion_rate>50%</goal_1_conversion_rate>
+			<goal_1_nb_conversions>1</goal_1_nb_conversions>
+			<goal_1_revenue_per_visit>$5</goal_1_revenue_per_visit>
+			<goal_1_revenue>$10</goal_1_revenue>
+			<goal_1_nb_conversions_attrib>0.25</goal_1_nb_conversions_attrib>
+			<goal_1_revenue_attrib>$2.50</goal_1_revenue_attrib>
+			<goal_1_nb_conversions_page_rate>33.3%</goal_1_nb_conversions_page_rate>
+			<goal_2_conversion_rate>50%</goal_2_conversion_rate>
+			<goal_2_nb_conversions>1</goal_2_nb_conversions>
+			<goal_2_revenue_per_visit>$5</goal_2_revenue_per_visit>
+			<goal_2_revenue>$10</goal_2_revenue>
+			<goal_2_nb_conversions_attrib>0.2</goal_2_nb_conversions_attrib>
+			<goal_2_revenue_attrib>$2</goal_2_revenue_attrib>
+			<goal_2_nb_conversions_page_rate>100%</goal_2_nb_conversions_page_rate>
+			<avg_time_on_page>00:06:00</avg_time_on_page>
+			<exit_rate>0%</exit_rate>
+		</row>
+		<row>
+			<label> Page A - X</label>
+			<nb_visits>1</nb_visits>
+			<nb_hits>1</nb_hits>
+			<bounce_rate>0%</bounce_rate>
+			<goal_1_conversion_rate>100%</goal_1_conversion_rate>
+			<goal_1_nb_conversions>1</goal_1_nb_conversions>
+			<goal_1_revenue_per_visit>$10</goal_1_revenue_per_visit>
+			<goal_1_revenue>$10</goal_1_revenue>
+			<goal_1_nb_conversions_attrib>0.25</goal_1_nb_conversions_attrib>
+			<goal_1_revenue_attrib>$2.50</goal_1_revenue_attrib>
+			<goal_1_nb_conversions_page_rate>33.3%</goal_1_nb_conversions_page_rate>
+			<goal_2_conversion_rate>0%</goal_2_conversion_rate>
+			<goal_2_nb_conversions>0</goal_2_nb_conversions>
+			<goal_2_revenue_per_visit>$0</goal_2_revenue_per_visit>
+			<goal_2_revenue>$0</goal_2_revenue>
+			<goal_2_nb_conversions_attrib />
+			<goal_2_revenue_attrib>$0</goal_2_revenue_attrib>
+			<goal_2_nb_conversions_page_rate />
+			<avg_time_on_page>00:06:00</avg_time_on_page>
+			<exit_rate>0%</exit_rate>
+		</row>
+		<row>
+			<label> Page A - Z</label>
+			<nb_visits>1</nb_visits>
+			<nb_hits>1</nb_hits>
+			<bounce_rate>0%</bounce_rate>
+			<goal_1_conversion_rate>100%</goal_1_conversion_rate>
+			<goal_1_nb_conversions>1</goal_1_nb_conversions>
+			<goal_1_revenue_per_visit>$10</goal_1_revenue_per_visit>
+			<goal_1_revenue>$10</goal_1_revenue>
+			<goal_1_nb_conversions_attrib>0.3333</goal_1_nb_conversions_attrib>
+			<goal_1_revenue_attrib>$3.33</goal_1_revenue_attrib>
+			<goal_1_nb_conversions_page_rate>33.3%</goal_1_nb_conversions_page_rate>
+			<goal_2_conversion_rate>0%</goal_2_conversion_rate>
+			<goal_2_nb_conversions>0</goal_2_nb_conversions>
+			<goal_2_revenue_per_visit>$0</goal_2_revenue_per_visit>
+			<goal_2_revenue>$0</goal_2_revenue>
+			<goal_2_nb_conversions_attrib />
+			<goal_2_revenue_attrib>$0</goal_2_revenue_attrib>
+			<goal_2_nb_conversions_page_rate />
+			<avg_time_on_page>00:06:00</avg_time_on_page>
+			<exit_rate>0%</exit_rate>
+		</row>
+		<row>
+			<label> Page D</label>
+			<nb_visits>1</nb_visits>
+			<nb_hits>1</nb_hits>
+			<bounce_rate>0%</bounce_rate>
+			<goal_1_conversion_rate>0%</goal_1_conversion_rate>
+			<goal_1_nb_conversions>0</goal_1_nb_conversions>
+			<goal_1_revenue_per_visit>$0</goal_1_revenue_per_visit>
+			<goal_1_revenue>$0</goal_1_revenue>
+			<goal_1_nb_conversions_attrib />
+			<goal_1_revenue_attrib>$0</goal_1_revenue_attrib>
+			<goal_1_nb_conversions_page_rate />
+			<goal_2_conversion_rate>0%</goal_2_conversion_rate>
+			<goal_2_nb_conversions>0</goal_2_nb_conversions>
+			<goal_2_revenue_per_visit>$0</goal_2_revenue_per_visit>
+			<goal_2_revenue>$0</goal_2_revenue>
+			<goal_2_nb_conversions_attrib />
+			<goal_2_revenue_attrib>$0</goal_2_revenue_attrib>
+			<goal_2_nb_conversions_page_rate />
+			<avg_time_on_page>00:00:00</avg_time_on_page>
+			<exit_rate>100%</exit_rate>
+		</row>
+	</reportData>
+	<reportMetadata>
+		<row>
+			<segment>pageTitle==Page%2BA%2B-%2Bindex.html</segment>
+		</row>
+		<row>
+			<segment>pageTitle==Page%2BC</segment>
+		</row>
+		<row>
+			<segment>pageTitle==Page%2BB</segment>
+		</row>
+		<row>
+			<segment>pageTitle==Page%2BA%2B-%2BX</segment>
+		</row>
+		<row>
+			<segment>pageTitle==Page%2BA%2B-%2BZ</segment>
+		</row>
+		<row>
+			<segment>pageTitle==Page%2BD</segment>
+		</row>
+	</reportMetadata>
+	<reportTotal>
+		<nb_visits>12</nb_visits>
+		<nb_uniq_visitors>12</nb_uniq_visitors>
+		<nb_hits>14</nb_hits>
+		<sum_time_spent>3600</sum_time_spent>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<entry_nb_uniq_visitors>4</entry_nb_uniq_visitors>
+		<entry_nb_visits>4</entry_nb_visits>
+		<entry_nb_actions>18</entry_nb_actions>
+		<entry_sum_visit_length>5047</entry_sum_visit_length>
+		<entry_bounce_count>0</entry_bounce_count>
+		<goals>
+			<row idgoal="1">
+				<nb_conversions>9</nb_conversions>
+				<revenue>90</revenue>
+				<nb_conv_pages_before>19</nb_conv_pages_before>
+				<nb_conversions_attrib>2.9999</nb_conversions_attrib>
+				<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
+				<revenue_attrib>29.99</revenue_attrib>
+				<revenue_entry>30</revenue_entry>
+				<revenue_per_entry>7.5</revenue_per_entry>
+				<nb_conversions_entry>3</nb_conversions_entry>
+				<nb_conversions_page_rate>2.999</nb_conversions_page_rate>
+				<nb_conversions_entry_rate>0.75</nb_conversions_entry_rate>
+			</row>
+			<row idgoal="2">
+				<nb_conversions>5</nb_conversions>
+				<revenue>50</revenue>
+				<nb_conv_pages_before>15</nb_conv_pages_before>
+				<nb_conversions_attrib>1</nb_conversions_attrib>
+				<nb_conversions_page_uniq>5</nb_conversions_page_uniq>
+				<revenue_attrib>10</revenue_attrib>
+				<revenue_entry>10</revenue_entry>
+				<revenue_per_entry>2.5</revenue_per_entry>
+				<nb_conversions_entry>1</nb_conversions_entry>
+				<nb_conversions_page_rate>3</nb_conversions_page_rate>
+				<nb_conversions_entry_rate>0.25</nb_conversions_entry_rate>
+			</row>
+		</goals>
+		<exit_nb_uniq_visitors>4</exit_nb_uniq_visitors>
+		<exit_nb_visits>4</exit_nb_visits>
+	</reportTotal>
+</result>

--- a/plugins/Goals/tests/Unit/CalculateConversionPageRateTest.php
+++ b/plugins/Goals/tests/Unit/CalculateConversionPageRateTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Goals\tests\Unit;
+
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+use Piwik\Metrics;
+
+/**
+ * @group CalculateConversionPageRateTest
+ * @group DataTable
+ * @group Filter
+ * @group Goals
+ */
+class CalculateConversionPageRateTest extends \PHPUnit\Framework\TestCase
+{
+    public function testFilterUsesNbConversionsFallbackIncludingSummaryRow()
+    {
+        $table = new DataTable();
+        $table->addRowsFromArray([
+            [Row::COLUMNS => [
+                Metrics::INDEX_GOALS => [
+                    '1' => [
+                        Metrics::INDEX_GOAL_NB_CONVERSIONS => 3,
+                        Metrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY => 30,
+                        Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_UNIQ => 1,
+                    ],
+                ],
+            ]],
+            [Row::COLUMNS => [
+                Metrics::INDEX_GOALS => [
+                    '1' => [
+                        Metrics::INDEX_GOAL_NB_CONVERSIONS => 3,
+                        Metrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY => 30,
+                        Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_UNIQ => 2,
+                    ],
+                ],
+            ]],
+            DataTable::ID_SUMMARY_ROW => [Row::COLUMNS => [
+                Metrics::INDEX_GOALS => [
+                    '1' => [
+                        Metrics::INDEX_GOAL_NB_CONVERSIONS => 4,
+                        Metrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY => 40,
+                        Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_UNIQ => 3,
+                    ],
+                ],
+            ]],
+        ]);
+
+        $table->filter('Piwik\Plugins\Goals\DataTable\Filter\CalculateConversionPageRate');
+
+        $firstRowGoalMetrics = $table->getRowFromId(0)->getColumn(Metrics::INDEX_GOALS)['1'];
+        $secondRowGoalMetrics = $table->getRowFromId(1)->getColumn(Metrics::INDEX_GOALS)['1'];
+        $this->assertSame(0.1, $firstRowGoalMetrics[Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_RATE]);
+        $this->assertSame(0.2, $secondRowGoalMetrics[Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_RATE]);
+    }
+
+    public function testFilterCapsPageConversionRateAtOneWhenFallbackTotalsAreUsed()
+    {
+        $table = new DataTable();
+        $table->addRowsFromArray([
+            [Row::COLUMNS => [
+                Metrics::INDEX_GOALS => [
+                    '1' => [
+                        Metrics::INDEX_GOAL_NB_CONVERSIONS => 1,
+                        Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_UNIQ => 3,
+                    ],
+                ],
+            ]],
+        ]);
+
+        $table->filter('Piwik\Plugins\Goals\DataTable\Filter\CalculateConversionPageRate');
+
+        $goalMetrics = $table->getFirstRow()->getColumn(Metrics::INDEX_GOALS)['1'];
+        $this->assertSame(1, $goalMetrics[Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_RATE]);
+    }
+}


### PR DESCRIPTION
### Description

`CalculateConversionPageRate` depends on top-level goal totals from archive numerics.
In some contexts these totals can be missing/zero, causing page conversion rates to be skipped or incorrect.

If archive totals are unavailable, using reliable totals present in the table allows rate calculation to proceed safely.

refs #24191

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
