### PR TITLE
Embedded graphs in reports render with raw metrics.

### DIFF
--- a/plugins/ImageGraph/API.php
+++ b/plugins/ImageGraph/API.php
@@ -594,11 +594,11 @@ class API extends \Piwik\Plugin\API
 
     private static function parseOrdinateValue($ordinateValue): float
     {
-        if (is_int($ordinateValue) || is_float($ordinateValue)) {
+        if (is_numeric($ordinateValue)) {
             return (float) $ordinateValue;
         }
 
-        $ordinateValue = @str_replace(',', '.', (string) $ordinateValue);
+        $ordinateValue = str_replace(',', '.', (string) $ordinateValue);
 
         // convert hh:mm:ss formatted time values to number of seconds
         if (preg_match('/([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2}(\.[0-9]{2})?)/', $ordinateValue, $matches)) {
@@ -612,11 +612,11 @@ class API extends \Piwik\Plugin\API
         // OK, only numbers from here please (strip out currency sign)
         $ordinateValue = preg_replace('/[^0-9.]/', '', $ordinateValue);
 
-        if ($ordinateValue === null || $ordinateValue === '' || $ordinateValue === '.') {
+        if (empty($ordinateValue) || $ordinateValue === '.') {
             return 0.0;
         }
 
-        return is_numeric($ordinateValue) ? (float) $ordinateValue : 0.0;
+        return (float) $ordinateValue;
     }
 
     private static function getFontPath(string $font): string

--- a/plugins/ImageGraph/API.php
+++ b/plugins/ImageGraph/API.php
@@ -425,6 +425,7 @@ class API extends \Piwik\Plugin\API
                     'hideMetricsDoc' => false,
                     'idSubtable' => $idSubtable,
                     'showRawMetrics' => false,
+                    'format_metrics' => 0,
                 ];
                 /** @var array $processedReport */
                 $processedReport = Request::processRequest('API.getProcessedReport', $parameters);
@@ -470,8 +471,7 @@ class API extends \Piwik\Plugin\API
                     }
                     $i++;
                 }
-            } else // if the report has no dimension we have multiple reports each with only one row within the reportData
-            {
+            } else { // if the report has no dimension we have multiple reports each with only one row within the reportData
                 /** @var DataTable[] $periodsData */
                 $periodsData = array_values($reportData->getDataTables());
                 $periodsCount = count($periodsData);
@@ -592,9 +592,13 @@ class API extends \Piwik\Plugin\API
         $_GET['filter_truncate'] = PiwikRequest::fromRequest()->getIntegerParameter('filter_truncate', $default);
     }
 
-    private static function parseOrdinateValue($ordinateValue)
+    private static function parseOrdinateValue($ordinateValue): float
     {
-        $ordinateValue = @str_replace(',', '.', $ordinateValue);
+        if (is_int($ordinateValue) || is_float($ordinateValue)) {
+            return (float) $ordinateValue;
+        }
+
+        $ordinateValue = @str_replace(',', '.', (string) $ordinateValue);
 
         // convert hh:mm:ss formatted time values to number of seconds
         if (preg_match('/([0-9]{1,2}):([0-9]{1,2}):([0-9]{1,2}(\.[0-9]{2})?)/', $ordinateValue, $matches)) {
@@ -606,7 +610,13 @@ class API extends \Piwik\Plugin\API
         }
 
         // OK, only numbers from here please (strip out currency sign)
-        return preg_replace('/[^0-9.]/', '', $ordinateValue);
+        $ordinateValue = preg_replace('/[^0-9.]/', '', $ordinateValue);
+
+        if ($ordinateValue === null || $ordinateValue === '' || $ordinateValue === '.') {
+            return 0.0;
+        }
+
+        return is_numeric($ordinateValue) ? (float) $ordinateValue : 0.0;
     }
 
     private static function getFontPath(string $font): string

--- a/plugins/ImageGraph/tests/Unit/APITest.php
+++ b/plugins/ImageGraph/tests/Unit/APITest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Piwik\Plugins\ImageGraph\tests\Unit;
+
+use Piwik\Plugins\ImageGraph\API;
+use ReflectionMethod;
+
+/**
+ * @group ImageGraph
+ * @group APITest
+ */
+class APITest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider getOrdinateValuesToParse
+     */
+    public function testParseOrdinateValueReturnsFloat($value, float $expected): void
+    {
+        $method = new ReflectionMethod(API::class, 'parseOrdinateValue');
+
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        $actual = $method->invoke(null, $value);
+
+        $this->assertIsFloat($actual);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function getOrdinateValuesToParse(): array
+    {
+        return [
+            [2.05, 2.05],
+            ['2.05', 2.05],
+            [205, 205.0],
+            ['01:02:03.50', 3723.5],
+            ['', 0.0],
+        ];
+    }
+}


### PR DESCRIPTION
### Description

Addresses #24273 

When generating a report with embedded graphs in a language that uses different delimiters with numbers (e.g. '1.2' becomes '1,2'), the ImageGraph API was fetching metrics in the translated form, and using them to create the graphs to embed. Older PHP versions would implicitly handle these metrics (on PHP 7.2, '1,2' would be intepreted as 1), however newer PHP versions will hard fail on the `ceil()` method when passed a string.

This fix addresses this by first requesting raw metrics when generating the graph. This means that metrics should always be formatted in the standard style, which is intepreted by PHP type casting more consistently. Secondly, the method for processing ordinance values for the ImageGraph API has been hardened to always return a Float, which is what the graph generation code is expecting. 

Since the raw metrics are only used to generate the graph shape (bar size, line shape etc), the end user should not be able to see any difference.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
