### PR TITLE
Add magic accessors to ThemeStyles

### DIFF
--- a/core/Plugin/ThemeStyles.php
+++ b/core/Plugin/ThemeStyles.php
@@ -71,212 +71,212 @@ class ThemeStyles
     /**
      * @var string|array<string>
      */
-    public $fontFamilyBase = '-apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Cantarell, \'Helvetica Neue\', sans-serif';
+    protected $fontFamilyBase = '-apple-system, BlinkMacSystemFont, \'Segoe UI\', Roboto, Oxygen-Sans, Cantarell, \'Helvetica Neue\', sans-serif';
 
     /**
      * @var string|array<string>
      */
-    public $colorBrand = ['#43a047', '#778fd4'];
+    protected $colorBrand = ['#43a047', '#778fd4'];
 
     /**
      * @var string|array<string>
      */
-    public $colorBrandContrast = ['#fff', '#ffffff'];
+    protected $colorBrandContrast = ['#fff', '#ffffff'];
 
     /**
      * @var string|array<string>
      */
-    public $colorFocusRing = '#0969da';
+    protected $colorFocusRing = '#0969da';
 
     /**
      * @var string|array<string>
      */
-    public $colorFocusRingAlternative;
+    protected $colorFocusRingAlternative;
 
     /**
      * @var string|array<string>
      */
-    public $colorTextHighContrast = ['#000', '#d9d9d9'];
+    protected $colorTextHighContrast = ['#000', '#d9d9d9'];
 
     /**
      * @var string|array<string>
      */
-    public $colorText = ['#212121', '#ccc'];
+    protected $colorText = ['#212121', '#ccc'];
 
     /**
      * @var string|array<string>
      */
-    public $colorTextContrast = ['#37474f', '#bbb'];
+    protected $colorTextContrast = ['#37474f', '#bbb'];
 
     /**
      * @var string|array<string>
      */
-    public $colorTextLight = ['#444', '#aaa'];
+    protected $colorTextLight = ['#444', '#aaa'];
 
     /**
      * @var string|array<string>
      */
-    public $colorTextLighter = ['#646464', '#999'];
+    protected $colorTextLighter = ['#646464', '#999'];
 
     /**
      * @var string|array<string>
      */
-    public $colorTextOnDisabled = ['#666666', '#999'];
+    protected $colorTextOnDisabled = ['#666666', '#999'];
 
     /**
      * @var string|array<string>
      */
-    public $colorTextInvert = ['#ccc', '#555'];
+    protected $colorTextInvert = ['#ccc', '#555'];
 
     /**
      * @var string|array<string>
      */
-    public $colorTextInvertContrast = ['#fff', '#000'];
+    protected $colorTextInvertContrast = ['#fff', '#000'];
 
     /**
      * @var string|array<string>
      */
-    public $colorTextInvertLight = ['#b9b9b9', '#666'];
+    protected $colorTextInvertLight = ['#b9b9b9', '#666'];
 
     /**
      * @var string|array<string>
      */
-    public $colorTextDisabled = ['#aaa', '#666'];
+    protected $colorTextDisabled = ['#aaa', '#666'];
 
     /**
      * @var string|array<string>
      */
-    public $colorLink = ['#1976D2', '#778fd4'];
+    protected $colorLink = ['#1976D2', '#778fd4'];
 
     /**
      * @var string|array<string>
      */
-    public $colorBaseSeries = '#ee3024';
+    protected $colorBaseSeries = '#ee3024';
 
     /**
      * @var string|array<string>
      */
-    public $colorHeadlineAlternative = ['#4E4E4E', '#aaa'];
+    protected $colorHeadlineAlternative = ['#4E4E4E', '#aaa'];
 
     /**
      * @var string|array<string>
      */
-    public $colorHeaderBackground;
+    protected $colorHeaderBackground;
 
     /**
      * @var string|array<string>
      */
-    public $colorHeaderText;
+    protected $colorHeaderText;
 
     /**
      * @var string|array<string>
      */
-    public $colorMenuContrastText;
+    protected $colorMenuContrastText;
 
     /**
      * @var string|array<string>
      */
-    public $colorMenuContrastTextSelected;
+    protected $colorMenuContrastTextSelected;
 
     /**
      * @var string|array<string>
      */
-    public $colorMenuContrastTextActive = ['#1976D2', '#fff'];
+    protected $colorMenuContrastTextActive = ['#1976D2', '#fff'];
 
     /**
      * @var string|array<string>
      */
-    public $colorMenuContrastBackgroundHover = ['#eff0f1', '#151819'];
+    protected $colorMenuContrastBackgroundHover = ['#eff0f1', '#151819'];
 
     /**
      * @var string|array<string>
      */
-    public $colorMenuContrastBackground;
+    protected $colorMenuContrastBackground;
 
     /**
      * @var string|array<string>
      */
-    public $colorWidgetExportedBackgroundBase;
+    protected $colorWidgetExportedBackgroundBase;
 
     /**
      * @var string|array<string>
      */
-    public $colorWidgetTitleText;
+    protected $colorWidgetTitleText;
 
     /**
      * @var string|array<string>
      */
-    public $colorWidgetTitleBackground;
+    protected $colorWidgetTitleBackground;
 
     /**
      * @var string|array<string>
      */
-    public $colorBackgroundBase = ['#f5f5f5', '#151819'];
+    protected $colorBackgroundBase = ['#f5f5f5', '#151819'];
 
     /**
      * @var string|array<string>
      */
-    public $colorBackgroundTinyContrast = ['#f2f2f2', '#182c32'];
+    protected $colorBackgroundTinyContrast = ['#f2f2f2', '#182c32'];
 
     /**
      * @var string|array<string>
      */
-    public $colorBackgroundLowContrast = ['#d9d9d9', '#192d33'];
+    protected $colorBackgroundLowContrast = ['#d9d9d9', '#192d33'];
 
     /**
      * @var string|array<string>
      */
-    public $colorBackgroundContrast = ['#fff', '#202329'];
+    protected $colorBackgroundContrast = ['#fff', '#202329'];
 
     /**
      * @var string|array<string>
      */
-    public $colorBackgroundHighContrast = ['#202020', '#404349'];
+    protected $colorBackgroundHighContrast = ['#202020', '#404349'];
 
     /**
      * @var string|array<string>
      */
-    public $colorBackgroundDisabled = ['#d9d9d9', '#303339'];
+    protected $colorBackgroundDisabled = ['#d9d9d9', '#303339'];
 
     /**
      * @var string|array<string>
      */
-    public $colorBorderLight = ['#a9a399', '#645e54'];
+    protected $colorBorderLight = ['#a9a399', '#645e54'];
 
     /**
      * @var string|array<string>
      */
-    public $colorBorder = ['#cccccc', '#555555'];
+    protected $colorBorder = ['#cccccc', '#555555'];
 
     /**
      * @var string|array<string>
      */
-    public $colorBoxShadow = ['rgba(0, 0, 0, 0.1)', 'rgba(0, 0, 0, 0.1)'];
+    protected $colorBoxShadow = ['rgba(0, 0, 0, 0.1)', 'rgba(0, 0, 0, 0.1)'];
 
     /**
      * @var string|array<string>
      */
-    public $colorCode = '#f3f3f3';
+    protected $colorCode = '#f3f3f3';
 
     /**
      * @var string|array<string>
      */
-    public $colorCodeBackground = '#4d4d4d';
+    protected $colorCodeBackground = '#4d4d4d';
 
     /**
      * @var string|array<string>
      */
-    public $colorWidgetBackground;
+    protected $colorWidgetBackground;
 
     /**
      * @var string|array<string>
      */
-    public $colorWidgetBorder;
+    protected $colorWidgetBorder;
 
     /**
      * @var string|array<string>
      */
-    public $filterOnIllustration = ['none', 'brightness(89%) invert(100%) hue-rotate(180deg)'];
+    protected $filterOnIllustration = ['none', 'brightness(89%) invert(100%) hue-rotate(180deg)'];
 
     public function __construct(string $themeMode)
     {
@@ -322,6 +322,23 @@ class ThemeStyles
     public function getThemeMode(): string
     {
         return $this->themeMode;
+    }
+
+    public function __get(string $name): string
+    {
+        return $this->getPropertyValue($name);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function __set(string $name, $value): void
+    {
+        if (!property_exists($this, $name)) {
+            return;
+        }
+
+        $this->$name = $value;
     }
 
     public function getPropertyValue(string $name): string

--- a/tests/PHPUnit/Unit/Plugin/ThemeStylesTest.php
+++ b/tests/PHPUnit/Unit/Plugin/ThemeStylesTest.php
@@ -24,6 +24,13 @@ class ThemeStylesTest extends TestCase
         $this->assertSame('#43a047', $styles->getPropertyValue('colorBrand'));
     }
 
+    public function testMagicGetterReturnsResolvedPropertyValue()
+    {
+        $styles = new ThemeStyles(ThemeStyles::LIGHT_MODE);
+
+        $this->assertSame('#43a047', $styles->colorBrand);
+    }
+
     public function testGetPropertyValueReturnsDarkModeArrayValue()
     {
         $styles = new ThemeStyles(ThemeStyles::DARK_MODE);
@@ -53,6 +60,14 @@ class ThemeStylesTest extends TestCase
         $this->assertSame('#123456', $styles->getPropertyValue('colorBrand'));
     }
 
+    public function testMagicSetterAllowsOverridingProtectedProperty()
+    {
+        $styles = new ThemeStyles(ThemeStyles::DARK_MODE);
+        $styles->colorBrand = ['#123456'];
+
+        $this->assertSame('#123456', $styles->colorBrand);
+    }
+
     public function testGetPropertyValueFallsBackToDarkValueWhenLightValueIsMissing()
     {
         $styles = new ThemeStyles(ThemeStyles::LIGHT_MODE);
@@ -67,6 +82,13 @@ class ThemeStylesTest extends TestCase
         $styles->colorCode = null;
 
         $this->assertSame('', $styles->getPropertyValue('colorCode'));
+    }
+
+    public function testMagicGetterReturnsEmptyStringForUnknownProperty()
+    {
+        $styles = new ThemeStyles(ThemeStyles::LIGHT_MODE);
+
+        $this->assertSame('', $styles->unknownProperty);
     }
 
     public function testGetPropertyValueReturnsEmptyStringWhenArrayEntriesAreUnusable()


### PR DESCRIPTION
### Description

This change makes ThemeStyles return the final theme value when a property is accessed directly, instead of returning the raw light/dark array. This avoids breaking existing code when a theme variable later gets a dark mode variation, since callers will still receive a single color or string value.

issue 20133

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
