### PR TITLE
Fix incorrect upgrade message when Matomo is too new for a plugin

### DIFF
--- a/core/Plugin/Dependency.php
+++ b/core/Plugin/Dependency.php
@@ -49,11 +49,16 @@ class Dependency
             $missingVersions = $this->getMissingVersions($currentVersion, $requiredVersion);
 
             if (!empty($missingVersions)) {
+                $allUpperBounds = count(array_filter($missingVersions, function ($v) {
+                    return (bool) preg_match('/^</', $v);
+                })) === count($missingVersions);
+
                 $missingRequirements[] = array(
                     'requirement'     => $name,
                     'actualVersion'   => $currentVersion,
                     'requiredVersion' => $requiredVersion,
                     'causedBy'        => implode(', ', $missingVersions),
+                    'tooNew'          => $allUpperBounds,
                 );
             }
         }

--- a/plugins/CorePluginsAdmin/PluginInstaller.php
+++ b/plugins/CorePluginsAdmin/PluginInstaller.php
@@ -200,8 +200,9 @@ class PluginInstaller
                     $params   = array(ucfirst($dep['requirement']), $dep['requiredVersion'], $metadata->name);
                     $message .= Piwik::translate('CorePluginsAdmin_MissingRequirementsPleaseInstallNotice', $params);
                 } else {
-                    $params   = array(ucfirst($dep['requirement']), $dep['actualVersion'], $dep['requiredVersion']);
-                    $message .= Piwik::translate('CorePluginsAdmin_MissingRequirementsNotice', $params);
+                    $params = array(ucfirst($dep['requirement']), $dep['actualVersion'], $dep['requiredVersion']);
+                    $key    = !empty($dep['tooNew']) ? 'CorePluginsAdmin_MissingRequirementsNoticeTooNew' : 'CorePluginsAdmin_MissingRequirementsNotice';
+                    $message .= Piwik::translate($key, $params);
                 }
             }
 

--- a/plugins/CorePluginsAdmin/lang/en.json
+++ b/plugins/CorePluginsAdmin/lang/en.json
@@ -31,6 +31,7 @@
         "OncePluginIsInstalledYouMayActivateHere": "Once a plugin is installed, you may activate it or deactivate it here.",
         "MenuPlatform": "Platform",
         "MissingRequirementsNotice": "Please update %1$s %2$s to a newer version, %1$s %3$s is required.",
+        "MissingRequirementsNoticeTooNew": "This plugin is not yet compatible with your Matomo version (%1$s %2$s). Supported versions: %3$s. Please downgrade Matomo or wait for a plugin update.",
         "MissingRequirementsPleaseInstallNotice": "Please install %1$s %2$s as it is required by %3$s.",
         "NoZipFileSelected": "Please select a ZIP file.",
         "FileExceedsUploadLimit": "The selected file exceeds the upload limit of your server.",

--- a/plugins/Marketplace/Marketplace.php
+++ b/plugins/Marketplace/Marketplace.php
@@ -71,6 +71,7 @@ class Marketplace extends \Piwik\Plugin
         $translationKeys[] = 'CorePluginsAdmin_Deactivate';
         $translationKeys[] = 'CorePluginsAdmin_Marketplace';
         $translationKeys[] = 'CorePluginsAdmin_MissingRequirementsNotice';
+        $translationKeys[] = 'CorePluginsAdmin_MissingRequirementsNoticeTooNew';
         $translationKeys[] = 'CorePluginsAdmin_PluginsExtendPiwik';
         $translationKeys[] = 'CorePluginsAdmin_Status';
         $translationKeys[] = 'CorePluginsAdmin_Theme';

--- a/plugins/Marketplace/vue/src/MissingReqsNotice/MissingReqsNotice.vue
+++ b/plugins/Marketplace/vue/src/MissingReqsNotice/MissingReqsNotice.vue
@@ -12,7 +12,9 @@
     class="alert alert-danger"
   >
     {{ translate(
-      'CorePluginsAdmin_MissingRequirementsNotice',
+      req.tooNew
+        ? 'CorePluginsAdmin_MissingRequirementsNoticeTooNew'
+        : 'CorePluginsAdmin_MissingRequirementsNotice',
       requirement(req.requirement),
       req.actualVersion,
       req.requiredVersion,


### PR DESCRIPTION
## Description

Fixes #23945

When a plugin only supports older Matomo versions (e.g. `"matomo": ">=4.0.0,<5.0.0-b1"`), the error message incorrectly told the user to **update Matomo to a newer version**, when in fact Matomo is already *too new* for the plugin.

**Before:**
> Please update Matomo 5.10.0-alpha to a newer version, Matomo >=4.0.0,<5.0.0-b1 is required.

**After:**
> This plugin is not yet compatible with your Matomo version (Matomo 5.10.0-alpha). Supported versions: >=4.0.0,<5.0.0-b1. Please downgrade Matomo or wait for a plugin update.

## Changes

- `core/Plugin/Dependency.php` — detect `tooNew` when all failing version constraints are upper-bound (`<`), meaning Matomo exceeds the plugin's maximum supported version
- `plugins/CorePluginsAdmin/lang/en.json` — add `MissingRequirementsNoticeTooNew` translation key with accurate wording
- `plugins/CorePluginsAdmin/PluginInstaller.php` — use the new key when `tooNew` is set
- `plugins/Marketplace/Marketplace.php` — expose the new key to the client side
- `plugins/Marketplace/vue/src/MissingReqsNotice/MissingReqsNotice.vue` — use the correct translation based on `req.tooNew`

## Screenshots

**Before (buggy message):**
<img width="1651" height="749" alt="issue-23945-before" src="https://github.com/user-attachments/assets/c85d9cfa-8f9c-4556-9b9e-bef6a437cf7f" />


**After (correct message):**
<img width="1651" height="749" alt="issue-23945-after" src="https://github.com/user-attachments/assets/6756feda-a36c-4d8f-a5bb-12db0d04cfb1" />

## Checklist

- [x] I have understood, reviewed, and tested all AI outputs before use
- [x] All AI instructions respect security, IP, and privacy rules