### PR TITLE
Add DDEV commands for mounting local plugins with PHP compatibility checks

### DIFF
--- a/.ddev/.gitignore
+++ b/.ddev/.gitignore
@@ -11,6 +11,7 @@
 /config.local.y*ml
 /config.*.local.y*ml
 /db_snapshots
+/docker-compose.local-plugins.yaml
 /mutagen/mutagen.yml
 /mutagen/.start-synced
 /nginx_full/nginx-site.conf

--- a/.ddev/README.md
+++ b/.ddev/README.md
@@ -84,6 +84,22 @@ The command `ddev matomo:console` provides access to all Matomo console commands
 - `cache:clear` - Remove all caches, including CSS and JavaScript
 - `vue:build` - Builds vue modules for one or more plugins
 
+To mount local plugin repositories into Matomo without symlinks, use the host commands:
+
+```
+ddev matomo:plugins:mount
+ddev matomo:plugins:mount ../plugin-FormAnalytics ../plugin-HeatmapSessionRecording
+ddev matomo:plugins:mount ../ '^.*/plugin-(FormAnalytics|Funnels)$'
+ddev matomo:plugins:unmount FormAnalytics
+ddev matomo:plugins:unmount
+```
+
+`ddev matomo:plugins:mount` creates a local-only `.ddev/docker-compose.local-plugins.yaml`, adds bind mounts for discovered `plugin-*` directories, and restarts DDEV automatically. If you pass a plugin directory path directly, the command reads the plugin name from `plugin.json` when present and otherwise infers it from directory names like `plugin-FormAnalytics`.
+
+When a plugin declares `require.php` in `plugin.json`, the mount command compares it with the PHP version currently used by DDEV. Simple constraints such as `>=7.2.0` are enforced and incompatible plugins are skipped. More complex Composer-style expressions are only warned about and the plugin is mounted anyway.
+
+`ddev matomo:plugins:unmount` removes one or more managed plugin mounts by plugin name. If all managed mounts are removed, the generated compose override is deleted automatically.
+
 For more information about Matomo development, check out the official [Matomo Developer Documentation](https://developer.matomo.org/).
 
 ## Update PHP or MySQL version

--- a/.ddev/commands/host/matomo_plugins_lib.sh
+++ b/.ddev/commands/host/matomo_plugins_lib.sh
@@ -10,6 +10,89 @@ MATOMO_PLUGINS_DDEV_PHP_VERSION=""
 MATOMO_PLUGINS_DDEV_PHP_VERSION_READY=0
 MATOMO_PLUGINS_DDEV_PHP_VERSION_UNAVAILABLE=0
 MATOMO_PLUGINS_PHP_CHECK_RESULT="ok"
+MATOMO_PLUGINS_MAP_SEPARATOR=$'\t'
+
+matomo_plugins::map_get() {
+  local map_name="${1}"
+  local wanted_key="${2}"
+  local entry=""
+  local entry_key=""
+  local entry_value=""
+
+  eval "for entry in \"\${${map_name}[@]+\"\${${map_name}[@]}\"}\"; do
+    entry_key=\${entry%%\"\${MATOMO_PLUGINS_MAP_SEPARATOR}\"*}
+    if [[ \"\${entry}\" == *\"\${MATOMO_PLUGINS_MAP_SEPARATOR}\"* ]]; then
+      entry_value=\${entry#*\"\${MATOMO_PLUGINS_MAP_SEPARATOR}\"}
+    else
+      entry_value=''
+    fi
+    if [[ \"\${entry_key}\" == \"\${wanted_key}\" ]]; then
+      printf '%s\n' \"\${entry_value}\"
+      break
+    fi
+  done"
+}
+
+matomo_plugins::map_set() {
+  local map_name="${1}"
+  local wanted_key="${2}"
+  local wanted_value="${3}"
+  local entry=""
+  local entry_key=""
+  local -a updated_entries=()
+
+  eval "for entry in \"\${${map_name}[@]+\"\${${map_name}[@]}\"}\"; do
+    entry_key=\${entry%%\"\${MATOMO_PLUGINS_MAP_SEPARATOR}\"*}
+    if [[ \"\${entry_key}\" != \"\${wanted_key}\" ]]; then
+      updated_entries+=(\"\${entry}\")
+    fi
+  done"
+
+  updated_entries+=("${wanted_key}${MATOMO_PLUGINS_MAP_SEPARATOR}${wanted_value}")
+  eval "${map_name}=(\"\${updated_entries[@]}\")"
+}
+
+matomo_plugins::map_unset() {
+  local map_name="${1}"
+  local wanted_key="${2}"
+  local entry=""
+  local entry_key=""
+  local -a updated_entries=()
+
+  eval "for entry in \"\${${map_name}[@]+\"\${${map_name}[@]}\"}\"; do
+    entry_key=\${entry%%\"\${MATOMO_PLUGINS_MAP_SEPARATOR}\"*}
+    if [[ \"\${entry_key}\" != \"\${wanted_key}\" ]]; then
+      updated_entries+=(\"\${entry}\")
+    fi
+  done"
+
+  eval "${map_name}=(\"\${updated_entries[@]}\")"
+}
+
+matomo_plugins::map_keys_sorted() {
+  local map_name="${1}"
+  local entry=""
+  local entry_key=""
+
+  eval "for entry in \"\${${map_name}[@]+\"\${${map_name}[@]}\"}\"; do
+    entry_key=\${entry%%\"\${MATOMO_PLUGINS_MAP_SEPARATOR}\"*}
+    printf '%s\n' \"\${entry_key}\"
+  done" | sort
+}
+
+matomo_plugins::map_size() {
+  local map_name="${1}"
+
+  eval "printf '%s\n' \"\${#${map_name}[@]}\""
+}
+
+matomo_plugins::map_is_empty() {
+  local map_name="${1}"
+  local size
+
+  size="$(matomo_plugins::map_size "${map_name}")"
+  [[ "${size}" -eq 0 ]]
+}
 
 matomo_plugins::app_root() {
   printf '%s\n' "${MATOMO_APP_ROOT}"
@@ -135,8 +218,6 @@ matomo_plugins::load_mounts() {
   local line
   local mount_path
   local plugin_name
-  local -n mounts_ref="${map_name}"
-
   config_file="$(matomo_plugins::generated_config)"
   if [[ ! -f "${config_file}" ]]; then
     return 0
@@ -146,7 +227,7 @@ matomo_plugins::load_mounts() {
     if [[ "${line}" =~ ^[[:space:]]*-[[:space:]]*\"([^\"]+):/var/www/html/plugins/([^\"]+)\"[[:space:]]*$ ]]; then
       mount_path="${BASH_REMATCH[1]}"
       plugin_name="${BASH_REMATCH[2]}"
-      mounts_ref["${plugin_name}"]="${mount_path}"
+      matomo_plugins::map_set "${map_name}" "${plugin_name}" "${mount_path}"
     fi
   done < "${config_file}"
 }
@@ -269,7 +350,7 @@ matomo_plugins::write_mounts_to_temp() {
   local map_name="${1}"
   local tmp_file="${2}"
   local plugin_name
-  local -n mounts_ref="${map_name}"
+  local plugin_path
 
   {
     echo "#ddev-generated"
@@ -279,8 +360,9 @@ matomo_plugins::write_mounts_to_temp() {
     echo "    volumes:"
 
     while IFS= read -r plugin_name; do
-      printf '      - "%s:/var/www/html/plugins/%s"\n' "${mounts_ref[${plugin_name}]}" "${plugin_name}"
-    done < <(printf '%s\n' "${!mounts_ref[@]}" | sort)
+      plugin_path="$(matomo_plugins::map_get "${map_name}" "${plugin_name}")"
+      printf '      - "%s:/var/www/html/plugins/%s"\n' "${plugin_path}" "${plugin_name}"
+    done < <(matomo_plugins::map_keys_sorted "${map_name}")
   } > "${tmp_file}"
 }
 
@@ -290,12 +372,11 @@ matomo_plugins::apply_mounts() {
   local config_file
   local tmp_file
   local mount_count=0
-  local -n mounts_ref="${map_name}"
 
   MATOMO_PLUGINS_LAST_CHANGE=0
 
   config_file="$(matomo_plugins::generated_config)"
-  mount_count="${#mounts_ref[@]}"
+  mount_count="$(matomo_plugins::map_size "${map_name}")"
 
   if [[ "${mount_count}" -eq 0 ]]; then
     if [[ -f "${config_file}" ]]; then
@@ -339,20 +420,22 @@ matomo_plugins::record_mount() {
   local plugin_name="${2}"
   local plugin_path="${3}"
   local source_label="${4}"
-  local -n mounts_ref="${map_name}"
+  local existing_path=""
 
-  if [[ -n "${mounts_ref[${plugin_name}]:-}" ]]; then
-    if [[ "${mounts_ref[${plugin_name}]}" == "${plugin_path}" ]]; then
+  existing_path="$(matomo_plugins::map_get "${map_name}" "${plugin_name}")"
+
+  if [[ -n "${existing_path}" ]]; then
+    if [[ "${existing_path}" == "${plugin_path}" ]]; then
       echo "Keeping ${plugin_name} mounted from ${plugin_path} (${source_label})."
       return 0
     fi
 
-    echo "Replacing ${plugin_name}: ${mounts_ref[${plugin_name}]} -> ${plugin_path} (${source_label})."
+    echo "Replacing ${plugin_name}: ${existing_path} -> ${plugin_path} (${source_label})."
   else
     echo "Mounting ${plugin_name} from ${plugin_path} (${source_label})."
   fi
 
-  mounts_ref["${plugin_name}"]="${plugin_path}"
+  matomo_plugins::map_set "${map_name}" "${plugin_name}" "${plugin_path}"
 }
 
 matomo_plugins::scan_explicit_dir() {
@@ -362,7 +445,6 @@ matomo_plugins::scan_explicit_dir() {
   local plugin_name
   local normalized_dir
   local source_label="path:${explicit_dir}"
-  local -n mounts_ref="${map_name}"
 
   normalized_dir="$(matomo_plugins::normalize_path "${explicit_dir}")"
 

--- a/.ddev/commands/host/matomo_plugins_lib.sh
+++ b/.ddev/commands/host/matomo_plugins_lib.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MATOMO_APP_ROOT="${DDEV_APPROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
+MATOMO_PLUGINS_DIR="${MATOMO_APP_ROOT}/plugins"
+MATOMO_GENERATED_PLUGIN_MOUNTS="${MATOMO_APP_ROOT}/.ddev/docker-compose.local-plugins.yaml"
+MATOMO_PLUGINS_LAST_CHANGE=0
+MATOMO_PLUGINS_DDEV_PHP_VERSION=""
+MATOMO_PLUGINS_DDEV_PHP_VERSION_READY=0
+MATOMO_PLUGINS_DDEV_PHP_VERSION_UNAVAILABLE=0
+MATOMO_PLUGINS_PHP_CHECK_RESULT="ok"
+
+matomo_plugins::app_root() {
+  printf '%s\n' "${MATOMO_APP_ROOT}"
+}
+
+matomo_plugins::generated_config() {
+  printf '%s\n' "${MATOMO_GENERATED_PLUGIN_MOUNTS}"
+}
+
+matomo_plugins::normalize_path() {
+  local target_path="${1}"
+  if [[ ! -d "${target_path}" ]]; then
+    return 1
+  fi
+
+  (cd "${target_path}" && pwd)
+}
+
+matomo_plugins::extract_name_from_plugin_json() {
+  local plugin_json="${1}"
+
+  python3 - "${plugin_json}" <<'PY'
+import json
+import sys
+
+plugin_json = sys.argv[1]
+
+try:
+    with open(plugin_json, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+except Exception:
+    sys.exit(0)
+
+name = data.get("name")
+if isinstance(name, str):
+    print(name.strip())
+PY
+}
+
+matomo_plugins::extract_php_requirement_from_plugin_json() {
+  local plugin_json="${1}"
+
+  python3 - "${plugin_json}" <<'PY'
+import json
+import sys
+
+plugin_json = sys.argv[1]
+
+try:
+    with open(plugin_json, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+except Exception:
+    sys.exit(0)
+
+require = data.get("require")
+if isinstance(require, dict):
+    php_requirement = require.get("php")
+    if isinstance(php_requirement, str):
+        print(php_requirement.strip())
+PY
+}
+
+matomo_plugins::infer_name_from_path() {
+  local candidate_dir="${1}"
+  local base_name
+
+  base_name="$(basename "${candidate_dir}")"
+
+  if [[ "${base_name}" == plugin-* ]]; then
+    printf '%s\n' "${base_name#plugin-}"
+    return 0
+  fi
+
+  return 1
+}
+
+matomo_plugins::resolve_name() {
+  local candidate_dir="${1}"
+  local plugin_json="${candidate_dir}/plugin.json"
+  local plugin_name=""
+
+  if [[ -f "${plugin_json}" ]]; then
+    plugin_name="$(matomo_plugins::extract_name_from_plugin_json "${plugin_json}")"
+  fi
+
+  if [[ -n "${plugin_name}" ]]; then
+    printf '%s\n' "${plugin_name}"
+    return 0
+  fi
+
+  matomo_plugins::infer_name_from_path "${candidate_dir}"
+}
+
+matomo_plugins::find_candidate_dirs() {
+  local scan_root="${1}"
+
+  find "${scan_root}" \
+    \( -name .git -o -name node_modules -o -name vendor -o -name tmp -o -name '.*' -o -path '*/plugins/*' \) -prune -o \
+    \( -type d -name 'plugin-*' -print \) \
+    2>/dev/null | sort -u
+}
+
+matomo_plugins::regex_matches() {
+  local pattern="${1}"
+  local subject="${2}"
+
+  if printf '%s\n' "${subject}" | grep -Eq -- "${pattern}"; then
+    return 0
+  fi
+
+  local grep_status=$?
+  if [[ ${grep_status} -eq 2 ]]; then
+    echo "Invalid regex: ${pattern}" >&2
+    exit 1
+  fi
+
+  return 1
+}
+
+matomo_plugins::load_mounts() {
+  local map_name="${1}"
+  local config_file
+  local line
+  local mount_path
+  local plugin_name
+  local -n mounts_ref="${map_name}"
+
+  config_file="$(matomo_plugins::generated_config)"
+  if [[ ! -f "${config_file}" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r line; do
+    if [[ "${line}" =~ ^[[:space:]]*-[[:space:]]*\"([^\"]+):/var/www/html/plugins/([^\"]+)\"[[:space:]]*$ ]]; then
+      mount_path="${BASH_REMATCH[1]}"
+      plugin_name="${BASH_REMATCH[2]}"
+      mounts_ref["${plugin_name}"]="${mount_path}"
+    fi
+  done < "${config_file}"
+}
+
+matomo_plugins::get_ddev_php_version() {
+  if [[ "${MATOMO_PLUGINS_DDEV_PHP_VERSION_READY}" == "1" ]]; then
+    printf '%s\n' "${MATOMO_PLUGINS_DDEV_PHP_VERSION}"
+    return 0
+  fi
+
+  if [[ "${MATOMO_PLUGINS_DDEV_PHP_VERSION_UNAVAILABLE}" == "1" ]]; then
+    return 1
+  fi
+
+  MATOMO_PLUGINS_DDEV_PHP_VERSION="$(ddev exec php -r 'echo PHP_VERSION;' </dev/null 2>/dev/null | tr -d '\r\n')"
+
+  if [[ -n "${MATOMO_PLUGINS_DDEV_PHP_VERSION}" ]]; then
+    MATOMO_PLUGINS_DDEV_PHP_VERSION_READY=1
+    printf '%s\n' "${MATOMO_PLUGINS_DDEV_PHP_VERSION}"
+    return 0
+  fi
+
+  MATOMO_PLUGINS_DDEV_PHP_VERSION_UNAVAILABLE=1
+  echo "Warning: could not determine the active DDEV PHP version. PHP requirement checks will be skipped." >&2
+  return 1
+}
+
+matomo_plugins::evaluate_php_requirement() {
+  local actual_php_version="${1}"
+  local php_requirement="${2}"
+
+  php -r '
+$version = trim($argv[1]);
+$constraint = trim($argv[2]);
+
+if ($constraint === "") {
+    echo "none";
+    exit(0);
+}
+
+if (preg_match("/[\\^~*|]/", $constraint)) {
+    echo "complex";
+    exit(0);
+}
+
+$normalized = str_replace(",", " ", $constraint);
+$pattern = "/(>=|<=|!=|==|=|>|<)\\s*([0-9A-Za-z._+-]+)/";
+$matched = preg_match_all($pattern, $normalized, $matches, PREG_SET_ORDER);
+
+if (!$matched) {
+    echo "complex";
+    exit(0);
+}
+
+$leftovers = preg_replace([$pattern, "/[\\s,]+/"], "", $normalized);
+if ($leftovers !== "") {
+    echo "complex";
+    exit(0);
+}
+
+foreach ($matches as $match) {
+    $operator = $match[1] === "=" ? "==" : $match[1];
+    if (!version_compare($version, $match[2], $operator)) {
+        echo "simple_incompatible";
+        exit(0);
+    }
+}
+
+echo "simple_compatible";
+' -- "${actual_php_version}" "${php_requirement}"
+}
+
+matomo_plugins::check_php_requirement() {
+  local plugin_name="${1}"
+  local plugin_path="${2}"
+  local plugin_json="${plugin_path}/plugin.json"
+  local php_requirement=""
+  local ddev_php_version=""
+  local requirement_status=""
+
+  MATOMO_PLUGINS_PHP_CHECK_RESULT="ok"
+
+  if [[ ! -f "${plugin_json}" ]]; then
+    return 0
+  fi
+
+  php_requirement="$(matomo_plugins::extract_php_requirement_from_plugin_json "${plugin_json}")"
+  if [[ -z "${php_requirement}" ]]; then
+    return 0
+  fi
+
+  if ! ddev_php_version="$(matomo_plugins::get_ddev_php_version)"; then
+    echo "Warning: mounting ${plugin_name} from ${plugin_path} without enforcing PHP requirement ${php_requirement}." >&2
+    return 0
+  fi
+
+  requirement_status="$(matomo_plugins::evaluate_php_requirement "${ddev_php_version}" "${php_requirement}")"
+
+  case "${requirement_status}" in
+    simple_compatible)
+      echo "PHP requirement OK for ${plugin_name}: ${php_requirement} (DDEV PHP ${ddev_php_version})."
+      return 0
+      ;;
+    simple_incompatible)
+      echo "Warning: skipping ${plugin_name} from ${plugin_path}; requires PHP ${php_requirement}, current DDEV PHP is ${ddev_php_version}." >&2
+      MATOMO_PLUGINS_PHP_CHECK_RESULT="skip"
+      return 0
+      ;;
+    complex)
+      echo "Warning: could not strictly validate PHP requirement ${php_requirement} for ${plugin_name} against DDEV PHP ${ddev_php_version}. Mounting anyway." >&2
+      return 0
+      ;;
+  esac
+
+  echo "Warning: unexpected PHP requirement evaluation result for ${plugin_name}. Mounting anyway." >&2
+  return 0
+}
+
+matomo_plugins::write_mounts_to_temp() {
+  local map_name="${1}"
+  local tmp_file="${2}"
+  local plugin_name
+  local -n mounts_ref="${map_name}"
+
+  {
+    echo "#ddev-generated"
+    echo "# Generated by ddev matomo:plugins:mount / ddev matomo:plugins:unmount"
+    echo "services:"
+    echo "  web:"
+    echo "    volumes:"
+
+    while IFS= read -r plugin_name; do
+      printf '      - "%s:/var/www/html/plugins/%s"\n' "${mounts_ref[${plugin_name}]}" "${plugin_name}"
+    done < <(printf '%s\n' "${!mounts_ref[@]}" | sort)
+  } > "${tmp_file}"
+}
+
+matomo_plugins::apply_mounts() {
+  local map_name="${1}"
+  local action_label="${2}"
+  local config_file
+  local tmp_file
+  local mount_count=0
+  local -n mounts_ref="${map_name}"
+
+  MATOMO_PLUGINS_LAST_CHANGE=0
+
+  config_file="$(matomo_plugins::generated_config)"
+  mount_count="${#mounts_ref[@]}"
+
+  if [[ "${mount_count}" -eq 0 ]]; then
+    if [[ -f "${config_file}" ]]; then
+      rm -f "${config_file}"
+      echo "Removed ${config_file}."
+      MATOMO_PLUGINS_LAST_CHANGE=1
+    else
+      echo "No managed plugin mounts remain."
+    fi
+    return 0
+  fi
+
+  tmp_file="$(mktemp)"
+  trap 'rm -f "${tmp_file}"' RETURN
+
+  matomo_plugins::write_mounts_to_temp "${map_name}" "${tmp_file}"
+
+  if [[ -f "${config_file}" ]] && cmp -s "${tmp_file}" "${config_file}"; then
+    echo "Managed plugin mounts already up to date."
+    return 0
+  fi
+
+  mv "${tmp_file}" "${config_file}"
+  trap - RETURN
+  echo "${action_label}: wrote ${config_file} with ${mount_count} managed mount(s)."
+  MATOMO_PLUGINS_LAST_CHANGE=1
+}
+
+matomo_plugins::restart_ddev_if_needed() {
+  if [[ "${MATOMO_PLUGINS_LAST_CHANGE}" != "1" ]]; then
+    echo "No DDEV restart needed."
+    return 0
+  fi
+
+  echo "Restarting DDEV to apply plugin mount changes ..."
+  ddev restart
+}
+
+matomo_plugins::record_mount() {
+  local map_name="${1}"
+  local plugin_name="${2}"
+  local plugin_path="${3}"
+  local source_label="${4}"
+  local -n mounts_ref="${map_name}"
+
+  if [[ -n "${mounts_ref[${plugin_name}]:-}" ]]; then
+    if [[ "${mounts_ref[${plugin_name}]}" == "${plugin_path}" ]]; then
+      echo "Keeping ${plugin_name} mounted from ${plugin_path} (${source_label})."
+      return 0
+    fi
+
+    echo "Replacing ${plugin_name}: ${mounts_ref[${plugin_name}]} -> ${plugin_path} (${source_label})."
+  else
+    echo "Mounting ${plugin_name} from ${plugin_path} (${source_label})."
+  fi
+
+  mounts_ref["${plugin_name}"]="${plugin_path}"
+}
+
+matomo_plugins::scan_explicit_dir() {
+  local map_name="${1}"
+  local explicit_dir="${2}"
+  local candidate_dir
+  local plugin_name
+  local normalized_dir
+  local source_label="path:${explicit_dir}"
+  local -n mounts_ref="${map_name}"
+
+  normalized_dir="$(matomo_plugins::normalize_path "${explicit_dir}")"
+
+  if plugin_name="$(matomo_plugins::resolve_name "${normalized_dir}")"; then
+    if [[ -n "${plugin_name}" ]]; then
+      matomo_plugins::check_php_requirement "${plugin_name}" "${normalized_dir}"
+      if [[ "${MATOMO_PLUGINS_PHP_CHECK_RESULT}" != "skip" ]]; then
+        matomo_plugins::record_mount "${map_name}" "${plugin_name}" "${normalized_dir}" "${source_label}"
+      fi
+    fi
+  fi
+
+  while IFS= read -r candidate_dir; do
+    if [[ "${candidate_dir}" == "${normalized_dir}" ]]; then
+      continue
+    fi
+
+    if plugin_name="$(matomo_plugins::resolve_name "${candidate_dir}")"; then
+      if [[ -n "${plugin_name}" ]]; then
+        matomo_plugins::check_php_requirement "${plugin_name}" "${candidate_dir}"
+        if [[ "${MATOMO_PLUGINS_PHP_CHECK_RESULT}" != "skip" ]]; then
+          matomo_plugins::record_mount "${map_name}" "${plugin_name}" "${candidate_dir}" "${source_label}"
+        fi
+      fi
+    fi
+  done < <(matomo_plugins::find_candidate_dirs "${normalized_dir}")
+
+  return 0
+}
+
+matomo_plugins::scan_regex() {
+  local map_name="${1}"
+  local pattern="${2}"
+  shift 2
+  local root
+  local candidate_dir
+  local plugin_name
+  local matched_any=0
+
+  for root in "$@"; do
+    while IFS= read -r candidate_dir; do
+      if ! matomo_plugins::regex_matches "${pattern}" "${candidate_dir}"; then
+        continue
+      fi
+
+      if plugin_name="$(matomo_plugins::resolve_name "${candidate_dir}")"; then
+        if [[ -n "${plugin_name}" ]]; then
+          matched_any=1
+          matomo_plugins::check_php_requirement "${plugin_name}" "${candidate_dir}"
+          if [[ "${MATOMO_PLUGINS_PHP_CHECK_RESULT}" != "skip" ]]; then
+            matomo_plugins::record_mount "${map_name}" "${plugin_name}" "${candidate_dir}" "regex:${pattern}"
+          fi
+        fi
+      fi
+    done < <(matomo_plugins::find_candidate_dirs "${root}")
+  done
+
+  if [[ "${matched_any}" -eq 0 ]]; then
+    echo "Regex matched no plugin candidates: ${pattern}"
+  fi
+
+  return 0
+}

--- a/.ddev/commands/host/matomo_plugins_mount
+++ b/.ddev/commands/host/matomo_plugins_mount
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+## Description: Mount local plugin directories into Matomo via a generated DDEV compose override
+## Usage: matomo:plugins:mount [<path-or-regex> ...]
+## Example: ddev matomo:plugins:mount ../plugin-FormAnalytics ../plugin-HeatmapSessionRecording
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/matomo_plugins_lib.sh"
+
+declare -A managed_mounts=()
+declare -a literal_roots=()
+declare -a original_args=("$@")
+
+matomo_plugins::load_mounts managed_mounts
+
+if [[ ${#original_args[@]} -eq 0 ]]; then
+  echo "Scanning default root ../ for plugin candidates ..."
+  matomo_plugins::scan_explicit_dir managed_mounts "$(matomo_plugins::app_root)/.."
+else
+  for arg in "${original_args[@]}"; do
+    if normalized_root="$(matomo_plugins::normalize_path "${arg}")"; then
+      literal_roots+=("${normalized_root}")
+    fi
+  done
+
+  for arg in "${original_args[@]}"; do
+    if normalized_root="$(matomo_plugins::normalize_path "${arg}")"; then
+      echo "Scanning ${normalized_root} for plugin candidates ..."
+      matomo_plugins::scan_explicit_dir managed_mounts "${normalized_root}"
+      continue
+    fi
+
+    if [[ ${#literal_roots[@]} -eq 0 ]]; then
+      literal_roots=("$(matomo_plugins::normalize_path "$(matomo_plugins::app_root)/..")")
+    fi
+
+    echo "Scanning regex ${arg} within ${literal_roots[*]} ..."
+    matomo_plugins::scan_regex managed_mounts "${arg}" "${literal_roots[@]}"
+  done
+fi
+
+matomo_plugins::apply_mounts managed_mounts "Mount command"
+matomo_plugins::restart_ddev_if_needed

--- a/.ddev/commands/host/matomo_plugins_mount
+++ b/.ddev/commands/host/matomo_plugins_mount
@@ -9,7 +9,7 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/matomo_plugins_lib.sh"
 
-declare -A managed_mounts=()
+managed_mounts=()
 declare -a literal_roots=()
 declare -a original_args=("$@")
 

--- a/.ddev/commands/host/matomo_plugins_unmount
+++ b/.ddev/commands/host/matomo_plugins_unmount
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+## Description: Unmount managed local plugin directories from Matomo and remove the generated DDEV override when empty
+## Usage: matomo:plugins:unmount [<plugin-name> ...]
+## Example: ddev matomo:plugins:unmount FormAnalytics HeatmapSessionRecording
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/matomo_plugins_lib.sh"
+
+declare -A managed_mounts=()
+
+matomo_plugins::load_mounts managed_mounts
+
+if [[ ${#managed_mounts[@]} -eq 0 ]]; then
+  echo "No managed plugin mounts found."
+  exit 0
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "Unmounting all managed plugins ..."
+  managed_mounts=()
+else
+  for plugin_name in "$@"; do
+    if [[ -n "${managed_mounts[${plugin_name}]:-}" ]]; then
+      echo "Unmounting ${plugin_name} from ${managed_mounts[${plugin_name}]}."
+      unset "managed_mounts[${plugin_name}]"
+    else
+      echo "Plugin ${plugin_name} is not currently managed."
+    fi
+  done
+fi
+
+matomo_plugins::apply_mounts managed_mounts "Unmount command"
+matomo_plugins::restart_ddev_if_needed

--- a/.ddev/commands/host/matomo_plugins_unmount
+++ b/.ddev/commands/host/matomo_plugins_unmount
@@ -9,11 +9,11 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/matomo_plugins_lib.sh"
 
-declare -A managed_mounts=()
+managed_mounts=()
 
 matomo_plugins::load_mounts managed_mounts
 
-if [[ ${#managed_mounts[@]} -eq 0 ]]; then
+if matomo_plugins::map_is_empty managed_mounts; then
   echo "No managed plugin mounts found."
   exit 0
 fi
@@ -23,9 +23,10 @@ if [[ $# -eq 0 ]]; then
   managed_mounts=()
 else
   for plugin_name in "$@"; do
-    if [[ -n "${managed_mounts[${plugin_name}]:-}" ]]; then
-      echo "Unmounting ${plugin_name} from ${managed_mounts[${plugin_name}]}."
-      unset "managed_mounts[${plugin_name}]"
+    plugin_path="$(matomo_plugins::map_get managed_mounts "${plugin_name}")"
+    if [[ -n "${plugin_path}" ]]; then
+      echo "Unmounting ${plugin_name} from ${plugin_path}."
+      matomo_plugins::map_unset managed_mounts "${plugin_name}"
     else
       echo "Plugin ${plugin_name} is not currently managed."
     fi


### PR DESCRIPTION
## Description

  This PR adds new DDEV host commands to manage local plugin bind mounts for Matomo development without relying on
  symlinks.

  It introduces:

  - `ddev matomo:plugins:mount`
  - `ddev matomo:plugins:unmount`

  These commands generate and maintain a local-only DDEV compose override that mounts plugin repositories into Matomo’s
  `plugins/` directory. This is intended for local development setups where plugin repositories live outside the Matomo
  checkout, for example as sibling directories like `../plugin-FormAnalytics`.

  The PR also adds PHP compatibility checks during mounting:

  - simple `require.php` constraints from `plugin.json` are enforced
  - incompatible plugins are skipped
  - more complex Composer-style expressions emit a warning but are still mounted

  ### What Changed

  A shared helper was added for plugin mount management logic, including:

  - scanning directories for `plugin-*` repositories
  - resolving plugin names from `plugin.json` where available
  - falling back to the directory name for `plugin-*` folders
  - loading and rewriting the generated DDEV compose override
  - removing the generated override when no managed mounts remain
  - restarting DDEV only when the effective mount set changes

  Two new host commands were added:

  - `ddev matomo:plugins:mount`
    - with no arguments, scans `../`
    - accepts one or more paths and/or regexes
    - adds or updates managed mounts
  - `ddev matomo:plugins:unmount`
    - removes one or more managed plugin mounts by plugin name
    - with no arguments, removes all managed mounts

  The generated override is stored in:

  - `.ddev/docker-compose.local-plugins.yaml`

  and is ignored via `.ddev/.gitignore`.

  ### PHP Compatibility Check

  When mounting a plugin, the command now inspects `plugin.json` for `require.php`.

  Behavior:

  - no PHP requirement: mount normally
  - simple constraint like `>=7.2.0`: compare against the active DDEV PHP version and enforce it
  - incompatible simple constraint: warn and skip the plugin
  - complex expression like `^8.1 || ^8.2`: warn and mount anyway

  The active PHP version is taken from the running DDEV container using:

```bash
ddev exec php -r 'echo PHP_VERSION;'
```

  ### Usage Examples

  Mount all sibling plugin-* repositories:

  ddev matomo:plugins:mount

  Mount specific plugin paths:

  ddev matomo:plugins:mount ../plugin-FormAnalytics ../plugin-HeatmapSessionRecording

  Mount using a regex within a scan root:

  ddev matomo:plugins:mount ../ '^.*/plugin-(FormAnalytics|Funnels)$'

  Unmount one plugin:

  ddev matomo:plugins:unmount FormAnalytics

  Unmount all managed plugins:

  ddev matomo:plugins:unmount

  ## Verification

  Verified locally by checking:

  - direct path mounting
  - no-argument scanning of ../
  - skipping incompatible plugins such as Cloud on PHP 7.2
  - continuing scans after skipped plugins
  - warning-only behavior for complex constraints
  - deletion of the generated override when all mounts are removed
  - no restart when no effective config change occurs

  Also confirmed that the real ddev matomo:plugins:mount flow now continues past incompatible plugins during full-
  directory scans.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
