### PR TITLE
Make resetting of the viewport to fullpage optional for page.screenshotSelector

### DIFF
--- a/tests/UI/expected-screenshots/Menus_mobile_left.png
+++ b/tests/UI/expected-screenshots/Menus_mobile_left.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a1c8f82a833736b631714c44af64d5831845bd8eb24d3a6b5f608982fae8b32
-size 36127
+oid sha256:cac0c18f07a87170b1f482c0cc99addddd98e9bc8ae9261079d27d7501960ac1
+size 35229

--- a/tests/UI/specs/Menus_spec.js
+++ b/tests/UI/specs/Menus_spec.js
@@ -93,7 +93,7 @@ describe("Menus", function () {
     });
 
     it('should load the admin left menu correctly on mobile', async function() {
-        await page.webpage.setViewport({ width: 815, height: 1500 });
+        await page.webpage.setViewport({ width: 815, height: 1600 });
         await page.goto("?module=CoreAdminHome&action=home");
         await page.waitForNetworkIdle();
         await page.click('[data-target="mobile-left-menu"]');
@@ -106,7 +106,7 @@ describe("Menus", function () {
         await page.click('ul#mobile-left-menu > li:nth-child(6) a');
         await page.waitForTimeout(500);
 
-        expect(await page.screenshotSelector('#mobile-left-menu')).to.matchImage('mobile_left_admin');
+        expect(await page.screenshotSelector('#mobile-left-menu', false)).to.matchImage('mobile_left_admin');
     });
 
     it('should load the admin top menu correctly on mobile', async function() {
@@ -122,7 +122,7 @@ describe("Menus", function () {
     });
 
     it('should load the left reporting menu correctly on mobile', async function() {
-        await page.webpage.setViewport({ width: 768, height: 1200 });
+        await page.webpage.setViewport({ width: 768, height: 1000 });
         await page.goto("?" + generalParams + "&module=CoreHome&action=index#?category=General_Visitors&subcategory=General_Overview");
         await page.waitForNetworkIdle();
         await page.evaluate(function(){
@@ -132,6 +132,6 @@ describe("Menus", function () {
         await (await page.jQuery('#mobile-left-menu>li>ul:contains(Goals)')).click();
         await page.waitForTimeout(500);
 
-        expect(await page.screenshotSelector('#mobile-left-menu')).to.matchImage('mobile_left');
+        expect(await page.screenshotSelector('#mobile-left-menu', false)).to.matchImage('mobile_left');
     });
 });

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -197,10 +197,12 @@ PageRenderer.prototype.resizeViewportToFullPage = async function () {
     await this.webpage.setViewport(JSON.parse(dims));
 };
 
-PageRenderer.prototype.screenshotSelector = async function (selector) {
+PageRenderer.prototype.screenshotSelector = async function (selector, shouldResizeViewport = true) {
     await this.waitForFunction(() => !! window.$, { timeout: 60000 });
 
-    await this.resizeViewportToFullPage();
+    if (shouldResizeViewport) {
+        await this.resizeViewportToFullPage();
+    }
 
     const result = await this.webpage.evaluate(function (selector) {
         window.jQuery('html').addClass('uiTest');


### PR DESCRIPTION
### Description

When taking a screenshot using `page.screenshotSelector` it will always try to resize the viewport to fullpage. This was alright before, but with the changes in layout and our side menu height is more dynamic (100vh), this causes issues when trying to take a screenshot. 

Setting the viewport before calling `page.screenshotSelector` is no longer working too well for the height. 
This PR is for adding a parameter to page.screenshotSelector so that we can skip resizing the viewport so that we can manually set the viewport height using `page.webpage.setViewport({ width: x, height: y });`
### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
