### PR TITLE
  Fix nb_conversions_page_rate=0 on subtable rows in Goals pages

### DIFF
--- a/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
+++ b/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
@@ -87,7 +87,7 @@ class CalculateConversionPageRate extends BaseFilter
                         $goalsCol[$goalIdString][Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_RATE] = $rate;
                     }
                 }
-                $row->setColumn(Metrics::INDEX_GOALS, $goalsCol);
+                $row->setColumn((string) Metrics::INDEX_GOALS, $goalsCol);
             }
 
             $subTable = $row->getSubtable();

--- a/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
+++ b/plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
@@ -32,41 +32,67 @@ class CalculateConversionPageRate extends BaseFilter
      */
     public function filter($table)
     {
-
-        // Find all goal ids used in the table and store in an array
+        // Collect goal ids from the whole table tree so we can look up totals once,
+        // even when this filter is invoked on a parent table whose goal data lives
+        // in subtable rows (e.g. Actions.getPageUrls page subpages, or flat=1).
         $goals = [];
-        foreach ($table->getRowsWithoutSummaryRow() as $row) {
-            if (isset($row[Metrics::INDEX_GOALS])) {
-                foreach ($row[Metrics::INDEX_GOALS] as $goalIdString => $metrics) {
-                    $goals[$goalIdString] = $goalIdString;
-                }
-            }
-        }
+        $this->collectGoalIds($table, $goals);
 
-        // Get the total top-level conversions for the goals in the table
         $goalTotals = $this->getGoalTotalConversions($table, $goals);
         if (count($goalTotals) === 0) {
             return;
         }
 
-        // Walk the rows and populate the nb_conversions_page_rate with nb_conversions_page_uniq / $goalTotals[goal id]
-        foreach ($table->getRowsWithoutSummaryRow() as &$row) {
-            if (isset($row[Metrics::INDEX_GOALS])) {
-                foreach ($row[Metrics::INDEX_GOALS] as $goalIdString => $metrics) {
-                    if (isset($row[Metrics::INDEX_GOALS][$goalIdString][Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_UNIQ])) {
+        $this->populateRates($table, $goalTotals);
+    }
+
+    private function collectGoalIds(DataTable $table, array &$goals): void
+    {
+        foreach ($table->getRowsWithoutSummaryRow() as $row) {
+            $goalsCol = $row->getColumn(Metrics::INDEX_GOALS);
+            if (is_array($goalsCol)) {
+                foreach ($goalsCol as $goalIdString => $metrics) {
+                    $goals[$goalIdString] = $goalIdString;
+                }
+            }
+
+            $subTable = $row->getSubtable();
+            if ($subTable) {
+                $this->collectGoalIds($subTable, $goals);
+            }
+        }
+    }
+
+    private function populateRates(DataTable $table, array $goalTotals): void
+    {
+        foreach ($table->getRowsWithoutSummaryRow() as $row) {
+            $goalsCol = $row->getColumn(Metrics::INDEX_GOALS);
+            if (is_array($goalsCol)) {
+                foreach ($goalsCol as $goalIdString => $metrics) {
+                    if (
+                        isset($goalsCol[$goalIdString][Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_UNIQ])
+                        && isset($goalTotals[$goalIdString])
+                    ) {
                         $rate = Piwik::getQuotientSafe(
-                            $row[Metrics::INDEX_GOALS][$goalIdString][Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_UNIQ],
+                            $goalsCol[$goalIdString][Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_UNIQ],
                             $goalTotals[$goalIdString],
                             3
                         );
-                        // Prevent page rates over 100% which can happen when there are subpages
+                        // Prevent page rates over 100% which can happen when subpage
+                        // unique counts add up to more than the parent's total.
                         if ($rate > 1) {
                             $rate = 1;
                         }
 
-                        $row[Metrics::INDEX_GOALS][$goalIdString][Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_RATE] = $rate;
+                        $goalsCol[$goalIdString][Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_RATE] = $rate;
                     }
                 }
+                $row->setColumn(Metrics::INDEX_GOALS, $goalsCol);
+            }
+
+            $subTable = $row->getSubtable();
+            if ($subTable) {
+                $this->populateRates($subTable, $goalTotals);
             }
         }
     }

--- a/plugins/Goals/tests/System/TrackGoalsPagesTest.php
+++ b/plugins/Goals/tests/System/TrackGoalsPagesTest.php
@@ -9,7 +9,9 @@
 
 namespace Piwik\Plugins\Goals\tests\System;
 
+use Piwik\API\Request;
 use Piwik\Common;
+use Piwik\DataTable;
 use Piwik\Db;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\Tests\Fixtures\SomePageGoalVisitsWithConversions;
@@ -115,6 +117,68 @@ class TrackGoalsPagesTest extends SystemTestCase
             ['id' => 29, 'expected' => 1],
             ['id' => 33, 'expected' => 3],
         ];
+    }
+
+    /**
+     * Regression test for DEV-13925.
+     *
+     * Subtable page rows in Actions.getPageUrls report goal metrics, but the
+     * nb_conversions_page_rate column stays at 0 because the post-processing
+     * filter never recurses into subtables. flat=1 surfaces those subtable
+     * rows at the top level, which makes the bug user-visible.
+     */
+    public function testPageRateIsCalculatedForFlattenedSubtableRows()
+    {
+        /** @var DataTable $urls */
+        $urls = Request::processRequest('Actions.getPageUrls', [
+            'idSite'        => self::$fixture->idSite,
+            'period'        => 'week',
+            'date'          => self::$fixture->dateTime,
+            'idGoal'        => 1,
+            'flat'          => '1',
+            'filter_limit'  => -1,
+        ]);
+
+        $rowsByLabel = [];
+        foreach ($urls->getRows() as $row) {
+            $rowsByLabel[(string) $row->getColumn('label')] = $row;
+        }
+
+        // Goal 1 has 5 total conversions across the week (visits 1, 2, 4, 5, 6).
+        // /page_A/index.html: 5 unique => 5 / 5 = 1
+        // /page_A/Z:          2 unique => 2 / 5 = 0.4
+        // /page_A/X:          1 unique => 1 / 5 = 0.2
+        // Without the fix all three subtable rates are 0.
+        $expected = [
+            '/page_A/index.html' => ['uniq' => 5, 'rate' => 1.0],
+            '/page_A/Z'          => ['uniq' => 2, 'rate' => 0.4],
+            '/page_A/X'          => ['uniq' => 1, 'rate' => 0.2],
+        ];
+
+        foreach ($expected as $label => $expectedRow) {
+            $row = $rowsByLabel[$label] ?? null;
+            $this->assertNotNull(
+                $row,
+                "Row '$label' missing from flattened report. Got labels: " . implode(', ', array_keys($rowsByLabel))
+            );
+
+            $goals = $row->getColumn('goals');
+            $this->assertIsArray($goals, "'goals' column not an array on $label");
+            $this->assertArrayHasKey('idgoal=1', $goals, "Goal 1 data missing on $label");
+
+            $this->assertSame(
+                $expectedRow['uniq'],
+                (int) ($goals['idgoal=1']['nb_conversions_page_uniq'] ?? 0),
+                "Unexpected nb_conversions_page_uniq for $label"
+            );
+
+            $actualRate = round((float) ($goals['idgoal=1']['nb_conversions_page_rate'] ?? 0), 3);
+            $this->assertSame(
+                $expectedRow['rate'],
+                $actualRate,
+                "Expected nb_conversions_page_rate $expectedRow[rate] for $label but got $actualRate"
+            );
+        }
     }
 
     public static function getOutputPrefix()

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pages__Actions.getEntryPageUrls_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pages__Actions.getEntryPageUrls_day.xml
@@ -77,7 +77,7 @@
 						<revenue>30</revenue>
 						<nb_conv_pages_before>4</nb_conv_pages_before>
 						<nb_conversions_attrib>1.0833</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>3</nb_conversions_page_uniq>
 						<revenue_attrib>10.83</revenue_attrib>
 						<revenue_entry>30</revenue_entry>
@@ -90,7 +90,7 @@
 						<revenue>20</revenue>
 						<nb_conv_pages_before>5</nb_conv_pages_before>
 						<nb_conversions_attrib>0.4</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>4</revenue_attrib>
 						<revenue_entry>10</revenue_entry>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pages__Actions.getPageUrls_week.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pages__Actions.getPageUrls_week.xml
@@ -68,7 +68,7 @@
 						<revenue>50</revenue>
 						<nb_conv_pages_before>8</nb_conv_pages_before>
 						<nb_conversions_attrib>2.3333</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>5</nb_conversions_page_uniq>
 						<revenue_attrib>23.33</revenue_attrib>
 						<revenue_entry>50</revenue_entry>
@@ -81,7 +81,7 @@
 						<revenue>50</revenue>
 						<nb_conv_pages_before>15</nb_conv_pages_before>
 						<nb_conversions_attrib>1.0191</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>5</nb_conversions_page_uniq>
 						<revenue_attrib>10.19</revenue_attrib>
 						<revenue_entry>30</revenue_entry>
@@ -115,7 +115,7 @@
 						<revenue>20</revenue>
 						<nb_conv_pages_before>7</nb_conv_pages_before>
 						<nb_conversions_attrib>0.5833</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.4</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>5.83</revenue_attrib>
 					</row>
@@ -124,7 +124,7 @@
 						<revenue>20</revenue>
 						<nb_conv_pages_before>10</nb_conv_pages_before>
 						<nb_conversions_attrib>0.4762</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.667</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>4.76</revenue_attrib>
 					</row>
@@ -153,7 +153,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>4</nb_conv_pages_before>
 						<nb_conversions_attrib>0.25</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.2</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>2.5</revenue_attrib>
 					</row>
@@ -180,7 +180,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>4</nb_conv_pages_before>
 						<nb_conversions_attrib>0.25</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.2</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>2.5</revenue_attrib>
 					</row>
@@ -189,7 +189,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>7</nb_conv_pages_before>
 						<nb_conversions_attrib>0.1429</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.333</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1.43</revenue_attrib>
 					</row>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pages_segment__Actions.getEntryPageUrls_week.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pages_segment__Actions.getEntryPageUrls_week.xml
@@ -64,7 +64,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_pages_segment__Actions.getPageUrls_week.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_pages_segment__Actions.getPageUrls_week.xml
@@ -56,7 +56,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>

--- a/plugins/PrivacyManager/tests/System/expected/test_DataRoundingCoverage_cnil_enabled_segmented_multi_site_mixed_policy__Actions.getPageUrls_year.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_DataRoundingCoverage_cnil_enabled_segmented_multi_site_mixed_policy__Actions.getPageUrls_year.xml
@@ -112,7 +112,7 @@
 							<revenue>620</revenue>
 							<nb_conv_pages_before>30</nb_conv_pages_before>
 							<nb_conversions_attrib>120</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.295</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>120</nb_conversions_page_uniq>
 							<revenue_attrib>620</revenue_attrib>
 							<revenue_entry>620</revenue_entry>
@@ -125,7 +125,7 @@
 							<revenue>465</revenue>
 							<nb_conv_pages_before>30</nb_conv_pages_before>
 							<nb_conversions_attrib>90</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.31</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>90</nb_conversions_page_uniq>
 							<revenue_attrib>465</revenue_attrib>
 							<revenue_entry>465</revenue_entry>
@@ -177,7 +177,7 @@
 									<revenue>160</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>30</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.076</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>30</nb_conversions_page_uniq>
 									<revenue_attrib>160</revenue_attrib>
 									<revenue_entry>160</revenue_entry>
@@ -190,7 +190,7 @@
 									<revenue>120</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>20</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.08</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 									<revenue_attrib>120</revenue_attrib>
 									<revenue_entry>120</revenue_entry>
@@ -246,7 +246,7 @@
 									<revenue>160</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>30</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.076</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>30</nb_conversions_page_uniq>
 									<revenue_attrib>160</revenue_attrib>
 									<revenue_entry>160</revenue_entry>
@@ -259,7 +259,7 @@
 									<revenue>120</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>20</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.08</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 									<revenue_attrib>120</revenue_attrib>
 									<revenue_entry>120</revenue_entry>
@@ -315,7 +315,7 @@
 									<revenue>160</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>30</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.076</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>30</nb_conversions_page_uniq>
 									<revenue_attrib>160</revenue_attrib>
 									<revenue_entry>160</revenue_entry>
@@ -328,7 +328,7 @@
 									<revenue>120</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>20</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.08</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 									<revenue_attrib>120</revenue_attrib>
 									<revenue_entry>120</revenue_entry>
@@ -384,7 +384,7 @@
 									<revenue>140</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>30</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.067</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>30</nb_conversions_page_uniq>
 									<revenue_attrib>140</revenue_attrib>
 									<revenue_entry>140</revenue_entry>
@@ -397,7 +397,7 @@
 									<revenue>105</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>20</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.07</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 									<revenue_attrib>105</revenue_attrib>
 									<revenue_entry>105</revenue_entry>
@@ -530,7 +530,7 @@
 							<revenue>180</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>40</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.086</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>40</nb_conversions_page_uniq>
 							<revenue_attrib>180</revenue_attrib>
 							<revenue_entry>140</revenue_entry>
@@ -543,7 +543,7 @@
 							<revenue>180</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>40</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.12</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>40</nb_conversions_page_uniq>
 							<revenue_attrib>180</revenue_attrib>
 							<revenue_entry>140</revenue_entry>
@@ -810,7 +810,7 @@
 							<revenue>2666.64</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>1</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 							<revenue_attrib>777.77</revenue_attrib>
 							<revenue_entry>777.77</revenue_entry>
@@ -823,7 +823,7 @@
 							<revenue>170</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>30</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.081</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>30</nb_conversions_page_uniq>
 							<revenue_attrib>170</revenue_attrib>
 							<revenue_entry>130</revenue_entry>
@@ -836,7 +836,7 @@
 							<revenue>170</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>30</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.113</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>30</nb_conversions_page_uniq>
 							<revenue_attrib>170</revenue_attrib>
 							<revenue_entry>130</revenue_entry>
@@ -889,7 +889,7 @@
 									<revenue>2666.64</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>1</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 									<revenue_attrib>777.77</revenue_attrib>
 									<revenue_entry>777.77</revenue_entry>
@@ -902,7 +902,7 @@
 									<revenue>170</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>30</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.081</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>30</nb_conversions_page_uniq>
 									<revenue_attrib>170</revenue_attrib>
 									<revenue_entry>130</revenue_entry>
@@ -915,7 +915,7 @@
 									<revenue>170</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>30</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.113</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>30</nb_conversions_page_uniq>
 									<revenue_attrib>170</revenue_attrib>
 									<revenue_entry>130</revenue_entry>
@@ -1048,7 +1048,7 @@
 							<revenue>110</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>20</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.052</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 							<revenue_attrib>110</revenue_attrib>
 							<revenue_entry>55</revenue_entry>
@@ -1061,7 +1061,7 @@
 							<revenue>110</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>20</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.073</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 							<revenue_attrib>110</revenue_attrib>
 							<revenue_entry>55</revenue_entry>
@@ -1113,7 +1113,7 @@
 									<revenue>100</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>20</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.048</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 									<revenue_attrib>100</revenue_attrib>
 									<revenue_entry>50</revenue_entry>
@@ -1126,7 +1126,7 @@
 									<revenue>100</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>20</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.067</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 									<revenue_attrib>100</revenue_attrib>
 									<revenue_entry>50</revenue_entry>
@@ -1178,7 +1178,7 @@
 											<revenue>100</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>20</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.048</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 											<revenue_attrib>100</revenue_attrib>
 											<revenue_entry>50</revenue_entry>
@@ -1191,7 +1191,7 @@
 											<revenue>100</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>20</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.067</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 											<revenue_attrib>100</revenue_attrib>
 											<revenue_entry>50</revenue_entry>
@@ -1249,7 +1249,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -1262,7 +1262,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -1314,7 +1314,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>5</revenue_entry>
@@ -1327,7 +1327,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>5</revenue_entry>
@@ -1387,7 +1387,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -1400,7 +1400,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -1452,7 +1452,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -1465,7 +1465,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -1517,7 +1517,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>5</revenue_entry>
@@ -1530,7 +1530,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>5</revenue_entry>
@@ -1582,7 +1582,7 @@
 													<revenue>10</revenue>
 													<nb_conv_pages_before>10</nb_conv_pages_before>
 													<nb_conversions_attrib>10</nb_conversions_attrib>
-													<nb_conversions_page_rate>0</nb_conversions_page_rate>
+													<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 													<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 													<revenue_attrib>10</revenue_attrib>
 													<revenue_entry>5</revenue_entry>
@@ -1595,7 +1595,7 @@
 													<revenue>10</revenue>
 													<nb_conv_pages_before>10</nb_conv_pages_before>
 													<nb_conversions_attrib>10</nb_conversions_attrib>
-													<nb_conversions_page_rate>0</nb_conversions_page_rate>
+													<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 													<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 													<revenue_attrib>10</revenue_attrib>
 													<revenue_entry>5</revenue_entry>
@@ -1731,7 +1731,7 @@
 							<revenue>35</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.017</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>35</revenue_attrib>
 							<revenue_entry>35</revenue_entry>
@@ -1744,7 +1744,7 @@
 							<revenue>35</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.023</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>35</revenue_attrib>
 							<revenue_entry>35</revenue_entry>
@@ -2059,7 +2059,7 @@
 							<revenue>500</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>20</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.238</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>100</nb_conversions_page_uniq>
 							<revenue_attrib>112.64</revenue_attrib>
 							<revenue_entry>110</revenue_entry>
@@ -2072,7 +2072,7 @@
 							<revenue>35</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.023</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>35</revenue_attrib>
 							<revenue_entry>25</revenue_entry>
@@ -2123,7 +2123,7 @@
 							<revenue>15</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>3.92</revenue_attrib>
 						</row>
@@ -2168,7 +2168,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>2.25</revenue_attrib>
 						</row>
@@ -2213,7 +2213,7 @@
 							<revenue>20</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.01</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>6.42</revenue_attrib>
 						</row>
@@ -2414,7 +2414,7 @@
 							<revenue>35</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.017</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>35</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -2427,7 +2427,7 @@
 							<revenue>35</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.023</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>35</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -2479,7 +2479,7 @@
 									<revenue>30</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.014</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>30</revenue_attrib>
 									<revenue_entry>10</revenue_entry>
@@ -2492,7 +2492,7 @@
 									<revenue>30</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>30</revenue_attrib>
 									<revenue_entry>10</revenue_entry>
@@ -2544,7 +2544,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>10</revenue_entry>
@@ -2557,7 +2557,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>10</revenue_entry>
@@ -2607,7 +2607,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 										</row>
@@ -2616,7 +2616,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 										</row>
@@ -2662,7 +2662,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 										</row>
@@ -2671,7 +2671,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 										</row>
@@ -2719,7 +2719,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 								</row>
@@ -2728,7 +2728,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 								</row>
@@ -2771,7 +2771,7 @@
 											<revenue>5</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>5</revenue_attrib>
 										</row>
@@ -2780,7 +2780,7 @@
 											<revenue>5</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>5</revenue_attrib>
 										</row>
@@ -2829,7 +2829,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 						</row>
@@ -2838,7 +2838,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 						</row>
@@ -3171,7 +3171,7 @@
 							<revenue>30</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.014</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>30</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -3184,7 +3184,7 @@
 							<revenue>30</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>30</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -3236,7 +3236,7 @@
 									<revenue>30</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.014</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>30</revenue_attrib>
 									<revenue_entry>10</revenue_entry>
@@ -3249,7 +3249,7 @@
 									<revenue>30</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>30</revenue_attrib>
 									<revenue_entry>10</revenue_entry>
@@ -3301,7 +3301,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>10</revenue_entry>
@@ -3314,7 +3314,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>10</revenue_entry>
@@ -3364,7 +3364,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 										</row>
@@ -3373,7 +3373,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 										</row>
@@ -3419,7 +3419,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 										</row>
@@ -3428,7 +3428,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 										</row>
@@ -3557,7 +3557,7 @@
 							<revenue>30</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.014</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>30</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -3570,7 +3570,7 @@
 							<revenue>30</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>30</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -3622,7 +3622,7 @@
 									<revenue>30</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.014</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>30</revenue_attrib>
 									<revenue_entry>10</revenue_entry>
@@ -3635,7 +3635,7 @@
 									<revenue>30</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>30</revenue_attrib>
 									<revenue_entry>10</revenue_entry>
@@ -3687,7 +3687,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>10</revenue_entry>
@@ -3700,7 +3700,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>10</revenue_entry>
@@ -3750,7 +3750,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 										</row>
@@ -3759,7 +3759,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 										</row>
@@ -3805,7 +3805,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 										</row>
@@ -3814,7 +3814,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 										</row>
@@ -3944,7 +3944,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -3957,7 +3957,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4013,7 +4013,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4026,7 +4026,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4082,7 +4082,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4095,7 +4095,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4151,7 +4151,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4164,7 +4164,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4220,7 +4220,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4233,7 +4233,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4364,7 +4364,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4377,7 +4377,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4433,7 +4433,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4446,7 +4446,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4502,7 +4502,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4515,7 +4515,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4571,7 +4571,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4584,7 +4584,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4640,7 +4640,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4653,7 +4653,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4784,7 +4784,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4797,7 +4797,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4853,7 +4853,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4866,7 +4866,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4922,7 +4922,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4935,7 +4935,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4991,7 +4991,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5004,7 +5004,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5060,7 +5060,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5073,7 +5073,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5204,7 +5204,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5217,7 +5217,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5273,7 +5273,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5286,7 +5286,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5342,7 +5342,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5355,7 +5355,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5411,7 +5411,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5424,7 +5424,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5480,7 +5480,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5493,7 +5493,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5624,7 +5624,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5637,7 +5637,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5693,7 +5693,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5706,7 +5706,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5762,7 +5762,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5775,7 +5775,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5831,7 +5831,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5844,7 +5844,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5900,7 +5900,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5913,7 +5913,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6044,7 +6044,7 @@
 							<revenue>20</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.01</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>20</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -6057,7 +6057,7 @@
 							<revenue>20</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.013</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>20</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -6109,7 +6109,7 @@
 									<revenue>20</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.01</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>20</revenue_attrib>
 									<revenue_entry>10</revenue_entry>
@@ -6122,7 +6122,7 @@
 									<revenue>20</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.013</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>20</revenue_attrib>
 									<revenue_entry>10</revenue_entry>
@@ -6180,7 +6180,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6193,7 +6193,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6249,7 +6249,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6262,7 +6262,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6314,7 +6314,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -6327,7 +6327,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -6460,7 +6460,7 @@
 							<revenue>20</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.01</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>20</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -6473,7 +6473,7 @@
 							<revenue>20</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.013</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>20</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -6529,7 +6529,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6542,7 +6542,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6594,7 +6594,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -6607,7 +6607,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -6665,7 +6665,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6678,7 +6678,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6730,7 +6730,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -6743,7 +6743,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -6881,7 +6881,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6894,7 +6894,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -7052,13 +7052,14 @@
 							<nb_conversions>10</nb_conversions>
 							<revenue>100</revenue>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
+							<nb_conversions_page_rate>0.2</nb_conversions_page_rate>
 						</row>
 						<row idgoal='1'>
 							<nb_conversions>10</nb_conversions>
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -7071,7 +7072,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -7286,7 +7287,7 @@
 							<revenue>65</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>15.9</revenue_attrib>
 							<revenue_entry>65</revenue_entry>
@@ -7299,7 +7300,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -7349,7 +7350,7 @@
 							<revenue>60</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.029</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10.9</revenue_attrib>
 						</row>
@@ -7394,7 +7395,7 @@
 							<revenue>105</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.05</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 							<revenue_attrib>15.13</revenue_attrib>
 						</row>
@@ -7439,7 +7440,7 @@
 							<revenue>120</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.057</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 							<revenue_attrib>13.62</revenue_attrib>
 						</row>
@@ -7546,7 +7547,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 						</row>
@@ -7555,7 +7556,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 						</row>
@@ -7600,7 +7601,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 						</row>
@@ -7609,7 +7610,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 						</row>
@@ -7830,7 +7831,7 @@
 							<revenue>110</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.052</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 							<revenue_attrib>31.49</revenue_attrib>
 							<revenue_entry>20</revenue_entry>
@@ -7843,7 +7844,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -7898,7 +7899,7 @@
 									<revenue>105</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.05</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 									<revenue_attrib>26.49</revenue_attrib>
 									<revenue_entry>20</revenue_entry>
@@ -7911,7 +7912,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -7961,7 +7962,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 								</row>
@@ -7970,7 +7971,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 								</row>
@@ -8013,7 +8014,7 @@
 											<revenue>5</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>5</revenue_attrib>
 										</row>
@@ -8022,7 +8023,7 @@
 											<revenue>5</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>5</revenue_attrib>
 										</row>
@@ -8125,7 +8126,7 @@
 							<revenue>185</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.088</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>40</nb_conversions_page_uniq>
 							<revenue_attrib>23.3</revenue_attrib>
 						</row>
@@ -8171,7 +8172,7 @@
 							<revenue>85</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.04</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>20</nb_conversions_page_uniq>
 							<revenue_attrib>7.27</revenue_attrib>
 						</row>
@@ -8752,7 +8753,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -8765,7 +8766,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -8896,7 +8897,7 @@
 							<revenue>52</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>52</revenue_attrib>
 							<revenue_entry>52</revenue_entry>
@@ -8909,7 +8910,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -11211,7 +11212,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.002</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -11224,7 +11225,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.003</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -11355,7 +11356,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -11368,7 +11369,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -11420,7 +11421,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -11433,7 +11434,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -11566,7 +11567,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -11579,7 +11580,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -11710,7 +11711,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -11723,7 +11724,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -11854,7 +11855,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -11867,7 +11868,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -11998,7 +11999,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -12011,7 +12012,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -12063,7 +12064,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -12076,7 +12077,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>10</nb_conv_pages_before>
 									<nb_conversions_attrib>10</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -12128,7 +12129,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>5</revenue_entry>
@@ -12141,7 +12142,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>10</nb_conv_pages_before>
 											<nb_conversions_attrib>10</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>5</revenue_entry>
@@ -12193,7 +12194,7 @@
 													<revenue>10</revenue>
 													<nb_conv_pages_before>10</nb_conv_pages_before>
 													<nb_conversions_attrib>10</nb_conversions_attrib>
-													<nb_conversions_page_rate>0</nb_conversions_page_rate>
+													<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 													<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 													<revenue_attrib>10</revenue_attrib>
 													<revenue_entry>5</revenue_entry>
@@ -12206,7 +12207,7 @@
 													<revenue>10</revenue>
 													<nb_conv_pages_before>10</nb_conv_pages_before>
 													<nb_conversions_attrib>10</nb_conversions_attrib>
-													<nb_conversions_page_rate>0</nb_conversions_page_rate>
+													<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 													<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 													<revenue_attrib>10</revenue_attrib>
 													<revenue_entry>5</revenue_entry>
@@ -12258,7 +12259,7 @@
 															<revenue>10</revenue>
 															<nb_conv_pages_before>10</nb_conv_pages_before>
 															<nb_conversions_attrib>10</nb_conversions_attrib>
-															<nb_conversions_page_rate>0</nb_conversions_page_rate>
+															<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 															<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 															<revenue_attrib>10</revenue_attrib>
 															<revenue_entry>5</revenue_entry>
@@ -12271,7 +12272,7 @@
 															<revenue>10</revenue>
 															<nb_conv_pages_before>10</nb_conv_pages_before>
 															<nb_conversions_attrib>10</nb_conversions_attrib>
-															<nb_conversions_page_rate>0</nb_conversions_page_rate>
+															<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 															<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 															<revenue_attrib>10</revenue_attrib>
 															<revenue_entry>5</revenue_entry>
@@ -12323,7 +12324,7 @@
 																	<revenue>10</revenue>
 																	<nb_conv_pages_before>10</nb_conv_pages_before>
 																	<nb_conversions_attrib>10</nb_conversions_attrib>
-																	<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																	<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 																	<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 																	<revenue_attrib>10</revenue_attrib>
 																	<revenue_entry>5</revenue_entry>
@@ -12336,7 +12337,7 @@
 																	<revenue>10</revenue>
 																	<nb_conv_pages_before>10</nb_conv_pages_before>
 																	<nb_conversions_attrib>10</nb_conversions_attrib>
-																	<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																	<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 																	<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 																	<revenue_attrib>10</revenue_attrib>
 																	<revenue_entry>5</revenue_entry>
@@ -12388,7 +12389,7 @@
 																			<revenue>10</revenue>
 																			<nb_conv_pages_before>10</nb_conv_pages_before>
 																			<nb_conversions_attrib>10</nb_conversions_attrib>
-																			<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																			<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 																			<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 																			<revenue_attrib>10</revenue_attrib>
 																			<revenue_entry>5</revenue_entry>
@@ -12401,7 +12402,7 @@
 																			<revenue>10</revenue>
 																			<nb_conv_pages_before>10</nb_conv_pages_before>
 																			<nb_conversions_attrib>10</nb_conversions_attrib>
-																			<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																			<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 																			<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 																			<revenue_attrib>10</revenue_attrib>
 																			<revenue_entry>5</revenue_entry>
@@ -12453,7 +12454,7 @@
 																					<revenue>10</revenue>
 																					<nb_conv_pages_before>10</nb_conv_pages_before>
 																					<nb_conversions_attrib>10</nb_conversions_attrib>
-																					<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																					<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 																					<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 																					<revenue_attrib>10</revenue_attrib>
 																					<revenue_entry>5</revenue_entry>
@@ -12466,7 +12467,7 @@
 																					<revenue>10</revenue>
 																					<nb_conv_pages_before>10</nb_conv_pages_before>
 																					<nb_conversions_attrib>10</nb_conversions_attrib>
-																					<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																					<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 																					<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 																					<revenue_attrib>10</revenue_attrib>
 																					<revenue_entry>5</revenue_entry>
@@ -12518,7 +12519,7 @@
 																							<revenue>10</revenue>
 																							<nb_conv_pages_before>10</nb_conv_pages_before>
 																							<nb_conversions_attrib>10</nb_conversions_attrib>
-																							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 																							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 																							<revenue_attrib>10</revenue_attrib>
 																							<revenue_entry>5</revenue_entry>
@@ -12531,7 +12532,7 @@
 																							<revenue>10</revenue>
 																							<nb_conv_pages_before>10</nb_conv_pages_before>
 																							<nb_conversions_attrib>10</nb_conversions_attrib>
-																							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 																							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 																							<revenue_attrib>10</revenue_attrib>
 																							<revenue_entry>5</revenue_entry>
@@ -12678,7 +12679,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.005</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -12691,7 +12692,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.007</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -12797,7 +12798,7 @@
 							<revenue>40</revenue>
 							<nb_conv_pages_before>10</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.019</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>12.92</revenue_attrib>
 						</row>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_flat__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_flat__Actions.getPageUrls_month.xml
@@ -23,7 +23,7 @@
 				<revenue>45</revenue>
 				<nb_conv_pages_before>4</nb_conv_pages_before>
 				<nb_conversions_attrib>9</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 				<revenue_attrib>45</revenue_attrib>
 				<revenue_entry>45</revenue_entry>
@@ -551,7 +551,7 @@
 				<revenue>10</revenue>
 				<nb_conv_pages_before>2</nb_conv_pages_before>
 				<nb_conversions_attrib>2</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 				<revenue_attrib>10</revenue_attrib>
 				<revenue_entry>10</revenue_entry>
@@ -818,7 +818,7 @@
 				<revenue>10</revenue>
 				<nb_conv_pages_before>2</nb_conv_pages_before>
 				<nb_conversions_attrib>2</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 				<revenue_attrib>10</revenue_attrib>
 				<revenue_entry>10</revenue_entry>
@@ -1088,7 +1088,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>
@@ -1355,7 +1355,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>
@@ -1625,7 +1625,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>
@@ -1895,7 +1895,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>
@@ -2165,7 +2165,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>
@@ -2435,7 +2435,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>
@@ -2705,7 +2705,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>
@@ -2972,7 +2972,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>
@@ -3488,7 +3488,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>
@@ -4010,7 +4010,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>
@@ -4736,7 +4736,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>
@@ -5273,7 +5273,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>
@@ -5543,7 +5543,7 @@
 				<revenue>5</revenue>
 				<nb_conv_pages_before>1</nb_conv_pages_before>
 				<nb_conversions_attrib>1</nb_conversions_attrib>
-				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 				<revenue_attrib>5</revenue_attrib>
 				<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_invertCompare__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_invertCompare__Actions.getPageUrls_month.xml
@@ -359,7 +359,7 @@
 						<revenue>50</revenue>
 						<nb_conv_pages_before>5</nb_conv_pages_before>
 						<nb_conversions_attrib>10</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.313</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 						<revenue_attrib>50</revenue_attrib>
 						<revenue_entry>50</revenue_entry>
@@ -441,7 +441,7 @@
 								<revenue>45</revenue>
 								<nb_conv_pages_before>4</nb_conv_pages_before>
 								<nb_conversions_attrib>9</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 								<revenue_attrib>45</revenue_attrib>
 								<revenue_entry>45</revenue_entry>
@@ -523,7 +523,7 @@
 										<revenue>45</revenue>
 										<nb_conv_pages_before>4</nb_conv_pages_before>
 										<nb_conversions_attrib>9</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 										<revenue_attrib>45</revenue_attrib>
 										<revenue_entry>45</revenue_entry>
@@ -617,7 +617,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -705,7 +705,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -777,7 +777,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -859,7 +859,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -941,7 +941,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -1023,7 +1023,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -1444,7 +1444,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -1590,7 +1590,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>2</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>10</revenue_entry>
@@ -1757,7 +1757,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1939,7 +1939,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2108,7 +2108,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2510,7 +2510,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -2662,7 +2662,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2787,7 +2787,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2930,7 +2930,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3072,7 +3072,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -5642,7 +5642,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -5703,7 +5703,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -6114,7 +6114,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -6520,7 +6520,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -6944,7 +6944,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -7426,7 +7426,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -7487,7 +7487,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -7548,7 +7548,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -7609,7 +7609,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -7670,7 +7670,7 @@
 														<revenue>5</revenue>
 														<nb_conv_pages_before>1</nb_conv_pages_before>
 														<nb_conversions_attrib>1</nb_conversions_attrib>
-														<nb_conversions_page_rate>0</nb_conversions_page_rate>
+														<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 														<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 														<revenue_attrib>5</revenue_attrib>
 														<revenue_entry>5</revenue_entry>
@@ -7731,7 +7731,7 @@
 																<revenue>5</revenue>
 																<nb_conv_pages_before>1</nb_conv_pages_before>
 																<nb_conversions_attrib>1</nb_conversions_attrib>
-																<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																<revenue_attrib>5</revenue_attrib>
 																<revenue_entry>5</revenue_entry>
@@ -7792,7 +7792,7 @@
 																		<revenue>5</revenue>
 																		<nb_conv_pages_before>1</nb_conv_pages_before>
 																		<nb_conversions_attrib>1</nb_conversions_attrib>
-																		<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																		<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																		<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																		<revenue_attrib>5</revenue_attrib>
 																		<revenue_entry>5</revenue_entry>
@@ -7853,7 +7853,7 @@
 																				<revenue>5</revenue>
 																				<nb_conv_pages_before>1</nb_conv_pages_before>
 																				<nb_conversions_attrib>1</nb_conversions_attrib>
-																				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																				<revenue_attrib>5</revenue_attrib>
 																				<revenue_entry>5</revenue_entry>
@@ -7914,7 +7914,7 @@
 																						<revenue>5</revenue>
 																						<nb_conv_pages_before>1</nb_conv_pages_before>
 																						<nb_conversions_attrib>1</nb_conversions_attrib>
-																						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																						<revenue_attrib>5</revenue_attrib>
 																						<revenue_entry>5</revenue_entry>
@@ -8339,7 +8339,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -8769,7 +8769,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -8856,7 +8856,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_multipleMultiPeriods__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_multipleMultiPeriods__Actions.getPageUrls_day.xml
@@ -506,7 +506,7 @@
 							<revenue>20</revenue>
 							<nb_conv_pages_before>2</nb_conv_pages_before>
 							<nb_conversions_attrib>4</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.364</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>4</nb_conversions_page_uniq>
 							<revenue_attrib>20</revenue_attrib>
 							<revenue_entry>20</revenue_entry>
@@ -584,7 +584,7 @@
 									<revenue>15</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>3</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.273</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>3</nb_conversions_page_uniq>
 									<revenue_attrib>15</revenue_attrib>
 									<revenue_entry>15</revenue_entry>
@@ -665,7 +665,7 @@
 											<revenue>15</revenue>
 											<nb_conv_pages_before>1</nb_conv_pages_before>
 											<nb_conversions_attrib>3</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.273</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>3</nb_conversions_page_uniq>
 											<revenue_attrib>15</revenue_attrib>
 											<revenue_entry>15</revenue_entry>
@@ -752,7 +752,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.091</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -833,7 +833,7 @@
 											<revenue>5</revenue>
 											<nb_conv_pages_before>1</nb_conv_pages_before>
 											<nb_conversions_attrib>1</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.091</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 											<revenue_attrib>5</revenue_attrib>
 											<revenue_entry>5</revenue_entry>
@@ -1412,7 +1412,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.091</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -1545,7 +1545,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.091</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -1676,7 +1676,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.091</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -1763,7 +1763,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.091</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -1886,7 +1886,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.091</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -3060,7 +3060,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.091</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -3141,7 +3141,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.091</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -3718,7 +3718,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.091</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4293,7 +4293,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.091</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -4867,7 +4867,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>2</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.25</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -4945,7 +4945,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>2</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.25</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>10</revenue_entry>
@@ -5026,7 +5026,7 @@
 											<revenue>10</revenue>
 											<nb_conv_pages_before>1</nb_conv_pages_before>
 											<nb_conversions_attrib>2</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.25</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 											<revenue_attrib>10</revenue_attrib>
 											<revenue_entry>10</revenue_entry>
@@ -5115,7 +5115,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -5193,7 +5193,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -5271,7 +5271,7 @@
 											<revenue>5</revenue>
 											<nb_conv_pages_before>1</nb_conv_pages_before>
 											<nb_conversions_attrib>1</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 											<revenue_attrib>5</revenue_attrib>
 											<revenue_entry>5</revenue_entry>
@@ -5352,7 +5352,7 @@
 													<revenue>5</revenue>
 													<nb_conv_pages_before>1</nb_conv_pages_before>
 													<nb_conversions_attrib>1</nb_conversions_attrib>
-													<nb_conversions_page_rate>0</nb_conversions_page_rate>
+													<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 													<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 													<revenue_attrib>5</revenue_attrib>
 													<revenue_entry>5</revenue_entry>
@@ -5933,7 +5933,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6074,7 +6074,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6197,7 +6197,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -6819,7 +6819,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -6942,7 +6942,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -7567,7 +7567,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -8142,7 +8142,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -8764,7 +8764,7 @@
 							<revenue>15</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>3</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.333</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>3</nb_conversions_page_uniq>
 							<revenue_attrib>15</revenue_attrib>
 							<revenue_entry>15</revenue_entry>
@@ -8842,7 +8842,7 @@
 									<revenue>15</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>3</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.333</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>3</nb_conversions_page_uniq>
 									<revenue_attrib>15</revenue_attrib>
 									<revenue_entry>15</revenue_entry>
@@ -8923,7 +8923,7 @@
 											<revenue>15</revenue>
 											<nb_conv_pages_before>1</nb_conv_pages_before>
 											<nb_conversions_attrib>3</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.333</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>3</nb_conversions_page_uniq>
 											<revenue_attrib>15</revenue_attrib>
 											<revenue_entry>15</revenue_entry>
@@ -11538,7 +11538,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.111</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -11619,7 +11619,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.111</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -12196,7 +12196,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.111</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -12768,7 +12768,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.111</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -12846,7 +12846,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.111</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -12924,7 +12924,7 @@
 											<revenue>5</revenue>
 											<nb_conv_pages_before>1</nb_conv_pages_before>
 											<nb_conversions_attrib>1</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.111</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 											<revenue_attrib>5</revenue_attrib>
 											<revenue_entry>5</revenue_entry>
@@ -13002,7 +13002,7 @@
 													<revenue>5</revenue>
 													<nb_conv_pages_before>1</nb_conv_pages_before>
 													<nb_conversions_attrib>1</nb_conversions_attrib>
-													<nb_conversions_page_rate>0</nb_conversions_page_rate>
+													<nb_conversions_page_rate>0.111</nb_conversions_page_rate>
 													<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 													<revenue_attrib>5</revenue_attrib>
 													<revenue_entry>5</revenue_entry>
@@ -13080,7 +13080,7 @@
 															<revenue>5</revenue>
 															<nb_conv_pages_before>1</nb_conv_pages_before>
 															<nb_conversions_attrib>1</nb_conversions_attrib>
-															<nb_conversions_page_rate>0</nb_conversions_page_rate>
+															<nb_conversions_page_rate>0.111</nb_conversions_page_rate>
 															<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 															<revenue_attrib>5</revenue_attrib>
 															<revenue_entry>5</revenue_entry>
@@ -13158,7 +13158,7 @@
 																	<revenue>5</revenue>
 																	<nb_conv_pages_before>1</nb_conv_pages_before>
 																	<nb_conversions_attrib>1</nb_conversions_attrib>
-																	<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																	<nb_conversions_page_rate>0.111</nb_conversions_page_rate>
 																	<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																	<revenue_attrib>5</revenue_attrib>
 																	<revenue_entry>5</revenue_entry>
@@ -13236,7 +13236,7 @@
 																			<revenue>5</revenue>
 																			<nb_conv_pages_before>1</nb_conv_pages_before>
 																			<nb_conversions_attrib>1</nb_conversions_attrib>
-																			<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																			<nb_conversions_page_rate>0.111</nb_conversions_page_rate>
 																			<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																			<revenue_attrib>5</revenue_attrib>
 																			<revenue_entry>5</revenue_entry>
@@ -13314,7 +13314,7 @@
 																					<revenue>5</revenue>
 																					<nb_conv_pages_before>1</nb_conv_pages_before>
 																					<nb_conversions_attrib>1</nb_conversions_attrib>
-																					<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																					<nb_conversions_page_rate>0.111</nb_conversions_page_rate>
 																					<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																					<revenue_attrib>5</revenue_attrib>
 																					<revenue_entry>5</revenue_entry>
@@ -13395,7 +13395,7 @@
 																							<revenue>5</revenue>
 																							<nb_conv_pages_before>1</nb_conv_pages_before>
 																							<nb_conversions_attrib>1</nb_conversions_attrib>
-																							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																							<nb_conversions_page_rate>0.111</nb_conversions_page_rate>
 																							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																							<revenue_attrib>5</revenue_attrib>
 																							<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_multipleSites_multipleCompare__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_multipleSites_multipleCompare__Actions.getPageUrls_month.xml
@@ -557,7 +557,7 @@
 							<revenue>50</revenue>
 							<nb_conv_pages_before>5</nb_conv_pages_before>
 							<nb_conversions_attrib>10</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.313</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 							<revenue_attrib>50</revenue_attrib>
 							<revenue_entry>50</revenue_entry>
@@ -660,7 +660,7 @@
 									<revenue>45</revenue>
 									<nb_conv_pages_before>4</nb_conv_pages_before>
 									<nb_conversions_attrib>9</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 									<revenue_attrib>45</revenue_attrib>
 									<revenue_entry>45</revenue_entry>
@@ -763,7 +763,7 @@
 											<revenue>45</revenue>
 											<nb_conv_pages_before>4</nb_conv_pages_before>
 											<nb_conversions_attrib>9</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 											<revenue_attrib>45</revenue_attrib>
 											<revenue_entry>45</revenue_entry>
@@ -881,7 +881,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -996,7 +996,7 @@
 											<revenue>5</revenue>
 											<nb_conv_pages_before>1</nb_conv_pages_before>
 											<nb_conversions_attrib>1</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 											<revenue_attrib>5</revenue_attrib>
 											<revenue_entry>5</revenue_entry>
@@ -1068,7 +1068,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -1177,7 +1177,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -1259,7 +1259,7 @@
 											<revenue>5</revenue>
 											<nb_conv_pages_before>1</nb_conv_pages_before>
 											<nb_conversions_attrib>1</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 											<revenue_attrib>5</revenue_attrib>
 											<revenue_entry>5</revenue_entry>
@@ -1341,7 +1341,7 @@
 													<revenue>5</revenue>
 													<nb_conv_pages_before>1</nb_conv_pages_before>
 													<nb_conversions_attrib>1</nb_conversions_attrib>
-													<nb_conversions_page_rate>0</nb_conversions_page_rate>
+													<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 													<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 													<revenue_attrib>5</revenue_attrib>
 													<revenue_entry>5</revenue_entry>
@@ -1970,7 +1970,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>2</nb_conv_pages_before>
 							<nb_conversions_attrib>2</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -2116,7 +2116,7 @@
 									<revenue>10</revenue>
 									<nb_conv_pages_before>2</nb_conv_pages_before>
 									<nb_conversions_attrib>2</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 									<revenue_attrib>10</revenue_attrib>
 									<revenue_entry>10</revenue_entry>
@@ -2283,7 +2283,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -2465,7 +2465,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -2634,7 +2634,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -3238,7 +3238,7 @@
 							<revenue>10</revenue>
 							<nb_conv_pages_before>2</nb_conv_pages_before>
 							<nb_conversions_attrib>2</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 							<revenue_attrib>10</revenue_attrib>
 							<revenue_entry>10</revenue_entry>
@@ -3390,7 +3390,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -3515,7 +3515,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -3658,7 +3658,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -3800,7 +3800,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -7932,7 +7932,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -7993,7 +7993,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -8616,7 +8616,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -9228,7 +9228,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -9854,7 +9854,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -10548,7 +10548,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -10609,7 +10609,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>
@@ -10670,7 +10670,7 @@
 											<revenue>5</revenue>
 											<nb_conv_pages_before>1</nb_conv_pages_before>
 											<nb_conversions_attrib>1</nb_conversions_attrib>
-											<nb_conversions_page_rate>0</nb_conversions_page_rate>
+											<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 											<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 											<revenue_attrib>5</revenue_attrib>
 											<revenue_entry>5</revenue_entry>
@@ -10731,7 +10731,7 @@
 													<revenue>5</revenue>
 													<nb_conv_pages_before>1</nb_conv_pages_before>
 													<nb_conversions_attrib>1</nb_conversions_attrib>
-													<nb_conversions_page_rate>0</nb_conversions_page_rate>
+													<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 													<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 													<revenue_attrib>5</revenue_attrib>
 													<revenue_entry>5</revenue_entry>
@@ -10792,7 +10792,7 @@
 															<revenue>5</revenue>
 															<nb_conv_pages_before>1</nb_conv_pages_before>
 															<nb_conversions_attrib>1</nb_conversions_attrib>
-															<nb_conversions_page_rate>0</nb_conversions_page_rate>
+															<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 															<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 															<revenue_attrib>5</revenue_attrib>
 															<revenue_entry>5</revenue_entry>
@@ -10853,7 +10853,7 @@
 																	<revenue>5</revenue>
 																	<nb_conv_pages_before>1</nb_conv_pages_before>
 																	<nb_conversions_attrib>1</nb_conversions_attrib>
-																	<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																	<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																	<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																	<revenue_attrib>5</revenue_attrib>
 																	<revenue_entry>5</revenue_entry>
@@ -10914,7 +10914,7 @@
 																			<revenue>5</revenue>
 																			<nb_conv_pages_before>1</nb_conv_pages_before>
 																			<nb_conversions_attrib>1</nb_conversions_attrib>
-																			<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																			<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																			<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																			<revenue_attrib>5</revenue_attrib>
 																			<revenue_entry>5</revenue_entry>
@@ -10975,7 +10975,7 @@
 																					<revenue>5</revenue>
 																					<nb_conv_pages_before>1</nb_conv_pages_before>
 																					<nb_conversions_attrib>1</nb_conversions_attrib>
-																					<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																					<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																					<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																					<revenue_attrib>5</revenue_attrib>
 																					<revenue_entry>5</revenue_entry>
@@ -11036,7 +11036,7 @@
 																							<revenue>5</revenue>
 																							<nb_conv_pages_before>1</nb_conv_pages_before>
 																							<nb_conversions_attrib>1</nb_conversions_attrib>
-																							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																							<revenue_attrib>5</revenue_attrib>
 																							<revenue_entry>5</revenue_entry>
@@ -11673,7 +11673,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -12335,7 +12335,7 @@
 							<revenue>5</revenue>
 							<nb_conv_pages_before>1</nb_conv_pages_before>
 							<nb_conversions_attrib>1</nb_conversions_attrib>
-							<nb_conversions_page_rate>0</nb_conversions_page_rate>
+							<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 							<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 							<revenue_attrib>5</revenue_attrib>
 							<revenue_entry>5</revenue_entry>
@@ -12422,7 +12422,7 @@
 									<revenue>5</revenue>
 									<nb_conv_pages_before>1</nb_conv_pages_before>
 									<nb_conversions_attrib>1</nb_conversions_attrib>
-									<nb_conversions_page_rate>0</nb_conversions_page_rate>
+									<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 									<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 									<revenue_attrib>5</revenue_attrib>
 									<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_periods__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_periods__Actions.getPageUrls_month.xml
@@ -216,7 +216,7 @@
 						<revenue>50</revenue>
 						<nb_conv_pages_before>5</nb_conv_pages_before>
 						<nb_conversions_attrib>10</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.313</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 						<revenue_attrib>50</revenue_attrib>
 						<revenue_entry>50</revenue_entry>
@@ -319,7 +319,7 @@
 								<revenue>45</revenue>
 								<nb_conv_pages_before>4</nb_conv_pages_before>
 								<nb_conversions_attrib>9</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 								<revenue_attrib>45</revenue_attrib>
 								<revenue_entry>45</revenue_entry>
@@ -422,7 +422,7 @@
 										<revenue>45</revenue>
 										<nb_conv_pages_before>4</nb_conv_pages_before>
 										<nb_conversions_attrib>9</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 										<revenue_attrib>45</revenue_attrib>
 										<revenue_entry>45</revenue_entry>
@@ -540,7 +540,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -655,7 +655,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -727,7 +727,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -836,7 +836,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -918,7 +918,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -1000,7 +1000,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -1302,7 +1302,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -1384,7 +1384,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>2</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>10</revenue_entry>
@@ -1478,7 +1478,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1576,7 +1576,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1664,7 +1664,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1938,7 +1938,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -2030,7 +2030,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2112,7 +2112,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2206,7 +2206,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2294,7 +2294,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -3904,7 +3904,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3965,7 +3965,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -4248,7 +4248,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4520,7 +4520,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4816,7 +4816,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -5121,7 +5121,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -5182,7 +5182,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -5243,7 +5243,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -5304,7 +5304,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -5365,7 +5365,7 @@
 														<revenue>5</revenue>
 														<nb_conv_pages_before>1</nb_conv_pages_before>
 														<nb_conversions_attrib>1</nb_conversions_attrib>
-														<nb_conversions_page_rate>0</nb_conversions_page_rate>
+														<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 														<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 														<revenue_attrib>5</revenue_attrib>
 														<revenue_entry>5</revenue_entry>
@@ -5426,7 +5426,7 @@
 																<revenue>5</revenue>
 																<nb_conv_pages_before>1</nb_conv_pages_before>
 																<nb_conversions_attrib>1</nb_conversions_attrib>
-																<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																<revenue_attrib>5</revenue_attrib>
 																<revenue_entry>5</revenue_entry>
@@ -5487,7 +5487,7 @@
 																		<revenue>5</revenue>
 																		<nb_conv_pages_before>1</nb_conv_pages_before>
 																		<nb_conversions_attrib>1</nb_conversions_attrib>
-																		<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																		<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																		<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																		<revenue_attrib>5</revenue_attrib>
 																		<revenue_entry>5</revenue_entry>
@@ -5548,7 +5548,7 @@
 																				<revenue>5</revenue>
 																				<nb_conv_pages_before>1</nb_conv_pages_before>
 																				<nb_conversions_attrib>1</nb_conversions_attrib>
-																				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																				<revenue_attrib>5</revenue_attrib>
 																				<revenue_entry>5</revenue_entry>
@@ -5609,7 +5609,7 @@
 																						<revenue>5</revenue>
 																						<nb_conv_pages_before>1</nb_conv_pages_before>
 																						<nb_conversions_attrib>1</nb_conversions_attrib>
-																						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																						<revenue_attrib>5</revenue_attrib>
 																						<revenue_entry>5</revenue_entry>
@@ -5906,7 +5906,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -6201,7 +6201,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -6264,7 +6264,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_rangePeriodAgainstSingle__Actions.getPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_rangePeriodAgainstSingle__Actions.getPageUrls_range.xml
@@ -505,7 +505,7 @@
 						<revenue>45</revenue>
 						<nb_conv_pages_before>4</nb_conv_pages_before>
 						<nb_conversions_attrib>9</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.3</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 						<revenue_attrib>45</revenue_attrib>
 						<revenue_entry>45</revenue_entry>
@@ -604,7 +604,7 @@
 								<revenue>40</revenue>
 								<nb_conv_pages_before>3</nb_conv_pages_before>
 								<nb_conversions_attrib>8</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.267</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>8</nb_conversions_page_uniq>
 								<revenue_attrib>40</revenue_attrib>
 								<revenue_entry>40</revenue_entry>
@@ -703,7 +703,7 @@
 										<revenue>40</revenue>
 										<nb_conv_pages_before>3</nb_conv_pages_before>
 										<nb_conversions_attrib>8</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.267</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>8</nb_conversions_page_uniq>
 										<revenue_attrib>40</revenue_attrib>
 										<revenue_entry>40</revenue_entry>
@@ -817,7 +817,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -924,7 +924,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -992,7 +992,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1095,7 +1095,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1173,7 +1173,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -1251,7 +1251,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -1832,7 +1832,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.067</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -1973,7 +1973,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>2</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.067</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>10</revenue_entry>
@@ -2135,7 +2135,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2307,7 +2307,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2464,7 +2464,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -3017,7 +3017,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.067</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -3161,7 +3161,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3281,7 +3281,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -3419,7 +3419,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3551,7 +3551,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -7247,7 +7247,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -7304,7 +7304,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -7857,7 +7857,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -8408,7 +8408,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -8983,7 +8983,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -9606,7 +9606,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -9663,7 +9663,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -9720,7 +9720,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -9777,7 +9777,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -9834,7 +9834,7 @@
 														<revenue>5</revenue>
 														<nb_conv_pages_before>1</nb_conv_pages_before>
 														<nb_conversions_attrib>1</nb_conversions_attrib>
-														<nb_conversions_page_rate>0</nb_conversions_page_rate>
+														<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 														<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 														<revenue_attrib>5</revenue_attrib>
 														<revenue_entry>5</revenue_entry>
@@ -9891,7 +9891,7 @@
 																<revenue>5</revenue>
 																<nb_conv_pages_before>1</nb_conv_pages_before>
 																<nb_conversions_attrib>1</nb_conversions_attrib>
-																<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 																<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																<revenue_attrib>5</revenue_attrib>
 																<revenue_entry>5</revenue_entry>
@@ -9948,7 +9948,7 @@
 																		<revenue>5</revenue>
 																		<nb_conv_pages_before>1</nb_conv_pages_before>
 																		<nb_conversions_attrib>1</nb_conversions_attrib>
-																		<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																		<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 																		<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																		<revenue_attrib>5</revenue_attrib>
 																		<revenue_entry>5</revenue_entry>
@@ -10005,7 +10005,7 @@
 																				<revenue>5</revenue>
 																				<nb_conv_pages_before>1</nb_conv_pages_before>
 																				<nb_conversions_attrib>1</nb_conversions_attrib>
-																				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																				<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 																				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																				<revenue_attrib>5</revenue_attrib>
 																				<revenue_entry>5</revenue_entry>
@@ -10062,7 +10062,7 @@
 																						<revenue>5</revenue>
 																						<nb_conv_pages_before>1</nb_conv_pages_before>
 																						<nb_conversions_attrib>1</nb_conversions_attrib>
-																						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																						<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 																						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																						<revenue_attrib>5</revenue_attrib>
 																						<revenue_entry>5</revenue_entry>
@@ -10629,7 +10629,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.033</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_segmentsAndPeriods__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_segmentsAndPeriods__Actions.getPageUrls_month.xml
@@ -556,7 +556,7 @@
 						<revenue>50</revenue>
 						<nb_conv_pages_before>5</nb_conv_pages_before>
 						<nb_conversions_attrib>10</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.313</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 						<revenue_attrib>50</revenue_attrib>
 						<revenue_entry>50</revenue_entry>
@@ -659,7 +659,7 @@
 								<revenue>45</revenue>
 								<nb_conv_pages_before>4</nb_conv_pages_before>
 								<nb_conversions_attrib>9</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 								<revenue_attrib>45</revenue_attrib>
 								<revenue_entry>45</revenue_entry>
@@ -762,7 +762,7 @@
 										<revenue>45</revenue>
 										<nb_conv_pages_before>4</nb_conv_pages_before>
 										<nb_conversions_attrib>9</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 										<revenue_attrib>45</revenue_attrib>
 										<revenue_entry>45</revenue_entry>
@@ -880,7 +880,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -995,7 +995,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -1067,7 +1067,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1176,7 +1176,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1258,7 +1258,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -1340,7 +1340,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -1969,7 +1969,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -2115,7 +2115,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>2</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>10</revenue_entry>
@@ -2282,7 +2282,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2464,7 +2464,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2633,7 +2633,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -3237,7 +3237,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -3389,7 +3389,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3514,7 +3514,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -3657,7 +3657,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3799,7 +3799,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -7931,7 +7931,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -7992,7 +7992,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -8615,7 +8615,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -9227,7 +9227,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -9853,7 +9853,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -10547,7 +10547,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -10608,7 +10608,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -10669,7 +10669,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -10730,7 +10730,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -10791,7 +10791,7 @@
 														<revenue>5</revenue>
 														<nb_conv_pages_before>1</nb_conv_pages_before>
 														<nb_conversions_attrib>1</nb_conversions_attrib>
-														<nb_conversions_page_rate>0</nb_conversions_page_rate>
+														<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 														<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 														<revenue_attrib>5</revenue_attrib>
 														<revenue_entry>5</revenue_entry>
@@ -10852,7 +10852,7 @@
 																<revenue>5</revenue>
 																<nb_conv_pages_before>1</nb_conv_pages_before>
 																<nb_conversions_attrib>1</nb_conversions_attrib>
-																<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																<revenue_attrib>5</revenue_attrib>
 																<revenue_entry>5</revenue_entry>
@@ -10913,7 +10913,7 @@
 																		<revenue>5</revenue>
 																		<nb_conv_pages_before>1</nb_conv_pages_before>
 																		<nb_conversions_attrib>1</nb_conversions_attrib>
-																		<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																		<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																		<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																		<revenue_attrib>5</revenue_attrib>
 																		<revenue_entry>5</revenue_entry>
@@ -10974,7 +10974,7 @@
 																				<revenue>5</revenue>
 																				<nb_conv_pages_before>1</nb_conv_pages_before>
 																				<nb_conversions_attrib>1</nb_conversions_attrib>
-																				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																				<revenue_attrib>5</revenue_attrib>
 																				<revenue_entry>5</revenue_entry>
@@ -11035,7 +11035,7 @@
 																						<revenue>5</revenue>
 																						<nb_conv_pages_before>1</nb_conv_pages_before>
 																						<nb_conversions_attrib>1</nb_conversions_attrib>
-																						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																						<revenue_attrib>5</revenue_attrib>
 																						<revenue_entry>5</revenue_entry>
@@ -11672,7 +11672,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -12334,7 +12334,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -12421,7 +12421,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_segments__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_segments__Actions.getPageUrls_month.xml
@@ -154,7 +154,7 @@
 						<revenue>50</revenue>
 						<nb_conv_pages_before>5</nb_conv_pages_before>
 						<nb_conversions_attrib>10</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.313</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 						<revenue_attrib>50</revenue_attrib>
 						<revenue_entry>50</revenue_entry>
@@ -215,7 +215,7 @@
 								<revenue>45</revenue>
 								<nb_conv_pages_before>4</nb_conv_pages_before>
 								<nb_conversions_attrib>9</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 								<revenue_attrib>45</revenue_attrib>
 								<revenue_entry>45</revenue_entry>
@@ -276,7 +276,7 @@
 										<revenue>45</revenue>
 										<nb_conv_pages_before>4</nb_conv_pages_before>
 										<nb_conversions_attrib>9</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 										<revenue_attrib>45</revenue_attrib>
 										<revenue_entry>45</revenue_entry>
@@ -346,7 +346,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -407,7 +407,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -479,7 +479,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -540,7 +540,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -601,7 +601,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -662,7 +662,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -865,7 +865,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -969,7 +969,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>2</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>10</revenue_entry>
@@ -1088,7 +1088,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1210,7 +1210,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1325,7 +1325,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1527,7 +1527,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.063</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -1625,7 +1625,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1708,7 +1708,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1803,7 +1803,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1891,7 +1891,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2912,7 +2912,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2973,7 +2973,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -3176,7 +3176,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3377,7 +3377,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3577,7 +3577,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3803,7 +3803,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3864,7 +3864,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -3925,7 +3925,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -3986,7 +3986,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -4047,7 +4047,7 @@
 														<revenue>5</revenue>
 														<nb_conv_pages_before>1</nb_conv_pages_before>
 														<nb_conversions_attrib>1</nb_conversions_attrib>
-														<nb_conversions_page_rate>0</nb_conversions_page_rate>
+														<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 														<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 														<revenue_attrib>5</revenue_attrib>
 														<revenue_entry>5</revenue_entry>
@@ -4108,7 +4108,7 @@
 																<revenue>5</revenue>
 																<nb_conv_pages_before>1</nb_conv_pages_before>
 																<nb_conversions_attrib>1</nb_conversions_attrib>
-																<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																<revenue_attrib>5</revenue_attrib>
 																<revenue_entry>5</revenue_entry>
@@ -4169,7 +4169,7 @@
 																		<revenue>5</revenue>
 																		<nb_conv_pages_before>1</nb_conv_pages_before>
 																		<nb_conversions_attrib>1</nb_conversions_attrib>
-																		<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																		<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																		<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																		<revenue_attrib>5</revenue_attrib>
 																		<revenue_entry>5</revenue_entry>
@@ -4230,7 +4230,7 @@
 																				<revenue>5</revenue>
 																				<nb_conv_pages_before>1</nb_conv_pages_before>
 																				<nb_conversions_attrib>1</nb_conversions_attrib>
-																				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																				<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																				<revenue_attrib>5</revenue_attrib>
 																				<revenue_entry>5</revenue_entry>
@@ -4291,7 +4291,7 @@
 																						<revenue>5</revenue>
 																						<nb_conv_pages_before>1</nb_conv_pages_before>
 																						<nb_conversions_attrib>1</nb_conversions_attrib>
-																						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 																						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																						<revenue_attrib>5</revenue_attrib>
 																						<revenue_entry>5</revenue_entry>
@@ -4508,7 +4508,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4714,7 +4714,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4801,7 +4801,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_singleAgainstRange__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_singleAgainstRange__Actions.getPageUrls_day.xml
@@ -146,7 +146,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.25</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -224,7 +224,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.25</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>10</revenue_entry>
@@ -305,7 +305,7 @@
 										<revenue>10</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>2</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.25</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 										<revenue_attrib>10</revenue_attrib>
 										<revenue_entry>10</revenue_entry>
@@ -394,7 +394,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -472,7 +472,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -550,7 +550,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -631,7 +631,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -853,7 +853,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -938,7 +938,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1019,7 +1019,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1234,7 +1234,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1315,7 +1315,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1533,7 +1533,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1749,7 +1749,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.125</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_subtableActions__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_subtableActions__Actions.getPageUrls_month.xml
@@ -505,7 +505,7 @@
 						<revenue>45</revenue>
 						<nb_conv_pages_before>4</nb_conv_pages_before>
 						<nb_conversions_attrib>9</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 						<revenue_attrib>45</revenue_attrib>
 						<revenue_entry>45</revenue_entry>
@@ -604,7 +604,7 @@
 								<revenue>45</revenue>
 								<nb_conv_pages_before>4</nb_conv_pages_before>
 								<nb_conversions_attrib>9</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.281</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 								<revenue_attrib>45</revenue_attrib>
 								<revenue_entry>45</revenue_entry>
@@ -718,7 +718,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -825,7 +825,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1378,7 +1378,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1456,7 +1456,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1534,7 +1534,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.031</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_month.xml
@@ -63,7 +63,7 @@
 						<revenue>50</revenue>
 						<nb_conv_pages_before>5</nb_conv_pages_before>
 						<nb_conversions_attrib>10</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.256</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 						<revenue_attrib>50</revenue_attrib>
 						<revenue_entry>50</revenue_entry>
@@ -100,7 +100,7 @@
 								<revenue>45</revenue>
 								<nb_conv_pages_before>4</nb_conv_pages_before>
 								<nb_conversions_attrib>9</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.231</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 								<revenue_attrib>45</revenue_attrib>
 								<revenue_entry>45</revenue_entry>
@@ -137,7 +137,7 @@
 										<revenue>45</revenue>
 										<nb_conv_pages_before>4</nb_conv_pages_before>
 										<nb_conversions_attrib>9</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.231</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 										<revenue_attrib>45</revenue_attrib>
 										<revenue_entry>45</revenue_entry>
@@ -180,7 +180,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -217,7 +217,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -262,7 +262,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -299,7 +299,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -336,7 +336,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -373,7 +373,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -462,7 +462,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -499,7 +499,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>2</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>10</revenue_entry>
@@ -542,7 +542,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -583,7 +583,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -620,7 +620,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -705,7 +705,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -746,7 +746,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -783,7 +783,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -826,7 +826,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -863,7 +863,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -992,7 +992,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1029,7 +1029,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1072,7 +1072,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1109,7 +1109,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1146,7 +1146,7 @@
 										<revenue>10</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>2</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 										<revenue_attrib>10</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -1183,7 +1183,7 @@
 												<revenue>10</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>2</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 												<revenue_attrib>10</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -1271,7 +1271,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1308,7 +1308,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1345,7 +1345,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -1382,7 +1382,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -1470,7 +1470,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1727,7 +1727,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1810,7 +1810,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1847,7 +1847,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1932,7 +1932,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2015,7 +2015,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2098,7 +2098,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2181,7 +2181,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2264,7 +2264,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2301,7 +2301,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2338,7 +2338,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -2375,7 +2375,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -2412,7 +2412,7 @@
 														<revenue>5</revenue>
 														<nb_conv_pages_before>1</nb_conv_pages_before>
 														<nb_conversions_attrib>1</nb_conversions_attrib>
-														<nb_conversions_page_rate>0</nb_conversions_page_rate>
+														<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 														<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 														<revenue_attrib>5</revenue_attrib>
 														<revenue_entry>5</revenue_entry>
@@ -2449,7 +2449,7 @@
 																<revenue>5</revenue>
 																<nb_conv_pages_before>1</nb_conv_pages_before>
 																<nb_conversions_attrib>1</nb_conversions_attrib>
-																<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 																<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																<revenue_attrib>5</revenue_attrib>
 																<revenue_entry>5</revenue_entry>
@@ -2486,7 +2486,7 @@
 																		<revenue>5</revenue>
 																		<nb_conv_pages_before>1</nb_conv_pages_before>
 																		<nb_conversions_attrib>1</nb_conversions_attrib>
-																		<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																		<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 																		<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																		<revenue_attrib>5</revenue_attrib>
 																		<revenue_entry>5</revenue_entry>
@@ -2523,7 +2523,7 @@
 																				<revenue>5</revenue>
 																				<nb_conv_pages_before>1</nb_conv_pages_before>
 																				<nb_conversions_attrib>1</nb_conversions_attrib>
-																				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																				<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 																				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																				<revenue_attrib>5</revenue_attrib>
 																				<revenue_entry>5</revenue_entry>
@@ -2560,7 +2560,7 @@
 																						<revenue>5</revenue>
 																						<nb_conv_pages_before>1</nb_conv_pages_before>
 																						<nb_conversions_attrib>1</nb_conversions_attrib>
-																						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 																						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																						<revenue_attrib>5</revenue_attrib>
 																						<revenue_entry>5</revenue_entry>
@@ -2659,7 +2659,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2742,7 +2742,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2779,7 +2779,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_range.xml
@@ -98,7 +98,7 @@
 						<revenue>55</revenue>
 						<nb_conv_pages_before>6</nb_conv_pages_before>
 						<nb_conversions_attrib>11</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.216</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>11</nb_conversions_page_uniq>
 						<revenue_attrib>55</revenue_attrib>
 						<revenue_entry>55</revenue_entry>
@@ -150,7 +150,7 @@
 								<revenue>50</revenue>
 								<nb_conv_pages_before>5</nb_conv_pages_before>
 								<nb_conversions_attrib>10</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.196</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 								<revenue_attrib>50</revenue_attrib>
 								<revenue_entry>50</revenue_entry>
@@ -202,7 +202,7 @@
 										<revenue>50</revenue>
 										<nb_conv_pages_before>5</nb_conv_pages_before>
 										<nb_conversions_attrib>10</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.196</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 										<revenue_attrib>50</revenue_attrib>
 										<revenue_entry>50</revenue_entry>
@@ -260,7 +260,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -312,7 +312,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -372,7 +372,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -424,7 +424,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -476,7 +476,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -528,7 +528,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -588,7 +588,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -640,7 +640,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -692,7 +692,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -754,7 +754,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -806,7 +806,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -858,7 +858,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -910,7 +910,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -1098,7 +1098,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -1150,7 +1150,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>2</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>10</revenue_entry>
@@ -1208,7 +1208,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1264,7 +1264,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1316,7 +1316,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1374,7 +1374,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1426,7 +1426,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1546,7 +1546,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -1602,7 +1602,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1654,7 +1654,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1712,7 +1712,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1764,7 +1764,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1884,7 +1884,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1936,7 +1936,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1994,7 +1994,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2046,7 +2046,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2098,7 +2098,7 @@
 										<revenue>10</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>2</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 										<revenue_attrib>10</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -2150,7 +2150,7 @@
 												<revenue>10</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>2</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 												<revenue_attrib>10</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -2273,7 +2273,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2325,7 +2325,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2377,7 +2377,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -2429,7 +2429,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -2552,7 +2552,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2604,7 +2604,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2724,7 +2724,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -2842,7 +2842,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3278,7 +3278,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3394,7 +3394,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3511,7 +3511,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3629,7 +3629,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3747,7 +3747,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3865,7 +3865,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3983,7 +3983,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4035,7 +4035,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -4087,7 +4087,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -4139,7 +4139,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -4191,7 +4191,7 @@
 														<revenue>5</revenue>
 														<nb_conv_pages_before>1</nb_conv_pages_before>
 														<nb_conversions_attrib>1</nb_conversions_attrib>
-														<nb_conversions_page_rate>0</nb_conversions_page_rate>
+														<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 														<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 														<revenue_attrib>5</revenue_attrib>
 														<revenue_entry>5</revenue_entry>
@@ -4243,7 +4243,7 @@
 																<revenue>5</revenue>
 																<nb_conv_pages_before>1</nb_conv_pages_before>
 																<nb_conversions_attrib>1</nb_conversions_attrib>
-																<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 																<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																<revenue_attrib>5</revenue_attrib>
 																<revenue_entry>5</revenue_entry>
@@ -4295,7 +4295,7 @@
 																		<revenue>5</revenue>
 																		<nb_conv_pages_before>1</nb_conv_pages_before>
 																		<nb_conversions_attrib>1</nb_conversions_attrib>
-																		<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																		<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 																		<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																		<revenue_attrib>5</revenue_attrib>
 																		<revenue_entry>5</revenue_entry>
@@ -4347,7 +4347,7 @@
 																				<revenue>5</revenue>
 																				<nb_conv_pages_before>1</nb_conv_pages_before>
 																				<nb_conversions_attrib>1</nb_conversions_attrib>
-																				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																				<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 																				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																				<revenue_attrib>5</revenue_attrib>
 																				<revenue_entry>5</revenue_entry>
@@ -4399,7 +4399,7 @@
 																						<revenue>5</revenue>
 																						<nb_conv_pages_before>1</nb_conv_pages_before>
 																						<nb_conversions_attrib>1</nb_conversions_attrib>
-																						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 																						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																						<revenue_attrib>5</revenue_attrib>
 																						<revenue_entry>5</revenue_entry>
@@ -4533,7 +4533,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4651,7 +4651,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4703,7 +4703,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_month.xml
@@ -63,7 +63,7 @@
 						<revenue>50</revenue>
 						<nb_conv_pages_before>5</nb_conv_pages_before>
 						<nb_conversions_attrib>10</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.256</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 						<revenue_attrib>50</revenue_attrib>
 						<revenue_entry>50</revenue_entry>
@@ -100,7 +100,7 @@
 								<revenue>45</revenue>
 								<nb_conv_pages_before>4</nb_conv_pages_before>
 								<nb_conversions_attrib>9</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.231</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 								<revenue_attrib>45</revenue_attrib>
 								<revenue_entry>45</revenue_entry>
@@ -137,7 +137,7 @@
 										<revenue>45</revenue>
 										<nb_conv_pages_before>4</nb_conv_pages_before>
 										<nb_conversions_attrib>9</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.231</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 										<revenue_attrib>45</revenue_attrib>
 										<revenue_entry>45</revenue_entry>
@@ -180,7 +180,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -217,7 +217,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -262,7 +262,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -299,7 +299,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -336,7 +336,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -373,7 +373,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -462,7 +462,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -499,7 +499,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>2</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>10</revenue_entry>
@@ -542,7 +542,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -583,7 +583,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -620,7 +620,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -705,7 +705,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -746,7 +746,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -783,7 +783,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -826,7 +826,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -863,7 +863,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -992,7 +992,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1029,7 +1029,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1072,7 +1072,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1109,7 +1109,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1146,7 +1146,7 @@
 										<revenue>10</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>2</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 										<revenue_attrib>10</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -1183,7 +1183,7 @@
 												<revenue>10</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>2</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 												<revenue_attrib>10</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -1271,7 +1271,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1308,7 +1308,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1345,7 +1345,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -1452,7 +1452,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1691,7 +1691,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1774,7 +1774,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1811,7 +1811,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1896,7 +1896,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1979,7 +1979,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2062,7 +2062,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2145,7 +2145,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2228,7 +2228,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2265,7 +2265,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2302,7 +2302,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -2339,7 +2339,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -2376,7 +2376,7 @@
 														<revenue>5</revenue>
 														<nb_conv_pages_before>1</nb_conv_pages_before>
 														<nb_conversions_attrib>1</nb_conversions_attrib>
-														<nb_conversions_page_rate>0</nb_conversions_page_rate>
+														<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 														<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 														<revenue_attrib>5</revenue_attrib>
 														<revenue_entry>5</revenue_entry>
@@ -2413,7 +2413,7 @@
 																<revenue>5</revenue>
 																<nb_conv_pages_before>1</nb_conv_pages_before>
 																<nb_conversions_attrib>1</nb_conversions_attrib>
-																<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 																<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																<revenue_attrib>5</revenue_attrib>
 																<revenue_entry>5</revenue_entry>
@@ -2450,7 +2450,7 @@
 																		<revenue>5</revenue>
 																		<nb_conv_pages_before>1</nb_conv_pages_before>
 																		<nb_conversions_attrib>1</nb_conversions_attrib>
-																		<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																		<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 																		<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																		<revenue_attrib>5</revenue_attrib>
 																		<revenue_entry>5</revenue_entry>
@@ -2487,7 +2487,7 @@
 																				<revenue>5</revenue>
 																				<nb_conv_pages_before>1</nb_conv_pages_before>
 																				<nb_conversions_attrib>1</nb_conversions_attrib>
-																				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																				<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 																				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																				<revenue_attrib>5</revenue_attrib>
 																				<revenue_entry>5</revenue_entry>
@@ -2524,7 +2524,7 @@
 																						<revenue>5</revenue>
 																						<nb_conv_pages_before>1</nb_conv_pages_before>
 																						<nb_conversions_attrib>1</nb_conversions_attrib>
-																						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 																						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																						<revenue_attrib>5</revenue_attrib>
 																						<revenue_entry>5</revenue_entry>
@@ -2623,7 +2623,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2706,7 +2706,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2743,7 +2743,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_range.xml
@@ -98,7 +98,7 @@
 						<revenue>55</revenue>
 						<nb_conv_pages_before>6</nb_conv_pages_before>
 						<nb_conversions_attrib>11</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.216</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>11</nb_conversions_page_uniq>
 						<revenue_attrib>55</revenue_attrib>
 						<revenue_entry>55</revenue_entry>
@@ -150,7 +150,7 @@
 								<revenue>50</revenue>
 								<nb_conv_pages_before>5</nb_conv_pages_before>
 								<nb_conversions_attrib>10</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.196</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 								<revenue_attrib>50</revenue_attrib>
 								<revenue_entry>50</revenue_entry>
@@ -202,7 +202,7 @@
 										<revenue>50</revenue>
 										<nb_conv_pages_before>5</nb_conv_pages_before>
 										<nb_conversions_attrib>10</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.196</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 										<revenue_attrib>50</revenue_attrib>
 										<revenue_entry>50</revenue_entry>
@@ -260,7 +260,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -312,7 +312,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -372,7 +372,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -424,7 +424,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -476,7 +476,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -528,7 +528,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -588,7 +588,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -640,7 +640,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -692,7 +692,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -754,7 +754,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -806,7 +806,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -858,7 +858,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -910,7 +910,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -1098,7 +1098,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -1150,7 +1150,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>2</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>10</revenue_entry>
@@ -1208,7 +1208,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1264,7 +1264,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1316,7 +1316,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1374,7 +1374,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1426,7 +1426,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1546,7 +1546,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -1602,7 +1602,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1654,7 +1654,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1712,7 +1712,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1764,7 +1764,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1884,7 +1884,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1936,7 +1936,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1994,7 +1994,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2046,7 +2046,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2098,7 +2098,7 @@
 										<revenue>10</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>2</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 										<revenue_attrib>10</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -2150,7 +2150,7 @@
 												<revenue>10</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>2</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 												<revenue_attrib>10</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -2273,7 +2273,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2325,7 +2325,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2377,7 +2377,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -2570,7 +2570,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2622,7 +2622,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2742,7 +2742,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -2860,7 +2860,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3278,7 +3278,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3475,7 +3475,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3593,7 +3593,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3711,7 +3711,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3829,7 +3829,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3947,7 +3947,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3999,7 +3999,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -4051,7 +4051,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -4103,7 +4103,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -4155,7 +4155,7 @@
 														<revenue>5</revenue>
 														<nb_conv_pages_before>1</nb_conv_pages_before>
 														<nb_conversions_attrib>1</nb_conversions_attrib>
-														<nb_conversions_page_rate>0</nb_conversions_page_rate>
+														<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 														<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 														<revenue_attrib>5</revenue_attrib>
 														<revenue_entry>5</revenue_entry>
@@ -4207,7 +4207,7 @@
 																<revenue>5</revenue>
 																<nb_conv_pages_before>1</nb_conv_pages_before>
 																<nb_conversions_attrib>1</nb_conversions_attrib>
-																<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 																<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																<revenue_attrib>5</revenue_attrib>
 																<revenue_entry>5</revenue_entry>
@@ -4259,7 +4259,7 @@
 																		<revenue>5</revenue>
 																		<nb_conv_pages_before>1</nb_conv_pages_before>
 																		<nb_conversions_attrib>1</nb_conversions_attrib>
-																		<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																		<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 																		<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																		<revenue_attrib>5</revenue_attrib>
 																		<revenue_entry>5</revenue_entry>
@@ -4311,7 +4311,7 @@
 																				<revenue>5</revenue>
 																				<nb_conv_pages_before>1</nb_conv_pages_before>
 																				<nb_conversions_attrib>1</nb_conversions_attrib>
-																				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																				<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 																				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																				<revenue_attrib>5</revenue_attrib>
 																				<revenue_entry>5</revenue_entry>
@@ -4363,7 +4363,7 @@
 																						<revenue>5</revenue>
 																						<nb_conv_pages_before>1</nb_conv_pages_before>
 																						<nb_conversions_attrib>1</nb_conversions_attrib>
-																						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 																						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																						<revenue_attrib>5</revenue_attrib>
 																						<revenue_entry>5</revenue_entry>
@@ -4497,7 +4497,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4615,7 +4615,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4667,7 +4667,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_day.xml
@@ -61,7 +61,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -135,7 +135,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>1</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -173,7 +173,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>1</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_month.xml
@@ -63,7 +63,7 @@
 						<revenue>50</revenue>
 						<nb_conv_pages_before>5</nb_conv_pages_before>
 						<nb_conversions_attrib>10</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.256</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 						<revenue_attrib>50</revenue_attrib>
 						<revenue_entry>50</revenue_entry>
@@ -100,7 +100,7 @@
 								<revenue>45</revenue>
 								<nb_conv_pages_before>4</nb_conv_pages_before>
 								<nb_conversions_attrib>9</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.231</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 								<revenue_attrib>45</revenue_attrib>
 								<revenue_entry>45</revenue_entry>
@@ -137,7 +137,7 @@
 										<revenue>45</revenue>
 										<nb_conv_pages_before>4</nb_conv_pages_before>
 										<nb_conversions_attrib>9</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.231</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>9</nb_conversions_page_uniq>
 										<revenue_attrib>45</revenue_attrib>
 										<revenue_entry>45</revenue_entry>
@@ -180,7 +180,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -217,7 +217,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -262,7 +262,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -299,7 +299,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -336,7 +336,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -373,7 +373,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -462,7 +462,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -499,7 +499,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>2</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>10</revenue_entry>
@@ -542,7 +542,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -583,7 +583,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -620,7 +620,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -705,7 +705,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -746,7 +746,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -783,7 +783,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -826,7 +826,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -863,7 +863,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -992,7 +992,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1029,7 +1029,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1072,7 +1072,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1109,7 +1109,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1146,7 +1146,7 @@
 										<revenue>10</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>2</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 										<revenue_attrib>10</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -1183,7 +1183,7 @@
 												<revenue>10</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>2</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 												<revenue_attrib>10</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -1271,7 +1271,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1308,7 +1308,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1345,7 +1345,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -1382,7 +1382,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -1491,7 +1491,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1772,7 +1772,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1855,7 +1855,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1892,7 +1892,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1977,7 +1977,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2060,7 +2060,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2143,7 +2143,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2226,7 +2226,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.051</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2309,7 +2309,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2346,7 +2346,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2383,7 +2383,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -2420,7 +2420,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -2457,7 +2457,7 @@
 														<revenue>5</revenue>
 														<nb_conv_pages_before>1</nb_conv_pages_before>
 														<nb_conversions_attrib>1</nb_conversions_attrib>
-														<nb_conversions_page_rate>0</nb_conversions_page_rate>
+														<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 														<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 														<revenue_attrib>5</revenue_attrib>
 														<revenue_entry>5</revenue_entry>
@@ -2494,7 +2494,7 @@
 																<revenue>5</revenue>
 																<nb_conv_pages_before>1</nb_conv_pages_before>
 																<nb_conversions_attrib>1</nb_conversions_attrib>
-																<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 																<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																<revenue_attrib>5</revenue_attrib>
 																<revenue_entry>5</revenue_entry>
@@ -2531,7 +2531,7 @@
 																		<revenue>5</revenue>
 																		<nb_conv_pages_before>1</nb_conv_pages_before>
 																		<nb_conversions_attrib>1</nb_conversions_attrib>
-																		<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																		<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 																		<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																		<revenue_attrib>5</revenue_attrib>
 																		<revenue_entry>5</revenue_entry>
@@ -2568,7 +2568,7 @@
 																				<revenue>5</revenue>
 																				<nb_conv_pages_before>1</nb_conv_pages_before>
 																				<nb_conversions_attrib>1</nb_conversions_attrib>
-																				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																				<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 																				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																				<revenue_attrib>5</revenue_attrib>
 																				<revenue_entry>5</revenue_entry>
@@ -2605,7 +2605,7 @@
 																						<revenue>5</revenue>
 																						<nb_conv_pages_before>1</nb_conv_pages_before>
 																						<nb_conversions_attrib>1</nb_conversions_attrib>
-																						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 																						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																						<revenue_attrib>5</revenue_attrib>
 																						<revenue_entry>5</revenue_entry>
@@ -2704,7 +2704,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2787,7 +2787,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2824,7 +2824,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.026</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_range.xml
@@ -98,7 +98,7 @@
 						<revenue>55</revenue>
 						<nb_conv_pages_before>6</nb_conv_pages_before>
 						<nb_conversions_attrib>11</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.216</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>11</nb_conversions_page_uniq>
 						<revenue_attrib>55</revenue_attrib>
 						<revenue_entry>55</revenue_entry>
@@ -150,7 +150,7 @@
 								<revenue>50</revenue>
 								<nb_conv_pages_before>5</nb_conv_pages_before>
 								<nb_conversions_attrib>10</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.196</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 								<revenue_attrib>50</revenue_attrib>
 								<revenue_entry>50</revenue_entry>
@@ -202,7 +202,7 @@
 										<revenue>50</revenue>
 										<nb_conv_pages_before>5</nb_conv_pages_before>
 										<nb_conversions_attrib>10</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.196</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>10</nb_conversions_page_uniq>
 										<revenue_attrib>50</revenue_attrib>
 										<revenue_entry>50</revenue_entry>
@@ -260,7 +260,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -312,7 +312,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -372,7 +372,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -424,7 +424,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -476,7 +476,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -528,7 +528,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -588,7 +588,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -640,7 +640,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -692,7 +692,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -754,7 +754,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -806,7 +806,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -858,7 +858,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -910,7 +910,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -1098,7 +1098,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -1150,7 +1150,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>2</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>10</revenue_entry>
@@ -1208,7 +1208,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1264,7 +1264,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1316,7 +1316,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1374,7 +1374,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1426,7 +1426,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1546,7 +1546,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>2</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -1602,7 +1602,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1654,7 +1654,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1712,7 +1712,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1764,7 +1764,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1884,7 +1884,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -1936,7 +1936,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -1994,7 +1994,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2046,7 +2046,7 @@
 								<revenue>10</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>2</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 								<revenue_attrib>10</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2098,7 +2098,7 @@
 										<revenue>10</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>2</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 										<revenue_attrib>10</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -2150,7 +2150,7 @@
 												<revenue>10</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>2</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 												<revenue_attrib>10</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -2273,7 +2273,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2325,7 +2325,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2377,7 +2377,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -2429,7 +2429,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -2624,7 +2624,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -2676,7 +2676,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -2796,7 +2796,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>10</revenue_entry>
@@ -2914,7 +2914,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3394,7 +3394,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3510,7 +3510,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3706,7 +3706,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3824,7 +3824,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -3942,7 +3942,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4060,7 +4060,7 @@
 						<revenue>10</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>2</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.039</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>10</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4178,7 +4178,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4230,7 +4230,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>
@@ -4282,7 +4282,7 @@
 										<revenue>5</revenue>
 										<nb_conv_pages_before>1</nb_conv_pages_before>
 										<nb_conversions_attrib>1</nb_conversions_attrib>
-										<nb_conversions_page_rate>0</nb_conversions_page_rate>
+										<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 										<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 										<revenue_attrib>5</revenue_attrib>
 										<revenue_entry>5</revenue_entry>
@@ -4334,7 +4334,7 @@
 												<revenue>5</revenue>
 												<nb_conv_pages_before>1</nb_conv_pages_before>
 												<nb_conversions_attrib>1</nb_conversions_attrib>
-												<nb_conversions_page_rate>0</nb_conversions_page_rate>
+												<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 												<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 												<revenue_attrib>5</revenue_attrib>
 												<revenue_entry>5</revenue_entry>
@@ -4386,7 +4386,7 @@
 														<revenue>5</revenue>
 														<nb_conv_pages_before>1</nb_conv_pages_before>
 														<nb_conversions_attrib>1</nb_conversions_attrib>
-														<nb_conversions_page_rate>0</nb_conversions_page_rate>
+														<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 														<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 														<revenue_attrib>5</revenue_attrib>
 														<revenue_entry>5</revenue_entry>
@@ -4438,7 +4438,7 @@
 																<revenue>5</revenue>
 																<nb_conv_pages_before>1</nb_conv_pages_before>
 																<nb_conversions_attrib>1</nb_conversions_attrib>
-																<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 																<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																<revenue_attrib>5</revenue_attrib>
 																<revenue_entry>5</revenue_entry>
@@ -4490,7 +4490,7 @@
 																		<revenue>5</revenue>
 																		<nb_conv_pages_before>1</nb_conv_pages_before>
 																		<nb_conversions_attrib>1</nb_conversions_attrib>
-																		<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																		<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 																		<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																		<revenue_attrib>5</revenue_attrib>
 																		<revenue_entry>5</revenue_entry>
@@ -4542,7 +4542,7 @@
 																				<revenue>5</revenue>
 																				<nb_conv_pages_before>1</nb_conv_pages_before>
 																				<nb_conversions_attrib>1</nb_conversions_attrib>
-																				<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																				<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 																				<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																				<revenue_attrib>5</revenue_attrib>
 																				<revenue_entry>5</revenue_entry>
@@ -4594,7 +4594,7 @@
 																						<revenue>5</revenue>
 																						<nb_conv_pages_before>1</nb_conv_pages_before>
 																						<nb_conversions_attrib>1</nb_conversions_attrib>
-																						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+																						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 																						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 																						<revenue_attrib>5</revenue_attrib>
 																						<revenue_entry>5</revenue_entry>
@@ -4728,7 +4728,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4846,7 +4846,7 @@
 						<revenue>5</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>5</revenue_attrib>
 						<revenue_entry>5</revenue_entry>
@@ -4898,7 +4898,7 @@
 								<revenue>5</revenue>
 								<nb_conv_pages_before>1</nb_conv_pages_before>
 								<nb_conversions_attrib>1</nb_conversions_attrib>
-								<nb_conversions_page_rate>0</nb_conversions_page_rate>
+								<nb_conversions_page_rate>0.02</nb_conversions_page_rate>
 								<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 								<revenue_attrib>5</revenue_attrib>
 								<revenue_entry>5</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getEntryPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getEntryPageTitles_day.xml
@@ -105,7 +105,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getEntryPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getEntryPageUrls_day.xml
@@ -169,7 +169,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getExitPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getExitPageTitles_day.xml
@@ -105,7 +105,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getExitPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getExitPageUrls_day.xml
@@ -151,7 +151,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getPageTitles_day.xml
@@ -105,7 +105,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__Actions.getPageUrls_day.xml
@@ -270,7 +270,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___Actions.getPageTitles_day.xml
@@ -94,7 +94,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getEntryPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getEntryPageTitles_day.xml
@@ -101,7 +101,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getEntryPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getEntryPageUrls_day.xml
@@ -163,7 +163,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getExitPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getExitPageTitles_day.xml
@@ -101,7 +101,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getExitPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getExitPageUrls_day.xml
@@ -146,7 +146,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getPageTitles_day.xml
@@ -101,7 +101,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Actions.getPageUrls_day.xml
@@ -261,7 +261,7 @@
 						<revenue>1</revenue>
 						<nb_conv_pages_before>1</nb_conv_pages_before>
 						<nb_conversions_attrib>1</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>1</nb_conversions_page_uniq>
 						<revenue_attrib>1</revenue_attrib>
 						<revenue_entry>1</revenue_entry>

--- a/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI__Actions.getPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI__Actions.getPageUrls_range.xml
@@ -97,7 +97,7 @@
 						<revenue>0</revenue>
 						<nb_conv_pages_before>3</nb_conv_pages_before>
 						<nb_conversions_attrib>0.6666</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>0</revenue_attrib>
 					</row>

--- a/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI_pagesegment__Actions.getPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI_pagesegment__Actions.getPageUrls_range.xml
@@ -97,7 +97,7 @@
 						<revenue>0</revenue>
 						<nb_conv_pages_before>3</nb_conv_pages_before>
 						<nb_conversions_attrib>0.6666</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>0</revenue_attrib>
 					</row>


### PR DESCRIPTION
## Problem

On the Goals → Pages report (and any Actions Pages report viewed with a goal selected, or with `flat=1`), the **Conversion rate** column showed `0%` for sub-pages, even when those pages had recorded unique conversions. Only top-level page rows displayed a rate.

<img width="1130" height="620" alt="image" src="https://github.com/user-attachments/assets/4de6ae30-fa18-4f6d-a8df-906485160be8" />

## Root cause

`CalculateConversionPageRate` only walked the top-level rows of the report. Page sub-pages live in subtable rows, and `flat=1` re-surfaces those same subtable rows at the top level - but the filter never recursed into them, so `nb_conversions_page_rate` stayed at the archive default of `0`.

## Fix

Make the filter recurse into subtables in both phases: collecting goal ids and writing rates. Goal totals are still fetched once from the top-level table metadata and reused across the tree. The cap-to-1 rule (subpage uniques exceeding their parent total) still applies.

Includes a regression test and updated expected fixtures for the system tests that were freezing the buggy `0` values.

fixes #19616

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
