### PR TITLE
Fix ecommerce abandoned cart sparkline context

### DIFF
--- a/plugins/CoreHome/javascripts/sparkline.js
+++ b/plugins/CoreHome/javascripts/sparkline.js
@@ -110,6 +110,9 @@ window.initializeSparklines = function () {
                     if (urlParams.rows) {
                         params.rows = decodeURIComponent(urlParams.rows);
                     }
+                    if (urlParams.idGoal) {
+                        params.idGoal = decodeURIComponent(urlParams.idGoal);
+                    }
                 }
 
                 // on click, reload the graph with the new url

--- a/plugins/Ecommerce/Controller.php
+++ b/plugins/Ecommerce/Controller.php
@@ -76,10 +76,13 @@ class Controller extends \Piwik\Plugins\Goals\Controller
             'idGoal' => $idGoal,
             'allow_multiple' => (int) $allowMultiple,
             'only_summary' => 0,
-        ], function () use ($translations, $extraSparklineMetrics) {
+        ], function () use ($idGoal, $translations, $extraSparklineMetrics) {
             /** @var Sparklines $view */
             $view = ViewDataTableFactory::build(Sparklines::ID, 'Goals.get', 'Ecommerce.' . __METHOD__, true);
             $view->config->show_title = false;
+            $view->config->custom_parameters = [
+                'idGoal' => $idGoal,
+            ];
             $view->config->addTranslations($translations);
 
             foreach ($extraSparklineMetrics as [$columns, $order]) {

--- a/plugins/Goals/Controller.php
+++ b/plugins/Goals/Controller.php
@@ -217,8 +217,8 @@ class Controller extends \Piwik\Plugin\Controller
         if ($idGoal == Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER) {
             $nameToLabel['nb_conversions'] = 'General_EcommerceOrders';
         } elseif ($idGoal == Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_CART) {
-            $nameToLabel['nb_conversions'] = $this->translator->translate('General_VisitsWith', $this->translator->translate('Goals_AbandonedCart'));
-            $nameToLabel['conversion_rate'] = $nameToLabel['nb_conversions'];
+            $nameToLabel['nb_conversions'] = 'General_AbandonedCarts';
+            $nameToLabel['conversion_rate'] = $this->translator->translate('Goals_ConversionRate', $this->translator->translate('Goals_AbandonedCart'));
             $nameToLabel['revenue'] = $this->translator->translate('Goals_LeftInCart', $this->translator->translate('General_ColumnRevenue'));
             $nameToLabel['items'] = $this->translator->translate('Goals_LeftInCart', $this->translator->translate('Goals_Products'));
         }

--- a/plugins/Goals/tests/UI/GoalsPages_spec.js
+++ b/plugins/Goals/tests/UI/GoalsPages_spec.js
@@ -123,6 +123,20 @@ describe("GoalsPages", function () {
     expect(await page.screenshotSelector('.pageWrap')).to.matchImage('individual_goal_updated');
   });
 
+  it('should include the abandoned cart goal in ecommerce abandoned cart sparkline links', async function () {
+    var monthParams = 'idSite=1&period=month&date=2012-01-09';
+    await page.goto("?" + urlBase + "#?" + monthParams + "&category=Goals_Ecommerce&subcategory=General_Overview");
+    await page.waitForNetworkIdle();
+
+    const sparklineImage = await findSparkline('left in cart', 'img');
+    const dataSrc = await page.evaluate((element) => element.getAttribute('data-src'), sparklineImage);
+
+    expect(dataSrc).to.contain('idGoal=ecommerceAbandonedCart');
+
+    await page.goto("?" + urlBase + "#?" + generalParams + "&category=Goals_Goals&subcategory=1");
+    await page.waitForNetworkIdle();
+  });
+
   // should load the row evolution [see #11526]
   it('should show rov evolution for goal tables', async function () {
     await page.waitForNetworkIdle();

--- a/plugins/Goals/tests/UI/GoalsPages_spec.js
+++ b/plugins/Goals/tests/UI/GoalsPages_spec.js
@@ -33,6 +33,25 @@ describe("GoalsPages", function () {
     }, text, childSelector);
   };
 
+  const trackRequests = async function (action) {
+    const requests = [];
+    const requestHandler = (request) => {
+      requests.push({
+        resourceType: request.resourceType(),
+        url: request.url(),
+      });
+    };
+
+    page.webpage.on('request', requestHandler);
+    try {
+      await action();
+    } finally {
+      page.webpage.removeListener('request', requestHandler);
+    }
+
+    return requests;
+  };
+
   // goals pages
   it('should load the goals > ecommerce page correctly', async function () {
     await page.goto("?" + urlBase + "#?" + generalParams + "&category=Goals_Ecommerce&subcategory=General_Overview")
@@ -132,6 +151,30 @@ describe("GoalsPages", function () {
     const dataSrc = await page.evaluate((element) => element.getAttribute('data-src'), sparklineImage);
 
     expect(dataSrc).to.contain('idGoal=ecommerceAbandonedCart');
+
+    await page.goto("?" + urlBase + "#?" + generalParams + "&category=Goals_Goals&subcategory=1");
+    await page.waitForNetworkIdle();
+  });
+
+  it('should reload the main evolution graph with the abandoned cart goal when an abandoned cart sparkline is clicked', async function () {
+    var monthParams = 'idSite=1&period=month&date=2012-01-09';
+    await page.goto("?" + urlBase + "#?" + monthParams + "&category=Goals_Ecommerce&subcategory=General_Overview");
+    await page.waitForNetworkIdle();
+
+    const requests = await trackRequests(async () => {
+      const sparkline = await findSparkline('left in cart');
+      await sparkline.click();
+      await page.waitForNetworkIdle();
+    });
+
+    const evolutionGraphRequest = requests.find((request) => {
+      return request.resourceType === 'xhr'
+        && request.url.indexOf('module=Goals') !== -1
+        && request.url.indexOf('action=getEvolutionGraph') !== -1
+        && request.url.indexOf('idGoal=ecommerceAbandonedCart') !== -1;
+    });
+
+    expect(evolutionGraphRequest).to.be.ok;
 
     await page.goto("?" + urlBase + "#?" + generalParams + "&category=Goals_Goals&subcategory=1");
     await page.waitForNetworkIdle();


### PR DESCRIPTION
### Description

This fixes the Ecommerce Overview page so clicking an abandoned-cart sparkline reloads the main evolution graph in the abandoned-cart context instead of keeping the order context.

#### Before this change:

https://github.com/user-attachments/assets/f7398dc6-5cb2-422d-9094-89cf2e8f5dc2

  - clicking Total Revenue correctly showed the order revenue graph
  - clicking Revenue Left In Cart could still show the order revenue graph
  - the main graph stayed in the ecommerceOrder context because the abandoned-cart sparkline did not carry idGoal=ecommerceAbandonedCart

#### After this change:

https://github.com/user-attachments/assets/d989a3f3-e7a4-44a4-948f-2165666e346a

  - abandoned-cart sparkline links include idGoal=ecommerceAbandonedCart
  - sparkline click reloads preserve idGoal
  - the evolution graph can switch to the correct abandoned-cart dataset
  - abandoned-cart graph labels are now clearer and distinct

#### Root cause

Shared Ecommerce sparklines for abandoned carts were missing idGoal in their generated sparkline URLs. As a result, clicking those sparklines only changed the selected metric column and not the goal context, so the evolution graph remained on ecommerceOrder.

issue dev-18631

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
