### PR TITLE
Refresh stale archive ID cache when archive rows disappear

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -606,6 +606,16 @@ class Archive implements ArchiveQuery
         $result->setAsBuiltWithoutArchives(false);
 
         $archiveData = ArchiveSelector::getArchiveData($archiveIds, $archiveNames, $archiveDataType, $idSubtable);
+        if (empty($archiveData)) {
+            // Archive IDs are cached in-memory. During nested archiving, older archives can be pruned,
+            // so cached IDs might become stale. Retry once with refreshed cache.
+            $this->clearArchiveIdCache();
+            [$archiveIds, $archiveStates] = $this->getArchiveIdsAndStates($archiveNames);
+            if (!empty($archiveIds)) {
+                $archiveData = ArchiveSelector::getArchiveData($archiveIds, $archiveNames, $archiveDataType, $idSubtable);
+            }
+        }
+
         $archiveState = new ArchiveState();
 
         $this->addDataToResultCollection($result, $archiveData, $archiveDataType);
@@ -891,6 +901,12 @@ class Archive implements ArchiveQuery
         if (!isset($this->idarchives[$doneFlag])) {
             $this->idarchives[$doneFlag] = [];
         }
+    }
+
+    private function clearArchiveIdCache(): void
+    {
+        $this->idarchives = [];
+        $this->idarchiveStates = [];
     }
 
     /**

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -143,7 +143,7 @@ class Archive implements ArchiveQuery
      *     )
      * )
      *
-     * @var array
+     * @var array<string, array<string, list<int>>>
      */
     private $idarchives = [];
 
@@ -162,7 +162,7 @@ class Archive implements ArchiveQuery
      *     )
      *  )
      *
-     * @var array
+     * @var array<int, array<string, array<string, array<int, int>>>>
      */
     private $idarchiveStates = [];
 
@@ -870,12 +870,13 @@ class Archive implements ArchiveQuery
      */
     private function formatNumericValue($value)
     {
+        if ($value === false) {
+            return 0;
+        }
+
         // If there is no dot, we return as is
         // Note: this could be an integer bigger than 32 bits
-        if (strpos($value, '.') === false) {
-            if ($value === false) {
-                return 0;
-            }
+        if (strpos((string)$value, '.') === false) {
             return (float)$value;
         }
 
@@ -964,7 +965,13 @@ class Archive implements ArchiveQuery
             $report = 'AIAgents_Metrics';
         }
 
-        $plugin = substr($report, 0, strpos($report, '_'));
+        $pluginSeparatorPos = strpos($report, '_');
+        if ($pluginSeparatorPos === false) {
+            $plugin = '';
+        } else {
+            $plugin = substr($report, 0, $pluginSeparatorPos);
+        }
+
         if (
             empty($plugin)
             || !\Piwik\Plugin\Manager::getInstance()->isPluginActivated($plugin)

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -54,7 +54,7 @@ class ArchiveTest extends IntegrationTestCase
         $data = $archive->getDataTableFromNumeric([]);
         $this->assertEquals([], $data->getRows());
 
-        $data = $archive->getDataTableFromNumeric(null);
+        $data = $archive->getDataTableFromNumeric('');
         $this->assertEquals([], $data->getRows());
 
         $data = $archive->getDataTableFromNumeric(['']);
@@ -147,7 +147,7 @@ class ArchiveTest extends IntegrationTestCase
         $this->assertEquals($expected, $metrics);
     }
 
-    public function testStaleCachedArchiveIdsAreRefreshedWhenArchiveRowsAreMissing()
+    public function testStaleCachedArchiveIdsAreRefreshedWhenArchiveRowsAreMissing(): void
     {
         $idSite = 1;
         $date = '2014-05-10';
@@ -191,7 +191,7 @@ class ArchiveTest extends IntegrationTestCase
         );
     }
 
-    public function testStaleCachedArchiveIdsAreRefreshedAfterArchiveRowsArePurged()
+    public function testStaleCachedArchiveIdsAreRefreshedAfterArchiveRowsArePurged(): void
     {
         $idSite = 1;
         $date = '2014-05-11';

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -147,6 +147,96 @@ class ArchiveTest extends IntegrationTestCase
         $this->assertEquals($expected, $metrics);
     }
 
+    public function testStaleCachedArchiveIdsAreRefreshedWhenArchiveRowsAreMissing()
+    {
+        $idSite = 1;
+        $date = '2014-05-10';
+        $periodRange = $date . ',' . $date;
+        $tracker = Fixture::getTracker($idSite, $date . ' 12:00:00');
+        $tracker->setUrl('https://example.org/cache-test');
+        Fixture::checkResponse($tracker->doTrackPageView('cache test'));
+
+        $archive = Archive::build($idSite, 'day', $date);
+        $metric = $archive->getNumeric('nb_visits');
+        $expectedValue = (float) $metric;
+        $this->assertGreaterThan(0.0, $expectedValue);
+
+        $archiveClass = new \ReflectionClass(Archive::class);
+
+        $idArchivesProp = $archiveClass->getProperty('idarchives');
+        $idArchivesProp->setAccessible(true);
+        $idArchivesProp->setValue($archive, [
+            'done' => [
+                $periodRange => [99999999],
+            ],
+        ]);
+
+        $idArchiveStatesProp = $archiveClass->getProperty('idarchiveStates');
+        $idArchiveStatesProp->setAccessible(true);
+        $idArchiveStatesProp->setValue($archive, [
+            $idSite => [
+                'done' => [
+                    $periodRange => [
+                        99999999 => ArchiveWriter::DONE_OK,
+                    ],
+                ],
+            ],
+        ]);
+
+        $metric = $archive->getNumeric('nb_visits');
+        $this->assertSame(
+            $expectedValue,
+            (float) $metric,
+            'Expected stale cached archive IDs to be refreshed and return data from the current archive.'
+        );
+    }
+
+    public function testStaleCachedArchiveIdsAreRefreshedAfterArchiveRowsArePurged()
+    {
+        $idSite = 1;
+        $date = '2014-05-11';
+        $tracker = Fixture::getTracker($idSite, $date . ' 12:00:00');
+        $tracker->setUrl('https://example.org/cache-test-normal-flow');
+        Fixture::checkResponse($tracker->doTrackPageView('cache test normal flow'));
+
+        // Keep this Archive instance to preserve its in-memory idarchive cache.
+        $archive = Archive::build($idSite, 'day', $date);
+        $initialMetric = (float) $archive->getNumeric('nb_visits');
+        $this->assertGreaterThan(0.0, $initialMetric);
+
+        $wasBrowserTriggerEnabled = Rules::isBrowserTriggerEnabled();
+        Rules::setBrowserTriggerArchiving(true);
+
+        try {
+            $numericTable = ArchiveTableCreator::getNumericTable(Date::factory($date));
+            $blobTable = ArchiveTableCreator::getBlobTable(Date::factory($date));
+
+            $deletedNumericRows = Db::query(
+                "DELETE FROM `$numericTable` WHERE idsite = ? AND period = ? AND date1 = ? AND date2 = ?",
+                [$idSite, 1, $date, $date]
+            )->rowCount();
+            $deletedBlobRows = Db::query(
+                "DELETE FROM `$blobTable` WHERE idsite = ? AND period = ? AND date1 = ? AND date2 = ?",
+                [$idSite, 1, $date, $date]
+            )->rowCount();
+
+            $this->assertGreaterThan(
+                0,
+                $deletedNumericRows + $deletedBlobRows,
+                'Expected archive rows to be removed to simulate concurrent purge.'
+            );
+
+            $metricAfterPurge = (float) $archive->getNumeric('nb_visits');
+            $this->assertSame(
+                $initialMetric,
+                $metricAfterPurge,
+                'Expected stale cached archive IDs to be refreshed after archive rows are purged in normal flow.'
+            );
+        } finally {
+            Rules::setBrowserTriggerArchiving($wasBrowserTriggerEnabled);
+        }
+    }
+
     public function testPluginSpecificArchiveUsedEvenIfAllArchiveExistsIfThereAreNoDataInAllArchiveWithBrowserArchivingDisabled()
     {
         self::$fixture->getTestEnvironment()->overrideConfig('General', 'enable_browser_archiving_triggering', 0);


### PR DESCRIPTION
## Summary

This PR fixes a stale-archive-cache issue in Archive::get() that can return empty data from valid reports when cached
archive IDs point to rows that no longer exist.

refs #24191

## Problem

Archive caches archive IDs in-memory. If those rows are removed after the cache is populated, later reads in the same
request can still query with stale IDs and return no rows, leading to incorrect zeroed metrics.

## Root Cause

Archive::get() trusted cached IDs unconditionally and had no recovery path when ArchiveSelector::getArchiveData()
returned empty for otherwise valid archive queries.

## Fix

When archive data comes back empty, Archive::get() now:

1. Clears in-memory archive ID/state cache.
2. Fetches archive IDs/states again.
3. Retries data fetch once.

## Tests

Added integration regression tests in tests/PHPUnit/Integration/ArchiveTest.php:

1. testStaleCachedArchiveIdsAreRefreshedWhenArchiveRowsAreMissing
2. testStaleCachedArchiveIdsAreRefreshedAfterArchiveRowsArePurged

The second test reproduces the issue via normal flow (no reflection-based cache overwrite): cache is primed, archive
rows are removed, then the same Archive instance is queried again.

## Expected Impact

Prevents false-empty archive reads and incorrect zero metrics when cached archive IDs become stale mid-request.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
