### PR TITLE
Unsanitize row evolution pretty labels

### DIFF
--- a/plugins/API/RowEvolution.php
+++ b/plugins/API/RowEvolution.php
@@ -586,7 +586,7 @@ class RowEvolution
 
                     $prettyLabel = $labelRow->getColumn('label_html');
                     if ($prettyLabel !== false) {
-                        $actualLabels[$labelIdx] = $prettyLabel;
+                        $actualLabels[$labelIdx] = Common::unsanitizeInputValue($prettyLabel);
                     } elseif (!empty($labelPretty[$labelIdx])) {
                         $actualLabels[$labelIdx] = $labelPretty[$labelIdx];
                     }

--- a/plugins/CoreHome/DataTableRowAction/RowEvolution.php
+++ b/plugins/CoreHome/DataTableRowAction/RowEvolution.php
@@ -496,7 +496,7 @@ class RowEvolution
             $labelPretty = array_filter($labelPretty, 'strlen');
             $labelPretty = current($labelPretty);
             if (!empty($labelPretty)) {
-                return $labelPretty;
+                return Common::unsanitizeInputValue($labelPretty);
             }
         }
         return $rowLabel;


### PR DESCRIPTION
Fix double-encoded row evolution labels by unsanitizing `label_html` before it is reused in the row evolution UI and API response. This keeps the existing safe-decoding behavior for normal labels and only removes the extra encoding layer that shows up as `&amp;quot;` in the rendered output.

I could not run PHP syntax checks in this environment because `php` is not installed here, but the change is intentionally narrow and only touches the row-evolution label display path.