### PR TITLE
Fix PagePerformance averages in summary rows

### DIFF
--- a/plugins/PagePerformance/PagePerformance.php
+++ b/plugins/PagePerformance/PagePerformance.php
@@ -10,6 +10,8 @@
 namespace Piwik\Plugins\PagePerformance;
 
 use Piwik\DataTable;
+use Piwik\DataTable\Row;
+use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\CoreVisualizations\Visualizations\HtmlTable;
 
@@ -85,7 +87,13 @@ class PagePerformance extends \Piwik\Plugin
 
     public function enrichApi($dataTable, $params)
     {
-        if ('Actions' !== $params['module'] || !$dataTable instanceof DataTable\DataTableInterface) {
+        if (!$dataTable instanceof DataTable\DataTableInterface) {
+            return;
+        }
+
+        $this->addPagePerformanceAggregationOps($dataTable);
+
+        if ('Actions' !== $params['module']) {
             return;
         }
 
@@ -133,6 +141,73 @@ class PagePerformance extends \Piwik\Plugin
 
             $dataTable->setMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME, $extraProcessedMetrics);
         });
+    }
+
+    private function addPagePerformanceAggregationOps(DataTable\DataTableInterface $dataTable): void
+    {
+        $dataTable->filter(function (DataTable $table) {
+            $aggregationOps = $table->getMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME);
+
+            if (!is_array($aggregationOps)) {
+                $aggregationOps = [];
+            }
+
+            foreach (array_keys(Metrics::getPagePerformanceMetrics()) as $metricName) {
+                $aggregationOps[$metricName] = function ($thisColumnValue, $columnToSumValue, Row $thisRow, Row $rowToSum) use ($metricName) {
+                    return $this->aggregateAveragePerformanceMetric($thisColumnValue, $columnToSumValue, $thisRow, $rowToSum, $metricName);
+                };
+            }
+
+            $aggregationOps['avg_page_load_time'] = [$this, 'aggregateAveragePageLoadTime'];
+
+            $table->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $aggregationOps);
+        });
+    }
+
+    public function aggregateAveragePerformanceMetric($thisColumnValue, $columnToSumValue, Row $thisRow, Row $rowToSum, $columnName)
+    {
+        $metricId = substr($columnName, strlen('avg_'));
+        $sum = $thisRow->getColumn('sum_' . $metricId);
+        $hits = $thisRow->getColumn('nb_hits_with_' . $metricId);
+
+        if (is_numeric($sum) && is_numeric($hits)) {
+            return Piwik::getQuotientSafe($sum, $hits, $precision = 3);
+        }
+
+        return $this->sumNumericValues($thisColumnValue, $columnToSumValue);
+    }
+
+    public function aggregateAveragePageLoadTime($thisColumnValue, $columnToSumValue, Row $thisRow, Row $rowToSum)
+    {
+        $sum = 0;
+        $hasMetric = false;
+
+        foreach (array_keys(Metrics::getPagePerformanceMetrics()) as $metricName) {
+            $value = $thisRow->getColumn($metricName);
+            if (is_numeric($value)) {
+                $sum += $value;
+                $hasMetric = true;
+            }
+        }
+
+        if ($hasMetric) {
+            return $sum;
+        }
+
+        return $this->sumNumericValues($thisColumnValue, $columnToSumValue);
+    }
+
+    private function sumNumericValues($thisColumnValue, $columnToSumValue)
+    {
+        if (!is_numeric($thisColumnValue)) {
+            return $columnToSumValue;
+        }
+
+        if (!is_numeric($columnToSumValue)) {
+            return $thisColumnValue;
+        }
+
+        return $thisColumnValue + $columnToSumValue;
     }
 
     public function configureViewDataTable(ViewDataTable $view)

--- a/plugins/PagePerformance/tests/Unit/PagePerformanceTest.php
+++ b/plugins/PagePerformance/tests/Unit/PagePerformanceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\PagePerformance\tests\Unit;
+
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+use Piwik\Plugins\PagePerformance\PagePerformance;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group PagePerformance
+ * @group Plugins
+ */
+class PagePerformanceTest extends TestCase
+{
+    public function testTruncatedSummaryRowAggregatesPagePerformanceAveragesAsWeightedAverages(): void
+    {
+        $table = new DataTable();
+        $table->addRow($this->buildPerformanceRow('first', 100, 2));
+        $table->addRow($this->buildPerformanceRow('second', 90, 1));
+
+        $plugin = new PagePerformance();
+        $plugin->enrichApi($table, ['module' => 'CustomReports', 'action' => 'getCustomReport']);
+
+        $table->filter('Truncate', [0]);
+
+        $summaryRow = $table->getRowFromId(DataTable::ID_SUMMARY_ROW);
+
+        self::assertInstanceOf(Row::class, $summaryRow);
+        self::assertSame(190, $summaryRow->getColumn('sum_time_network'));
+        self::assertSame(3, $summaryRow->getColumn('nb_hits_with_time_network'));
+        self::assertSame(63.333, $summaryRow->getColumn('avg_time_network'));
+    }
+
+    private function buildPerformanceRow(string $label, int $sumTimeNetwork, int $hits): Row
+    {
+        $average = round($sumTimeNetwork / $hits, 3);
+
+        return new Row([
+            Row::COLUMNS => [
+                'label' => $label,
+                'sum_time_network' => $sumTimeNetwork,
+                'nb_hits_with_time_network' => $hits,
+                'avg_time_network' => $average,
+                'avg_page_load_time' => $average,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
### Description

Fixes #24407.

This PR fixes Page Performance average metrics when reports are truncated and Matomo creates a summary / "Others" row.

Previously, Page Performance average columns such as `avg_time_network`, `avg_time_server`, and `avg_page_load_time` could be summed when rows were merged. This made scheduled reports show totals of averages instead of weighted averages.

The fix adds Page Performance-specific aggregation operations so summary rows recalculate averages from the underlying `sum_time_*` and `nb_hits_with_time_*` columns. This applies beyond `Actions` reports as well, so custom reports that include Page Performance metrics aggregate correctly.

A unit test was added to cover a truncated report table with Page Performance metrics and assert that the summary row uses the weighted average.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

### Tests

- `vendor\bin\phpunit.bat -c tests\PHPUnit\phpunit.xml.dist plugins\PagePerformance\tests\Unit\PagePerformanceTest.php`
- `vendor\bin\phpunit.bat -c tests\PHPUnit\phpunit.xml.dist plugins\ScheduledReports\tests\Integration\ApiTest.php --filter generateReport`
- `vendor\bin\phpcs.bat --standard=phpcs.xml plugins\PagePerformance\PagePerformance.php plugins\PagePerformance\tests\Unit\PagePerformanceTest.php`