### PR TITLE
Update hover text for Visitor Profile export

### DIFF
--- a/plugins/Live/lang/en.json
+++ b/plugins/Live/lang/en.json
@@ -5,6 +5,7 @@
         "ClickToViewMoreAboutVisit": "Click for more info about this visit",
         "ClickToViewAllActions": "Click for all actions of this group in detail",
         "ConvertedNGoals": "Converted %s goals",
+        "ExportThisDatasetToXml": "Export this dataset to XML",
         "FirstVisit": "First visit",
         "GoalType": "Type",
         "HideMap": "hide map",

--- a/plugins/Live/templates/getVisitorProfilePopup.twig
+++ b/plugins/Live/templates/getVisitorProfilePopup.twig
@@ -49,7 +49,7 @@
                                     <span>{{ visitorData.visitorId }}</span>
                                     {%- if widgetizedLink is defined %}</a>{% endif %}
                                 <a class="visitor-profile-export" href="{{ exportLink }}" target="_blank"
-                                   title="{{ 'General_ExportThisReport'|translate }}">
+                                   title="{{ 'Live_ExportThisDatasetToXml'|translate }}">
                                     <span class="icon-export"></span>
                                 </a>
                             </div>

--- a/plugins/Live/tests/UI/Live_spec.js
+++ b/plugins/Live/tests/UI/Live_spec.js
@@ -73,6 +73,15 @@ describe("Live", function () {
         expect(await dialog.screenshot()).to.matchImage('visitor_profile');
     });
 
+    it('should show XML export tooltip in visitor profile', async function() {
+        const exportTooltip = await page.$eval(
+            '.visitor-profile-export',
+            (element) => element.getAttribute('title'),
+        );
+
+        expect(exportTooltip).to.equal('Export this dataset to XML');
+    });
+
     it('should load additional visits in visitor log', async function() {
 
         await page.click('.visitor-profile-more-info a');


### PR DESCRIPTION
### Description

We wanted to change the hover text for our export for Visitor Profile


### Acceptance Criteria
 - Go to Visitors > User IDs and click on 'View Visitor Profile' for any user
 - Hover on the export option
 - Hover tooltip should be "Export this dataset to XML”

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
