### PR TITLE
Fix segmented visitor log for sites with URL aliases

### DIFF
--- a/plugins/Actions/DataTable/Filter/Actions.php
+++ b/plugins/Actions/DataTable/Filter/Actions.php
@@ -14,6 +14,7 @@ use Piwik\Config\GeneralConfig;
 use Piwik\DataTable\BaseFilter;
 use Piwik\DataTable;
 use Piwik\Plugins\Actions\ArchivingHelper;
+use Piwik\Plugins\SitesManager\API as SitesManagerAPI;
 use Piwik\Tracker\Action;
 use Piwik\Tracker\PageUrl;
 
@@ -74,7 +75,7 @@ class Actions extends BaseFilter
                             }
                         }
                     } elseif ($folderUrlStart) {
-                        $row->setMetadata('segment', 'pageUrl=^' . urlencode(urlencode($folderUrlStart)));
+                        $row->setMetadata('segment', $this->buildFolderUrlSegment($folderUrlStart, $site));
                     } elseif ($pageTitlePath) {
                         if ($row->getIdSubDataTable()) {
                             $row->setMetadata('segment', 'pageTitle=^' . urlencode(urlencode(trim($pageTitlePath))));
@@ -98,7 +99,10 @@ class Actions extends BaseFilter
                             // segmenting by an "empty" value is currently broken for actions, so we do not set a segment value to hide row actions like segmented visit log
                             $row->setMetadata('segment', null);
                         } elseif ($urlPrefix) {
-                            $row->setMetadata('segment', 'pageUrl=^' . urlencode(urlencode($urlPrefix . '/' . $label)));
+                            $row->setMetadata(
+                                'segment',
+                                $this->buildFolderUrlSegment($urlPrefix . '/' . $label, $site)
+                            );
                         }
                     }
                 }
@@ -126,5 +130,58 @@ class Actions extends BaseFilter
                 $this->filter($subtable);
             }
         }
+    }
+
+    /**
+     * Builds the `pageUrl=^` segment for a folder row. If the site has additional URL
+     * aliases registered, the segment is an OR-joined list with one `pageUrl=^` clause
+     * per host so the visitor log query matches rows tracked under any of the site's
+     * known hosts, not only `main_url`.
+     */
+    private function buildFolderUrlSegment(string $folderUrlStart, $site): string
+    {
+        $original = 'pageUrl=^' . urlencode(urlencode($folderUrlStart));
+
+        if (!$site || !is_callable([$site, 'getId']) || !is_callable([$site, 'getMainUrl'])) {
+            return $original;
+        }
+
+        $mainUrl = $site->getMainUrl();
+        if (empty($mainUrl)) {
+            return $original;
+        }
+
+        // `folder_url_start` (and the legacy fallback) is always built as
+        // `<main_url>/<path-to-folder>`. Strip the main URL to get the path-only portion
+        // that we can re-attach to each known host.
+        $mainUrlNormalized = rtrim($mainUrl, '/') . '/';
+        if (strpos($folderUrlStart, $mainUrlNormalized) !== 0) {
+            return $original;
+        }
+        $folderPath = substr($folderUrlStart, strlen($mainUrlNormalized));
+
+        try {
+            $allUrls = SitesManagerAPI::getInstance()->getSiteUrlsFromId((int) $site->getId());
+        } catch (\Exception $e) {
+            return $original;
+        }
+
+        $seenHosts = [];
+        $clauses = [];
+        foreach ($allUrls as $url) {
+            $host = parse_url($url, PHP_URL_HOST);
+            if (!$host || isset($seenHosts[$host])) {
+                continue;
+            }
+            $seenHosts[$host] = true;
+            $scheme = parse_url($url, PHP_URL_SCHEME) ?: 'https';
+            $clauses[] = 'pageUrl=^' . urlencode(urlencode($scheme . '://' . $host . '/' . $folderPath));
+        }
+
+        if (empty($clauses)) {
+            return $original;
+        }
+
+        return implode(',', $clauses);
     }
 }

--- a/plugins/Actions/DataTable/Filter/Actions.php
+++ b/plugins/Actions/DataTable/Filter/Actions.php
@@ -21,6 +21,15 @@ use Piwik\Tracker\PageUrl;
 class Actions extends BaseFilter
 {
     private $actionType;
+
+    /**
+     * Per-instance cache of the host list resolved for an idSite. `null` marks a site
+     * we already tried to resolve and could not (so we don't retry on every row).
+     *
+     * @var array<int, array<int, array{scheme: string, host: string}>|null>
+     */
+    private $siteHostsCache = [];
+
     /**
      * @param DataTable $table The table to eventually filter.
      * @param int $actionType The action type being processed.
@@ -142,7 +151,7 @@ class Actions extends BaseFilter
     {
         $original = 'pageUrl=^' . urlencode(urlencode($folderUrlStart));
 
-        if (!$site || !is_callable([$site, 'getId']) || !is_callable([$site, 'getMainUrl'])) {
+        if (!$site) {
             return $original;
         }
 
@@ -160,22 +169,15 @@ class Actions extends BaseFilter
         }
         $folderPath = substr($folderUrlStart, strlen($mainUrlNormalized));
 
-        try {
-            $allUrls = SitesManagerAPI::getInstance()->getSiteUrlsFromId((int) $site->getId());
-        } catch (\Exception $e) {
+        $hosts = $this->getResolvedHosts((int) $site->getId());
+        if ($hosts === null) {
             return $original;
         }
 
-        $seenHosts = [];
         $clauses = [];
-        foreach ($allUrls as $url) {
-            $host = parse_url($url, PHP_URL_HOST);
-            if (!$host || isset($seenHosts[$host])) {
-                continue;
-            }
-            $seenHosts[$host] = true;
-            $scheme = parse_url($url, PHP_URL_SCHEME) ?: 'https';
-            $clauses[] = 'pageUrl=^' . urlencode(urlencode($scheme . '://' . $host . '/' . $folderPath));
+        foreach ($hosts as $entry) {
+            $clauses[] = 'pageUrl=^'
+                . urlencode(urlencode($entry['scheme'] . '://' . $entry['host'] . '/' . $folderPath));
         }
 
         if (empty($clauses)) {
@@ -183,5 +185,37 @@ class Actions extends BaseFilter
         }
 
         return implode(',', $clauses);
+    }
+
+    /**
+     * @return array<int, array{scheme: string, host: string}>|null Null on API failure.
+     */
+    private function getResolvedHosts(int $idSite): ?array
+    {
+        if (array_key_exists($idSite, $this->siteHostsCache)) {
+            return $this->siteHostsCache[$idSite];
+        }
+
+        try {
+            $allUrls = SitesManagerAPI::getInstance()->getSiteUrlsFromId($idSite);
+        } catch (\Exception $e) {
+            return $this->siteHostsCache[$idSite] = null;
+        }
+
+        $seenHosts = [];
+        $hosts = [];
+        foreach ($allUrls as $url) {
+            $host = parse_url($url, PHP_URL_HOST);
+            if (!$host || isset($seenHosts[$host])) {
+                continue;
+            }
+            $seenHosts[$host] = true;
+            $hosts[] = [
+                'scheme' => parse_url($url, PHP_URL_SCHEME) ?: 'https',
+                'host' => $host,
+            ];
+        }
+
+        return $this->siteHostsCache[$idSite] = $hosts;
     }
 }

--- a/plugins/Actions/DataTable/Filter/Actions.php
+++ b/plugins/Actions/DataTable/Filter/Actions.php
@@ -23,12 +23,13 @@ class Actions extends BaseFilter
     private $actionType;
 
     /**
-     * Per-instance cache of the host list resolved for an idSite. `null` marks a site
-     * we already tried to resolve and could not (so we don't retry on every row).
+     * Per-instance cache of the normalized base URL list resolved for an idSite.
+     * `null` marks a site we already tried to resolve and could not (so we don't
+     * retry on every row).
      *
-     * @var array<int, array<int, array{scheme: string, host: string}>|null>
+     * @var array<int, list<string>|null>
      */
-    private $siteHostsCache = [];
+    private $siteBaseUrlsCache = [];
 
     /**
      * @param DataTable $table The table to eventually filter.
@@ -169,15 +170,14 @@ class Actions extends BaseFilter
         }
         $folderPath = substr($folderUrlStart, strlen($mainUrlNormalized));
 
-        $hosts = $this->getResolvedHosts((int) $site->getId());
-        if ($hosts === null) {
+        $baseUrls = $this->getResolvedBaseUrls((int) $site->getId());
+        if ($baseUrls === null) {
             return $original;
         }
 
         $clauses = [];
-        foreach ($hosts as $entry) {
-            $clauses[] = 'pageUrl=^'
-                . urlencode(urlencode($entry['scheme'] . '://' . $entry['host'] . '/' . $folderPath));
+        foreach ($baseUrls as $baseUrl) {
+            $clauses[] = 'pageUrl=^' . urlencode(urlencode($baseUrl . $folderPath));
         }
 
         if (empty($clauses)) {
@@ -188,34 +188,40 @@ class Actions extends BaseFilter
     }
 
     /**
-     * @return array<int, array{scheme: string, host: string}>|null Null on API failure.
+     * Returns the site's main URL and aliases as a list of normalized base URLs
+     * (each ending with `/`). Preserves any path component carried on `main_url`
+     * or on individual aliases so the rebuilt segment still matches the archived
+     * folder rows. Returns `null` if the API failed for this site (callers fall
+     * back to the single-clause original segment).
+     *
+     * @return list<string>|null
      */
-    private function getResolvedHosts(int $idSite): ?array
+    private function getResolvedBaseUrls(int $idSite): ?array
     {
-        if (array_key_exists($idSite, $this->siteHostsCache)) {
-            return $this->siteHostsCache[$idSite];
+        if (array_key_exists($idSite, $this->siteBaseUrlsCache)) {
+            return $this->siteBaseUrlsCache[$idSite];
         }
 
         try {
             $allUrls = SitesManagerAPI::getInstance()->getSiteUrlsFromId($idSite);
         } catch (\Exception $e) {
-            return $this->siteHostsCache[$idSite] = null;
+            return $this->siteBaseUrlsCache[$idSite] = null;
         }
 
-        $seenHosts = [];
-        $hosts = [];
+        $seen = [];
+        $baseUrls = [];
         foreach ($allUrls as $url) {
-            $host = parse_url($url, PHP_URL_HOST);
-            if (!$host || isset($seenHosts[$host])) {
+            if (!parse_url($url, PHP_URL_HOST)) {
                 continue;
             }
-            $seenHosts[$host] = true;
-            $hosts[] = [
-                'scheme' => parse_url($url, PHP_URL_SCHEME) ?: 'https',
-                'host' => $host,
-            ];
+            $normalized = rtrim($url, '/') . '/';
+            if (isset($seen[$normalized])) {
+                continue;
+            }
+            $seen[$normalized] = true;
+            $baseUrls[] = $normalized;
         }
 
-        return $this->siteHostsCache[$idSite] = $hosts;
+        return $this->siteBaseUrlsCache[$idSite] = $baseUrls;
     }
 }

--- a/plugins/Actions/tests/Unit/DataTableFilterActionsTest.php
+++ b/plugins/Actions/tests/Unit/DataTableFilterActionsTest.php
@@ -126,6 +126,37 @@ class DataTableFilterActionsTest extends \PHPUnit\Framework\TestCase
         (new ActionsFilter($table, Action::TYPE_PAGE_URL))->filter($table);
     }
 
+    public function testFilterPreservesMainUrlPathPrefixWhenRebuildingFolderSegment()
+    {
+        ArchivingHelper::reloadConfig();
+
+        $site = $this->createMock(Site::class);
+        $site->method('getId')->willReturn(1);
+        $site->method('getMainUrl')->willReturn('https://example.com/section');
+
+        $sitesManager = $this->getMockBuilder(SitesManagerAPI::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getSiteUrlsFromId'])
+            ->getMock();
+        $sitesManager->method('getSiteUrlsFromId')->willReturn([
+            'https://example.com/section',
+            'https://alias.example.com/branch/',
+        ]);
+        SitesManagerAPI::setSingletonInstance($sitesManager);
+
+        $table = new DataTable();
+        $table->setMetadata('site', $site);
+        $row = new Row([Row::COLUMNS => ['label' => 'products']]);
+        $row->setMetadata('folder_url_start', 'https://example.com/section/products');
+        $table->addRow($row);
+
+        (new ActionsFilter($table, Action::TYPE_PAGE_URL))->filter($table);
+
+        $mainClause = 'pageUrl=^' . urlencode(urlencode('https://example.com/section/products'));
+        $aliasClause = 'pageUrl=^' . urlencode(urlencode('https://alias.example.com/branch/products'));
+        $this->assertSame($mainClause . ',' . $aliasClause, $row->getMetadata('segment'));
+    }
+
     public function testFilterFallsBackToSingleClauseWhenSiteMetadataIsMissing()
     {
         ArchivingHelper::reloadConfig();

--- a/plugins/Actions/tests/Unit/DataTableFilterActionsTest.php
+++ b/plugins/Actions/tests/Unit/DataTableFilterActionsTest.php
@@ -13,6 +13,8 @@ use Piwik\DataTable;
 use Piwik\DataTable\Row;
 use Piwik\Plugins\Actions\ArchivingHelper;
 use Piwik\Plugins\Actions\DataTable\Filter\Actions as ActionsFilter;
+use Piwik\Plugins\SitesManager\API as SitesManagerAPI;
+use Piwik\Site;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tracker\Action;
 
@@ -33,6 +35,7 @@ class DataTableFilterActionsTest extends \PHPUnit\Framework\TestCase
     public function tearDown(): void
     {
         Fixture::resetTranslations();
+        SitesManagerAPI::unsetInstance();
     }
 
     public function testFilterSetsNullSegmentForUnknownPageUrlEvenWithoutSiteUrlPrefix()
@@ -50,5 +53,59 @@ class DataTableFilterActionsTest extends \PHPUnit\Framework\TestCase
         $allMetadata = $row->getMetadata();
         $this->assertArrayHasKey('segment', $allMetadata);
         $this->assertNull($allMetadata['segment']);
+    }
+
+    public function testFilterEmitsOrJoinedSegmentForFolderRowOnSiteWithAliases()
+    {
+        ArchivingHelper::reloadConfig();
+
+        // Site stub: main_url + getId.
+        $site = $this->createMock(Site::class);
+        $site->method('getId')->willReturn(1);
+        $site->method('getMainUrl')->willReturn('https://main.example.com');
+
+        // SitesManager API stub returning main + one alias.
+        $sitesManager = $this->getMockBuilder(SitesManagerAPI::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getSiteUrlsFromId'])
+            ->getMock();
+        $sitesManager->method('getSiteUrlsFromId')->willReturn([
+            'https://main.example.com',
+            'https://alias.example.com',
+        ]);
+        SitesManagerAPI::setSingletonInstance($sitesManager);
+
+        $table = new DataTable();
+        $table->setMetadata('site', $site);
+        $row = new Row([Row::COLUMNS => ['label' => 'products']]);
+        $row->setMetadata('folder_url_start', 'https://main.example.com/products');
+        $table->addRow($row);
+
+        (new ActionsFilter($table, Action::TYPE_PAGE_URL))->filter($table);
+
+        $segment = $row->getMetadata('segment');
+        $this->assertIsString($segment);
+
+        $mainClause = 'pageUrl=^' . urlencode(urlencode('https://main.example.com/products'));
+        $aliasClause = 'pageUrl=^' . urlencode(urlencode('https://alias.example.com/products'));
+
+        $this->assertStringContainsString($mainClause, $segment);
+        $this->assertStringContainsString($aliasClause, $segment);
+        $this->assertSame($mainClause . ',' . $aliasClause, $segment);
+    }
+
+    public function testFilterFallsBackToSingleClauseWhenSiteMetadataIsMissing()
+    {
+        ArchivingHelper::reloadConfig();
+
+        $table = new DataTable();
+        $row = new Row([Row::COLUMNS => ['label' => 'products']]);
+        $row->setMetadata('folder_url_start', 'https://main.example.com/products');
+        $table->addRow($row);
+
+        (new ActionsFilter($table, Action::TYPE_PAGE_URL))->filter($table);
+
+        $expected = 'pageUrl=^' . urlencode(urlencode('https://main.example.com/products'));
+        $this->assertSame($expected, $row->getMetadata('segment'));
     }
 }

--- a/plugins/Actions/tests/Unit/DataTableFilterActionsTest.php
+++ b/plugins/Actions/tests/Unit/DataTableFilterActionsTest.php
@@ -94,6 +94,38 @@ class DataTableFilterActionsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($mainClause . ',' . $aliasClause, $segment);
     }
 
+    public function testFilterResolvesSiteUrlsOncePerIdSiteAcrossMultipleFolderRows()
+    {
+        ArchivingHelper::reloadConfig();
+
+        $site = $this->createMock(Site::class);
+        $site->method('getId')->willReturn(1);
+        $site->method('getMainUrl')->willReturn('https://main.example.com');
+
+        $sitesManager = $this->getMockBuilder(SitesManagerAPI::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getSiteUrlsFromId'])
+            ->getMock();
+        $sitesManager->expects($this->once())
+            ->method('getSiteUrlsFromId')
+            ->with(1)
+            ->willReturn([
+                'https://main.example.com',
+                'https://alias.example.com',
+            ]);
+        SitesManagerAPI::setSingletonInstance($sitesManager);
+
+        $table = new DataTable();
+        $table->setMetadata('site', $site);
+        foreach (['products', 'blog', 'docs'] as $folder) {
+            $row = new Row([Row::COLUMNS => ['label' => $folder]]);
+            $row->setMetadata('folder_url_start', 'https://main.example.com/' . $folder);
+            $table->addRow($row);
+        }
+
+        (new ActionsFilter($table, Action::TYPE_PAGE_URL))->filter($table);
+    }
+
     public function testFilterFallsBackToSingleClauseWhenSiteMetadataIsMissing()
     {
         ArchivingHelper::reloadConfig();


### PR DESCRIPTION
### Description

When a Matomo site has multiple URL aliases (main URL + extra hosts in *Manage Websites > Edit > URLs*), opening the **Segmented Visitor Log** from a folder row in Behaviour > Pages came back empty for many folders, even though the same folder showed pageviews in the report behind it. Page Titles still worked, which is what made it look inconsistent.

The reason: the folder row's segment was always built using the site's main URL as the prefix. Any folder whose actual visits were tracked under one of the alias hosts (or any host other than the main one) ended up with a segment that couldn't match the data, so the popover rendered "There is no data for this report."

This PR rebuilds the folder-row segment at filter time to fan out across every URL registered on the site (main URL + aliases) as an OR-joined segment. So clicking the Visitor Log icon on a Pages folder row now returns visits regardless of which of the site's registered hosts they were tracked under.

No archive format change - the fix is applied when the report is rendered, so existing archived data works without re-archiving.

#### Scenario it fixes (in product terms)

  1. A site has more than one URL configured (e.g. main URL `https://main.example.com`, alias `https://shop.example.com`).
  2. A visitor browses `https://shop.example.com/products/scuba-fins/` - tracked into that site.
  3. The user goes to Behaviour > Pages, expands `products`, clicks the Segmented Visitor Log icon on a row whose underlying URL lives on the alias host.
  4. Before this PR: popover shows "There is no data for this report."
  5. After this PR: popover shows the matching visits as expected.

  The same shape applies whenever the main URL host doesn't match the host the actions were actually tracked on (multi-host setups, alias-only traffic, or main URL configured as a host that doesn't itself receive pageviews).

  ### In scope
  - Folder row segment generation in `plugins/Actions/DataTable/Filter/Actions.php` for the Pages report and the older-archive fallback.
  - Unit coverage in `plugins/Actions/tests/Unit/DataTableFilterActionsTest.php` for the new OR-joined output and the no-site fallback.

  ### Out of scope
  - Hosts that receive tracked traffic but are **not** registered as aliases on the site (config drift — fixable via the site's URL settings).
  - Same-dimension segment collision when a Page URL segment is already applied to the report — handled separately in #24543. Both PRs can land independently.
  - Archive-time changes (`Actions/RecordBuilders/ActionReports.php`, `ArchivingHelper::setFolderPathMetadata`) are left untouched so existing
  `folder_url_start` archived metadata keeps working.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
