### PR TITLE
add normalisation for bulk archive requests to avoid permission failure

### DIFF
--- a/plugins/API/tests/Integration/APITest.php
+++ b/plugins/API/tests/Integration/APITest.php
@@ -431,8 +431,7 @@ class APITest extends IntegrationTestCase
         ?string $tokenAuth = null,
         string $method = 'CoreAdminHome.archiveReports',
         string $module = 'API'
-    ): string
-    {
+    ): string {
         $params = [
             'module' => $module,
             'method' => $method,

--- a/plugins/API/tests/Integration/APITest.php
+++ b/plugins/API/tests/Integration/APITest.php
@@ -161,6 +161,25 @@ class APITest extends IntegrationTestCase
         }
     }
 
+    public function testGetBulkRequestWithHtmlEntityMethodDeniesArchiveReportsForViewOnlyUser()
+    {
+        $this->setAnonymousAccessForSite(1, 'view');
+
+        try {
+            $response = $this->processRootApiRequest([
+                'module' => 'API',
+                'method' => 'API.getBulkRequest',
+                'format' => 'json',
+                'urls' => [$this->makeArchiveReportsBulkUrl(1, null, 'CoreAdminHome.&#97;rchiveReports', 'CoreHome')],
+            ]);
+
+            $this->assertCount(1, $response);
+            $this->assertResponseIsSuperUserPermissionError($response[0]);
+        } finally {
+            $this->restoreAnonymousAccessForSite(1);
+        }
+    }
+
     public function testGetBulkRequestAllowsArchiveReportsForSuperUser()
     {
         $this->setSuperUserContext();
@@ -407,9 +426,15 @@ class APITest extends IntegrationTestCase
         }
     }
 
-    private function makeArchiveReportsBulkUrl(int $idSite, ?string $tokenAuth = null, string $method = 'CoreAdminHome.archiveReports'): string
+    private function makeArchiveReportsBulkUrl(
+        int $idSite,
+        ?string $tokenAuth = null,
+        string $method = 'CoreAdminHome.archiveReports',
+        string $module = 'API'
+    ): string
     {
         $params = [
+            'module' => $module,
             'method' => $method,
             'idSite' => $idSite,
             'period' => 'day',

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -18,6 +18,7 @@ use Piwik\Access;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\ArchiveProcessor;
 use Piwik\Config;
+use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Archive\ArchiveInvalidator;
 use Piwik\CronArchive;
@@ -401,12 +402,17 @@ class API extends \Piwik\Plugin\API
 
     private function shouldRequireSuperUserForArchiveReports(): bool
     {
-        $rootApiMethod = trim(Request::getRootApiRequestMethod() ?: '');
-        $currentApiMethod = trim(PiwikRequest::fromRequest()->getStringParameter('method', ''));
+        $rootApiMethod = $this->normalizeApiMethodName(Request::getRootApiRequestMethod() ?: '');
+        $currentApiMethod = $this->normalizeApiMethodName(PiwikRequest::fromRequest()->getStringParameter('method', ''));
 
         // Require superuser for direct archiveReports calls and archiveReports inside bulk requests.
         return $rootApiMethod === 'CoreAdminHome.archiveReports'
             || ($rootApiMethod === 'API.getBulkRequest' && $currentApiMethod === 'CoreAdminHome.archiveReports');
+    }
+
+    private function normalizeApiMethodName(string $method): string
+    {
+        return preg_replace('/[^\w\.]+/', '', Common::sanitizeInputValue($method));
     }
 
     /**


### PR DESCRIPTION
### Description

Closes an issue where malformed request methods can be used to trigger bulk archives without the correct permission level.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
