### PR TITLE
Fix marketplace test leakage 

### DIFF
--- a/plugins/Marketplace/tests/Fixtures/SimpleFixtureTrackFewVisits.php
+++ b/plugins/Marketplace/tests/Fixtures/SimpleFixtureTrackFewVisits.php
@@ -10,30 +10,17 @@
 namespace Piwik\Plugins\Marketplace\tests\Fixtures;
 
 use Piwik\Date;
-use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Fixtures\UITestFixture;
 
-class SimpleFixtureTrackFewVisits extends Fixture
+class SimpleFixtureTrackFewVisits extends UITestFixture
 {
     public $dateTime = '2013-01-23 01:23:45';
     public $idSite = 1;
 
     public function setUp(): void
     {
-        $this->setUpWebsite();
+        parent::setUp();
         $this->trackVisits();
-    }
-
-    public function tearDown(): void
-    {
-        // empty
-    }
-
-    private function setUpWebsite()
-    {
-        if (!self::siteCreated($this->idSite)) {
-            $idSite = self::createWebsite($this->dateTime, $ecommerce = 1);
-            $this->assertSame($this->idSite, $idSite);
-        }
     }
 
     protected function trackVisits()

--- a/plugins/Marketplace/tests/Fixtures/SimpleFixtureTrackFewVisits.php
+++ b/plugins/Marketplace/tests/Fixtures/SimpleFixtureTrackFewVisits.php
@@ -10,17 +10,30 @@
 namespace Piwik\Plugins\Marketplace\tests\Fixtures;
 
 use Piwik\Date;
-use Piwik\Tests\Fixtures\UITestFixture;
+use Piwik\Tests\Framework\Fixture;
 
-class SimpleFixtureTrackFewVisits extends UITestFixture
+class SimpleFixtureTrackFewVisits extends Fixture
 {
     public $dateTime = '2013-01-23 01:23:45';
     public $idSite = 1;
 
     public function setUp(): void
     {
-        parent::setUp();
+        $this->setUpWebsite();
         $this->trackVisits();
+    }
+
+    public function tearDown(): void
+    {
+        // empty
+    }
+
+    private function setUpWebsite()
+    {
+        if (!self::siteCreated($this->idSite)) {
+            $idSite = self::createWebsite($this->dateTime, $ecommerce = 1);
+            $this->assertSame($this->idSite, $idSite);
+        }
     }
 
     protected function trackVisits()

--- a/plugins/Marketplace/tests/UI/Marketplace_RequestTrial_spec.js
+++ b/plugins/Marketplace/tests/UI/Marketplace_RequestTrial_spec.js
@@ -22,12 +22,22 @@ describe('Marketplace_RequestTrial', function () {
     testEnvironment.save();
   });
 
-  after(function(){
+  after(async function () {
     delete testEnvironment.consumer;
     delete testEnvironment.fakeIdentity;
     delete testEnvironment.idSitesViewAccess;
     delete testEnvironment.mockMarketplaceApiService;
+
+    // The success-notification test persists Marketplace.PluginTrialRequest.PaidPlugin1
+    // in the option table. With --persist-fixture-data the option survives into sibling
+    // specs sharing this fixture's DB and makes user-mode CTAs render "Trial Requested"
+    // instead of "Request Trial". Wipe it via optionsOverride.
+    testEnvironment.optionsOverride = testEnvironment.optionsOverride || {};
+    testEnvironment.optionsOverride['Marketplace.PluginTrialRequest.PaidPlugin1'] = '[]';
     testEnvironment.save();
+
+    // optionsOverride is applied during proxy bootstrap; trigger one request.
+    await page.goto('?module=API&method=API.getMatomoVersion&format=json');
   });
 
   it('should display a "request trial" button', async function () {


### PR DESCRIPTION
### Description

  Fixes 3 user-mode screenshot failures in the Marketplace plugin's UI suite when run under --plugin=Marketplace:

  - Marketplace_paid_plugins_no_license_user.png
  - Marketplace_paid_plugin_details_no_license_user.png
  - Marketplace_paid_plugin_details_add_to_cart_user.png

  These failures only appeared after the UI-test split that his PR is targetting.

You can see now in this run that the marketplace tests are passing when run in isolation with --plugin:

https://github.com/matomo-org/matomo/actions/runs/25407712989/job/74522428394?pr=24490

And here is where it failed previously:
https://github.com/matomo-org/matomo/actions/runs/25357300992/job/74349172292

**This PR is targetting the branch that will have the UI tests split up and hopefully all working per plugin, so the rest of the CI in this PR shouldnt need to pass**

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
