### PR TITLE
Fix DevicePlugins.getPlugin for multi-site multi-period requests

### DIFF
--- a/plugins/DevicePlugins/API.php
+++ b/plugins/DevicePlugins/API.php
@@ -46,56 +46,64 @@ class API extends \Piwik\Plugin\API
         $archive = Archive::build($idSite, $period, $date, $segment);
         $visitsSums = $archive->getDataTableFromNumeric('nb_visits');
 
-        // check whether given tables are arrays
         if ($dataTable instanceof DataTable\Map) {
-            $dataTableMap = $dataTable->getDataTables();
-            $browserVersionsArray = $browserVersions->getDataTables();
-            $visitSumsArray = $visitsSums->getDataTables();
-        } else {
-            $dataTableMap = array($dataTable);
-            $browserVersionsArray = array($browserVersions);
-            $visitSumsArray = array($visitsSums);
-        }
-
-        // walk through the results and calculate the percentage
-        foreach ($dataTableMap as $key => $table) {
-            // Calculate percentage, but ignore IE users because plugin detection doesn't work on IE
-            $ieVisits = 0;
-
-            $browserVersionsToExclude = array(
-                'IE;10.0',
-                'IE;9.0',
-                'IE;8.0',
-                'IE;7.0',
-                'IE;6.0',
-            );
-            foreach ($browserVersionsToExclude as $browserVersionToExclude) {
-                $ieStats = $browserVersionsArray[$key]->getRowFromLabel($browserVersionToExclude);
-                if ($ieStats !== false) {
-                    $ieVisits += $ieStats->getColumn(Metrics::INDEX_NB_VISITS);
+            $dataTable->multiFilter(
+                [
+                    $browserVersions instanceof DataTable\Map ? $browserVersions : null,
+                    $visitsSums instanceof DataTable\Map ? $visitsSums : null,
+                ],
+                function (DataTable $pluginTable, ?DataTable $browserVersionsTable, ?DataTable $visitsTable): void {
+                    $this->addVisitsPercentProcessedMetric($pluginTable, $browserVersionsTable, $visitsTable);
                 }
-            }
-
-            // get according visitsSum
-            $visits = $visitSumsArray[$key];
-            if ($visits->getRowsCount() == 0) {
-                $visitsSumTotal = 0;
-            } else {
-                $visitsSumTotal = (float) $visits->getFirstRow()->getColumn('nb_visits');
-            }
-
-            $visitsSum = $visitsSumTotal - $ieVisits;
-
-            $extraProcessedMetrics = $table->getMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME);
-            $extraProcessedMetrics = is_array($extraProcessedMetrics) ? $extraProcessedMetrics : [];
-            $extraProcessedMetrics[] = new VisitsPercent($visitsSum);
-            $table->setMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME, $extraProcessedMetrics);
+            );
+        } else {
+            $this->addVisitsPercentProcessedMetric(
+                $dataTable,
+                $browserVersions instanceof DataTable ? $browserVersions : null,
+                $visitsSums instanceof DataTable ? $visitsSums : null
+            );
         }
 
-        $dataTable->queueFilter('ColumnCallbackAddMetadata', array('label', 'logo', __NAMESPACE__ . '\getPluginsLogo'));
-        $dataTable->queueFilter('ColumnCallbackReplace', array('label', 'ucfirst'));
-        $dataTable->queueFilter('RangeCheck', array('nb_visits_percentage', 0, 1));
+        $dataTable->queueFilter('ColumnCallbackAddMetadata', ['label', 'logo', __NAMESPACE__ . '\getPluginsLogo']);
+        $dataTable->queueFilter('ColumnCallbackReplace', ['label', 'ucfirst']);
+        $dataTable->queueFilter('RangeCheck', ['nb_visits_percentage', 0, 1]);
 
         return $dataTable;
+    }
+
+    private function addVisitsPercentProcessedMetric(
+        DataTable $table,
+        ?DataTable $browserVersions,
+        ?DataTable $visits
+    ): void {
+        // Calculate percentage, but ignore IE users because plugin detection doesn't work on IE
+        $ieVisits = 0;
+
+        $browserVersionsToExclude = [
+            'IE;10.0',
+            'IE;9.0',
+            'IE;8.0',
+            'IE;7.0',
+            'IE;6.0',
+        ];
+        foreach ($browserVersionsToExclude as $browserVersionToExclude) {
+            $ieStats = $browserVersions ? $browserVersions->getRowFromLabel($browserVersionToExclude) : false;
+            if ($ieStats !== false) {
+                $ieVisits += $ieStats->getColumn(Metrics::INDEX_NB_VISITS);
+            }
+        }
+
+        if (!$visits || $visits->getRowsCount() == 0) {
+            $visitsSumTotal = 0;
+        } else {
+            $visitsSumTotal = (float)$visits->getFirstRow()->getColumn('nb_visits');
+        }
+
+        $visitsSum = $visitsSumTotal - $ieVisits;
+
+        $extraProcessedMetrics   = $table->getMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME);
+        $extraProcessedMetrics   = is_array($extraProcessedMetrics) ? $extraProcessedMetrics : [];
+        $extraProcessedMetrics[] = new VisitsPercent($visitsSum);
+        $table->setMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME, $extraProcessedMetrics);
     }
 }

--- a/plugins/DevicePlugins/tests/Integration/GetPluginApiTest.php
+++ b/plugins/DevicePlugins/tests/Integration/GetPluginApiTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\DevicePlugins\tests\Integration;
+
+use Piwik\DataTable;
+use Piwik\Plugins\CoreHome\Columns\Metrics\VisitsPercent;
+use Piwik\Plugins\DevicePlugins\API;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group DevicePlugins
+ * @group Plugins
+ */
+class GetPluginApiTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createWebsite('2024-01-01 00:00:00');
+        Fixture::createWebsite('2024-01-01 00:00:00');
+        Fixture::createSuperUser();
+
+        $this->trackVisit(1, '2024-01-16 10:00:00');
+        $this->trackVisit(1, '2024-01-17 10:00:00');
+        $this->trackVisit(2, '2024-01-16 11:00:00');
+        $this->trackVisit(2, '2024-01-17 11:00:00');
+    }
+
+    public function testGetPluginShouldSupportMultiSiteAndMultiPeriodRequests(): void
+    {
+        $result = API::getInstance()->getPlugin('1,2', 'day', '2024-01-16,2024-01-17');
+
+        self::assertInstanceOf(DataTable\Map::class, $result);
+
+        $result->applyQueuedFilters();
+
+        foreach ($result->getDataTables() as $siteTable) {
+            self::assertInstanceOf(DataTable\Map::class, $siteTable);
+
+            foreach ($siteTable->getDataTables() as $periodTable) {
+                self::assertInstanceOf(DataTable::class, $periodTable);
+                self::assertNotEmpty(
+                    array_filter(
+                        $periodTable->getMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME) ?: [],
+                        function ($metric) {
+                            return $metric instanceof VisitsPercent;
+                        }
+                    )
+                );
+                self::assertGreaterThan(0, $periodTable->getRowsCount());
+            }
+        }
+    }
+
+    private function trackVisit(int $idSite, string $dateTime): void
+    {
+        $tracker = Fixture::getTracker($idSite, $dateTime, true, true);
+        $tracker->setIp(sprintf('10.0.0.%d', $idSite));
+        $tracker->setPlugins(true, false, true, false, true);
+        $tracker->setUrl(sprintf('https://example.org/site-%d', $idSite));
+        Fixture::checkResponse($tracker->doTrackPageView('Plugin Report Visit'));
+    }
+}


### PR DESCRIPTION
### Description

  DevicePlugins.getPlugin fails when both multiple sites and multiple periods are requested together, for example:

  idSite=1,2&period=day&date=last2

  The method handled DataTable\Map results as if they were only one level deep. In the multi-site + multi-period case,
  Matomo returns a nested map (site -> period -> DataTable), so the existing loop eventually processed an inner
  DataTable\Map as if it were a leaf DataTable.

  ## Fix

  This change updates DevicePlugins.getPlugin to traverse the returned tables leaf-by-leaf using multiFilter(), keeping
  these result sets aligned at every nesting level:

  - plugin report table
  - browser versions table
  - nb_visits numeric table

  The VisitsPercent processed metric is now added only to actual leaf DataTable instances, which makes the API work for:

  - single site / single period
  - single site / multi period
  - multi site / single period
  - multi site / multi period

  ## Tests

  Added an integration test covering a multi-site + multi-period request and verifying the nested result structure is
  processed correctly.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
