### PR TITLE
Fix issue with widgetized map getting a negative height

### DIFF
--- a/plugins/UserCountryMap/javascripts/visitor-map.js
+++ b/plugins/UserCountryMap/javascripts/visitor-map.js
@@ -1354,7 +1354,11 @@
             h = w / ratio;
 
             // special handling for widgetize mode
-            if (!this.theWidget && map.container.parents('.widget').length) {
+            // Widgetize iframe mode: clamp the map height to the viewport so the SVG
+            // fits the embedded frame. The previous gate (a `.widget` ancestor) also
+            // matched dashboard widgets and the AddWidget preview, where `$('html').height()`
+            // far exceeds the viewport and made `maxHeight` go negative.
+            if (!this.theWidget && $('body').hasClass('widgetized')) {
                 var maxHeight = $(window).height() - ($('html').height() - map.container.height());
                 h = Math.min(maxHeight, h);
             }

--- a/plugins/UserCountryMap/tests/UI/VisitorMap_spec.js
+++ b/plugins/UserCountryMap/tests/UI/VisitorMap_spec.js
@@ -62,4 +62,31 @@ describe("VisitorMap", function () {
 
         expect(await page.screenshot({ fullPage: true })).to.matchImage('cities');
     });
+
+    it("should render with a positive svg height inside the AddWidget preview", async function () {
+        // Regression: the resize clamp previously fired on any `.widget` ancestor,
+        // including the AddWidget preview, which made maxHeight negative and
+        // collapsed the SVG. The clamp now only fires for the Widgetize iframe.
+        const dashboardParams = 'idSite=1&period=year&date=2012-08-09';
+        const modalSelector = '.modal.open.add-widget-modal';
+
+        await page.goto('?module=CoreHome&action=index&' + dashboardParams
+            + '#?' + dashboardParams + '&category=Dashboard_Dashboard&subcategory=1');
+        await page.waitForNetworkIdle();
+
+        await page.click('.dashboard-manager .title');
+        await page.waitForTimeout(50);
+        await page.click('.dashboard-manager .addWidget');
+        await page.waitForSelector(modalSelector);
+        await page.waitForSelector(modalSelector + ' .widgetpreview-categorylist>li');
+
+        await (await page.jQuery(modalSelector + ' .widgetpreview-categorylist>li:contains(Visitors - Locations):first')).hover();
+        await (await page.jQuery(modalSelector + ' .widgetpreview-widgetlist>li:contains(Visitor Map):first')).hover();
+        await page.waitForNetworkIdle();
+
+        const svg = await page.waitForSelector(modalSelector + ' .widgetpreview-preview .UserCountryMap_map svg');
+        const box = await svg.boundingBox();
+
+        expect(box.height).to.be.above(0);
+    });
 });


### PR DESCRIPTION
### Description

Fixes a "negative SVG height" error in the Visitor Map widget when previewed in the dashboard's "Add a widget" modal.

### Root cause

The resize handler in `plugins/UserCountryMap/javascripts/visitor-map.js` applies a viewport-fitting clamp intended for the Widgetize iframe:

```js
var maxHeight = $(window).height() - ($('html').height() - map.container.height());
h = Math.min(maxHeight, h);
```
The gate matched any `.widget` ancestor, which also catches dashboard widgets and the AddWidget preview. On those pages `$('html').height()` is much taller than the viewport, so `maxHeight` went negative and the SVG was sized to a negative value.


### Fix
Narrow the gate to $('body').hasClass('widgetized'), which is set exclusively by plugins/Widgetize/templates/iframe.twig. The clamp now runs only for the Widgetize iframe path it was originally written for; dashboard widgets and the AddWidget preview no longer hit it.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
