### PR TITLE
Remove Carriage return from CSV/TSV values

### DIFF
--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -215,7 +215,7 @@ class Csv extends Renderer
         $value = $this->formatFormulas($value);
 
         if (is_string($value)) {
-            $value = str_replace(["\t"], ' ', $value);
+            $value = str_replace(["\t", "\r"], ' ', $value);
 
             // surround value with double quotes if it contains a double quote or a commonly used separator
             if (

--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -18,6 +18,7 @@ use Piwik\Period;
 use Piwik\Period\Range;
 use Piwik\Piwik;
 use Piwik\ProxyHttp;
+use Piwik\Request;
 
 /**
  * CSV export
@@ -57,6 +58,9 @@ class Csv extends Renderer
      */
     public const NO_DATA_AVAILABLE = 'No data available';
 
+    /**
+     * @var string[]
+     */
     private $unsupportedColumns = [];
 
     /**
@@ -76,8 +80,6 @@ class Csv extends Renderer
 
     /**
      * Enables / Disables unicode converting
-     *
-     * @param $bool
      */
     public function setConvertToUnicode(bool $convertToUnicode): void
     {
@@ -95,7 +97,7 @@ class Csv extends Renderer
     /**
      * Computes the output of the given data table
      *
-     * @param DataTable|array $table
+     * @param DataTable|DataTable\Map|array $table
      * @param array $allColumns
      */
     protected function renderTable($table, array &$allColumns = []): string
@@ -239,6 +241,10 @@ class Csv extends Renderer
         return $value;
     }
 
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
     protected function formatFormulas($value)
     {
         // Excel / Libreoffice formulas may start with one of these characters
@@ -271,8 +277,9 @@ class Csv extends Renderer
     {
         $fileName = Piwik::translate('General_Export');
 
-        $period = Common::getRequestVar('period', false);
-        $date = Common::getRequestVar('date', false);
+        $period = Request::fromRequest()->getStringParameter('period', '');
+        $date   = Request::fromRequest()->getStringParameter('date', '');
+
         if ($period || $date) {
             // in test cases, there are no request params set
 
@@ -380,7 +387,7 @@ class Csv extends Renderer
     }
 
     /**
-     * @param $table
+     * @param DataTable $table
      * @param array $allColumns
      * @return array of csv data
      */
@@ -446,7 +453,7 @@ class Csv extends Renderer
     }
 
     /**
-     * @param $str
+     * @param string $str
      * @return string
      */
     private function convertToUnicode($str)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -906,11 +906,6 @@ parameters:
 			path: core/DataTable/Renderer.php
 
 		-
-			message: "#^Instanceof between Piwik\\\\DataTable and Piwik\\\\DataTable\\\\Map will always evaluate to false\\.$#"
-			count: 1
-			path: core/DataTable/Renderer/Csv.php
-
-		-
 			message: "#^Parameter \\#1 \\$table of method Piwik\\\\DataTable\\\\Renderer\\\\Html\\:\\:buildTableStructure\\(\\) expects Piwik\\\\DataTable\\|Piwik\\\\DataTable\\\\Map, Piwik\\\\DataTable\\\\DataTableInterface given\\.$#"
 			count: 1
 			path: core/DataTable/Renderer/Html.php

--- a/plugins/RssWidget/RssRenderer.php
+++ b/plugins/RssWidget/RssRenderer.php
@@ -76,7 +76,8 @@ class RssRenderer
                 $date = @strftime("%B %e, %Y", strtotime($post->pubDate));
                 $link = $post->link;
 
-                $output .= '<li><a class="rss-title" title="" target="_blank" rel="noreferrer noopener" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '">' . $title . '</a>' .
+                $output .= '<li><a class="rss-title" title="" target="_blank" rel="noreferrer noopener" href="' . htmlspecialchars($link, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '">' .
+                    htmlspecialchars($title, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</a>' .
                     '<span class="rss-date">' . $date . '</span>';
                 if ($this->showDescription) {
                     $output .= '<div class="rss-description">' . $this->addTargetBlankAndNoReferrerToLinks($post->description) . '</div>';

--- a/tests/PHPUnit/Unit/DataTable/Renderer/CsvTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/CsvTest.php
@@ -260,6 +260,15 @@ b,d,f,g',
             "\"header\nbreak\",header\nvalue,\"value\nbreak\"",
         ];
 
+        yield 'carriage return and tab in value should be replaced with a space' => [
+            function () {
+                return [
+                    "header\rwith\tcr" => "value\rwith\tcr",
+                ];
+            },
+            "header with cr\nvalue with cr",
+        ];
+
         yield 'renders headers and values correctly escaped' => [
             function () {
                 return self::getDataTableSimpleWithCommasInCells();


### PR DESCRIPTION
### Description

Excel / Libre Office might interpret a CR as record separator - even if the value is correctly surrounded by `"`.
Removing CRs should therefor prevent broken tables if such a char is tracked by accident.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
