### PR TITLE
SegmentManagementPage: keep action buttons styled on focus

### DIFF
--- a/plugins/CoreHome/stylesheets/dataTable/_entityTable.less
+++ b/plugins/CoreHome/stylesheets/dataTable/_entityTable.less
@@ -105,8 +105,9 @@ table.entityTable tbody tr .entityTable_ActionCell-3 {
     text-decoration: none!important;
   }
 
+  &:focus,
   &:hover {
-    background-color: @theme-color-background-base !important;
+    background-color: @theme-color-background-base;
     box-shadow: 0 1px 2px 0 rgba(0,0,0,0.16), 0 1px 5px 0 rgba(0,0,0,0.12);
     cursor: pointer;
   }


### PR DESCRIPTION
### Description

This PR updates the entity table action button styling so the focus state matches the hover state.

Use case: on the segment management page, this prevents the edit action from showing an unintended gray background after being clicked and keeps the interaction styling consistent.

  Before / After

  | **Before** | **After** |
  | --- | --- |
  | ![segmentActionBefore](https://github.com/user-attachments/assets/47efbe65-f056-4823-85d5-ad92a66bed99) | ![segmentActionAfter](https://github.com/user-attachments/assets/200a9a71-e642-4b54-b968-9d8263d999f1) |

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
