### PR TITLE
Fix whats new link for subdirectory installs

### DIFF
--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -411,6 +411,12 @@ class Controller extends ControllerAdmin
             return $link;
         }
 
+        // Use a path relative to the current Matomo install so subdirectory installs
+        // don't resolve internal "What's New" links against the web root.
+        if (strpos($link, '/index.php') === 0) {
+            $link = substr($link, 1);
+        }
+
         $parsedLink = @parse_url($link);
         if (!is_array($parsedLink)) {
             return $link;

--- a/plugins/CoreAdminHome/tests/Integration/ControllerTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/ControllerTest.php
@@ -180,7 +180,8 @@ class ControllerTest extends IntegrationTestCase
         $html = $this->controller->whatIsNew();
 
         $this->assertStringContainsString('index.php?module=UsersManager&amp;action=userSettings&amp;idSite=2', $html);
-        $this->assertStringContainsString('/index.php?module=CoreHome&amp;action=index&amp;idSite=2#?idSite=2&amp;category=General_Visitors', $html);
+        $this->assertStringContainsString('index.php?module=CoreHome&amp;action=index&amp;idSite=2#?idSite=2&amp;category=General_Visitors', $html);
+        $this->assertStringNotContainsString('href="/index.php?', $html);
         $this->assertStringNotContainsString('idSite=1', $html);
     }
 


### PR DESCRIPTION
### Description

Fixes broken internal links in the “What’s New” popup for Matomo installs hosted in a subdirectory, such as `https://example.org/matomo/index.php`.

Internal change links that were defined as `/index.php?...` were being resolved from the domain root instead of the current Matomo base path. This updates “What’s New” link normalization to use install-relative `index.php?...` links and adds test coverage for that behavior.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
