### PR TITLE
Dark Mode: fix flags border

### DIFF
--- a/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard4.png
+++ b/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard4.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12fbbe817c1301ee7bc375a140755284fcf6d0e462cd2cceb1bd511c6c7dc99d
-size 724589
+oid sha256:dbfe210ebb8cac593fb14a92ff4f72da20462cb2039acebd3357e44103352534
+size 724626

--- a/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard5.png
+++ b/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard5.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4ba8bef36db886c0e2ad6d28788313c6b3eb9e261854d31293e608ee166edc1a
-size 402805
+oid sha256:bf51e9e6e2abcb206ba4506802ef13ee501de581d3d580d69ca98b9b07c6cc68
+size 403120

--- a/plugins/UserCountry/stylesheets/userCountry.less
+++ b/plugins/UserCountry/stylesheets/userCountry.less
@@ -1,8 +1,10 @@
-#widgetUserCountrygetRegion, #widgetUserCountrygetCountry, #widgetUserCountrygetCity {
+#widgetUserCountrygetRegion,
+#widgetUserCountrygetCountry,
+#widgetUserCountrygetCity {
     .dataTable .label > img {
-        border: 1px solid lightgray;
+        border: 1px solid @theme-color-border;
         box-sizing: content-box;
-        margin-top: -1px;
+        background: white;
     }
 }
 

--- a/tests/UI/expected-screenshots/UIIntegrationTest_visitors_locations_provider.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_visitors_locations_provider.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77eabf1bf9f49f3c55ac0a33eee15171b9204d3046893aeb77829d02b9dac294
-size 180288
+oid sha256:61dddb0d64e5f062fef4bd9ecc783c1c349a2e1a2399493ef03b24a958fb693d
+size 180444


### PR DESCRIPTION
### Description

dev-20028

This PR updates the flag styling in the UserCountry widgets to improve rendering in dark mode:
  - replace the hardcoded color with a theme-aware one
  - add a white background to keep flags readable

#### Why

In dark mode, the previous hardcoded border color did not integrate well with the theme. This change aligns the flag styling with the current theme variables and preserves a clear visual separation around the flag. The unknown flag has transparency and was hard to read in dark mode.

| **Before | **After** |
|---|---|
| <img width="513" height="455" alt="Screenshot 2026-04-14 at 13 11 42" src="https://github.com/user-attachments/assets/9735ff73-c13c-4631-b440-33de43f64703" /> | <img width="513" height="455" alt="Screenshot 2026-04-14 at 12 59 37" src="https://github.com/user-attachments/assets/aea6835d-0634-421a-95a3-31ba40dbd6da" /> |
| <img width="513" height="455" alt="Screenshot 2026-04-14 at 13 11 37" src="https://github.com/user-attachments/assets/016112b3-b4de-4bbb-ad32-1f5a8c280775" /> | <img width="513" height="455" alt="Screenshot 2026-04-14 at 12 59 45" src="https://github.com/user-attachments/assets/31f77770-4cea-4b02-be91-487cafb2f798" /> |
| <img width="513" height="305" alt="Screenshot 2026-04-14 at 13 11 06" src="https://github.com/user-attachments/assets/ffba1c6c-7290-4cea-b9c2-46d952808a98" /> | <img width="513" height="305" alt="Screenshot 2026-04-14 at 13 09 35" src="https://github.com/user-attachments/assets/164afcad-415d-43f1-a0a3-9727f212a726" />| 
| <img width="513" height="305" alt="Screenshot 2026-04-14 at 13 11 10" src="https://github.com/user-attachments/assets/5ead8370-2e40-48b0-a833-8f33bd33d631" /> | <img width="513" height="305" alt="Screenshot 2026-04-14 at 13 09 29" src="https://github.com/user-attachments/assets/8d34fbff-c218-4c34-be08-358b96a50f39" /> |

#### Belt and suspenders

With the white background behind flags, we fix the issue for users. But the root cause is likely that the unknown country flag itself uses transparency. That is why I am also opening a PR in the matomo-icons project.

- https://github.com/matomo-org/matomo-icons/pull/59

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
