### PR TITLE
Clean up renamed daily unique metrics on parent rows in Actions hierarchy

### DIFF
--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -381,6 +381,12 @@ class ArchivingHelper
                 foreach (Metrics::$columnsToDeleteAfterAggregation as $name) {
                     $row->deleteColumn($name);
                 }
+
+                if ($idSubtable !== null) {
+                    foreach (array_values(Metrics::$columnsToRenameAfterAggregation) as $name) {
+                        $row->deleteColumn($name);
+                    }
+                }
             }
         }
 

--- a/plugins/Actions/tests/Unit/ArchiverTest.php
+++ b/plugins/Actions/tests/Unit/ArchiverTest.php
@@ -9,6 +9,9 @@
 
 namespace Piwik\Plugins\Actions\tests\Unit;
 
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+use Piwik\Metrics as PiwikMetrics;
 use Piwik\Plugins\Actions\ArchivingHelper;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tracker\Action;
@@ -126,5 +129,72 @@ class ArchiverTests extends \PHPUnit\Framework\TestCase
         ArchivingHelper::reloadConfig();
         $processed = ArchivingHelper::getActionExplodedNames($params['name'], $params['type'], (isset($params['urlPrefix']) ? $params['urlPrefix'] : null));
         $this->assertEquals($expected, $processed);
+    }
+
+    public function testDeleteInvalidSummedColumnsFromDataTableRemovesRenamedUniqMetricsFromParentRowsOnly()
+    {
+        $table = new DataTable();
+
+        $parentRow = new Row([Row::COLUMNS => [
+            'label' => '/parent',
+            PiwikMetrics::INDEX_NB_UNIQ_VISITORS => 12,
+            PiwikMetrics::INDEX_PAGE_ENTRY_NB_UNIQ_VISITORS => 8,
+            PiwikMetrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS => 4,
+            PiwikMetrics::INDEX_SUM_DAILY_NB_UNIQ_VISITORS => 20,
+            PiwikMetrics::INDEX_PAGE_ENTRY_SUM_DAILY_NB_UNIQ_VISITORS => 16,
+            PiwikMetrics::INDEX_PAGE_EXIT_SUM_DAILY_NB_UNIQ_VISITORS => 14,
+        ]]);
+        $parentRow->setSubtable(new DataTable());
+        $table->addRow($parentRow);
+
+        $leafRow = new Row([Row::COLUMNS => [
+            'label' => '/leaf',
+            PiwikMetrics::INDEX_NB_UNIQ_VISITORS => 5,
+            PiwikMetrics::INDEX_PAGE_ENTRY_NB_UNIQ_VISITORS => 4,
+            PiwikMetrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS => 3,
+            PiwikMetrics::INDEX_SUM_DAILY_NB_UNIQ_VISITORS => 9,
+            PiwikMetrics::INDEX_PAGE_ENTRY_SUM_DAILY_NB_UNIQ_VISITORS => 7,
+            PiwikMetrics::INDEX_PAGE_EXIT_SUM_DAILY_NB_UNIQ_VISITORS => 6,
+        ]]);
+        $table->addRow($leafRow);
+
+        ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($table);
+
+        $this->assertFalse($parentRow->hasColumn(PiwikMetrics::INDEX_NB_UNIQ_VISITORS));
+        $this->assertFalse($parentRow->hasColumn(PiwikMetrics::INDEX_PAGE_ENTRY_NB_UNIQ_VISITORS));
+        $this->assertFalse($parentRow->hasColumn(PiwikMetrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS));
+        $this->assertFalse($parentRow->hasColumn(PiwikMetrics::INDEX_SUM_DAILY_NB_UNIQ_VISITORS));
+        $this->assertFalse($parentRow->hasColumn(PiwikMetrics::INDEX_PAGE_ENTRY_SUM_DAILY_NB_UNIQ_VISITORS));
+        $this->assertFalse($parentRow->hasColumn(PiwikMetrics::INDEX_PAGE_EXIT_SUM_DAILY_NB_UNIQ_VISITORS));
+
+        $this->assertSame(9, $leafRow->getColumn(PiwikMetrics::INDEX_SUM_DAILY_NB_UNIQ_VISITORS));
+        $this->assertSame(7, $leafRow->getColumn(PiwikMetrics::INDEX_PAGE_ENTRY_SUM_DAILY_NB_UNIQ_VISITORS));
+        $this->assertSame(6, $leafRow->getColumn(PiwikMetrics::INDEX_PAGE_EXIT_SUM_DAILY_NB_UNIQ_VISITORS));
+    }
+
+    public function testDeleteInvalidSummedColumnsFromDataTableKeepsRenamedUniqMetricsOnSummaryRow()
+    {
+        $table = new DataTable();
+        $summaryRow = new Row([Row::COLUMNS => [
+            'label' => DataTable::LABEL_SUMMARY_ROW,
+            PiwikMetrics::INDEX_NB_UNIQ_VISITORS => 12,
+            PiwikMetrics::INDEX_PAGE_ENTRY_NB_UNIQ_VISITORS => 8,
+            PiwikMetrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS => 4,
+            PiwikMetrics::INDEX_SUM_DAILY_NB_UNIQ_VISITORS => 20,
+            PiwikMetrics::INDEX_PAGE_ENTRY_SUM_DAILY_NB_UNIQ_VISITORS => 16,
+            PiwikMetrics::INDEX_PAGE_EXIT_SUM_DAILY_NB_UNIQ_VISITORS => 14,
+        ]]);
+        $table->addSummaryRow($summaryRow);
+
+        ArchivingHelper::deleteInvalidSummedColumnsFromDataTable($table);
+
+        $summaryRow = $table->getRowFromId(DataTable::ID_SUMMARY_ROW);
+        $this->assertNotNull($summaryRow);
+        $this->assertFalse($summaryRow->hasColumn(PiwikMetrics::INDEX_NB_UNIQ_VISITORS));
+        $this->assertFalse($summaryRow->hasColumn(PiwikMetrics::INDEX_PAGE_ENTRY_NB_UNIQ_VISITORS));
+        $this->assertFalse($summaryRow->hasColumn(PiwikMetrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS));
+        $this->assertSame(20, $summaryRow->getColumn(PiwikMetrics::INDEX_SUM_DAILY_NB_UNIQ_VISITORS));
+        $this->assertSame(16, $summaryRow->getColumn(PiwikMetrics::INDEX_PAGE_ENTRY_SUM_DAILY_NB_UNIQ_VISITORS));
+        $this->assertSame(14, $summaryRow->getColumn(PiwikMetrics::INDEX_PAGE_EXIT_SUM_DAILY_NB_UNIQ_VISITORS));
     }
 }


### PR DESCRIPTION
### Problem

Actions report aggregation uses renamed helper metrics for non-additive unique values:

- nb_uniq_visitors -> sum_daily_nb_uniq_visitors
- entry_nb_uniq_visitors -> sum_daily_entry_nb_uniq_visitors
- exit_nb_uniq_visitors -> sum_daily_exit_nb_uniq_visitors

Rows with subtables are aggregate container rows (hierarchy parents). Showing these helper metrics on parent rows is misleading, because they are not semantically valid rollups for hierarchy containers.

### Root cause

`plugins/Actions/ArchivingHelper::deleteInvalidSummedColumnsFromDataTable()` already removed raw unique columns on parent rows via `Metrics::$columnsToDeleteAfterAggregation`, but it did not remove the renamed daily helper variants from `Metrics::$columnsToRenameAfterAggregation`.

### Change

In `plugins/Actions/ArchivingHelper.php`, update `deleteInvalidSummedColumnsFromDataTable()` to also remove renamed `sum_daily_*` unique helper metrics on rows that have a subtable.

### Why this is correct

- Preserves proper semantics for non-additive unique metrics.
- Prevents helper/intermediate aggregation columns from leaking into hierarchical parent rows.
- Keeps report output consistent and easier to interpret.

### Impact

- Actions report output cleanup for hierarchical parent rows.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
