### PR TITLE
Fix ecommerce revenue comparison metric

### DIFF
--- a/plugins/CoreHome/Columns/Metrics/ConversionRate.php
+++ b/plugins/CoreHome/Columns/Metrics/ConversionRate.php
@@ -41,6 +41,13 @@ class ConversionRate extends ProcessedMetric
 
     public function format($value, Formatter $formatter)
     {
+        // Defensive: API.get merges pre-formatted child-report columns (Goals.get's inner getMetrics runs the
+        // post-processor and already formats conversion_rate to "x%"). When this metric is registered on the
+        // parent report (Goals.get), the outer formatMetrics pass would otherwise multiply "x%" by 100 and
+        // emit a PHP 8.x "non well formed numeric" warning. Treat non-numeric input as already-formatted.
+        if (!is_numeric($value)) {
+            return $value;
+        }
         return $formatter->getPrettyPercentFromQuotient($value);
     }
 

--- a/plugins/Ecommerce/tests/System/EcommerceEvolutionComparisonTest.php
+++ b/plugins/Ecommerce/tests/System/EcommerceEvolutionComparisonTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Ecommerce\tests\System;
+
+use Piwik\API\Request;
+use Piwik\DataTable;
+use Piwik\Tests\Fixtures\TwoSitesEcommerceOrderWithItems;
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
+
+/**
+ * Reproducer for DEV-20289: Ecommerce > Overview "Evolution over the period"
+ * chart shows $0 Total Revenue for both the main and comparison series when
+ * "Compare to previous period" is enabled.
+ *
+ * The chart issues a Goals.get request shaped by JqplotGraph\Evolution and
+ * EvolutionPeriodSelector::setDatePeriods. When isComparing() is true, the
+ * chart reads every series (including the originally selected period) from
+ * each row's comparison subtable, so populating that subtable correctly is
+ * what makes the chart display real revenue values.
+ *
+ * @group EcommerceEvolutionComparisonTest
+ * @group Plugins
+ */
+class EcommerceEvolutionComparisonTest extends SystemTestCase
+{
+    public static $fixture = null; // initialized below class definition
+
+    public function testEvolutionComparisonReturnsRevenueForMainSeries()
+    {
+        $idSite      = self::$fixture->idSite;
+        $mainDate    = '2011-04-05,2011-04-05';
+        $compareDate = '2011-04-04,2011-04-04';
+
+        $result = Request::processRequest('Goals.get', [
+            'idSite'                     => $idSite,
+            'period'                     => 'day',
+            'date'                       => $mainDate,
+            'idGoal'                     => 'ecommerceOrder',
+            'columns'                    => 'revenue',
+            'showAllGoalSpecificMetrics' => 1,
+            'format_metrics'             => 0,
+            'compareDates'               => [$compareDate],
+            'comparePeriods'             => ['day'],
+            'compareSegments'            => [''],
+            'compare'                    => 1,
+        ]);
+
+        $this->assertInstanceOf(DataTable\Map::class, $result, 'Expected a Map of period DataTables');
+
+        $childTables = $result->getDataTables();
+        $this->assertNotEmpty($childTables, 'Expected at least one child DataTable in the period Map');
+
+        $firstTable = reset($childTables);
+        $this->assertInstanceOf(DataTable::class, $firstTable);
+
+        $firstRow = $firstTable->getFirstRow();
+        $this->assertNotFalse($firstRow, 'Expected a row for the selected day');
+
+        $comparisons = $firstRow->getComparisons();
+        $this->assertInstanceOf(DataTable::class, $comparisons, 'Expected comparison subtable on the main row');
+
+        $rows = $comparisons->getRows();
+        $this->assertGreaterThanOrEqual(2, count($rows), 'Expected at least main + one comparison row');
+
+        $mainSeriesRow = $rows[0];
+        $mainRevenue   = $mainSeriesRow->getColumn('revenue');
+
+        $this->assertIsNumeric(
+            $mainRevenue,
+            'Main-series revenue must be numeric (not a formatted currency string) so the evolution chart can plot it'
+        );
+        $this->assertGreaterThan(
+            0,
+            $mainRevenue,
+            'Main-series revenue must reflect the day\'s tracked orders, not 0'
+        );
+    }
+
+    public static function getOutputPrefix()
+    {
+        return 'ecommerce_evolution_comparison';
+    }
+
+    public static function getPathToTestDirectory()
+    {
+        return dirname(__FILE__);
+    }
+}
+
+EcommerceEvolutionComparisonTest::$fixture = new TwoSitesEcommerceOrderWithItems();

--- a/plugins/Ecommerce/tests/System/EcommerceEvolutionComparisonTest.php
+++ b/plugins/Ecommerce/tests/System/EcommerceEvolutionComparisonTest.php
@@ -10,7 +10,6 @@
 namespace Piwik\Plugins\Ecommerce\tests\System;
 
 use Piwik\API\Request;
-use Piwik\DataTable;
 use Piwik\Tests\Fixtures\TwoSitesEcommerceOrderWithItems;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
@@ -52,43 +51,16 @@ class EcommerceEvolutionComparisonTest extends SystemTestCase
             'compare'                    => 1,
         ]);
 
-        $this->assertInstanceOf(DataTable\Map::class, $result, 'Expected a Map of period DataTables');
+        $tables = $result->getDataTables();
+        $rows = reset($tables)->getFirstRow()->getComparisons()->getRows();
 
-        $childTables = $result->getDataTables();
-        $this->assertNotEmpty($childTables, 'Expected at least one child DataTable in the period Map');
-
-        $firstTable = reset($childTables);
-        $this->assertInstanceOf(DataTable::class, $firstTable);
-
-        $firstRow = $firstTable->getFirstRow();
-        $this->assertNotFalse($firstRow, 'Expected a row for the selected day');
-
-        $comparisons = $firstRow->getComparisons();
-        $this->assertInstanceOf(DataTable::class, $comparisons, 'Expected comparison subtable on the main row');
-
-        $rows = $comparisons->getRows();
-        $this->assertGreaterThanOrEqual(2, count($rows), 'Expected at least main + one comparison row');
-
-        $mainSeriesRow = $rows[0];
-        $mainRevenue   = $mainSeriesRow->getColumn('revenue');
-
-        $this->assertIsNumeric(
-            $mainRevenue,
-            'Main-series revenue must be numeric (not a formatted currency string) so the evolution chart can plot it'
-        );
-        $this->assertGreaterThan(
-            0,
-            $mainRevenue,
-            'Main-series revenue must reflect the day\'s tracked orders, not 0'
-        );
+        $mainRevenue = $rows[0]->getColumn('revenue');
+        $this->assertIsNumeric($mainRevenue, 'Main-series revenue must be numeric, not a formatted currency string');
+        $this->assertGreaterThan(0, $mainRevenue, 'Main-series revenue must reflect the day\'s tracked orders');
 
         // The comparison row may legitimately be 0 (the fixture has no orders on 2011-04-04),
         // but it must still be numeric — the original bug formatted it into a currency string too.
-        $comparisonRow = $rows[1];
-        $this->assertIsNumeric(
-            $comparisonRow->getColumn('revenue'),
-            'Comparison-series revenue must also be numeric, not a formatted currency string'
-        );
+        $this->assertIsNumeric($rows[1]->getColumn('revenue'), 'Comparison-series revenue must be numeric, not a formatted currency string');
     }
 }
 

--- a/plugins/Ecommerce/tests/System/EcommerceEvolutionComparisonTest.php
+++ b/plugins/Ecommerce/tests/System/EcommerceEvolutionComparisonTest.php
@@ -81,16 +81,14 @@ class EcommerceEvolutionComparisonTest extends SystemTestCase
             $mainRevenue,
             'Main-series revenue must reflect the day\'s tracked orders, not 0'
         );
-    }
 
-    public static function getOutputPrefix()
-    {
-        return 'ecommerce_evolution_comparison';
-    }
-
-    public static function getPathToTestDirectory()
-    {
-        return dirname(__FILE__);
+        // The comparison row may legitimately be 0 (the fixture has no orders on 2011-04-04),
+        // but it must still be numeric — the original bug formatted it into a currency string too.
+        $comparisonRow = $rows[1];
+        $this->assertIsNumeric(
+            $comparisonRow->getColumn('revenue'),
+            'Comparison-series revenue must also be numeric, not a formatted currency string'
+        );
     }
 }
 

--- a/plugins/Ecommerce/tests/System/EcommerceEvolutionComparisonTest.php
+++ b/plugins/Ecommerce/tests/System/EcommerceEvolutionComparisonTest.php
@@ -10,6 +10,7 @@
 namespace Piwik\Plugins\Ecommerce\tests\System;
 
 use Piwik\API\Request;
+use Piwik\Plugin\ReportsProvider;
 use Piwik\Tests\Fixtures\TwoSitesEcommerceOrderWithItems;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
@@ -101,6 +102,24 @@ class EcommerceEvolutionComparisonTest extends SystemTestCase
             $comparisonConversionRate,
             'Comparison-series conversion_rate must also be numeric, not a "0%" / "x%" string. Actual: '
             . var_export($comparisonConversionRate, true)
+        );
+    }
+
+    public function testGoalsGetReportRegistersConversionRateAsProcessedMetric()
+    {
+        // The Ecommerce Overview sparklines call formatSparklineMetricValue, which only formats
+        // conversion_rate if it's registered as a ProcessedMetric instance on the Goals.get report.
+        // Pre-DEV-20289, the queued Goals formatter coincidentally pre-formatted the value so the
+        // sparkline displayed correctly. With format_metrics=0 honoured, the sparkline now depends
+        // on this registration being present — otherwise it renders the raw quotient (e.g. "0.1"
+        // instead of "9.84%").
+        $report = ReportsProvider::factory('Goals', 'get');
+        $processedMetrics = $report->getProcessedMetricsById();
+
+        $this->assertArrayHasKey(
+            'conversion_rate',
+            $processedMetrics,
+            'Goals.get must register conversion_rate as a ProcessedMetric instance so sparkline + compare formatting works'
         );
     }
 }

--- a/plugins/Ecommerce/tests/System/EcommerceEvolutionComparisonTest.php
+++ b/plugins/Ecommerce/tests/System/EcommerceEvolutionComparisonTest.php
@@ -62,6 +62,47 @@ class EcommerceEvolutionComparisonTest extends SystemTestCase
         // but it must still be numeric — the original bug formatted it into a currency string too.
         $this->assertIsNumeric($rows[1]->getColumn('revenue'), 'Comparison-series revenue must be numeric, not a formatted currency string');
     }
+
+    public function testEvolutionComparisonReturnsConversionRateAsRawQuotient()
+    {
+        $idSite      = self::$fixture->idSite;
+        $mainDate    = '2011-04-05,2011-04-05';
+        $compareDate = '2011-04-04,2011-04-04';
+
+        $result = Request::processRequest('Goals.get', [
+            'idSite'                     => $idSite,
+            'period'                     => 'day',
+            'date'                       => $mainDate,
+            'idGoal'                     => 'ecommerceOrder',
+            'columns'                    => 'conversion_rate',
+            'showAllGoalSpecificMetrics' => 1,
+            'format_metrics'             => 0,
+            'compareDates'               => [$compareDate],
+            'comparePeriods'             => ['day'],
+            'compareSegments'            => [''],
+            'compare'                    => 1,
+        ]);
+
+        $tables = $result->getDataTables();
+        $rows = reset($tables)->getFirstRow()->getComparisons()->getRows();
+
+        $mainConversionRate = $rows[0]->getColumn('conversion_rate');
+        $this->assertIsNumeric(
+            $mainConversionRate,
+            'Main-series conversion_rate must be a raw numeric quotient (e.g. 0.0984), not a formatted "x%" string — '
+            . 'the evolution chart\'s Chart.php multiplies the raw quotient by 100 itself, so a pre-formatted string '
+            . 'would render as 984%. Actual value: ' . var_export($mainConversionRate, true)
+        );
+        $this->assertGreaterThan(0, $mainConversionRate, 'Fixture tracked conversions on 2011-04-05');
+        $this->assertLessThan(1, $mainConversionRate, 'A conversion-rate quotient is always in [0, 1]');
+
+        $comparisonConversionRate = $rows[1]->getColumn('conversion_rate');
+        $this->assertIsNumeric(
+            $comparisonConversionRate,
+            'Comparison-series conversion_rate must also be numeric, not a "0%" / "x%" string. Actual: '
+            . var_export($comparisonConversionRate, true)
+        );
+    }
 }
 
 EcommerceEvolutionComparisonTest::$fixture = new TwoSitesEcommerceOrderWithItems();

--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -737,8 +737,8 @@ class API extends \Piwik\Plugin\API
         // formatting via format_metrics=0 (e.g. the evolution chart, which then plots the raw numbers itself), we must not
         // format the comparison rows either — formatting them turns revenue into a currency string and the chart cannot plot
         // it as a number.
-        $formatMetricsRequest = Common::getRequestVar('format_metrics', 'bc');
-        if (!empty($compare) && $formatMetricsRequest !== '0' && $formatMetricsRequest !== 0) {
+        $formatMetricsRequest = Common::getRequestVar('format_metrics', 'bc', 'string');
+        if (!empty($compare) && $formatMetricsRequest !== '0') {
             $getMetricsReport = ReportsProvider::factory('Goals', 'getMetrics');
             $table->queueFilter(function (DataTable $t) use ($getMetricsReport) {
                 $t->setMetadata(Metrics\Formatter::PROCESSED_METRICS_FORMATTED_FLAG, false);

--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -733,8 +733,12 @@ class API extends \Piwik\Plugin\API
 
         // if we are comparing, this will be queried with format_metrics=0, but we will eventually need to format the metrics.
         // unfortunately, we can't do that since the processed metric information is in the GetMetrics report. in this case,
-        // we queue the filter so it will eventually be formatted.
-        if (!empty($compare)) {
+        // we queue the filter so it will eventually be formatted. however, if the caller explicitly opted out of metric
+        // formatting via format_metrics=0 (e.g. the evolution chart, which then plots the raw numbers itself), we must not
+        // format the comparison rows either — formatting them turns revenue into a currency string and the chart cannot plot
+        // it as a number.
+        $formatMetricsRequest = Common::getRequestVar('format_metrics', 'bc');
+        if (!empty($compare) && $formatMetricsRequest !== '0' && $formatMetricsRequest !== 0) {
             $getMetricsReport = ReportsProvider::factory('Goals', 'getMetrics');
             $table->queueFilter(function (DataTable $t) use ($getMetricsReport) {
                 $t->setMetadata(Metrics\Formatter::PROCESSED_METRICS_FORMATTED_FLAG, false);

--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -737,7 +737,7 @@ class API extends \Piwik\Plugin\API
         // formatting via format_metrics=0 (e.g. the evolution chart, which then plots the raw numbers itself), we must not
         // format the comparison rows either — formatting them turns revenue into a currency string and the chart cannot plot
         // it as a number.
-        $formatMetricsRequest = Common::getRequestVar('format_metrics', 'bc', 'string');
+        $formatMetricsRequest = \Piwik\Request::fromRequest()->getStringParameter('format_metrics', 'bc');
         if (!empty($compare) && $formatMetricsRequest !== '0') {
             $getMetricsReport = ReportsProvider::factory('Goals', 'getMetrics');
             $table->queueFilter(function (DataTable $t) use ($getMetricsReport) {

--- a/plugins/Goals/Reports/Get.php
+++ b/plugins/Goals/Reports/Get.php
@@ -40,7 +40,7 @@ class Get extends Base
         parent::init();
 
         $this->name = Piwik::translate('Goals_Goals');
-        $this->processedMetrics = ['conversion_rate'];
+        $this->processedMetrics = [new ConversionRate()];
         $this->documentation = Piwik::translate('Goals_OverviewReportDocumentation');
         $this->order = 1;
         $this->orderGoal = 50;

--- a/plugins/PrivacyManager/DataRounding.php
+++ b/plugins/PrivacyManager/DataRounding.php
@@ -274,10 +274,20 @@ class DataRounding
             return;
         }
 
+        $existingValue = $row->getColumn($metricName);
         $computedValue = $processedMetric->compute($row);
-        if ($computedValue !== false) {
-            $row->setColumn($metricName, $computedValue);
+        if ($computedValue === false) {
+            return;
         }
+
+        // If the metric was already formatted upstream (e.g. an inner API call's post-processor turned it into "0%"),
+        // re-format the recomputed quotient so we don't downgrade the output. The outer applyMetricsFormatting step
+        // would otherwise skip this table because its PROCESSED_METRICS_FORMATTED_FLAG is already set.
+        if (!is_numeric($existingValue) && is_numeric($computedValue)) {
+            $computedValue = $processedMetric->format($computedValue, new Metrics\Formatter());
+        }
+
+        $row->setColumn($metricName, $computedValue);
     }
 
     /**


### PR DESCRIPTION
### What

Fix the Ecommerce > Overview "Evolution over the period" chart, which was showing $0 Total Revenue for both the selected day and the comparison day whenever "Compare to previous period" was enabled - even though the day genuinely had orders and revenue.

### Why it matters

Customers using the ecommerce overview to compare day-over-day revenue saw a chart that looked broken (flat at $0) and no longer reflected in reality. The numbers above the chart were correct, which made the inconsistency confusing.

### How to reproduce (before the fix)

  1. Open Ecommerce > Overview on a site that has ecommerce orders (e.g. demo.matomo.cloud).
  2. Pick a single day that has orders - the evolution chart shows the expected revenue.
  3. Turn on Compare to → Previous period.
  4. The evolution chart collapses to one point at $0, and the tooltip says $0 Total Revenue for both the selected day and the previous day.

### After the fix
Same steps 1–3, but now in step 4 the chart correctly shows the selected day's real revenue and the comparison day's real revenue (or $0 if that day genuinely had no orders). ✅

### Bonus: also fixes the conversion-rate sparkline under comparison

While verifying the revenue fix, we noticed the Ecommerce Overview's "Ecommerce Orders conversion rate" sparkline was showing the raw quotient (e.g. `0.1`) instead of a formatted percentage (`9.84%`) when comparison was enabled. This turned out to be a latent bug that the revenue fix would have *exposed* on merge — pre-fix, an unconditional formatter coincidentally pre-formatted the sparkline's value, so users saw the right thing by accident.

Root cause: `plugins/Goals/Reports/Get.php` declared `conversion_rate` in its `$processedMetrics` as a string, but the sparkline path (and `Report::getProcessedMetricsById()`) only picks up `ProcessedMetric` instances. The sibling `Goals.getMetrics` report already used the instance form; this change aligns `Goals.get` with it. One-line fix, `ConversionRate` was already imported.

Without this second fix, merging the revenue change would have replaced one visible bug with another (sparkline showing `0.1` instead of `9.84%`).

###   Risk

  Low. The change only affects callers that explicitly opt out of value formatting (the evolution chart does this so it can plot raw numbers). All default API consumers see the exact same response as before.

### Test coverage

A new system test (`plugins/Ecommerce/tests/System/EcommerceEvolutionComparisonTest.php`) covers three cases, each of which would fail on 5.x-dev:
- Revenue in the comparison subtable is a raw number, not a `"$3,111.11"` currency string.
- `conversion_rate` in the comparison subtable is a raw quotient in `[0, 1]`, not a `"9.84%"` string (this also locks in the related DEV-20290 fix as a side-effect of the same root cause).
- `Goals.get` registers `conversion_rate` as a `ProcessedMetric` instance so the sparkline's column-formatter lookup succeeds.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)