### PR TITLE
Support --core-tests-only in test runner

### DIFF
--- a/plugins/TestRunner/Commands/TestsRunUI.php
+++ b/plugins/TestRunner/Commands/TestsRunUI.php
@@ -32,6 +32,7 @@ class TestsRunUI extends ConsoleCommand
         $this->addNoValueOption('assume-artifacts', null, "Assume the diffviewer and processed screenshots will be stored on the builds artifacts server. For use with CI build.");
         $this->addRequiredValueOption('plugin', null, "Execute all tests for a plugin.");
         $this->addNoValueOption('core', null, "Execute only tests for Piwik core & core plugins.");
+        $this->addNoValueOption('core-tests-only', null, 'Execute only tests from tests/UI and skip plugin UI specs.');
         $this->addNoValueOption('skip-delete-assets', null, "Skip deleting of merged assets (will speed up a test run, but not by a lot).");
         $this->addNoValueOption('skip-screenshots', null, 'Run UI tests without image diff assertions (local functional debugging).');
         $this->addNoValueOption('screenshot-repo', null, "For tests");
@@ -55,6 +56,7 @@ class TestsRunUI extends ConsoleCommand
         $plugin = $input->getOption('plugin');
         $skipDeleteAssets = $input->getOption('skip-delete-assets');
         $core = $input->getOption('core');
+        $coreTestsOnly = $input->getOption('core-tests-only');
         $extraOptions = $input->getOption('extra-options');
         $storeInUiTestsRepo = $input->getOption('store-in-ui-tests-repo');
         $screenshotRepo = $input->getOption('screenshot-repo');
@@ -103,6 +105,10 @@ class TestsRunUI extends ConsoleCommand
 
         if ($core && !$plugin) {
             $options[] = "--core";
+        }
+
+        if ($coreTestsOnly) {
+            $options[] = '--core-tests-only';
         }
 
         if ($storeInUiTestsRepo) {

--- a/plugins/TestRunner/Commands/TestsRunUI.php
+++ b/plugins/TestRunner/Commands/TestsRunUI.php
@@ -101,7 +101,7 @@ class TestsRunUI extends ConsoleCommand
             $options[] = "--plugin=" . $plugin;
         }
 
-        if ($core) {
+        if ($core && !$plugin) {
             $options[] = "--core";
         }
 

--- a/tests/lib/screenshot-testing/support/app.js
+++ b/tests/lib/screenshot-testing/support/app.js
@@ -79,6 +79,7 @@ Application.prototype.printHelpAndExit = function () {
     console.log("  --screenshot-repo:        Specifies the GitHub repository that contains the expected screenshots");
     console.log("                            to link to in the diffviewer. For use with CI build.");
     console.log("  --core:                   Only execute UI tests that are for Matomo core or Matomo core plugins.");
+    console.log("  --core-tests-only:        Only execute UI tests from tests/UI and skip plugin UI specs.");
     console.log("  --num-test-groups:        Divide all test execution into this many overall groups. Use --test-group to pick which group to run in this execution.");
     console.log("  --test-group:             The test group to run.");
 
@@ -143,10 +144,12 @@ Application.prototype.loadTestModules = function () {
         });
     }
 
-    plugins.forEach(function (pluginPath) {
-        walk(path.join(pluginPath, 'Test'), /_spec\.js$/, modulePaths);
-        walk(path.join(pluginPath, 'tests'), /_spec\.js$/, modulePaths);
-    });
+    if (!options['core-tests-only']) {
+        plugins.forEach(function (pluginPath) {
+            walk(path.join(pluginPath, 'Test'), /_spec\.js$/, modulePaths);
+            walk(path.join(pluginPath, 'tests'), /_spec\.js$/, modulePaths);
+        });
+    }
 
     modulePaths.forEach(function (path) {
         self.currentModulePath = path;

--- a/tests/lib/screenshot-testing/support/app.js
+++ b/tests/lib/screenshot-testing/support/app.js
@@ -131,7 +131,7 @@ Application.prototype.loadTestModules = function () {
     // load all UI tests we can find
     var modulePaths = walk(uiTestsDir, /_spec\.js$/);
 
-    if (options.core && !options['store-in-ui-tests-repo']) {
+    if (options.core && !options.plugin) {
         plugins = plugins.filter(function (path) {
             return isCorePlugin(path);
         });


### PR DESCRIPTION
### Description

In preparation of having multiple GH actions for UI tests and splitting between core/plugins.

This adds the option of `core-tests-only` which executes only the UI tests for core, not bundled plugins.

In addition there is a small bug fix:

 In TestsRunUI.php, do not forward --core when --plugin is also set.
      - In support/app.js, do not apply core-plugin filtering when options.plugin is set.
      - Reason: --plugin is a more specific selector. Today, forwarding both can filter the plugin list before plugin matching runs, which can exclude git-backed/submodule plugins and. result in no suites loading.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
