### PR TITLE
Inject component name in createVueApp

### DIFF
--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -227,21 +227,23 @@ window.piwikHelper = {
         var useExternalPluginComponent = CoreHome.useExternalPluginComponent;
         var createVueApp = CoreHome.createVueApp;
         var component;
+        let pluginName = parts[0];
+        let componentName = parts[1];
 
-        var shouldLoadOnDemand = (piwik.pluginsToLoadOnDemand || []).indexOf(parts[0]) !== -1;
+        var shouldLoadOnDemand = (piwik.pluginsToLoadOnDemand || []).indexOf(pluginName) !== -1;
         if (!shouldLoadOnDemand) {
-          var plugin = window[parts[0]];
+          var plugin = window[pluginName];
           if (!plugin) {
             // plugin may not be activated
             return;
           }
 
-          component = plugin[parts[1]];
+          component = plugin[componentName];
           if (!component) {
             throw new Error('Unknown component in vue-entry: ' + entry);
           }
         } else {
-          component = useExternalPluginComponent(parts[0], parts[1]);
+          component = useExternalPluginComponent(pluginName, componentName);
         }
 
         var paramsStr = '';
@@ -279,6 +281,7 @@ window.piwikHelper = {
         // template that references the root component and wraps the vue-entry component's html.
         // this allows using slots in twig.
         var app = createVueApp({
+          name: componentName+'Entry',
           template: '<root ' + paramsStr + '>' + this.innerHTML.replace('{{', '{&lbrace;') + '</root>',
           data: function () {
             return componentParams;

--- a/plugins/Morpheus/vue/src/piwikHelper.spec.ts
+++ b/plugins/Morpheus/vue/src/piwikHelper.spec.ts
@@ -1,0 +1,43 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+describe('piwikHelper', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    delete (window as any).CoreHome;
+    delete (window as any).MyPlugin;
+    (window.piwik as any).pluginsToLoadOnDemand = [];
+  });
+
+  it('should pass a component name to createVueApp for vue-entry components', () => {
+    const app = {
+      component: jest.fn(),
+      mount: jest.fn(() => ({})),
+      unmount: jest.fn(),
+    };
+
+    const createVueApp = jest.fn(() => app);
+
+    (window as any).CoreHome = {
+      createVueApp,
+      useExternalPluginComponent: jest.fn(),
+    };
+    (window as any).MyPlugin = {
+      MyComponent: {},
+    };
+    (window.piwik as any).pluginsToLoadOnDemand = [];
+
+    document.body.innerHTML = '<div id="root"><div vue-entry="MyPlugin.MyComponent"></div></div>';
+
+    window.piwikHelper.compileVueEntryComponents('#root');
+
+    expect(createVueApp).toHaveBeenCalledTimes(1);
+    expect(createVueApp).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'MyComponentEntry',
+    }));
+  });
+});


### PR DESCRIPTION
### Description

This is to add a name to our root components when mounting them using `createVueApp`.
This will help in showing the component names in Vue console, and making it easier to identify components you are debugging

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
