### PR TITLE
Fix 'occured' -> 'occurred' typos in i18n strings and AjaxHelper

### DIFF
--- a/plugins/CoreHome/vue/src/AjaxHelper/AjaxHelper.ts
+++ b/plugins/CoreHome/vue/src/AjaxHelper/AjaxHelper.ts
@@ -395,7 +395,7 @@ export default class AjaxHelper<T = any> { // eslint-disable-line
         if (errorMessage.length) {
           errorMessage += '<br />';
         }
-        // append error count if it occured more than once
+        // append error count if it occurred more than once
         if (errors[error] > 1) {
           errorMessage += `${error} (${errors[error]}x)`;
         } else {

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -83,7 +83,7 @@
         "SystemCheckDatabaseSSLNotWorking": "%s is set to '1', but the SSL connection is not working",
         "SystemCheckDatabaseSSLOn": "Your database is not using SSL-connections, but supports it. Check the SSL settings of your database in the Matomo config file",
         "SystemCheckDebugBacktraceHelp": "View::factory won't be able to create views for the calling module.",
-        "SystemCheckError": "An error occured and must be fixed before proceeding",
+        "SystemCheckError": "An error occurred and must be fixed before proceeding",
         "SystemCheckEvalHelp": "Required by HTML QuickForm and the Twig templating system.",
         "SystemCheckExtensions": "Other required extensions",
         "SystemCheckFileIntegrity": "File integrity",

--- a/plugins/Live/lang/en.json
+++ b/plugins/Live/lang/en.json
@@ -45,7 +45,7 @@
         "QueryMaxExecutionTimeExceededReasonSegment": "Maybe the selected segment didn't match any visits?",
         "QueryMaxExecutionTimeExceededReasonUnknown": "Please try again. Get in touch with your administrator or support if the problem persists.",
         "VisitorLog": "Visits Log",
-        "VisitorLogDocumentation": "This table shows the latest visits within the selected date range. Hover over the date of a vist to find out when the most recent one occured. %1$s If the date range includes today, you can see your visitors in real-time. %2$s The data displayed here is always live, regardless of whether and how often you make use of the archiving cron-job.",
+        "VisitorLogDocumentation": "This table shows the latest visits within the selected date range. Hover over the date of a vist to find out when the most recent one occurred. %1$s If the date range includes today, you can see your visitors in real-time. %2$s The data displayed here is always live, regardless of whether and how often you make use of the archiving cron-job.",
         "VisitorLogNoDataMessagePurged": "The data has likely been purged because the regular deletion of old raw data is on, and the date for this report is more than %s days old. A superuser can change this setting by going to Administration → Privacy.",
         "VisitorProfile": "Visitor profile",
         "VisitorsInRealTime": "Visits in real-time",


### PR DESCRIPTION
Fix 3 instances of `occured` → `occurred`:

- `plugins/Live/lang/en.json` line 48: **User-visible** tooltip in VisitorLogDocumentation (`most recent one occured`)
- `plugins/Installation/lang/en.json` line 86: **User-visible** system check error text (`An error occured and must be fixed before proceeding`)
- `plugins/CoreHome/vue/src/AjaxHelper/AjaxHelper.ts` line 398: Inline comment

Only the English source strings are updated — translation files for other locales are not touched (those regenerate from source via the normal translation pipeline).



### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules