### PR TITLE
Fix flaky screenshot for BotTracking site with no data

### DIFF
--- a/plugins/BotTracking/Controller.php
+++ b/plugins/BotTracking/Controller.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Piwik\Plugins\BotTracking;
 
+use Piwik\Container\StaticContainer;
 use Piwik\DataTable\Renderer\Json;
 use Piwik\Piwik;
 use Piwik\Plugins\BotTracking\BotTrackingMethod\BotTrackingMethodAbstract;
@@ -181,7 +182,7 @@ class Controller extends \Piwik\Plugin\Controller
 
     protected function buildSiteContentDetector(): SiteContentDetector
     {
-        return new SiteContentDetector();
+        return StaticContainer::get(SiteContentDetector::class);
     }
 
     protected function buildAIBotsOverviewUrl(string $period, string $date): string

--- a/plugins/BotTracking/tests/UI/BotTrackingSiteWithoutData_spec.js
+++ b/plugins/BotTracking/tests/UI/BotTrackingSiteWithoutData_spec.js
@@ -15,7 +15,7 @@ describe('BotTrackingSiteWithoutData', function () {
     const urlOverview = `?${urlBase}#?${generalParams}&category=General_AIAssistants&subcategory=BotTracking_AIChatbotsOverview`;
 
     before(function () {
-        testEnvironment.detectedContentDetections = [];
+        testEnvironment.detectedContentDetections = ['WordPress', 'AmazonCloudFront'];
         testEnvironment.connectedConsentManagers = [];
         testEnvironment.save();
     });


### PR DESCRIPTION
### Description

The flaky-ness happens when `SiteContentDetector` was instantiated using `new` keyword. 
This was causing the fake/mock `SiteContentDetector` in the UI tests to be bypassed because this was being passed in our UI tests via the `StaticContainer`.

NOTE: We took the pragmatic route here in just making the  `buildSiteContentDetector` grab the `SiteContentDetector` directly from `StaticContainer` instead of using constructor injection like `/PrivacyManager/Controller.php` so that its an easier fix rather than to have to add more complexity to fix a flaky screenshot

fixes #24432

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
