### PR TITLE
Harden ddev matomo:init:dev for fresh environments

### DIFF
--- a/.ddev/commands/host/matomo_init_dev
+++ b/.ddev/commands/host/matomo_init_dev
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 ## Description: Initialize Matomo environment for development
 ## Usage: matomo:init:dev [--with-sourcemaps]
 ## Example: ddev matomo:init:dev --with-sourcemaps

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -14,7 +14,7 @@ hooks:
         - exec: MYSQL_PWD=root mysql -uroot -e "GRANT ALL PRIVILEGES ON *.* to 'db'@'%'"
           service: db
         - exec-host: ddev matomo:init
-webimage_extra_packages: [build-essential, chromium, default-jre, fonts-dejavu, fonts-liberation, imagemagick, imagemagick-doc, libasound2, libatk1.0-0, libcairo2, libdrm2, libgbm1, libgdk-pixbuf-2.0-0, libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libpangocairo-1.0-0, libx11-xcb1, libxcomposite1, libxcursor1, libxdamage1, libxfixes3, libxi6, libxrandr2, libxrender1, libxshmfence1, libxss1, libxtst6, ripgrep, ttf-mscorefonts-installer, xdg-utils]
+webimage_extra_packages: [build-essential, chromium, default-jre, fonts-dejavu, fonts-liberation, imagemagick, imagemagick-doc, libasound2, libatk1.0-0, libcairo2, libdrm2, libgbm1, libgdk-pixbuf-2.0-0, libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libpangocairo-1.0-0, libx11-xcb1, libxcomposite1, libxcursor1, libxdamage1, libxfixes3, libxi6, libxrandr2, libxrender1, libxshmfence1, libxss1, libxtst6, python3-setuptools, ripgrep, ttf-mscorefonts-installer, xdg-utils]
 use_dns_when_possible: true
 composer_version: "2"
 web_environment:


### PR DESCRIPTION
### Description

This PR fixes a fresh-environment failure in `ddev matomo:init:dev`.

The problem happens when Matomo is initialized in a new DDEV project that has to run a real npm install, such as a newly created git worktree with its own DDEV project name. In that case, npm rebuilds deasync, node-gyp runs under Python 3.13, and the build fails because distutils is missing in the DDEV web image.

The impact before this change is that new worktrees or other fresh Matomo DDEV environments cannot complete ddev `matomo:init:dev`, which blocks frontend/dev setup even though an older existing checkout may still work. The host wrapper script also continued after the failed npm install and printed a success message, which made the failure misleading.

**This PR makes two exact changes:**

  - It adds python3-setuptools to the DDEV web image packages so Python provides the distutils compatibility needed by the current node-gyp path during fresh npm installs.
  - It makes .ddev/commands/host/matomo_init_dev fail fast with set -euo pipefail, so the command stops immediately on setup failures instead of continuing and reporting success.

**In practice, this means:**

  - ddev matomo:init:dev now succeeds in fresh helper-created worktrees and other clean DDEV environments.
  - Failures in the init script are now surfaced accurately instead of being masked by the rest of the script continuing.

Error before with `ddev matomo:init:dev` on a worktree
<img width="1873" height="415" alt="image" src="https://github.com/user-attachments/assets/bdbe3ce4-9c27-4432-b7e3-6d0c3388f084" />

After:
<img width="898" height="480" alt="image" src="https://github.com/user-attachments/assets/f86627f1-cd33-470d-bb3b-f5145069bdfc" />



### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
