### PR TITLE
Document per-CVE reasoning in composer audit ignore entries for twig/twig to unlock composer update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,25 @@
         "source": "https://github.com/matomo-org/matomo"
     },
     "config": {
+        "audit": {
+            "ignore": {
+                "PKSA-1tmc-rt7x-12w6": "CVE-2026-48806 (sandbox `__toString()` bypass via dynamic mapping keys): not exploitable - Matomo does not enable Twig's sandbox. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-21g2-dzjv-sky5": "CVE-2026-46634 (`template_from_string()` escapes a SourcePolicy-driven sandbox): not exploitable - Matomo does not call `template_from_string`/`createTemplate` at runtime (only one TagManager test fixture) and does not implement `SourcePolicyInterface`. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-3mcc-k66d-pydb": "CVE-2026-46638 (`{% sandbox %}{% include %}` skips `checkSecurity()` on cached templates): not exploitable - Matomo uses neither the `{% sandbox %}` tag nor `SandboxExtension`. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-dpx1-78wg-1kqs": "CVE-2026-47732 (multiple sandbox `__toString()` bypasses via unguarded string coercion points): not exploitable - Matomo does not enable Twig's sandbox. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-fbvq-z33h-r2np": "CVE-2026-48808 (sandbox property allowlist bypass via `column` filter under `SourcePolicyInterface`): not exploitable - Matomo does not register `SandboxExtension` or implement `SourcePolicyInterface`. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-g9zw-qxh8-pq8w": "CVE-2026-48805 (sandbox state regression in deprecated wrappers in `vendor/twig/twig/src/Resources/core.php`): not exploitable - Matomo does not enable Twig's sandbox. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-gw7n-z4yx-7xjt": "CVE-2026-24425 (possible sandbox bypass when using a source policy): not exploitable - Matomo does not implement `SourcePolicyInterface` or enable Twig's sandbox. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-h8hf-ytnd-5t9q": "CVE-2026-46633 (PHP code injection via `{% use %}` template name): not exploitable - no Matomo template uses the `{% use %}` tag and no PHP code emits `{% use` content at runtime. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-hgmw-wn4d-hpcy": "CVE-2026-46639 (sandbox property and method bypass via object-destructuring assignment): not exploitable - Matomo does not enable Twig's sandbox; vulnerable range (Twig >=3.24.0,<3.26.0) does not even cover Matomo's pinned 3.11.3. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-kvv6-36cr-fkzb": "CVE-2026-46627 (sandbox does not protect against resource exhaustion): not exploitable - Matomo does not enable Twig's sandbox; templates are author-trusted. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-n14z-jjjg-g8vd": "CVE-2026-46635 (sandbox property allowlist bypass via `column` filter / `array_column` on objects): not exploitable - Matomo does not enable Twig's sandbox. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-sjvz-tbbr-vwth": "CVE-2026-46628 (`spaceless` filter implicitly marks output as safe): not exploitable - variables inside Matomo's six `{% apply spaceless %}` blocks (CoreHome, CustomAlerts, Marketplace, Ecommerce, SegmentEditor) go through normal `{{ }}` auto-escaping; no `|spaceless` filter form is used, and the only `|raw` uses inside cover plugin-supplied metadata (e.g. `html_label_prefix`, `menu._html`), not request input. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-wwb1-81rc-pd65": "CVE-2026-47730 (XSS in profiler `HtmlDumper` via unescaped template and profile names): not exploitable - Matomo does not register `ProfilerExtension` or use `HtmlDumper`. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-xx6c-6d96-db2w": "CVE-2026-48807 (sandbox `__toString()` bypass via `Traversable` in `join`/`replace` filters and `in`/`not in` operators): not exploitable - Matomo does not enable Twig's sandbox. Upgrade blocked while Matomo supports PHP 7.2.",
+                "PKSA-yd6k-t2gh-1m43": "CVE-2026-46636 (cached-Template sandbox allow-list bypass when sandbox state changes between renders): not exploitable - Matomo does not enable Twig's sandbox or toggle sandbox state. Upgrade blocked while Matomo supports PHP 7.2."
+            }
+        },
         "platform": {
             "php": "7.2.9"
         },
@@ -69,7 +88,7 @@
         "szymach/c-pchart": "~3.0.13",
         "tecnickcom/tcpdf": "~6.0",
         "tedivm/jshrink": "^1.7.0",
-        "twig/twig": "^3.0",
+        "twig/twig": ">=3.11.3 <3.12",
         "wikimedia/less.php": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
  ## Summary

  - Tighten the `twig/twig` constraint from `^3.0` to `>=3.11.3 <3.12`. Matomo still requires PHP >= 7.2.5, while every Twig 3 release that patches
  the recent batch of CVEs requires PHP >= 8.1. 3.11.3 is the newest Twig 3 build that still supports our PHP floor.
  - Add `config.audit.ignore` entries for the 15 `twig/twig` advisories that `composer audit` flags against 3.11.3. Without these, `composer update`
  and `composer install --audit` exit non-zero, blocking dependency maintenance on this branch.
  - Each ignore reason documents the specific CVE, the vulnerability class, and the concrete reason it is **not exploitable in Matomo** (no
  `SandboxExtension`, no `SourcePolicyInterface`, no `{% use %}` tag, no `ProfilerExtension`/`HtmlDumper`, `template_from_string` unused at runtime,
  `{% apply spaceless %}` usages reviewed). The PHP 7.2 upgrade blocker is retained on every entry so the entries can be revisited and removed once
  the PHP floor is raised.

  ## Advisories covered (all non-exploitable in Matomo)

  Sandbox-feature CVEs (Matomo never registers `Twig\Extension\SandboxExtension` or a `SecurityPolicy` — `Piwik\View\SecurityPolicy` is an unrelated
  HTTP-CSP header builder):

  - CVE-2026-24425, CVE-2026-46627, CVE-2026-46634, CVE-2026-46635, CVE-2026-46636, CVE-2026-46638, CVE-2026-46639, CVE-2026-47732, CVE-2026-48805,
  CVE-2026-48806, CVE-2026-48807, CVE-2026-48808

  Non-sandbox CVEs that need a specific Twig feature Matomo doesn't use:

  - **CVE-2026-46633** ({% use %} RCE) — no `{% use %}` tag exists in any Matomo template, and no PHP code emits one.
  - **CVE-2026-47730** (Profiler HtmlDumper XSS) — Matomo does not register `ProfilerExtension`.
  - **CVE-2026-46628** (`spaceless` marks output safe) — all 6 `{% apply spaceless %}` blocks (CoreHome, CustomAlerts, Marketplace, Ecommerce,
  SegmentEditor) interpolate via auto-escaping `{{ }}`; no `|spaceless` filter form is used; the only `|raw` inside spaceless blocks renders
  plugin-supplied metadata (`html_label_prefix`, `menu._html`, …), not request input.

  CVE-2026-46640 (RCE via dynamic `_self.(<string>)`) and CVE-2026-46637 / CVE-2026-46629 (twig/extras) are not flagged by `composer audit` against
  our pinned version — they affect either newer Twig 3 features (≥3.24) or extension packages we do not install.

  ## Follow-ups

  - When the PHP floor moves to ≥ 8.1, drop the `audit.ignore` block and bump `twig/twig` to the latest patched 3.x line.


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
