### PR TITLE
Fix page.screenshotSelector issue

### DIFF
--- a/tests/UI/expected-screenshots/Menus_mobile_left_admin.png
+++ b/tests/UI/expected-screenshots/Menus_mobile_left_admin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66b8ef8348610618aaedc424bd6f2c96bf285266c1d13d7d129f8984e95a4cee
-size 63474
+oid sha256:a5450508024f91cc5a388d24413f02faee54f8df2bfb7cb436cf2f692fbf439b
+size 66725

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -63,6 +63,7 @@ const PAGE_METHODS_TO_PROXY = [
     'waitForSelector',
     'waitForTimeout',
     'waitForXPath',
+    'screenshotNoResize',
 ];
 
 const PAGE_PROPERTIES_TO_PROXY = [
@@ -185,8 +186,21 @@ PageRenderer.prototype.jQuery = async function (selector, options = {}) {
     return await this.webpage.$('.' + selectorMarkerClass);
 };
 
+PageRenderer.prototype.resizeViewportToFullPage = async function () {
+    await this.webpage.waitForFunction(() => !! document.documentElement);
+
+    const dims = await this.webpage.evaluate(() => JSON.stringify({
+        width: document.documentElement.scrollWidth,
+        height: document.documentElement.scrollHeight,
+    }));
+
+    await this.webpage.setViewport(JSON.parse(dims));
+};
+
 PageRenderer.prototype.screenshotSelector = async function (selector) {
     await this.waitForFunction(() => !! window.$, { timeout: 60000 });
+
+    await this.resizeViewportToFullPage();
 
     const result = await this.webpage.evaluate(function (selector) {
         window.jQuery('html').addClass('uiTest');
@@ -261,7 +275,7 @@ PageRenderer.prototype.screenshotSelector = async function (selector) {
         return;
     }
 
-    return await this.screenshot({
+    return await this.screenshotNoResize({
         clip: {
             x: result.left,
             y: result.top,
@@ -294,17 +308,13 @@ PAGE_METHODS_TO_PROXY.forEach(function (methodName) {
         let result;
         if (methodName === 'screenshot') {
             // change viewport to entire page before screenshot
-            result = this.webpage.waitForFunction(() => !! document.documentElement)
-                .then(() => {
-                    return this.webpage.evaluate(() => JSON.stringify({
-                        width: document.documentElement.scrollWidth,
-                        height: document.documentElement.scrollHeight,
-                    }));
-                }).then((dims) => {
-                    return this.webpage.setViewport(JSON.parse(dims));
-                }).then(() => {
-                    return this.webpage[methodName](...args);
-                });
+            result = this.resizeViewportToFullPage()
+              .then(() => {
+                return this.webpage[methodName](...args);
+              });
+        } else if (methodName === 'screenshotNoResize') {
+            // we do not need to resize the viewport since we did it on top anyway
+            return this.webpage.screenshot(...args);
         } else {
             result = this.webpage[methodName](...args);
         }


### PR DESCRIPTION
### Description

The function `page.screenShotSelector` is having an issue with dynamic pages. The bug seems to happen when the function 'screenshot' is called and it tries to resize the view port to full size. Its ok for normal calls, but since page.screenshotSelector gets the bounding rectangle for the element it wants to get a screenshot before the resize happens, when the viewport gets resized, the bounding rectangle is already stale. This was not an issue before when the page does not really change size that much. 

But with our new changes in layout, we are making our left menu span the whole page now, and this makes the page height more dynamic, the screenshots for some modals break/gets cut off because of the change in page height after the bounding rectangle is taken.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
