### PR TITLE
improve archiving performance with temp tables on all visits segment

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -976,7 +976,7 @@ class LogAggregator
     public function queryEcommerceItems($dimension)
     {
         $query = $this->generateQuery(
-        // SELECT ...
+            // SELECT ...
             implode(
                 ', ',
                 array(

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -239,7 +239,7 @@ class LogAggregator
      */
     public function cleanup()
     {
-        if (!$this->segment->isEmpty() && $this->isSegmentCacheEnabled()) {
+        if ($this->isSegmentCacheEnabled()) {
             $segmentTable = $this->getSegmentTmpTableName();
             $segmentTable = Common::prefixTable($segmentTable);
 
@@ -373,7 +373,7 @@ class LogAggregator
         $segment = $this->segment;
         $bind = $this->getGeneralQueryBindParams();
 
-        if (!$this->segment->isEmpty() && $this->isSegmentCacheEnabled()) {
+        if ($this->isSegmentCacheEnabled()) {
             $segment = new Segment('', $this->sites, $this->params->getPeriod()->getDateTimeStart(), $this->params->getPeriod()->getDateTimeEnd());
 
             $logTablesProvider = $this->getLogTableProvider();


### PR DESCRIPTION
### Description

Currently we use temporary tables to improve performance when archiving with segments. The proposal is that using these temp tables with the all visits segment (e.g. no segment) will also improve performance.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
