### PR TITLE
fix: what's new identation in menu is the same now as the rest #24481

### DIFF
--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -565,7 +565,7 @@ ul.browser-default {
 .badge-menu-item {
   position: absolute;
   top: 12px;
-  left: 0px;
+  left: 0;
   z-index: 2;
 
   background-color: rgba(212, 19, 13, 1);

--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -560,11 +560,12 @@ ul.browser-default {
 .badge-menu-item-container {
   line-height: inherit;
   position: relative;
+  padding: 0 32px;
 }
 .badge-menu-item {
   position: absolute;
   top: 12px;
-  left: 15px;
+  left: 0px;
   z-index: 2;
 
   background-color: rgba(212, 19, 13, 1);

--- a/plugins/Morpheus/stylesheets/ui/_navs.less
+++ b/plugins/Morpheus/stylesheets/ui/_navs.less
@@ -100,7 +100,7 @@ nav .sidenav-trigger {
 
       > .badge-menu-item {
         top: 6px;
-        right: 20px;
+        right: 35px;
         left: unset;
       }
     }


### PR DESCRIPTION
### Description

I have added the fix to show correctly the what's new menu item for issue #24481
<img width="283" height="383" alt="image" src="https://github.com/user-attachments/assets/0136bacd-842b-4b13-a9e0-17eb9b3edecd" />

fixes #24481

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [X] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [X] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [X] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [X] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [X] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [X] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [X] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [X] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [X] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [X] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

