### PR TITLE
Ensure to correctly detect anonymous user

### DIFF
--- a/plugins/Dashboard/API.php
+++ b/plugins/Dashboard/API.php
@@ -221,7 +221,7 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserIsNotAnonymous();
 
-        if ($login === 'anonymous') {
+        if (strtolower($login) === 'anonymous') {
             throw new \Exception('This method can\'t be performed for anonymous user');
         }
     }

--- a/plugins/LanguagesManager/API.php
+++ b/plugins/LanguagesManager/API.php
@@ -299,7 +299,7 @@ class API extends \Piwik\Plugin\API
      */
     public function getLanguageForUser(string $login)
     {
-        if ($login == 'anonymous') {
+        if (strtolower($login) === 'anonymous') {
             return false;
         }
 
@@ -344,7 +344,7 @@ class API extends \Piwik\Plugin\API
      */
     public function uses12HourClockForUser(string $login): bool
     {
-        if ($login === 'anonymous') {
+        if (strtolower($login) === 'anonymous') {
             return false;
         }
 
@@ -362,7 +362,7 @@ class API extends \Piwik\Plugin\API
      */
     public function set12HourClockForUser(string $login, bool $use12HourClock): bool
     {
-        if ($login === 'anonymous') {
+        if (strtolower($login) === 'anonymous') {
             return false;
         }
 

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -235,7 +235,7 @@ class Login extends \Piwik\Plugin
 
         if (
             empty($login)
-            || $login === 'anonymous'
+            || strtolower($login) === 'anonymous'
         ) {
             return; // can't do the check if we don't know the login
         }

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -212,7 +212,7 @@ class PasswordResetter
         $this->checkNewPassword($newPassword);
 
         // 'anonymous' has no password and cannot be reset
-        if ($loginOrEmail === 'anonymous') {
+        if (strtolower($loginOrEmail) === 'anonymous') {
             throw new Exception(Piwik::translate('Login_InvalidUsernameEmail'));
         }
 

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -242,7 +242,7 @@ class API extends \Piwik\Plugin\API
             throw new Exception('User does not exist: ' . $userLogin);
         }
 
-        if ($userLogin === 'anonymous') {
+        if (strtolower($userLogin) === 'anonymous') {
             Piwik::checkUserHasSuperUserAccess();
         }
 
@@ -1104,7 +1104,7 @@ class API extends \Piwik\Plugin\API
      */
     public function userExists(string $userLogin): bool
     {
-        if ($userLogin === 'anonymous') {
+        if (strtolower($userLogin) === 'anonymous') {
             return true;
         }
 
@@ -1186,7 +1186,7 @@ class API extends \Piwik\Plugin\API
 
         // check password confirmation only when using session auth and setting view access for anonymous user
         if (
-            $userLogin === 'anonymous'
+            strtolower($userLogin) === 'anonymous'
             && StaticContainer::get(AuthenticationToken::class)->isSessionToken()
             && $access === 'view'
         ) {
@@ -1194,7 +1194,7 @@ class API extends \Piwik\Plugin\API
         }
 
         if (
-            $userLogin === 'anonymous' &&
+            strtolower($userLogin) === 'anonymous' &&
             (is_array($access) || !in_array($access, ['view', 'noaccess'], true))
         ) {
             throw new Exception(Piwik::translate(
@@ -1249,7 +1249,7 @@ class API extends \Piwik\Plugin\API
             }
 
             // Send notification to all super users if anonymous access is set for a site
-            if ($userLogin === 'anonymous' && $access === 'view') {
+            if (strtolower($userLogin) === 'anonymous' && $access === 'view') {
                 $container = StaticContainer::getContainer();
 
                 $siteNames = [];
@@ -1290,7 +1290,7 @@ class API extends \Piwik\Plugin\API
         $this->executeConcurrencySafe($userLogin, function () use ($userLogin, $capabilities, $idSites) {
             $idSites = $this->getIdSitesCheckAdminAccess($idSites);
 
-            if ($userLogin == 'anonymous') {
+            if (strtolower($userLogin) === 'anonymous') {
                 throw new Exception(Piwik::translate("UsersManager_ExceptionAnonymousNoCapabilities"));
             }
 
@@ -1463,7 +1463,7 @@ class API extends \Piwik\Plugin\API
 
     private function checkUserIsNotAnonymous(string $userLogin): void
     {
-        if ($userLogin == 'anonymous') {
+        if (strtolower($userLogin) === 'anonymous') {
             throw new Exception(Piwik::translate("UsersManager_ExceptionEditAnonymous"));
         }
     }


### PR DESCRIPTION
### Description

Fixes a case-sensitivity gap in anonymous-user detection. Several API methods and guard conditions compared a user-supplied `$login` parameter against the literal string 'anonymous' using exact match. Because MySQL's default collation is case-insensitive, a caller passing 'Anonymous' or 'ANONYMOUS' would find the user in the database but bypass the guard conditions that restrict operations on the anonymous user.

Note: Changing data of the anonymous user does not really have any impact, but it should be detected correctly nevertheless.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
