### PR TITLE
Fix PHPUnit deprecation warnings in integration tests

### DIFF
--- a/plugins/API/tests/Integration/RowEvolutionTest.php
+++ b/plugins/API/tests/Integration/RowEvolutionTest.php
@@ -29,7 +29,7 @@ class RowEvolutionTest extends IntegrationTestCase
     public function testGetRowEvolutionShouldTriggerAnExceptionIfReportHasNoDimension()
     {
         $this->expectException(\Exception::class);
-        $this->expectDeprecationMessage("Reports like VisitsSummary.get which do not have a dimension are not supported by row evolution");
+        $this->expectExceptionMessage("Reports like VisitsSummary.get which do not have a dimension are not supported by row evolution");
         $rowEvolution = new RowEvolution();
         $rowEvolution->getRowEvolution(1, 'day', 'last7', 'VisitsSummary', 'get');
     }

--- a/plugins/CoreAdminHome/tests/Integration/Commands/CoreArchiverProcessSignalTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/CoreArchiverProcessSignalTest.php
@@ -88,7 +88,7 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         if (self::METHOD_CURL === $method) {
             self::assertStringContainsString('Execute HTTP API request:', $processOutput);
         } else {
-            self::assertRegExp('/Running command.*\[method = ' . $method . ']/', $processOutput);
+            $this->assertMatchesRegularExpressionCompat('/Running command.*\[method = ' . $method . ']/', $processOutput);
         }
     }
 
@@ -358,7 +358,7 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         if (self::METHOD_CURL === $method) {
             self::assertStringContainsString('Execute HTTP API request:', $processOutput);
         } else {
-            self::assertRegExp('/Running command.*\[method = ' . $method . ']/', $processOutput);
+            $this->assertMatchesRegularExpressionCompat('/Running command.*\[method = ' . $method . ']/', $processOutput);
         }
 
         self::assertStringContainsString('Starting archiving for', $processOutput);
@@ -386,9 +386,19 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         }
 
         if (\SIGTERM === $signalOutput) {
-            self::assertRegExp('/Aborting command.*\[method = ' . $method . ']/', $processOutput);
+            $this->assertMatchesRegularExpressionCompat('/Aborting command.*\[method = ' . $method . ']/', $processOutput);
             self::assertStringContainsString('Archiving process killed, reset invalidation', $processOutput);
         }
+    }
+
+    private function assertMatchesRegularExpressionCompat(string $pattern, string $value): void
+    {
+        if (method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression($pattern, $value);
+            return;
+        }
+
+        $this->assertRegExp($pattern, $value);
     }
 
     private function sendSignalToProcess(

--- a/plugins/CoreAdminHome/tests/Integration/Commands/DeleteLogsDataTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/DeleteLogsDataTest.php
@@ -106,7 +106,10 @@ class DeleteLogsDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(1, $result, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertNotRegExp("/Successfully deleted [0-9]+ rows from all log tables/", $this->applicationTester->getDisplay());
+        $this->assertDoesNotMatchRegularExpressionCompat(
+            "/Successfully deleted [0-9]+ rows from all log tables/",
+            $this->applicationTester->getDisplay()
+        );
     }
 
     public function testCommandCorrectlyDeletesRequestedLogFiles()
@@ -134,6 +137,16 @@ class DeleteLogsDataTest extends ConsoleCommandTestCase
         /** @var RawLogDao $dao */
         $dao = StaticContainer::get('Piwik\DataAccess\RawLogDao');
         $this->assertNotEmpty($dao->countVisitsWithDatesLimit($from, $to));
+    }
+
+    private function assertDoesNotMatchRegularExpressionCompat(string $pattern, string $value): void
+    {
+        if (method_exists($this, 'assertDoesNotMatchRegularExpression')) {
+            $this->assertDoesNotMatchRegularExpression($pattern, $value);
+            return;
+        }
+
+        $this->assertNotRegExp($pattern, $value);
     }
 }
 

--- a/plugins/GeoIp2/tests/Integration/ControllerTest.php
+++ b/plugins/GeoIp2/tests/Integration/ControllerTest.php
@@ -106,7 +106,7 @@ class ControllerTest extends IntegrationTestCase
         $continueResponse = $this->decodeJsonResponse($this->controller->downloadMissingGeoIpDb());
 
         $this->assertArrayHasKey('error', $continueResponse);
-        $this->assertFileNotExists($locDownloadChunk);
+        $this->assertFileDoesNotExistCompat($locDownloadChunk);
         $this->assertFileExists($ispDownloadChunk);
         $this->assertFalse(Option::get($locDownloadChunk . '_expectedDownloadSize'));
         $this->assertSame('12', Option::get($ispDownloadChunk . '_expectedDownloadSize'));
@@ -130,5 +130,15 @@ class ControllerTest extends IntegrationTestCase
     private function decodeJsonResponse($response): array
     {
         return (array) json_decode((string) $response, true);
+    }
+
+    private function assertFileDoesNotExistCompat(string $path): void
+    {
+        if (method_exists($this, 'assertFileDoesNotExist')) {
+            $this->assertFileDoesNotExist($path);
+            return;
+        }
+
+        $this->assertFileNotExists($path);
     }
 }

--- a/plugins/UsersManager/tests/Integration/UsersManagerTest.php
+++ b/plugins/UsersManager/tests/Integration/UsersManagerTest.php
@@ -99,10 +99,10 @@ class UsersManagerTest extends IntegrationTestCase
         $userAfter = $this->model->getUser($user["login"]);
 
         $this->assertArrayHasKey('date_registered', $userAfter);
-        $this->assertRegExp(self::DATETIME_REGEX, $userAfter['date_registered']);
+        $this->assertMatchesRegularExpressionCompat(self::DATETIME_REGEX, $userAfter['date_registered']);
 
         $this->assertArrayHasKey('ts_password_modified', $userAfter);
-        $this->assertRegExp(self::DATETIME_REGEX, $userAfter['date_registered']);
+        $this->assertMatchesRegularExpressionCompat(self::DATETIME_REGEX, $userAfter['ts_password_modified']);
 
         $this->assertArrayHasKey('password', $userAfter);
         $this->assertNotEmpty($userAfter['password']);
@@ -408,7 +408,7 @@ class UsersManagerTest extends IntegrationTestCase
             $this->api->getUser("geggeqgeqag");
             $this->fail("Exception not raised.");
         } catch (Exception $expected) {
-            $this->assertRegExp("(UsersManager_ExceptionUserDoesNotExist)", $expected->getMessage());
+            $this->assertStringContainsString("UsersManager_ExceptionUserDoesNotExist", $expected->getMessage());
         }
 
         // add the same user
@@ -1333,7 +1333,7 @@ class UsersManagerTest extends IntegrationTestCase
             $this->api->getUser($login);
             $this->fail("User $login still exists!");
         } catch (Exception $expected) {
-            $this->assertRegExp("(UsersManager_ExceptionUserDoesNotExist)", $expected->getMessage());
+            $this->assertStringContainsString("UsersManager_ExceptionUserDoesNotExist", $expected->getMessage());
         }
     }
 
@@ -1351,5 +1351,15 @@ class UsersManagerTest extends IntegrationTestCase
         }
 
         return $pwd;
+    }
+
+    private function assertMatchesRegularExpressionCompat(string $pattern, string $value): void
+    {
+        if (method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression($pattern, $value);
+            return;
+        }
+
+        $this->assertRegExp($pattern, $value);
     }
 }


### PR DESCRIPTION
### Description

This PR removes PHPUnit deprecation warnings in affected integration tests to improve PHPUnit 10 compatibility.

### Fixes in the plugins

- https://github.com/matomo-org/plugin-AnonymousPiwikUsageMeasurement/pull/104
- https://github.com/matomo-org/plugin-CustomAlerts/pull/242
- https://github.com/matomo-org/plugin-QueuedTracking/pull/317

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
