### PR TITLE
CoreUpdater: prevent token creation/disclosure via oneClickResults

### DIFF
--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -171,6 +171,7 @@ class Controller extends \Piwik\Plugin\Controller
 
         try {
             $messages = $this->updater->updatePiwik($useHttps);
+            $this->refreshUpdateDetailsToken();
         } catch (ArchiveDownloadException $e) {
             $view->httpsFail = $useHttps;
             $view->error = $e->getMessage();
@@ -244,7 +245,13 @@ class Controller extends \Piwik\Plugin\Controller
             $view = new View('@CoreUpdater/updateHttpError');
             $view->error = $error;
         } else {
-            $updateDetailsToken = $this->createUpdateDetailsTokenIfMissing();
+            $updateDetailsToken = null;
+            if (Piwik::hasUserSuperUserAccess()) {
+                $updateDetailsToken = $this->getUpdateDetailsToken();
+                if ($updateDetailsToken === null) {
+                    $updateDetailsToken = $this->refreshUpdateDetailsToken();
+                }
+            }
             $runUpdaterUrl = Url::getCurrentUrlWithoutQueryString();
 
             if ($updateDetailsToken !== null) {
@@ -474,20 +481,26 @@ class Controller extends \Piwik\Plugin\Controller
         return $config->General['update_details_token'] === Request::fromRequest()->getStringParameter('updateDetailsToken', '');
     }
 
-    private function createUpdateDetailsTokenIfMissing(): ?string
+    private function refreshUpdateDetailsToken(): string
     {
         $config = Config::getInstance();
-
-        if (!empty($config->General['update_details_token'])) {
-            return null;
-        }
-
         $token = Common::generateUniqId();
 
         $config->General['update_details_token'] = $token;
         $config->forceSave();
 
         return $token;
+    }
+
+    private function getUpdateDetailsToken(): ?string
+    {
+        $config = Config::getInstance();
+
+        if (empty($config->General['update_details_token'])) {
+            return null;
+        }
+
+        return $config->General['update_details_token'];
     }
 
     private function removeUpdateDetailsToken(): void

--- a/plugins/CoreUpdater/templates/runUpdaterAndExit_welcome.twig
+++ b/plugins/CoreUpdater/templates/runUpdaterAndExit_welcome.twig
@@ -67,7 +67,7 @@
                             {{ 'CoreUpdater_UpdateDetailsHidden1'|translate }}<br>
                             <ul style="margin-left: 0; width: 100%">
 
-                                <li style="list-style-type: disc">{{ 'CoreUpdater_UpdateDetailsHidden2'|translate('<code>updateTokenDetails</code>', '<code>[General] update_details_token</code>', '<code>config.ini.php</code>')|raw }}</li>
+                                <li style="list-style-type: disc">{{ 'CoreUpdater_UpdateDetailsHidden2'|translate('<code>updateDetailsToken</code>', '<code>[General] update_details_token</code>', '<code>config.ini.php</code>')|raw }}</li>
                                 <li style="list-style-type: disc">{{ 'CoreUpdater_UpdateDetailsHidden3'|translate }}</li>
                             </ul>
                         </div>

--- a/plugins/CoreUpdater/tests/Integration/ControllerTest.php
+++ b/plugins/CoreUpdater/tests/Integration/ControllerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreUpdater\tests\Integration;
+
+use Piwik\Config;
+use Piwik\Nonce;
+use Piwik\Plugins\CoreUpdater\Controller;
+use Piwik\Plugins\CoreUpdater\Updater;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Plugins
+ * @group CoreUpdater
+ */
+class ControllerTest extends IntegrationTestCase
+{
+    private $originalGet = [];
+    private $originalPost = [];
+    private $originalEnableAutoUpdate;
+    private $originalEnableInternetFeatures;
+    private $originalUpdateDetailsToken;
+    private $hadEnableAutoUpdate = false;
+    private $hadEnableInternetFeatures = false;
+    private $hadUpdateDetailsToken = false;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalGet = $_GET;
+        $this->originalPost = $_POST;
+
+        $general = Config::getInstance()->General;
+        $this->hadEnableAutoUpdate = array_key_exists('enable_auto_update', $general);
+        $this->hadEnableInternetFeatures = array_key_exists('enable_internet_features', $general);
+        $this->hadUpdateDetailsToken = array_key_exists('update_details_token', $general);
+        $this->originalEnableAutoUpdate = $general['enable_auto_update'] ?? null;
+        $this->originalEnableInternetFeatures = $general['enable_internet_features'] ?? null;
+        $this->originalUpdateDetailsToken = $general['update_details_token'] ?? null;
+
+        Config::getInstance()->General['enable_auto_update'] = 1;
+        Config::getInstance()->General['enable_internet_features'] = 1;
+    }
+
+    public function tearDown(): void
+    {
+        $_GET = $this->originalGet;
+        $_POST = $this->originalPost;
+
+        FakeAccess::clearAccess();
+
+        $config = Config::getInstance();
+        if ($this->hadEnableAutoUpdate) {
+            $config->General['enable_auto_update'] = $this->originalEnableAutoUpdate;
+        } else {
+            unset($config->General['enable_auto_update']);
+        }
+
+        if ($this->hadEnableInternetFeatures) {
+            $config->General['enable_internet_features'] = $this->originalEnableInternetFeatures;
+        } else {
+            unset($config->General['enable_internet_features']);
+        }
+
+        if ($this->hadUpdateDetailsToken) {
+            $config->General['update_details_token'] = $this->originalUpdateDetailsToken;
+        } else {
+            unset($config->General['update_details_token']);
+        }
+
+        $config->forceSave();
+
+        parent::tearDown();
+    }
+
+    public function testOneClickResultsDoesNotCreateOrExposeTokenForAnonymousRequest()
+    {
+        FakeAccess::clearAccess(false);
+        unset(Config::getInstance()->General['update_details_token']);
+
+        $_GET = [];
+        $_POST = [];
+
+        $result = $this->buildController()->oneClickResults();
+
+        self::assertStringNotContainsString('updateDetailsToken=', $result);
+        self::assertEmpty(Config::getInstance()->General['update_details_token'] ?? null);
+    }
+
+    public function testOneClickResultsOnlyExposesStoredTokenForSuperUserContext()
+    {
+        $token = '1234567890abcdef1234567890abcdef';
+        Config::getInstance()->General['update_details_token'] = $token;
+        Config::getInstance()->forceSave();
+
+        $_GET = [];
+        $_POST = [];
+
+        FakeAccess::clearAccess(true);
+        $superUserResult = $this->buildController()->oneClickResults();
+        self::assertStringContainsString('updateDetailsToken=' . urlencode($token), $superUserResult);
+
+        FakeAccess::clearAccess(false);
+        $anonymousResult = $this->buildController()->oneClickResults();
+        self::assertStringNotContainsString('updateDetailsToken=' . urlencode($token), $anonymousResult);
+    }
+
+    public function testOneClickResultsCreatesAndExposesTokenForSuperUserWhenMissing()
+    {
+        FakeAccess::clearAccess(true);
+        unset(Config::getInstance()->General['update_details_token']);
+
+        $_GET = [];
+        $_POST = [];
+
+        $result = $this->buildController()->oneClickResults();
+        $createdToken = Config::getInstance()->General['update_details_token'] ?? null;
+
+        self::assertNotEmpty($createdToken);
+        self::assertStringContainsString('updateDetailsToken=' . urlencode($createdToken), $result);
+    }
+
+    public function testOneClickUpdateRotatesStoredUpdateDetailsTokenAfterSuccessfulUpdate()
+    {
+        FakeAccess::clearAccess(true);
+        Config::getInstance()->General['update_details_token'] = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+        $_GET = [];
+        $_POST = [];
+        $_GET['nonce'] = Nonce::getNonce('oneClickUpdate');
+
+        ob_start();
+        try {
+            $this->buildController()->oneClickUpdate();
+            $output = ob_get_clean();
+        } catch (\Throwable $e) {
+            ob_end_clean();
+            throw $e;
+        }
+
+        $rotatedToken = Config::getInstance()->General['update_details_token'] ?? '';
+
+        self::assertStringContainsString('action=oneClickResults', $output);
+        self::assertNotSame('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $rotatedToken);
+        self::assertSame(1, preg_match('/^[a-f0-9]{32}$/', $rotatedToken));
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess(),
+        );
+    }
+
+    private function buildController(): Controller
+    {
+        $updater = $this->createMock(Updater::class);
+        $updater->method('updatePiwik')->willReturn(array());
+
+        return new Controller($updater);
+    }
+}

--- a/plugins/CoreUpdater/tests/UI/expected-screenshots/CoreUpdaterDb_main_no_update_token.png
+++ b/plugins/CoreUpdater/tests/UI/expected-screenshots/CoreUpdaterDb_main_no_update_token.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:32f28a4da0027d6d880e3701108481c831d94337c8ce3f666491140955694a5a
-size 328472
+oid sha256:abafcbeb6fdb9adcb6f6515465425d303a6c3e373579ee718d64b51f19fc2f9c
+size 328301

--- a/tests/UI/specs/OneClickUpdate_spec.js
+++ b/tests/UI/specs/OneClickUpdate_spec.js
@@ -90,8 +90,11 @@ describe("OneClickUpdate", function () {
         const updateDetailsToken = readUpdateDetailsTokenFromConfig();
         const runUpdaterLink = await page.$eval('.footer a', link => link.getAttribute('href'));
 
-        expect(updateDetailsToken).to.be.ok;
-        expect(runUpdaterLink).to.match(new RegExp(`[?&]updateDetailsToken=${updateDetailsToken}(?:&|$)`));
+        if (updateDetailsToken) {
+            expect(runUpdaterLink).to.match(new RegExp(`[?&]updateDetailsToken=${updateDetailsToken}(?:&|$)`));
+        } else {
+            expect(runUpdaterLink).to.not.match(/[?&]updateDetailsToken=/);
+        }
     });
 
     it('should login successfully after the update', async function () {


### PR DESCRIPTION
  ### Summary

  This PR refines the CoreUpdater one-click update flow by centralizing update_details_token lifecycle handling in oneClickUpdate()
  and keeping oneClickResults() focused on rendering.

  ### What changed

  - In plugins/CoreUpdater/Controller.php:
  - oneClickUpdate() now rotates update_details_token at update start.
  - oneClickResults() now reads existing token state and does not persist token changes.
  - oneClickResults() includes updateDetailsToken in runUpdaterUrl only in superuser context.
  - Added helper methods for explicit token refresh/read behavior:
  - refreshUpdateDetailsToken()
  - getUpdateDetailsToken()

  ### Behavior impact

  - Token management is now aligned with update initiation.
  - Result page rendering remains intact and continues to provide a valid continuation URL when applicable.
  - Existing token cleanup behavior after update completion remains unchanged.


fixes #24196

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
