### PR TITLE
CNIL:  Incorrectly reads the IP Anonymization

### DIFF
--- a/plugins/PrivacyManager/Settings/IpAddressMaskLength.php
+++ b/plugins/PrivacyManager/Settings/IpAddressMaskLength.php
@@ -69,7 +69,7 @@ class IpAddressMaskLength implements CustomSettingInterface, PolicyComparisonInt
     public static function getComplianceRequirementNote(?int $idSite = null): string
     {
         // TODO add in logic for generating message for different policy requirements
-        $currentValue = self::getInstance($idSite)->getValue();
+        $currentValue = self::getCurrentMaskLength($idSite);
         return Piwik::translate('PrivacyManager_AnonymizeIpMaskLengthSettingRequirementNote', [ 2, $currentValue ]);
     }
 
@@ -103,9 +103,19 @@ class IpAddressMaskLength implements CustomSettingInterface, PolicyComparisonInt
             return true;
         }
 
-        $currentValue = self::getInstance($idSite)->getValue();
+        $currentValue = self::getCurrentMaskLength($idSite);
 
         return $currentValue >= $policyValues[$policy];
+    }
+
+    private static function getCurrentMaskLength(?int $idSite = null): int
+    {
+        // When IP anonymization is disabled, the stored mask length is only a saved preference.
+        if (!IPAnonymisation::getInstance($idSite)->getValue()) {
+            return 0;
+        }
+
+        return (int) self::getInstance($idSite)->getValue();
     }
 
     protected static function compareStrictness($value1, $value2)

--- a/plugins/PrivacyManager/tests/Integration/ApiTest.php
+++ b/plugins/PrivacyManager/tests/Integration/ApiTest.php
@@ -13,7 +13,9 @@ use Exception;
 use Piwik\Access;
 use Piwik\Container\StaticContainer;
 use Piwik\NoAccessException;
+use Piwik\Policy\CnilPolicy;
 use Piwik\Plugins\PrivacyManager\API;
+use Piwik\Plugins\PrivacyManager\Settings\IpAddressMaskLength;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -124,6 +126,30 @@ class ApiTest extends IntegrationTestCase
             unset($_POST['token_auth']);
             unset($_POST['force_api_session']);
         }
+    }
+
+    public function testIpAddressMaskLengthComplianceUsesCurrentMaskLengthWhenIpAnonymizationIsDisabled(): void
+    {
+        $anonymizeIp = true;
+        $maskLength = 3;
+        $this->api->setAnonymizeIpSettings(
+            $anonymizeIp,
+            $maskLength,
+            true
+        );
+
+        $this->assertSame(3, IpAddressMaskLength::getCustomValue());
+        $this->assertTrue(IpAddressMaskLength::isCompliant(CnilPolicy::class, $this->siteId));
+
+        $anonymizeIp = false;
+        $this->api->setAnonymizeIpSettings(
+            $anonymizeIp,
+            $maskLength,
+            true
+        );
+
+        $this->assertSame($maskLength, IpAddressMaskLength::getCustomValue());
+        $this->assertFalse(IpAddressMaskLength::isCompliant(CnilPolicy::class, $this->siteId));
     }
 
     public function provideContainerConfig()


### PR DESCRIPTION
### Description
DEV-20322

This fixes the issue where `IP Address mask-length` still says compliant even though `IP Anonymization` is disabled

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
