### PR TITLE
Change from screenshot to text assertion for flaky test

### DIFF
--- a/plugins/UsersManager/tests/UI/UsersManager_spec.js
+++ b/plugins/UsersManager/tests/UI/UsersManager_spec.js
@@ -496,6 +496,7 @@ describe("UsersManager", function () {
 
         expect(roles.hunter12).to.equal('string:view');
         expect(roles.hunter32).to.equal('string:view');
+        expect(roles.hunter82).to.equal('string:view');
         expect(roles.hunter2).to.equal('string:write');
         expect(roles.hunter22).to.equal('string:write');
     });

--- a/plugins/UsersManager/tests/UI/UsersManager_spec.js
+++ b/plugins/UsersManager/tests/UI/UsersManager_spec.js
@@ -12,6 +12,26 @@ describe("UsersManager", function () {
 
     var url = "?module=UsersManager&action=index";
 
+    async function getVisibleSiteRoles() {
+        await page.waitForFunction(() => !$('.userPermissionsEdit').hasClass('loading'));
+        await page.waitForSelector('#sitesForPermission tbody tr:not(.select-all-row)', { visible: true });
+
+        return page.evaluate(() => {
+            const roles = {};
+
+            $('#sitesForPermission tbody tr').not('.select-all-row').each(function () {
+                const siteName = $(this).find('td:eq(1) span').text().trim();
+                const role = $(this).find('.role-select select').val();
+
+                if (siteName) {
+                    roles[siteName] = role;
+                }
+            });
+
+            return roles;
+        });
+    }
+
     before(async function() {
         await page.webpage.setViewport({
             width: 1250,
@@ -470,13 +490,14 @@ describe("UsersManager", function () {
             $('.access-filter select').val('string:some').change();
         });
         await page.waitForNetworkIdle();
-        await page.waitForTimeout(250); // animation
-        await page.evaluate(() => window.scrollTo(0, 0));
+        await page.waitForFunction(() => !$('.userPermissionsEdit').hasClass('loading'));
 
-        expect(await page.screenshotSelector('.user-permissions')).to.matchImage({
-            imageName: 'permissions_bulk_access_set_all',
-            comparisonThreshold: 0.0015
-        });
+        const roles = await getVisibleSiteRoles();
+
+        expect(roles.hunter12).to.equal('string:view');
+        expect(roles.hunter32).to.equal('string:view');
+        expect(roles.hunter2).to.equal('string:write');
+        expect(roles.hunter22).to.equal('string:write');
     });
 
     it('should set access to single site when select in table is used', async function () {

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_bulk_access_set_all.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_bulk_access_set_all.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:140aafa18580ea2eb9455b20b28a133932bdeec04fca2192153988e92111de8e
-size 65220


### PR DESCRIPTION
### Description

Test is still flaky despite previous attempt.

Test passing here: https://github.com/matomo-org/matomo/actions/runs/23583075736/job/68669863231?pr=24267#step:3:1570

Removed screenshot test and just asserted some values the general screen is tested enough already here:

```
  - plugins/UsersManager/tests/UI/UsersManager_spec.js:388 already covers bulk-changing selected sites through the same bulk-action menu and confirm flow.
  - plugins/UsersManager/tests/UI/UsersManager_spec.js:408 already covers applying the permissions filters.
  - plugins/UsersManager/tests/UI/UsersManager_spec.js:330 covers the separate areAllResultsSelected branch, where the action applies to all websites in the search result set.
  
  
  - plugins/UsersManager/tests/Integration/APITest.php:908 verifies returned site-access data after setUserAccess.
  - plugins/UsersManager/tests/Integration/APITest.php:966 covers search filtering in getSitesAccessForUser.
  - plugins/UsersManager/tests/Integration/APITest.php:1002 covers access-level filtering.
  - plugins/UsersManager/tests/Integration/APITest.php:1052 covers the "some" filter semantics used when this flaky UI test clears the admin filter.
```

**Can probably apply this to other tests in this file, but I want to see how this does first.**

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
