### PR TITLE
Only display plugin name in what's new for plugins not bundled with core

### DIFF
--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -355,10 +355,27 @@ class Controller extends ControllerAdmin
         $user = $model->getUser(Piwik::getCurrentUserLogin());
         if (!empty($user)) {
             $userChanges = new UserChanges($user);
-            $changes = $userChanges->getChanges();
+            $changes = $this->enrichChangesForWhatIsNew($userChanges->getChanges());
             return $this->renderTemplate('whatIsNew', ['changes' => $changes]);
         } else {
             throw new \Exception('Unable to getUser() when attempting to show whatIsNew');
         }
+    }
+
+    /**
+     * Adds metadata used for rendering entries in the What's New popup.
+     */
+    private function enrichChangesForWhatIsNew(array $changes): array
+    {
+        $pluginManager = Plugin\Manager::getInstance();
+
+        foreach ($changes as &$change) {
+            $pluginName = $change['plugin_name'] ?? '';
+            $change['showPluginPrefix'] = !empty($pluginName)
+                && !$pluginManager->isPluginBundledWithCore($pluginName);
+        }
+        unset($change);
+
+        return $changes;
     }
 }

--- a/plugins/CoreAdminHome/templates/whatIsNew.twig
+++ b/plugins/CoreAdminHome/templates/whatIsNew.twig
@@ -10,10 +10,10 @@
         <div class="card">
             <div class="card-content">
                 <span style="float: left; font-size:32px; color:#3450A3; margin-right:10px" class="icon-new_releases"></span>
-                {% if change.plugin_name == "CoreHome" or change.plugin_name == "ProfessionalServices"%}
-                    <h2 class="card-title">{{ change.title }}</h2>
-                {% else %}
+                {% if change.showPluginPrefix %}
                     <h2 class="card-title">{{ change.plugin_name }} - {{ change.title }}</h2>
+                {% else %}
+                    <h2 class="card-title">{{ change.title }}</h2>
                 {% endif %}
                 {{ change.description | raw }}
                 {% if not change.link is empty and not change.link_name is empty %}

--- a/plugins/CoreAdminHome/tests/Integration/ControllerTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/ControllerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Integration;
+
+use Piwik\Changes\Model as ChangesModel;
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\Plugins\CoreAdminHome\Controller;
+use Piwik\Plugins\CoreAdminHome\OptOutManager;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Translation\Loader\DevelopmentLoader;
+use Piwik\Translation\Loader\JsonFileLoader;
+use Piwik\Translation\Translator;
+
+/**
+ * @group CoreAdminHome
+ * @group ControllerTest
+ * @group Plugins
+ */
+class ControllerTest extends IntegrationTestCase
+{
+    /** @var Controller */
+    private $controller;
+    /** @var array */
+    private $backupGet;
+    /** @var array */
+    private $backupRequest;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->backupGet = $_GET;
+        $this->backupRequest = $_REQUEST;
+
+        Fixture::createSuperUser();
+        if (!Fixture::siteCreated(1)) {
+            Fixture::createWebsite('2012-01-01 00:00:00');
+        }
+        FakeAccess::clearAccess(
+            $superUser = true,
+            $idSitesAdmin = [1],
+            $idSitesView = [1],
+            $identity = 'superUserLogin'
+        );
+        $_GET = ['idSite' => 1, 'period' => 'day', 'date' => 'today'];
+        $_REQUEST = $_GET;
+
+        $this->controller = new Controller(
+            new Translator(new DevelopmentLoader(new JsonFileLoader())),
+            new OptOutManager()
+        );
+    }
+
+    public function testWhatIsNewDoesNotPrefixBundledPluginsAndPrefixesThirdPartyPlugins(): void
+    {
+        $this->deleteAllChanges();
+
+        $changesModel = new ChangesModel();
+        $changesModel->addChange('CoreHome', [
+            'version' => '1.0.0',
+            'title' => 'Core bundled change',
+            'description' => 'Core bundled description',
+        ]);
+        $changesModel->addChange('ProfessionalServices', [
+            'version' => '1.0.0',
+            'title' => 'Professional services bundled change',
+            'description' => 'Professional services bundled description',
+        ]);
+        $changesModel->addChange('ThirdPartyPlugin', [
+            'version' => '1.0.0',
+            'title' => 'Third party change',
+            'description' => 'Third party description',
+        ]);
+
+        $html = $this->controller->whatIsNew();
+
+        $this->assertStringContainsString('>Core bundled change<', $html);
+        $this->assertStringContainsString('>Professional services bundled change<', $html);
+        $this->assertStringContainsString('>ThirdPartyPlugin - Third party change<', $html);
+
+        $this->assertStringNotContainsString('>CoreHome - Core bundled change<', $html);
+        $this->assertStringNotContainsString('>ProfessionalServices - Professional services bundled change<', $html);
+    }
+
+    public function tearDown(): void
+    {
+        $this->deleteAllChanges();
+        $_GET = $this->backupGet;
+        $_REQUEST = $this->backupRequest;
+        parent::tearDown();
+    }
+
+    public function provideContainerConfig()
+    {
+        return [
+            'Piwik\Access' => new FakeAccess(),
+            'test.vars.loadChanges' => true,
+        ];
+    }
+
+    private function deleteAllChanges(): void
+    {
+        Db::query('DELETE FROM `' . Common::prefixTable('changes') . '`');
+    }
+}

--- a/plugins/CoreHome/tests/Integration/ChangesTest.php
+++ b/plugins/CoreHome/tests/Integration/ChangesTest.php
@@ -45,7 +45,7 @@ class ChangesTest extends IntegrationTestCase
 
     public function testCoreHomeChangesShouldAllowChangeItemAddWithoutLink()
     {
-        $json = '{"idchange":3,"plugin_name":"CoreHome","version":"4.5.0","title":"New feature y added","description":"Now you can do c with d like this","link_name":null,"link":null}';
+        $json = '{"idchange":3,"plugin_name":"CustomAlerts","version":"4.5.0","title":"New feature y added","description":"Now you can do c with d like this","link_name":null,"link":null}';
         $changesModel = new ChangesModel();
         $changes = $changesModel->getChangeItems();
         $r = $changes[1];

--- a/plugins/CoreHome/tests/UI/expected-screenshots/WhatIsNew_what_is_new.png
+++ b/plugins/CoreHome/tests/UI/expected-screenshots/WhatIsNew_what_is_new.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bacbd989599f1b05d9a29c82187e7580d7bdc167c205afe4aef44706db5829cb
-size 50210
+oid sha256:a089993c403cd54d4cfe8f5df6f818a280df55d3e73bbbcdc54bb47f740f5be7
+size 52785

--- a/tests/PHPUnit/Fixtures/CreateChanges.php
+++ b/tests/PHPUnit/Fixtures/CreateChanges.php
@@ -48,11 +48,13 @@ class CreateChanges extends Fixture
              'description' => 'Now you can do a with b like this',
              'link_name' => 'For more information go here',
              'link' => 'https://www.matomo.org',
+             'plugin' => 'CoreHome',
             ],
             [
              'version' => '4.5.0',
              'title' => 'New feature y added',
              'description' => 'Now you can do c with d like this',
+             'plugin' => 'CustomAlerts',
             ],
             [
              'version' => '4.4.0',
@@ -60,13 +62,14 @@ class CreateChanges extends Fixture
              'description' => 'Now you can do e with f like this',
              'link_name' => 'For more information go here',
              'link' => 'https://www.matomo.org',
+             'plugin' => 'CustomDimensions',
             ],
         ];
 
         $changes = array_reverse($changes);
         $changesModel = new ChangesModel(); // Intentionally not using the FakeChangesModel, we want these changes added
         foreach ($changes as $change) {
-            $changesModel->addChange('CoreHome', $change);
+            $changesModel->addChange($change['plugin'], $change);
         }
     }
 


### PR DESCRIPTION
### Description

There is no value in displaying the plugin name for changes provided by core.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
