### PR TITLE
Improve help icons and inline help in dark mode

### DIFF
--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -370,14 +370,14 @@ ul.browser-default {
         }
 
         .item-help-icon {
-          display:none;
+          display: none;
           opacity: 0.2;
           position: absolute;
           right: 0;
           top: 0;
           padding: 10px;
           line-height: 13px;
-          height: calc(100%);
+          height: 100%;
           align-items: center;
           justify-content: center;
 
@@ -389,11 +389,11 @@ ul.browser-default {
 
         &.menuTab li:hover {
           .item-help-icon:not(.active) {
-            display:inline-flex;
-            color: @color-black-matomo;
+            display: inline-flex;
+            color: @theme-color-text;
 
             &:hover {
-              color: @theme-color-help-background-color;
+              color: @theme-color-link;
               opacity: 0.75;
             }
           }
@@ -401,7 +401,7 @@ ul.browser-default {
 
         .item-help-icon.active {
           display: inline-flex;
-          color: @theme-color-help-background-color;
+          color: @theme-color-link;
           opacity: 0.75;
         }
 

--- a/plugins/CoreHome/vue/src/EnrichedHeadline/EnrichedHeadline.less
+++ b/plugins/CoreHome/vue/src/EnrichedHeadline/EnrichedHeadline.less
@@ -15,11 +15,11 @@
 
     .inlineHelp {
         display: block;
-        background: #F7F7F7;
+        background: @theme-color-background-base;
         font-size: 12px;
         line-height: 1.1;
         font-weight: normal;
-        border: 1px solid #E4E5E4;
+        border: 1px solid @theme-color-border-alternative;
         margin: 10px 0 10px 0;
         padding: 10px;
         border-radius: 2px;
@@ -56,7 +56,7 @@
         text-decoration: none;
 
         &:hover, &.active {
-            color: @theme-color-help-background-color !important;
+            color: @theme-color-link !important;
             opacity: 0.9;
             text-decoration: none;
         }

--- a/plugins/Morpheus/stylesheets/base/colors.less
+++ b/plugins/Morpheus/stylesheets/base/colors.less
@@ -95,7 +95,6 @@
 
 @default-box-shade: 0 2px 3px 0 rgba(0,0,0,0.16), 0 0px 3px 0 rgba(0,0,0,0.12);
 
-@theme-color-help-background-color: #6200ea;
 /*
 Qualitative data color series inspired from colorbrewer2.org/
 next ones could be: #cab2d6 #ffff99 # #b2df8a

--- a/tests/UI/expected-screenshots/UIIntegrationTest_actions_pages_tooltip_help.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_actions_pages_tooltip_help.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec9d740ffe7eb848eb86c73c263a9891af807a8cb9d27e51a2aa4cbfc5a19015
-size 391915
+oid sha256:36d949bde8c16718b743843a45e5e4a5bb8c6542c0810184838a38ff589597b3
+size 391835

--- a/tests/UI/expected-screenshots/UIIntegrationTest_category_help.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_category_help.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33970f424d69fc8a215558dcf71263adcb9f80dbb5751c80f92f77889eddbcbf
-size 156759
+oid sha256:5384dbaba59212b08f1f0fc641f68bc40c0cef902aebc06c93fda2b3c27af704
+size 156792


### PR DESCRIPTION
### Description

Improve dark mode for help icons and inline help

| *before* | *after* |
|---|---|
| <img width="414" height="366" alt="Screenshot 2026-06-17 at 01 23 17" src="https://github.com/user-attachments/assets/9a7ba2c6-0d04-4e83-a737-e07b21ebd517" /> | <img width="414" height="366" alt="Screenshot 2026-06-17 at 01 23 38" src="https://github.com/user-attachments/assets/b3fa7063-a218-4a8c-9662-b59e775a68a8" /> |
| <img width="414" height="366" alt="Screenshot 2026-06-17 at 01 23 21" src="https://github.com/user-attachments/assets/0b77ae71-f316-44c0-be74-b9924b5ffccc" /> | <img width="414" height="366" alt="Screenshot 2026-06-17 at 01 23 41" src="https://github.com/user-attachments/assets/ef86e3a3-06bb-4e9f-b091-4249ab655ee6" /> |
| <img width="414" height="366" alt="Screenshot 2026-06-17 at 01 22 24" src="https://github.com/user-attachments/assets/dd3bb78a-9a8e-422a-ba52-751e8dcdf529" /> | <img width="414" height="366" alt="Screenshot 2026-06-17 at 01 23 52" src="https://github.com/user-attachments/assets/19112ca4-e985-459a-959d-8a6d14a3a9fc" /> |
| <img width="414" height="366" alt="Screenshot 2026-06-17 at 01 22 28" src="https://github.com/user-attachments/assets/ac27bd31-84b6-4042-8c9d-9dcfb6c3a6ea" /> | <img width="414" height="366" alt="Screenshot 2026-06-17 at 01 23 56" src="https://github.com/user-attachments/assets/17e04ef8-0530-48be-8f64-8b6fa0b10a38" /> |
| <img width="617" height="200" alt="Screenshot 2026-06-17 at 01 29 32" src="https://github.com/user-attachments/assets/fdbbbd91-c0d9-49be-8a42-635a66faf7fb" /> | <img width="617" height="200" alt="Screenshot 2026-06-17 at 01 29 40" src="https://github.com/user-attachments/assets/9487ab94-2388-44fb-8bc1-39003b41af58" /> |
| <img width="617" height="200" alt="Screenshot 2026-06-17 at 01 29 57" src="https://github.com/user-attachments/assets/96388232-11ee-4d97-99f1-ac38203b54f4" /> | <img width="617" height="200" alt="Screenshot 2026-06-17 at 01 30 18" src="https://github.com/user-attachments/assets/6b172f09-4ee2-47ae-ac89-0f2538309edb" /> |
| <img width="617" height="200" alt="Screenshot 2026-06-17 at 01 30 27" src="https://github.com/user-attachments/assets/01cc54bd-7a87-4753-a7cc-1745d100523d" /> | <img width="617" height="200" alt="Screenshot 2026-06-17 at 01 30 23" src="https://github.com/user-attachments/assets/f742a954-f5cf-4bc4-850c-7cd7d648254f" /> |


issue dev-20169

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
