### PR TITLE
Actions: use configured delimiters for flat report labels

### DIFF
--- a/plugins/Actions/Reports/Base.php
+++ b/plugins/Actions/Reports/Base.php
@@ -10,11 +10,18 @@
 namespace Piwik\Plugins\Actions\Reports;
 
 use Piwik\Common;
+use Piwik\Config\GeneralConfig;
 use Piwik\Metrics;
 use Piwik\Metrics\Formatter;
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\Actions\Actions;
+use Piwik\Plugins\Actions\Columns\EntryPageTitle;
+use Piwik\Plugins\Actions\Columns\EntryPageUrl;
+use Piwik\Plugins\Actions\Columns\ExitPageTitle;
+use Piwik\Plugins\Actions\Columns\ExitPageUrl;
+use Piwik\Plugins\Actions\Columns\PageTitle;
+use Piwik\Plugins\Actions\Columns\PageUrl;
 use Piwik\Plugins\CoreVisualizations\Visualizations\HtmlTable;
 use Piwik\API\Request;
 
@@ -122,5 +129,31 @@ abstract class Base extends \Piwik\Plugin\Report
                 return min($visitsInfo->getColumn('max_actions') - 1, $nbActionsLowPopulationThreshold - 1);
             };
         }
+    }
+
+    public function getRecursiveLabelSeparator()
+    {
+        $legacyDelimiter = GeneralConfig::getConfigValue('action_category_delimiter');
+        if (!empty($legacyDelimiter)) {
+            return $legacyDelimiter;
+        }
+
+        if (
+            $this->dimension instanceof PageTitle
+            || $this->dimension instanceof EntryPageTitle
+            || $this->dimension instanceof ExitPageTitle
+        ) {
+            return GeneralConfig::getConfigValue('action_title_category_delimiter') ?: $this->recursiveLabelSeparator;
+        }
+
+        if (
+            $this->dimension instanceof PageUrl
+            || $this->dimension instanceof EntryPageUrl
+            || $this->dimension instanceof ExitPageUrl
+        ) {
+            return GeneralConfig::getConfigValue('action_url_category_delimiter') ?: $this->recursiveLabelSeparator;
+        }
+
+        return parent::getRecursiveLabelSeparator();
     }
 }

--- a/plugins/Actions/tests/Unit/Reports/BaseTest.php
+++ b/plugins/Actions/tests/Unit/Reports/BaseTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Actions\tests\Unit\Reports;
+
+use Piwik\Config;
+use Piwik\Plugins\Actions\Reports\GetEntryPageTitles;
+use Piwik\Plugins\Actions\Reports\GetPageTitles;
+use Piwik\Plugins\Actions\Reports\GetPageUrls;
+
+class BaseTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetRecursiveLabelSeparatorUsesTitleDelimiterForPageTitleReports()
+    {
+        $this->withActionDelimiters('', ' :: ', '/', function () {
+            $this->assertSame(' :: ', (new GetPageTitles())->getRecursiveLabelSeparator());
+            $this->assertSame(' :: ', (new GetEntryPageTitles())->getRecursiveLabelSeparator());
+        });
+    }
+
+    public function testGetRecursiveLabelSeparatorUsesLegacyDelimiterWhenConfigured()
+    {
+        $this->withActionDelimiters(' > ', ' :: ', '/', function () {
+            $this->assertSame(' > ', (new GetPageTitles())->getRecursiveLabelSeparator());
+            $this->assertSame(' > ', (new GetPageUrls())->getRecursiveLabelSeparator());
+        });
+    }
+
+    private function withActionDelimiters($legacyDelimiter, $titleDelimiter, $urlDelimiter, callable $callback)
+    {
+        $config = Config::getInstance();
+
+        $keys = [
+            'action_category_delimiter',
+            'action_title_category_delimiter',
+            'action_url_category_delimiter',
+        ];
+
+        $previousValues = [];
+        foreach ($keys as $key) {
+            $hadValue = array_key_exists($key, $config->General);
+            $previousValues[$key] = [
+                'hadValue' => $hadValue,
+                'value' => $hadValue ? $config->General[$key] : null,
+            ];
+        }
+
+        $config->General['action_category_delimiter'] = $legacyDelimiter;
+        $config->General['action_title_category_delimiter'] = $titleDelimiter;
+        $config->General['action_url_category_delimiter'] = $urlDelimiter;
+
+        try {
+            $callback();
+        } finally {
+            foreach ($previousValues as $key => $previousValue) {
+                if ($previousValue['hadValue']) {
+                    $config->General[$key] = $previousValue['value'];
+                } else {
+                    unset($config->General[$key]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
  ## Summary

  This change makes flattened Actions reports use the configured recursive label separator instead of always using `/`.

  ## Problem

  For `flat=1`, Actions reports are flattened by the generic report flattener. That flattener uses the report’s recursive label separator, and Actions currently hard-codes that separator to `/` in plugins/Actions/Reports/Base.php.

  As a result, page title reports can still be flattened with / even when:

  - `action_category_delimiter` is not set
  - `action_title_category_delimiter` is configured to a different value, for example a space

  ## Change

  `plugins/Actions/Reports/Base.php` now resolves the recursive label separator from config:

  1. `action_category_delimiter` if set, for backwards compatibility
  2. `action_title_category_delimiter` for page title reports
  3. `action_url_category_delimiter` for page URL reports
  4. `/` as fallback

  This keeps existing legacy behavior when the old shared delimiter is configured, while allowing page title and page URL reports to respect their type-specific delimiter settings when flattened.

  ## Impact

  - `flat=1` page title reports now use `action_title_category_delimiter` when no legacy shared delimiter is configured
  - `flat=1` page URL reports now use `action_url_category_delimiter` when no legacy shared delimiter is configured
  - No archive format or archiving logic changes
  - Scope is limited to report flattening output

  ## Tests

  Added unit coverage in `plugins/Actions/tests/Unit/Reports/BaseTest.php` to verify:

  1. page title reports use the configured title delimiter
  2. the legacy shared delimiter still overrides type-specific delimiters when configured

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
