### PR TITLE
Fix dashboardmanager widget list flake

### DIFF
--- a/plugins/Dashboard/tests/UI/DashboardManager_spec.js
+++ b/plugins/Dashboard/tests/UI/DashboardManager_spec.js
@@ -40,13 +40,13 @@ describe("DashboardManager", function () {
         await visitors.click();
 
         await page.waitForNetworkIdle();
-        await page.waitForSelector(modalSelector + ' .widgetpreview-widgetlist>li');
+        await page.waitForSelector(modalSelector + ' .widgetpreview-widgetlist>li', { visible: true });
 
         expect(await page.screenshotSelector(modalSelector)).to.matchImage('widget_list_shown');
     });
 
     it("should load a widget preview when a widget is hovered", async function() {
-        await page.waitForSelector(modalSelector + ' .widgetpreview-widgetlist>li');
+        await page.waitForSelector(modalSelector + ' .widgetpreview-widgetlist>li', { visible: true });
 
         vot = await page.jQuery(modalSelector + ' .widgetpreview-widgetlist>li:contains(Visits Over Time)');
         await vot.hover();

--- a/plugins/Dashboard/tests/UI/DashboardManager_spec.js
+++ b/plugins/Dashboard/tests/UI/DashboardManager_spec.js
@@ -40,11 +40,14 @@ describe("DashboardManager", function () {
         await visitors.click();
 
         await page.waitForNetworkIdle();
+        await page.waitForSelector(modalSelector + ' .widgetpreview-widgetlist>li');
 
         expect(await page.screenshotSelector(modalSelector)).to.matchImage('widget_list_shown');
     });
 
     it("should load a widget preview when a widget is hovered", async function() {
+        await page.waitForSelector(modalSelector + ' .widgetpreview-widgetlist>li');
+
         vot = await page.jQuery(modalSelector + ' .widgetpreview-widgetlist>li:contains(Visits Over Time)');
         await vot.hover();
 


### PR DESCRIPTION
### Description

Quite flaky, often fail across PRs. waiting until things are visible helps.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
