### PR TITLE
Reset fixture between suites

### DIFF
--- a/plugins/PrivacyManager/tests/UI/PrivacyManager_SiteSpecific_spec.js
+++ b/plugins/PrivacyManager/tests/UI/PrivacyManager_SiteSpecific_spec.js
@@ -13,9 +13,37 @@ describe("PrivacyManager_SiteSpecific", function () {
     var generalParams = 'idSite=1&period=day&date=2017-01-02',
         urlBase = '?module=SitesManager&' + generalParams + '&action=';
 
+    async function resetSiteSpecificPrivacySettings()
+    {
+        // Persisted UI test runs can reuse a dirty fixture, so make sure the site-specific
+        // privacy settings for the sites we touch always start from the baseline fixture state.
+        for (const idSiteSpecific of [1, 2]) {
+            await testEnvironment.callApi('PrivacyManager.setAnonymizeIpSettings', {
+                anonymizeIPEnable: false,
+                ipAddressMaskLength: 0,
+                useAnonymizedIpForVisitEnrichment: false,
+                anonymizeUserId: false,
+                anonymizeOrderId: false,
+                anonymizeReferrer: '',
+                forceCookielessTracking: false,
+                randomizeConfigId: false,
+                idSiteSpecific,
+                useSiteSpecificSettings: false,
+            });
+        }
+    }
+
     before(function () {
         testEnvironment.pluginsToLoad = ['PrivacyManager'];
         testEnvironment.save();
+    });
+
+    before(async function () {
+        await resetSiteSpecificPrivacySettings();
+    });
+
+    after(async function () {
+        await resetSiteSpecificPrivacySettings();
     });
 
     async function loadBasePage()

--- a/plugins/PrivacyManager/tests/UI/PrivacyManager_SiteSpecific_spec.js
+++ b/plugins/PrivacyManager/tests/UI/PrivacyManager_SiteSpecific_spec.js
@@ -13,8 +13,19 @@ describe("PrivacyManager_SiteSpecific", function () {
     var generalParams = 'idSite=1&period=day&date=2017-01-02',
         urlBase = '?module=SitesManager&' + generalParams + '&action=';
 
-    async function resetSiteSpecificPrivacySettings()
+    async function resetPrivacySettings()
     {
+        await testEnvironment.callApi('PrivacyManager.setAnonymizeIpSettings', {
+            anonymizeIPEnable: false,
+            ipAddressMaskLength: 0,
+            useAnonymizedIpForVisitEnrichment: false,
+            anonymizeUserId: false,
+            anonymizeOrderId: false,
+            anonymizeReferrer: '',
+            forceCookielessTracking: false,
+            randomizeConfigId: false,
+        });
+
         // Persisted UI test runs can reuse a dirty fixture, so make sure the site-specific
         // privacy settings for the sites we touch always start from the baseline fixture state.
         for (const idSiteSpecific of [1, 2]) {
@@ -33,17 +44,14 @@ describe("PrivacyManager_SiteSpecific", function () {
         }
     }
 
-    before(function () {
-        testEnvironment.pluginsToLoad = ['PrivacyManager'];
-        testEnvironment.save();
-    });
-
     before(async function () {
-        await resetSiteSpecificPrivacySettings();
+        testEnvironment.pluginsToLoad = ['PrivacyManager'];
+        await testEnvironment.save();
+        await resetPrivacySettings();
     });
 
     after(async function () {
-        await resetSiteSpecificPrivacySettings();
+        await resetPrivacySettings();
     });
 
     async function loadBasePage()

--- a/plugins/PrivacyManager/tests/UI/PrivacyManager_spec.js
+++ b/plugins/PrivacyManager/tests/UI/PrivacyManager_spec.js
@@ -13,9 +13,35 @@ describe("PrivacyManager", function () {
     var generalParams = 'idSite=1&period=day&date=2017-01-02',
         urlBase = '?module=PrivacyManager&' + generalParams + '&action=';
 
+    async function resetSiteSpecificPrivacySettings()
+    {
+        for (const idSiteSpecific of [1, 2]) {
+            await testEnvironment.callApi('PrivacyManager.setAnonymizeIpSettings', {
+                anonymizeIPEnable: false,
+                ipAddressMaskLength: 0,
+                useAnonymizedIpForVisitEnrichment: false,
+                anonymizeUserId: false,
+                anonymizeOrderId: false,
+                anonymizeReferrer: '',
+                forceCookielessTracking: false,
+                randomizeConfigId: false,
+                idSiteSpecific,
+                useSiteSpecificSettings: false,
+            });
+        }
+    }
+
     before(function () {
         testEnvironment.pluginsToLoad = ['PrivacyManager'];
         testEnvironment.save();
+    });
+
+    before(async function () {
+        await resetSiteSpecificPrivacySettings();
+    });
+
+    after(async function () {
+        await resetSiteSpecificPrivacySettings();
     });
 
     async function setAnonymizeStartEndDate()

--- a/plugins/PrivacyManager/tests/UI/PrivacyManager_spec.js
+++ b/plugins/PrivacyManager/tests/UI/PrivacyManager_spec.js
@@ -13,8 +13,19 @@ describe("PrivacyManager", function () {
     var generalParams = 'idSite=1&period=day&date=2017-01-02',
         urlBase = '?module=PrivacyManager&' + generalParams + '&action=';
 
-    async function resetSiteSpecificPrivacySettings()
+    async function resetPrivacySettings()
     {
+        await testEnvironment.callApi('PrivacyManager.setAnonymizeIpSettings', {
+            anonymizeIPEnable: false,
+            ipAddressMaskLength: 0,
+            useAnonymizedIpForVisitEnrichment: false,
+            anonymizeUserId: false,
+            anonymizeOrderId: false,
+            anonymizeReferrer: '',
+            forceCookielessTracking: false,
+            randomizeConfigId: false,
+        });
+
         for (const idSiteSpecific of [1, 2]) {
             await testEnvironment.callApi('PrivacyManager.setAnonymizeIpSettings', {
                 anonymizeIPEnable: false,
@@ -31,17 +42,14 @@ describe("PrivacyManager", function () {
         }
     }
 
-    before(function () {
-        testEnvironment.pluginsToLoad = ['PrivacyManager'];
-        testEnvironment.save();
-    });
-
     before(async function () {
-        await resetSiteSpecificPrivacySettings();
+        testEnvironment.pluginsToLoad = ['PrivacyManager'];
+        await testEnvironment.save();
+        await resetPrivacySettings();
     });
 
     after(async function () {
-        await resetSiteSpecificPrivacySettings();
+        await resetPrivacySettings();
     });
 
     async function setAnonymizeStartEndDate()


### PR DESCRIPTION
### Description

Fix PrivacyManager UI tests when running under --plugin

This change fixes a UI test state leak that showed up when PrivacyManager was run as an isolated plugin job in CI.

Why it happened:

  - The screenshot test runner treats PrivacyManager and --plugin=PrivacyManager differently.
  - Passing the suite name alone runs the matching suite, but --plugin=PrivacyManager switches the runner into plugin mode and reuses persisted fixture state differently.
  - Under --persist-fixture-data, that let PrivacyManager settings from previous tests carry into later runs, which caused Anonymize Order ID and Anonymize Referrer to appear in the wrong state.

  How to reproduce:

  - ddev matomo:console tests:run-ui PrivacyManager --persist-fixture-data
  - ddev matomo:console tests:run-ui --plugin=PrivacyManager --persist-fixture-data

  What changed:

  - Reset PrivacyManager instance-level settings and site-specific overrides before and after the affected UI suites.
  - This keeps the screenshot tests self-contained even when fixture data is persisted across runs.

  Why this matters:

  - CI is being split to target individual plugins, so these tests need to behave correctly when PrivacyManager runs in isolation instead of as part of a larger shared UI batch.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
