### PR TITLE
Live: intersect clicked row segment at visit level to avoid same-dimension collision with report segment

### DIFF
--- a/plugins/Actions/tests/UI/ActionsDataTable_spec.js
+++ b/plugins/Actions/tests/UI/ActionsDataTable_spec.js
@@ -147,4 +147,30 @@ describe("ActionsDataTable", function () {
 
         expect(await page.screenshot({ fullPage: true })).to.matchImage('auto_expand');
     });
+
+    it("should generate a readable title when opening the visitor log while a segment is applied", async function() {
+        // Regression for the "better popup title": when a segment is already applied, the clicked row
+        // is intersected at the visit level (see Model::queryLogVisits $intersectSegment) and the popup
+        // title must describe that clicked row in a readable way (dimension + value) rather than dumping
+        // the raw combined segment string, which previously leaked the current segment and the raw
+        // "pageUrl==" operator into the title.
+        await page.goto(url + '&segment=' + encodeURIComponent('visitCount>=1'));
+        await page.waitForNetworkIdle();
+
+        const row = 'tr:contains("index.htm") ';
+        const first = await page.jQuery(row + 'td.column:first');
+        await first.hover();
+        await page.evaluate(function () {
+            $('tr:contains("index.htm") td.label .actionSegmentVisitorLog').click();
+        });
+        await page.mouse.move(-10, -10);
+        await page.waitForSelector('.ui-dialog');
+        await page.waitForNetworkIdle();
+
+        const title = await page.$eval('.ui-dialog .ui-dialog-title', (el) => el.textContent.trim());
+        // The title describes the clicked row in the readable "<Dimension> is <value>" form. Before the
+        // fix it dumped the raw combined segment instead, e.g. 'Segment is "visitCount>=1 and
+        // pageUrl==http://example.org/index.htm"', leaking the applied segment and the raw operator.
+        expect(title).to.equal('Visits log showing visits where Page URL is "http://example.org/index.htm"');
+    });
 });

--- a/plugins/Actions/tests/UI/ActionsDataTable_spec.js
+++ b/plugins/Actions/tests/UI/ActionsDataTable_spec.js
@@ -94,6 +94,11 @@ describe("ActionsDataTable", function () {
         await page.mouse.move(-10, -10);
         await page.waitForSelector('.ui-dialog');
         await page.waitForNetworkIdle();
+        const title = await page.$eval('.ui-dialog .ui-dialog-title', (el) => el.textContent.trim());
+        expect(title).to.contain('Page URL');
+        expect(title).to.contain('index.htm');
+        expect(title).to.not.contain('pageUrl==');
+        expect(title).to.not.contain('pageTitle==');
         const element = await page.$('.ui-dialog');
         expect(await element.screenshot()).to.matchImage('segmented_visitor_log');
     });

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -158,8 +158,6 @@ class API extends \Piwik\Plugin\API
      * @param string|null|false $segment Custom segment to filter the visits.
      *                                   Example: "referrerName==example.com"
      *                                   Supports AND (;) and OR (,) operators.
-     *                                   Supports the optional request parameter `additionalSegment`
-     *                                   to intersect an extra segment at the visit level.
      * @param int|false $countVisitorsToFetch Deprecated explicit row limit. Prefer `filter_offset` and `filter_limit`.
      * @param int|false $minTimestamp Optional minimum timestamp for incremental refreshes or pagination.
      * @param bool $flat Whether to flatten action details into the visit rows.
@@ -204,6 +202,7 @@ class API extends \Piwik\Plugin\API
         }
 
         $filterSortOrder = \Piwik\Request::fromRequest()->getStringParameter('filter_sort_order', '');
+        // Internal context used by the segmented visitor log row action.
         $additionalSegment = \Piwik\Request::fromRequest()->getStringParameter('additionalSegment', '');
         if ($additionalSegment === '') {
             $additionalSegment = false;
@@ -454,9 +453,8 @@ class API extends \Piwik\Plugin\API
      * @param int $offset
      * @param int $limit
      * @param int|false $minTimestamp
-     * @param string|false $filterSortOrder Sort order for visits.
-     * @param string|false $visitorId Optional visitor ID filter.
-     * @param string|false $additionalSegment Optional extra segment to intersect at the visit level.
+     * @param string|false $filterSortOrder
+     * @param string|false $visitorId
      */
     private function loadLastVisitsDetailsFromDatabase($idSite, $period, $date, $segment = false, $offset = 0, $limit = 100, $minTimestamp = false, $filterSortOrder = false, $visitorId = false, $additionalSegment = false): DataTable
     {

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -158,6 +158,8 @@ class API extends \Piwik\Plugin\API
      * @param string|null|false $segment Custom segment to filter the visits.
      *                                   Example: "referrerName==example.com"
      *                                   Supports AND (;) and OR (,) operators.
+     *                                   Supports the optional request parameter `additionalSegment`
+     *                                   to intersect an extra segment at the visit level.
      * @param int|false $countVisitorsToFetch Deprecated explicit row limit. Prefer `filter_offset` and `filter_limit`.
      * @param int|false $minTimestamp Optional minimum timestamp for incremental refreshes or pagination.
      * @param bool $flat Whether to flatten action details into the visit rows.
@@ -202,12 +204,12 @@ class API extends \Piwik\Plugin\API
         }
 
         $filterSortOrder = \Piwik\Request::fromRequest()->getStringParameter('filter_sort_order', '');
-        $segmentVisitorLogRow = \Piwik\Request::fromRequest()->getStringParameter('segmentVisitorLogRow', '');
-        if ($segmentVisitorLogRow === '') {
-            $segmentVisitorLogRow = false;
+        $additionalSegment = \Piwik\Request::fromRequest()->getStringParameter('additionalSegment', '');
+        if ($additionalSegment === '') {
+            $additionalSegment = false;
         }
 
-        $dataTable = $this->loadLastVisitsDetailsFromDatabase($idSites, $period, $date, $segment, $filterOffset, $filterLimit, $minTimestamp, $filterSortOrder, $visitorId = false, $segmentVisitorLogRow);
+        $dataTable = $this->loadLastVisitsDetailsFromDatabase($idSites, $period, $date, $segment, $filterOffset, $filterLimit, $minTimestamp, $filterSortOrder, $visitorId = false, $additionalSegment);
         $this->addFilterToCleanVisitors($dataTable, $flat, $doNotFetchActions);
 
         $filterSortColumn = \Piwik\Request::fromRequest()->getStringParameter('filter_sort_column', '');
@@ -452,13 +454,14 @@ class API extends \Piwik\Plugin\API
      * @param int $offset
      * @param int $limit
      * @param int|false $minTimestamp
-     * @param string|false $filterSortOrder
-     * @param string|false $visitorId
+     * @param string|false $filterSortOrder Sort order for visits.
+     * @param string|false $visitorId Optional visitor ID filter.
+     * @param string|false $additionalSegment Optional extra segment to intersect at the visit level.
      */
-    private function loadLastVisitsDetailsFromDatabase($idSite, $period, $date, $segment = false, $offset = 0, $limit = 100, $minTimestamp = false, $filterSortOrder = false, $visitorId = false, $segmentVisitorLogRow = false): DataTable
+    private function loadLastVisitsDetailsFromDatabase($idSite, $period, $date, $segment = false, $offset = 0, $limit = 100, $minTimestamp = false, $filterSortOrder = false, $visitorId = false, $additionalSegment = false): DataTable
     {
         $model = new Model();
-        [$data, $hasMoreVisits] = $model->queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, true, $segmentVisitorLogRow);
+        [$data, $hasMoreVisits] = $model->queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, true, $additionalSegment);
         return $this->makeVisitorTableFromArray($data, $hasMoreVisits);
     }
 

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -202,8 +202,12 @@ class API extends \Piwik\Plugin\API
         }
 
         $filterSortOrder = \Piwik\Request::fromRequest()->getStringParameter('filter_sort_order', '');
+        $segmentVisitorLogRow = \Piwik\Request::fromRequest()->getStringParameter('segmentVisitorLogRow', '', false);
+        if ($segmentVisitorLogRow === '') {
+            $segmentVisitorLogRow = false;
+        }
 
-        $dataTable = $this->loadLastVisitsDetailsFromDatabase($idSites, $period, $date, $segment, $filterOffset, $filterLimit, $minTimestamp, $filterSortOrder, $visitorId = false);
+        $dataTable = $this->loadLastVisitsDetailsFromDatabase($idSites, $period, $date, $segment, $filterOffset, $filterLimit, $minTimestamp, $filterSortOrder, $visitorId = false, $segmentVisitorLogRow);
         $this->addFilterToCleanVisitors($dataTable, $flat, $doNotFetchActions);
 
         $filterSortColumn = \Piwik\Request::fromRequest()->getStringParameter('filter_sort_column', '');
@@ -451,10 +455,10 @@ class API extends \Piwik\Plugin\API
      * @param string|false $filterSortOrder
      * @param string|false $visitorId
      */
-    private function loadLastVisitsDetailsFromDatabase($idSite, $period, $date, $segment = false, $offset = 0, $limit = 100, $minTimestamp = false, $filterSortOrder = false, $visitorId = false): DataTable
+    private function loadLastVisitsDetailsFromDatabase($idSite, $period, $date, $segment = false, $offset = 0, $limit = 100, $minTimestamp = false, $filterSortOrder = false, $visitorId = false, $segmentVisitorLogRow = false): DataTable
     {
         $model = new Model();
-        [$data, $hasMoreVisits] = $model->queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, true);
+        [$data, $hasMoreVisits] = $model->queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, true, $segmentVisitorLogRow);
         return $this->makeVisitorTableFromArray($data, $hasMoreVisits);
     }
 

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -202,7 +202,7 @@ class API extends \Piwik\Plugin\API
         }
 
         $filterSortOrder = \Piwik\Request::fromRequest()->getStringParameter('filter_sort_order', '');
-        $segmentVisitorLogRow = \Piwik\Request::fromRequest()->getStringParameter('segmentVisitorLogRow', '', false);
+        $segmentVisitorLogRow = \Piwik\Request::fromRequest()->getStringParameter('segmentVisitorLogRow', '');
         if ($segmentVisitorLogRow === '') {
             $segmentVisitorLogRow = false;
         }

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -203,12 +203,12 @@ class API extends \Piwik\Plugin\API
 
         $filterSortOrder = \Piwik\Request::fromRequest()->getStringParameter('filter_sort_order', '');
         // Internal context used by the segmented visitor log row action.
-        $additionalSegment = \Piwik\Request::fromRequest()->getStringParameter('additionalSegment', '');
-        if ($additionalSegment === '') {
-            $additionalSegment = false;
+        $intersectSegment = \Piwik\Request::fromRequest()->getStringParameter('intersectSegment', '');
+        if ($intersectSegment === '') {
+            $intersectSegment = false;
         }
 
-        $dataTable = $this->loadLastVisitsDetailsFromDatabase($idSites, $period, $date, $segment, $filterOffset, $filterLimit, $minTimestamp, $filterSortOrder, $visitorId = false, $additionalSegment);
+        $dataTable = $this->loadLastVisitsDetailsFromDatabase($idSites, $period, $date, $segment, $filterOffset, $filterLimit, $minTimestamp, $filterSortOrder, $visitorId = false, $intersectSegment);
         $this->addFilterToCleanVisitors($dataTable, $flat, $doNotFetchActions);
 
         $filterSortColumn = \Piwik\Request::fromRequest()->getStringParameter('filter_sort_column', '');
@@ -455,11 +455,12 @@ class API extends \Piwik\Plugin\API
      * @param int|false $minTimestamp
      * @param string|false $filterSortOrder
      * @param string|false $visitorId
+     * @param string|false $intersectSegment Extra segment intersected at the visit level; see Model::queryLogVisits().
      */
-    private function loadLastVisitsDetailsFromDatabase($idSite, $period, $date, $segment = false, $offset = 0, $limit = 100, $minTimestamp = false, $filterSortOrder = false, $visitorId = false, $additionalSegment = false): DataTable
+    private function loadLastVisitsDetailsFromDatabase($idSite, $period, $date, $segment = false, $offset = 0, $limit = 100, $minTimestamp = false, $filterSortOrder = false, $visitorId = false, $intersectSegment = false): DataTable
     {
         $model = new Model();
-        [$data, $hasMoreVisits] = $model->queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, true, $additionalSegment);
+        [$data, $hasMoreVisits] = $model->queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, true, $intersectSegment);
         return $this->makeVisitorTableFromArray($data, $hasMoreVisits);
     }
 

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -163,9 +163,17 @@ class API extends \Piwik\Plugin\API
      * @param bool $flat Whether to flatten action details into the visit rows.
      * @param bool $doNotFetchActions Whether to skip fetching action details for better performance.
      * @param bool $enhanced Whether plugins should enrich the returned visit details.
+     * @param string|false $intersectSegment Optional extra segment intersected with the result at the
+     *                                        visit level rather than combined with $segment. Unlike
+     *                                        $segment (whose conditions are ANDed and may all match on a
+     *                                        single action row), a visit is kept only when it also
+     *                                        matches this segment on its own. Used by the segmented
+     *                                        visitor log row action so a clicked row further restricts
+     *                                        the visits without collapsing same-dimension conditions.
+     *                                        See Model::queryLogVisits().
      * @return DataTable Recent visit details.
      */
-    public function getLastVisitsDetails($idSite, $period = false, $date = false, $segment = false, $countVisitorsToFetch = false, $minTimestamp = false, $flat = false, $doNotFetchActions = false, $enhanced = false): DataTable
+    public function getLastVisitsDetails($idSite, $period = false, $date = false, $segment = false, $countVisitorsToFetch = false, $minTimestamp = false, $flat = false, $doNotFetchActions = false, $enhanced = false, $intersectSegment = false): DataTable
     {
         Piwik::checkUserHasViewAccess($idSite);
         $idSites = Site::getIdSitesFromIdSitesString($idSite, false, true);
@@ -202,8 +210,7 @@ class API extends \Piwik\Plugin\API
         }
 
         $filterSortOrder = \Piwik\Request::fromRequest()->getStringParameter('filter_sort_order', '');
-        // Internal context used by the segmented visitor log row action.
-        $intersectSegment = \Piwik\Request::fromRequest()->getStringParameter('intersectSegment', '');
+        // Normalize an empty value (e.g. an empty request parameter) to the documented false default.
         if ($intersectSegment === '') {
             $intersectSegment = false;
         }

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -43,10 +43,17 @@ class Model
      * @param int|false $minTimestamp
      * @param string|false $filterSortOrder
      * @param bool $checkforMoreEntries
-     * @param string|false $additionalSegment Optional extra segment to intersect at the visit level.
+     * @param string|false $intersectSegment Optional extra segment, intersected with the result at the
+     *                                        visit level rather than combined with $segment. Unlike
+     *                                        $segment (whose conditions are ANDed and may all match on a
+     *                                        single action row), this segment is applied as a subquery on
+     *                                        log_visit.idvisit, so a visit is kept only when it also
+     *                                        matches this segment on its own. Generic on purpose: any
+     *                                        caller needing to further restrict visits by an independent
+     *                                        segment can pass one (e.g. the visitor-log row action).
      * @return array
      */
-    public function queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, $checkforMoreEntries = false, $additionalSegment = false)
+    public function queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, $checkforMoreEntries = false, $intersectSegment = false)
     {
         // to check for more entries increase the limit by one, but cut off the last entry before returning the result
         if ((int)$limit > -1 && $checkforMoreEntries) {
@@ -81,13 +88,13 @@ class Model
                 }
             }
 
-            [$sql, $bind] = $this->makeLogVisitsQueryString($idSite, $queryRange[0], $queryRange[1], $segment, $remainingOffset, $updatedLimit, $visitorId, $minTimestamp, $filterSortOrder, $additionalSegment);
+            [$sql, $bind] = $this->makeLogVisitsQueryString($idSite, $queryRange[0], $queryRange[1], $segment, $remainingOffset, $updatedLimit, $visitorId, $minTimestamp, $filterSortOrder, $intersectSegment);
             $visits = $this->executeLogVisitsQuery($sql, $bind, $segment, $dateStart, $dateEnd, $minTimestamp, $limit);
 
             if (!empty($remainingOffset)) {
                 if (empty($visits)) {
                     // No visits returned - need to count total in range to adjust offset
-                    $totalInRange = $this->countLogVisitsInRange($idSite, $queryRange[0], $queryRange[1], $segment, $visitorId, $minTimestamp, $additionalSegment);
+                    $totalInRange = $this->countLogVisitsInRange($idSite, $queryRange[0], $queryRange[1], $segment, $visitorId, $minTimestamp, $intersectSegment);
                     $remainingOffset = max(0, $remainingOffset - $totalInRange);
                     continue;
                 } else {
@@ -131,16 +138,17 @@ class Model
      * @param string $segment
      * @param string $visitorId
      * @param int $minTimestamp
+     * @param string|false $intersectSegment Extra segment intersected at the visit level; see queryLogVisits().
      * @return int
      * @throws Exception
      */
-    private function countLogVisitsInRange($idSite, $dateStart, $dateEnd, $segment, $visitorId, $minTimestamp, $additionalSegment = false)
+    private function countLogVisitsInRange($idSite, $dateStart, $dateEnd, $segment, $visitorId, $minTimestamp, $intersectSegment = false)
     {
         [$whereClause, $bindIdSites] = $this->getIdSitesWhereClause($idSite);
         [$whereBind, $where] = $this->getWhereClauseAndBind($whereClause, $bindIdSites, $dateStart, $dateEnd, $visitorId, $minTimestamp);
 
         $segment = new Segment($segment, $idSite, $dateStart, $dateEnd);
-        [$whereBind, $where] = $this->addAdditionalSegmentFilter($idSite, $dateStart, $dateEnd, $additionalSegment, $whereBind, $where);
+        [$whereBind, $where] = $this->addIntersectSegmentFilter($idSite, $dateStart, $dateEnd, $intersectSegment, $whereBind, $where);
 
         // Use COUNT(*), do not load all data
         $select = "COUNT(*) as count";
@@ -634,15 +642,16 @@ class Model
      * @param $visitorId
      * @param $minTimestamp
      * @param $filterSortOrder
+     * @param string|false $intersectSegment Extra segment intersected at the visit level; see queryLogVisits().
      * @return array
      * @throws Exception
      */
-    public function makeLogVisitsQueryString($idSite, $startDate, $endDate, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, $additionalSegment = false)
+    public function makeLogVisitsQueryString($idSite, $startDate, $endDate, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, $intersectSegment = false)
     {
         [$whereClause, $bindIdSites] = $this->getIdSitesWhereClause($idSite);
 
         [$whereBind, $where] = $this->getWhereClauseAndBind($whereClause, $bindIdSites, $startDate, $endDate, $visitorId, $minTimestamp);
-        [$whereBind, $where] = $this->addAdditionalSegmentFilter($idSite, $startDate, $endDate, $additionalSegment, $whereBind, $where);
+        [$whereBind, $where] = $this->addIntersectSegmentFilter($idSite, $startDate, $endDate, $intersectSegment, $whereBind, $where);
 
         if (strtolower($filterSortOrder) !== 'asc') {
             $filterSortOrder = 'DESC';
@@ -690,16 +699,33 @@ class Model
         return array($innerQuery['sql'], $bind);
     }
 
-    private function addAdditionalSegmentFilter($idSite, $startDate, $endDate, $additionalSegment, array $whereBind, $where)
+    /**
+     * Augments a WHERE clause so the result is intersected with an independent segment at the visit
+     * level. The extra segment is applied as a subquery on log_visit.idvisit (rather than ANDed into
+     * the main segment string), so a visit is kept only when it also matches this segment on its own.
+     * When no extra segment is given the clause is returned unchanged.
+     *
+     * @param int|list<int>|string $idSite
+     * @param Date|null $startDate
+     * @param Date|null $endDate
+     * @param string|false $intersectSegment Extra segment to intersect at the visit level; see queryLogVisits().
+     * @param array $whereBind Bind values collected so far for the WHERE clause.
+     * @param string|false $where The WHERE clause built so far (false when empty).
+     * @return array{0: array, 1: string|false} The [bind values, WHERE clause] pair, with the
+     *                                           intersection appended when an extra segment was given.
+     * @throws Exception
+     */
+    private function addIntersectSegmentFilter($idSite, $startDate, $endDate, $intersectSegment, array $whereBind, $where): array
     {
-        if (empty($additionalSegment)) {
+        if (empty($intersectSegment)) {
             return [$whereBind, $where];
         }
 
-        // Additional report context needs to be intersected at the visit level. Appending it to the
-        // main segment string would evaluate both same-dimension conditions on a single action row.
-        $additionalSegment = new Segment($additionalSegment, $idSite, $startDate, $endDate);
-        $additionalSegmentQuery = $additionalSegment->getSelectQuery(
+        // The extra segment must be intersected at the visit level. Appending it to the main segment
+        // string would let both same-dimension conditions be satisfied by a single action row; keeping
+        // it as a separate subquery on idvisit ensures the visit matches this segment on its own.
+        $intersectSegment = new Segment($intersectSegment, $idSite, $startDate, $endDate);
+        $intersectSegmentQuery = $intersectSegment->getSelectQuery(
             'log_visit.idvisit',
             'log_visit',
             $where,
@@ -711,8 +737,8 @@ class Model
             true
         );
 
-        $where .= ' AND log_visit.idvisit IN (' . $additionalSegmentQuery['sql'] . ')';
-        $whereBind = array_merge($whereBind, $additionalSegmentQuery['bind']);
+        $where .= ' AND log_visit.idvisit IN (' . $intersectSegmentQuery['sql'] . ')';
+        $whereBind = array_merge($whereBind, $intersectSegmentQuery['bind']);
 
         return [$whereBind, $where];
     }

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -695,6 +695,8 @@ class Model
             return [$whereBind, $where];
         }
 
+        // The clicked row segment needs to be intersected at the visit level. Appending it to the
+        // main segment string would evaluate both same-dimension conditions on a single action row.
         $rowSegment = new Segment($segmentVisitorLogRow, $idSite, $startDate, $endDate);
         $rowSegmentQuery = $rowSegment->getSelectQuery(
             'log_visit.idvisit',

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -33,19 +33,20 @@ class Model
     public $queryAndWhereSleepTestsOnly = false;
 
     /**
-     * @param $idSite
-     * @param $period
-     * @param $date
-     * @param $segment
-     * @param $offset
-     * @param $limit
-     * @param $visitorId
-     * @param $minTimestamp
-     * @param $filterSortOrder
-     * @param $checkforMoreEntries
+     * @param int|list<int>|string $idSite
+     * @param string|false $period
+     * @param string|false $date
+     * @param string|false $segment
+     * @param int $offset
+     * @param int $limit
+     * @param string|false $visitorId
+     * @param int|false $minTimestamp
+     * @param string|false $filterSortOrder
+     * @param bool $checkforMoreEntries
+     * @param string|false $additionalSegment Optional extra segment to intersect at the visit level.
      * @return array
      */
-    public function queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, $checkforMoreEntries = false, $segmentVisitorLogRow = false)
+    public function queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, $checkforMoreEntries = false, $additionalSegment = false)
     {
         // to check for more entries increase the limit by one, but cut off the last entry before returning the result
         if ((int)$limit > -1 && $checkforMoreEntries) {
@@ -80,13 +81,13 @@ class Model
                 }
             }
 
-            [$sql, $bind] = $this->makeLogVisitsQueryString($idSite, $queryRange[0], $queryRange[1], $segment, $remainingOffset, $updatedLimit, $visitorId, $minTimestamp, $filterSortOrder, $segmentVisitorLogRow);
+            [$sql, $bind] = $this->makeLogVisitsQueryString($idSite, $queryRange[0], $queryRange[1], $segment, $remainingOffset, $updatedLimit, $visitorId, $minTimestamp, $filterSortOrder, $additionalSegment);
             $visits = $this->executeLogVisitsQuery($sql, $bind, $segment, $dateStart, $dateEnd, $minTimestamp, $limit);
 
             if (!empty($remainingOffset)) {
                 if (empty($visits)) {
                     // No visits returned - need to count total in range to adjust offset
-                    $totalInRange = $this->countLogVisitsInRange($idSite, $queryRange[0], $queryRange[1], $segment, $visitorId, $minTimestamp, $segmentVisitorLogRow);
+                    $totalInRange = $this->countLogVisitsInRange($idSite, $queryRange[0], $queryRange[1], $segment, $visitorId, $minTimestamp, $additionalSegment);
                     $remainingOffset = max(0, $remainingOffset - $totalInRange);
                     continue;
                 } else {
@@ -133,13 +134,13 @@ class Model
      * @return int
      * @throws Exception
      */
-    private function countLogVisitsInRange($idSite, $dateStart, $dateEnd, $segment, $visitorId, $minTimestamp, $segmentVisitorLogRow = false)
+    private function countLogVisitsInRange($idSite, $dateStart, $dateEnd, $segment, $visitorId, $minTimestamp, $additionalSegment = false)
     {
         [$whereClause, $bindIdSites] = $this->getIdSitesWhereClause($idSite);
         [$whereBind, $where] = $this->getWhereClauseAndBind($whereClause, $bindIdSites, $dateStart, $dateEnd, $visitorId, $minTimestamp);
 
         $segment = new Segment($segment, $idSite, $dateStart, $dateEnd);
-        [$whereBind, $where] = $this->addSegmentVisitorLogRowFilter($idSite, $dateStart, $dateEnd, $segmentVisitorLogRow, $whereBind, $where);
+        [$whereBind, $where] = $this->addAdditionalSegmentFilter($idSite, $dateStart, $dateEnd, $additionalSegment, $whereBind, $where);
 
         // Use COUNT(*), do not load all data
         $select = "COUNT(*) as count";
@@ -636,12 +637,12 @@ class Model
      * @return array
      * @throws Exception
      */
-    public function makeLogVisitsQueryString($idSite, $startDate, $endDate, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, $segmentVisitorLogRow = false)
+    public function makeLogVisitsQueryString($idSite, $startDate, $endDate, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, $additionalSegment = false)
     {
         [$whereClause, $bindIdSites] = $this->getIdSitesWhereClause($idSite);
 
         [$whereBind, $where] = $this->getWhereClauseAndBind($whereClause, $bindIdSites, $startDate, $endDate, $visitorId, $minTimestamp);
-        [$whereBind, $where] = $this->addSegmentVisitorLogRowFilter($idSite, $startDate, $endDate, $segmentVisitorLogRow, $whereBind, $where);
+        [$whereBind, $where] = $this->addAdditionalSegmentFilter($idSite, $startDate, $endDate, $additionalSegment, $whereBind, $where);
 
         if (strtolower($filterSortOrder) !== 'asc') {
             $filterSortOrder = 'DESC';
@@ -689,16 +690,16 @@ class Model
         return array($innerQuery['sql'], $bind);
     }
 
-    private function addSegmentVisitorLogRowFilter($idSite, $startDate, $endDate, $segmentVisitorLogRow, array $whereBind, $where)
+    private function addAdditionalSegmentFilter($idSite, $startDate, $endDate, $additionalSegment, array $whereBind, $where)
     {
-        if (empty($segmentVisitorLogRow)) {
+        if (empty($additionalSegment)) {
             return [$whereBind, $where];
         }
 
-        // The clicked row segment needs to be intersected at the visit level. Appending it to the
+        // Additional report context needs to be intersected at the visit level. Appending it to the
         // main segment string would evaluate both same-dimension conditions on a single action row.
-        $rowSegment = new Segment($segmentVisitorLogRow, $idSite, $startDate, $endDate);
-        $rowSegmentQuery = $rowSegment->getSelectQuery(
+        $additionalSegment = new Segment($additionalSegment, $idSite, $startDate, $endDate);
+        $additionalSegmentQuery = $additionalSegment->getSelectQuery(
             'log_visit.idvisit',
             'log_visit',
             $where,
@@ -710,8 +711,8 @@ class Model
             true
         );
 
-        $where .= ' AND log_visit.idvisit IN (' . $rowSegmentQuery['sql'] . ')';
-        $whereBind = array_merge($whereBind, $rowSegmentQuery['bind']);
+        $where .= ' AND log_visit.idvisit IN (' . $additionalSegmentQuery['sql'] . ')';
+        $whereBind = array_merge($whereBind, $additionalSegmentQuery['bind']);
 
         return [$whereBind, $where];
     }

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -724,6 +724,12 @@ class Model
         // The extra segment must be intersected at the visit level. Appending it to the main segment
         // string would let both same-dimension conditions be satisfied by a single action row; keeping
         // it as a separate subquery on idvisit ensures the visit matches this segment on its own.
+        //
+        // The outer $where (idsite + date range) is intentionally reused inside the subquery. It is
+        // redundant for correctness — idvisit is unique, so the outer WHERE already constrains the
+        // result once the IN-intersection is applied — but MySQL does not push the outer predicates
+        // into this non-correlated subquery, and the date bound comes only from $where. Reusing it
+        // keeps the subquery scanning the same site/date window instead of the whole history.
         $intersectSegment = new Segment($intersectSegment, $idSite, $startDate, $endDate);
         $intersectSegmentQuery = $intersectSegment->getSelectQuery(
             'log_visit.idvisit',

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -45,7 +45,7 @@ class Model
      * @param $checkforMoreEntries
      * @return array
      */
-    public function queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, $checkforMoreEntries = false)
+    public function queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, $checkforMoreEntries = false, $segmentVisitorLogRow = false)
     {
         // to check for more entries increase the limit by one, but cut off the last entry before returning the result
         if ((int)$limit > -1 && $checkforMoreEntries) {
@@ -80,13 +80,13 @@ class Model
                 }
             }
 
-            [$sql, $bind] = $this->makeLogVisitsQueryString($idSite, $queryRange[0], $queryRange[1], $segment, $remainingOffset, $updatedLimit, $visitorId, $minTimestamp, $filterSortOrder);
+            [$sql, $bind] = $this->makeLogVisitsQueryString($idSite, $queryRange[0], $queryRange[1], $segment, $remainingOffset, $updatedLimit, $visitorId, $minTimestamp, $filterSortOrder, $segmentVisitorLogRow);
             $visits = $this->executeLogVisitsQuery($sql, $bind, $segment, $dateStart, $dateEnd, $minTimestamp, $limit);
 
             if (!empty($remainingOffset)) {
                 if (empty($visits)) {
                     // No visits returned - need to count total in range to adjust offset
-                    $totalInRange = $this->countLogVisitsInRange($idSite, $queryRange[0], $queryRange[1], $segment, $visitorId, $minTimestamp);
+                    $totalInRange = $this->countLogVisitsInRange($idSite, $queryRange[0], $queryRange[1], $segment, $visitorId, $minTimestamp, $segmentVisitorLogRow);
                     $remainingOffset = max(0, $remainingOffset - $totalInRange);
                     continue;
                 } else {
@@ -133,12 +133,13 @@ class Model
      * @return int
      * @throws Exception
      */
-    private function countLogVisitsInRange($idSite, $dateStart, $dateEnd, $segment, $visitorId, $minTimestamp)
+    private function countLogVisitsInRange($idSite, $dateStart, $dateEnd, $segment, $visitorId, $minTimestamp, $segmentVisitorLogRow = false)
     {
         [$whereClause, $bindIdSites] = $this->getIdSitesWhereClause($idSite);
         [$whereBind, $where] = $this->getWhereClauseAndBind($whereClause, $bindIdSites, $dateStart, $dateEnd, $visitorId, $minTimestamp);
 
         $segment = new Segment($segment, $idSite, $dateStart, $dateEnd);
+        [$whereBind, $where] = $this->addSegmentVisitorLogRowFilter($idSite, $dateStart, $dateEnd, $segmentVisitorLogRow, $whereBind, $where);
 
         // Use COUNT(*), do not load all data
         $select = "COUNT(*) as count";
@@ -635,11 +636,12 @@ class Model
      * @return array
      * @throws Exception
      */
-    public function makeLogVisitsQueryString($idSite, $startDate, $endDate, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder)
+    public function makeLogVisitsQueryString($idSite, $startDate, $endDate, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, $segmentVisitorLogRow = false)
     {
         [$whereClause, $bindIdSites] = $this->getIdSitesWhereClause($idSite);
 
         [$whereBind, $where] = $this->getWhereClauseAndBind($whereClause, $bindIdSites, $startDate, $endDate, $visitorId, $minTimestamp);
+        [$whereBind, $where] = $this->addSegmentVisitorLogRowFilter($idSite, $startDate, $endDate, $segmentVisitorLogRow, $whereBind, $where);
 
         if (strtolower($filterSortOrder) !== 'asc') {
             $filterSortOrder = 'DESC';
@@ -685,6 +687,31 @@ class Model
         }
 
         return array($innerQuery['sql'], $bind);
+    }
+
+    private function addSegmentVisitorLogRowFilter($idSite, $startDate, $endDate, $segmentVisitorLogRow, array $whereBind, $where)
+    {
+        if (empty($segmentVisitorLogRow)) {
+            return [$whereBind, $where];
+        }
+
+        $rowSegment = new Segment($segmentVisitorLogRow, $idSite, $startDate, $endDate);
+        $rowSegmentQuery = $rowSegment->getSelectQuery(
+            'log_visit.idvisit',
+            'log_visit',
+            $where,
+            $whereBind,
+            '',
+            'log_visit.idvisit',
+            0,
+            0,
+            true
+        );
+
+        $where .= ' AND log_visit.idvisit IN (' . $rowSegmentQuery['sql'] . ')';
+        $whereBind = array_merge($whereBind, $rowSegmentQuery['bind']);
+
+        return [$whereBind, $where];
     }
 
     /**

--- a/plugins/Live/javascripts/SegmentedVisitorLog.js
+++ b/plugins/Live/javascripts/SegmentedVisitorLog.js
@@ -58,7 +58,7 @@ var SegmentedVisitorLog = function() {
         return getLabelFromTr($tr, apiMethod);
     }
 
-    function setPopoverTitle(apiMethod, segment, index) {
+    function setPopoverTitle(apiMethod, segment, index, rowSegment) {
         var dataTable = getDataTableFromApiMethod(apiMethod);
 
         if (!dataTable) {
@@ -66,18 +66,19 @@ var SegmentedVisitorLog = function() {
                 // this is needed when the popover is opened before the dataTable is there which can often
                 // happen when opening the popover directly via URL (broadcast.popoverHandler)
                 setTimeout(function () {
-                    setPopoverTitle(apiMethod, segment, index + 1);
+                    setPopoverTitle(apiMethod, segment, index + 1, rowSegment);
                 }, 150);
             }
             return;
         }
 
         var segmentName = getDimensionFromApiMethod(apiMethod);
-        var segmentValue = findTitleOfRowHavingRawSegmentValue(apiMethod, segment);
+        var displayedSegment = rowSegment || segment;
+        var segmentValue = findTitleOfRowHavingRawSegmentValue(apiMethod, displayedSegment);
 
-        if (!segmentName || (segment && segment.indexOf(';') > 0)) {
+        if (!segmentName || (displayedSegment && displayedSegment.indexOf(';') > 0)) {
             segmentName = _pk_translate('General_Segment');
-            var segmentParts = segment.split(';');
+            var segmentParts = displayedSegment.split(';');
             segmentValue = segmentParts.join(' ' + _pk_translate('General_And') + ' ');
         }
 
@@ -126,7 +127,7 @@ var SegmentedVisitorLog = function() {
 
             Piwik_Popover.setTitle(defaultTitle);
 
-            setPopoverTitle(apiMethod, segment, 0);
+            setPopoverTitle(apiMethod, segment, 0, extraParams.segmentVisitorLogRow);
         };
 
         // prepare loading the popover contents
@@ -155,4 +156,3 @@ var SegmentedVisitorLog = function() {
         show: show
     }
 }();
-

--- a/plugins/Live/javascripts/SegmentedVisitorLog.js
+++ b/plugins/Live/javascripts/SegmentedVisitorLog.js
@@ -127,7 +127,7 @@ var SegmentedVisitorLog = function() {
 
             Piwik_Popover.setTitle(defaultTitle);
 
-            setPopoverTitle(apiMethod, segment, 0, extraParams.additionalSegment);
+            setPopoverTitle(apiMethod, segment, 0, extraParams.intersectSegment);
         };
 
         // prepare loading the popover contents

--- a/plugins/Live/javascripts/SegmentedVisitorLog.js
+++ b/plugins/Live/javascripts/SegmentedVisitorLog.js
@@ -127,7 +127,7 @@ var SegmentedVisitorLog = function() {
 
             Piwik_Popover.setTitle(defaultTitle);
 
-            setPopoverTitle(apiMethod, segment, 0, extraParams.segmentVisitorLogRow);
+            setPopoverTitle(apiMethod, segment, 0, extraParams.additionalSegment);
         };
 
         // prepare loading the popover contents

--- a/plugins/Live/javascripts/rowaction.js
+++ b/plugins/Live/javascripts/rowaction.js
@@ -62,6 +62,10 @@
         'date',
         'period',
         'segment',
+        // Extra segment intersected at the visit level by Live\Model (see Model::queryLogVisits
+        // $intersectSegment). Like `segment` it is a segment definition validated server-side by
+        // the Segment class, so it grants no capability beyond the already-allowed `segment` key.
+        'intersectSegment',
     ];
 
     // Filter a parsed extraParams object against the allowlist. Returns a new

--- a/plugins/Live/javascripts/rowaction.js
+++ b/plugins/Live/javascripts/rowaction.js
@@ -96,7 +96,7 @@
 
         if (currentSegment) {
             segment = decodeURIComponent(currentSegment);
-            extraParams.additionalSegment = clickedSegment;
+            extraParams.intersectSegment = clickedSegment;
         } else {
             segment = clickedSegment;
         }
@@ -109,7 +109,7 @@
             }
 
             if (!currentSegment) {
-                extraParams.additionalSegment = clickedSegment;
+                extraParams.intersectSegment = clickedSegment;
             }
         }
 

--- a/plugins/Live/javascripts/rowaction.js
+++ b/plugins/Live/javascripts/rowaction.js
@@ -91,26 +91,29 @@
     DataTable_RowActions_SegmentVisitorLog.prototype.trigger = function (tr, e, subTableLabel) {
         var clickedSegment = getRawSegmentValueFromRow(tr);
         var currentSegment = this.dataTable.param.segment || '';
-        var segment = '';
+        var suffix = this.dataTable.props.segmented_visitor_log_segment_suffix || '';
         var extraParams = {};
 
+        // The main segment is the report's own context: its current segment (if any) plus any
+        // report-defined suffix, ANDed together at the action level. The clicked row's segment is
+        // always intersected at the visit level instead (see Model::queryLogVisits $intersectSegment),
+        // so a same-dimension condition — e.g. current pageUrl==X with clicked pageUrl==Y — is not
+        // collapsed onto a single action row, which would match nothing.
+        var parts = [];
         if (currentSegment) {
-            segment = decodeURIComponent(currentSegment);
+            parts.push(decodeURIComponent(currentSegment));
+        }
+        if (suffix) {
+            parts.push(suffix);
+        }
+        var segment = parts.join(';');
+
+        if (segment) {
             extraParams.intersectSegment = clickedSegment;
         } else {
+            // No report context at all: the clicked segment is the whole segment. Evaluating it at
+            // the action level is fine here because there is no other condition to collide with.
             segment = clickedSegment;
-        }
-
-        if (this.dataTable.props.segmented_visitor_log_segment_suffix) {
-            if (segment) {
-                segment = segment + ';' + this.dataTable.props.segmented_visitor_log_segment_suffix;
-            } else {
-                segment = this.dataTable.props.segmented_visitor_log_segment_suffix;
-            }
-
-            if (!currentSegment) {
-                extraParams.intersectSegment = clickedSegment;
-            }
         }
 
         this.performAction(segment, tr, e, null, extraParams);

--- a/plugins/Live/javascripts/rowaction.js
+++ b/plugins/Live/javascripts/rowaction.js
@@ -96,7 +96,7 @@
 
         if (currentSegment) {
             segment = decodeURIComponent(currentSegment);
-            extraParams.segmentVisitorLogRow = clickedSegment;
+            extraParams.additionalSegment = clickedSegment;
         } else {
             segment = clickedSegment;
         }
@@ -109,7 +109,7 @@
             }
 
             if (!currentSegment) {
-                extraParams.segmentVisitorLogRow = clickedSegment;
+                extraParams.additionalSegment = clickedSegment;
             }
         }
 

--- a/plugins/Live/javascripts/rowaction.js
+++ b/plugins/Live/javascripts/rowaction.js
@@ -89,27 +89,42 @@
     };
 
     DataTable_RowActions_SegmentVisitorLog.prototype.trigger = function (tr, e, subTableLabel) {
-        var segment = getRawSegmentValueFromRow(tr);
+        var clickedSegment = getRawSegmentValueFromRow(tr);
+        var currentSegment = this.dataTable.param.segment || '';
+        var segment = '';
+        var extraParams = {};
 
-        if (this.dataTable.param.segment) {
-            segment = decodeURIComponent(this.dataTable.param.segment) + ';' + segment;
+        if (currentSegment) {
+            segment = decodeURIComponent(currentSegment);
+            extraParams.segmentVisitorLogRow = clickedSegment;
+        } else {
+            segment = clickedSegment;
         }
 
         if (this.dataTable.props.segmented_visitor_log_segment_suffix) {
-            segment = segment + ';' + this.dataTable.props.segmented_visitor_log_segment_suffix;
+            if (segment) {
+                segment = segment + ';' + this.dataTable.props.segmented_visitor_log_segment_suffix;
+            } else {
+                segment = this.dataTable.props.segmented_visitor_log_segment_suffix;
+            }
+
+            if (!currentSegment) {
+                extraParams.segmentVisitorLogRow = clickedSegment;
+            }
         }
 
-        this.performAction(segment, tr, e);
+        this.performAction(segment, tr, e, null, extraParams);
     };
 
-    DataTable_RowActions_SegmentVisitorLog.prototype.performAction = function (segment, tr, e, originalRow) {
+    DataTable_RowActions_SegmentVisitorLog.prototype.performAction = function (segment, tr, e, originalRow, extraParamsOverride) {
 
         var apiMethod = this.dataTable.param.module + '.' + this.dataTable.param.action;
 
-        var extraParams = {};
+        var extraParams = extraParamsOverride || {};
 
         if (this.dataTable.param.date && this.dataTable.param.period) {
-            extraParams = {date: this.dataTable.param.date, period: this.dataTable.param.period};
+            extraParams.date = this.dataTable.param.date;
+            extraParams.period = this.dataTable.param.period;
         }
 
         var paramOverride = $(originalRow || tr).data('param-override');

--- a/plugins/Live/tests/Integration/APITest.php
+++ b/plugins/Live/tests/Integration/APITest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Live\tests\Integration;
+
+use Piwik\Date;
+use Piwik\Plugins\Live\API;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Live
+ * @group APITest
+ * @group Plugins
+ */
+class APITest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createSuperUser();
+        $this->setSuperUser();
+        Fixture::createWebsite('2010-01-01');
+    }
+
+    /**
+     * Regression coverage for the $intersectSegment method argument: it must be the source of truth,
+     * honored even when the ambient request does not contain an "intersectSegment" parameter (as is the
+     * case for a direct PHP call). If the value were read from the request instead, the direct call
+     * below would silently drop the filter and return both visits.
+     */
+    public function testGetLastVisitsDetailsHonorsIntersectSegmentArgumentFromDirectCall()
+    {
+        $categoryUrl = 'https://example.org/category/exampleblue-travel-tips/essential-example/';
+        $bestOfUrl = 'https://example.org/exampleblue-travel-tips/essential-example/best-of-example-1/';
+
+        // Visit A matches the current segment (best-of page) AND the clicked row (category page).
+        $this->trackVisitWithActions('2012-01-01 10:00:00', [$categoryUrl, $bestOfUrl]);
+        // Visit B matches only the current segment: it never visited the category page.
+        $this->trackVisitWithActions('2012-01-01 11:00:00', [$bestOfUrl]);
+
+        $currentSegment = 'pageUrl==https%253A%252F%252Fexample.org%252Fexampleblue-travel-tips%252Fessential-example%252Fbest-of-example-1%252F';
+        $clickedRowSegment = 'pageUrl=^https%253A%252F%252Fexample.org%252Fcategory';
+
+        $api = API::getInstance();
+
+        // Sanity check: the current segment alone matches both visits.
+        $withoutIntersect = $api->getLastVisitsDetails(1, 'day', '2012-01-01', $currentSegment);
+        $this->assertSame(2, $withoutIntersect->getRowsCount());
+
+        // Passing $intersectSegment as the method argument must narrow the result to the single visit
+        // that also matches it, without any "intersectSegment" request parameter being present.
+        $withIntersect = $api->getLastVisitsDetails(
+            1,
+            'day',
+            '2012-01-01',
+            $currentSegment,
+            $countVisitorsToFetch = false,
+            $minTimestamp = false,
+            $flat = false,
+            $doNotFetchActions = false,
+            $enhanced = false,
+            $clickedRowSegment
+        );
+        $this->assertSame(1, $withIntersect->getRowsCount());
+        // ...and it is the right one: visit A (which also visited the category page), not visit B.
+        $this->assertSame(
+            '2012-01-01 10:00:01',
+            $withIntersect->getFirstRow()->getColumn('visit_last_action_time')
+        );
+    }
+
+    private function trackVisitWithActions(string $dateTime, array $urls): void
+    {
+        $tracker = Fixture::getTracker(1, $dateTime, $defaultInit = true);
+        $tracker->setTokenAuth(Fixture::getTokenAuth());
+        $tracker->setNewVisitorId();
+
+        foreach ($urls as $index => $url) {
+            $actionTime = Date::factory($dateTime)->addPeriod($index, 'second')->getDatetime();
+            $tracker->setForceVisitDateTime($actionTime);
+            $tracker->setUrl($url);
+            Fixture::checkResponse($tracker->doTrackPageView('Visit action ' . $index));
+        }
+    }
+
+    protected function setSuperUser()
+    {
+        FakeAccess::$superUser = true;
+    }
+
+    public function provideContainerConfig()
+    {
+        return [
+            'Piwik\Access' => new FakeAccess(),
+        ];
+    }
+}

--- a/plugins/Live/tests/Integration/ModelTest.php
+++ b/plugins/Live/tests/Integration/ModelTest.php
@@ -748,6 +748,39 @@ class ModelTest extends IntegrationTestCase
         $this->assertEquals('2011-01-01 03:00:00', $visits[1]['visit_last_action_time']);
     }
 
+    public function testQueryLogVisitsCanIntersectCurrentSegmentWithClickedRowAtVisitLevel()
+    {
+        $dateTime = '2012-01-01 10:00:00';
+        $this->trackVisitWithActions($dateTime, [
+            'https://example.org/category/exampleblue-travel-tips/essential-example/',
+            'https://example.org/exampleblue-travel-tips/essential-example/best-of-example-1/',
+        ]);
+        $this->trackVisitWithActions('2012-01-01 11:00:00', [
+            'https://example.org/category/exampleblue-travel-tips/essential-example/',
+        ]);
+
+        $model = new Model();
+        $currentSegment = 'pageUrl==https%253A%252F%252Fexample.org%252Fexampleblue-travel-tips%252Fessential-example%252Fbest-of-example-1%252F';
+        $clickedRowSegment = 'pageUrl=^https%253A%252F%252Fexample.org%252Fcategory';
+
+        $visits = $model->queryLogVisits(
+            1,
+            'day',
+            '2012-01-01',
+            $currentSegment,
+            0,
+            10,
+            false,
+            false,
+            'desc',
+            false,
+            $clickedRowSegment
+        );
+
+        $this->assertCount(1, $visits);
+        $this->assertEquals('2012-01-01 10:00:01', $visits[0]['visit_last_action_time']);
+    }
+
     protected function setSuperUser()
     {
         FakeAccess::$superUser = true;
@@ -791,6 +824,20 @@ class ModelTest extends IntegrationTestCase
         $t->setForceVisitDateTime($dateTime);
         $t->setUrl('http://example.org/' . str_replace([' ', ':'], '-', $dateTime));
         Fixture::checkResponse($t->doTrackPageView('Visit at ' . $dateTime));
+    }
+
+    private function trackVisitWithActions(string $dateTime, array $urls): void
+    {
+        $tracker = Fixture::getTracker(1, $dateTime, $defaultInit = true);
+        $tracker->setTokenAuth(Fixture::getTokenAuth());
+        $tracker->setNewVisitorId();
+
+        foreach ($urls as $index => $url) {
+            $actionTime = Date::factory($dateTime)->addPeriod($index, 'second')->getDatetime();
+            $tracker->setForceVisitDateTime($actionTime);
+            $tracker->setUrl($url);
+            Fixture::checkResponse($tracker->doTrackPageView('Visit action ' . $index));
+        }
     }
 
     private function countVisitsBetween(string $startDate, string $endDate): int

--- a/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
+++ b/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
@@ -70,7 +70,7 @@ describe('Live/SegmentVisitorLog row action', () => {
       expect.objectContaining({
         date: '2012-08-09',
         period: 'day',
-        additionalSegment: CATEGORY_ROW_SEGMENT,
+        intersectSegment: CATEGORY_ROW_SEGMENT,
       }),
     );
   });
@@ -99,7 +99,7 @@ describe('Live/SegmentVisitorLog row action', () => {
       expect.objectContaining({
         date: '2012-08-09',
         period: 'day',
-        additionalSegment: CATEGORY_ROW_SEGMENT,
+        intersectSegment: CATEGORY_ROW_SEGMENT,
       }),
     );
   });

--- a/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
+++ b/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
@@ -5,6 +5,7 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
+import type { Mock, MockInstance } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
@@ -14,8 +15,8 @@ const CATEGORY_ROW_SEGMENT = 'pageUrl=^https%253A%252F%252Fexample.org%252Fcateg
 const SUFFIX_SEGMENT = 'visitEcommerceStatus==ordered';
 
 describe('Live/SegmentVisitorLog row action', () => {
-  let rowActionInstance: { trigger: (tr: JQuery<HTMLElement>, event: Event) => void; openPopover: jest.Mock };
-  let openPopoverSpy: jest.SpyInstance;
+  let rowActionInstance: { trigger: (tr: JQuery<HTMLElement>, event: Event) => void; openPopover: Mock };
+  let openPopoverSpy: MockInstance;
 
   beforeAll(async () => {
     window.eval(readFileSync(resolve(__dirname, '../../../../CoreHome/javascripts/dataTable_rowactions.js'), 'utf8'));
@@ -49,7 +50,7 @@ describe('Live/SegmentVisitorLog row action', () => {
       props: {},
     });
 
-    openPopoverSpy = jest.spyOn(rowActionInstance, 'openPopover').mockImplementation(() => undefined);
+    openPopoverSpy = vi.spyOn(rowActionInstance, 'openPopover').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
@@ -89,7 +90,7 @@ describe('Live/SegmentVisitorLog row action', () => {
         segmented_visitor_log_segment_suffix: SUFFIX_SEGMENT,
       },
     });
-    openPopoverSpy = jest.spyOn(rowActionInstance, 'openPopover').mockImplementation(() => undefined);
+    openPopoverSpy = vi.spyOn(rowActionInstance, 'openPopover').mockImplementation(() => undefined);
 
     rowActionInstance.trigger(window.$('#segment-row'), new window.MouseEvent('click'));
 
@@ -118,7 +119,7 @@ describe('Live/SegmentVisitorLog row action', () => {
         segmented_visitor_log_segment_suffix: SUFFIX_SEGMENT,
       },
     });
-    openPopoverSpy = jest.spyOn(rowActionInstance, 'openPopover').mockImplementation(() => undefined);
+    openPopoverSpy = vi.spyOn(rowActionInstance, 'openPopover').mockImplementation(() => undefined);
 
     rowActionInstance.trigger(window.$('#segment-row'), new window.MouseEvent('click'));
 

--- a/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
+++ b/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
@@ -11,14 +11,21 @@ import { resolve } from 'path';
 const CURRENT_PAGE_SEGMENT = 'countryCode==pt;pageUrl==https%253A%252F%252Fexample.org%252Fexampleblue-travel-tips%252Fessential-example%252Fbest-of-example-1%252F';
 const DECODED_CURRENT_PAGE_SEGMENT = decodeURIComponent(CURRENT_PAGE_SEGMENT);
 const CATEGORY_ROW_SEGMENT = 'pageUrl=^https%253A%252F%252Fexample.org%252Fcategory';
+const PAGE_TITLE_ROW_SEGMENT = 'pageTitle==Peek%2BInside%2BParadise%2BSlideshow%2B%257C%2BExample%2BBlue';
 const SUFFIX_SEGMENT = 'visitEcommerceStatus==ordered';
 
 describe('Live/SegmentVisitorLog row action', () => {
   let rowActionInstance: { trigger: (tr: JQuery<HTMLElement>, event: Event) => void; openPopover: jest.Mock };
   let openPopoverSpy: jest.SpyInstance;
+  let originalRequire: any;
+  let originalAjaxHelper: any;
+  let originalVisitorLogEnabled: boolean;
+  let originalVueSanitize: any;
+  let originalTranslate: any;
 
   beforeAll(async () => {
     window.eval(readFileSync(resolve(__dirname, '../../../../CoreHome/javascripts/dataTable_rowactions.js'), 'utf8'));
+    window.eval(readFileSync(resolve(__dirname, '../../../../Live/javascripts/SegmentedVisitorLog.js'), 'utf8'));
     window.eval(readFileSync(resolve(__dirname, '../../../../Live/javascripts/rowaction.js'), 'utf8'));
     await Promise.resolve();
     await Promise.resolve();
@@ -33,7 +40,100 @@ describe('Live/SegmentVisitorLog row action', () => {
           </td>
         </tr>
       </table>
+      <div
+        class="dataTable"
+        data-report="Actions.getPageUrls"
+      ></div>
+      <div
+        class="dataTable"
+        data-report="Actions.getPageTitles"
+      ></div>
     `;
+
+    originalRequire = (window as any).require;
+    (window as any).require = (moduleName: string) => {
+      if (moduleName === 'piwik/UI') {
+        return {
+          DataTable: {
+            getDataTableByReport: (apiMethod: string) => {
+              return document.querySelector(`[data-report="${apiMethod}"]`);
+            },
+          },
+        };
+      }
+
+      return originalRequire ? originalRequire(moduleName) : undefined;
+    };
+
+    const pageUrlsTable = window.$('[data-report="Actions.getPageUrls"]');
+    pageUrlsTable.data('uiControlObject', {
+      getReportMetadata: () => ({
+        dimension: 'Page URL',
+      }),
+    });
+
+    const pageTitlesTable = window.$('[data-report="Actions.getPageTitles"]');
+    pageTitlesTable.data('uiControlObject', {
+      getReportMetadata: () => ({
+        dimension: 'Page Title',
+      }),
+    });
+
+    originalVisitorLogEnabled = (window as any).piwik?.visitorLogEnabled;
+    (window as any).piwik = {
+      ...(window as any).piwik,
+      visitorLogEnabled: true,
+    };
+
+    originalAjaxHelper = (window as any).ajaxHelper;
+    originalVueSanitize = (window as any).vueSanitize;
+    originalTranslate = (window as any)._pk_translate;
+    (window as any)._pk_translate = (key: string, args: string[] = []) => `${key} ${args.join(' ')}`;
+    (window as any).vueSanitize = (value: string) => value;
+    (window as any).ajaxHelper = class {
+      callback!: (html: string) => void;
+
+      addParams() {
+        return this;
+      }
+
+      withTokenInUrl() {
+        return this;
+      }
+
+      setCallback(callback: (html: string) => void) {
+        this.callback = callback;
+        return this;
+      }
+
+      setFormat() {
+        return this;
+      }
+
+      send() {
+        this.callback(
+          '<div><h2 class="enrichedHeadline"><span class="title">Segmented Visits Log</span></h2></div>',
+        );
+      }
+    };
+
+    window.Piwik_Popover = {
+      showLoading: jest.fn((title: string) => {
+        const popover = window.$(
+          `<div id="Piwik_Popover"><h2 class="enrichedHeadline"><span class="title">${title}</span></h2></div>`,
+        );
+        window.$('body').append(popover);
+
+        return popover;
+      }),
+      setContent: jest.fn((html: string) => {
+        window.$('#Piwik_Popover').html(html);
+      }),
+      setTitle: jest.fn(),
+      onClose: jest.fn(),
+      isOpen: jest.fn(() => true),
+      close: jest.fn(),
+    } as any;
 
     const action = (window as any).DataTable_RowActions_Registry.getActionByName('SegmentVisitorLog');
 
@@ -56,6 +156,15 @@ describe('Live/SegmentVisitorLog row action', () => {
     if (openPopoverSpy) {
       openPopoverSpy.mockRestore();
     }
+    (window as any).require = originalRequire;
+    (window as any).ajaxHelper = originalAjaxHelper;
+    (window as any).vueSanitize = originalVueSanitize;
+    (window as any)._pk_translate = originalTranslate;
+    (window as any).piwik = {
+      ...(window as any).piwik,
+      visitorLogEnabled: originalVisitorLogEnabled,
+    };
+    (window as any).Piwik_Popover = undefined;
     document.body.innerHTML = '';
   });
 
@@ -102,5 +211,29 @@ describe('Live/SegmentVisitorLog row action', () => {
         additionalSegment: CATEGORY_ROW_SEGMENT,
       }),
     );
+  });
+
+  it('should render the popup title from the clicked row label instead of the raw combined segment', () => {
+    window.$('[data-report="Actions.getPageTitles"] tr').remove();
+    window.$('[data-report="Actions.getPageTitles"]').append(`
+      <table>
+        <tr data-segment-filter="${PAGE_TITLE_ROW_SEGMENT}">
+          <td class="label">
+            <span class="value">Peek Inside Paradise Slideshow | Example Blue</span>
+          </td>
+        </tr>
+      </table>
+    `);
+
+    (window as any).SegmentedVisitorLog.show('Actions.getPageTitles', DECODED_CURRENT_PAGE_SEGMENT, {
+      additionalSegment: PAGE_TITLE_ROW_SEGMENT,
+    });
+
+    const setTitleCalls = (window.Piwik_Popover.setTitle as jest.Mock).mock.calls;
+    const finalTitle = setTitleCalls[setTitleCalls.length - 1][0];
+
+    expect(finalTitle).toContain('Peek Inside Paradise Slideshow | Example Blue');
+    expect(finalTitle).not.toContain('pageUrl==');
+    expect(finalTitle).not.toContain('pageTitle==');
   });
 });

--- a/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
+++ b/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
@@ -70,7 +70,7 @@ describe('Live/SegmentVisitorLog row action', () => {
       expect.objectContaining({
         date: '2012-08-09',
         period: 'day',
-        segmentVisitorLogRow: CATEGORY_ROW_SEGMENT,
+        additionalSegment: CATEGORY_ROW_SEGMENT,
       }),
     );
   });
@@ -99,7 +99,7 @@ describe('Live/SegmentVisitorLog row action', () => {
       expect.objectContaining({
         date: '2012-08-09',
         period: 'day',
-        segmentVisitorLogRow: CATEGORY_ROW_SEGMENT,
+        additionalSegment: CATEGORY_ROW_SEGMENT,
       }),
     );
   });

--- a/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
+++ b/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
@@ -103,4 +103,35 @@ describe('Live/SegmentVisitorLog row action', () => {
       }),
     );
   });
+
+  it('should use only the suffix as the main segment and keep the clicked row at the visit level when there is no current segment', () => {
+    rowActionInstance = (window as any).DataTable_RowActions_Registry.getActionByName('SegmentVisitorLog').createInstance({
+      param: {
+        module: 'Actions',
+        action: 'getPageUrls',
+        segment: '',
+        date: '2012-08-09',
+        period: 'day',
+        idSite: 1,
+      },
+      props: {
+        segmented_visitor_log_segment_suffix: SUFFIX_SEGMENT,
+      },
+    });
+    openPopoverSpy = jest.spyOn(rowActionInstance, 'openPopover').mockImplementation(() => undefined);
+
+    rowActionInstance.trigger(window.$('#segment-row'), new window.MouseEvent('click'));
+
+    // The clicked row must NOT also be appended to the main segment: it is intersected at the visit
+    // level only, consistent with the current-segment cases above.
+    expect(openPopoverSpy).toHaveBeenCalledWith(
+      'Actions.getPageUrls',
+      SUFFIX_SEGMENT,
+      expect.objectContaining({
+        date: '2012-08-09',
+        period: 'day',
+        intersectSegment: CATEGORY_ROW_SEGMENT,
+      }),
+    );
+  });
 });

--- a/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
+++ b/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
@@ -1,0 +1,106 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const CURRENT_PAGE_SEGMENT = 'countryCode==pt;pageUrl==https%253A%252F%252Fexample.org%252Fexampleblue-travel-tips%252Fessential-example%252Fbest-of-example-1%252F';
+const DECODED_CURRENT_PAGE_SEGMENT = decodeURIComponent(CURRENT_PAGE_SEGMENT);
+const CATEGORY_ROW_SEGMENT = 'pageUrl=^https%253A%252F%252Fexample.org%252Fcategory';
+const SUFFIX_SEGMENT = 'visitEcommerceStatus==ordered';
+
+describe('Live/SegmentVisitorLog row action', () => {
+  let rowActionInstance: { trigger: (tr: JQuery<HTMLElement>, event: Event) => void; openPopover: jest.Mock };
+  let openPopoverSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    window.eval(readFileSync(resolve(__dirname, '../../../../CoreHome/javascripts/dataTable_rowactions.js'), 'utf8'));
+    window.eval(readFileSync(resolve(__dirname, '../../../../Live/javascripts/rowaction.js'), 'utf8'));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <table>
+        <tr id="segment-row" data-segment-filter="${CATEGORY_ROW_SEGMENT}">
+          <td class="label">
+            <span class="label">category</span>
+          </td>
+        </tr>
+      </table>
+    `;
+
+    const action = (window as any).DataTable_RowActions_Registry.getActionByName('SegmentVisitorLog');
+
+    rowActionInstance = action.createInstance({
+      param: {
+        module: 'Actions',
+        action: 'getPageUrls',
+        segment: CURRENT_PAGE_SEGMENT,
+        date: '2012-08-09',
+        period: 'day',
+        idSite: 1,
+      },
+      props: {},
+    });
+
+    openPopoverSpy = jest.spyOn(rowActionInstance, 'openPopover').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    if (openPopoverSpy) {
+      openPopoverSpy.mockRestore();
+    }
+    document.body.innerHTML = '';
+  });
+
+  it('should keep the current report segment and send the clicked row as a dedicated visitor-log filter', () => {
+    const row = window.$('#segment-row');
+
+    rowActionInstance.trigger(row, new window.MouseEvent('click'));
+
+    expect(openPopoverSpy).toHaveBeenCalledWith(
+      'Actions.getPageUrls',
+      DECODED_CURRENT_PAGE_SEGMENT,
+      expect.objectContaining({
+        date: '2012-08-09',
+        period: 'day',
+        segmentVisitorLogRow: CATEGORY_ROW_SEGMENT,
+      }),
+    );
+  });
+
+  it('should append the configured visitor log suffix to the current segment and keep the clicked row separate', () => {
+    rowActionInstance = (window as any).DataTable_RowActions_Registry.getActionByName('SegmentVisitorLog').createInstance({
+      param: {
+        module: 'Actions',
+        action: 'getPageUrls',
+        segment: CURRENT_PAGE_SEGMENT,
+        date: '2012-08-09',
+        period: 'day',
+        idSite: 1,
+      },
+      props: {
+        segmented_visitor_log_segment_suffix: SUFFIX_SEGMENT,
+      },
+    });
+    openPopoverSpy = jest.spyOn(rowActionInstance, 'openPopover').mockImplementation(() => undefined);
+
+    rowActionInstance.trigger(window.$('#segment-row'), new window.MouseEvent('click'));
+
+    expect(openPopoverSpy).toHaveBeenCalledWith(
+      'Actions.getPageUrls',
+      `${DECODED_CURRENT_PAGE_SEGMENT};${SUFFIX_SEGMENT}`,
+      expect.objectContaining({
+        date: '2012-08-09',
+        period: 'day',
+        segmentVisitorLogRow: CATEGORY_ROW_SEGMENT,
+      }),
+    );
+  });
+});

--- a/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
+++ b/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
@@ -15,7 +15,11 @@ const CATEGORY_ROW_SEGMENT = 'pageUrl=^https%253A%252F%252Fexample.org%252Fcateg
 const SUFFIX_SEGMENT = 'visitEcommerceStatus==ordered';
 
 describe('Live/SegmentVisitorLog row action', () => {
-  let rowActionInstance: { trigger: (tr: JQuery<HTMLElement>, event: Event) => void; openPopover: Mock };
+  let rowActionInstance: {
+    trigger: (tr: JQuery<HTMLElement>, event: Event) => void;
+    openPopover: Mock;
+    doOpenPopover: (urlParam: string) => void;
+  };
   let openPopoverSpy: MockInstance;
 
   beforeAll(async () => {
@@ -134,5 +138,55 @@ describe('Live/SegmentVisitorLog row action', () => {
         intersectSegment: CATEGORY_ROW_SEGMENT,
       }),
     );
+  });
+
+  it('should preserve intersectSegment through the popover URL round-trip and pass it to the visitor log', () => {
+    // The cases above stop at openPopover, before doOpenPopover() re-parses the serialized payload
+    // and runs it through the allowlist filter. This drives the full round-trip to prove
+    // intersectSegment is on the allowlist and actually reaches SegmentedVisitorLog.show(); if it
+    // were dropped, only the report segment would survive and the visit-level fix would be defeated.
+    const showSpy = vi.fn();
+    (window as any).SegmentedVisitorLog = { show: showSpy };
+    const propagateSpy = vi.fn();
+    (window as any).broadcast = { propagateNewPopoverParameter: propagateSpy };
+
+    // Use the real openPopover so the extraParams are serialized exactly as in production.
+    openPopoverSpy.mockRestore();
+
+    rowActionInstance.trigger(window.$('#segment-row'), new window.MouseEvent('click'));
+
+    // broadcast receives 'SegmentVisitorLog:' + urlParam; doOpenPopover() expects the urlParam alone.
+    const [popoverName, popoverParam] = propagateSpy.mock.calls[0];
+    expect(popoverName).toBe('RowAction');
+    const urlParam = (popoverParam as string).replace(/^SegmentVisitorLog:/, '');
+
+    rowActionInstance.doOpenPopover(urlParam);
+
+    expect(showSpy).toHaveBeenCalledWith(
+      'Actions.getPageUrls',
+      DECODED_CURRENT_PAGE_SEGMENT,
+      expect.objectContaining({
+        date: '2012-08-09',
+        period: 'day',
+        intersectSegment: CATEGORY_ROW_SEGMENT,
+      }),
+    );
+  });
+
+  it('should drop keys that are not on the allowlist during the popover URL round-trip', () => {
+    const showSpy = vi.fn();
+    (window as any).SegmentedVisitorLog = { show: showSpy };
+
+    openPopoverSpy.mockRestore();
+
+    // A crafted payload carrying both the legitimate intersectSegment and a smuggled key.
+    const extraParams = { intersectSegment: CATEGORY_ROW_SEGMENT, idGoal: '1' };
+    const urlParam = `Actions.getPageUrls:${encodeURIComponent(DECODED_CURRENT_PAGE_SEGMENT)}:${encodeURIComponent(JSON.stringify(extraParams))}`;
+
+    rowActionInstance.doOpenPopover(urlParam);
+
+    const passedExtraParams = showSpy.mock.calls[0][2];
+    expect(passedExtraParams.intersectSegment).toBe(CATEGORY_ROW_SEGMENT);
+    expect(passedExtraParams.idGoal).toBeUndefined();
   });
 });

--- a/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
+++ b/plugins/Live/vue/src/RowActions/SegmentVisitorLog.spec.ts
@@ -11,21 +11,14 @@ import { resolve } from 'path';
 const CURRENT_PAGE_SEGMENT = 'countryCode==pt;pageUrl==https%253A%252F%252Fexample.org%252Fexampleblue-travel-tips%252Fessential-example%252Fbest-of-example-1%252F';
 const DECODED_CURRENT_PAGE_SEGMENT = decodeURIComponent(CURRENT_PAGE_SEGMENT);
 const CATEGORY_ROW_SEGMENT = 'pageUrl=^https%253A%252F%252Fexample.org%252Fcategory';
-const PAGE_TITLE_ROW_SEGMENT = 'pageTitle==Peek%2BInside%2BParadise%2BSlideshow%2B%257C%2BExample%2BBlue';
 const SUFFIX_SEGMENT = 'visitEcommerceStatus==ordered';
 
 describe('Live/SegmentVisitorLog row action', () => {
   let rowActionInstance: { trigger: (tr: JQuery<HTMLElement>, event: Event) => void; openPopover: jest.Mock };
   let openPopoverSpy: jest.SpyInstance;
-  let originalRequire: any;
-  let originalAjaxHelper: any;
-  let originalVisitorLogEnabled: boolean;
-  let originalVueSanitize: any;
-  let originalTranslate: any;
 
   beforeAll(async () => {
     window.eval(readFileSync(resolve(__dirname, '../../../../CoreHome/javascripts/dataTable_rowactions.js'), 'utf8'));
-    window.eval(readFileSync(resolve(__dirname, '../../../../Live/javascripts/SegmentedVisitorLog.js'), 'utf8'));
     window.eval(readFileSync(resolve(__dirname, '../../../../Live/javascripts/rowaction.js'), 'utf8'));
     await Promise.resolve();
     await Promise.resolve();
@@ -36,104 +29,11 @@ describe('Live/SegmentVisitorLog row action', () => {
       <table>
         <tr id="segment-row" data-segment-filter="${CATEGORY_ROW_SEGMENT}">
           <td class="label">
-            <span class="label">category</span>
+            <span class="value">category</span>
           </td>
         </tr>
       </table>
-      <div
-        class="dataTable"
-        data-report="Actions.getPageUrls"
-      ></div>
-      <div
-        class="dataTable"
-        data-report="Actions.getPageTitles"
-      ></div>
     `;
-
-    originalRequire = (window as any).require;
-    (window as any).require = (moduleName: string) => {
-      if (moduleName === 'piwik/UI') {
-        return {
-          DataTable: {
-            getDataTableByReport: (apiMethod: string) => {
-              return document.querySelector(`[data-report="${apiMethod}"]`);
-            },
-          },
-        };
-      }
-
-      return originalRequire ? originalRequire(moduleName) : undefined;
-    };
-
-    const pageUrlsTable = window.$('[data-report="Actions.getPageUrls"]');
-    pageUrlsTable.data('uiControlObject', {
-      getReportMetadata: () => ({
-        dimension: 'Page URL',
-      }),
-    });
-
-    const pageTitlesTable = window.$('[data-report="Actions.getPageTitles"]');
-    pageTitlesTable.data('uiControlObject', {
-      getReportMetadata: () => ({
-        dimension: 'Page Title',
-      }),
-    });
-
-    originalVisitorLogEnabled = (window as any).piwik?.visitorLogEnabled;
-    (window as any).piwik = {
-      ...(window as any).piwik,
-      visitorLogEnabled: true,
-    };
-
-    originalAjaxHelper = (window as any).ajaxHelper;
-    originalVueSanitize = (window as any).vueSanitize;
-    originalTranslate = (window as any)._pk_translate;
-    (window as any)._pk_translate = (key: string, args: string[] = []) => `${key} ${args.join(' ')}`;
-    (window as any).vueSanitize = (value: string) => value;
-    (window as any).ajaxHelper = class {
-      callback!: (html: string) => void;
-
-      addParams() {
-        return this;
-      }
-
-      withTokenInUrl() {
-        return this;
-      }
-
-      setCallback(callback: (html: string) => void) {
-        this.callback = callback;
-        return this;
-      }
-
-      setFormat() {
-        return this;
-      }
-
-      send() {
-        this.callback(
-          '<div><h2 class="enrichedHeadline"><span class="title">Segmented Visits Log</span></h2></div>',
-        );
-      }
-    };
-
-    window.Piwik_Popover = {
-      showLoading: jest.fn((title: string) => {
-        const popover = window.$(
-          `<div id="Piwik_Popover"><h2 class="enrichedHeadline"><span class="title">${title}</span></h2></div>`,
-        );
-        window.$('body').append(popover);
-
-        return popover;
-      }),
-      setContent: jest.fn((html: string) => {
-        window.$('#Piwik_Popover').html(html);
-      }),
-      setTitle: jest.fn(),
-      onClose: jest.fn(),
-      isOpen: jest.fn(() => true),
-      close: jest.fn(),
-    } as any;
 
     const action = (window as any).DataTable_RowActions_Registry.getActionByName('SegmentVisitorLog');
 
@@ -156,15 +56,6 @@ describe('Live/SegmentVisitorLog row action', () => {
     if (openPopoverSpy) {
       openPopoverSpy.mockRestore();
     }
-    (window as any).require = originalRequire;
-    (window as any).ajaxHelper = originalAjaxHelper;
-    (window as any).vueSanitize = originalVueSanitize;
-    (window as any)._pk_translate = originalTranslate;
-    (window as any).piwik = {
-      ...(window as any).piwik,
-      visitorLogEnabled: originalVisitorLogEnabled,
-    };
-    (window as any).Piwik_Popover = undefined;
     document.body.innerHTML = '';
   });
 
@@ -211,29 +102,5 @@ describe('Live/SegmentVisitorLog row action', () => {
         additionalSegment: CATEGORY_ROW_SEGMENT,
       }),
     );
-  });
-
-  it('should render the popup title from the clicked row label instead of the raw combined segment', () => {
-    window.$('[data-report="Actions.getPageTitles"] tr').remove();
-    window.$('[data-report="Actions.getPageTitles"]').append(`
-      <table>
-        <tr data-segment-filter="${PAGE_TITLE_ROW_SEGMENT}">
-          <td class="label">
-            <span class="value">Peek Inside Paradise Slideshow | Example Blue</span>
-          </td>
-        </tr>
-      </table>
-    `);
-
-    (window as any).SegmentedVisitorLog.show('Actions.getPageTitles', DECODED_CURRENT_PAGE_SEGMENT, {
-      additionalSegment: PAGE_TITLE_ROW_SEGMENT,
-    });
-
-    const setTitleCalls = (window.Piwik_Popover.setTitle as jest.Mock).mock.calls;
-    const finalTitle = setTitleCalls[setTitleCalls.length - 1][0];
-
-    expect(finalTitle).toContain('Peek Inside Paradise Slideshow | Example Blue');
-    expect(finalTitle).not.toContain('pageUrl==');
-    expect(finalTitle).not.toContain('pageTitle==');
   });
 });

--- a/plugins/SegmentEditor/SegmentEditor.php
+++ b/plugins/SegmentEditor/SegmentEditor.php
@@ -293,7 +293,7 @@ class SegmentEditor extends \Piwik\Plugin
 
         // if no visits recorded, data will not appear, so don't show the message
         $liveModel = new \Piwik\Plugins\Live\Model();
-        $visits = $liveModel->queryLogVisits($idSites, $periodStr, $date, $segment->getString(), $offset = 0, $limit = 1, null, null, 'ASC');
+        $visits = $liveModel->queryLogVisits($idSites, $periodStr, $date, $segment->getString(), $offset = 0, $limit = 1, false, false, 'ASC');
         if (empty($visits)) {
             return null;
         }

--- a/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbee4d777aa58b022d8d80c167e8251b7a946736b810efe14ede9c11cb3a4f52
-size 5416893
+oid sha256:9f5b560f1893a7d4cff248abe939a0a4fc9830c331a0aa9c23f9c8245e8d116a
+size 5417210

--- a/tests/UI/expected-screenshots/UIIntegrationTest_segmented_visitorlog.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_segmented_visitorlog.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66e5115c62c718235f92e7df761a225fe355d04d888cbbeaea9b0c3a6ca09e12
-size 431671
+oid sha256:a04c4863d6420050162ebdc2884fd96b431d2f5b052abdb780ae779046a891f0
+size 482586

--- a/tests/UI/expected-screenshots/UIIntegrationTest_segmented_visitorlog.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_segmented_visitorlog.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a04c4863d6420050162ebdc2884fd96b431d2f5b052abdb780ae779046a891f0
-size 482586
+oid sha256:66e5115c62c718235f92e7df761a225fe355d04d888cbbeaea9b0c3a6ca09e12
+size 431671


### PR DESCRIPTION
### Description

When opening the "Segmented visits log" from a report row while a segment is already applied, Matomo combined both conditions into a single segment string, evaluated at the **action level**. Two conditions on the same dimension (e.g. two `pageUrl`s) then had to match on one action row, so the popup could come back empty or wrong even though the clicked row had data in the report.

https://github.com/user-attachments/assets/661c3034-9818-4b2c-b284-8445e1edb3b3

**Right content**

| *before* | *after* |
|---|---|
| <img width="1221" height="692" alt="before content" src="https://github.com/user-attachments/assets/0456ffcc-ec00-45e3-81fa-ad179efaa535" /> | <img width="1221" height="692" alt="after content" src="https://github.com/user-attachments/assets/f4ee2a95-cd20-4dd0-b598-9701e92980d3" /> |

**Better popup title**

| *before* | *after* |
|---|---|
| <img width="1221" height="102" alt="before title" src="https://github.com/user-attachments/assets/7f8ee504-2486-4041-884a-8a2a04819075" /> | <img width="1221" height="102" alt="after title" src="https://github.com/user-attachments/assets/fcfa1f5d-ee70-4030-9af7-66735a55b93c" /> |

### Technical fix

- Keep the applied report segment as the main segment.
- Send the clicked row as a separate `intersectSegment` parameter.
- In `Live\Model`, intersect it at the **visit level** via a subquery on `log_visit.idvisit`, so a visit is kept only if it matches the clicked segment on its own.

Result: the popup is scoped to visits matching the report segment **and** containing the clicked row.

### How to reproduce

1. Create a segment filtered by page URL (e.g. `/folder/page`) and open *Behaviour > Pages*.
2. Open the "Segmented visits log" for `/other`.
   - **Expected:** only visits that were on both `/other/page` **and** `/folder/page` (e.g. visitor B appears, visitor C does not).

Same scenario applies to *Behaviour > Page titles*.

### ⚠️ Scope

The fix is in the generic row-action mechanism, so it affects **every report exposing the "Segmented visits log" row action** — not just Pages/Page Titles. This includes Behaviour (Page URLs, Titles, Entry pages…), Visitors (Locations, Devices, Software, Times…), Acquisition/Referrers (Channels, Keywords, Search engines, Websites, Social, Campaigns…), Goals/Ecommerce, and Custom Dimensions.

issue dev-20360

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
