### PR TITLE
Fix flaky Incomple Period Visualization test

### DIFF
--- a/tests/PHPUnit/Fixtures/SomeVisitsLastYearAndThisYear.php
+++ b/tests/PHPUnit/Fixtures/SomeVisitsLastYearAndThisYear.php
@@ -23,10 +23,9 @@ class SomeVisitsLastYearAndThisYear extends Fixture
     public function setUp(): void
     {
         Fixture::createSuperUser();
+        $this->year = Date::today()->toString('Y');
         $this->setUpWebsites();
         $this->trackVisits();
-
-        $this->year = Date::today()->toString('Y');
     }
 
     public function tearDown(): void
@@ -45,19 +44,18 @@ class SomeVisitsLastYearAndThisYear extends Fixture
     private function trackVisits()
     {
 
-        // This year, 5 visits
-        for ($i = 0; $i < 5; $i++) {
-            $dateTime = Date::factory($this->year . '-01-01')->toString();
-            $t = self::getTracker($this->idSite, $dateTime, $defaultInit = true);
+        // This year, one visit with 5 page views
+        $this->trackVisitWithFivePageViews(Date::factory($this->year . '-01-01'));
 
-            $t->setUrl('http://example.org/index.htm');
-            self::checkResponse($t->doTrackPageView('0'));
-        }
+        // Last year, one visit with 5 page views
+        $this->trackVisitWithFivePageViews(Date::factory($this->year . '-01-01')->subYear(1));
+    }
 
-        // Last Year
+    private function trackVisitWithFivePageViews(Date $visitDateTime)
+    {
         for ($i = 0; $i < 5; $i++) {
-            $dateTime = Date::factory($this->year . '-01-01')->subYear(1)->toString();
-            $t = self::getTracker($this->idSite, $dateTime, $defaultInit = true);
+            // All page views share the same timestamp so the average visit duration is a stable 1s
+            $t = self::getTracker($this->idSite, $visitDateTime->getDatetime(), $defaultInit = true);
 
             $t->setUrl('http://example.org/index.htm');
             self::checkResponse($t->doTrackPageView('0'));


### PR DESCRIPTION
### Description

Fixes: https://github.com/matomo-org/matomo/issues/24436
DEV-20189

Fixing flaky test by making sure the year variable is actually defined before it is used to avoid the Date::factory(null, '-01-01') issue that is causing the flaky-ness

### Testing and Verification

This was verified by running the `IncompletePeriodVisualisation` spec test manually. 
I have been able to run 5 consecutive tests successfully:
 - https://github.com/matomo-org/matomo/actions/runs/27521259080
 - https://github.com/matomo-org/matomo/actions/runs/27521822578
 - https://github.com/matomo-org/matomo/actions/runs/27521927209
 - https://github.com/matomo-org/matomo/actions/runs/27522006889
 - https://github.com/matomo-org/matomo/actions/runs/27522417344

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
