### PR TITLE
Rebrand login page

### DIFF
--- a/plugins/Login/stylesheets/login.less
+++ b/plugins/Login/stylesheets/login.less
@@ -15,6 +15,9 @@
             max-height: 32px;
         }
     }
+    #logo:not(.center) {
+        padding-left: 16px;
+    }
 
     .message_container {
         margin-top: 16px;
@@ -40,11 +43,12 @@
 
         > .col {
             max-width: 750px;
+        }
+        > .col:not(.invite-form-section-div):not(.onboardingImage){
             float: none;
             margin-left: auto;
             margin-right: auto;
         }
-
         .icon.prefix {
             font-size: 1.5rem;
             width: 2.5rem;

--- a/plugins/Login/tests/UI/expected-screenshots/Invite_set_password.png
+++ b/plugins/Login/tests/UI/expected-screenshots/Invite_set_password.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7629a492340c03822a2c6aeb31a06a3ba4d08241c1015f698287dcfff81b4e1b
-size 81279
+oid sha256:2d7fc57fe43efda3e7587990c4a088e84b1ff696d14ae370217f4e242602a376
+size 78379

--- a/plugins/Login/tests/UI/expected-screenshots/Invite_wrong_password.png
+++ b/plugins/Login/tests/UI/expected-screenshots/Invite_wrong_password.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:da2e8ef95c5c8e8685c1073fd222fd9b20ed6482adf6678d981ca2d21b58af08
-size 86845
+oid sha256:64098830ebe61de6eef2bd0364ee3a12a008303652e7a4e78942e3ee0d90a460
+size 83348


### PR DESCRIPTION
### Description
DEV-20160

This is the pull request to fix the issue of the login page logo too close to the left side of the page. 
This also fixes the issue for accept invitation page image no longer aligned horzontally

### Acceptance Criteria:
 
 - Login logo moves to the right 16px
 - Accept invitation page is horizontally aligned

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
