### PR TITLE
Make it possible to force a state for discontinued feature flags

### DIFF
--- a/plugins/FeatureFlags/FeatureFlagManager.php
+++ b/plugins/FeatureFlags/FeatureFlagManager.php
@@ -42,6 +42,10 @@ class FeatureFlagManager
             return false;
         }
 
+        if ($featureFlagObj instanceof ForcedFeatureFlagStateInterface) {
+            return $featureFlagObj->getForcedFeatureFlagState();
+        }
+
         $featureActive = false;
 
         foreach ($this->storages as $storage) {

--- a/plugins/FeatureFlags/ForcedFeatureFlagStateInterface.php
+++ b/plugins/FeatureFlags/ForcedFeatureFlagStateInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\FeatureFlags;
+
+interface ForcedFeatureFlagStateInterface
+{
+    public function getForcedFeatureFlagState(): bool;
+}

--- a/plugins/FeatureFlags/tests/Integration/FeatureFlagManagerTests.php
+++ b/plugins/FeatureFlags/tests/Integration/FeatureFlagManagerTests.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Piwik\Plugins\FeatureFlags\FeatureFlagManager;
 use Piwik\Plugins\FeatureFlags\Storage\ConfigFeatureFlagStorage;
 use Piwik\Plugins\FeatureFlags\tests\Integration\FeatureFlags\FakeFeatureFlag;
+use Piwik\Plugins\FeatureFlags\tests\Integration\FeatureFlags\FakeForcedEnabledFeatureFlag;
 use Piwik\Tests\Framework\Mock\FakeConfig;
 use Piwik\Tests\Framework\Mock\FakeLogger;
 
@@ -30,5 +31,19 @@ class FeatureFlagManagerTests extends TestCase
         );
 
         $this->assertTrue($featureFlagManager->isFeatureActive(FakeFeatureFlag::class));
+    }
+
+    public function testForcedFeatureStateOverridesDisabledConfig(): void
+    {
+        $config = new FakeConfig(['FeatureFlags' => ['ForcedEnabled_feature' => 'disabled']]);
+
+        $configFeatureFlagStorage = new ConfigFeatureFlagStorage($config);
+
+        $featureFlagManager = new FeatureFlagManager(
+            [$configFeatureFlagStorage],
+            new FakeLogger()
+        );
+
+        $this->assertTrue($featureFlagManager->isFeatureActive(FakeForcedEnabledFeatureFlag::class));
     }
 }

--- a/plugins/FeatureFlags/tests/Integration/FeatureFlags/FakeForcedEnabledFeatureFlag.php
+++ b/plugins/FeatureFlags/tests/Integration/FeatureFlags/FakeForcedEnabledFeatureFlag.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\FeatureFlags\tests\Integration\FeatureFlags;
+
+use Piwik\Plugins\FeatureFlags\FeatureFlagInterface;
+use Piwik\Plugins\FeatureFlags\ForcedFeatureFlagStateInterface;
+
+class FakeForcedEnabledFeatureFlag implements FeatureFlagInterface, ForcedFeatureFlagStateInterface
+{
+    public function getName(): string
+    {
+        return 'ForcedEnabled';
+    }
+
+    public function getForcedFeatureFlagState(): bool
+    {
+        return true;
+    }
+}

--- a/plugins/FeatureFlags/tests/Unit/FeatureFlagManagerTest.php
+++ b/plugins/FeatureFlags/tests/Unit/FeatureFlagManagerTest.php
@@ -14,6 +14,7 @@ use Piwik\Log\LoggerInterface;
 use Piwik\Plugins\FeatureFlags\FeatureFlagInterface;
 use Piwik\Plugins\FeatureFlags\FeatureFlagManager;
 use Piwik\Plugins\FeatureFlags\FeatureFlagStorageInterface;
+use Piwik\Plugins\FeatureFlags\ForcedFeatureFlagStateInterface;
 
 class FeatureFlagManagerTest extends TestCase
 {
@@ -61,6 +62,29 @@ class FeatureFlagManagerTest extends TestCase
         );
 
         $this->assertEquals($expectedOutcome, $sut->isFeatureActive(get_class($mockFeature)));
+    }
+
+    public function testIsFeatureActiveReturnsForcedStateWithoutConsultingStorages(): void
+    {
+        $storage = $this->createMock(FeatureFlagStorageInterface::class);
+        $storage->expects($this->never())->method('isFeatureActive');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $sut = new FeatureFlagManager([$storage], $logger);
+
+        $featureFlag = new class () implements FeatureFlagInterface, ForcedFeatureFlagStateInterface {
+            public function getName(): string
+            {
+                return 'ForcedEnabledFeature';
+            }
+
+            public function getForcedFeatureFlagState(): bool
+            {
+                return true;
+            }
+        };
+
+        $this->assertTrue($sut->isFeatureActive(get_class($featureFlag)));
     }
 
     public function listOfStorages(): \Generator


### PR DESCRIPTION
### Description

  This change adds a compatibility mechanism for discontinued feature flags that should now be permanently enabled.

  Some external plugins still call FeatureFlagManager::isFeatureActive() for flags that we have already removed checks
  for in core. Without extra handling, those plugins can still see the flag as disabled depending on saved config. This
  PR introduces a forced runtime state for discontinued flags so those old checks continue to behave correctly without
  requiring changes in external plugins.

  What changed

  - Added a new optional interface: ForcedFeatureFlagStateInterface
  - Updated FeatureFlagManager::isFeatureActive() to return the forced state immediately when a feature flag implements
    that interface
  - Marked PrivacyCompliance as force-enabled by implementing the new interface and returning true
  - Added unit and integration tests covering:
      - the forced-state short-circuit
      - override of a disabled config value

  Behavior

  - Normal feature flags continue to use the existing storage/config cascade
  - Discontinued flags can now self-declare a forced runtime state
  - For forced-state flags, runtime evaluation ignores stored config and always returns the forced value

  Why this approach

  - Keeps the existing feature flag classes as compatibility points for external plugins
  - Avoids changing external plugins or their config
  - Keeps the forced-state logic centralized in the feature flag system instead of spreading special cases across call
    sites
  - Does not require changing FeatureFlagInterface or updating every existing flag class


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
