### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2727,16 +2727,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -2788,7 +2788,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -2808,7 +2808,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php73",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
                                                      Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading symfony/polyfill-mbstring (v1.38.1 => v1.38.2)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downloading symfony/polyfill-mbstring (v1.38.2)
  - Upgrading symfony/polyfill-mbstring (v1.38.1 => v1.38.2): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
54 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Found 14 ignored security vulnerability advisories affecting 1 package.
Run "composer audit" for a full list of advisories.
```
