### PR TITLE
Fix settings link on Manage Plugins page

### DIFF
--- a/plugins/CorePluginsAdmin/vue/src/PluginsTable/PluginsTable.vue
+++ b/plugins/CorePluginsAdmin/vue/src/PluginsTable/PluginsTable.vue
@@ -87,7 +87,7 @@
           <span v-if="pluginNamesHavingSettings.indexOf(name) !== -1">
             <br /><br />
             <a
-              :href="`${generalSettingsLink}#${name}`"
+              :href="`${generalSettingsLink}#/${name}`"
               class="settingsLink"
             >{{ translate('General_Settings') }}</a>
           </span>


### PR DESCRIPTION
Plugins with a link to their settings page now have a working link in the list of all installed plugins

### Description

This fixes #24361

The settings link for a given plugin on the "Manage plugins" page currently does not work since it does not follow the expected pattern of `#/PLUGINNAME`. This PR fixes this.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [x] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [x] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
