### PR TITLE
harden RSS rendering to properly escape values

### DIFF
--- a/core/DataTable/Renderer/Rss.php
+++ b/core/DataTable/Renderer/Rss.php
@@ -161,7 +161,7 @@ class Rss extends Renderer
                 if ($this->translateColumnNames) {
                     $name = $this->translateColumnName($name);
                 }
-                $html .= "\n\t<td><strong>$name</strong></td>";
+                $html .= "\n\t<td><strong>" . self::formatValueXml($name) . "</strong></td>";
             }
         }
         $html .= "\n</tr>";
@@ -172,7 +172,7 @@ class Rss extends Renderer
                 if ($toDisplay !== false) {
                     $value = "-";
                     if (isset($row[$columnName])) {
-                        $value = urldecode($row[$columnName]);
+                        $value = self::formatValueXml(urldecode($row[$columnName]));
                     }
 
                     $html .= "\n\t<td>$value</td>";

--- a/core/DataTable/Renderer/Rss.php
+++ b/core/DataTable/Renderer/Rss.php
@@ -70,7 +70,7 @@ class Rss extends Renderer
             $dateInSiteTimezone = $dateInSiteTimezone->toString('Y-m-d');
             $thisPiwikUrl = Common::sanitizeInputValue($piwikUrl . "&date=$dateInSiteTimezone");
             $siteName = $site ? $site->getName() : '';
-            $title = $siteName . " on " . $date;
+            $title = self::formatValueXml($siteName . " on " . $date);
 
             $out .= "\t<item>
 		<pubDate>$pudDate</pubDate>


### PR DESCRIPTION
### Description

Aligns RSS rendering to escape values in the same way that HTML rendering does.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
