### PR TITLE
Introduce new type-safe methods for receiving config section values

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -28,6 +28,8 @@ use Piwik\Tracker\TrackerConfig;
  */
 class Common
 {
+    private const FLOAT_REGEX = "/^[-+]?((([0-9]+(_[0-9]+)*)|(([0-9]+(_[0-9]+)*)?\.([0-9]+(_[0-9]+)*))|(([0-9]+(_[0-9]+)*)\.([0-9]+(_[0-9]+)*)?))([eE][+-]?([0-9]+(_[0-9]+)*))?)$/";
+
     // constants used to map the referrer type to an integer in the log_visit table
     public const REFERRER_TYPE_DIRECT_ENTRY = 1;
     public const REFERRER_TYPE_SEARCH_ENGINE = 2;
@@ -1091,6 +1093,26 @@ class Common
         }
 
         return str_replace(',', '.', $value);
+    }
+
+    /**
+     * Parses the given value as float and returns null if it cannot be represented as a PHP float.
+     *
+     * Supports the same string notations as PHP floats, including underscore notation.
+     *
+     * @param mixed $value
+     */
+    public static function parseFloat($value): ?float
+    {
+        if (is_float($value) || is_int($value)) {
+            return (float)$value;
+        }
+
+        if (is_string($value) && preg_match(self::FLOAT_REGEX, $value)) {
+            return (float)str_replace('_', '', $value);
+        }
+
+        return null;
     }
 
     /**

--- a/core/Config/SectionConfig.php
+++ b/core/Config/SectionConfig.php
@@ -10,9 +10,14 @@
 namespace Piwik\Config;
 
 use Piwik\Config;
+use Piwik\Common;
+use Piwik\Container\StaticContainer;
+use Piwik\Log\LoggerInterface;
 
 abstract class SectionConfig
 {
+    private const FLOAT_REGEX = "/^[-+]?((([0-9]+(_[0-9]+)*)|(([0-9]+(_[0-9]+)*)?\.([0-9]+(_[0-9]+)*))|(([0-9]+(_[0-9]+)*)\.([0-9]+(_[0-9]+)*)?))([eE][+-]?([0-9]+(_[0-9]+)*))?)$/";
+
     abstract public static function getSectionName(): string;
 
     /**
@@ -38,32 +43,224 @@ abstract class SectionConfig
      */
     public static function getConfigValue(string $name, ?int $idSite = null)
     {
-        $config = self::getConfig();
-        if (!empty($idSite)) {
-            $siteSpecificConfig = self::getSiteSpecificConfig($idSite);
-            $config = array_merge($config, $siteSpecificConfig);
-        }
+        return static::getRawConfigValue($name, $idSite);
+    }
+
+    public static function getIntegerConfigValue(string $name, ?int $default = null, ?int $idSite = null): ?int
+    {
+        return self::castIntConfigValue($name, static::getRawConfigValue($name, $idSite), $default);
+    }
+
+    public static function getFloatConfigValue(string $name, ?float $default = null, ?int $idSite = null): ?float
+    {
+        return self::castFloatConfigValue($name, static::getRawConfigValue($name, $idSite), $default);
+    }
+
+    public static function getBooleanConfigValue(string $name, ?bool $default = null, ?int $idSite = null): ?bool
+    {
+        return self::castBoolConfigValue($name, static::getRawConfigValue($name, $idSite), $default);
+    }
+
+    public static function getStringConfigValue(string $name, ?string $default = null, ?int $idSite = null): ?string
+    {
+        return self::castStringConfigValue($name, static::getRawConfigValue($name, $idSite), $default);
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public static function getArrayConfigValue(string $name, ?array $default = null, ?int $idSite = null): ?array
+    {
+        return self::castArrayConfigValue($name, static::getRawConfigValue($name, $idSite), $default);
+    }
+
+    /**
+     * @return mixed|null
+     */
+    protected static function getRawConfigValue(string $name, ?int $idSite = null)
+    {
+        $config = self::getMergedConfig($idSite);
         return $config[$name] ?? null;
     }
 
     /**
      * Get the section config as an array
      *
-     * @return array|string
+     * @return array<string, mixed>
      */
-    private static function getConfig()
+    private static function getConfig(): array
     {
-        return Config::getInstance()->{static::getSectionName()};
+        $config = Config::getInstance()->{static::getSectionName()};
+        return is_array($config) ? $config : [];
     }
 
     /**
      * Get the site specific config (if any) as an array
      *
-     * @return array|string
+     * @return array<string, mixed>
      */
-    private static function getSiteSpecificConfig(int $idSite)
+    private static function getSiteSpecificConfig(int $idSite): array
     {
         $key = static::getSectionName() . '_' . $idSite;
-        return Config::getInstance()->$key;
+        $config = Config::getInstance()->$key;
+        return is_array($config) ? $config : [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function getMergedConfig(?int $idSite = null): array
+    {
+        $config = self::getConfig();
+        if (!empty($idSite)) {
+            $config = array_merge($config, self::getSiteSpecificConfig($idSite));
+        }
+        return $config;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function castIntConfigValue(string $name, $value, ?int $default): ?int
+    {
+        if ($value === null) {
+            return $default;
+        }
+
+        if ((is_string($value) || is_numeric($value)) && (string) $value === (string) (int) $value) {
+            return (int) $value;
+        }
+
+        self::logTypeCastWarning($name, 'int', $value);
+        return $default;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function castFloatConfigValue(string $name, $value, ?float $default): ?float
+    {
+        if ($value === null) {
+            return $default;
+        }
+
+        if (is_float($value) || is_int($value)) {
+            return (float) $value;
+        }
+
+        if (is_string($value) && preg_match(self::FLOAT_REGEX, $value)) {
+            return (float) str_replace('_', '', $value);
+        }
+
+        self::logTypeCastWarning($name, 'float', $value);
+        return $default;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function castBoolConfigValue(string $name, $value, ?bool $default): ?bool
+    {
+        if ($value === null) {
+            return $default;
+        }
+
+        if ($value === false || $value === true) {
+            return $value;
+        }
+
+        if ((is_string($value) && strtolower($value) === 'false') || $value === '0' || $value === 0) {
+            return false;
+        }
+
+        if ((is_string($value) && strtolower($value) === 'true') || $value === '1' || $value === 1) {
+            return true;
+        }
+
+        self::logTypeCastWarning($name, 'bool', $value);
+        return $default;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function castStringConfigValue(string $name, $value, ?string $default): ?string
+    {
+        if ($value === null) {
+            return $default;
+        }
+
+        if (is_string($value) || is_numeric($value)) {
+            return Common::sanitizeNullBytes((string) $value);
+        }
+
+        self::logTypeCastWarning($name, 'string', $value);
+        return $default;
+    }
+
+    /**
+     * @param mixed $value
+     * @return array<mixed>|null
+     */
+    private static function castArrayConfigValue(string $name, $value, ?array $default): ?array
+    {
+        if ($value === null) {
+            return $default;
+        }
+
+        if (is_array($value)) {
+            /** @var array<mixed> $sanitizedValue */
+            $sanitizedValue = self::filterNullBytes($value);
+            return $sanitizedValue;
+        }
+
+        self::logTypeCastWarning($name, 'array', $value);
+        return $default;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function logTypeCastWarning(string $name, string $type, $value): void
+    {
+        StaticContainer::get(LoggerInterface::class)->warning(
+            'Failed to cast config value {section}.{name} to {type}; actual type was {actualType}.',
+            [
+                'section' => static::getSectionName(),
+                'name' => $name,
+                'type' => $type,
+                'actualType' => self::getValueType($value),
+            ]
+        );
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function getValueType($value): string
+    {
+        if (is_object($value)) {
+            return get_class($value);
+        }
+
+        return gettype($value);
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    private static function filterNullBytes($value)
+    {
+        if (is_array($value)) {
+            $result = [];
+            foreach ($value as $key => $arrayValue) {
+                $result[$key] = self::filterNullBytes($arrayValue);
+            }
+
+            return $result;
+        }
+
+        return is_string($value) ? Common::sanitizeNullBytes($value) : $value;
     }
 }

--- a/core/Config/SectionConfig.php
+++ b/core/Config/SectionConfig.php
@@ -54,7 +54,7 @@ abstract class SectionConfig
         return self::castFloatConfigValue($name, static::getRawConfigValue($name, $idSite), $default);
     }
 
-    public static function getBooleanConfigValue(string $name, ?bool $default = null, ?int $idSite = null): ?bool
+    public static function getBoolConfigValue(string $name, ?bool $default = null, ?int $idSite = null): ?bool
     {
         return self::castBoolConfigValue($name, static::getRawConfigValue($name, $idSite), $default);
     }

--- a/core/Config/SectionConfig.php
+++ b/core/Config/SectionConfig.php
@@ -16,8 +16,6 @@ use Piwik\Log\LoggerInterface;
 
 abstract class SectionConfig
 {
-    private const FLOAT_REGEX = "/^[-+]?((([0-9]+(_[0-9]+)*)|(([0-9]+(_[0-9]+)*)?\.([0-9]+(_[0-9]+)*))|(([0-9]+(_[0-9]+)*)\.([0-9]+(_[0-9]+)*)?))([eE][+-]?([0-9]+(_[0-9]+)*))?)$/";
-
     abstract public static function getSectionName(): string;
 
     /**
@@ -140,16 +138,9 @@ abstract class SectionConfig
      */
     private static function castFloatConfigValue(string $name, $value, ?float $default): ?float
     {
-        if ($value === null) {
-            return $default;
-        }
-
-        if (is_float($value) || is_int($value)) {
-            return (float) $value;
-        }
-
-        if (is_string($value) && preg_match(self::FLOAT_REGEX, $value)) {
-            return (float) str_replace('_', '', $value);
+        $parsedFloat = Common::parseFloat($value);
+        if ($parsedFloat !== null) {
+            return $parsedFloat;
         }
 
         self::logTypeCastWarning($name, 'float', $value);

--- a/core/Config/SectionConfig.php
+++ b/core/Config/SectionConfig.php
@@ -44,21 +44,33 @@ abstract class SectionConfig
         return static::getRawConfigValue($name, $idSite);
     }
 
+    /**
+     * @phpstan-return ($default is null ? int|null : int)
+     */
     public static function getIntegerConfigValue(string $name, ?int $default = null, ?int $idSite = null): ?int
     {
         return self::castIntConfigValue($name, static::getRawConfigValue($name, $idSite), $default);
     }
 
+    /**
+     * @phpstan-return ($default is null ? float|null : float)
+     */
     public static function getFloatConfigValue(string $name, ?float $default = null, ?int $idSite = null): ?float
     {
         return self::castFloatConfigValue($name, static::getRawConfigValue($name, $idSite), $default);
     }
 
+    /**
+     * @phpstan-return ($default is null ? bool|null : bool)
+     */
     public static function getBoolConfigValue(string $name, ?bool $default = null, ?int $idSite = null): ?bool
     {
         return self::castBoolConfigValue($name, static::getRawConfigValue($name, $idSite), $default);
     }
 
+    /**
+     * @phpstan-return ($default is null ? string|null : string)
+     */
     public static function getStringConfigValue(string $name, ?string $default = null, ?int $idSite = null): ?string
     {
         return self::castStringConfigValue($name, static::getRawConfigValue($name, $idSite), $default);
@@ -66,6 +78,7 @@ abstract class SectionConfig
 
     /**
      * @return array<mixed>|null
+     * @phpstan-return ($default is null ? array<mixed>|null : array<mixed>)
      */
     public static function getArrayConfigValue(string $name, ?array $default = null, ?int $idSite = null): ?array
     {

--- a/core/Config/SectionConfig.php
+++ b/core/Config/SectionConfig.php
@@ -34,6 +34,13 @@ abstract class SectionConfig
     /**
      * Get a setting value
      *
+     * Prefer one of the type-safe getters if a specific type is expected:
+     * @see getIntegerConfigValue()
+     * @see getFloatConfigValue()
+     * @see getBoolConfigValue()
+     * @see getStringConfigValue()
+     * @see getArrayConfigValue()
+     *
      * @param string    $name     Setting name
      * @param int|null  $idSite   Optional site Id
      *
@@ -151,6 +158,10 @@ abstract class SectionConfig
      */
     private static function castFloatConfigValue(string $name, $value, ?float $default): ?float
     {
+        if ($value === null) {
+            return $default;
+        }
+
         $parsedFloat = Common::parseFloat($value);
         if ($parsedFloat !== null) {
             return $parsedFloat;

--- a/core/DataTable/Filter/PivotByDimension.php
+++ b/core/DataTable/Filter/PivotByDimension.php
@@ -581,7 +581,7 @@ class PivotByDimension extends BaseFilter
      */
     public static function isSegmentFetchingEnabledInConfig()
     {
-        return (bool)GeneralConfig::getConfigValue('pivot_by_filter_enable_fetch_by_segment');
+        return GeneralConfig::getBooleanConfigValue('pivot_by_filter_enable_fetch_by_segment', false);
     }
 
     /**
@@ -592,7 +592,7 @@ class PivotByDimension extends BaseFilter
      */
     public static function getDefaultColumnLimit()
     {
-        return (int)GeneralConfig::getConfigValue('pivot_by_filter_default_column_limit');
+        return GeneralConfig::getIntegerConfigValue('pivot_by_filter_default_column_limit', 0);
     }
 
     /**

--- a/core/DataTable/Filter/PivotByDimension.php
+++ b/core/DataTable/Filter/PivotByDimension.php
@@ -581,7 +581,7 @@ class PivotByDimension extends BaseFilter
      */
     public static function isSegmentFetchingEnabledInConfig()
     {
-        return GeneralConfig::getBooleanConfigValue('pivot_by_filter_enable_fetch_by_segment', false);
+        return GeneralConfig::getBoolConfigValue('pivot_by_filter_enable_fetch_by_segment', false);
     }
 
     /**

--- a/core/Request.php
+++ b/core/Request.php
@@ -156,17 +156,9 @@ class Request
     public function getFloatParameter(string $name, ?float $default = null): float
     {
         $parameter = $this->getParameter($name, $default);
-
-        if (is_float($parameter) || is_int($parameter)) {
-            return (float)$parameter;
-        }
-
-        // Regex for all supported float notations in PHP (see https://www.php.net/manual/en/language.types.float.php)
-        $floatRegex = "/^[-+]?((([0-9]+(_[0-9]+)*)|(([0-9]+(_[0-9]+)*)?\.([0-9]+(_[0-9]+)*))|(([0-9]+(_[0-9]+)*)\.([0-9]+(_[0-9]+)*)?))([eE][+-]?([0-9]+(_[0-9]+)*))?)$/";
-
-        if (is_string($parameter) && preg_match($floatRegex, $parameter)) {
-            // underscores would break numbers if not removed before
-            return (float) str_replace('_', '', $parameter);
+        $parsedFloat = Common::parseFloat($parameter);
+        if ($parsedFloat !== null) {
+            return $parsedFloat;
         }
 
         if (null !== $default) {

--- a/core/SiteContentDetector.php
+++ b/core/SiteContentDetector.php
@@ -347,7 +347,7 @@ class SiteContentDetector
         }
 
         // If internet features are disabled, we don't try to fetch any site content
-        if (0 === (int) GeneralConfig::getConfigValue('enable_internet_features')) {
+        if (0 === GeneralConfig::getIntegerConfigValue('enable_internet_features', 0)) {
             return [];
         }
 

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -377,12 +377,12 @@ class Tracker
     private static function isDebugEnabled()
     {
         try {
-            $debug = (bool) TrackerConfig::getConfigValue('debug');
+            $debug = TrackerConfig::getBooleanConfigValue('debug', false);
             if ($debug) {
                 return true;
             }
 
-            $debugOnDemand = (bool) TrackerConfig::getConfigValue('debug_on_demand');
+            $debugOnDemand = TrackerConfig::getBooleanConfigValue('debug_on_demand', false);
             if ($debugOnDemand) {
                 return (bool) Common::getRequestVar('debug', false);
             }

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -377,12 +377,12 @@ class Tracker
     private static function isDebugEnabled()
     {
         try {
-            $debug = TrackerConfig::getBooleanConfigValue('debug', false);
+            $debug = TrackerConfig::getBoolConfigValue('debug', false);
             if ($debug) {
                 return true;
             }
 
-            $debugOnDemand = TrackerConfig::getBooleanConfigValue('debug_on_demand', false);
+            $debugOnDemand = TrackerConfig::getBoolConfigValue('debug_on_demand', false);
             if ($debugOnDemand) {
                 return (bool) Common::getRequestVar('debug', false);
             }

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -100,8 +100,9 @@ class Request
         // check for 4byte utf8 characters in all tracking params and replace them with � if not support by database
         $this->params = $this->replaceUnsupportedUtf8Chars($this->params);
 
-        $this->customTimestampDoesNotRequireTokenauthWhenNewerThan = (int) TrackerConfig::getConfigValue(
+        $this->customTimestampDoesNotRequireTokenauthWhenNewerThan = TrackerConfig::getIntegerConfigValue(
             'tracking_requests_require_authentication_when_custom_timestamp_newer_than',
+            0,
             $this->getIdSiteIfExists()
         );
     }

--- a/core/Tracker/TrackerConfig.php
+++ b/core/Tracker/TrackerConfig.php
@@ -9,46 +9,25 @@
 
 namespace Piwik\Tracker;
 
-use Piwik\Config;
+use Piwik\Config\SectionConfig;
 use Piwik\Tracker\Config\ThirdPartyCookies;
 
-class TrackerConfig
+class TrackerConfig extends SectionConfig
 {
-    /**
-     * Update Tracker config
-     *
-     * @param string $name Setting name
-     * @param mixed $value Value
-     */
-    public static function setConfigValue($name, $value)
+    public static function getSectionName(): string
     {
-        $section = self::getConfig();
-        $section[$name] = $value;
-        Config::getInstance()->Tracker = $section;
+        return 'Tracker';
     }
 
-    public static function getConfigValue($name, $idSite = null)
+    /**
+     * @return mixed|null
+     */
+    protected static function getRawConfigValue(string $name, ?int $idSite = null)
     {
         if ($name === 'use_third_party_id_cookie') {
             return ThirdPartyCookies::getInstance($idSite)->getValue();
         }
 
-        $config = self::getConfig();
-        if (!empty($idSite)) {
-            $siteSpecificConfig = self::getSiteSpecificConfig($idSite);
-            $config = array_merge($config, $siteSpecificConfig);
-        }
-        return $config[$name] ?? null;
-    }
-
-    private static function getConfig()
-    {
-        return Config::getInstance()->Tracker;
-    }
-
-    private static function getSiteSpecificConfig($idSite)
-    {
-        $key = 'Tracker_' . $idSite;
-        return Config::getInstance()->$key;
+        return parent::getRawConfigValue($name, $idSite);
     }
 }

--- a/plugins/BotTracking/RecordBuilders/AIChatbotReports.php
+++ b/plugins/BotTracking/RecordBuilders/AIChatbotReports.php
@@ -51,8 +51,8 @@ class AIChatbotReports extends RecordBuilder
         parent::__construct();
 
         $this->columnToSortByBeforeTruncation = Metrics::COLUMN_REQUESTS;
-        $this->maxRowsInTable                 = (int)GeneralConfig::getConfigValue('datatable_archiving_maximum_rows_bots');
-        $this->maxRowsInSubtable              = (int)GeneralConfig::getConfigValue('datatable_archiving_maximum_rows_subtable_bots');
+        $this->maxRowsInTable                 = GeneralConfig::getIntegerConfigValue('datatable_archiving_maximum_rows_bots', 0);
+        $this->maxRowsInSubtable              = GeneralConfig::getIntegerConfigValue('datatable_archiving_maximum_rows_subtable_bots', 0);
         $this->rankingQueryLimit              = $this->getRankingQueryLimit();
         $this->columnAggregationOps           = [
             Metrics::METRIC_AI_CHATBOTS_UNIQUE_PAGE_URLS     => 'skip',
@@ -247,7 +247,7 @@ class AIChatbotReports extends RecordBuilder
         $maxRowsInTable    = (int)$this->maxRowsInTable;
         $maxRowsInSubtable = (int)$this->maxRowsInSubtable;
 
-        $configLimit = (int)GeneralConfig::getConfigValue('archiving_ranking_query_row_limit');
+        $configLimit = GeneralConfig::getIntegerConfigValue('archiving_ranking_query_row_limit', 0);
         $configLimit = max($configLimit, 10 * $maxRowsInTable);
 
         if ($configLimit === 0) {

--- a/plugins/BulkTracking/Tracker/Handler.php
+++ b/plugins/BulkTracking/Tracker/Handler.php
@@ -114,7 +114,7 @@ class Handler extends Tracker\Handler
      */
     private function isTransactionSupported()
     {
-        return (bool) TrackerConfig::getConfigValue('bulk_requests_use_transaction');
+        return TrackerConfig::getBooleanConfigValue('bulk_requests_use_transaction', false);
     }
 
     private function isBulkTrackingRequestAuthenticated(RequestSet $requestSet)

--- a/plugins/BulkTracking/Tracker/Handler.php
+++ b/plugins/BulkTracking/Tracker/Handler.php
@@ -114,7 +114,7 @@ class Handler extends Tracker\Handler
      */
     private function isTransactionSupported()
     {
-        return TrackerConfig::getBooleanConfigValue('bulk_requests_use_transaction', false);
+        return TrackerConfig::getBoolConfigValue('bulk_requests_use_transaction', false);
     }
 
     private function isBulkTrackingRequestAuthenticated(RequestSet $requestSet)

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -200,7 +200,7 @@ class VisitRequestProcessor extends RequestProcessor
         }
 
         $wasLastActionYesterday = $this->wasLastActionNotToday($visitProperties, $request, $lastKnownVisit);
-        $forceNewVisitAtMidnight = (bool) TrackerConfig::getConfigValue('create_new_visit_after_midnight', $request->getIdSiteIfExists());
+        $forceNewVisitAtMidnight = TrackerConfig::getBooleanConfigValue('create_new_visit_after_midnight', false, $request->getIdSiteIfExists());
 
         if ($wasLastActionYesterday && $forceNewVisitAtMidnight) {
             Common::printDebug("Visitor detected, but last action was yesterday...");

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -200,7 +200,7 @@ class VisitRequestProcessor extends RequestProcessor
         }
 
         $wasLastActionYesterday = $this->wasLastActionNotToday($visitProperties, $request, $lastKnownVisit);
-        $forceNewVisitAtMidnight = TrackerConfig::getBooleanConfigValue('create_new_visit_after_midnight', false, $request->getIdSiteIfExists());
+        $forceNewVisitAtMidnight = TrackerConfig::getBoolConfigValue('create_new_visit_after_midnight', false, $request->getIdSiteIfExists());
 
         if ($wasLastActionYesterday && $forceNewVisitAtMidnight) {
             Common::printDebug("Visitor detected, but last action was yesterday...");

--- a/plugins/Live/Controller.php
+++ b/plugins/Live/Controller.php
@@ -43,7 +43,7 @@ class Controller extends \Piwik\Plugin\Controller
         $view = new View('@Live/index');
         $view->idSite = $this->idSite;
         $view->isWidgetized = \Piwik\Request::fromRequest()->getIntegerParameter('widget', 0);
-        $view->liveRefreshAfterMs = (int)GeneralConfig::getConfigValue('live_widget_refresh_after_seconds', $this->idSite) * 1000;
+        $view->liveRefreshAfterMs = GeneralConfig::getIntegerConfigValue('live_widget_refresh_after_seconds', 0, $this->idSite) * 1000;
         return $this->render($view);
     }
 
@@ -214,7 +214,7 @@ class Controller extends \Piwik\Plugin\Controller
 
         $filterLimit  = \Piwik\Request::fromRequest()->getIntegerParameter('filter_offset', 0);
         $startCounter = \Piwik\Request::fromRequest()->getIntegerParameter('start_number', 0);
-        $limit        = (int)GeneralConfig::getConfigValue('live_visitor_profile_max_visits_to_aggregate', $this->idSite);
+        $limit        = GeneralConfig::getIntegerConfigValue('live_visitor_profile_max_visits_to_aggregate', 0, $this->idSite);
 
         if ($startCounter >= $limit) {
             return ''; // do not return more visits than configured for profile

--- a/plugins/Live/Reports/GetSimpleLastVisitCount.php
+++ b/plugins/Live/Reports/GetSimpleLastVisitCount.php
@@ -33,8 +33,8 @@ class GetSimpleLastVisitCount extends Base
     public function render()
     {
         $view = new View('@Live/getSimpleLastVisitCount');
-        $view->lastMinutes = (int)GeneralConfig::getConfigValue(Controller::SIMPLE_VISIT_COUNT_WIDGET_LAST_MINUTES_CONFIG_KEY);
-        $view->refreshAfterXSecs = (int)GeneralConfig::getConfigValue('live_widget_refresh_after_seconds');
+        $view->lastMinutes = GeneralConfig::getIntegerConfigValue(Controller::SIMPLE_VISIT_COUNT_WIDGET_LAST_MINUTES_CONFIG_KEY, 0);
+        $view->refreshAfterXSecs = GeneralConfig::getIntegerConfigValue('live_widget_refresh_after_seconds', 0);
 
         return $view->render();
     }

--- a/plugins/Marketplace/Controller.php
+++ b/plugins/Marketplace/Controller.php
@@ -334,7 +334,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
             if ($plugin['isEligibleForFreeTrial']) {
                 $plugin['isTrialRequested'] = StaticContainer::get(PluginTrialService::class)->wasRequested($plugin['name']);
-                $plugin['canTrialBeRequested'] = (int) GeneralConfig::getConfigValue('plugin_trial_request_expiration_in_days') !== -1;
+                $plugin['canTrialBeRequested'] = GeneralConfig::getIntegerConfigValue('plugin_trial_request_expiration_in_days', 0) !== -1;
             }
         }
 

--- a/plugins/Marketplace/PluginTrial/Service.php
+++ b/plugins/Marketplace/PluginTrial/Service.php
@@ -123,6 +123,6 @@ final class Service
 
     public function isEnabled(): bool
     {
-        return -1 !== (int) GeneralConfig::getConfigValue('plugin_trial_request_expiration_in_days');
+        return -1 !== GeneralConfig::getIntegerConfigValue('plugin_trial_request_expiration_in_days', 0);
     }
 }

--- a/plugins/Marketplace/PluginTrial/Storage.php
+++ b/plugins/Marketplace/PluginTrial/Storage.php
@@ -56,7 +56,7 @@ class Storage
             return false;
         }
 
-        $expirationTime = (int) GeneralConfig::getConfigValue('plugin_trial_request_expiration_in_days');
+        $expirationTime = GeneralConfig::getIntegerConfigValue('plugin_trial_request_expiration_in_days', 0);
 
         if ($this->storage['requestTime'] < (time() - $expirationTime * 24 * 3600)) {
             $this->clearStorage(); // remove outdated request

--- a/plugins/Overlay/API.php
+++ b/plugins/Overlay/API.php
@@ -81,7 +81,7 @@ class API extends \Piwik\Plugin\API
         $resultDataTable = new DataTable();
 
         try {
-            $limitBeforeGrouping = (int)GeneralConfig::getConfigValue('overlay_following_pages_limit');
+            $limitBeforeGrouping = GeneralConfig::getIntegerConfigValue('overlay_following_pages_limit', 0);
             $transitionsReport = APITransitions::getInstance()->getTransitionsForAction(
                 $url,
                 $type = 'url',

--- a/plugins/UserCountry/LocationProvider.php
+++ b/plugins/UserCountry/LocationProvider.php
@@ -383,7 +383,7 @@ abstract class LocationProvider
      */
     public static function getDefaultProviderId()
     {
-        if (!!TrackerConfig::getConfigValue('enable_default_location_provider')) {
+        if (TrackerConfig::getBooleanConfigValue('enable_default_location_provider', false)) {
             return DefaultProvider::ID;
         }
 

--- a/plugins/UserCountry/LocationProvider.php
+++ b/plugins/UserCountry/LocationProvider.php
@@ -383,7 +383,7 @@ abstract class LocationProvider
      */
     public static function getDefaultProviderId()
     {
-        if (TrackerConfig::getBooleanConfigValue('enable_default_location_provider', false)) {
+        if (TrackerConfig::getBoolConfigValue('enable_default_location_provider', false)) {
             return DefaultProvider::ID;
         }
 

--- a/plugins/UserCountry/LocationProvider/DefaultProvider.php
+++ b/plugins/UserCountry/LocationProvider/DefaultProvider.php
@@ -116,7 +116,7 @@ class DefaultProvider extends LocationProvider
      */
     public function isAvailable()
     {
-        return TrackerConfig::getBooleanConfigValue('enable_default_location_provider', false);
+        return TrackerConfig::getBoolConfigValue('enable_default_location_provider', false);
     }
 
 
@@ -127,7 +127,7 @@ class DefaultProvider extends LocationProvider
      */
     public function isVisible()
     {
-        return TrackerConfig::getBooleanConfigValue('enable_default_location_provider', false);
+        return TrackerConfig::getBoolConfigValue('enable_default_location_provider', false);
     }
 
     /**

--- a/plugins/UserCountry/LocationProvider/DefaultProvider.php
+++ b/plugins/UserCountry/LocationProvider/DefaultProvider.php
@@ -116,7 +116,7 @@ class DefaultProvider extends LocationProvider
      */
     public function isAvailable()
     {
-        return !!TrackerConfig::getConfigValue('enable_default_location_provider');
+        return TrackerConfig::getBooleanConfigValue('enable_default_location_provider', false);
     }
 
 
@@ -127,7 +127,7 @@ class DefaultProvider extends LocationProvider
      */
     public function isVisible()
     {
-        return !!TrackerConfig::getConfigValue('enable_default_location_provider');
+        return TrackerConfig::getBooleanConfigValue('enable_default_location_provider', false);
     }
 
     /**

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -372,7 +372,7 @@ class API extends \Piwik\Plugin\API
                 }
                 return false;
             case self::PREFERENCE_DEFAULT_REPORT_DATE:
-                return (string)GeneralConfig::getConfigValue('default_day');
+                return GeneralConfig::getStringConfigValue('default_day', '');
             default:
                 return false;
         }
@@ -997,7 +997,7 @@ class API extends \Piwik\Plugin\API
             // this will indirectly invalidate the invitation sent to the previous address
             $this->userRepository->reInviteUser(
                 $userLogin,
-                (int)GeneralConfig::getConfigValue('default_invite_user_token_expiry_days')
+                GeneralConfig::getIntegerConfigValue('default_invite_user_token_expiry_days', 0)
             );
         } elseif ($hasEmailChanged && $isEmailNotificationOnInConfig) {
             $this->sendEmailChangedEmail($userInfo, $email);

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -510,7 +510,7 @@ class Controller extends ControllerAdmin
             'nonce' => Nonce::getNonce(self::NONCE_ADD_AUTH_TOKEN),
             'noDescription' => $postRequestHasData && $noDescription,
             'invalidExpireDate' => $postRequestHasData && $invalidExpireDate,
-            'forceSecureOnly' => (bool) GeneralConfig::getConfigValue('only_allow_secure_auth_tokens'),
+            'forceSecureOnly' => GeneralConfig::getBooleanConfigValue('only_allow_secure_auth_tokens', false),
             'initialExpireDate' => $today->addDay($defaultExpireDays)->toString(),
             'defaultExpirationDays' => $defaultExpireDays,
             'expirationReminderDays' => GeneralConfig::getConfigValue('auth_token_expiration_notification_days'),

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -510,7 +510,7 @@ class Controller extends ControllerAdmin
             'nonce' => Nonce::getNonce(self::NONCE_ADD_AUTH_TOKEN),
             'noDescription' => $postRequestHasData && $noDescription,
             'invalidExpireDate' => $postRequestHasData && $invalidExpireDate,
-            'forceSecureOnly' => GeneralConfig::getBooleanConfigValue('only_allow_secure_auth_tokens', false),
+            'forceSecureOnly' => GeneralConfig::getBoolConfigValue('only_allow_secure_auth_tokens', false),
             'initialExpireDate' => $today->addDay($defaultExpireDays)->toString(),
             'defaultExpirationDays' => $defaultExpireDays,
             'expirationReminderDays' => GeneralConfig::getConfigValue('auth_token_expiration_notification_days'),

--- a/tests/PHPUnit/Integration/Tracker/TrackerConfigTest.php
+++ b/tests/PHPUnit/Integration/Tracker/TrackerConfigTest.php
@@ -30,6 +30,6 @@ class TrackerConfigTest extends IntegrationTestCase
         Config::getInstance()->Tracker_10 = ['use_third_party_id_cookie' => false];
 
         $this->assertTrue(TrackerConfig::getBooleanConfigValue('use_third_party_id_cookie'));
-        $this->assertFalse(TrackerConfig::getBooleanConfigValue('use_third_party_id_cookie', 10));
+        $this->assertFalse(TrackerConfig::getBooleanConfigValue('use_third_party_id_cookie', null, 10));
     }
 }

--- a/tests/PHPUnit/Integration/Tracker/TrackerConfigTest.php
+++ b/tests/PHPUnit/Integration/Tracker/TrackerConfigTest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Tests\Integration\Tracker;
 
+use Piwik\Config;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Tracker\TrackerConfig;
 
@@ -21,5 +22,14 @@ class TrackerConfigTest extends IntegrationTestCase
     public function testGetConfigValueWithUseThirdPartyIdCookieReturnsResult(): void
     {
         $this->assertEquals(false, TrackerConfig::getConfigValue('use_third_party_id_cookie'));
+    }
+
+    public function testGetBooleanConfigValueWithUseThirdPartyIdCookieReturnsResult(): void
+    {
+        Config::getInstance()->Tracker = ['use_third_party_id_cookie' => true];
+        Config::getInstance()->Tracker_10 = ['use_third_party_id_cookie' => false];
+
+        $this->assertTrue(TrackerConfig::getBooleanConfigValue('use_third_party_id_cookie'));
+        $this->assertFalse(TrackerConfig::getBooleanConfigValue('use_third_party_id_cookie', 10));
     }
 }

--- a/tests/PHPUnit/Integration/Tracker/TrackerConfigTest.php
+++ b/tests/PHPUnit/Integration/Tracker/TrackerConfigTest.php
@@ -29,7 +29,7 @@ class TrackerConfigTest extends IntegrationTestCase
         Config::getInstance()->Tracker = ['use_third_party_id_cookie' => true];
         Config::getInstance()->Tracker_10 = ['use_third_party_id_cookie' => false];
 
-        $this->assertTrue(TrackerConfig::getBooleanConfigValue('use_third_party_id_cookie'));
-        $this->assertFalse(TrackerConfig::getBooleanConfigValue('use_third_party_id_cookie', null, 10));
+        $this->assertTrue(TrackerConfig::getBoolConfigValue('use_third_party_id_cookie'));
+        $this->assertFalse(TrackerConfig::getBoolConfigValue('use_third_party_id_cookie', null, 10));
     }
 }

--- a/tests/PHPUnit/Unit/Config/SectionConfigTest.php
+++ b/tests/PHPUnit/Unit/Config/SectionConfigTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Config;
+
+use Piwik\Config;
+use Piwik\Config\SectionConfig;
+use Piwik\Container\StaticContainer;
+use Piwik\Log\LoggerInterface;
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
+
+class SectionConfigTest extends UnitTestCase
+{
+    public function testGetTypedConfigValueReturnsNullWhenConfigIsMissing(): void
+    {
+        $this->assertNull(TestSectionConfig::getIntegerConfigValue('missing'));
+        $this->assertNull(TestSectionConfig::getFloatConfigValue('missing'));
+        $this->assertNull(TestSectionConfig::getBooleanConfigValue('missing'));
+        $this->assertNull(TestSectionConfig::getStringConfigValue('missing'));
+        $this->assertNull(TestSectionConfig::getArrayConfigValue('missing'));
+    }
+
+    public function testGetTypedConfigValueReturnsExpectedTypes(): void
+    {
+        Config::getInstance()->TestSection = [
+            'integer' => '17',
+            'float' => '17.25',
+            'boolean' => 'true',
+            'string' => "ran\0dom",
+            'array' => ['key' => "val\0ue"],
+        ];
+
+        $this->assertSame(17, TestSectionConfig::getIntegerConfigValue('integer'));
+        $this->assertSame(17.25, TestSectionConfig::getFloatConfigValue('float'));
+        $this->assertTrue(TestSectionConfig::getBooleanConfigValue('boolean'));
+        $this->assertSame('random', TestSectionConfig::getStringConfigValue('string'));
+        $this->assertSame(['key' => 'value'], TestSectionConfig::getArrayConfigValue('array'));
+    }
+
+    public function testGetTypedConfigValueReturnsDefaultWhenConfigIsMissing(): void
+    {
+        $this->assertSame(7, TestSectionConfig::getIntegerConfigValue('missing', 7));
+        $this->assertSame(7.5, TestSectionConfig::getFloatConfigValue('missing', 7.5));
+        $this->assertTrue(TestSectionConfig::getBooleanConfigValue('missing', true));
+        $this->assertSame('fallback', TestSectionConfig::getStringConfigValue('missing', 'fallback'));
+        $this->assertSame(['fallback'], TestSectionConfig::getArrayConfigValue('missing', ['fallback']));
+    }
+
+    public function testGetConfigValueReturnsSiteSpecificOverride(): void
+    {
+        Config::getInstance()->TestSection = [
+            'integer' => '17',
+        ];
+        Config::getInstance()->TestSection_4 = [
+            'integer' => '23',
+        ];
+
+        $this->assertSame(17, TestSectionConfig::getIntegerConfigValue('integer', null, 3));
+        $this->assertSame(23, TestSectionConfig::getIntegerConfigValue('integer', null, 4));
+    }
+
+    /**
+     * @dataProvider getInvalidConfigValues
+     */
+    public function testGetTypedConfigValueLogsWarningWhenCastFails(string $method, $value, string $expectedType): void
+    {
+        Config::getInstance()->TestSection = [
+            'setting' => $value,
+        ];
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->once())
+            ->method('warning')
+            ->with(
+                'Failed to cast config value {section}.{name} to {type}; actual type was {actualType}.',
+                [
+                    'section' => 'TestSection',
+                    'name' => 'setting',
+                    'type' => $expectedType,
+                    'actualType' => is_object($value) ? get_class($value) : gettype($value),
+                ]
+            );
+
+        StaticContainer::getContainer()->set(LoggerInterface::class, $loggerMock);
+
+        $this->assertNull(TestSectionConfig::$method('setting'));
+    }
+
+    /**
+     * @dataProvider getInvalidConfigValuesWithDefaults
+     */
+    public function testGetTypedConfigValueReturnsDefaultAndLogsWarningWhenCastFails(
+        string $method,
+        $value,
+        $default,
+        string $expectedType
+    ): void {
+        Config::getInstance()->TestSection = [
+            'setting' => $value,
+        ];
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->once())
+            ->method('warning')
+            ->with(
+                'Failed to cast config value {section}.{name} to {type}; actual type was {actualType}.',
+                [
+                    'section' => 'TestSection',
+                    'name' => 'setting',
+                    'type' => $expectedType,
+                    'actualType' => is_object($value) ? get_class($value) : gettype($value),
+                ]
+            );
+
+        StaticContainer::getContainer()->set(LoggerInterface::class, $loggerMock);
+
+        $this->assertSame($default, TestSectionConfig::$method('setting', $default));
+    }
+
+    /**
+     * @return iterable<string, array{string, mixed, string}>
+     */
+    public function getInvalidConfigValues(): iterable
+    {
+        yield 'int from invalid string' => ['getIntegerConfigValue', 'abc', 'int'];
+        yield 'float from invalid string' => ['getFloatConfigValue', 'abc', 'float'];
+        yield 'bool from invalid integer' => ['getBooleanConfigValue', 2, 'bool'];
+        yield 'string from bool' => ['getStringConfigValue', true, 'string'];
+        yield 'array from csv string' => ['getArrayConfigValue', 'a,b', 'array'];
+        yield 'int from object' => ['getIntegerConfigValue', new \stdClass(), 'int'];
+    }
+
+    /**
+     * @return iterable<string, array{string, mixed, mixed, string}>
+     */
+    public function getInvalidConfigValuesWithDefaults(): iterable
+    {
+        yield 'int from invalid string with default' => ['getIntegerConfigValue', 'abc', 9, 'int'];
+        yield 'float from invalid string with default' => ['getFloatConfigValue', 'abc', 9.5, 'float'];
+        yield 'bool from invalid integer with default' => ['getBooleanConfigValue', 2, true, 'bool'];
+        yield 'string from bool with default' => ['getStringConfigValue', true, 'fallback', 'string'];
+        yield 'array from csv string with default' => ['getArrayConfigValue', 'a,b', ['fallback'], 'array'];
+    }
+}
+
+class TestSectionConfig extends SectionConfig
+{
+    public static function getSectionName(): string
+    {
+        return 'TestSection';
+    }
+}

--- a/tests/PHPUnit/Unit/Config/SectionConfigTest.php
+++ b/tests/PHPUnit/Unit/Config/SectionConfigTest.php
@@ -21,7 +21,7 @@ class SectionConfigTest extends UnitTestCase
     {
         $this->assertNull(TestSectionConfig::getIntegerConfigValue('missing'));
         $this->assertNull(TestSectionConfig::getFloatConfigValue('missing'));
-        $this->assertNull(TestSectionConfig::getBooleanConfigValue('missing'));
+        $this->assertNull(TestSectionConfig::getBoolConfigValue('missing'));
         $this->assertNull(TestSectionConfig::getStringConfigValue('missing'));
         $this->assertNull(TestSectionConfig::getArrayConfigValue('missing'));
     }
@@ -38,7 +38,7 @@ class SectionConfigTest extends UnitTestCase
 
         $this->assertSame(17, TestSectionConfig::getIntegerConfigValue('integer'));
         $this->assertSame(17.25, TestSectionConfig::getFloatConfigValue('float'));
-        $this->assertTrue(TestSectionConfig::getBooleanConfigValue('boolean'));
+        $this->assertTrue(TestSectionConfig::getBoolConfigValue('boolean'));
         $this->assertSame('random', TestSectionConfig::getStringConfigValue('string'));
         $this->assertSame(['key' => 'value'], TestSectionConfig::getArrayConfigValue('array'));
     }
@@ -47,7 +47,7 @@ class SectionConfigTest extends UnitTestCase
     {
         $this->assertSame(7, TestSectionConfig::getIntegerConfigValue('missing', 7));
         $this->assertSame(7.5, TestSectionConfig::getFloatConfigValue('missing', 7.5));
-        $this->assertTrue(TestSectionConfig::getBooleanConfigValue('missing', true));
+        $this->assertTrue(TestSectionConfig::getBoolConfigValue('missing', true));
         $this->assertSame('fallback', TestSectionConfig::getStringConfigValue('missing', 'fallback'));
         $this->assertSame(['fallback'], TestSectionConfig::getArrayConfigValue('missing', ['fallback']));
     }
@@ -130,7 +130,7 @@ class SectionConfigTest extends UnitTestCase
     {
         yield 'int from invalid string' => ['getIntegerConfigValue', 'abc', 'int'];
         yield 'float from invalid string' => ['getFloatConfigValue', 'abc', 'float'];
-        yield 'bool from invalid integer' => ['getBooleanConfigValue', 2, 'bool'];
+        yield 'bool from invalid integer' => ['getBoolConfigValue', 2, 'bool'];
         yield 'string from bool' => ['getStringConfigValue', true, 'string'];
         yield 'array from csv string' => ['getArrayConfigValue', 'a,b', 'array'];
         yield 'int from object' => ['getIntegerConfigValue', new \stdClass(), 'int'];
@@ -143,7 +143,7 @@ class SectionConfigTest extends UnitTestCase
     {
         yield 'int from invalid string with default' => ['getIntegerConfigValue', 'abc', 9, 'int'];
         yield 'float from invalid string with default' => ['getFloatConfigValue', 'abc', 9.5, 'float'];
-        yield 'bool from invalid integer with default' => ['getBooleanConfigValue', 2, true, 'bool'];
+        yield 'bool from invalid integer with default' => ['getBoolConfigValue', 2, true, 'bool'];
         yield 'string from bool with default' => ['getStringConfigValue', true, 'fallback', 'string'];
         yield 'array from csv string with default' => ['getArrayConfigValue', 'a,b', ['fallback'], 'array'];
     }

--- a/tests/PHPUnit/Unit/Tracker/TrackerConfigTest.php
+++ b/tests/PHPUnit/Unit/Tracker/TrackerConfigTest.php
@@ -15,19 +15,28 @@ use Piwik\Tracker\TrackerConfig;
 
 class TrackerConfigTest extends UnitTestCase
 {
-    public function testGetConfigValueReturnsTrackerConfigValueIfNoSiteSpecificValue()
+    public function testGetConfigValueReturnsTrackerConfigValueIfNoSiteSpecificValue(): void
     {
-        Config::getInstance()->Tracker['setting'] = 1;
-        Config::getInstance()->Tracker_10['setting'] = 0;
+        Config::getInstance()->Tracker = ['setting' => 1];
+        Config::getInstance()->Tracker_10 = ['setting' => 0];
 
-        $this->assertEquals(1, TrackerConfig::getConfigValue('setting', 5));
+        $this->assertSame(1, TrackerConfig::getConfigValue('setting', 5));
     }
 
-    public function testGetConfigValueReturnsSiteSpecificConfigValueIfOneIsSpecified()
+    public function testGetConfigValueReturnsSiteSpecificConfigValueIfOneIsSpecified(): void
     {
-        Config::getInstance()->Tracker['setting'] = 1;
-        Config::getInstance()->Tracker_10['setting'] = 0;
+        Config::getInstance()->Tracker = ['setting' => 1];
+        Config::getInstance()->Tracker_10 = ['setting' => 0];
 
-        $this->assertEquals(0, TrackerConfig::getConfigValue('setting', 10));
+        $this->assertSame(0, TrackerConfig::getConfigValue('setting', 10));
+    }
+
+    public function testGetBooleanConfigValueReturnsTypedTrackerConfigValue(): void
+    {
+        Config::getInstance()->Tracker = ['setting' => '1'];
+        Config::getInstance()->Tracker_10 = ['setting' => '0'];
+
+        $this->assertTrue(TrackerConfig::getBooleanConfigValue('setting', null, 5));
+        $this->assertFalse(TrackerConfig::getBooleanConfigValue('setting', null, 10));
     }
 }

--- a/tests/PHPUnit/Unit/Tracker/TrackerConfigTest.php
+++ b/tests/PHPUnit/Unit/Tracker/TrackerConfigTest.php
@@ -36,7 +36,7 @@ class TrackerConfigTest extends UnitTestCase
         Config::getInstance()->Tracker = ['setting' => '1'];
         Config::getInstance()->Tracker_10 = ['setting' => '0'];
 
-        $this->assertTrue(TrackerConfig::getBooleanConfigValue('setting', null, 5));
-        $this->assertFalse(TrackerConfig::getBooleanConfigValue('setting', null, 10));
+        $this->assertTrue(TrackerConfig::getBoolConfigValue('setting', null, 5));
+        $this->assertFalse(TrackerConfig::getBoolConfigValue('setting', null, 10));
     }
 }


### PR DESCRIPTION
### Description

This changes the section config helpers to support typed access with optional typed defaults, and updates existing manual-cast call sites to use those helpers while preserving previous behavior.

#### What changed

  SectionConfig now provides typed getters for config values:

  - `getIntegerConfigValue(string $name, ?int $default = null, ?int $idSite = null): ?int`
  - `getFloatConfigValue(string $name, ?float $default = null, ?int $idSite = null): ?float`
  - `getBoolConfigValue(string $name, ?bool $default = null, ?int $idSite = null): ?bool`
  - `getStringConfigValue(string $name, ?string $default = null, ?int $idSite = null): ?string`
  - `getArrayConfigValue(string $name, ?array $default = null, ?int $idSite = null): ?array`

#### Behavior:

  - If the config value is missing, the typed default is returned.
  - If the value cannot be cast to the requested type, a warning is logged and the typed default is returned.
  - If no default is provided, null is returned.

  TrackerConfig was refactored to extend SectionConfig, while keeping the `use_third_party_id_cookie` special handling.

  Existing call sites that previously did manual casts on GeneralConfig, DatabaseConfig, or TrackerConfig were updated to use the typed getters instead. Where the old code relied on PHP cast fallback behavior, explicit defaults were added so behavior stays the same:

  - old `(int)` casts now pass `0`
  - old `(bool)` / `!!` casts now pass `false`
  - old `(string)` casts now pass `''`

#### Why

  This avoids repeating ad-hoc casts throughout the codebase, makes the expected type explicit at the config access point, and centralizes invalid-value handling and logging.

#### Notes

  The migrated call sites were reviewed to preserve previous semantics. In particular, places that previously depended on PHP cast behavior now pass explicit defaults instead of implicitly returning null.


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
