### PR TITLE
center scheduled reports unsubscribe page

### DIFF
--- a/plugins/ScheduledReports/stylesheets/scheduledreports.less
+++ b/plugins/ScheduledReports/stylesheets/scheduledreports.less
@@ -42,3 +42,16 @@
 .periodTooltipList {
   padding-bottom: 10px;
 }
+
+.scheduledReportsUnsubscribePage {
+  .loginSection {
+    margin-top: 32px;
+
+    > .col {
+      max-width: 750px;
+      float: none;
+      margin-left: auto;
+      margin-right: auto;
+    }
+  }
+}

--- a/plugins/ScheduledReports/templates/unsubscribe.twig
+++ b/plugins/ScheduledReports/templates/unsubscribe.twig
@@ -7,6 +7,7 @@
 {% set title %}{{ 'ScheduledReports_ReportUnsubscribe'|translate }}{% endset %}
 
 {% set bodyId = 'loginPage' %}
+{% set bodyClass = 'scheduledReportsUnsubscribePage' %}
 
 {% block body %}
 

--- a/plugins/ScheduledReports/tests/UI/ScheduledReports_spec.js
+++ b/plugins/ScheduledReports/tests/UI/ScheduledReports_spec.js
@@ -14,7 +14,19 @@ describe("ScheduledReports", function () {
         await page.goto("?module=ScheduledReports&action=unsubscribe&token=mycustomtoken");
         await page.waitForNetworkIdle();
 
-        expect(await page.screenshot({ fullPage: true })).to.matchImage('unsubscribe_form_centered');
+        const margins = await page.$eval(
+            ".scheduledReportsUnsubscribePage .loginSection > .col",
+            (col) => {
+                const style = window.getComputedStyle(col);
+                return { left: style.marginLeft, right: style.marginRight };
+            },
+        );
+
+        // `margin: auto` resolves to equal, non-zero pixel values on a centred block,
+        // so this catches the regression even when the Login plugin (and its CSS)
+        // is loaded in the test environment.
+        expect(margins.left).to.equal(margins.right);
+        expect(parseFloat(margins.left)).to.be.above(0);
     });
 
     it("should show an error if no token was provided", async function () {

--- a/plugins/ScheduledReports/tests/UI/ScheduledReports_spec.js
+++ b/plugins/ScheduledReports/tests/UI/ScheduledReports_spec.js
@@ -10,6 +10,13 @@
 describe("ScheduledReports", function () {
     this.fixture = "Piwik\\Plugins\\ScheduledReports\\tests\\Fixtures\\ReportSubscription";
 
+    it("should center the unsubscribe form relative to the header", async function () {
+        await page.goto("?module=ScheduledReports&action=unsubscribe&token=mycustomtoken");
+        await page.waitForNetworkIdle();
+
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('unsubscribe_form_centered');
+    });
+
     it("should show an error if no token was provided", async function () {
         await page.goto("?module=ScheduledReports&action=unsubscribe&token=");
 

--- a/plugins/ScheduledReports/tests/UI/expected-screenshots/ScheduledReports_unsubscribe_form_centered.png
+++ b/plugins/ScheduledReports/tests/UI/expected-screenshots/ScheduledReports_unsubscribe_form_centered.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ea6f4d44d54df30c2d1bc71c2f0f0c359efee7c32ded4f4ba4556193b86ba91
-size 24466

--- a/plugins/ScheduledReports/tests/UI/expected-screenshots/ScheduledReports_unsubscribe_form_centered.png
+++ b/plugins/ScheduledReports/tests/UI/expected-screenshots/ScheduledReports_unsubscribe_form_centered.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ea6f4d44d54df30c2d1bc71c2f0f0c359efee7c32ded4f4ba4556193b86ba91
+size 24466


### PR DESCRIPTION
## Description

Centers the Scheduled Reports unsubscribe card relative to the header. Previously the card was pushed to the right in the Login plugin's stylesheet (#loginPage .loginSection > .col), which isn't loaded when Login is disabled or its CSS is overridden.

### Why self-contained, not extends "@Login/loginLayout.twig"

Extending loginLayout.twig would create a hard dependency on Login figured it was easier to add a small scoped centering rule in scheduledreports.less so the page owns its own layout independently.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
