### PR TITLE
Add unit test for version update problem

### DIFF
--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -700,10 +700,19 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
             $files = array();
         }
 
+        // Strip the pre-release suffix (-alpha, -b1, -rc1, ...) from Version::VERSION before
+        // comparing. Update files for the upcoming release are routinely added while
+        // Version::VERSION still carries the prior pre-release marker (e.g. 5.11.0-b1.php
+        // exists while Version::VERSION is 5.11.0-alpha), and Updater::getComponentUpdateFiles
+        // intentionally runs migrations whose file version is greater than the installed
+        // version. The guardrail here is for files that target a version beyond the upcoming
+        // stable release.
+        [$currentStableVersion] = explode('-', Version::VERSION, 2);
+
         $futureUpdateFiles = array();
         foreach ($files as $file) {
             $fileVersion = basename($file, '.php');
-            if (version_compare($fileVersion, Version::VERSION) === 1) {
+            if (version_compare($fileVersion, $currentStableVersion) === 1) {
                 $futureUpdateFiles[] = sprintf(
                     '%s targets %s, but core/Version.php is %s',
                     $file,
@@ -713,7 +722,14 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
             }
         }
 
-        $this->assertSame(array(), $futureUpdateFiles, implode("\n", $futureUpdateFiles));
+        // sanity check that the glob picked something up so an accidentally wrong path does not
+        // make the assertion below pass vacuously
+        $this->assertGreaterThan(0, count($files));
+
+        $this->assertEmpty(
+            $futureUpdateFiles,
+            "The following core update files target a future Matomo version:\n" . implode("\n", $futureUpdateFiles)
+        );
     }
 
     public function testBowerComponentsBcReferencesFilesThatExists()

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -19,6 +19,7 @@ use Piwik\Filesystem;
 use Piwik\Plugin\Manager;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\Tracker;
+use Piwik\Version;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
@@ -689,6 +690,30 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
         $this->assertGreaterThan(50, $numTestedCorePlugins);
         // eg this here shows the plugins that have update files but from older matomo versions.
         $this->assertSame(array('CustomDimensions', 'DevicesDetection', 'ExamplePlugin', 'Goals', 'LanguagesManager'), array_values(array_unique($pluginsWithUpdates)));
+    }
+
+    public function testCoreUpdateFilesDoNotTargetFutureVersions()
+    {
+        $pathToUpdates = PIWIK_INCLUDE_PATH . '/core/Updates/*.php';
+        $files = _glob($pathToUpdates);
+        if (empty($files)) {
+            $files = array();
+        }
+
+        $futureUpdateFiles = array();
+        foreach ($files as $file) {
+            $fileVersion = basename($file, '.php');
+            if (version_compare($fileVersion, Version::VERSION) === 1) {
+                $futureUpdateFiles[] = sprintf(
+                    '%s targets %s, but core/Version.php is %s',
+                    $file,
+                    $fileVersion,
+                    Version::VERSION
+                );
+            }
+        }
+
+        $this->assertSame(array(), $futureUpdateFiles, implode("\n", $futureUpdateFiles));
     }
 
     public function testBowerComponentsBcReferencesFilesThatExists()

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -700,19 +700,10 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
             $files = array();
         }
 
-        // Strip the pre-release suffix (-alpha, -b1, -rc1, ...) from Version::VERSION before
-        // comparing. Update files for the upcoming release are routinely added while
-        // Version::VERSION still carries the prior pre-release marker (e.g. 5.11.0-b1.php
-        // exists while Version::VERSION is 5.11.0-alpha), and Updater::getComponentUpdateFiles
-        // intentionally runs migrations whose file version is greater than the installed
-        // version. The guardrail here is for files that target a version beyond the upcoming
-        // stable release.
-        [$currentStableVersion] = explode('-', Version::VERSION, 2);
-
         $futureUpdateFiles = array();
         foreach ($files as $file) {
             $fileVersion = basename($file, '.php');
-            if (version_compare($fileVersion, $currentStableVersion) === 1) {
+            if (version_compare($fileVersion, Version::VERSION) === 1) {
                 $futureUpdateFiles[] = sprintf(
                     '%s targets %s, but core/Version.php is %s',
                     $file,


### PR DESCRIPTION
### Description

This can easily happen if we are not careful, hoping this integration test prevents this mistake in the future.

[Here is a CI run](https://github.com/matomo-org/matomo/actions/runs/26200883810/job/77090397293?pr=24540#step:4:604) on this branch before the version was corrected in `5.x-dev`.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
