### PR TITLE
Prevent widgetizing actions that do not serve HTML content

### DIFF
--- a/plugins/Widgetize/Controller.php
+++ b/plugins/Widgetize/Controller.php
@@ -96,9 +96,47 @@ class Controller extends \Piwik\Plugin\Controller
             $view->content = $widgetView->render();
         } else {
             $view->content = FrontController::getInstance()->fetchDispatch($controllerName, $actionName);
+
+            // Only actions that return HTML may be embedded into the widgetized iframe document.
+            $this->assertDispatchedContentIsEmbeddable($controllerName, $actionName);
         }
 
         return $view->render();
+    }
+
+    private function assertDispatchedContentIsEmbeddable(string $module, string $action): void
+    {
+        $contentType = $this->getDispatchedContentType();
+
+        // An empty content type means the action did not set one explicitly and the (HTML) default applies.
+        // Only actions returning HTML (or no explicit content type) can be embedded into the iframe document.
+        if (
+            $contentType !== ''
+            && stripos($contentType, 'text/html') === false
+            && stripos($contentType, 'application/xhtml') === false
+        ) {
+            throw new \Exception(sprintf(
+                "%s.%s cannot be widgetized: only actions returning HTML can be embedded.",
+                $module,
+                $action
+            ));
+        }
+    }
+
+    private function getDispatchedContentType(): string
+    {
+        // In CLI / test mode no real headers are emitted, but Common::sendHeader() records them instead.
+        if (Common::isPhpCliMode()) {
+            return (string) (Common::$headersSentInTests['Content-Type'] ?? '');
+        }
+
+        foreach (headers_list() as $header) {
+            if (stripos($header, 'content-type:') === 0) {
+                return trim(substr($header, strlen('content-type:')));
+            }
+        }
+
+        return '';
     }
 
     private function findClientWidgetMetadata(string $module, string $action): ?array

--- a/plugins/Widgetize/tests/Integration/ControllerTest.php
+++ b/plugins/Widgetize/tests/Integration/ControllerTest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\Widgetize\tests\Integration;
 
+use Piwik\Common;
 use Piwik\Plugins\Widgetize\Controller;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
@@ -72,6 +73,8 @@ class ControllerTest extends IntegrationTestCase
         $_GET = $this->backupGet;
         $_REQUEST = $this->backupRequest;
 
+        unset(Common::$headersSentInTests['Content-Type']);
+
         parent::tearDown();
     }
 
@@ -109,5 +112,45 @@ class ControllerTest extends IntegrationTestCase
         $method->setAccessible(true);
 
         $this->assertNull($method->invoke($this->controller, $config));
+    }
+
+    public function testIframeRefusesToEmbedActionsThatDoNotReturnHtml(): void
+    {
+        // Actions returning a non-HTML response (e.g. JSON via Json::sendHeaderJSON()) cannot be embedded.
+        Common::$headersSentInTests['Content-Type'] = 'application/json; charset=utf-8';
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Dashboard.getAllDashboards cannot be widgetized');
+
+        $this->invokeEmbeddableAssertion('Dashboard', 'getAllDashboards');
+    }
+
+    /**
+     * @dataProvider getEmbeddableContentTypes
+     */
+    public function testIframeAllowsActionsThatReturnHtml(string $contentType): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        Common::$headersSentInTests['Content-Type'] = $contentType;
+
+        // must not throw for HTML responses, or when no explicit content type was set (HTML default)
+        $this->invokeEmbeddableAssertion('AnyModule', 'anyAction');
+    }
+
+    public function getEmbeddableContentTypes(): array
+    {
+        return [
+            ['text/html; charset=utf-8'],
+            ['application/xhtml+xml'],
+            [''],
+        ];
+    }
+
+    private function invokeEmbeddableAssertion(string $module, string $action): void
+    {
+        $method = new \ReflectionMethod(Controller::class, 'assertDispatchedContentIsEmbeddable');
+        $method->setAccessible(true);
+        $method->invoke($this->controller, $module, $action);
     }
 }


### PR DESCRIPTION
### Description

We currently have a couple of controller actions, that are providing data or configuration for certain features or widgets.
Those actions often serve JSON content.
The possibility to widgetize actions, currently does not further restrict which actions can be used.
Widgetizing actions that serve JSON was never intended to be possible, but currently works.
This PR ensures that only actions serving HTML will be rendered widgetized.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
