### PR TITLE
Improve name shown in Vue Developer Console

### DIFF
--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -281,7 +281,7 @@ window.piwikHelper = {
         // template that references the root component and wraps the vue-entry component's html.
         // this allows using slots in twig.
         var app = createVueApp({
-          name: componentName+'Entry',
+          name: entry,
           template: '<root ' + paramsStr + '>' + this.innerHTML.replace('{{', '{&lbrace;') + '</root>',
           data: function () {
             return componentParams;

--- a/plugins/Morpheus/vue/src/piwikHelper.spec.ts
+++ b/plugins/Morpheus/vue/src/piwikHelper.spec.ts
@@ -37,7 +37,7 @@ describe('piwikHelper', () => {
 
     expect(createVueApp).toHaveBeenCalledTimes(1);
     expect(createVueApp).toHaveBeenCalledWith(expect.objectContaining({
-      name: 'MyComponentEntry',
+      name: 'MyPlugin.MyComponent',
     }));
   });
 });


### PR DESCRIPTION
### Description

This is just an improvement to the PR that added Vue Component name to Vue developer console. This now adds in the Plugin name together with Component name so that its clearer. 

New name is now `PluginName.ComponentName` and this should show when you open Vue Developer tools in Dev Console

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
