### PR TITLE
Clean up PrivacyManager site-specific privacy state leaks

### DIFF
--- a/plugins/PrivacyManager/tests/UI/PrivacyManager_SiteSpecific_spec.js
+++ b/plugins/PrivacyManager/tests/UI/PrivacyManager_SiteSpecific_spec.js
@@ -18,6 +18,46 @@ describe("PrivacyManager_SiteSpecific", function () {
         testEnvironment.save();
     });
 
+    after(async function () {
+        // The "should show site-specific settings defaulting to instance-level..."
+        // tests use testEnvironment.optionsOverride to write PrivacyManager.* rows
+        // to the option table, then reset optionsOverride to {}. That stops future
+        // bootstraps from re-setting them, but the rows already written stay. Under
+        // --plugin=PrivacyManager --persist-fixture-data the next spec sharing this
+        // fixture DB (PrivacyManager_spec) then renders privacy settings with leaked
+        // mask length, anonymize order id and anonymize referrer values. Re-apply
+        // fixture-matching values so the following bootstraps overwrite the leaks.
+        // randomizeConfigId is intentionally omitted because PrivacyManager_spec
+        // saves it via the form and would be reset on every reload otherwise.
+        testEnvironment.optionsOverride = testEnvironment.optionsOverride || {};
+        testEnvironment.optionsOverride['PrivacyManager.ipAnonymizerEnabled'] = '0';
+        testEnvironment.optionsOverride['PrivacyManager.ipAddressMaskLength'] = '0';
+        testEnvironment.optionsOverride['PrivacyManager.useAnonymizedIpForVisitEnrichment'] = '0';
+        testEnvironment.optionsOverride['PrivacyManager.doNotTrackEnabled'] = '0';
+        testEnvironment.optionsOverride['PrivacyManager.anonymizeUserId'] = '0';
+        testEnvironment.optionsOverride['PrivacyManager.anonymizeOrderId'] = '0';
+        testEnvironment.optionsOverride['PrivacyManager.anonymizeReferrer'] = '';
+        testEnvironment.save();
+
+        // The "should save site-specific" / "...for site 2" tests write per-site
+        // rows like PrivacyManager.idSite(N).%. Config::useSiteSpecificSettings()
+        // returns true while any such row exists, so even values that match the
+        // defaults still flip the compliance page rendering. optionsOverride can
+        // only Option::set, so call setAnonymizeIpSettings with
+        // useSiteSpecificSettings=false to invoke Config::removeForSite() and
+        // delete every row under that prefix. Each call also bootstraps the
+        // proxy, applying the instance-level overrides above.
+        for (const idSiteSpecific of [1, 2]) {
+            await testEnvironment.callApi('PrivacyManager.setAnonymizeIpSettings', {
+                anonymizeIPEnable: false,
+                ipAddressMaskLength: 0,
+                useAnonymizedIpForVisitEnrichment: false,
+                idSiteSpecific,
+                useSiteSpecificSettings: false,
+            });
+        }
+    });
+
     async function loadBasePage()
     {
         await page.goto(urlBase);


### PR DESCRIPTION
Fixes 7 screenshot failures in the PrivacyManager plugin's UI suite when run under --plugin=PrivacyManager:

  - PrivacyManager_privacy_settings_default.png
  - PrivacyManager_config_id_randomisation_on_password_required.png
  - PrivacyManager_config_id_randomisation_on.png
  - PrivacyManager_config_id_randomisation_off_password_not_required.png
  - PrivacyManager_compliance.png
  - PrivacyManager_compliance_enforced.png
  - PrivacyManager_compliance_different_site.png

  These failures only appeared after the UI-test split that this PR is targetting.

  You can see now in this run that the PrivacyManager tests are passing when run in isolation with --plugin:

  And here is where it failed previously:
  https://github.com/matomo-org/matomo/actions/runs/25357300992/job/74349172339
  
  Successful in this run here:
  https://github.com/matomo-org/matomo/actions/runs/25410460043/job/74530861604?pr=24496

  Root cause: 

under --persist-fixture-data PrivacyManager_SiteSpecific_spec and PrivacyManager_spec share the same fixture DB. SiteSpecific writes instance-level PrivacyManager.* options via testEnvironment.optionsOverride and per-site PrivacyManager.idSite(N).% rows via the per-site Save form. Resetting optionsOverride to {} only stops further bootstraps from re-applying the values; the rows already written by Option::set persist and flip the privacy settings and compliance pages rendered by PrivacyManager_spec.

  Fix: an after hook on PrivacyManager_SiteSpecific_spec re-applies fixture-matching values via optionsOverride for the leaked instance-level options, and calls PrivacyManager.setAnonymizeIpSettings useSiteSpecificSettings=false for sites 1 and 2 to invoke Config::removeForSite() and delete every PrivacyManager.idSite(N).% randomizeConfigId is intentionally omitted so PrivacyManager_spec's randomizeConfigId tests
  aren't reset on every reload.

  This PR is targetting the branch that will have the UI tests split up and hopefully all working per plugin, so the rest of the CI in this PR shouldn't need to pass.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
