### PR TITLE
Improve parameter type handling for DataRounding

### DIFF
--- a/plugins/PrivacyManager/DataRounding.php
+++ b/plugins/PrivacyManager/DataRounding.php
@@ -614,11 +614,11 @@ class DataRounding
                 $idSite = $requestObject->getParameter('idsite', null);
             }
 
-            if (!is_scalar($idSite) || trim((string) $idSite) === '') {
+            if (!is_array($idSite) && !is_scalar($idSite)) {
                 return [];
             }
 
-            return Site::getIdSitesFromIdSitesString((string) $idSite, false, false);
+            return Site::getIdSitesFromIdSitesString($idSite, false, false);
         } catch (Throwable $e) {
             return [];
         }

--- a/plugins/PrivacyManager/tests/Unit/DataRoundingTest.php
+++ b/plugins/PrivacyManager/tests/Unit/DataRoundingTest.php
@@ -611,6 +611,79 @@ class DataRoundingTest extends \PHPUnit\Framework\TestCase
         $this->assertSame([1, 2], $actual);
     }
 
+    public function testExtractRequestedSiteIdsHandlesIdSiteArray(): void
+    {
+        $actual = $this->invokeDataRoundingMethod('extractRequestedSiteIds', [[
+            'idSite' => [1, 2],
+            'segment' => 'visitCount>=1',
+        ]]);
+
+        $this->assertSame([1, 2], $actual);
+    }
+
+    public function testExtractRequestedSiteIdsHandlesIdSiteArrayOfStrings(): void
+    {
+        $actual = $this->invokeDataRoundingMethod('extractRequestedSiteIds', [[
+            'idSite' => ['1', '2'],
+        ]]);
+
+        $this->assertSame([1, 2], $actual);
+    }
+
+    public function testExtractRequestedSiteIdsHandlesCommaSeparatedString(): void
+    {
+        $actual = $this->invokeDataRoundingMethod('extractRequestedSiteIds', [[
+            'idSite' => '1,3',
+        ]]);
+
+        $this->assertSame([1, 3], $actual);
+    }
+
+    public function testExtractRequestedSiteIdsFiltersAndDeduplicatesCommaSeparatedString(): void
+    {
+        $actual = $this->invokeDataRoundingMethod('extractRequestedSiteIds', [[
+            'idSite' => '1, foo, 1, 3, 0, -2',
+        ]]);
+
+        $this->assertSame([1, 3], array_values($actual));
+    }
+
+    public function testExtractRequestedSiteIdsIgnoresInvalidEntriesInArray(): void
+    {
+        $actual = $this->invokeDataRoundingMethod('extractRequestedSiteIds', [[
+            'idSite' => ['1', 'foo', '', '0', '-3', '2'],
+        ]]);
+
+        $this->assertSame([1, 2], $actual);
+    }
+
+    public function testExtractRequestedSiteIdsReturnsEmptyForEmptyString(): void
+    {
+        $actual = $this->invokeDataRoundingMethod('extractRequestedSiteIds', [[
+            'idSite' => '',
+        ]]);
+
+        $this->assertSame([], $actual);
+    }
+
+    public function testExtractRequestedSiteIdsReturnsEmptyWhenIdSiteMissing(): void
+    {
+        $actual = $this->invokeDataRoundingMethod('extractRequestedSiteIds', [[
+            'segment' => 'visitCount>=1',
+        ]]);
+
+        $this->assertSame([], $actual);
+    }
+
+    public function testExtractRequestedSiteIdsReturnsEmptyForBoolean(): void
+    {
+        $actual = $this->invokeDataRoundingMethod('extractRequestedSiteIds', [[
+            'idSite' => true,
+        ]]);
+
+        $this->assertSame([], $actual);
+    }
+
     public function testRoundCountMetricsForRequestRoundsOnlyEnabledSitesWithinSiteKeyedMap(): void
     {
         $siteOneTable = new DataTable();


### PR DESCRIPTION
### Description

DataRounding is currently not handling idSites correctly that are provided as array. 

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
