### PR TITLE
Fix bash compatibility in DDEV plugin mount scripts

### DIFF
--- a/.ddev/commands/host/matomo_plugins_lib.sh
+++ b/.ddev/commands/host/matomo_plugins_lib.sh
@@ -10,6 +10,89 @@ MATOMO_PLUGINS_DDEV_PHP_VERSION=""
 MATOMO_PLUGINS_DDEV_PHP_VERSION_READY=0
 MATOMO_PLUGINS_DDEV_PHP_VERSION_UNAVAILABLE=0
 MATOMO_PLUGINS_PHP_CHECK_RESULT="ok"
+MATOMO_PLUGINS_MAP_SEPARATOR=$'\t'
+
+matomo_plugins::map_get() {
+  local map_name="${1}"
+  local wanted_key="${2}"
+  local entry=""
+  local entry_key=""
+  local entry_value=""
+
+  eval "for entry in \"\${${map_name}[@]+\"\${${map_name}[@]}\"}\"; do
+    entry_key=\${entry%%\"\${MATOMO_PLUGINS_MAP_SEPARATOR}\"*}
+    if [[ \"\${entry}\" == *\"\${MATOMO_PLUGINS_MAP_SEPARATOR}\"* ]]; then
+      entry_value=\${entry#*\"\${MATOMO_PLUGINS_MAP_SEPARATOR}\"}
+    else
+      entry_value=''
+    fi
+    if [[ \"\${entry_key}\" == \"\${wanted_key}\" ]]; then
+      printf '%s\n' \"\${entry_value}\"
+      break
+    fi
+  done"
+}
+
+matomo_plugins::map_set() {
+  local map_name="${1}"
+  local wanted_key="${2}"
+  local wanted_value="${3}"
+  local entry=""
+  local entry_key=""
+  local -a updated_entries=()
+
+  eval "for entry in \"\${${map_name}[@]+\"\${${map_name}[@]}\"}\"; do
+    entry_key=\${entry%%\"\${MATOMO_PLUGINS_MAP_SEPARATOR}\"*}
+    if [[ \"\${entry_key}\" != \"\${wanted_key}\" ]]; then
+      updated_entries+=(\"\${entry}\")
+    fi
+  done"
+
+  updated_entries+=("${wanted_key}${MATOMO_PLUGINS_MAP_SEPARATOR}${wanted_value}")
+  eval "${map_name}=(\"\${updated_entries[@]}\")"
+}
+
+matomo_plugins::map_unset() {
+  local map_name="${1}"
+  local wanted_key="${2}"
+  local entry=""
+  local entry_key=""
+  local -a updated_entries=()
+
+  eval "for entry in \"\${${map_name}[@]+\"\${${map_name}[@]}\"}\"; do
+    entry_key=\${entry%%\"\${MATOMO_PLUGINS_MAP_SEPARATOR}\"*}
+    if [[ \"\${entry_key}\" != \"\${wanted_key}\" ]]; then
+      updated_entries+=(\"\${entry}\")
+    fi
+  done"
+
+  eval "${map_name}=(\"\${updated_entries[@]}\")"
+}
+
+matomo_plugins::map_keys_sorted() {
+  local map_name="${1}"
+  local entry=""
+  local entry_key=""
+
+  eval "for entry in \"\${${map_name}[@]+\"\${${map_name}[@]}\"}\"; do
+    entry_key=\${entry%%\"\${MATOMO_PLUGINS_MAP_SEPARATOR}\"*}
+    printf '%s\n' \"\${entry_key}\"
+  done" | sort
+}
+
+matomo_plugins::map_size() {
+  local map_name="${1}"
+
+  eval "printf '%s\n' \"\${#${map_name}[@]}\""
+}
+
+matomo_plugins::map_is_empty() {
+  local map_name="${1}"
+  local size
+
+  size="$(matomo_plugins::map_size "${map_name}")"
+  [[ "${size}" -eq 0 ]]
+}
 
 matomo_plugins::app_root() {
   printf '%s\n' "${MATOMO_APP_ROOT}"
@@ -135,8 +218,6 @@ matomo_plugins::load_mounts() {
   local line
   local mount_path
   local plugin_name
-  local -n mounts_ref="${map_name}"
-
   config_file="$(matomo_plugins::generated_config)"
   if [[ ! -f "${config_file}" ]]; then
     return 0
@@ -146,7 +227,7 @@ matomo_plugins::load_mounts() {
     if [[ "${line}" =~ ^[[:space:]]*-[[:space:]]*\"([^\"]+):/var/www/html/plugins/([^\"]+)\"[[:space:]]*$ ]]; then
       mount_path="${BASH_REMATCH[1]}"
       plugin_name="${BASH_REMATCH[2]}"
-      mounts_ref["${plugin_name}"]="${mount_path}"
+      matomo_plugins::map_set "${map_name}" "${plugin_name}" "${mount_path}"
     fi
   done < "${config_file}"
 }
@@ -269,7 +350,7 @@ matomo_plugins::write_mounts_to_temp() {
   local map_name="${1}"
   local tmp_file="${2}"
   local plugin_name
-  local -n mounts_ref="${map_name}"
+  local plugin_path
 
   {
     echo "#ddev-generated"
@@ -279,8 +360,9 @@ matomo_plugins::write_mounts_to_temp() {
     echo "    volumes:"
 
     while IFS= read -r plugin_name; do
-      printf '      - "%s:/var/www/html/plugins/%s"\n' "${mounts_ref[${plugin_name}]}" "${plugin_name}"
-    done < <(printf '%s\n' "${!mounts_ref[@]}" | sort)
+      plugin_path="$(matomo_plugins::map_get "${map_name}" "${plugin_name}")"
+      printf '      - "%s:/var/www/html/plugins/%s"\n' "${plugin_path}" "${plugin_name}"
+    done < <(matomo_plugins::map_keys_sorted "${map_name}")
   } > "${tmp_file}"
 }
 
@@ -290,12 +372,11 @@ matomo_plugins::apply_mounts() {
   local config_file
   local tmp_file
   local mount_count=0
-  local -n mounts_ref="${map_name}"
 
   MATOMO_PLUGINS_LAST_CHANGE=0
 
   config_file="$(matomo_plugins::generated_config)"
-  mount_count="${#mounts_ref[@]}"
+  mount_count="$(matomo_plugins::map_size "${map_name}")"
 
   if [[ "${mount_count}" -eq 0 ]]; then
     if [[ -f "${config_file}" ]]; then
@@ -339,20 +420,22 @@ matomo_plugins::record_mount() {
   local plugin_name="${2}"
   local plugin_path="${3}"
   local source_label="${4}"
-  local -n mounts_ref="${map_name}"
+  local existing_path=""
 
-  if [[ -n "${mounts_ref[${plugin_name}]:-}" ]]; then
-    if [[ "${mounts_ref[${plugin_name}]}" == "${plugin_path}" ]]; then
+  existing_path="$(matomo_plugins::map_get "${map_name}" "${plugin_name}")"
+
+  if [[ -n "${existing_path}" ]]; then
+    if [[ "${existing_path}" == "${plugin_path}" ]]; then
       echo "Keeping ${plugin_name} mounted from ${plugin_path} (${source_label})."
       return 0
     fi
 
-    echo "Replacing ${plugin_name}: ${mounts_ref[${plugin_name}]} -> ${plugin_path} (${source_label})."
+    echo "Replacing ${plugin_name}: ${existing_path} -> ${plugin_path} (${source_label})."
   else
     echo "Mounting ${plugin_name} from ${plugin_path} (${source_label})."
   fi
 
-  mounts_ref["${plugin_name}"]="${plugin_path}"
+  matomo_plugins::map_set "${map_name}" "${plugin_name}" "${plugin_path}"
 }
 
 matomo_plugins::scan_explicit_dir() {
@@ -362,7 +445,6 @@ matomo_plugins::scan_explicit_dir() {
   local plugin_name
   local normalized_dir
   local source_label="path:${explicit_dir}"
-  local -n mounts_ref="${map_name}"
 
   normalized_dir="$(matomo_plugins::normalize_path "${explicit_dir}")"
 

--- a/.ddev/commands/host/matomo_plugins_mount
+++ b/.ddev/commands/host/matomo_plugins_mount
@@ -9,7 +9,7 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/matomo_plugins_lib.sh"
 
-declare -A managed_mounts=()
+managed_mounts=()
 declare -a literal_roots=()
 declare -a original_args=("$@")
 

--- a/.ddev/commands/host/matomo_plugins_unmount
+++ b/.ddev/commands/host/matomo_plugins_unmount
@@ -9,11 +9,11 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/matomo_plugins_lib.sh"
 
-declare -A managed_mounts=()
+managed_mounts=()
 
 matomo_plugins::load_mounts managed_mounts
 
-if [[ ${#managed_mounts[@]} -eq 0 ]]; then
+if matomo_plugins::map_is_empty managed_mounts; then
   echo "No managed plugin mounts found."
   exit 0
 fi
@@ -23,9 +23,10 @@ if [[ $# -eq 0 ]]; then
   managed_mounts=()
 else
   for plugin_name in "$@"; do
-    if [[ -n "${managed_mounts[${plugin_name}]:-}" ]]; then
-      echo "Unmounting ${plugin_name} from ${managed_mounts[${plugin_name}]}."
-      unset "managed_mounts[${plugin_name}]"
+    plugin_path="$(matomo_plugins::map_get managed_mounts "${plugin_name}")"
+    if [[ -n "${plugin_path}" ]]; then
+      echo "Unmounting ${plugin_name} from ${plugin_path}."
+      matomo_plugins::map_unset managed_mounts "${plugin_name}"
     else
       echo "Plugin ${plugin_name} is not currently managed."
     fi


### PR DESCRIPTION
### Description

Fix Bash compatibility for the DDEV host plugin mount scripts on macOS.

The previous implementation used associative arrays (declare -A) and namerefs (local -n), which are not supported by the system Bash shipped with macOS (bash 3.2). As a result, commands like ddev matomo:plugins:mount ../plugin-Bandwidth failed before any mount logic ran.
 
#### Changes

  - Replaced associative-array based mount bookkeeping with Bash 3 compatible helper functions in matomo_plugins_lib.sh
  - Removed local -n usage from the shared helpers
  - Updated mount/unmount scripts to use the new compatibility layer
  - Fixed empty-array handling under set -u so mount operations work cleanly when no managed mounts exist

#### Before

Running:

```
ddev matomo:plugins:mount ../plugin-Bandwidth
```

failed with:

```
declare: -A: invalid option
```

#### After

The same command now:

  - detects the plugin correctly
  - writes .ddev/docker-compose.local-plugins.yaml
  - restarts DDEV successfully

#### Testing

Verified with:

```
bash -n .ddev/commands/host/matomo_plugins_mount
bash -n .ddev/commands/host/matomo_plugins_unmount
bash -n .ddev/commands/host/matomo_plugins_lib.sh
ddev matomo:plugins:mount ../plugin-Bandwidth
```

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
