### PR TITLE
Record failed login attempt on 2FA failure when creating app specific token through API

### DIFF
--- a/plugins/TwoFactorAuth/TwoFactorAuth.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuth.php
@@ -152,13 +152,13 @@ class TwoFactorAuth extends \Piwik\Plugin
             $authCode = Common::getRequestVar('authCode', '', 'string');
             $twoFa = $this->getTwoFa();
 
-            if (
-                $authCode
-                && TwoFactorAuthentication::isUserUsingTwoFactorAuthentication($login)
-                && $twoFa->validateAuthCode($login, $authCode)
-            ) {
-                $sessionFingerprint = new SessionFingerprint();
-                $sessionFingerprint->setTwoFactorAuthenticationVerified($login);
+            if ($authCode && TwoFactorAuthentication::isUserUsingTwoFactorAuthentication($login)) {
+                if ($twoFa->validateAuthCode($login, $authCode)) {
+                    $sessionFingerprint = new SessionFingerprint();
+                    $sessionFingerprint->setTwoFactorAuthenticationVerified($login);
+                } else {
+                    $this->recordFailedTwoFactorAttempt($login);
+                }
             }
         }
     }

--- a/plugins/TwoFactorAuth/TwoFactorAuth.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuth.php
@@ -15,6 +15,7 @@ use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Exception\NoPrivilegesException;
 use Piwik\FrontController;
+use Piwik\IP;
 use Piwik\Piwik;
 use Piwik\Plugins\Login\Controller as LoginController;
 use Piwik\Request\AuthenticationToken;
@@ -196,9 +197,11 @@ class TwoFactorAuth extends \Piwik\Plugin
                 // we only return an error when the login/password combo was correct. otherwise you could brute force
                 // auth tokens
                 if (!$authCode) {
+                    $this->recordFailedTwoFactorAttempt($login);
                     throw new NoPrivilegesException(Piwik::translate('TwoFactorAuth_MissingAuthCodeAPI'));
                 }
                 if (!$twoFa->validateAuthCode($login, $authCode)) {
+                    $this->recordFailedTwoFactorAttempt($login);
                     throw new NoPrivilegesException(Piwik::translate('TwoFactorAuth_InvalidAuthCode'));
                 }
             } elseif (
@@ -207,6 +210,21 @@ class TwoFactorAuth extends \Piwik\Plugin
             ) {
                 throw new Exception(Piwik::translate('TwoFactorAuth_RequiredAuthCodeNotConfiguredAPI'));
             }
+        }
+    }
+
+    /**
+     * Records a failed login attempt so the existing brute-force protection can engage.
+     */
+    private function recordFailedTwoFactorAttempt(string $login): void
+    {
+        try {
+            $bruteForce = StaticContainer::get('Piwik\Plugins\Login\Security\BruteForceDetection');
+            if ($bruteForce->isEnabled()) {
+                $bruteForce->addFailedAttempt(IP::getIpFromHeader(), $login);
+            }
+        } catch (Exception $e) {
+            // ignore error eg if login plugin is disabled
         }
     }
 

--- a/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
@@ -90,7 +90,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
     public function tearDown(): void
     {
         $this->bruteForceDetection->deleteAll();
-        unset($_GET['authCode']);
+        unset($_GET['authCode'], $_GET['module'], $_GET['action']);
     }
 
     public function testLoginTwoFactorAuthRequiresFreshLoginWhenCurrentUserDoesNotMatchPendingSessionUser()
@@ -308,6 +308,33 @@ class TwoFactorAuthTest extends IntegrationTestCase
             'description' => 'twofa test',
         ));
         $this->assertEquals(32, strlen($token));
+    }
+
+    public function testOnSuccessfulSessionRecordsFailedAttemptWhenInvalidAuthCodeDuringLogme()
+    {
+        $_GET['module'] = 'Login';
+        $_GET['action'] = 'logme';
+        $_GET['authCode'] = '111222';
+
+        $this->assertCount(0, $this->bruteForceDetection->getAll());
+
+        $plugin = new TwoFactorAuth();
+        $plugin->onSuccessfulSession($this->userWith2Fa);
+
+        $attempts = $this->bruteForceDetection->getAll();
+        $this->assertCount(1, $attempts);
+        $this->assertSame($this->userWith2Fa, $attempts[0]['login']);
+    }
+
+    public function testOnSuccessfulSessionDoesNotRecordFailedAttemptWhenNoAuthCodeDuringLogme()
+    {
+        $_GET['module'] = 'Login';
+        $_GET['action'] = 'logme';
+
+        $plugin = new TwoFactorAuth();
+        $plugin->onSuccessfulSession($this->userWith2Fa);
+
+        $this->assertCount(0, $this->bruteForceDetection->getAll());
     }
 
     public function testOnDeleteUserRemovesAllRecoveryCodesWhenUsingTwoFa()

--- a/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
@@ -15,6 +15,7 @@ use Piwik\Auth;
 use Piwik\AuthResult;
 use Piwik\Session\SessionFingerprint;
 use Piwik\Container\StaticContainer;
+use Piwik\Plugins\Login\Security\BruteForceDetection;
 use Piwik\Plugins\TwoFactorAuth\Dao\RecoveryCodeDao;
 use Piwik\Plugins\TwoFactorAuth\Dao\TwoFaSecretRandomGenerator;
 use Piwik\Plugins\TwoFactorAuth\SystemSettings;
@@ -47,6 +48,11 @@ class TwoFactorAuthTest extends IntegrationTestCase
      */
     private $twoFa;
 
+    /**
+     * @var BruteForceDetection
+     */
+    private $bruteForceDetection;
+
     private $userWith2Fa = 'myloginWith';
     private $userWithout2Fa = 'myloginWithout';
     private $userPassword = '123abcDk3_l3';
@@ -74,11 +80,16 @@ class TwoFactorAuthTest extends IntegrationTestCase
         $this->dao->createRecoveryCodesForLogin($this->otherUserWith2Fa);
         $this->twoFa->saveSecret($this->userWith2Fa, $this->user2faSecret);
         $this->twoFa->saveSecret($this->otherUserWith2Fa, $this->otherUser2faSecret);
+
+        $this->bruteForceDetection = StaticContainer::get(BruteForceDetection::class);
+        $this->bruteForceDetection->deleteAll();
+
         unset($_GET['authCode']);
     }
 
     public function tearDown(): void
     {
+        $this->bruteForceDetection->deleteAll();
         unset($_GET['authCode']);
     }
 
@@ -221,6 +232,60 @@ class TwoFactorAuthTest extends IntegrationTestCase
             'passwordConfirmation' => $this->userPassword,
             'description' => 'twofa test',
         ));
+    }
+
+    public function testOnCreateAppSpecificTokenAuthRecordsFailedAttemptWhenInvalidAuthCode()
+    {
+        $this->assertCount(0, $this->bruteForceDetection->getAll());
+
+        $_GET['authCode'] = '111222';
+        try {
+            Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+                'userLogin' => $this->userWith2Fa,
+                'passwordConfirmation' => $this->userPassword,
+                'description' => 'twofa test',
+            ));
+            $this->fail('Expected an exception to be thrown for the invalid auth code');
+        } catch (\Exception $e) {
+            $this->assertStringContainsString('TwoFactorAuth_InvalidAuthCode', $e->getMessage());
+        }
+
+        $attempts = $this->bruteForceDetection->getAll();
+        $this->assertCount(1, $attempts);
+        $this->assertSame($this->userWith2Fa, $attempts[0]['login']);
+    }
+
+    public function testOnCreateAppSpecificTokenAuthRecordsFailedAttemptWhenMissingAuthCode()
+    {
+        $this->assertCount(0, $this->bruteForceDetection->getAll());
+
+        try {
+            Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+                'userLogin' => $this->userWith2Fa,
+                'passwordConfirmation' => $this->userPassword,
+                'description' => 'twofa test',
+            ));
+            $this->fail('Expected an exception to be thrown for the missing auth code');
+        } catch (\Exception $e) {
+            $this->assertStringContainsString('TwoFactorAuth_MissingAuthCodeAPI', $e->getMessage());
+        }
+
+        $attempts = $this->bruteForceDetection->getAll();
+        $this->assertCount(1, $attempts);
+        $this->assertSame($this->userWith2Fa, $attempts[0]['login']);
+    }
+
+    public function testOnCreateAppSpecificTokenAuthDoesNotRecordFailedAttemptWhenAuthCodeIsValid()
+    {
+        $_GET['authCode'] = $this->generateValidAuthCode($this->user2faSecret);
+        $token = Request::processRequest('UsersManager.createAppSpecificTokenAuth', array(
+            'userLogin' => $this->userWith2Fa,
+            'passwordConfirmation' => $this->userPassword,
+            'description' => 'twofa test',
+        ));
+
+        $this->assertEquals(32, strlen($token));
+        $this->assertCount(0, $this->bruteForceDetection->getAll());
     }
 
     public function testOnCreateAppSpecificTokenAuthReturnsCorrectTokenWhenProvidingCorrectAuthTokenOnAuthenticationUsingEmail()


### PR DESCRIPTION
### Description

Ensures the existing brute-force protection engages when an app specific token is requested with a missing or incorrect two-factor authentication code, consistent with the interactive login form.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
