### PR TITLE
Preload relocated psr/log classes before applying a one-click update

### DIFF
--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -339,8 +339,40 @@ class Updater
         return $disabledPluginNames;
     }
 
+    /**
+     * Some dependency classes move to a different file path between Matomo major versions (for example
+     * psr/log moved from Psr/Log to src). Loading them now - while the current files are still in place -
+     * keeps them available to this already running process after installNewFiles() has replaced the files.
+     * Otherwise the initialised autoloader can no longer resolve them from their old paths and the rest of
+     * the update request fails (e.g. "Class Psr\Log\NullLogger not found").
+     *
+     * This is only needed for the one-click update from Matomo 5 to Matomo 6 (the upgrade in which psr/log
+     * relocates). It can be removed again in Matomo 6: once an install runs Matomo 6 the classes are already
+     * at their new location, so no preloading is required for subsequent updates.
+     */
+    private function preloadRelocatedClasses(): void
+    {
+        $classesToPreload = [
+            'Psr\Log\LoggerInterface',
+            'Psr\Log\AbstractLogger',
+            'Psr\Log\NullLogger',
+            'Psr\Log\LoggerTrait',
+            'Psr\Log\LogLevel',
+            'Psr\Log\InvalidArgumentException',
+            'Psr\Log\LoggerAwareInterface',
+            'Psr\Log\LoggerAwareTrait',
+        ];
+
+        foreach ($classesToPreload as $classToPreload) {
+            class_exists($classToPreload) || interface_exists($classToPreload) || trait_exists($classToPreload);
+        }
+    }
+
     private function installNewFiles($extractedArchiveDirectory)
     {
+        // Load classes that move to a different file path in the new version before any files are replaced.
+        $this->preloadRelocatedClasses();
+
         // Make sure the execute bit is set for this shell script
         if (!Rules::isBrowserTriggerEnabled()) {
             @chmod($extractedArchiveDirectory . '/misc/cron/archive.sh', 0755);


### PR DESCRIPTION
### Summary

Fixes a one-click-update failure on the **Matomo 5 → Matomo 6** upgrade path.

`psr/log` relocates its class files from `Psr/Log/` (v1, shipped with Matomo 5) to `src/` (v3, shipped with Matomo 6). During a one-click update the **running, pre-update process** (Matomo 5 code) replaces the install's files via `CoreUpdater\Updater::installNewFiles()`, but it keeps the composer autoloader it already initialised. That autoloader still maps the `psr/log` classes to their old `Psr/Log/` paths, which no longer exist once the new files are in place — so rendering the rest of the update request fatals with `Class "Psr\Log\NullLogger" not found`, and the update aborts before the database migration runs.

A Matomo 6 change cannot fix this, because the failing code runs from the Matomo 5 install (the new code only takes over on the next request). The fix has to live in the version being updated **from**, i.e. here in 5.x.

### Change

`Updater::installNewFiles()` now preloads the (small) `psr/log` package at the very start, while the old files are still present, so those classes stay resolvable in memory for the remainder of the request.

This is only needed for the 5 → 6 update (the upgrade in which `psr/log` relocates) and the code is commented as removable in Matomo 6 — once an install runs Matomo 6 the classes are already at their new location.

### Validation

The fix is proven end to end by the Matomo 6 dependency-upgrade PR matomo-org/matomo#24640: its `LatestStableInstall` test fixture emulates exactly this preload on the downloaded stable install, after which the one-click-update UI tests pass. (The relocation can't be exercised by a 5 → 5 update, so it isn't directly testable on this branch.)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
