### PR TITLE
Split IntegrationTestsCore, IntegrationsTestsPlugins and SystemTestsPlugins into multiple tasks

### DIFF
--- a/.github/scripts/list-bucket-tests.php
+++ b/.github/scripts/list-bucket-tests.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Naive round-robin test bucketing for Matomo's PHPUnit suites.
+ *
+ * Reads tests/PHPUnit/phpunit.xml.dist, expands the requested testsuite's
+ * <directory> globs against the live filesystem (so newly added test files
+ * are picked up automatically), removes anything matched by the suite's
+ * <exclude> rules, sorts alphabetically for a stable bucketing, then keeps
+ * files where index % bucket-count == bucket-index.
+ *
+ * Two output modes:
+ *   --list                 print the bucket's file paths to stdout
+ *   --write-xml=<path>     write a self-contained phpunit XML mirroring
+ *                          phpunit.xml.dist with a single
+ *                          <testsuite name="Bucket"> listing this bucket's
+ *                          files as <file> entries
+ *
+ * Supported suites: IntegrationTestsCore, IntegrationTestsPlugins,
+ * SystemTestsPlugins. The script rejects others so a typo in the workflow
+ * fails loudly.
+ */
+
+declare(strict_types=1);
+
+const SUPPORTED_SUITES = [
+    'IntegrationTestsCore',
+    'IntegrationTestsPlugins',
+    'SystemTestsPlugins',
+];
+
+function fail(string $msg, int $code = 2): void
+{
+    fwrite(STDERR, "list-bucket-tests: $msg\n");
+    exit($code);
+}
+
+if ($argc < 5) {
+    fail(
+        "usage: php list-bucket-tests.php <suite> <bucket-index> <bucket-count> "
+        . "--list | --write-xml=<path>"
+    );
+}
+
+[$suite, $bucketIndex, $bucketCount, $mode] = [$argv[1], (int) $argv[2], (int) $argv[3], $argv[4]];
+
+if (!in_array($suite, SUPPORTED_SUITES, true)) {
+    fail("suite '$suite' not supported. Allowed: " . implode(', ', SUPPORTED_SUITES));
+}
+if ($bucketCount < 1) {
+    fail("bucket-count must be >= 1");
+}
+if ($bucketIndex < 0 || $bucketIndex >= $bucketCount) {
+    fail("bucket-index must be in [0, bucket-count-1]");
+}
+
+$repoRoot      = realpath(__DIR__ . '/../..');
+$phpunitDir    = $repoRoot . '/tests/PHPUnit';
+$phpunitConfig = $phpunitDir . '/phpunit.xml.dist';
+
+if (!is_file($phpunitConfig)) {
+    fail("cannot find $phpunitConfig");
+}
+
+$xml = simplexml_load_file($phpunitConfig);
+if ($xml === false) {
+    fail("failed to parse $phpunitConfig");
+}
+
+$target = null;
+foreach ($xml->testsuites->testsuite as $ts) {
+    if ((string) $ts['name'] === $suite) {
+        $target = $ts;
+        break;
+    }
+}
+if ($target === null) {
+    fail("suite '$suite' not declared in phpunit.xml.dist");
+}
+
+$files = collect_files($phpunitDir, $target);
+sort($files, SORT_STRING);
+
+$bucket = [];
+foreach ($files as $i => $f) {
+    if ($i % $bucketCount === $bucketIndex) {
+        $bucket[] = $f;
+    }
+}
+
+if ($mode === '--list') {
+    foreach ($bucket as $f) {
+        echo $f . "\n";
+    }
+    exit(0);
+}
+
+if (strncmp($mode, '--write-xml=', 12) === 0) {
+    $outPath = substr($mode, 12);
+    if ($outPath === '') {
+        fail("--write-xml requires a path");
+    }
+    write_bucket_xml($phpunitConfig, $outPath, $bucket);
+    fwrite(
+        STDERR,
+        sprintf(
+            "list-bucket-tests: wrote %d files (suite=%s, bucket=%d/%d) to %s\n",
+            count($bucket),
+            $suite,
+            $bucketIndex,
+            $bucketCount,
+            $outPath
+        )
+    );
+    exit(0);
+}
+
+fail("unknown mode '$mode'");
+
+/**
+ * Walks the suite's <directory> entries and gathers every *Test.php file
+ * underneath, minus anything covered by an <exclude>.
+ */
+function collect_files(string $phpunitDir, SimpleXMLElement $suite): array
+{
+    $found = [];
+    foreach ($suite->directory as $dir) {
+        $pattern = trim((string) $dir);
+        foreach (glob_dirs($phpunitDir, $pattern) as $rootDir) {
+            foreach (recursive_test_files($rootDir) as $file) {
+                $found[$file] = true;
+            }
+        }
+    }
+
+    foreach ($suite->exclude as $excl) {
+        $pattern = trim((string) $excl);
+        foreach (glob_dirs($phpunitDir, $pattern) as $excludeDir) {
+            $excludeReal = realpath($excludeDir);
+            if ($excludeReal === false) {
+                continue;
+            }
+            $prefix = rtrim($excludeReal, '/') . '/';
+            foreach (array_keys($found) as $f) {
+                if (strncmp($f, $prefix, strlen($prefix)) === 0) {
+                    unset($found[$f]);
+                }
+            }
+        }
+    }
+
+    return array_keys($found);
+}
+
+/**
+ * Resolves a phpunit.xml-style directory pattern (relative to tests/PHPUnit/)
+ * to absolute directory paths. PHP's glob() handles `*` in middle path
+ * segments via libc, so plugins/* /tests/Integration expands directly.
+ */
+function glob_dirs(string $baseDir, string $relativePattern): array
+{
+    $absolute = $baseDir . '/' . $relativePattern;
+    $matches  = glob($absolute, GLOB_ONLYDIR | GLOB_NOSORT);
+    if ($matches === false) {
+        return [];
+    }
+    $out = [];
+    foreach ($matches as $m) {
+        $real = realpath($m);
+        if ($real !== false) {
+            $out[] = $real;
+        }
+    }
+    return $out;
+}
+
+function recursive_test_files(string $rootDir): array
+{
+    if (!is_dir($rootDir)) {
+        return [];
+    }
+    $out = [];
+    $it  = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($rootDir, FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($it as $info) {
+        /** @var SplFileInfo $info */
+        if ($info->isFile() && substr($info->getFilename(), -8) === 'Test.php') {
+            $out[] = $info->getPathname();
+        }
+    }
+    return $out;
+}
+
+/**
+ * Emits a phpunit config cloned from phpunit.xml.dist with the entire
+ * <testsuites> block replaced by a single <testsuite name="Bucket"> whose
+ * <file> children are this bucket's files (relative to the new XML's dir,
+ * so PHPUnit resolves them the same way it would resolve <directory>).
+ *
+ * Keeping the rest of the config verbatim (bootstrap, attributes, <filter>)
+ * means the bucket run behaves identically to the unsplit run for everything
+ * other than test selection.
+ */
+function write_bucket_xml(string $sourceConfig, string $outPath, array $files): void
+{
+    $dom                     = new DOMDocument('1.0', 'UTF-8');
+    $dom->preserveWhiteSpace = false;
+    $dom->formatOutput       = true;
+    if (!$dom->load($sourceConfig)) {
+        fail("failed to load $sourceConfig for cloning");
+    }
+
+    $testsuites = $dom->getElementsByTagName('testsuites')->item(0);
+    if ($testsuites === null) {
+        fail("source phpunit config has no <testsuites>");
+    }
+    while ($testsuites->firstChild) {
+        $testsuites->removeChild($testsuites->firstChild);
+    }
+
+    $bucketSuite = $dom->createElement('testsuite');
+    $bucketSuite->setAttribute('name', 'Bucket');
+    $testsuites->appendChild($bucketSuite);
+
+    $outDirReal = resolve_dir_for_output($outPath);
+    foreach ($files as $absoluteFile) {
+        $rel = make_relative($outDirReal, $absoluteFile);
+        $bucketSuite->appendChild($dom->createElement('file', $rel));
+    }
+
+    if ($dom->save($outPath) === false) {
+        fail("failed to write $outPath");
+    }
+}
+
+function resolve_dir_for_output(string $outPath): string
+{
+    $dir     = dirname($outPath);
+    $dirReal = realpath($dir);
+    if ($dirReal !== false) {
+        return $dirReal;
+    }
+    if (!mkdir($dir, 0777, true) && !is_dir($dir)) {
+        fail("cannot create output directory $dir");
+    }
+    $dirReal = realpath($dir);
+    if ($dirReal === false) {
+        fail("cannot resolve output directory $dir");
+    }
+    return $dirReal;
+}
+
+function make_relative(string $fromDir, string $toPath): string
+{
+    $fromParts = explode('/', trim($fromDir, '/'));
+    $toParts   = explode('/', trim($toPath, '/'));
+
+    $i = 0;
+    while (
+        $i < count($fromParts)
+        && $i < count($toParts)
+        && $fromParts[$i] === $toParts[$i]
+    ) {
+        $i++;
+    }
+
+    $up   = str_repeat('../', count($fromParts) - $i);
+    $down = implode('/', array_slice($toParts, $i));
+
+    return $up . $down;
+}

--- a/.github/scripts/list-bucket-tests.php
+++ b/.github/scripts/list-bucket-tests.php
@@ -255,17 +255,14 @@ function make_relative(string $fromDir, string $toPath): string
     $fromParts = explode('/', trim($fromDir, '/'));
     $toParts   = explode('/', trim($toPath, '/'));
 
-    $i = 0;
-    while (
-        $i < count($fromParts)
-        && $i < count($toParts)
-        && $fromParts[$i] === $toParts[$i]
-    ) {
-        $i++;
+    $shared = 0;
+    foreach ($fromParts as $i => $segment) {
+        if (($toParts[$i] ?? null) !== $segment) {
+            break;
+        }
+        $shared++;
     }
 
-    $up   = str_repeat('../', count($fromParts) - $i);
-    $down = implode('/', array_slice($toParts, $i));
-
-    return $up . $down;
+    return str_repeat('../', count($fromParts) - $shared)
+        . implode('/', array_slice($toParts, $shared));
 }

--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -135,7 +135,7 @@ jobs:
       fail-fast: ${{ inputs.is_preview == true }}
       max-parallel: ${{ fromJson(vars.MATOMO_INTEGRATION_CORE_MAX_PARALLEL || '10') }}
       matrix:
-        bucket: &php-buckets [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
+        bucket: &php-buckets [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
         environment: *php-environments
     steps:
       - uses: actions/checkout@v6
@@ -151,7 +151,7 @@ jobs:
         run: |
           php .github/scripts/list-bucket-tests.php \
             IntegrationTestsCore \
-            ${{ matrix.bucket }} \
+            $(( ${{ matrix.bucket }} - 1 )) \
             10 \
             --write-xml=tests/PHPUnit/phpunit-bucket-${{ matrix.bucket }}.xml
       - name: running tests
@@ -193,7 +193,7 @@ jobs:
         run: |
           php .github/scripts/list-bucket-tests.php \
             IntegrationTestsPlugins \
-            ${{ matrix.bucket }} \
+            $(( ${{ matrix.bucket }} - 1 )) \
             10 \
             --write-xml=tests/PHPUnit/phpunit-bucket-${{ matrix.bucket }}.xml
       - name: running tests
@@ -235,7 +235,7 @@ jobs:
         run: |
           php .github/scripts/list-bucket-tests.php \
             SystemTestsPlugins \
-            ${{ matrix.bucket }} \
+            $(( ${{ matrix.bucket }} - 1 )) \
             10 \
             --write-xml=tests/PHPUnit/phpunit-bucket-${{ matrix.bucket }}.xml
       - name: running tests

--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: ${{ inputs.is_preview == true }}
       matrix:
-        environment:
+        environment: &php-environments
           - php: '7.2'
             adapter: 'PDO_MYSQL'
             mysql-engine: 'Mysql'
@@ -103,20 +103,10 @@ jobs:
     strategy:
       fail-fast: ${{ inputs.is_preview == true }}
       matrix:
-        type: [ 'SystemTestsPlugins', 'SystemTestsCore', 'IntegrationTestsCore', 'IntegrationTestsPlugins' ]
-        environment:
-          - php: '7.2'
-            adapter: 'PDO_MYSQL'
-            mysql-engine: 'Mysql'
-            mysql-version: '5.7'
-          - php: '8.2'
-            adapter: 'PDO_MYSQL'
-            mysql-engine: 'Mariadb'
-            mysql-version: '11.4'
-          - php: '8.5'
-            adapter: 'MYSQLI'
-            mysql-engine: 'Mysql'
-            mysql-version: '8.0'
+        # IntegrationTestsCore, IntegrationTestsPlugins and SystemTestsPlugins are split
+        # into 10-bucket jobs below; only SystemTestsCore remains in this single-shard matrix.
+        type: [ 'SystemTestsCore' ]
+        environment: *php-environments
     steps:
       - uses: actions/checkout@v6
         with:
@@ -129,6 +119,132 @@ jobs:
         uses: matomo-org/github-action-tests@main
         with:
           test-type: ${{ matrix.type }}
+          mysql-driver: ${{ matrix.environment.adapter }}
+          mysql-engine: ${{ matrix.environment.mysql-engine }}
+          mysql-version: ${{ matrix.environment.mysql-version }}
+          php-version: ${{ matrix.environment.php }}
+          redis-service: true
+          artifacts-pass: ${{ secrets.ARTIFACTS_PASS }}
+          upload-artifacts: ${{ matrix.environment.php == '7.2' }}
+          testomatio: ${{ secrets.TESTOMATIO_INTEGRATION }}
+          testomatio-force-report: ${{ contains('schedule,push', github.event_name) && github.run_attempt < 2 }}
+  PHP-integration-core:
+    name: PHP (IntegrationTestsCore, bucket ${{ matrix.bucket }}/10, ${{ matrix.environment.php }}, ${{ matrix.environment.adapter }}, ${{ matrix.environment.mysql-engine }}, ${{ matrix.environment.mysql-version }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: ${{ inputs.is_preview == true }}
+      max-parallel: ${{ fromJson(vars.MATOMO_INTEGRATION_CORE_MAX_PARALLEL || '10') }}
+      matrix:
+        bucket: &php-buckets [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
+        environment: *php-environments
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: false
+          persist-credentials: false
+          submodules: true
+          path: matomo
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Generate bucket phpunit config
+        working-directory: matomo
+        shell: bash
+        run: |
+          php .github/scripts/list-bucket-tests.php \
+            IntegrationTestsCore \
+            ${{ matrix.bucket }} \
+            10 \
+            --write-xml=tests/PHPUnit/phpunit-bucket-${{ matrix.bucket }}.xml
+      - name: running tests
+        uses: matomo-org/github-action-tests@main
+        with:
+          test-type: 'IntegrationTestsCore'
+          phpunit-test-options: >-
+            --configuration tests/PHPUnit/phpunit-bucket-${{ matrix.bucket }}.xml
+            --testsuite Bucket
+          mysql-driver: ${{ matrix.environment.adapter }}
+          mysql-engine: ${{ matrix.environment.mysql-engine }}
+          mysql-version: ${{ matrix.environment.mysql-version }}
+          php-version: ${{ matrix.environment.php }}
+          redis-service: true
+          artifacts-pass: ${{ secrets.ARTIFACTS_PASS }}
+          upload-artifacts: ${{ matrix.environment.php == '7.2' }}
+          testomatio: ${{ secrets.TESTOMATIO_INTEGRATION }}
+          testomatio-force-report: ${{ contains('schedule,push', github.event_name) && github.run_attempt < 2 }}
+  PHP-integration-plugins:
+    name: PHP (IntegrationTestsPlugins, bucket ${{ matrix.bucket }}/10, ${{ matrix.environment.php }}, ${{ matrix.environment.adapter }}, ${{ matrix.environment.mysql-engine }}, ${{ matrix.environment.mysql-version }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: ${{ inputs.is_preview == true }}
+      max-parallel: ${{ fromJson(vars.MATOMO_INTEGRATION_PLUGINS_MAX_PARALLEL || '10') }}
+      matrix:
+        bucket: *php-buckets
+        environment: *php-environments
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: false
+          persist-credentials: false
+          submodules: true
+          path: matomo
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Generate bucket phpunit config
+        working-directory: matomo
+        shell: bash
+        run: |
+          php .github/scripts/list-bucket-tests.php \
+            IntegrationTestsPlugins \
+            ${{ matrix.bucket }} \
+            10 \
+            --write-xml=tests/PHPUnit/phpunit-bucket-${{ matrix.bucket }}.xml
+      - name: running tests
+        uses: matomo-org/github-action-tests@main
+        with:
+          test-type: 'IntegrationTestsPlugins'
+          phpunit-test-options: >-
+            --configuration tests/PHPUnit/phpunit-bucket-${{ matrix.bucket }}.xml
+            --testsuite Bucket
+          mysql-driver: ${{ matrix.environment.adapter }}
+          mysql-engine: ${{ matrix.environment.mysql-engine }}
+          mysql-version: ${{ matrix.environment.mysql-version }}
+          php-version: ${{ matrix.environment.php }}
+          redis-service: true
+          artifacts-pass: ${{ secrets.ARTIFACTS_PASS }}
+          upload-artifacts: ${{ matrix.environment.php == '7.2' }}
+          testomatio: ${{ secrets.TESTOMATIO_INTEGRATION }}
+          testomatio-force-report: ${{ contains('schedule,push', github.event_name) && github.run_attempt < 2 }}
+  PHP-system-plugins:
+    name: PHP (SystemTestsPlugins, bucket ${{ matrix.bucket }}/10, ${{ matrix.environment.php }}, ${{ matrix.environment.adapter }}, ${{ matrix.environment.mysql-engine }}, ${{ matrix.environment.mysql-version }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: ${{ inputs.is_preview == true }}
+      max-parallel: ${{ fromJson(vars.MATOMO_SYSTEM_PLUGINS_MAX_PARALLEL || '10') }}
+      matrix:
+        bucket: *php-buckets
+        environment: *php-environments
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: false
+          persist-credentials: false
+          submodules: true
+          path: matomo
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Generate bucket phpunit config
+        working-directory: matomo
+        shell: bash
+        run: |
+          php .github/scripts/list-bucket-tests.php \
+            SystemTestsPlugins \
+            ${{ matrix.bucket }} \
+            10 \
+            --write-xml=tests/PHPUnit/phpunit-bucket-${{ matrix.bucket }}.xml
+      - name: running tests
+        uses: matomo-org/github-action-tests@main
+        with:
+          test-type: 'SystemTestsPlugins'
+          phpunit-test-options: >-
+            --configuration tests/PHPUnit/phpunit-bucket-${{ matrix.bucket }}.xml
+            --testsuite Bucket
           mysql-driver: ${{ matrix.environment.adapter }}
           mysql-engine: ${{ matrix.environment.mysql-engine }}
           mysql-version: ${{ matrix.environment.mysql-version }}
@@ -269,7 +385,7 @@ jobs:
   ci-required:
     name: All required tests passed
     if: ${{ always() }}
-    needs: [ PHP, Javascript, Client, generate-plugin-ui-matrices, UI-plugins, UI-core ]
+    needs: [ PHP, PHP-integration-core, PHP-integration-plugins, PHP-system-plugins, Javascript, Client, generate-plugin-ui-matrices, UI-plugins, UI-core ]
     runs-on: ubuntu-24.04
     steps:
       - name: Verify required jobs succeeded


### PR DESCRIPTION
### Description

Splits the three slowest PHP suites (`IntegrationTestsCore`, `IntegrationTestsPlugins`, `SystemTestsPlugins`) into 10 parallel buckets per PHP/DB environment, so total wall-clock for `matomo-tests.yml` drops to roughly the slowest single bucket. `SystemTestsCore` stays single-shard -- it's small enough that runner startup would outweigh the gain.

 A new `.github/scripts/list-bucket-tests.php` reads `tests/PHPUnit/phpunit.xml.dist`, expands the selected suite's `<directory>` globs against the live filesystem (so new test files are picked up with no manual list to maintain), applies `<exclude>` rules, sorts alphabetically for deterministic bucketing, then emits a self-contained phpunit XML cloned from `phpunit.xml.dist` with `<testsuites>` replaced by a single `<testsuite name="Bucket">` of explicit `<file> entries. Everything else (bootstrap, filters, attributes) is preserved verbatim so a bucket run behaves identically to the unsplit run for everything other than test selection.

## How it splits

  ```
phpunit.xml.dist  ──►  list-bucket-tests.php
                         │  expand  globs (live FS)
                         │  drop  matches
                         │  sort alphabetically
                         ▼
                         AaaTest.php   (idx 0)  → bucket 1
                         BbbTest.php   (idx 1)  → bucket 2
                         CccTest.php   (idx 2)  → bucket 3
                         ...
                         JjjTest.php   (idx 9)  → bucket 10
                         KkkTest.php   (idx 10) → bucket 1
                         LlmTest.php   (idx 11) → bucket 2
                         ...
                         (round-robin: index % 10)

  Per bucket → phpunit-bucket-.xml (clone of phpunit.xml.dist
                                       with
                                       listing this bucket's files)

  GitHub matrix fan-out (per suite, per env):
    IntegrationTestsCore     × 10 buckets × 3 envs = 30 jobs
    IntegrationTestsPlugins  × 10 buckets × 3 envs = 30 jobs
    SystemTestsPlugins       × 10 buckets × 3 envs = 30 jobs
    SystemTestsCore (unsplit)             × 3 envs =  3 jobs

```

## Additional
  - **`ci-required`** updated to gate on the three new bucket jobs alongside `PHP`.

## Testing

I just analysed the dots output in the logs between a successful run on our current CI vs the new one.

The results are here:

```
  Method note

  "Number of dots" was used as a proxy for "tests executed"; PHPUnit prints one progress character per test, and at the end emits an authoritative summary (Tests: N, Assertions: M, … or OK (N tests, …)). I parsed the summary line from each job's log —
  this counts every executed test (passed, skipped, failed, risky, etc.), which is exactly what the dots represent and is more reliable than literal . counting (which would miss S/F/E/etc.).

  99 of 99 jobs produced a summary line — no MISSING entries.

  Totals (summed across all PHP/DB envs)

  Suite                     | Old CI Tests | New CI Tests | Delta
  --------------------------+--------------+--------------+------
  IntegrationTestsCore      |        7 359 |        7 359 |   0
  IntegrationTestsPlugins   |       28 602 |       28 602 |   0
  SystemTestsPlugins        |        3 373 |        3 373 |   0
  ```


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
