### PR TITLE
Fix flaky test for Dashboard

### DIFF
--- a/plugins/Dashboard/tests/UI/Dashboard_spec.js
+++ b/plugins/Dashboard/tests/UI/Dashboard_spec.js
@@ -56,8 +56,13 @@ describe("Dashboard", function () {
     await page.waitForNetworkIdle();
     await page.evaluate(() => { // give table headers constant width so the screenshot stays the same
       $('.dataTableScroller').css('overflow-x', 'scroll');
+      $('[widgetid="widgetRssWidgetrssChangelog"] .widgetContent').html(
+        '<div style="padding:10px 15px;"><ul class="rss"><li>' +
+        '<div class="rss-description">Changed to something static for tests</div>' +
+        '</li></ul></div>'
+      );
     });
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(100);
     pageWrap = await page.$('.pageWrap');
     expect(await pageWrap.screenshot()).to.matchImage('dashboard4');
   });

--- a/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard4.png
+++ b/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_dashboard4.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d41072eb7f5990bcc9043dc18fa4e59d4e9ba1685b5792d81be5109d4e316ac4
-size 745671
+oid sha256:6e5db10af54ac784096bc11f499d03bfb50f9b2f87a1d381db31954dd7ca5bb3
+size 745130


### PR DESCRIPTION
### Description

One test in Dashboard_spec.js was getting flaky because it was trying to grab some rss feed. 
This is an update so that the screenshot is no longer dependent on the content of the feed and is replaced in the test by something static.


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
