### PR TITLE
Fix top menu item spacing to match left menu

### DIFF
--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -69,10 +69,10 @@ ul.browser-default {
     margin-right: 4px;
 
     .navbar-icon {
-      padding: 8px;
+      padding: 8px 12px;
     }
     .navbar-label {
-      padding: 4px;
+      padding: 8px 12px;
     }
     .navbar-label, .navbar-icon {
       position: relative;


### PR DESCRIPTION
## Summary

- Top-bar labels were rendered with `padding: 4px`, which made the active/hover pill too tight (see screenshots in the issue).
- Aligns `.navbar-label` and `.navbar-icon` to `padding: 8px 12px`, matching the left menu's `.item` rule in the same file.
- The hover/active background is drawn via `&::after { inset: 0 }`, so it follows the padded box and now produces the comfortable pill shown in the "what should happen" screenshot.

Fixes #24463

## Test plan

- [x] Manually verify the top menu pills (Reporting, Personal, Administration, …) match the left menu padding on a Matomo page.
- [x] Hover + active states render a pill of the same height as the left menu items.
- [ ] No regression on the icon-only items in the top bar (notifications, language, etc.).
- [ ] UI screenshot tests: expect baseline updates wherever the top bar is captured.