### PR TITLE
Apply excluded query parameter logic to BotTracking page URLs

### DIFF
--- a/plugins/BotTracking/Tracker/BotRequestProcessor.php
+++ b/plugins/BotTracking/Tracker/BotRequestProcessor.php
@@ -127,6 +127,12 @@ class BotRequestProcessor extends \Piwik\Tracker\BotRequestProcessor
             return null;
         }
 
+        if ($actionType === Action::TYPE_PAGE_URL) {
+            // Apply the same excluded query parameter logic as normal page tracking.
+            // Download URLs are intentionally left untouched, matching ActionDownloadUrl.
+            $url = PageUrl::excludeQueryParametersFromUrl($url, $request->getIdSite());
+        }
+
         $urlInfo = PageUrl::normalizeUrl($url);
 
         $actionsToLookup = [

--- a/plugins/BotTracking/tests/Integration/Tracker/BotRequestProcessorTest.php
+++ b/plugins/BotTracking/tests/Integration/Tracker/BotRequestProcessorTest.php
@@ -129,6 +129,76 @@ class BotRequestProcessorTest extends IntegrationTestCase
         self::assertEquals(Action::TYPE_DOWNLOAD, $action[0]['type']);
     }
 
+    public function testExcludedQueryParametersAreStrippedFromPageUrl(): void
+    {
+        $idSite = Fixture::createWebsite(
+            '2025-01-01 00:00:00',
+            $ecommerce = 0,
+            $siteName = false,
+            $siteUrl = false,
+            $siteSearch = 1,
+            $searchKeywordParameters = null,
+            $searchCategoryParameters = null,
+            $timezone = null,
+            $type = null,
+            $excludeUnknownUrls = 0,
+            $excludedParameters = 'excluded'
+        );
+
+        $request = $this->makeRequest([
+            'idsite' => $idSite,
+            'url' => 'https://example.com/test?keep=1&excluded=secret',
+            'ua' => 'ChatGPT-User/1.0',
+        ]);
+
+        $this->requestProcessor->handleRequest($request);
+
+        self::assertEquals('example.com/test?keep=1', $this->getStoredActionName($idSite));
+    }
+
+    public function testGloballyExcludedQueryParametersAreStripped(): void
+    {
+        // gclid ships in the global url_query_parameter_to_exclude_from_url config
+        $request = $this->makeRequest([
+            'idsite' => $this->idSite,
+            'url' => 'https://example.com/page?gclid=abc&x=1',
+            'ua' => 'Claude-User/2.0',
+        ]);
+
+        $this->requestProcessor->handleRequest($request);
+
+        self::assertEquals('example.com/page?x=1', $this->getStoredActionName($this->idSite));
+    }
+
+    public function testDownloadUrlQueryParametersAreNotExcluded(): void
+    {
+        $idSite = Fixture::createWebsite(
+            '2025-01-01 00:00:00',
+            $ecommerce = 0,
+            $siteName = false,
+            $siteUrl = false,
+            $siteSearch = 1,
+            $searchKeywordParameters = null,
+            $searchCategoryParameters = null,
+            $timezone = null,
+            $type = null,
+            $excludeUnknownUrls = 0,
+            $excludedParameters = 'excluded'
+        );
+
+        $request = $this->makeRequest([
+            'idsite' => $idSite,
+            'url' => 'https://example.com/page',
+            'download' => 'https://example.com/document.pdf?excluded=secret',
+            'ua' => 'Claude-User/2.0',
+        ]);
+
+        $this->requestProcessor->handleRequest($request);
+
+        // Downloads must behave like normal tracking, which does not exclude parameters
+        self::assertEquals('example.com/document.pdf?excluded=secret', $this->getStoredActionName($idSite));
+    }
+
     /**
      * @dataProvider getBotUserAgents
      */
@@ -171,5 +241,22 @@ class BotRequestProcessorTest extends IntegrationTestCase
         ], $params);
 
         return new Request($params);
+    }
+
+    private function getStoredActionName(int $idSite): ?string
+    {
+        $tableName = BotRequestsDao::getPrefixedTableName();
+        $idActionUrl = Db::fetchOne(
+            "SELECT idaction_url FROM `{$tableName}` WHERE idsite = ? ORDER BY idrequest DESC LIMIT 1",
+            [$idSite]
+        );
+
+        if (empty($idActionUrl)) {
+            return null;
+        }
+
+        $actionTable = Common::prefixTable('log_action');
+
+        return Db::fetchOne("SELECT name FROM `{$actionTable}` WHERE idaction = ?", [$idActionUrl]);
     }
 }

--- a/plugins/BotTracking/tests/Integration/TrackerTest.php
+++ b/plugins/BotTracking/tests/Integration/TrackerTest.php
@@ -174,4 +174,50 @@ class TrackerTest extends IntegrationTestCase
         $sql       = "SELECT COUNT(*) FROM `{$tableName}`";
         self::assertEquals(1, Db::fetchOne($sql));
     }
+
+    public function testVisitsAndBotsShareActionsWhenQueryParametersAreExcluded(): void
+    {
+        $idSite = Fixture::createWebsite(
+            '2014-02-04',
+            $ecommerce = 0,
+            $siteName = false,
+            $siteUrl = false,
+            $siteSearch = 1,
+            $searchKeywordParameters = null,
+            $searchCategoryParameters = null,
+            $timezone = null,
+            $type = null,
+            $excludeUnknownUrls = 0,
+            $excludedParameters = 'excluded'
+        );
+
+        $url = 'https://matomo.org/faq/123?keep=1&excluded=secret';
+
+        // track a normal visit with the excluded parameter
+        $t = Fixture::getTracker($idSite, '2025-02-02 12:00:00');
+        $t->setUrl($url);
+        Fixture::checkResponse($t->doTrackPageView(''));
+
+        // track a bot request with the same URL
+        $t = Fixture::getTracker($idSite, '2025-02-02 12:00:00');
+        $t->setUserAgent('Gemini-Deep-Research/1.0');
+        $t->setUrl($url);
+        $t->setCustomTrackingParameter('recMode', '1');
+        Fixture::checkResponse($t->doTrackPageView(''));
+
+        // the bot request must store the same cleaned URL the normal visit stored,
+        // so both resolve to a single shared action
+        $tableName = BotRequestsDao::getPrefixedTableName();
+        $idActionUrl = Db::fetchOne("SELECT idaction_url FROM `{$tableName}` WHERE idsite = ?", [$idSite]);
+
+        $actionTable = Common::prefixTable('log_action');
+        $name = Db::fetchOne("SELECT name FROM `{$actionTable}` WHERE idaction = ?", [$idActionUrl]);
+        self::assertEquals('matomo.org/faq/123?keep=1', $name);
+
+        $count = Db::fetchOne("SELECT COUNT(*) FROM `{$actionTable}` WHERE name = ? AND type = ?", [
+            'matomo.org/faq/123?keep=1',
+            \Piwik\Tracker\Action::TYPE_PAGE_URL,
+        ]);
+        self::assertEquals(1, $count);
+    }
 }


### PR DESCRIPTION
### Description

BotTracking resolved page URLs via PageUrl::normalizeUrl() only, skipping the query parameter exclusion that normal page tracking applies. This made BotTracking store and report URLs that still contained excluded parameters, diverging from regular tracking for the same site.

Reuse PageUrl::excludeQueryParametersFromUrl() for page URLs, matching normal page tracking. Download URLs are intentionally left untouched, consistent with ActionDownloadUrl which does not exclude parameters from downloads.

refs #24591

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
