### PR TITLE
Update CNIL retention period requirement to 759 days

### DIFF
--- a/plugins/PrivacyManager/Settings/ReportRetention.php
+++ b/plugins/PrivacyManager/Settings/ReportRetention.php
@@ -84,7 +84,7 @@ class ReportRetention implements
     public static function getPolicyRequirements(): array
     {
         $policyValues = [];
-        $policyValues[CnilPolicy::class] = 180;
+        $policyValues[CnilPolicy::class] = 759;
 
         return $policyValues;
     }

--- a/plugins/PrivacyManager/tests/Integration/PrivacyManagerTest.php
+++ b/plugins/PrivacyManager/tests/Integration/PrivacyManagerTest.php
@@ -22,8 +22,8 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class PrivacyManagerTest extends IntegrationTestCase
 {
-    public const DELETE_LOGS_OLDER_THAN = 270;
-    public const DELETE_LOGS_OLDER_THAN_CNIL = 180;
+    public const DELETE_LOGS_OLDER_THAN = 1000;
+    public const DELETE_LOGS_OLDER_THAN_CNIL = 759;
 
     /**
      * @var PrivacyManager


### PR DESCRIPTION
### Description

Correct log retention period requirement.

Fixes: #24631 

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
