### PR TITLE
Use consistent vue tag order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,5 +39,8 @@ module.exports = {
     'no-restricted-imports': ['error', {
       patterns: ['**/vue/src'],
     }],
+    'vue/component-tags-order': ['warn', {
+      order: ['template', 'script', 'style'],
+    }],
   },
 };

--- a/plugins/CoreHome/vue/src/DraggableList/DraggableList.vue
+++ b/plugins/CoreHome/vue/src/DraggableList/DraggableList.vue
@@ -5,6 +5,35 @@
   @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
 -->
 
+<template>
+  <ul
+    class="draggableList"
+    :class="{
+      isDragging: draggedId !== null,
+      isDisabled: disabled,
+    }"
+  >
+    <li
+      v-for="(orderedItem, index) in orderedItems"
+      :key="orderedItem.id"
+      class="draggableListItem"
+      :class="{ isDragged: orderedItem.id === placeholderId }"
+      :data-item-id="orderedItem.id"
+      :draggable="canDrag"
+      :aria-grabbed="orderedItem.id === draggedId"
+      @dragstart="onDragStartForIndex($event, index)"
+      @dragover="onDragOverForIndex($event, index)"
+      @drop="onDrop"
+      @dragend="onDragEnd"
+    >
+      <slot
+        :item="orderedItem.item"
+        :index="orderedItem.sourceIndex"
+      />
+    </li>
+  </ul>
+</template>
+
 <script setup lang="ts">
 import {
   computed,
@@ -215,32 +244,3 @@ function onDragEnd() {
 // Refresh the local list if the parent sends new items
 watch([sourceItems, () => props.disabled], () => resetDragState(true), { immediate: true });
 </script>
-
-<template>
-  <ul
-    class="draggableList"
-    :class="{
-      isDragging: draggedId !== null,
-      isDisabled: disabled,
-    }"
-  >
-    <li
-      v-for="(orderedItem, index) in orderedItems"
-      :key="orderedItem.id"
-      class="draggableListItem"
-      :class="{ isDragged: orderedItem.id === placeholderId }"
-      :data-item-id="orderedItem.id"
-      :draggable="canDrag"
-      :aria-grabbed="orderedItem.id === draggedId"
-      @dragstart="onDragStartForIndex($event, index)"
-      @dragover="onDragOverForIndex($event, index)"
-      @drop="onDrop"
-      @dragend="onDragEnd"
-    >
-      <slot
-        :item="orderedItem.item"
-        :index="orderedItem.sourceIndex"
-      />
-    </li>
-  </ul>
-</template>


### PR DESCRIPTION
### Description

All our vue files are currently using the tag order `template`, `script`, `style`, except of one file.
This updates the file and adds this order to eslint as a warning.

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
