### PR TITLE
set text colour for skip content button

### DIFF
--- a/plugins/CoreHome/stylesheets/coreHome.less
+++ b/plugins/CoreHome/stylesheets/coreHome.less
@@ -53,6 +53,8 @@
     position: absolute;
     left: -10000px;
     top: 0;
+    color: @theme-color-header-text;
+    text-decoration: none;
 }
 .accessibility-skip-to-content:focus {
     display: block;

--- a/plugins/CoreHome/stylesheets/coreHome.less
+++ b/plugins/CoreHome/stylesheets/coreHome.less
@@ -54,7 +54,6 @@
     left: -10000px;
     top: 0;
     color: @theme-color-header-text;
-    text-decoration: none;
 }
 .accessibility-skip-to-content:focus {
     display: block;


### PR DESCRIPTION
### Description

**Light mode**
<img width="634" height="250" alt="skip-content-light-mode" src="https://github.com/user-attachments/assets/f478b2c5-ccb2-4e3c-bdda-5f73a417bc04" />

**Dark mode**
<img width="634" height="250" alt="skip-content-dark-mode" src="https://github.com/user-attachments/assets/0f555df7-1d12-424b-8046-c9f3b9c3bd84" />

fixes #24536

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
