### PR TITLE
Improve the logic of the update check function

### DIFF
--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -274,12 +274,12 @@ class SettingsPiwik
      */
     public static function isAutoUpdateEnabled(): bool
     {
-        $enableAutoUpdate = (bool) Config::getInstance()->General['enable_auto_update'];
-        if (self::isInternetEnabled() === true && $enableAutoUpdate === true) {
-            return true;
+        if (self::isInternetEnabled() === false) {
+            return false;
         }
 
-        return false;
+        $enableAutoUpdate = (bool) Config::getInstance()->General['enable_auto_update'];
+        return $enableAutoUpdate;
     }
 
     /**

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -256,6 +256,18 @@ class SettingsPiwik
     }
 
     /**
+     * Detect whether user has enabled checking for new versions of Matomo.
+     */
+    public static function isVersionUpdateCheckEnabled(): bool
+    {
+        if (self::isInternetEnabled() === false) {
+            return false;
+        }
+
+        return self::isAutoUpdateEnabled();
+    }
+
+    /**
      * Detect whether user has enabled auto updates. Please note this config is a bit misleading. It is currently
      * actually used for 2 things: To disable making any connections back to Piwik, and to actually disable the auto
      * update of core and plugins.

--- a/core/UpdateCheck.php
+++ b/core/UpdateCheck.php
@@ -31,6 +31,10 @@ class UpdateCheck
      */
     public static function check($force = false, $interval = null)
     {
+        if (!SettingsPiwik::isInternetEnabled()) {
+            return;
+        }
+
         if (!SettingsPiwik::isAutoUpdateEnabled()) {
             return;
         }

--- a/core/UpdateCheck.php
+++ b/core/UpdateCheck.php
@@ -31,11 +31,7 @@ class UpdateCheck
      */
     public static function check($force = false, $interval = null)
     {
-        if (!SettingsPiwik::isInternetEnabled()) {
-            return;
-        }
-
-        if (!SettingsPiwik::isAutoUpdateEnabled()) {
+        if (!SettingsPiwik::isVersionUpdateCheckEnabled()) {
             return;
         }
 

--- a/core/View.php
+++ b/core/View.php
@@ -272,7 +272,7 @@ class View implements ViewInterface
             $this->isMultiServerEnvironment = SettingsPiwik::isMultiServerEnvironment();
             $this->isInternetEnabled = SettingsPiwik::isInternetEnabled();
             $this->shouldPropagateTokenAuth = $this->shouldPropagateTokenAuthInAjaxRequests();
-            $this->isAutoUpdateEnabled = SettingsPiwik::isAutoUpdateEnabled();
+            $this->isVersionUpdateCheckEnabled = SettingsPiwik::isVersionUpdateCheckEnabled();
 
             $piwikAds = StaticContainer::get('Piwik\ProfessionalServices\Advertising');
             $this->areAdsForProfessionalServicesEnabled = $piwikAds->areAdsForProfessionalServicesEnabled();

--- a/plugins/CoreHome/templates/_headerMessage.twig
+++ b/plugins/CoreHome/templates/_headerMessage.twig
@@ -6,7 +6,7 @@
 {% endset %}
 
 {% if
-    isAutoUpdateEnabled and (
+    isVersionUpdateCheckEnabled and (
         (latest_version_available and hasSomeViewAccess and not isUserIsAnonymous and showUpdateNotificationToUser)
         or (
             isSuperUser

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -121,7 +121,7 @@ class Controller extends \Piwik\Plugin\Controller
         Piwik::checkUserHasSuperUserAccess();
 
         if (!SettingsPiwik::isVersionUpdateCheckEnabled()) {
-            throw new Exception('Auto updater is disabled');
+            throw new Exception('Version update check (enable_auto_update) is disabled');
         }
 
         $this->checkNewVersionIsAvailableOrDie();

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -120,7 +120,7 @@ class Controller extends \Piwik\Plugin\Controller
     {
         Piwik::checkUserHasSuperUserAccess();
 
-        if (!SettingsPiwik::isAutoUpdateEnabled()) {
+        if (!SettingsPiwik::isVersionUpdateCheckEnabled()) {
             throw new Exception('Auto updater is disabled');
         }
 

--- a/plugins/CoreUpdater/SystemSettings.php
+++ b/plugins/CoreUpdater/SystemSettings.php
@@ -58,7 +58,8 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         $isWritable = Piwik::hasUserSuperUserAccess() && CoreAdminController::isGeneralSettingsAdminEnabled();
         $this->releaseChannel = $this->createReleaseChannel();
         $this->releaseChannel->setIsWritableByCurrentUser($isWritable
-            && SettingsPiwik::isMultiServerEnvironment() === false);
+            && SettingsPiwik::isMultiServerEnvironment() === false
+            && SettingsPiwik::isVersionUpdateCheckEnabled());
 
         $this->sendPluginUpdateEmail = $this->createSendPluginUpdateEmail();
         $this->sendPluginUpdateEmail->setIsWritableByCurrentUser($isWritable

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -24,6 +24,7 @@ use Piwik\Plugin\ReleaseChannels;
 use Piwik\Plugins\CorePluginsAdmin\PluginInstaller;
 use Piwik\Plugins\Marketplace\API as MarketplaceApi;
 use Piwik\Plugins\Marketplace\Marketplace;
+use Piwik\SettingsPiwik;
 use Piwik\SettingsServer;
 use Piwik\Translation\Translator;
 use Piwik\Unzip;
@@ -87,6 +88,10 @@ class Updater
      */
     public function updatePiwik($https = true)
     {
+        if (!SettingsPiwik::isVersionUpdateCheckEnabled()) {
+            throw new Exception('Version update check (enable_auto_update) is disabled');
+        }
+
         if (!$this->isNewVersionAvailable()) {
             throw new Exception($this->translator->translate('CoreUpdater_ExceptionAlreadyLatestVersion', Version::VERSION));
         }

--- a/plugins/Diagnostics/Diagnostic/ConfigInformational.php
+++ b/plugins/Diagnostics/Diagnostic/ConfigInformational.php
@@ -41,6 +41,7 @@ class ConfigInformational implements Diagnostic
             $results[] = DiagnosticResult::informationalResult('Internet Enabled', SettingsPiwik::isInternetEnabled());
             $results[] = DiagnosticResult::informationalResult('Multi Server Environment', SettingsPiwik::isMultiServerEnvironment());
             $results[] = DiagnosticResult::informationalResult('Auto Update Enabled', SettingsPiwik::isAutoUpdateEnabled());
+            $results[] = DiagnosticResult::informationalResult('Automatic Version Check Enabled', SettingsPiwik::isVersionUpdateCheckEnabled());
             $results[] = DiagnosticResult::informationalResult('Custom User Path', PIWIK_USER_PATH != PIWIK_DOCUMENT_ROOT);
             $results[] = DiagnosticResult::informationalResult('Custom Include Path', PIWIK_INCLUDE_PATH != PIWIK_DOCUMENT_ROOT);
             $results[] = DiagnosticResult::informationalResult('Release Channel', Config::getInstance()->General['release_channel']);


### PR DESCRIPTION
### Description

The issue pointed out by @tsteur in the PR https://github.com/matomo-org/matomo/pull/14058#discussion_r252431792 is that it was needed to disable automatic updates for cloud deployments.

As I package Matomo in Debian this code has bitten me hard because I need to disable internet communications for the users of the matomo package. But not necessarily disable automatic updates (the author points out that it can be an issue: https://github.com/matomo-org/matomo/pull/14058#discussion_r252431792 and the phpdoc says it too)

Debian patch: https://sources.debian.org/src/matomo/5.5.1%2Bdfsg-3/debian/patches/0015-Do-not-allow-Internet-use-or-auto-updates.patch

This is why I do this PR:
- Improve the separation between version update and plugin download/updates
- Disable choosing a channel in the settings page when update check is disabled

This will allow me to disable update checks in Debian but still let the user do what is wanted.

Update check: disabled
Internet access: disabled
Update check: still controls the CoreUpdater plugin, maybe enable it back. Or provide Debian users with the console `core:update` CLI.

⚠️ The big issue that I found out today is that this update check setting blocks the CoreUpdater plugin. I was clueless that an update was not applied. Maybe the UI should still show this as a warning, but if update check setting is disabled make it not possible to update via UI.
What do you think @sgiehl ?

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [x] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [x] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
