### PR TITLE
GeoIP: Abort chunked downloads when location changes

### DIFF
--- a/plugins/GeoIp2/Controller.php
+++ b/plugins/GeoIp2/Controller.php
@@ -5,6 +5,7 @@ namespace Piwik\Plugins\GeoIp2;
 use Piwik\Common;
 use Piwik\DataTable\Renderer\Json;
 use Piwik\Http;
+use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugins\GeoIp2\LocationProvider\GeoIp2;
 use Piwik\Plugins\UserCountry\UserCountry;
@@ -12,6 +13,8 @@ use Piwik\View;
 
 class Controller extends \Piwik\Plugin\ControllerAdmin
 {
+    private const DOWNLOAD_URL_OPTION_PREFIX = 'geoip2.download_url.';
+
     /**
      * Starts or continues download of DBIP-City.mmdb.
      *
@@ -28,6 +31,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
      *   'expected_file_size' - The expected finished file size as returned by the HTTP server.
      *   'next_screen' - When the download finishes, this is the next screen that should be shown.
      *   'error' - When an error occurs, the message is returned in this property.
+     *
+     * @return string
      */
     public function downloadFreeDBIPLiteDB()
     {
@@ -64,11 +69,13 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                     $result['settings'] = GeoIP2AutoUpdater::getConfiguredUrls();
                 }
 
-                return json_encode($result);
+                return (string) json_encode($result);
             } catch (\Exception $ex) {
-                return json_encode(array('error' => $ex->getMessage()));
+                return (string) json_encode(array('error' => $ex->getMessage()));
             }
         }
+
+        return '';
     }
 
     /**
@@ -83,6 +90,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
      * Output (json):
      *   'error' - if an error occurs its message is set as the resulting JSON object's
      *             'error' property.
+     *
+     * @return string
      */
     public function updateGeoIPLinks()
     {
@@ -100,17 +109,19 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                 $info = $this->getNextMissingDbUrlInfoGeoIp2();
 
                 if ($info !== false) {
-                    return json_encode($info);
+                    return (string) json_encode($info);
                 } else {
                     $view = new View("@GeoIp2/_updaterNextRunTime");
                     $view->nextRunTime = GeoIP2AutoUpdater::getNextRunTime();
                     $nextRunTimeHtml = $view->render();
-                    return json_encode(array('nextRunTime' => $nextRunTimeHtml));
+                    return (string) json_encode(array('nextRunTime' => $nextRunTimeHtml));
                 }
             } catch (\Exception $ex) {
-                return json_encode(array('error' => $ex->getMessage()));
+                return (string) json_encode(array('error' => $ex->getMessage()));
             }
         }
+
+        return '';
     }
 
     /**
@@ -129,6 +140,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
      *                         downloading.
      *   'current_size' - Size of the current file on disk.
      *   'expected_file_size' - Size of the completely downloaded file.
+     *
+     * @return string
      */
     public function downloadMissingGeoIpDb()
     {
@@ -144,8 +157,14 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                 // based on the database type (provided by the 'key' query param) determine the
                 // url & output file name
                 $key = Common::getRequestVar('key', null, 'string');
+                $isContinuation = Common::getRequestVar('continue', true, 'int');
 
                 $url = GeoIP2AutoUpdater::getConfiguredUrl($key);
+                if (!is_string($url) || $url === '') {
+                    throw new \Exception(Piwik::translate('General_DownloadFail_HttpRequestFail'));
+                }
+                $this->trackOrValidateConfiguredDownloadUrl($key, $url, $isContinuation);
+
                 $filename = GeoIP2AutoUpdater::getZippedFilenameToDownloadTo($url, $key, GeoIP2AutoUpdater::getGeoIPUrlExtension($url));
                 $outputPath = GeoIP2AutoUpdater::getTemporaryFolder($filename, true);
 
@@ -153,30 +172,115 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                 $result = Http::downloadChunk(
                     $url,
                     $outputPath,
-                    Common::getRequestVar('continue', true, 'int')
+                    $isContinuation
                 );
 
                 // if the file is done
                 if ($result['current_size'] >= $result['expected_file_size']) {
+                    $this->assertConfiguredUrlDidNotChangeDuringDownload($key, $url);
                     GeoIP2AutoUpdater::unzipDownloadedFile($outputPath, $key, $url, $unlink = true);
+                    $this->deleteTrackedDownloadUrl($key);
 
                     $info = $this->getNextMissingDbUrlInfoGeoIp2();
                     if ($info !== false) {
-                        return json_encode($info);
+                        return (string) json_encode($info);
                     }
                 }
 
-                return json_encode($result);
+                return (string) json_encode($result);
             } catch (\Exception $ex) {
-                return json_encode(array('error' => $ex->getMessage()));
+                return (string) json_encode(array('error' => $ex->getMessage()));
             }
         }
+
+        return '';
+    }
+
+    private function trackOrValidateConfiguredDownloadUrl(string $key, string $configuredUrl, int $isContinuation): void
+    {
+        $optionName = $this->getDownloadUrlOptionName($key);
+        $expectedUrl = Option::get($optionName);
+
+        if (!$isContinuation || empty($expectedUrl)) {
+            Option::set($optionName, (string) $configuredUrl);
+            return;
+        }
+
+        if ((string) $expectedUrl !== (string) $configuredUrl) {
+            $this->abortDownloadForChangedConfiguredUrl($key, (string) $expectedUrl, $configuredUrl);
+        }
+    }
+
+    private function assertConfiguredUrlDidNotChangeDuringDownload(string $key, string $expectedUrl): void
+    {
+        $configuredUrl = GeoIP2AutoUpdater::getConfiguredUrl($key);
+
+        if ((string) $configuredUrl !== (string) $expectedUrl) {
+            $this->abortDownloadForChangedConfiguredUrl($key, $expectedUrl, (string) $configuredUrl);
+        }
+    }
+
+    private function abortDownloadForChangedConfiguredUrl(string $key, string $expectedUrl, string $configuredUrl): void
+    {
+        $this->deleteDownloadedChunksForType($key, $expectedUrl, $configuredUrl);
+        $this->deleteTrackedDownloadUrl($key);
+
+        throw new \Exception(Piwik::translate('General_DownloadFail_HttpRequestFail'));
+    }
+
+    private function deleteDownloadedChunksForType(string $key, string $expectedUrl, string $configuredUrl): void
+    {
+        $pathsToDelete = [];
+
+        $expectedOutputPath = $this->getDownloadOutputPath($key, $expectedUrl);
+        if (!empty($expectedOutputPath)) {
+            $pathsToDelete[] = $expectedOutputPath;
+        }
+
+        $configuredOutputPath = $this->getDownloadOutputPath($key, $configuredUrl);
+        if (!empty($configuredOutputPath)) {
+            $pathsToDelete[] = $configuredOutputPath;
+        }
+
+        foreach (array_unique($pathsToDelete) as $downloadPath) {
+            if (!is_file($downloadPath)) {
+                continue;
+            }
+
+            @unlink($downloadPath);
+            Option::delete($downloadPath . '_expectedDownloadSize');
+        }
+    }
+
+    private function getDownloadOutputPath(string $key, string $url): ?string
+    {
+        try {
+            $filename = GeoIP2AutoUpdater::getZippedFilenameToDownloadTo(
+                $url,
+                $key,
+                GeoIP2AutoUpdater::getGeoIPUrlExtension($url)
+            );
+
+            return GeoIP2AutoUpdater::getTemporaryFolder($filename, true);
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    private function getDownloadUrlOptionName(string $key): string
+    {
+        return self::DOWNLOAD_URL_OPTION_PREFIX . $key;
+    }
+
+    private function deleteTrackedDownloadUrl(string $key): void
+    {
+        Option::delete($this->getDownloadUrlOptionName($key));
     }
 
     /**
      * Gets information for the first missing GeoIP2 database (if any).
      *
-     * @return array|bool
+     * @return array<string, string>|false
      */
     private function getNextMissingDbUrlInfoGeoIp2()
     {
@@ -195,7 +299,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         return false;
     }
 
-    private function dieIfGeolocationAdminIsDisabled()
+    private function dieIfGeolocationAdminIsDisabled(): void
     {
         if (!UserCountry::isGeoLocationAdminEnabled()) {
             throw new \Exception('Geo location setting page has been disabled.');

--- a/plugins/GeoIp2/tests/Integration/ControllerTest.php
+++ b/plugins/GeoIp2/tests/Integration/ControllerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\GeoIp2\tests\Integration;
+
+use Piwik\Config;
+use Piwik\Option;
+use Piwik\Plugins\GeoIp2\Controller;
+use Piwik\Plugins\GeoIp2\GeoIP2AutoUpdater;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group GeoIp2
+ * @group ControllerTest
+ * @group Plugins
+ */
+class ControllerTest extends IntegrationTestCase
+{
+    private $controller;
+    private $server = [];
+    private $get = [];
+    private $post = [];
+    private $request = [];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Config::getInstance()->General['enable_geolocation_admin'] = 1;
+
+        $this->controller = $this->getMockBuilder(Controller::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['checkTokenInUrl'])
+            ->getMock();
+        $this->controller->expects($this->any())
+            ->method('checkTokenInUrl');
+
+        $this->server = $_SERVER;
+        $this->get = $_GET;
+        $this->post = $_POST;
+        $this->request = $_REQUEST;
+
+        Option::delete(GeoIP2AutoUpdater::LOC_URL_OPTION_NAME);
+        Option::delete(GeoIP2AutoUpdater::ISP_URL_OPTION_NAME);
+        Option::delete('geoip2.download_url.loc');
+        Option::delete('geoip2.download_url.isp');
+    }
+
+    public function tearDown(): void
+    {
+        $_SERVER = $this->server;
+        $_GET = $this->get;
+        $_POST = $this->post;
+        $_REQUEST = $this->request;
+
+        Option::delete(GeoIP2AutoUpdater::LOC_URL_OPTION_NAME);
+        Option::delete(GeoIP2AutoUpdater::ISP_URL_OPTION_NAME);
+        Option::delete('geoip2.download_url.loc');
+        Option::delete('geoip2.download_url.isp');
+
+        parent::tearDown();
+    }
+
+    public function testDownloadMissingGeoIpDbShouldAbortIfConfiguredUrlChangesMidDownloadAndDeleteChunks()
+    {
+        $oldLocUrl = 'https://download.db-ip.com/free/dbip-city-lite-2020-01.mmdb.gz';
+        $newLocUrl = 'https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=test&suffix=tar.gz';
+        $ispUrl = 'https://download.db-ip.com/free/dbip-asn-lite-2020-01.mmdb.gz';
+
+        Option::set(GeoIP2AutoUpdater::LOC_URL_OPTION_NAME, $oldLocUrl);
+        Option::set(GeoIP2AutoUpdater::ISP_URL_OPTION_NAME, $ispUrl);
+        Option::set('geoip2.download_url.loc', $oldLocUrl);
+        Option::set('geoip2.download_url.isp', $ispUrl);
+
+        $locDownloadChunk = GeoIP2AutoUpdater::getTemporaryFolder(
+            GeoIP2AutoUpdater::getZippedFilenameToDownloadTo(
+                $oldLocUrl,
+                'loc',
+                GeoIP2AutoUpdater::getGeoIPUrlExtension($oldLocUrl)
+            ),
+            true
+        );
+        $ispDownloadChunk = GeoIP2AutoUpdater::getTemporaryFolder(
+            GeoIP2AutoUpdater::getZippedFilenameToDownloadTo(
+                $ispUrl,
+                'isp',
+                GeoIP2AutoUpdater::getGeoIPUrlExtension($ispUrl)
+            ),
+            true
+        );
+
+        file_put_contents($locDownloadChunk, 'loc');
+        file_put_contents($ispDownloadChunk, 'isp');
+        Option::set($locDownloadChunk . '_expectedDownloadSize', '12');
+        Option::set($ispDownloadChunk . '_expectedDownloadSize', '12');
+
+        Option::set(GeoIP2AutoUpdater::LOC_URL_OPTION_NAME, $newLocUrl);
+
+        $this->setPostRequest(1, 'loc');
+        $continueResponse = $this->decodeJsonResponse($this->controller->downloadMissingGeoIpDb());
+
+        $this->assertArrayHasKey('error', $continueResponse);
+        $this->assertFileNotExists($locDownloadChunk);
+        $this->assertFileExists($ispDownloadChunk);
+        $this->assertFalse(Option::get($locDownloadChunk . '_expectedDownloadSize'));
+        $this->assertSame('12', Option::get($ispDownloadChunk . '_expectedDownloadSize'));
+        $this->assertFalse(Option::get('geoip2.download_url.loc'));
+
+        @unlink($ispDownloadChunk);
+        Option::delete($ispDownloadChunk . '_expectedDownloadSize');
+    }
+
+    private function setPostRequest(int $continue, string $key): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_GET = [
+            'continue' => $continue,
+            'key' => $key,
+        ];
+        $_POST = $_GET;
+        $_REQUEST = $_GET;
+    }
+
+    private function decodeJsonResponse($response): array
+    {
+        return (array) json_decode((string) $response, true);
+    }
+}


### PR DESCRIPTION
### Description

This fixes a bad behaviour that can happen due to race conditions. If one session starts an automatic download of geoip database, but another session changes the geoip configuration during the download it can occur that the download might try to continue adding it's chunks to a different file. This may then end up in a broken file. The broken file won't be used in that case, but it's cleaner nevertheless to directly abort pending downloads when the config is changed meanwhile.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
