### PR TITLE
Avoid overwriting $_GET during ScheduledReports generation

### DIFF
--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -662,29 +662,6 @@ class API extends \Piwik\Plugin\API
                     $apiParameters = $action['parameters'];
                 }
 
-                $mustRestoreGET = false;
-
-                // all Websites dashboard should not be truncated in the report
-                if ($apiModule == 'MultiSites') {
-                    $mustRestoreGET = $_GET;
-                    $_GET['enhanced'] = true;
-
-                    if ($apiAction == 'getAll') {
-                        $_GET['filter_truncate'] = false;
-                        $_GET['filter_limit'] = -1; // show all websites in all websites report
-
-                        // when a view/admin user created a report, workaround the fact that "Super User"
-                        // is enforced in Scheduled tasks, and ensure Multisites.getAll only return the websites that this user can access
-                        $userLogin = $report['login'];
-                        if (
-                            !empty($userLogin)
-                            && !Piwik::hasTheUserSuperUserAccess($userLogin)
-                        ) {
-                            $_GET['_restrictSitesToLogin'] = $userLogin;
-                        }
-                    }
-                }
-
                 $params = [
                     'idSite' => $idSite,
                     'period' => $period,
@@ -697,7 +674,31 @@ class API extends \Piwik\Plugin\API
                     'language' => $language,
                     'serialize' => 0,
                     'format' => 'original',
+                    // Always process report data with the default filters when generating a report,
+                    // regardless of the parameters present in the original request.
+                    'disable_queued_filters' => 0,
+                    'disable_generic_filters' => 0,
                 ];
+
+                // all Websites dashboard should not be truncated in the report
+                if ($apiModule == 'MultiSites') {
+                    $params['enhanced'] = true;
+
+                    if ($apiAction == 'getAll') {
+                        $params['filter_truncate'] = false;
+                        $params['filter_limit'] = -1; // show all websites in all websites report
+
+                        // when a view/admin user created a report, workaround the fact that "Super User"
+                        // is enforced in Scheduled tasks, and ensure Multisites.getAll only return the websites that this user can access
+                        $userLogin = $report['login'];
+                        if (
+                            !empty($userLogin)
+                            && !Piwik::hasTheUserSuperUserAccess($userLogin)
+                        ) {
+                            $params['_restrictSitesToLogin'] = $userLogin;
+                        }
+                    }
+                }
 
                 if ($segment != null) {
                     $params['segment'] = urlencode($segment['definition']);
@@ -724,10 +725,6 @@ class API extends \Piwik\Plugin\API
 
                 // TODO add static method getPrettyDate($period, $date) in Period
                 $prettyDate = $processedReport['prettyDate'];
-
-                if ($mustRestoreGET) {
-                    $_GET = $mustRestoreGET;
-                }
 
                 $processedReports[] = $processedReport;
             }


### PR DESCRIPTION
### Description

There is no need to overwrite and reset $_GET, as the parameters can also be directly passed into the `processRequest` call.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
