### PR TITLE
Make setMailSettings only accept POST parameters

### DIFF
--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -154,12 +154,16 @@ class Controller extends ControllerAdmin
             return '';
         }
 
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            throw new Exception('Invalid HTTP method.');
+        }
+
         $response = new ResponseBuilder('json');
         try {
             $this->checkTokenInUrl();
 
             // Update email settings
-            $request = Request::fromRequest();
+            $request = Request::fromPost();
             $mail = [];
             $mail['transport'] = $request->getBoolParameter('mailUseSmtp') ? 'smtp' : '';
             $mail['port'] = $request->getStringParameter('mailPort', '');
@@ -168,7 +172,7 @@ class Controller extends ControllerAdmin
             $mail['username'] = $request->getStringParameter('mailUsername', '');
             $mail['password'] = $request->getStringParameter('mailPassword', '');
 
-            if (!array_key_exists('mailPassword', $_POST) && Config::getInstance()->mail['host'] === $mail['host']) {
+            if (!array_key_exists('mailPassword', $request->getParameters()) && Config::getInstance()->mail['host'] === $mail['host']) {
                 // use old password if it wasn't set in request (and the host wasn't changed)
                 $mail['password'] = Config::getInstance()->mail['password'];
             }
@@ -178,14 +182,11 @@ class Controller extends ControllerAdmin
             Config::getInstance()->mail = $mail;
 
             $general = Config::getInstance()->General;
-            $fromName = Common::getRequestVar('mailFromName', '');
-            $general['noreply_email_name'] = Common::unsanitizeInputValue($fromName);
+            $general['noreply_email_name'] = $request->getStringParameter('mailFromName', '');
 
-            $mailFrom = Common::getRequestVar('mailFromAddress', '');
+            $mailFrom = $request->getStringParameter('mailFromAddress', '');
             if (empty($mailFrom)) {
                 $mailFrom = 'noreply@{DOMAIN}';
-            } else {
-                $mailFrom = Common::unsanitizeInputValue($mailFrom);
             }
             if (!Piwik::isValidEmailString($mailFrom) && !Common::stringEndsWith($mailFrom, '@{DOMAIN}')) {
                 throw new Exception(Piwik::translate('CoreAdminHome_ErrorEmailFromAddressNotValid'));

--- a/plugins/CoreAdminHome/tests/Integration/ControllerTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/ControllerTest.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\CoreAdminHome\tests\Integration;
 
 use Piwik\Changes\Model as ChangesModel;
 use Piwik\Common;
+use Piwik\Config;
 use Piwik\Db;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Plugins\CoreAdminHome\CoreAdminHome;
@@ -36,14 +37,28 @@ class ControllerTest extends IntegrationTestCase
     /** @var array */
     private $backupGet;
     /** @var array */
+    private $backupPost;
+    /** @var array */
     private $backupRequest;
+    /** @var array */
+    private $backupServer;
+    /** @var array */
+    private $backupMail;
+    /** @var array */
+    private $backupGeneral;
+    /** @var bool */
+    private $mailSettingsSaved = false;
 
     public function setUp(): void
     {
         parent::setUp();
 
         $this->backupGet = $_GET;
+        $this->backupPost = $_POST;
         $this->backupRequest = $_REQUEST;
+        $this->backupServer = $_SERVER;
+        $this->backupMail = Config::getInstance()->mail;
+        $this->backupGeneral = Config::getInstance()->General;
 
         Fixture::createSuperUser();
         if (!Fixture::siteCreated(1)) {
@@ -73,6 +88,38 @@ class ControllerTest extends IntegrationTestCase
             new Translator(new DevelopmentLoader(new JsonFileLoader())),
             new OptOutManager()
         );
+    }
+
+    public function testSetMailSettingsRejectsGetRequests(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_GET = $this->getMailSettingsRequest('get.example.test');
+        $_POST = [];
+        $_REQUEST = $_GET;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid HTTP method.');
+
+        $this->controller->setMailSettings();
+    }
+
+    public function testSetMailSettingsUsesPostParametersOnly(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_GET = $this->getMailSettingsRequest('get.example.test');
+        $_POST = $this->getMailSettingsRequest('post.example.test');
+        $_REQUEST = $_GET + $_POST;
+
+        $controller = $this->getControllerSkippingTokenCheck();
+
+        $controller->setMailSettings();
+        $this->mailSettingsSaved = true;
+
+        $this->assertSame('post.example.test', Config::getInstance()->mail['host']);
+        $this->assertSame('smtp-user-post', Config::getInstance()->mail['username']);
+        $this->assertSame('smtp-password-post', Config::getInstance()->mail['password']);
+        $this->assertSame('mail-post@example.test', Config::getInstance()->General['noreply_email_address']);
+        $this->assertSame('Acme <Team> & "post"', Config::getInstance()->General['noreply_email_name']);
     }
 
     public function testWhatIsNewDoesNotPrefixBundledPluginsAndPrefixesThirdPartyPlugins(): void
@@ -266,7 +313,14 @@ class ControllerTest extends IntegrationTestCase
     {
         $this->deleteAllChanges();
         $_GET = $this->backupGet;
+        $_POST = $this->backupPost;
         $_REQUEST = $this->backupRequest;
+        $_SERVER = $this->backupServer;
+        Config::getInstance()->mail = $this->backupMail;
+        Config::getInstance()->General = $this->backupGeneral;
+        if ($this->mailSettingsSaved) {
+            Config::getInstance()->forceSave();
+        }
         parent::tearDown();
     }
 
@@ -289,5 +343,35 @@ class ControllerTest extends IntegrationTestCase
         $method->setAccessible(true);
 
         return $method->invoke($this->controller, $changes);
+    }
+
+    private function getControllerSkippingTokenCheck(): Controller
+    {
+        $controller = $this->getMockBuilder(Controller::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['checkTokenInUrl'])
+            ->getMock();
+
+        $controller->expects($this->once())
+            ->method('checkTokenInUrl');
+
+        return $controller;
+    }
+
+    private function getMailSettingsRequest(string $mailHost): array
+    {
+        $hostPrefix = explode('.', $mailHost)[0];
+
+        return [
+            'mailUseSmtp' => '1',
+            'mailPort' => '25',
+            'mailHost' => $mailHost,
+            'mailType' => '',
+            'mailUsername' => 'smtp-user-' . $hostPrefix,
+            'mailPassword' => 'smtp-password-' . $hostPrefix,
+            'mailEncryption' => 'none',
+            'mailFromAddress' => 'mail-' . $hostPrefix . '@example.test',
+            'mailFromName' => 'Acme <Team> & "' . $hostPrefix . '"',
+        ];
     }
 }


### PR DESCRIPTION
### Description

DEV-20303

Make setMailSettings only accept POST parameters

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
