### PR TITLE
Fix plugin compatibility warning when plugins admin is disabled

### DIFF
--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -21,6 +21,7 @@ use Piwik\Menu\MenuTop;
 use Piwik\Notification;
 use Piwik\Notification\Manager as NotificationManager;
 use Piwik\Piwik;
+use Piwik\Plugins\CorePluginsAdmin\CorePluginsAdmin;
 use Piwik\Plugins\Marketplace\Marketplace;
 use Piwik\Tracker\TrackerConfig;
 use Piwik\Url;
@@ -107,18 +108,22 @@ abstract class ControllerAdmin extends Controller
             return;
         }
 
-        $pluginsLink = Url::getCurrentQueryStringWithParametersModified([
-            'module' => 'CorePluginsAdmin', 'action' => 'plugins',
+        $invalidPluginsWarning = Piwik::translate('CoreAdminHome_InvalidPluginsWarning', [
+            self::getPiwikVersion(),
+            '<strong>' . implode('</strong>,&nbsp;<wbr><strong>', $missingPlugins) . '</strong>',
         ]);
 
-        $invalidPluginsWarning = Piwik::translate('CoreAdminHome_InvalidPluginsWarning', [
-                self::getPiwikVersion(),
-                '<strong>' . implode('</strong>,&nbsp;<wbr><strong>', $missingPlugins) . '</strong>'])
-            . "<br/>"
-            . Piwik::translate('CoreAdminHome_InvalidPluginsYouCanUninstall', [
-                '<a href="' . $pluginsLink . '"/>',
+        if (CorePluginsAdmin::isPluginsAdminEnabled()) {
+            $pluginsLink = Url::getCurrentQueryStringWithParametersModified([
+                'module' => 'CorePluginsAdmin', 'action' => 'plugins',
+            ]);
+            $invalidPluginsWarning .= '<br/>' . Piwik::translate('CoreAdminHome_InvalidPluginsYouCanUninstall', [
+                '<a href="' . $pluginsLink . '">',
                 '</a>',
             ]);
+        } else {
+            $invalidPluginsWarning .= '<br/>' . Piwik::translate('CoreAdminHome_InvalidPluginsAdminDisabled');
+        }
 
         $notification = new Notification($invalidPluginsWarning);
         $notification->raw = true;

--- a/plugins/CoreAdminHome/lang/en.json
+++ b/plugins/CoreAdminHome/lang/en.json
@@ -39,6 +39,7 @@
         "InvalidSiteUrlErrorHelp": "Please go back to your previous page or return to your dashboard to select a website.",
         "InvalidPluginsWarning": "The following plugins are not compatible with %1$s and could not be loaded: %2$s.",
         "InvalidPluginsYouCanUninstall": "You can update or uninstall these plugins on the %1$sManage Plugins%2$s page.",
+        "InvalidPluginsAdminDisabled": "To update or uninstall these plugins, please contact your Matomo administrator, who can use the command line or update the configuration directly.",
         "JSTrackingIntro1": "You can track visitors to your website in many different ways. The recommended way to do it is through JavaScript. To use this method you must make sure every webpage of your website has some JavaScript code, which you can generate here.",
         "JSTrackingIntro2": "Once you have the JavaScript tracking code for your website, copy and paste it to all the pages you want to track with Matomo.",
         "JSTrackingIntro3a": "In most websites, blogs, CMS, etc. you can use a pre-made plugin to do the technical work for you. (See our %1$slist of plugins used to integrate Matomo%2$s.)",


### PR DESCRIPTION
When `enable_plugins_admin = 0` is configured, the warning about incompatible plugins still showed a link to the **Manage Plugins** page — which is inaccessible in that configuration.

## Changes

- `core/Plugin/ControllerAdmin.php`: check `CorePluginsAdmin::isPluginsAdminEnabled()` before rendering the Manage Plugins link; show alternative text if admin is disabled
- `plugins/CoreAdminHome/lang/en.json`: new translation key `InvalidPluginsAdminDisabled`

Fixes #23941


Before Fix:

<img width="1651" height="749" alt="bug-before" src="https://github.com/user-attachments/assets/f409e17e-e784-4a8a-ac95-7695cb29b93c" />


After Fix:

<img width="1651" height="749" alt="bug-after" src="https://github.com/user-attachments/assets/d909b4b8-a3c8-444e-9cec-00fdf34dfff6" />

## Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules