### PR TITLE
Check table exists in update for 5.11.0

### DIFF
--- a/core/Updates/5.11.0-b1.php
+++ b/core/Updates/5.11.0-b1.php
@@ -9,6 +9,8 @@
 
 namespace Piwik\Updates;
 
+use Piwik\Common;
+use Piwik\DbHelper;
 use Piwik\Updater;
 use Piwik\Updates;
 use Piwik\Updater\Migration\Factory as MigrationFactory;
@@ -27,10 +29,15 @@ class Updates_5_11_0_b1 extends Updates
 
     public function getMigrations(Updater $updater): array
     {
-        return [
+        $migrations = [
             $this->migration->db->addColumn('site', 'description', "VARCHAR(255) NOT NULL DEFAULT ''", 'name'),
-            $this->migration->db->addColumn('custom_dimensions', 'description', "VARCHAR(1000) NOT NULL DEFAULT ''", 'name'),
         ];
+
+        if (DbHelper::tableExists(Common::prefixTable('custom_dimensions'))) {
+            $migrations[] = $this->migration->db->addColumn('custom_dimensions', 'description', "VARCHAR(1000) NOT NULL DEFAULT ''", 'name');
+        }
+
+        return $migrations;
     }
 
     public function doUpdate(Updater $updater): void


### PR DESCRIPTION
### Description

On some older installs it might be possible that the `custom_dimensions` table might not exist, as the plugin was never used.

fixes #24611

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
