### PR TITLE
Overlay: tidy session bootstrap and canonicalise iframe URL

### DIFF
--- a/core/Request/AuthenticationToken.php
+++ b/core/Request/AuthenticationToken.php
@@ -103,13 +103,15 @@ class AuthenticationToken
         }
 
         $get = Request::fromGet();
-        $getTokenAuth = $get->getStringParameter('token_auth', '');
-        if (!empty($getTokenAuth)) {
-            $tokenAuthBySource['get'] = $getTokenAuth;
-        }
+        if (!$this->isNavigationOnlyEndpoint()) {
+            $getTokenAuth = $get->getStringParameter('token_auth', '');
+            if (!empty($getTokenAuth)) {
+                $tokenAuthBySource['get'] = $getTokenAuth;
+            }
 
-        if (array_key_exists('force_api_session', $_GET)) {
-            $forceApiSessionBySource['get'] = $get->getBoolParameter('force_api_session', false);
+            if (array_key_exists('force_api_session', $_GET)) {
+                $forceApiSessionBySource['get'] = $get->getBoolParameter('force_api_session', false);
+            }
         }
 
         $this->throwIfValuesConflict($tokenAuthBySource);
@@ -180,6 +182,10 @@ class AuthenticationToken
 
     private function initTokenFromGetRequest(): bool
     {
+        if ($this->isNavigationOnlyEndpoint()) {
+            return false;
+        }
+
         $request = Request::fromGet();
         $tokenAuth = $request->getStringParameter('token_auth', '');
 
@@ -191,6 +197,27 @@ class AuthenticationToken
         }
 
         return false;
+    }
+
+    /**
+     * Some endpoints exist only as browser navigations, not as API entry points. They are reached
+     * via a top-level GET and hand off to another page, so GET credentials are not part of their
+     * request contract and must not be consumed as authentication.
+     *
+     * Keep this list extremely small. Only add an endpoint here once it has been independently
+     * confirmed that the endpoint never needs URL-borne auth and never performs writes.
+     */
+    private function isNavigationOnlyEndpoint(): bool
+    {
+        if (SettingsServer::isTrackerApiRequest()) {
+            return false;
+        }
+
+        $get = Request::fromGet();
+        $module = $get->getStringParameter('module', '');
+        $action = $get->getStringParameter('action', '');
+
+        return $module === 'Overlay' && $action === 'startOverlaySession';
     }
 
     private function getTokenAuthFromHeader(): ?string

--- a/core/View.php
+++ b/core/View.php
@@ -508,7 +508,7 @@ class View implements ViewInterface
     }
 
     /**
-     * Sets whether a strict Referrer-Policy header will be sent (if not, nothing is sent).
+     * Sets whether a strict Referrer-Policy header will be sent.
      *
      * Passing `false` relaxes the response policy to `no-referrer-when-downgrade`, which exposes
      * the full request URL — including its query string — as the outgoing `Referer` header on the

--- a/core/View.php
+++ b/core/View.php
@@ -510,6 +510,15 @@ class View implements ViewInterface
     /**
      * Sets whether a strict Referrer-Policy header will be sent (if not, nothing is sent).
      *
+     * Passing `false` relaxes the response policy to `no-referrer-when-downgrade`, which exposes
+     * the full request URL — including its query string — as the outgoing `Referer` header on the
+     * next navigation, even across origins. Callers that disable the strict policy MUST ensure
+     * the current request URL carries no credentials (e.g. `token_auth`) or other sensitive
+     * parameters at the moment any subsequent cross-origin navigation runs. The established
+     * pattern is to rewrite the URL down to its required handshake fields before redirecting;
+     * see `plugins/Overlay/templates/startOverlaySession.twig` (`canonicalizeOverlayUrl()`) and
+     * `plugins/Overlay/Controller.php::startOverlaySession()` for a worked example.
+     *
      * @param bool $useStrictReferrerPolicy
      */
     public function setUseStrictReferrerPolicy($useStrictReferrerPolicy)

--- a/plugins/Overlay/Controller.php
+++ b/plugins/Overlay/Controller.php
@@ -185,6 +185,10 @@ class Controller extends \Piwik\Plugin\Controller
         $view->mainUrl   = $site['main_url'];
 
         $this->outputCORSHeaders();
+        // piwik.js::isOverlaySession() detects an Overlay session from this navigation URL.
+        // A strict referrer policy would strip the path/query and break that handshake, so the
+        // policy is relaxed here. Keep the URL canonical: only module, action, idSite, period,
+        // date, and segment belong on it. See canonicalizeOverlayUrl() in startOverlaySession.twig.
         $view->setUseStrictReferrerPolicy(false);
         Common::sendHeader('Content-Type: text/html; charset=UTF-8');
 

--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -21,6 +21,7 @@ var Piwik_Overlay = (function () {
     var idSite, period, date, segment;
 
     var iframeSrcBase;
+    var iframePostParams = null;
     var iframeDomain = '';
     var iframeCurrentPage = '';
     var iframeCurrentPageNormalized = '';
@@ -194,13 +195,36 @@ var Piwik_Overlay = (function () {
             if (location) {
                 iframeUrl += '#' + location;
             }
-            $iframe.attr('src', iframeUrl);
+            if (iframePostParams) {
+                submitIframePost(iframeUrl);
+            } else {
+                $iframe.attr('src', iframeUrl);
+            }
             showLoading();
         } else {
             loadSidebar(location);
         }
 
         updateComesFromInsideFrame = false;
+    }
+
+    function submitIframePost(iframeUrl) {
+        var $form = $('<form method="post" style="display:none"></form>');
+        $form.attr('action', iframeUrl);
+        $form.attr('target', 'overlayIframe');
+
+        Object.keys(iframePostParams).forEach(function (key) {
+            $('<input type="hidden">')
+                .attr('name', key)
+                .val(iframePostParams[key])
+                .appendTo($form);
+        });
+
+        $form.appendTo($body);
+        $form[0].submit();
+        window.setTimeout(function () {
+            $form.remove();
+        }, 0);
     }
 
     function handleApiRequests() {
@@ -271,8 +295,9 @@ var Piwik_Overlay = (function () {
     return {
 
         /** This method is called when Overlay loads  */
-        init: function (iframeSrc, pIdSite, pPeriod, pDate, pSegment) {
+        init: function (iframeSrc, pIdSite, pPeriod, pDate, pSegment, pIframePostParams) {
             iframeSrcBase = iframeSrc;
+            iframePostParams = pIframePostParams || null;
             idSite = pIdSite;
             period = pPeriod;
             date = pDate;

--- a/plugins/Overlay/templates/index.twig
+++ b/plugins/Overlay/templates/index.twig
@@ -73,8 +73,17 @@
             // The startOverlaySession URL is matched by piwik.js::isOverlaySession(). Only the
             // canonical handshake parameters (module, action, idSite, period, date, segment) belong here.
             var iframeSrc = 'index.php?module=Overlay&action=startOverlaySession&idSite={{ idSite }}&period={{ period }}&date={{ rawDate }}&segment={{ segment }}';
+            var iframePostParams = null;
+            if (piwik.shouldPropagateTokenAuth) {
+                iframePostParams = {
+                    token_auth: piwik.token_auth
+                };
+                if (!piwik.broadcast.isWidgetizeRequestWithoutSession()) {
+                    iframePostParams.force_api_session = '1';
+                }
+            }
 
-            Piwik_Overlay.init(iframeSrc, '{{ idSite }}', '{{ period }}', '{{ rawDate }}', '{{ segment }}');
+            Piwik_Overlay.init(iframeSrc, '{{ idSite }}', '{{ period }}', '{{ rawDate }}', '{{ segment }}', iframePostParams);
 
             window.Piwik_Overlay_Translations = {
                 domain: "{{ 'Overlay_Domain'|translate }}"

--- a/plugins/Overlay/templates/index.twig
+++ b/plugins/Overlay/templates/index.twig
@@ -70,13 +70,9 @@
         $(function () {
             Piwik_Overlay.siteUrls = {{ siteUrls|json_encode|raw }};
 
+            // The startOverlaySession URL is matched by piwik.js::isOverlaySession(). Only the
+            // canonical handshake parameters (module, action, idSite, period, date, segment) belong here.
             var iframeSrc = 'index.php?module=Overlay&action=startOverlaySession&idSite={{ idSite }}&period={{ period }}&date={{ rawDate }}&segment={{ segment }}';
-            if (piwik.shouldPropagateTokenAuth) {
-                if (!piwik.broadcast.isWidgetizeRequestWithoutSession()) {
-                    iframeSrc += '&force_api_session=1';
-                }
-                iframeSrc += '&token_auth=' + piwik.token_auth;
-            }
 
             Piwik_Overlay.init(iframeSrc, '{{ idSite }}', '{{ period }}', '{{ rawDate }}', '{{ segment }}');
 

--- a/plugins/Overlay/templates/index_noframe.twig
+++ b/plugins/Overlay/templates/index_noframe.twig
@@ -10,13 +10,42 @@
         // canonical handshake parameters (module, action, idSite, period, date, segment) belong here.
         var newLocation = 'index.php?module=Overlay&action=startOverlaySession&idSite={{ idSite }}&period={{ period }}&date={{ date }}&segment={{ segment }}';
 
+        function submitPostNavigation(action, params) {
+            var form = document.createElement('form');
+            form.method = 'post';
+            form.action = action;
+            form.style.display = 'none';
+
+            Object.keys(params).forEach(function (key) {
+                var input = document.createElement('input');
+                input.type = 'hidden';
+                input.name = key;
+                input.value = params[key];
+                form.appendChild(input);
+            });
+
+            document.body.appendChild(form);
+            form.submit();
+        }
+
         var locationParts = window.location.href.split('#');
         if (locationParts.length > 1) {
             var url = broadcast.getParamValue('l', locationParts[1]);
             url = Overlay_Helper.decodeFrameUrl(url);
             newLocation += '#' + url;
         }
-        window.location.href = newLocation;
+
+        if (piwik.shouldPropagateTokenAuth) {
+            var postParams = {
+                token_auth: piwik.token_auth
+            };
+            if (!piwik.broadcast.isWidgetizeRequestWithoutSession()) {
+                postParams.force_api_session = '1';
+            }
+            submitPostNavigation(newLocation, postParams);
+        } else {
+            window.location.href = newLocation;
+        }
     </script>
 
 </div>

--- a/plugins/Overlay/templates/index_noframe.twig
+++ b/plugins/Overlay/templates/index_noframe.twig
@@ -6,13 +6,9 @@
 <div id="overlayNoFrame">
 
     <script type="text/javascript">
+        // The startOverlaySession URL is matched by piwik.js::isOverlaySession(). Only the
+        // canonical handshake parameters (module, action, idSite, period, date, segment) belong here.
         var newLocation = 'index.php?module=Overlay&action=startOverlaySession&idSite={{ idSite }}&period={{ period }}&date={{ date }}&segment={{ segment }}';
-        if (piwik.shouldPropagateTokenAuth) {
-            if (!piwik.broadcast.isWidgetizeRequestWithoutSession()) {
-                newLocation += '&force_api_session=1';
-            }
-            newLocation += '&token_auth=' + piwik.token_auth;
-        }
 
         var locationParts = window.location.href.split('#');
         if (locationParts.length > 1) {

--- a/plugins/Overlay/templates/startOverlaySession.twig
+++ b/plugins/Overlay/templates/startOverlaySession.twig
@@ -8,6 +8,53 @@
         }
     }
 
+    // Keep the current URL in the canonical Overlay handshake shape before navigating away.
+    // piwik.js::isOverlaySession() depends on this field order, and unrelated parameters do not
+    // belong in this navigation contract.
+    function canonicalizeOverlayUrl() {
+        if (!window.history || typeof window.history.replaceState !== 'function') {
+            return;
+        }
+
+        var search = window.location.search || '';
+        if (search.charAt(0) === '?') {
+            search = search.substring(1);
+        }
+
+        var values = {};
+        if (search.length) {
+            var pairs = search.split('&');
+            for (var i = 0; i < pairs.length; i++) {
+                var eq = pairs[i].indexOf('=');
+                if (eq === -1) {
+                    continue;
+                }
+                values[pairs[i].substring(0, eq)] = pairs[i].substring(eq + 1);
+            }
+        }
+
+        // Order must match the regex in piwik.js::isOverlaySession().
+        var canonicalFields = ['module', 'action', 'idSite', 'period', 'date', 'segment'];
+        var rebuilt = [];
+        for (var j = 0; j < canonicalFields.length; j++) {
+            var field = canonicalFields[j];
+            if (Object.prototype.hasOwnProperty.call(values, field)) {
+                rebuilt.push(field + '=' + values[field]);
+            }
+        }
+
+        var cleanedUrl = window.location.pathname + (rebuilt.length ? '?' + rebuilt.join('&') : '') + window.location.hash;
+        try {
+            window.history.replaceState(null, '', cleanedUrl);
+        } catch (e) {
+            // history.replaceState can throw in unusual sandboxed contexts; fall through so the
+            // history.replaceState can throw in unusual sandboxed contexts; fall through so the
+            // redirect still happens.
+        }
+    }
+
+    canonicalizeOverlayUrl();
+
     if (window.location.hash) {
         var match = false;
         var parser = document.createElement('a');
@@ -23,15 +70,7 @@
                 var testHost = parser.hostname;
                 if (hostToRedirect === testHost && testHost) {
                     match = true;
-                    if (navigator.appName == "Microsoft Internet Explorer") {
-                        // internet explorer loses the referrer if we use window.location.href=X
-                        var referLink = document.createElement("a");
-                        referLink.href = handleProtocol(urlToRedirect);
-                        document.body.appendChild(referLink);
-                        referLink.click();
-                    } else {
-                        window.location.href = handleProtocol(urlToRedirect);
-                    }
+                    window.location.href = handleProtocol(urlToRedirect);
                     break;
                 }
             }

--- a/plugins/Overlay/templates/startOverlaySession.twig
+++ b/plugins/Overlay/templates/startOverlaySession.twig
@@ -48,7 +48,6 @@
             window.history.replaceState(null, '', cleanedUrl);
         } catch (e) {
             // history.replaceState can throw in unusual sandboxed contexts; fall through so the
-            // history.replaceState can throw in unusual sandboxed contexts; fall through so the
             // redirect still happens.
         }
     }

--- a/plugins/Overlay/tests/Unit/OverlayTest.php
+++ b/plugins/Overlay/tests/Unit/OverlayTest.php
@@ -137,20 +137,35 @@ class OverlayTest extends \PHPUnit\Framework\TestCase
         self::assertNotFalse($contents, 'Could not read template ' . $relativeTemplatePath);
 
         self::assertStringNotContainsString(
-            'token_auth',
+            '&token_auth',
             $contents,
             $relativeTemplatePath . ' must not append disallowed credential parameters to the startOverlaySession URL.'
         );
         self::assertStringNotContainsString(
-            'force_api_session',
+            '&force_api_session',
             $contents,
             $relativeTemplatePath . ' must not append session bootstrap parameters to the startOverlaySession URL.'
         );
-        self::assertStringNotContainsString(
-            'piwik.shouldPropagateTokenAuth',
-            $contents,
-            $relativeTemplatePath . ' must not gate URL building on request-auth propagation.'
-        );
+    }
+
+    public function testOverlayNavigationUsesPostHandoffWhenRequestAuthPropagationIsEnabled()
+    {
+        $indexContents = file_get_contents(__DIR__ . '/../../templates/index.twig');
+        $noFrameContents = file_get_contents(__DIR__ . '/../../templates/index_noframe.twig');
+        $overlayJsContents = file_get_contents(__DIR__ . '/../../javascripts/Piwik_Overlay.js');
+
+        self::assertNotFalse($indexContents);
+        self::assertNotFalse($noFrameContents);
+        self::assertNotFalse($overlayJsContents);
+
+        self::assertStringContainsString('iframePostParams = {', $indexContents);
+        self::assertStringContainsString('Piwik_Overlay.init(iframeSrc', $indexContents);
+        self::assertStringContainsString('iframePostParams);', $indexContents);
+
+        self::assertStringContainsString('submitPostNavigation(newLocation, postParams);', $noFrameContents);
+
+        self::assertStringContainsString('submitIframePost(iframeUrl);', $overlayJsContents);
+        self::assertStringContainsString('function submitIframePost(iframeUrl)', $overlayJsContents);
     }
 
     public function getOverlayNavigationTemplates(): array

--- a/plugins/Overlay/tests/Unit/OverlayTest.php
+++ b/plugins/Overlay/tests/Unit/OverlayTest.php
@@ -127,7 +127,12 @@ class OverlayTest extends \PHPUnit\Framework\TestCase
 
     /**
      * The Overlay parent templates build the startOverlaySession navigation URL. Keep that URL
-     * limited to the canonical handshake parameters.
+     * limited to the canonical handshake parameters — no `token_auth` or `force_api_session`
+     * may appear as a query-string parameter (either prefixed with `?` or `&`).
+     *
+     * The matching pattern intentionally requires the `?`/`&` prefix and the `=` suffix so it
+     * only fires on URL query-string appends, not on incidental identifier references in
+     * comments or in the JS object literal that builds the POST-handoff body.
      *
      * @dataProvider getOverlayNavigationTemplates
      */
@@ -136,18 +141,22 @@ class OverlayTest extends \PHPUnit\Framework\TestCase
         $contents = file_get_contents(__DIR__ . '/../../templates/' . $relativeTemplatePath);
         self::assertNotFalse($contents, 'Could not read template ' . $relativeTemplatePath);
 
-        self::assertStringNotContainsString(
-            '&token_auth',
+        self::assertNotRegExp(
+            '/[?&](token_auth|force_api_session)=/',
             $contents,
-            $relativeTemplatePath . ' must not append disallowed credential parameters to the startOverlaySession URL.'
-        );
-        self::assertStringNotContainsString(
-            '&force_api_session',
-            $contents,
-            $relativeTemplatePath . ' must not append session bootstrap parameters to the startOverlaySession URL.'
+            $relativeTemplatePath . ' must not append token_auth or force_api_session to the startOverlaySession URL'
+                . ' as a query-string parameter.'
         );
     }
 
+    /**
+     * The credential propagation that previously rode on the URL must now travel via the POST
+     * handoff. These assertions intentionally couple to the specific helper/identifier names in
+     * the JS: a future maintainer renaming `submitPostNavigation`, `submitIframePost`, or
+     * `iframePostParams` should re-pin these assertions to the new names rather than delete
+     * them. The pinning ensures a refactor that accidentally drops the POST hand-off path
+     * (and falls back to URL propagation) will fail this test.
+     */
     public function testOverlayNavigationUsesPostHandoffWhenRequestAuthPropagationIsEnabled()
     {
         $indexContents = file_get_contents(__DIR__ . '/../../templates/index.twig');

--- a/plugins/Overlay/tests/Unit/OverlayTest.php
+++ b/plugins/Overlay/tests/Unit/OverlayTest.php
@@ -124,4 +124,77 @@ class OverlayTest extends \PHPUnit\Framework\TestCase
             ],
         ];
     }
+
+    /**
+     * The Overlay parent templates build the startOverlaySession navigation URL. Keep that URL
+     * limited to the canonical handshake parameters.
+     *
+     * @dataProvider getOverlayNavigationTemplates
+     */
+    public function testOverlayNavigationTemplateKeepsCanonicalHandshakeUrl(string $relativeTemplatePath)
+    {
+        $contents = file_get_contents(__DIR__ . '/../../templates/' . $relativeTemplatePath);
+        self::assertNotFalse($contents, 'Could not read template ' . $relativeTemplatePath);
+
+        self::assertStringNotContainsString(
+            'token_auth',
+            $contents,
+            $relativeTemplatePath . ' must not append disallowed credential parameters to the startOverlaySession URL.'
+        );
+        self::assertStringNotContainsString(
+            'force_api_session',
+            $contents,
+            $relativeTemplatePath . ' must not append session bootstrap parameters to the startOverlaySession URL.'
+        );
+        self::assertStringNotContainsString(
+            'piwik.shouldPropagateTokenAuth',
+            $contents,
+            $relativeTemplatePath . ' must not gate URL building on request-auth propagation.'
+        );
+    }
+
+    public function getOverlayNavigationTemplates(): array
+    {
+        return [
+            ['index.twig'],
+            ['index_noframe.twig'],
+        ];
+    }
+
+    /**
+     * piwik.js::isOverlaySession() matches the canonical handshake fields. The
+     * startOverlaySession template canonicalizes its URL before continuing, and the resulting
+     * shape must still match.
+     *
+     * The regex below is the one in js/piwik.js. If it changes there, this test must change too.
+     *
+     * @dataProvider getCanonicalOverlayReferrers
+     */
+    public function testCanonicalOverlayReferrerMatchesPiwikJsRegex(string $referrer, bool $expectMatch)
+    {
+        $piwikJsRegex = '#index\.php\?module=Overlay&action=startOverlaySession&idSite=([0-9]+)&period=([^&]+)&date=([^&]+)(&segment=[^&]*)?#';
+        self::assertSame($expectMatch, (bool) preg_match($piwikJsRegex, $referrer));
+    }
+
+    public function getCanonicalOverlayReferrers(): array
+    {
+        return [
+            'canonical URL without segment matches' => [
+                'https://matomo.example/index.php?module=Overlay&action=startOverlaySession&idSite=1&period=day&date=today',
+                true,
+            ],
+            'canonical URL with segment matches' => [
+                'https://matomo.example/index.php?module=Overlay&action=startOverlaySession&idSite=2&period=range&date=2020-01-01,2020-12-31&segment=visitIp%3D%3D1.2.3.4',
+                true,
+            ],
+            'canonical URL with empty segment still matches' => [
+                'https://matomo.example/index.php?module=Overlay&action=startOverlaySession&idSite=3&period=day&date=today&segment=',
+                true,
+            ],
+            'reordered parameters do not match' => [
+                'https://matomo.example/index.php?action=startOverlaySession&module=Overlay&idSite=1&period=day&date=today',
+                false,
+            ],
+        ];
+    }
 }

--- a/plugins/Overlay/tests/Unit/OverlayTest.php
+++ b/plugins/Overlay/tests/Unit/OverlayTest.php
@@ -132,7 +132,9 @@ class OverlayTest extends \PHPUnit\Framework\TestCase
      *
      * The matching pattern intentionally requires the `?`/`&` prefix and the `=` suffix so it
      * only fires on URL query-string appends, not on incidental identifier references in
-     * comments or in the JS object literal that builds the POST-handoff body.
+     * comments or in the JS object literal that builds the POST-handoff body. The optional
+     * `amp;` group also covers the case where a future refactor moves the URL into an HTML
+     * attribute and the Twig auto-escape rewrites `&` to `&amp;`.
      *
      * @dataProvider getOverlayNavigationTemplates
      */
@@ -142,7 +144,7 @@ class OverlayTest extends \PHPUnit\Framework\TestCase
         self::assertNotFalse($contents, 'Could not read template ' . $relativeTemplatePath);
 
         self::assertNotRegExp(
-            '/[?&](token_auth|force_api_session)=/',
+            '/[?&](?:amp;)?(token_auth|force_api_session)=/',
             $contents,
             $relativeTemplatePath . ' must not append token_auth or force_api_session to the startOverlaySession URL'
                 . ' as a query-string parameter.'

--- a/tests/PHPUnit/Unit/Request/AuthenticationToken.php
+++ b/tests/PHPUnit/Unit/Request/AuthenticationToken.php
@@ -304,6 +304,78 @@ class AuthenticationToken extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    /**
+     * Overlay.startOverlaySession is a browser navigation endpoint with a fixed request shape.
+     * GET credentials are not part of that shape and must not be consumed as authentication.
+     *
+     * @dataProvider provideOverlayNavigationEndpointData
+     */
+    public function testGetAuthenticationTokenIgnoresGetCredentialsOnOverlayNavigationEndpoint(array $getParams)
+    {
+        $_GET = array_merge(['module' => 'Overlay', 'action' => 'startOverlaySession'], $getParams);
+        $_POST = [];
+        $_SERVER['HTTP_AUTHORIZATION'] = null;
+
+        $token = new \Piwik\Request\AuthenticationToken();
+
+        self::assertSame('', $token->getAuthToken());
+        self::assertFalse($token->wasTokenAuthProvidedSecurely());
+        self::assertFalse($token->isSessionToken());
+    }
+
+    public function provideOverlayNavigationEndpointData(): iterable
+    {
+        yield 'GET token_auth alone is ignored' => [
+            ['token_auth' => 'shouldBeIgnoredAccessToken'],
+        ];
+
+        yield 'GET token_auth with force_api_session is ignored' => [
+            ['token_auth' => 'shouldBeIgnoredAccessToken', 'force_api_session' => 1],
+        ];
+
+        yield 'GET force_api_session without token is ignored' => [
+            ['force_api_session' => 1],
+        ];
+    }
+
+    public function testOverlayNavigationEndpointDoesNotTreatGetTokenAsConflict()
+    {
+        // A session-authenticated user reaching startOverlaySession with stale GET credentials
+        // must not trigger a conflicting-auth-parameters exception, since the GET value is
+        // ignored on this endpoint.
+        $_GET = [
+            'module' => 'Overlay',
+            'action' => 'startOverlaySession',
+            'token_auth' => 'staleGetToken',
+        ];
+        $_POST = ['token_auth' => 'differentPostToken'];
+        $_SERVER['HTTP_AUTHORIZATION'] = null;
+
+        $token = new \Piwik\Request\AuthenticationToken();
+
+        self::assertSame('differentPostToken', $token->getAuthToken());
+    }
+
+    public function testGetAuthenticationTokenStillAcceptsGetTokenOnOtherEndpoints()
+    {
+        // Sanity check: the navigation-only exception is scoped to module=Overlay&action=startOverlaySession.
+        // Other endpoints that legitimately accept token_auth in the URL (widgetize, tracker, etc.)
+        // continue to work as before.
+        $_GET = [
+            'module' => 'API',
+            'action' => 'index',
+            'method' => 'API.getMatomoVersion',
+            'token_auth' => 'someAccessToken',
+        ];
+        $_POST = [];
+        $_SERVER['HTTP_AUTHORIZATION'] = null;
+
+        $token = new \Piwik\Request\AuthenticationToken();
+
+        self::assertSame('someAccessToken', $token->getAuthToken());
+        self::assertFalse($token->wasTokenAuthProvidedSecurely());
+    }
+
     private function setNestedApiInvocationCount(int $count): void
     {
         $reflectionClass = new \ReflectionClass(\Piwik\API\Request::class);


### PR DESCRIPTION
## Summary

  - Drop the obsolete Internet Explorer branch in `startOverlaySession.twig` and tidy the surrounding session bootstrap.
  - Move Overlay's iframe credential propagation from the GET query string onto a POST handoff, aligning with how `AjaxHelper.fetch({ withTokenInUrl: true })` already passes credentials elsewhere in the codebase.
  - Canonicalise the iframe's request URL with `history.replaceState` before the cross-origin redirect so the URL `piwik.js::isOverlaySession()` reads back on the tracked website only contains the canonical handshake fields.
  - Scope the auth-token entry point so a GET `token_auth` supplied on the navigation-only `Overlay.startOverlaySession` endpoint is no longer treated as an auth source — that endpoint immediately redirects and was never intended as an API entry.
  - Document the request-shape contract `piwik.js` depends on; add a forward-compat note on
  `View::setUseStrictReferrerPolicy()` describing what disabling the strict policy implies for downstream navigations.

  ## Background

  The Overlay session bootstrap predates several conventions that the rest of the codebase has settled on:

  - `AjaxHelper.fetch({ withTokenInUrl: true })` already routes credentials through the POST body and explicitly
  strips them from any GET (`plugins/CoreHome/vue/src/AjaxHelper/AjaxHelper.ts:992-1041`). The Overlay iframe was the
  odd one out.
  - The `setUseStrictReferrerPolicy(false)` callsite needs the request URL to stay canonical so the tracker's
  `isOverlaySession()` regex on the tracked site continues to match — but that requirement was nowhere written down.
  - `startOverlaySession` is a navigation-only top-level entry that immediately redirects. Treating GET parameters on
  it as auth sources mixes concerns the rest of the auth layer doesn't.
  - The `navigator.appName == "Microsoft Internet Explorer"` branch in `startOverlaySession.twig` is dead code now
  that Matomo has dropped IE support.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
