### PR TITLE
Update composer dev dependencies to latest versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     "require-dev": {
         "matomo-org/matomo-coding-standards": "dev-master",
         "phpstan/phpdoc-parser": "~1.24.0",
-        "phpstan/phpstan": "~1.12",
+        "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "~8.5",
         "symfony/var-dumper": "~6.4.0",
         "symfony/yaml": "~6.4.0"

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,6 @@
     },
     "require-dev": {
         "matomo-org/matomo-coding-standards": "dev-master",
-        "phpstan/phpdoc-parser": "~1.24.0",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^9.0",
         "symfony/var-dumper": "~6.4.0",

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "matomo-org/matomo-coding-standards": "dev-master",
         "phpstan/phpdoc-parser": "~1.24.0",
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "~8.5",
+        "phpunit/phpunit": "^9.0",
         "symfony/var-dumper": "~6.4.0",
         "symfony/yaml": "~6.4.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20daf39e2a9f3b6cf10af13dd0188903",
+    "content-hash": "aac5bfb98c2c2556f54be01ff7c76c00",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8bc70da92f954e03c9b791aee8854acb",
+    "content-hash": "e1e9d06900e378a42b69483d4cdba3c5",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -4010,15 +4010,15 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.33",
+            "version": "2.2.2",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
-                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "reference": "e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -4036,6 +4036,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -4059,7 +4070,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-28T20:30:03+00:00"
+            "time": "2026-06-05T09:00:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1e9d06900e378a42b69483d4cdba3c5",
+    "content-hash": "20daf39e2a9f3b6cf10af13dd0188903",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3673,30 +3673,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -3723,7 +3723,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -3739,7 +3739,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "matomo-org/matomo-coding-standards",
@@ -3842,6 +3842,64 @@
                 }
             ],
             "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -4074,40 +4132,44 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "7.0.17",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "40a4ed114a4aea5afd6df8d0f0c9cd3033097f66"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/40a4ed114a4aea5afd6df8d0f0c9cd3033097f66",
-                "reference": "40a4ed114a4aea5afd6df8d0f0c9cd3033097f66",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=7.2",
-                "phpunit/php-file-iterator": "^2.0.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.1.3 || ^4.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^4.2.2",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1.3"
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.2.2"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
-                "ext-xdebug": "^2.7.2"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.0-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -4135,7 +4197,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/7.0.17"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -4143,32 +4206,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:09:37+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.6",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "69deeb8664f611f156a924154985fbd4911eb36b"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/69deeb8664f611f156a924154985fbd4911eb36b",
-                "reference": "69deeb8664f611f156a924154985fbd4911eb36b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4195,7 +4258,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.6"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
@@ -4203,26 +4266,97 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:39:50+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -4246,34 +4380,40 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
             },
-            "time": "2015-06-21T13:50:34+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.4",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "a691211e94ff39a34811abd521c31bd5b305b0bb"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/a691211e94ff39a34811abd521c31bd5b305b0bb",
-                "reference": "a691211e94ff39a34811abd521c31bd5b305b0bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4299,7 +4439,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.4"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
             },
             "funding": [
                 {
@@ -4307,83 +4447,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:42:41+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "3.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9c1da83261628cb24b6a6df371b6e312b3954768",
-                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-07-26T12:15:06+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.52",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1015741814413c156abb0f53d7db7bbd03c6e858"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1015741814413c156abb0f53d7db7bbd03c6e858",
-                "reference": "1015741814413c156abb0f53d7db7bbd03c6e858",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.5.0",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -4393,25 +4474,27 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=7.2",
-                "phpunit/php-code-coverage": "^7.0.17",
-                "phpunit/php-file-iterator": "^2.0.6",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1.4",
-                "sebastian/comparator": "^3.0.7",
-                "sebastian/diff": "^3.0.6",
-                "sebastian/environment": "^4.2.5",
-                "sebastian/exporter": "^3.1.8",
-                "sebastian/global-state": "^3.0.6",
-                "sebastian/object-enumerator": "^3.0.5",
-                "sebastian/resource-operations": "^2.0.3",
-                "sebastian/type": "^1.1.5",
-                "sebastian/version": "^2.0.1"
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage",
-                "phpunit/php-invoker": "To allow enforcing time limits"
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -4419,10 +4502,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
                 "classmap": [
                     "src/"
                 ]
@@ -4448,7 +4534,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.52"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -4472,32 +4558,144 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T05:20:18+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.3",
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "92a1a52e86d34cde6caa54f1b5ffa9fda18e5d54"
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/92a1a52e86d34cde6caa54f1b5ffa9fda18e5d54",
-                "reference": "92a1a52e86d34cde6caa54f1b5ffa9fda18e5d54",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -4519,7 +4717,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
             },
             "funding": [
                 {
@@ -4527,34 +4725,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:45:45+00:00"
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.7",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "bc7d8ac2fe1cce229bff9b5fd4efe65918a1ff52"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/bc7d8ac2fe1cce229bff9b5fd4efe65918a1ff52",
-                "reference": "bc7d8ac2fe1cce229bff9b5fd4efe65918a1ff52",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4593,7 +4791,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.7"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -4613,33 +4811,90 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:20:25+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "3.0.6",
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "98ff311ca519c3aa73ccd3de053bdb377171d7b6"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/98ff311ca519c3aa73ccd3de053bdb377171d7b6",
-                "reference": "98ff311ca519c3aa73ccd3de053bdb377171d7b6",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4671,7 +4926,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.6"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
             "funding": [
                 {
@@ -4679,27 +4934,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:16:36+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.5",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "56932f6049a0482853056ffd617c91ffcc754205"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/56932f6049a0482853056ffd617c91ffcc754205",
-                "reference": "56932f6049a0482853056ffd617c91ffcc754205",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -4707,7 +4962,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -4734,7 +4989,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.5"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -4742,34 +4997,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:49:59+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.8",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "64cfeaa341951ceb2019d7b98232399d57bb2296"
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64cfeaa341951ceb2019d7b98232399d57bb2296",
-                "reference": "64cfeaa341951ceb2019d7b98232399d57bb2296",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4804,14 +5059,14 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.8"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
             },
             "funding": [
                 {
@@ -4831,30 +5086,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T05:55:14+00:00"
+            "time": "2025-09-24T06:03:27+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "3.0.6",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "800689427e3e8cf57a8fe38fcd1d4344c9b2f046"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/800689427e3e8cf57a8fe38fcd1d4344c9b2f046",
-                "reference": "800689427e3e8cf57a8fe38fcd1d4344c9b2f046",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^8.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -4862,7 +5117,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4887,7 +5142,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.6"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
@@ -4907,34 +5162,91 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T05:40:12+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.5",
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "ac5b293dba925751b808e02923399fb44ff0d541"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/ac5b293dba925751b808e02923399fb44ff0d541",
-                "reference": "ac5b293dba925751b808e02923399fb44ff0d541",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4956,7 +5268,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.5"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
             },
             "funding": [
                 {
@@ -4964,32 +5276,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:54:02+00:00"
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "1d439c229e61f244ff1f211e5c99737f90c67def"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/1d439c229e61f244ff1f211e5c99737f90c67def",
-                "reference": "1d439c229e61f244ff1f211e5c99737f90c67def",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -5011,7 +5323,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.3"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
             },
             "funding": [
                 {
@@ -5019,32 +5331,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:56:04+00:00"
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.3",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "8fe7e75986a9d24b4cceae847314035df7703a5a"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/8fe7e75986a9d24b4cceae847314035df7703a5a",
-                "reference": "8fe7e75986a9d24b4cceae847314035df7703a5a",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -5071,10 +5383,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
@@ -5094,29 +5406,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T05:25:53+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "2.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "72a7f7674d053d548003b16ff5a106e7e0e06eee"
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/72a7f7674d053d548003b16ff5a106e7e0e06eee",
-                "reference": "72a7f7674d053d548003b16ff5a106e7e0e06eee",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -5137,7 +5452,7 @@
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
             },
             "funding": [
                 {
@@ -5145,32 +5460,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:59:09+00:00"
+            "time": "2024-03-14T16:00:52+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "1.1.5",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "18f071c3a29892b037d35e6b20ddf3ea39b42874"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/18f071c3a29892b037d35e6b20ddf3ea39b42874",
-                "reference": "18f071c3a29892b037d35e6b20ddf3ea39b42874",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.2"
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -5193,7 +5508,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/1.1.5"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -5201,29 +5516,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T14:04:07+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -5246,9 +5561,15 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/master"
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
             },
-            "time": "2016-10-03T07:35:21+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "slevomat/coding-standard",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2671,22 +2671,10 @@ parameters:
 			path: plugins/BotTracking/API.php
 
 		-
-			message: '#^Instanceof between Piwik\\DataTable and Piwik\\DataTable will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: plugins/BotTracking/API.php
-
-		-
 			message: '#^Parameter &\$glossaryItems by\-ref type of method Piwik\\Plugins\\BotTracking\\BotTracking\:\:addGlossaryItems\(\) expects array\<string, array\{title\: string, entries\: array\<int, array\<string, string\>\>\}\>, non\-empty\-array\<string, array\{title\?\: string, entries\: array\<int, array\<string, string\>\>\}\> given\.$#'
 			identifier: parameterByRef.type
 			count: 1
 			path: plugins/BotTracking/BotTracking.php
-
-		-
-			message: '#^Instanceof between Piwik\\DataTable and Piwik\\DataTable will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: plugins/BotTracking/DataTable/FavouredPagesScorer.php
 
 		-
 			message: '#^Parameter &\$tables by\-ref type of method Piwik\\Plugins\\BotTracking\\RecordBuilders\\AIChatbotReports\:\:populateNumerics\(\) expects array\<string, Piwik\\DataTable\>, array\<string, int\|Piwik\\DataTable\> given\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -907,12 +907,6 @@ parameters:
 			path: core/FileIntegrity.php
 
 		-
-			message: '#^Path in require_once\(\) "/var/www/html/config/manifest\.inc\.php" is not a file or it does not exist\.$#'
-			identifier: requireOnce.fileNotFound
-			count: 1
-			path: core/FileIntegrity.php
-
-		-
 			message: '#^Strict comparison using \!\=\= between string and false will always evaluate to true\.$#'
 			identifier: notIdentical.alwaysTrue
 			count: 1
@@ -2377,12 +2371,6 @@ parameters:
 			path: core/Visualization/Sparkline.php
 
 		-
-			message: '#^Path in require_once\(\) "/var/www/html/\.\./\.\./autoload\.php" is not a file or it does not exist\.$#'
-			identifier: requireOnce.fileNotFound
-			count: 1
-			path: core/bootstrap.php
-
-		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 1
@@ -3395,12 +3383,6 @@ parameters:
 			identifier: property.onlyWritten
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/ArchiveInvalidationsInformational.php
-
-		-
-			message: '#^Loose comparison using \!\= between ''/var/www/html'' and ''/var/www/html'' will always evaluate to false\.$#'
-			identifier: notEqual.alwaysFalse
-			count: 2
-			path: plugins/Diagnostics/Diagnostic/ConfigInformational.php
 
 		-
 			message: '#^Parameter \#2 \$comment of static method Piwik\\Plugins\\Diagnostics\\Diagnostic\\DiagnosticResult\:\:informationalResult\(\) expects string, bool given\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,3015 +1,4813 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Class Piwik\\\\Log\\\\Logger extends @final class Monolog\\\\Logger\\.$#"
-			count: 1
-			path: core/Log/Logger.php
-
-		-
-			message: "#^Class Piwik\\\\Plugins\\\\Monolog\\\\Formatter\\\\ConsoleFormatter extends @final class Symfony\\\\Bridge\\\\Monolog\\\\Formatter\\\\ConsoleFormatter\\.$#"
-			count: 1
-			path: plugins/Monolog/Formatter/ConsoleFormatter.php
-		-
-			message: "#^Instanceof between Piwik\\\\DataTable and Piwik\\\\DataTable\\\\Map will always evaluate to false\\.$#"
+			message: '#^Instanceof between Piwik\\DataTable and Piwik\\DataTable\\Map will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
 			count: 1
 			path: core/API/DataTableGenericFilter.php
 
 		-
-			message: "#^Left side of && is always true\\.$#"
+			message: '#^Instanceof between Piwik\\Plugin\\ProcessedMetric and Piwik\\Plugin\\ProcessedMetric will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 1
 			path: core/API/DataTableGenericFilter.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 1
+			path: core/API/DataTableGenericFilter.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: core/API/DataTableManipulator.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^Instanceof between Piwik\\DataTable and Piwik\\DataTable will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: core/API/DataTableManipulator.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: core/API/DataTableManipulator/Flattener.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between Piwik\\\\DataTable and null will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between Piwik\\DataTable and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: core/API/DataTableManipulator/Flattener.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/API/DataTableManipulator/LabelFilter.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\DataTable\\\\DataTableInterface\\:\\:getRows\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\DataTable\\DataTableInterface\:\:getRows\(\)\.$#'
+			identifier: method.notFound
 			count: 2
 			path: core/API/DataTableManipulator/ReportTotalsCalculator.php
 
 		-
-			message: "#^Left side of && is always true\\.$#"
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
 			path: core/API/DataTableManipulator/ReportTotalsCalculator.php
 
 		-
-			message: "#^Property Piwik\\\\API\\\\DataTableManipulator\\\\ReportTotalsCalculator\\:\\:\\$report \\(Piwik\\\\Plugin\\\\Report\\) in empty\\(\\) is not falsy\\.$#"
+			message: '#^Property Piwik\\API\\DataTableManipulator\\ReportTotalsCalculator\:\:\$report \(Piwik\\Plugin\\Report\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
 			count: 1
 			path: core/API/DataTableManipulator/ReportTotalsCalculator.php
 
 		-
-			message: "#^Parameter \\#1 \\$dataTable of method Piwik\\\\API\\\\DataTableManipulator\\\\Flattener\\:\\:flatten\\(\\) expects Piwik\\\\DataTable, Piwik\\\\DataTable\\\\DataTableInterface given\\.$#"
+			message: '#^Parameter \#1 \$dataTable of method Piwik\\API\\DataTableManipulator\\Flattener\:\:flatten\(\) expects Piwik\\DataTable, Piwik\\DataTable\\DataTableInterface given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/API/DataTablePostProcessor.php
 
 		-
-			message: "#^Parameter \\#1 \\$table of method Piwik\\\\API\\\\DataTableGenericFilter\\:\\:filter\\(\\) expects Piwik\\\\DataTable, Piwik\\\\DataTable\\\\DataTableInterface given\\.$#"
+			message: '#^Parameter \#1 \$table of method Piwik\\API\\DataTableGenericFilter\:\:filter\(\) expects Piwik\\DataTable, Piwik\\DataTable\\DataTableInterface given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/API/DataTablePostProcessor.php
 
 		-
-			message: "#^Parameter \\#1 \\$table of method Piwik\\\\API\\\\DataTableManipulator\\\\ReportTotalsCalculator\\:\\:calculate\\(\\) expects Piwik\\\\DataTable, Piwik\\\\DataTable\\\\DataTableInterface given\\.$#"
+			message: '#^Parameter \#1 \$table of method Piwik\\API\\DataTableManipulator\\ReportTotalsCalculator\:\:calculate\(\) expects Piwik\\DataTable, Piwik\\DataTable\\DataTableInterface given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/API/DataTablePostProcessor.php
 
 		-
-			message: "#^Parameter \\#2 \\$dataTable of method Piwik\\\\API\\\\DataTableManipulator\\\\LabelFilter\\:\\:filter\\(\\) expects Piwik\\\\DataTable, Piwik\\\\DataTable\\\\DataTableInterface given\\.$#"
+			message: '#^Parameter \#2 \$dataTable of method Piwik\\API\\DataTableManipulator\\LabelFilter\:\:filter\(\) expects Piwik\\DataTable, Piwik\\DataTable\\DataTableInterface given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/API/DataTablePostProcessor.php
 
 		-
-			message: "#^Call to an undefined method ReflectionType\\:\\:getName\\(\\)\\.$#"
+			message: '#^Strict comparison using \!\=\= between non\-falsy\-string and ''0'' will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: core/API/DataTablePostProcessor.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between non\-falsy\-string and 0 will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: core/API/DataTablePostProcessor.php
+
+		-
+			message: '#^Call to an undefined method ReflectionType\:\:getName\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/API/Proxy.php
 
 		-
-			message: "#^Call to an undefined method ReflectionType\\:\\:isBuiltin\\(\\)\\.$#"
+			message: '#^Call to an undefined method ReflectionType\:\:isBuiltin\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/API/Proxy.php
 
 		-
-			message: "#^Negated boolean expression is always true\\.$#"
+			message: '#^Strict comparison using \=\=\= between null and null will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: core/API/Proxy.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
 			count: 1
 			path: core/API/Request.php
 
 		-
-			message: "#^Parameter \\#2 \\$columnToFilter of class Piwik\\\\DataTable\\\\Filter\\\\Pattern constructor expects string, array given\\.$#"
+			message: '#^PHPDoc tag @return has invalid value \(array\( \$module, \$action \)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 207 on line 7$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: core/API/Request.php
+
+		-
+			message: '#^Parameter \#2 \$columnToFilter of class Piwik\\DataTable\\Filter\\Pattern constructor expects string, array given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/API/ResponseBuilder.php
 
 		-
-			message: "#^Property Piwik\\\\API\\\\ResponseBuilder\\:\\:\\$outputFormat is never read, only written\\.$#"
+			message: '#^Property Piwik\\API\\ResponseBuilder\:\:\$outputFormat is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: core/API/ResponseBuilder.php
 
 		-
-			message: "#^Property Piwik\\\\Access\\:\\:\\$auth \\(Piwik\\\\Auth\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Property Piwik\\Access\:\:\$auth \(Piwik\\Auth\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: core/Access.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 6
 			path: core/Application/Environment.php
 
 		-
-			message: "#^Method Piwik\\\\Archive\\\\ArchiveInvalidator\\:\\:getSegmentArchiving\\(\\) is unused\\.$#"
+			message: '#^Method Piwik\\Archive\\ArchiveInvalidator\:\:getSegmentArchiving\(\) is unused\.$#'
+			identifier: method.unused
 			count: 1
 			path: core/Archive/ArchiveInvalidator.php
 
 		-
-			message: "#^Property Piwik\\\\Archive\\\\ArchiveInvalidator\\:\\:\\$allIdSitesCache \\(array\\<int\\>\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Property Piwik\\Archive\\ArchiveInvalidator\:\:\$allIdSitesCache \(array\<int\>\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: core/Archive/ArchiveInvalidator.php
 
 		-
-			message: "#^Property Piwik\\\\Archive\\\\ArchiveInvalidator\\:\\:\\$allIdSitesCache is never written, only read\\.$#"
+			message: '#^Property Piwik\\Archive\\ArchiveInvalidator\:\:\$allIdSitesCache is never written, only read\.$#'
+			identifier: property.onlyRead
 			count: 1
 			path: core/Archive/ArchiveInvalidator.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
 			count: 1
 			path: core/Archive/ArchiveInvalidator.php
 
 		-
-			message: "#^Property Piwik\\\\Archive\\\\ArchivePurger\\:\\:\\$today is never read, only written\\.$#"
+			message: '#^Property Piwik\\Archive\\ArchivePurger\:\:\$today is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: core/Archive/ArchivePurger.php
 
 		-
-			message: "#^Parameter \\#3 \\$archiveIdsFlipped of method Piwik\\\\Archive\\\\ArchiveState\\:\\:checkArchiveStates\\(\\) expects array\\<string, array\\<int, bool\\>\\>, array\\<string, array\\<int, \\(int\\|string\\)\\>\\> given\\.$#"
+			message: '#^Parameter \#3 \$archiveIdsFlipped of method Piwik\\Archive\\ArchiveState\:\:checkArchiveStates\(\) expects array\<string, array\<int, bool\>\>, array\<string, array\<int, \(int\|string\)\>\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Archive/ArchiveState.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
 			count: 1
 			path: core/Archive/DataTableFactory.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array and false will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between array and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: core/Archive/DataTableFactory.php
 
 		-
-			message: "#^Left side of && is always true\\.$#"
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
 			path: core/ArchiveProcessor/Loader.php
 
 		-
-			message: "#^Parameter \\#1 \\$archiveOnlyReport of method Piwik\\\\ArchiveProcessor\\\\Parameters\\:\\:setArchiveOnlyReport\\(\\) expects array\\<string\\>\\|string, null given\\.$#"
+			message: '#^Parameter \#1 \$archiveOnlyReport of method Piwik\\ArchiveProcessor\\Parameters\:\:setArchiveOnlyReport\(\) expects array\<string\>\|string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/ArchiveProcessor/Loader.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with non\\-falsy\\-string will always evaluate to false\\.$#"
+			message: '#^Call to function is_array\(\) with non\-falsy\-string will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/ArchiveProcessor/Parameters.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with string\\|null will always evaluate to false\\.$#"
+			message: '#^Call to function is_array\(\) with string\|null will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/ArchiveProcessor/Parameters.php
 
 		-
-			message: "#^Ternary operator condition is always true\\.$#"
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
 			count: 1
 			path: core/ArchiveProcessor/PluginsArchiver.php
 
 		-
-			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			message: '#^Expression on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.expr
 			count: 2
 			path: core/ArchiveProcessor/RecordBuilder.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
+			message: '#^Instanceof between Piwik\\ArchiveProcessor\\Record and Piwik\\ArchiveProcessor\\Record will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: core/ArchiveProcessor/RecordBuilder.php
+
+		-
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/ArchiveProcessor/Rules.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int\\<1, max\\> given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int\<1, max\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/ArchiveProcessor/Rules.php
 
 		-
-			message: "#^Parameter \\#2 \\$assetFetcher of class Piwik\\\\AssetManager\\\\UIAssetMerger\\\\JScriptUIAssetMerger constructor expects Piwik\\\\AssetManager\\\\UIAssetFetcher\\\\JScriptUIAssetFetcher, Piwik\\\\AssetManager\\\\UIAssetFetcher given\\.$#"
+			message: '#^Call to preg_quote\(\) is missing delimiter / to be effective\.$#'
+			identifier: argument.invalidPregQuote
+			count: 1
+			path: core/Archiver/Request.php
+
+		-
+			message: '#^Parameter \#2 \$assetFetcher of class Piwik\\AssetManager\\UIAssetMerger\\JScriptUIAssetMerger constructor expects Piwik\\AssetManager\\UIAssetFetcher\\JScriptUIAssetFetcher, Piwik\\AssetManager\\UIAssetFetcher given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/AssetManager.php
 
 		-
-			message: "#^Parameter \\#2 \\$assetFetcher of class Piwik\\\\AssetManager\\\\UIAssetMerger\\\\JScriptUIAssetMerger constructor expects Piwik\\\\AssetManager\\\\UIAssetFetcher\\\\JScriptUIAssetFetcher, Piwik\\\\AssetManager\\\\UIAssetFetcher\\\\StaticUIAssetFetcher given\\.$#"
+			message: '#^Parameter \#2 \$assetFetcher of class Piwik\\AssetManager\\UIAssetMerger\\JScriptUIAssetMerger constructor expects Piwik\\AssetManager\\UIAssetFetcher\\JScriptUIAssetFetcher, Piwik\\AssetManager\\UIAssetFetcher\\StaticUIAssetFetcher given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/AssetManager.php
 
 		-
-			message: "#^Property Piwik\\\\AssetManager\\\\UIAsset\\\\OnDiskUIAsset\\:\\:\\$relativeRootDir \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Call to function is_string\(\) with non\-falsy\-string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/AssetManager/UIAsset/OnDiskUIAsset.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			message: '#^Property Piwik\\AssetManager\\UIAsset\\OnDiskUIAsset\:\:\$relativeRootDir \(string\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: core/AssetManager/UIAsset/OnDiskUIAsset.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between mixed and null will always evaluate to false\\.$#"
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: core/AssetManager/UIAsset/OnDiskUIAsset.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between mixed and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: core/AssetManager/UIAssetFetcher.php
 
 		-
-			message: "#^Parameter \\#3 \\$pending of static method Piwik\\\\Piwik\\:\\:postEvent\\(\\) expects bool, null given\\.$#"
+			message: '#^Parameter \#3 \$pending of static method Piwik\\Piwik\:\:postEvent\(\) expects bool, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/AssetManager/UIAssetFetcher/JScriptUIAssetFetcher.php
 
 		-
-			message: "#^Parameter \\#3 \\$pending of static method Piwik\\\\Piwik\\:\\:postEvent\\(\\) expects bool, null given\\.$#"
+			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/AssetManager/UIAssetFetcher/PluginUmdAssetFetcher.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Piwik\\Plugin and ''shouldLoadUmdOnDema…'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/AssetManager/UIAssetFetcher/PluginUmdAssetFetcher.php
+
+		-
+			message: '#^Parameter \#3 \$pending of static method Piwik\\Piwik\:\:postEvent\(\) expects bool, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/AssetManager/UIAssetMerger/JScriptUIAssetMerger.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\\\AdapterInterface\\:\\:fetchAll\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\\AdapterInterface\:\:fetchAll\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Changes/Model.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\\\AdapterInterface\\:\\:query\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\\AdapterInterface\:\:query\(\)\.$#'
+			identifier: method.notFound
 			count: 2
 			path: core/Changes/Model.php
 
 		-
-			message: "#^Comparison operation \"\\>\" between int\\<1, max\\> and 0 is always true\\.$#"
+			message: '#^Comparison operation "\>" between int\<1, max\> and 0 is always true\.$#'
+			identifier: greater.alwaysTrue
 			count: 1
 			path: core/Changes/Model.php
 
 		-
-			message: "#^Left side of && is always true\\.$#"
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
 			path: core/Changes/Model.php
 
 		-
-			message: "#^Variable \\$response in empty\\(\\) always exists and is always falsy\\.$#"
+			message: '#^Variable \$response in empty\(\) always exists and is always falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: core/CliMulti.php
 
 		-
-			message: "#^Parameter \\#1 \\$environment of class Piwik\\\\Application\\\\Environment constructor expects string, null given\\.$#"
+			message: '#^Call to function is_string\(\) with non\-falsy\-string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/CliMulti/Output.php
+
+		-
+			message: '#^Parameter \#1 \$environment of class Piwik\\Application\\Environment constructor expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/CliMulti/RequestCommand.php
 
 		-
-			message: "#^Comparison operation \"\\<\" between int\\<2, 3\\> and 2 is always false\\.$#"
+			message: '#^Call to function is_array\(\) with array\<string\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/Columns/MetricsList.php
+
+		-
+			message: '#^Call to function is_object\(\) with mixed will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/Common.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
+			message: '#^Comparison operation "\<" between int\<2, 3\> and 2 is always false\.$#'
+			identifier: smaller.alwaysFalse
+			count: 1
+			path: core/Common.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between non\-falsy\-string and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: core/Common.php
+
+		-
+			message: '#^Call to function is_array\(\) with string will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/Concurrency/DistributedList.php
 
 		-
-			message: "#^Parameter \\#2 \\$data of method Matomo\\\\Cache\\\\Backend\\\\File\\:\\:doSave\\(\\) expects string, array\\<string, mixed\\> given\\.$#"
+			message: '#^Call to function is_object\(\) with Zend_Db_Statement will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/Concurrency/LockBackend/MySqlLockBackend.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Zend_Db_Statement and ''rowCount'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/Concurrency/LockBackend/MySqlLockBackend.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: core/Config.php
+
+		-
+			message: '#^Call to function is_array\(\) with non\-empty\-array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: core/Config/IniFileChain.php
+
+		-
+			message: '#^Parameter \#2 \$data of method Matomo\\Cache\\Backend\\File\:\:doSave\(\) expects string, array\<string, mixed\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Config/IniFileChain.php
 
 		-
-			message: "#^Argument of an invalid type Piwik\\\\Application\\\\Kernel\\\\GlobalSettingsProvider supplied for foreach, only iterables are supported\\.$#"
+			message: '#^PHPDoc tag @var with type Symfony\\Component\\Console\\Command\\Command is not subtype of native type Piwik\\Plugin\\ConsoleCommand\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: core/Console.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between null and null will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: core/Console.php
+
+		-
+			message: '#^Argument of an invalid type Piwik\\Application\\Kernel\\GlobalSettingsProvider supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: core/Container/IniConfigDefinitionSource.php
 
 		-
-			message: "#^Dead catch \\- UnexpectedValueException is never thrown in the try block\\.$#"
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/Container/IniConfigDefinitionSource.php
+
+		-
+			message: '#^Dead catch \- UnexpectedValueException is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
 			count: 1
 			path: core/CronArchive.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: core/CronArchive.php
 
 		-
-			message: "#^Parameter \\#1 \\$num of function round expects float\\|int, string given\\.$#"
+			message: '#^Parameter \#1 \$num of function round expects float\|int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/CronArchive.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int\\<1, max\\> given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int\<1, max\> given\.$#'
+			identifier: argument.type
 			count: 3
 			path: core/CronArchive.php
 
 		-
-			message: "#^Property Piwik\\\\CronArchive\\:\\:\\$archivingStartingTime is never read, only written\\.$#"
+			message: '#^Property Piwik\\CronArchive\:\:\$archivingStartingTime is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: core/CronArchive.php
 
 		-
-			message: "#^Property Piwik\\\\CronArchive\\:\\:\\$segmentArchiving \\(Piwik\\\\CronArchive\\\\SegmentArchiving\\) in empty\\(\\) is not falsy\\.$#"
+			message: '#^Property Piwik\\CronArchive\:\:\$segmentArchiving \(Piwik\\CronArchive\\SegmentArchiving\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
 			count: 2
 			path: core/CronArchive.php
 
 		-
-			message: "#^Method Piwik\\\\CronArchive\\\\ArchiveFilter\\:\\:getPeriodsToProcess\\(\\) is unused\\.$#"
+			message: '#^Method Piwik\\CronArchive\\ArchiveFilter\:\:getPeriodsToProcess\(\) is unused\.$#'
+			identifier: method.unused
 			count: 1
 			path: core/CronArchive/ArchiveFilter.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
 			count: 1
 			path: core/CronArchive/Performance/Logger.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: core/CronArchive/QueueConsumer.php
 
 		-
-			message: "#^Method Piwik\\\\CronArchive\\\\QueueConsumer\\:\\:isArchiveNonSegmentAndInProgressArchiveSegment\\(\\) is unused\\.$#"
+			message: '#^Method Piwik\\CronArchive\\QueueConsumer\:\:isArchiveNonSegmentAndInProgressArchiveSegment\(\) is unused\.$#'
+			identifier: method.unused
 			count: 1
 			path: core/CronArchive/QueueConsumer.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
 			count: 1
 			path: core/CronArchive/QueueConsumer.php
 
 		-
-			message: "#^Parameter \\#1 \\$subXPeriods of static method Piwik\\\\Period\\\\Range\\:\\:getDateXPeriodsAgo\\(\\) expects int, string given\\.$#"
+			message: '#^Parameter \#1 \$subXPeriods of static method Piwik\\Period\\Range\:\:getDateXPeriodsAgo\(\) expects int, string given\.$#'
+			identifier: argument.type
 			count: 2
 			path: core/CronArchive/SegmentArchiving.php
 
 		-
-			message: "#^Property Piwik\\\\CronArchive\\\\SegmentArchiving\\:\\:\\$now is never read, only written\\.$#"
+			message: '#^Property Piwik\\CronArchive\\SegmentArchiving\:\:\$now is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: core/CronArchive/SegmentArchiving.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, float given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, float given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/CronArchive/SharedSiteIds.php
 
 		-
-			message: "#^Call to method fetch\\(\\) on an unknown class Piwik\\\\Tracker\\\\PDOStatement\\.$#"
+			message: '#^Call to method fetch\(\) on an unknown class Piwik\\Tracker\\PDOStatement\.$#'
+			identifier: class.notFound
 			count: 1
 			path: core/DataAccess/ArchiveSelector.php
 
 		-
-			message: "#^Offset 'idarchive' on non\\-empty\\-array in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Offset ''idarchive'' on non\-empty\-array in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.offset
 			count: 2
 			path: core/DataAccess/ArchiveSelector.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between int\\|string and null will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between int\|string and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: core/DataAccess/ArchiveSelector.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: core/DataAccess/ArchivingDbAdapter.php
 
 		-
-			message: "#^Parameter \\#2 \\$flags of function json_encode expects int, true given\\.$#"
+			message: '#^Parameter \#2 \$flags of function json_encode expects int, true given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/DataAccess/ArchivingDbAdapter.php
 
 		-
-			message: "#^Parameter \\#3 \\$where of method Piwik\\\\DataAccess\\\\LogQueryBuilder\\:\\:buildSelectQuery\\(\\) expects string, false given\\.$#"
+			message: '#^Parameter \#3 \$where of method Piwik\\DataAccess\\LogQueryBuilder\:\:buildSelectQuery\(\) expects string, false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/DataAccess/LogQueryBuilder.php
 
 		-
-			message: "#^Parameter \\#6 \\$limitAndOffset of method Piwik\\\\DataAccess\\\\LogQueryBuilder\\:\\:buildSelectQuery\\(\\) expects int\\|string, null given\\.$#"
+			message: '#^Parameter \#6 \$limitAndOffset of method Piwik\\DataAccess\\LogQueryBuilder\:\:buildSelectQuery\(\) expects int\|string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/DataAccess/LogQueryBuilder.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:fetchCol\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:fetchCol\(\)\.$#'
+			identifier: method.notFound
 			count: 2
 			path: core/DataAccess/Model.php
 
 		-
-			message: "#^Constructor of class Piwik\\\\DataTable\\\\BaseFilter has an unused parameter \\$table\\.$#"
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/DataTable.php
+
+		-
+			message: '#^Call to method Piwik\\DataTable\\Row\:\:setColumn\(\) on a separate line has no effect\.$#'
+			identifier: method.resultUnused
+			count: 1
+			path: core/DataTable.php
+
+		-
+			message: '#^Constructor of class Piwik\\DataTable\\BaseFilter has an unused parameter \$table\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: core/DataTable/BaseFilter.php
 
 		-
-			message: "#^Constructor of class Piwik\\\\DataTable\\\\Filter\\\\AddColumnsProcessedMetricsGoal has an unused parameter \\$enable\\.$#"
+			message: '#^Constructor of class Piwik\\DataTable\\Filter\\AddColumnsProcessedMetricsGoal has an unused parameter \$enable\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: core/DataTable/Filter/AddColumnsProcessedMetricsGoal.php
 
 		-
-			message: "#^Property Piwik\\\\DataTable\\\\Filter\\\\AddSegmentByRangeLabel\\:\\:\\$delimiter is unused\\.$#"
+			message: '#^Property Piwik\\DataTable\\Filter\\AddSegmentByRangeLabel\:\:\$delimiter is unused\.$#'
+			identifier: property.unused
 			count: 1
 			path: core/DataTable/Filter/AddSegmentByRangeLabel.php
 
 		-
-			message: "#^Property Piwik\\\\DataTable\\\\Filter\\\\AddSegmentByRangeLabel\\:\\:\\$segments is unused\\.$#"
+			message: '#^Property Piwik\\DataTable\\Filter\\AddSegmentByRangeLabel\:\:\$segments is unused\.$#'
+			identifier: property.unused
 			count: 1
 			path: core/DataTable/Filter/AddSegmentByRangeLabel.php
 
 		-
-			message: "#^Property Piwik\\\\DataTable\\\\Filter\\\\AddSegmentBySegmentValue\\:\\:\\$report \\(Piwik\\\\Plugin\\\\Report\\) in empty\\(\\) is not falsy\\.$#"
+			message: '#^Property Piwik\\DataTable\\Filter\\AddSegmentBySegmentValue\:\:\$report \(Piwik\\Plugin\\Report\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
 			count: 1
 			path: core/DataTable/Filter/AddSegmentBySegmentValue.php
 
 		-
-			message: "#^Method Piwik\\\\DataTable\\\\Filter\\\\CalculateEvolutionFilter\\:\\:getDividend\\(\\) should return float\\|int but returns false\\.$#"
+			message: '#^Call to method Piwik\\DataTable\\Row\:\:setColumn\(\) on a separate line has no effect\.$#'
+			identifier: method.resultUnused
+			count: 1
+			path: core/DataTable/Filter/AddSummaryRow.php
+
+		-
+			message: '#^Method Piwik\\DataTable\\Filter\\CalculateEvolutionFilter\:\:getDividend\(\) should return float\|int but returns false\.$#'
+			identifier: return.type
 			count: 1
 			path: core/DataTable/Filter/CalculateEvolutionFilter.php
 
 		-
-			message: "#^Return type \\(string\\) of method Piwik\\\\DataTable\\\\Filter\\\\ColumnCallbackAddColumnPercentage\\:\\:formatValue\\(\\) should be compatible with return type \\(float\\|int\\) of method Piwik\\\\DataTable\\\\Filter\\\\ColumnCallbackAddColumnQuotient\\:\\:formatValue\\(\\)$#"
+			message: '#^Return type \(string\) of method Piwik\\DataTable\\Filter\\ColumnCallbackAddColumnPercentage\:\:formatValue\(\) should be compatible with return type \(float\|int\) of method Piwik\\DataTable\\Filter\\ColumnCallbackAddColumnQuotient\:\:formatValue\(\)$#'
+			identifier: method.childReturnType
 			count: 1
 			path: core/DataTable/Filter/ColumnCallbackAddColumnPercentage.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
 			count: 1
 			path: core/DataTable/Filter/ColumnCallbackAddColumnQuotient.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between float\\|int and false will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between float\|int and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: core/DataTable/Filter/ColumnCallbackAddColumnQuotient.php
 
 		-
-			message: "#^Property Piwik\\\\DataTable\\\\Filter\\\\Pattern\\:\\:\\$patternToSearch is never read, only written\\.$#"
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/DataTable/Filter/ColumnCallbackDeleteRow.php
+
+		-
+			message: '#^Property Piwik\\DataTable\\Filter\\Pattern\:\:\$columnToFilter \(array\|string\) is never assigned array so it can be removed from the property type\.$#'
+			identifier: property.unusedType
 			count: 1
 			path: core/DataTable/Filter/Pattern.php
 
 		-
-			message: "#^Property Piwik\\\\DataTable\\\\Filter\\\\PatternRecursive\\:\\:\\$patternToSearch is never read, only written\\.$#"
+			message: '#^Property Piwik\\DataTable\\Filter\\Pattern\:\:\$patternToSearch is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: core/DataTable/Filter/Pattern.php
+
+		-
+			message: '#^Property Piwik\\DataTable\\Filter\\PatternRecursive\:\:\$patternToSearch is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: core/DataTable/Filter/PatternRecursive.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
 			count: 1
 			path: core/DataTable/Filter/PivotByDimension.php
 
 		-
-			message: "#^Instanceof between Piwik\\\\DataTable\\|false and Piwik\\\\DataTable\\\\Map will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \!\=\= between mixed and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: core/DataTable/Filter/RangeCheck.php
+
+		-
+			message: '#^Instanceof between Piwik\\DataTable\|false and Piwik\\DataTable\\Map will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
 			count: 1
 			path: core/DataTable/Map.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
+			message: '#^Instanceof between Piwik\\DataTable\\DataTableInterface and Piwik\\DataTable\\DataTableInterface will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 1
 			path: core/DataTable/Renderer.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
 			count: 1
 			path: core/DataTable/Renderer.php
 
 		-
-			message: "#^Parameter \\#1 \\$table of method Piwik\\\\DataTable\\\\Renderer\\\\Html\\:\\:buildTableStructure\\(\\) expects Piwik\\\\DataTable\\|Piwik\\\\DataTable\\\\Map, Piwik\\\\DataTable\\\\DataTableInterface given\\.$#"
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
+			count: 1
+			path: core/DataTable/Renderer.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between int\|null and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: core/DataTable/Renderer/Csv.php
+
+		-
+			message: '#^Parameter \#1 \$table of method Piwik\\DataTable\\Renderer\\Html\:\:buildTableStructure\(\) expects Piwik\\DataTable\|Piwik\\DataTable\\Map, Piwik\\DataTable\\DataTableInterface given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/DataTable/Renderer/Html.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with 'array'\\|'boolean'\\|'double'\\|'integer'\\|'NULL'\\|'object'\\|'resource'\\|'resource \\(closed\\)'\\|'string'\\|'unknown type' will always evaluate to false\\.$#"
+			message: '#^Instanceof between Piwik\\DataTable\\Map and Piwik\\DataTable\\Map will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: core/DataTable/Renderer/Rss.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between true and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 2
+			path: core/DataTable/Renderer/Rss.php
+
+		-
+			message: '#^Call to function is_array\(\) with ''array''\|''boolean''\|''double''\|''integer''\|''NULL''\|''object''\|''resource''\|''resource \(closed\)''\|''string''\|''unknown type'' will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/DataTable/Row.php
 
 		-
-			message: "#^Method Piwik\\\\DataTable\\\\Row\\:\\:compareElements\\(\\) should return bool but returns int\\.$#"
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: core/DataTable/Row.php
+
+		-
+			message: '#^Method Piwik\\DataTable\\Row\:\:compareElements\(\) should return bool but returns int\.$#'
+			identifier: return.type
 			count: 4
 			path: core/DataTable/Row.php
 
 		-
-			message: "#^Method Piwik\\\\DataTable\\\\Row\\:\\:compareElements\\(\\) should return bool but returns int\\<\\-1, 1\\>\\.$#"
+			message: '#^Method Piwik\\DataTable\\Row\:\:compareElements\(\) should return bool but returns int\<\-1, 1\>\.$#'
+			identifier: return.type
 			count: 1
 			path: core/DataTable/Row.php
 
 		-
-			message: "#^Parameter \\#3 \\$data_comp_func of function array_udiff expects callable\\(mixed, mixed\\)\\: int, array\\{'Piwik\\\\\\\\DataTable\\\\\\\\Row', 'compareElements'\\} given\\.$#"
+			message: '#^Parameter \#3 \$data_comp_func of function array_udiff expects callable\(mixed, mixed\)\: int, array\{''Piwik\\\\DataTable\\\\Row'', ''compareElements''\} given\.$#'
+			identifier: argument.type
 			count: 2
 			path: core/DataTable/Row.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\|float\\|int and false will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between array\|float\|int and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: core/DataTable/Row.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
 			count: 1
 			path: core/DataTable/Row.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\\\AdapterInterface\\:\\:exec\\(\\)\\.$#"
+			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/Date.php
+
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/Date.php
+
+		-
+			message: '#^Call to an undefined method Piwik\\Db\\AdapterInterface\:\:exec\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Db.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with bool will always evaluate to false\\.$#"
+			message: '#^Call to function is_null\(\) with bool will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/Db.php
 
 		-
-			message: "#^Cannot access property \\$server_version on object\\|resource\\.$#"
+			message: '#^Cannot access property \$server_version on object\|resource\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: core/Db/Adapter/Mysqli.php
 
 		-
-			message: "#^Cannot call method query\\(\\) on object\\|resource\\.$#"
+			message: '#^Cannot call method query\(\) on object\|resource\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: core/Db/Adapter/Mysqli.php
 
 		-
-			message: "#^Cannot call method exec\\(\\) on object\\|resource\\.$#"
+			message: '#^Cannot call method exec\(\) on object\|resource\.$#'
+			identifier: method.nonObject
 			count: 2
 			path: core/Db/Adapter/Pdo/Mysql.php
 
 		-
-			message: "#^Cannot call method getAttribute\\(\\) on object\\|resource\\.$#"
+			message: '#^Cannot call method getAttribute\(\) on object\|resource\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: core/Db/Adapter/Pdo/Mysql.php
 
 		-
-			message: "#^Cannot call method setAttribute\\(\\) on object\\|resource\\.$#"
+			message: '#^Cannot call method setAttribute\(\) on object\|resource\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: core/Db/Adapter/Pdo/Mysql.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with mixed will always evaluate to false\\.$#"
+			message: '#^Call to function is_null\(\) with mixed will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/Db/BatchInsert.php
 
 		-
-			message: "#^Comparison operation \"\\<\" between int\\<min, \\-1\\>\\|int\\<1, max\\>\\|Zend_Db_Statement and 0 results in an error\\.$#"
-			count: 1
-			path: core/Db/BatchInsert.php
-
-		-
-			message: "#^Method Piwik\\\\Db\\\\Schema\\:\\:hasReachedEOL\\(\\) should return string but returns bool\\.$#"
+			message: '#^Method Piwik\\Db\\Schema\:\:hasReachedEOL\(\) should return string but returns bool\.$#'
+			identifier: return.type
 			count: 1
 			path: core/Db/Schema.php
 
 		-
-			message: "#^Method Piwik\\\\Db\\\\SchemaInterface\\:\\:dropDatabase\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			message: '#^Method Piwik\\Db\\SchemaInterface\:\:dropDatabase\(\) invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: core/Db/Schema.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:fetchCol\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:fetchCol\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Db/Schema/Mysql.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
 			count: 1
 			path: core/Db/Schema/Mysql.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:closeConnection\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:closeConnection\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/DbHelper.php
 
 		-
-			message: "#^Call to method rowCount\\(\\) on an unknown class Piwik\\\\Tracker\\\\PDOStatement\\.$#"
+			message: '#^Call to function is_array\(\) with non\-empty\-array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/DbHelper.php
 
 		-
-			message: "#^Right side of && is always false\\.$#"
+			message: '#^Call to method rowCount\(\) on an unknown class Piwik\\Tracker\\PDOStatement\.$#'
+			identifier: class.notFound
+			count: 1
+			path: core/DbHelper.php
+
+		-
+			message: '#^Call to preg_quote\(\) is missing delimiter / to be effective\.$#'
+			identifier: argument.invalidPregQuote
+			count: 1
+			path: core/DbHelper.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/DeviceDetector/DeviceDetectorFactory.php
+
+		-
+			message: '#^Right side of && is always false\.$#'
+			identifier: booleanAnd.rightAlwaysFalse
 			count: 1
 			path: core/ExceptionHandler.php
 
 		-
-			message: "#^Negated boolean expression is always true\\.$#"
+			message: '#^PHPDoc tag @return has invalid value \(array\(bool \$success, array \$messages\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 69 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: core/FileIntegrity.php
+
+		-
+			message: '#^Path in require_once\(\) "/var/www/html/config/manifest\.inc\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: core/FileIntegrity.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: core/Filechecks.php
+
+		-
+			message: '#^Call to function is_array\(\) with list\<string\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/Filesystem.php
 
 		-
-			message: "#^PHPDoc tag @param for parameter \\$beforeUnlink with type Closure\\|false is not subtype of native type Closure\\|null\\.$#"
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
 			count: 1
 			path: core/Filesystem.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 2
-			path: core/FrontController.php
+			message: '#^PHPDoc tag @param for parameter \$beforeUnlink with type Closure\|false is not subtype of native type Closure\|null\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: core/Filesystem.php
 
 		-
-			message: "#^Parameter \\#1 \\$e of method Piwik\\\\FrontController\\:\\:generateSafeModeOutputFromException\\(\\) expects Exception, Error given\\.$#"
+			message: '#^Call to function method_exists\(\) with ''Piwik\\\\SettingsPiwik'' and ''getPiwikUrl'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/FrontController.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
 			count: 2
 			path: core/FrontController.php
 
 		-
-			message: "#^Method Piwik\\\\Log\\:\\:getInstance\\(\\) should return static\\(Piwik\\\\Log\\) but returns Piwik\\\\Log\\.$#"
+			message: '#^Parameter \#1 \$e of method Piwik\\FrontController\:\:generateSafeModeOutputFromException\(\) expects Exception, Error given\.$#'
+			identifier: argument.type
+			count: 1
+			path: core/FrontController.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 2
+			path: core/FrontController.php
+
+		-
+			message: '#^Parameter \#3 \$value of function curl_setopt expects bool, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: core/Http.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between array\{scheme\?\: string, host\?\: string, port\?\: int\<0, 65535\>, user\?\: string, pass\?\: string, path\?\: string, query\?\: string, fragment\?\: string\} and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: core/Http.php
+
+		-
+			message: '#^Method Piwik\\Log\:\:getInstance\(\) should return static\(Piwik\\Log\) but returns Piwik\\Log\.$#'
+			identifier: return.type
 			count: 1
 			path: core/Log.php
 
 		-
-			message: "#^Property Piwik\\\\LogDeleter\\:\\:\\$logTablesProvider is never read, only written\\.$#"
+			message: '#^Class Piwik\\Log\\Logger extends @final class Monolog\\Logger\.$#'
+			identifier: class.extendsFinalByPhpDoc
+			count: 1
+			path: core/Log/Logger.php
+
+		-
+			message: '#^Property Piwik\\LogDeleter\:\:\$logTablesProvider is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: core/LogDeleter.php
 
 		-
-			message: "#^Parameter \\#1 \\$num of function dechex expects int, string given\\.$#"
+			message: '#^Parameter \#1 \$num of function dechex expects int, string given\.$#'
+			identifier: argument.type
 			count: 3
 			path: core/Mail/EmailStyles.php
 
 		-
-			message: "#^Parameter \\#1 \\$default of static method Piwik\\\\Url\\:\\:getCurrentHost\\(\\) expects string, null given\\.$#"
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: core/Menu/MenuAbstract.php
+
+		-
+			message: '#^Call to function is_null\(\) with null will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/Metrics.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between float\|int\|numeric\-string and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: core/Metrics/Formatter.php
+
+		-
+			message: '#^Parameter \#1 \$array \(list\<Piwik\\DataTable\\Row\>\) of array_values is already a list, call has no effect\.$#'
+			identifier: arrayValues.list
+			count: 1
+			path: core/Metrics/Sorter.php
+
+		-
+			message: '#^Call to preg_quote\(\) is missing delimiter / to be effective\.$#'
+			identifier: argument.invalidPregQuote
 			count: 1
 			path: core/Nonce.php
 
 		-
-			message: "#^Parameter \\#1 \\$num of function round expects float\\|int, string given\\.$#"
+			message: '#^Parameter \#1 \$default of static method Piwik\\Url\:\:getCurrentHost\(\) expects string, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: core/Nonce.php
+
+		-
+			message: '#^Parameter \#1 \$num of function round expects float\|int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/NumberFormatter.php
 
 		-
-			message: "#^Parameter \\#1 \\$valueLength of method Piwik\\\\NumberFormatter\\:\\:getMaxFractionDigitsForCompactFormat\\(\\) expects int, float given\\.$#"
+			message: '#^Parameter \#1 \$valueLength of method Piwik\\NumberFormatter\:\:getMaxFractionDigitsForCompactFormat\(\) expects int, float given\.$#'
+			identifier: argument.type
 			count: 2
 			path: core/NumberFormatter.php
 
 		-
-			message: "#^Parameter \\#2 \\$array of function implode expects array\\<string\\>, array\\<int, array\\<int, string\\>\\> given\\.$#"
+			message: '#^Parameter \#2 \$string of function explode expects string, float given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/NumberFormatter.php
 
 		-
-			message: "#^Parameter \\#2 \\$string of function explode expects string, float given\\.$#"
-			count: 1
-			path: core/NumberFormatter.php
-
-		-
-			message: "#^PHPDoc tag @param for parameter \\$timezone with type array\\<Piwik\\\\Date\\> is incompatible with native type string\\.$#"
+			message: '#^PHPDoc tag @param for parameter \$timezone with type array\<Piwik\\Date\> is incompatible with native type string\.$#'
+			identifier: parameter.phpDocType
 			count: 1
 			path: core/Period.php
 
 		-
-			message: "#^If condition is always false\\.$#"
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
 			count: 1
 			path: core/Period/Range.php
 
 		-
-			message: "#^Parameter \\#2 \\$strDate of class Piwik\\\\Period\\\\Range constructor expects string, int given\\.$#"
+			message: '#^Parameter \#2 \$strDate of class Piwik\\Period\\Range constructor expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Period/Range.php
 
 		-
-			message: "#^Binary operation \"\\-\" between string and 1 results in an error\\.$#"
+			message: '#^Binary operation "\-" between string and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: core/Period/Week.php
 
 		-
-			message: "#^Result of && is always true\\.$#"
+			message: '#^Call to function is_numeric\(\) with float\|int will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 3
+			path: core/Piwik.php
+
+		-
+			message: '#^Call to function is_numeric\(\) with float\|int\<min, \-1\>\|int\<1, max\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/Piwik.php
 
 		-
-			message: "#^Result of \\|\\| is always false\\.$#"
+			message: '#^Result of && is always true\.$#'
+			identifier: booleanAnd.alwaysTrue
 			count: 1
 			path: core/Piwik.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between 0\\|numeric\\-string and null will always evaluate to false\\.$#"
+			message: '#^Result of \|\| is always false\.$#'
+			identifier: booleanOr.alwaysFalse
 			count: 1
 			path: core/Piwik.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between float\\|int\\<min, \\-1\\>\\|int\\<1, max\\> and '\\-' will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between 0\|numeric\-string and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: core/Piwik.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			message: '#^Strict comparison using \=\=\= between float\|int\<min, \-1\>\|int\<1, max\> and ''\-'' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: core/Piwik.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with Matomo\\\\Cache\\\\Eager will always evaluate to false\\.$#"
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: core/Piwik.php
+
+		-
+			message: '#^Call to function is_null\(\) with Matomo\\Cache\\Eager will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/Plugin.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
 			count: 1
 			path: core/Plugin.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with Piwik\\\\Site will always evaluate to false\\.$#"
+			message: '#^Call to function is_null\(\) with Piwik\\Site will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/Plugin/Controller.php
 
 		-
-			message: "#^Default value of the parameter \\#3 \\$columnsToDisplay \\(false\\) of method Piwik\\\\Plugin\\\\Controller\\:\\:getLastUnitGraphAcrossPlugins\\(\\) is incompatible with type array\\.$#"
+			message: '#^Call to function property_exists\(\) with Piwik\\ViewDataTable\\Config and ''selectable_columns'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/Plugin/Controller.php
 
 		-
-			message: "#^Parameter \\#2 \\$action of method Piwik\\\\FrontController\\:\\:dispatch\\(\\) expects string\\|null, false given\\.$#"
+			message: '#^Default value of the parameter \#3 \$columnsToDisplay \(false\) of method Piwik\\Plugin\\Controller\:\:getLastUnitGraphAcrossPlugins\(\) is incompatible with type array\.$#'
+			identifier: parameter.defaultValue
 			count: 1
 			path: core/Plugin/Controller.php
 
 		-
-			message: "#^Property Piwik\\\\Plugin\\\\Controller\\:\\:\\$site \\(Piwik\\\\Site\\) in empty\\(\\) is not falsy\\.$#"
+			message: '#^Instanceof between Piwik\\Site and Piwik\\Site will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: core/Plugin/Controller.php
+
+		-
+			message: '#^Parameter \#2 \$action of method Piwik\\FrontController\:\:dispatch\(\) expects string\|null, false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: core/Plugin/Controller.php
+
+		-
+			message: '#^Property Piwik\\Plugin\\Controller\:\:\$site \(Piwik\\Site\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
 			count: 2
 			path: core/Plugin/Controller.php
 
 		-
-			message: "#^Property Piwik\\\\Plugin\\\\Controller\\:\\:\\$site \\(Piwik\\\\Site\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Property Piwik\\Plugin\\Controller\:\:\$site \(Piwik\\Site\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: core/Plugin/Controller.php
 
 		-
-			message: "#^Result of && is always true\\.$#"
+			message: '#^Result of && is always true\.$#'
+			identifier: booleanAnd.alwaysTrue
 			count: 1
 			path: core/Plugin/Controller.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
 			count: 2
 			path: core/Plugin/Controller.php
 
 		-
-			message: "#^Negated boolean expression is always true\\.$#"
+			message: '#^Strict comparison using \!\=\= between array and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: core/Plugin/Controller.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
 			count: 1
 			path: core/Plugin/Dimension/VisitDimension.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: core/Plugin/LogTablesProvider.php
 
 		-
-			message: "#^Left side of && is always true\\.$#"
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
 			path: core/Plugin/LogTablesProvider.php
 
 		-
-			message: "#^Right side of \\|\\| is always false\\.$#"
+			message: '#^Call to function method_exists\(\) with Piwik\\Plugin and ''shouldLoadUmdOnDema…'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/Plugin/Manager.php
 
 		-
-			message: "#^Variable \\$plugin in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Right side of \|\| is always false\.$#'
+			identifier: booleanOr.rightAlwaysFalse
 			count: 1
 			path: core/Plugin/Manager.php
 
 		-
-			message: "#^Parameter \\#1 \\$defaultDate of method Piwik\\\\Plugins\\\\UsersManager\\\\UserPreferences\\:\\:getDefaultPeriod\\(\\) expects string\\|null, false given\\.$#"
+			message: '#^Variable \$plugin in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: core/Plugin/Manager.php
+
+		-
+			message: '#^Parameter \#1 \$defaultDate of method Piwik\\Plugins\\UsersManager\\UserPreferences\:\:getDefaultPeriod\(\) expects string\|null, false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Plugin/Menu.php
 
 		-
-			message: "#^Parameter \\#4 \\$forceDefault of static method Piwik\\\\ViewDataTable\\\\Factory\\:\\:build\\(\\) expects bool, int given\\.$#"
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/Plugin/Report.php
 
 		-
-			message: "#^Property Piwik\\\\Plugin\\\\Report\\:\\:\\$dimension \\(Piwik\\\\Columns\\\\Dimension\\) in empty\\(\\) is not falsy\\.$#"
+			message: '#^Parameter \#4 \$forceDefault of static method Piwik\\ViewDataTable\\Factory\:\:build\(\) expects bool, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Plugin/Report.php
 
 		-
-			message: "#^Property Piwik\\\\ViewDataTable\\\\RequestConfig\\:\\:\\$filter_excludelowpop_value \\(Closure\\|string\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Property Piwik\\Plugin\\Report\:\:\$dimension \(Piwik\\Columns\\Dimension\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
+			count: 1
+			path: core/Plugin/Report.php
+
+		-
+			message: '#^Call to function is_string\(\) with non\-falsy\-string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/Plugin/Segment.php
+
+		-
+			message: '#^Instanceof between Piwik\\Scheduler\\Schedule\\Schedule and Piwik\\Scheduler\\Schedule\\Schedule will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: core/Plugin/Tasks.php
+
+		-
+			message: '#^Property Piwik\\ViewDataTable\\RequestConfig\:\:\$filter_excludelowpop_value \(Closure\|string\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: core/Plugin/ViewDataTable.php
 
 		-
-			message: "#^Instanceof between Piwik\\\\DataTable and Piwik\\\\DataTable\\\\Map will always evaluate to false\\.$#"
+			message: '#^Instanceof between Piwik\\DataTable and Piwik\\DataTable\\Map will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
 			count: 1
 			path: core/Plugin/Visualization.php
 
 		-
-			message: "#^Instanceof between Piwik\\\\DataTable\\|null and Piwik\\\\DataTable\\\\Map will always evaluate to false\\.$#"
+			message: '#^Instanceof between Piwik\\DataTable\|null and Piwik\\DataTable\\Map will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
 			count: 2
 			path: core/Plugin/Visualization.php
 
 		-
-			message: "#^Instanceof between null and Piwik\\\\DataTable\\\\Map will always evaluate to false\\.$#"
+			message: '#^Instanceof between null and Piwik\\DataTable\\Map will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
 			count: 1
 			path: core/Plugin/Visualization.php
 
 		-
-			message: "#^Parameter \\#1 \\$dataTable of method Piwik\\\\Plugin\\\\ViewDataTable\\:\\:setDataTable\\(\\) expects Piwik\\\\DataTable\\|Piwik\\\\DataTable\\\\Map, Piwik\\\\DataTable\\\\DataTableInterface given\\.$#"
+			message: '#^Parameter \#1 \$dataTable of method Piwik\\Plugin\\ViewDataTable\:\:setDataTable\(\) expects Piwik\\DataTable\|Piwik\\DataTable\\Map, Piwik\\DataTable\\DataTableInterface given\.$#'
+			identifier: argument.type
 			count: 2
 			path: core/Plugin/Visualization.php
 
 		-
-			message: "#^Parameter \\#2 \\$return of function print_r expects bool, int given\\.$#"
+			message: '#^Parameter \#2 \$return of function print_r expects bool, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Plugin/Visualization.php
 
 		-
-			message: "#^Ternary operator condition is always true\\.$#"
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
 			count: 1
 			path: core/Plugin/Visualization.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: core/Policy/CompliancePolicy.php
 
 		-
-			message: "#^Method Piwik\\\\ProfessionalServices\\\\Advertising\\:\\:getCampaignParametersForPromoUrl\\(\\) is unused\\.$#"
+			message: '#^Call to function is_a\(\) with arguments class\-string\<Piwik\\Policy\\CompliancePolicy\>, ''Piwik\\\\Policy\\\\CompliancePolicy'' and true will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/Policy/PolicyManager.php
+
+		-
+			message: '#^Method Piwik\\ProfessionalServices\\Advertising\:\:getCampaignParametersForPromoUrl\(\) is unused\.$#'
+			identifier: method.unused
 			count: 1
 			path: core/ProfessionalServices/Advertising.php
 
 		-
-			message: "#^Property Piwik\\\\ProfessionalServices\\\\Advertising\\:\\:\\$pluginManager is never read, only written\\.$#"
+			message: '#^Property Piwik\\ProfessionalServices\\Advertising\:\:\$pluginManager is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: core/ProfessionalServices/Advertising.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:getProfiler\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:getProfiler\(\)\.$#'
+			identifier: method.notFound
 			count: 3
 			path: core/Profiler.php
 
 		-
-			message: "#^Constant TIDEWAYS_FLAGS_CPU not found\\.$#"
+			message: '#^Constant TIDEWAYS_FLAGS_CPU not found\.$#'
+			identifier: constant.notFound
 			count: 1
 			path: core/Profiler.php
 
 		-
-			message: "#^Constant TIDEWAYS_FLAGS_MEMORY not found\\.$#"
+			message: '#^Constant TIDEWAYS_FLAGS_MEMORY not found\.$#'
+			identifier: constant.notFound
 			count: 1
 			path: core/Profiler.php
 
 		-
-			message: "#^Constant TIDEWAYS_XHPROF_FLAGS_CPU not found\\.$#"
+			message: '#^Constant TIDEWAYS_XHPROF_FLAGS_CPU not found\.$#'
+			identifier: constant.notFound
 			count: 1
 			path: core/Profiler.php
 
 		-
-			message: "#^Constant TIDEWAYS_XHPROF_FLAGS_MEMORY not found\\.$#"
+			message: '#^Constant TIDEWAYS_XHPROF_FLAGS_MEMORY not found\.$#'
+			identifier: constant.notFound
 			count: 1
 			path: core/Profiler.php
 
 		-
-			message: "#^Static method Piwik\\\\Profiler\\:\\:maxSumMsFirst\\(\\) is unused\\.$#"
+			message: '#^Static method Piwik\\Profiler\:\:maxSumMsFirst\(\) is unused\.$#'
+			identifier: method.unused
 			count: 1
 			path: core/Profiler.php
 
 		-
-			message: "#^Static method Piwik\\\\Profiler\\:\\:sortTimeDesc\\(\\) is unused\\.$#"
+			message: '#^Static method Piwik\\Profiler\:\:sortTimeDesc\(\) is unused\.$#'
+			identifier: method.unused
 			count: 1
 			path: core/Profiler.php
 
 		-
-			message: "#^Variable \\$xhprofData might not be defined\\.$#"
+			message: '#^Variable \$xhprofData might not be defined\.$#'
+			identifier: variable.undefined
 			count: 1
 			path: core/Profiler.php
 
 		-
-			message: "#^Call to an undefined method HTML_QuickForm2_Renderer_Proxy\\:\\:toArray\\(\\)\\.$#"
+			message: '#^Left side of \|\| is always false\.$#'
+			identifier: booleanOr.leftAlwaysFalse
+			count: 1
+			path: core/ProxyHttp.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: core/ProxyHttp.php
+
+		-
+			message: '#^Right side of \|\| is always false\.$#'
+			identifier: booleanOr.rightAlwaysFalse
+			count: 1
+			path: core/ProxyHttp.php
+
+		-
+			message: '#^Call to an undefined method HTML_QuickForm2_Renderer_Proxy\:\:toArray\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/QuickForm2.php
 
 		-
-			message: "#^Parameter \\#1 \\$viewDataTableId of method Piwik\\\\Report\\\\ReportWidgetConfig\\:\\:setDefaultViewDataTable\\(\\) expects string, null given\\.$#"
+			message: '#^Parameter \#1 \$viewDataTableId of method Piwik\\Report\\ReportWidgetConfig\:\:setDefaultViewDataTable\(\) expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Report/ReportWidgetFactory.php
 
 		-
-			message: "#^Method Piwik\\\\DataTable\\\\Renderer\\\\Csv\\:\\:render\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			message: '#^Method Piwik\\DataTable\\Renderer\\Csv\:\:render\(\) invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
 			count: 1
 			path: core/ReportRenderer/Csv.php
 
 		-
-			message: "#^Method Piwik\\\\Request\\:\\:fromGet\\(\\) should return static\\(Piwik\\\\Request\\) but returns Piwik\\\\Request\\.$#"
+			message: '#^Method Piwik\\Request\:\:fromGet\(\) should return static\(Piwik\\Request\) but returns Piwik\\Request\.$#'
+			identifier: return.type
 			count: 1
 			path: core/Request.php
 
 		-
-			message: "#^Method Piwik\\\\Request\\:\\:fromPost\\(\\) should return static\\(Piwik\\\\Request\\) but returns Piwik\\\\Request\\.$#"
+			message: '#^Method Piwik\\Request\:\:fromPost\(\) should return static\(Piwik\\Request\) but returns Piwik\\Request\.$#'
+			identifier: return.type
 			count: 1
 			path: core/Request.php
 
 		-
-			message: "#^Method Piwik\\\\Request\\:\\:fromQueryString\\(\\) should return static\\(Piwik\\\\Request\\) but returns Piwik\\\\Request\\.$#"
+			message: '#^Method Piwik\\Request\:\:fromQueryString\(\) should return static\(Piwik\\Request\) but returns Piwik\\Request\.$#'
+			identifier: return.type
 			count: 1
 			path: core/Request.php
 
 		-
-			message: "#^Method Piwik\\\\Request\\:\\:fromRequest\\(\\) should return static\\(Piwik\\\\Request\\) but returns Piwik\\\\Request\\.$#"
+			message: '#^Method Piwik\\Request\:\:fromRequest\(\) should return static\(Piwik\\Request\) but returns Piwik\\Request\.$#'
+			identifier: return.type
 			count: 1
 			path: core/Request.php
 
 		-
-			message: "#^Parameter \\#1 \\$hour of function mktime expects int, string given\\.$#"
+			message: '#^Parameter \#1 \$hour of function mktime expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Daily.php
 
 		-
-			message: "#^Parameter \\#2 \\$minute of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#2 \$minute of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Daily.php
 
 		-
-			message: "#^Parameter \\#3 \\$second of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#3 \$second of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Daily.php
 
 		-
-			message: "#^Parameter \\#4 \\$month of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#4 \$month of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Daily.php
 
 		-
-			message: "#^Parameter \\#6 \\$year of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#6 \$year of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Daily.php
 
 		-
-			message: "#^Parameter \\#3 \\$second of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#3 \$second of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Hourly.php
 
 		-
-			message: "#^Parameter \\#4 \\$month of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#4 \$month of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Hourly.php
 
 		-
-			message: "#^Parameter \\#5 \\$day of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#5 \$day of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Hourly.php
 
 		-
-			message: "#^Parameter \\#6 \\$year of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#6 \$year of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Hourly.php
 
 		-
-			message: "#^Parameter \\#1 \\$hour of function mktime expects int, string given\\.$#"
+			message: '#^Parameter \#1 \$hour of function mktime expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Monthly.php
 
 		-
-			message: "#^Parameter \\#2 \\$minute of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#2 \$minute of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Monthly.php
 
 		-
-			message: "#^Parameter \\#3 \\$second of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#3 \$second of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Monthly.php
 
 		-
-			message: "#^Parameter \\#6 \\$year of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#6 \$year of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Monthly.php
 
 		-
-			message: "#^Parameter \\#3 \\$second of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#3 \$second of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Schedule.php
 
 		-
-			message: "#^Parameter \\#4 \\$month of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#4 \$month of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Schedule.php
 
 		-
-			message: "#^Parameter \\#5 \\$day of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#5 \$day of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Schedule.php
 
 		-
-			message: "#^Parameter \\#6 \\$year of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#6 \$year of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Schedule.php
 
 		-
-			message: "#^Parameter \\#1 \\$hour of function mktime expects int, string given\\.$#"
+			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/Scheduler/Schedule/Weekly.php
 
 		-
-			message: "#^Parameter \\#2 \\$minute of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#1 \$hour of function mktime expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Weekly.php
 
 		-
-			message: "#^Parameter \\#3 \\$second of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#2 \$minute of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Weekly.php
 
 		-
-			message: "#^Parameter \\#4 \\$month of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#3 \$second of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Weekly.php
 
 		-
-			message: "#^Parameter \\#6 \\$year of function mktime expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#4 \$month of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Scheduler/Schedule/Weekly.php
 
 		-
-			message: "#^If condition is always false\\.$#"
+			message: '#^Parameter \#6 \$year of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: core/Scheduler/Schedule/Weekly.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
 			count: 1
 			path: core/Scheduler/Scheduler.php
 
 		-
-			message: "#^If condition is always false\\.$#"
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
 			count: 1
 			path: core/Segment.php
 
 		-
-			message: "#^Property Piwik\\\\Segment\\:\\:\\$endDate \\(Piwik\\\\Date\\) in empty\\(\\) is not falsy\\.$#"
-			count: 1
-			path: core/Segment.php
-
-		-
-			message: "#^Property Piwik\\\\Segment\\:\\:\\$startDate \\(Piwik\\\\Date\\) in empty\\(\\) is not falsy\\.$#"
-			count: 1
-			path: core/Segment.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
+			message: '#^Instanceof between Piwik\\Date and Piwik\\Date will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 2
 			path: core/Segment.php
 
 		-
-			message: "#^Offset 1 on array\\{array\\<int, string\\>, array\\<int, non\\-falsy\\-string\\>\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			message: '#^Property Piwik\\Segment\:\:\$endDate \(Piwik\\Date\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
+			count: 1
+			path: core/Segment.php
+
+		-
+			message: '#^Property Piwik\\Segment\:\:\$startDate \(Piwik\\Date\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
+			count: 1
+			path: core/Segment.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 2
+			path: core/Segment.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/Segment/SegmentExpression.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			message: '#^Offset 1 on array\{list\<string\>, list\<non\-falsy\-string\>\} in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
 			count: 1
 			path: core/Segment/SegmentExpression.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\\\AdapterInterface\\:\\:fetchOne\\(\\)\\.$#"
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: core/Segment/SegmentExpression.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between mixed and \*NEVER\* will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: core/Segment/SegmentExpression.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: core/Segment/SegmentExpression.php
+
+		-
+			message: '#^Call to an undefined method Piwik\\Db\\AdapterInterface\:\:fetchOne\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Sequence.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\\\AdapterInterface\\:\\:insert\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\\AdapterInterface\:\:insert\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Sequence.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\\\AdapterInterface\\:\\:lastInsertId\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\\AdapterInterface\:\:lastInsertId\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Sequence.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\\\AdapterInterface\\:\\:query\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\\AdapterInterface\:\:query\(\)\.$#'
+			identifier: method.notFound
 			count: 2
 			path: core/Sequence.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: core/Session.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:getConnection\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:getConnection\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Session/SaveHandler/DbTable.php
 
 		-
-			message: "#^Parameter \\#2 \\$login of class Piwik\\\\AuthResult constructor expects string, null given\\.$#"
+			message: '#^Parameter \#2 \$login of class Piwik\\AuthResult constructor expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Session/SessionAuth.php
 
 		-
-			message: "#^Parameter \\#3 \\$tokenAuth of class Piwik\\\\AuthResult constructor expects string, null given\\.$#"
+			message: '#^Parameter \#3 \$tokenAuth of class Piwik\\AuthResult constructor expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Session/SessionAuth.php
 
 		-
-			message: "#^Method Piwik\\\\Settings\\\\Plugin\\\\SystemSettings\\:\\:makeSettingManagedInConfigOnly\\(\\) should return Piwik\\\\Settings\\\\Plugin\\\\SystemSetting but returns Piwik\\\\Settings\\\\Plugin\\\\SystemConfigSetting\\.$#"
+			message: '#^Method Piwik\\Settings\\Plugin\\SystemSettings\:\:makeSettingManagedInConfigOnly\(\) should return Piwik\\Settings\\Plugin\\SystemSetting but returns Piwik\\Settings\\Plugin\\SystemConfigSetting\.$#'
+			identifier: return.type
 			count: 1
 			path: core/Settings/Plugin/SystemSettings.php
 
 		-
-			message: "#^Property Piwik\\\\Settings\\\\FieldConfig\\:\\:\\$uiControl \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Instanceof between Closure and Closure will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 3
+			path: core/Settings/Setting.php
+
+		-
+			message: '#^Property Piwik\\Settings\\FieldConfig\:\:\$uiControl \(string\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: core/Settings/Setting.php
 
 		-
-			message: "#^Property Piwik\\\\Settings\\\\Setting\\:\\:\\$type \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Property Piwik\\Settings\\Setting\:\:\$type \(string\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: core/Settings/Setting.php
 
 		-
-			message: "#^Property Piwik\\\\Settings\\\\Storage\\\\Backend\\\\BaseSettingsTable\\:\\:\\$db \\(Piwik\\\\Db\\\\AdapterInterface\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Property Piwik\\Settings\\Storage\\Backend\\BaseSettingsTable\:\:\$db \(Piwik\\Db\\AdapterInterface\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: core/Settings/Storage/Backend/BaseSettingsTable.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\\\AdapterInterface\\:\\:fetchAll\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\\AdapterInterface\:\:fetchAll\(\)\.$#'
+			identifier: method.notFound
 			count: 2
 			path: core/Settings/Storage/Backend/MeasurableSettingsTable.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\\\AdapterInterface\\:\\:query\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\\AdapterInterface\:\:query\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Settings/Storage/Backend/MeasurableSettingsTable.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\\\AdapterInterface\\:\\:fetchAll\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\\AdapterInterface\:\:fetchAll\(\)\.$#'
+			identifier: method.notFound
 			count: 6
 			path: core/Settings/Storage/Backend/PluginSettingsTable.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\\\AdapterInterface\\:\\:query\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\\AdapterInterface\:\:query\(\)\.$#'
+			identifier: method.notFound
 			count: 2
 			path: core/Settings/Storage/Backend/PluginSettingsTable.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
 			count: 1
 			path: core/SettingsPiwik.php
 
 		-
-			message: "#^Binary operation \"\\*\" between string and 1024 results in an error\\.$#"
+			message: '#^Binary operation "\*" between string and 1024 results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: core/SettingsServer.php
 
 		-
-			message: "#^Binary operation \"/\" between string and 1024 results in an error\\.$#"
+			message: '#^Binary operation "/" between string and 1024 results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: core/SettingsServer.php
 
 		-
-			message: "#^Method Piwik\\\\Site\\:\\:isEcommerceEnabledFor\\(\\) should return string but returns bool\\.$#"
+			message: '#^Call to function is_array\(\) with list\<string\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/SettingsServer.php
+
+		-
+			message: '#^Method Piwik\\Site\:\:isEcommerceEnabledFor\(\) should return string but returns bool\.$#'
+			identifier: return.type
 			count: 1
 			path: core/Site.php
 
 		-
-			message: "#^Method Piwik\\\\Site\\:\\:isSiteSearchEnabledFor\\(\\) should return string but returns bool\\.$#"
+			message: '#^Method Piwik\\Site\:\:isSiteSearchEnabledFor\(\) should return string but returns bool\.$#'
+			identifier: return.type
 			count: 1
 			path: core/Site.php
 
 		-
-			message: "#^Offset 4 does not exist on array\\<string, array\\<Piwik\\\\Plugins\\\\SitesManager\\\\SiteContentDetection\\\\SiteContentDetectionAbstract\\>\\>\\.$#"
+			message: '#^Parameter \#1 \$array \(list\<int\<1, max\>\>\) to function array_filter does not contain falsy values, the array will always stay the same\.$#'
+			identifier: arrayFilter.same
+			count: 1
+			path: core/Site.php
+
+		-
+			message: '#^Offset 4 does not exist on array\<string, array\<Piwik\\Plugins\\SitesManager\\SiteContentDetection\\SiteContentDetectionAbstract\>\>\.$#'
+			identifier: offsetAccess.notFound
 			count: 1
 			path: core/SiteContentDetector.php
 
 		-
-			message: "#^Offset int does not exist on array\\<string, array\\<string, Piwik\\\\Plugins\\\\SitesManager\\\\SiteContentDetection\\\\SiteContentDetectionAbstract\\>\\>\\.$#"
+			message: '#^Offset int does not exist on array\<string, array\<string, Piwik\\Plugins\\SitesManager\\SiteContentDetection\\SiteContentDetectionAbstract\>\>\.$#'
+			identifier: offsetAccess.notFound
 			count: 1
 			path: core/SiteContentDetector.php
 
 		-
-			message: "#^Offset int on array\\<string, array\\<Piwik\\\\Plugins\\\\SitesManager\\\\SiteContentDetection\\\\SiteContentDetectionAbstract\\>\\> in isset\\(\\) does not exist\\.$#"
+			message: '#^Offset int on array\<string, array\<Piwik\\Plugins\\SitesManager\\SiteContentDetection\\SiteContentDetectionAbstract\>\> in isset\(\) does not exist\.$#'
+			identifier: isset.offset
 			count: 1
 			path: core/SiteContentDetector.php
 
 		-
-			message: "#^Offset string on array\\<string, Piwik\\\\Plugins\\\\SitesManager\\\\SiteContentDetection\\\\SiteContentDetectionAbstract\\> on left side of \\?\\? always exists and is not nullable\\.$#"
+			message: '#^Offset string on non\-empty\-array\<string, Piwik\\Plugins\\SitesManager\\SiteContentDetection\\SiteContentDetectionAbstract\> on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
 			count: 1
 			path: core/SiteContentDetector.php
 
 		-
-			message: "#^Property Piwik\\\\SiteContentDetector\\:\\:\\$detectedContent \\(array\\<string, array\\<string, Piwik\\\\Plugins\\\\SitesManager\\\\SiteContentDetection\\\\SiteContentDetectionAbstract\\>\\>\\) does not accept array\\<int, array\\>\\.$#"
+			message: '#^Property Piwik\\SiteContentDetector\:\:\$detectedContent \(array\<string, array\<string, Piwik\\Plugins\\SitesManager\\SiteContentDetection\\SiteContentDetectionAbstract\>\>\) does not accept array\<int, array\>\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: core/SiteContentDetector.php
 
 		-
-			message: "#^Property Piwik\\\\SiteContentDetector\\:\\:\\$detectedContent \\(array\\<string, array\\<string, Piwik\\\\Plugins\\\\SitesManager\\\\SiteContentDetection\\\\SiteContentDetectionAbstract\\>\\>\\) does not accept default value of type array\\<int, array\\>\\.$#"
+			message: '#^Property Piwik\\SiteContentDetector\:\:\$detectedContent \(array\<string, array\<string, Piwik\\Plugins\\SitesManager\\SiteContentDetection\\SiteContentDetectionAbstract\>\>\) does not accept default value of type array\<int, array\>\.$#'
+			identifier: property.defaultValue
 			count: 1
 			path: core/SiteContentDetector.php
 
 		-
-			message: "#^Parameter \\#5 \\$ln of method TCPDF\\:\\:Cell\\(\\) expects int, false given\\.$#"
+			message: '#^Strict comparison using \!\=\= between null and Piwik\\Plugins\\SitesManager\\SiteContentDetection\\SiteContentDetectionAbstract will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: core/SiteContentDetector.php
+
+		-
+			message: '#^Parameter \#5 \$ln of method TCPDF\:\:Cell\(\) expects int, false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/TCPDF.php
 
 		-
-			message: "#^Parameter \\#7 \\$fill of method TCPDF\\:\\:Cell\\(\\) expects bool, int given\\.$#"
+			message: '#^Parameter \#7 \$fill of method TCPDF\:\:Cell\(\) expects bool, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/TCPDF.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\:\\:disconnect\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\:\:disconnect\(\)\.$#'
+			identifier: method.notFound
 			count: 2
 			path: core/Tracker.php
 
 		-
-			message: "#^Parameter \\#2 \\$flags of function json_encode expects int, true given\\.$#"
+			message: '#^Parameter \#2 \$flags of function json_encode expects int, true given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Tracker.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(mixed\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(mixed\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Tracker/ActionPageview.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with Matomo\\\\Cache\\\\Lazy will always evaluate to false\\.$#"
+			message: '#^Call to function is_null\(\) with Matomo\\Cache\\Lazy will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/Tracker/Cache.php
 
 		-
-			message: "#^Parameter \\#1 \\$id of method Matomo\\\\Cache\\\\Lazy\\:\\:delete\\(\\) expects string, int given\\.$#"
+			message: '#^Parameter \#1 \$id of method Matomo\\Cache\\Lazy\:\:delete\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Tracker/Cache.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between 'all' and int will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between ''all'' and int will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: core/Tracker/Cache.php
 
 		-
-			message: "#^Variable \\$content in empty\\(\\) always exists and is always falsy\\.$#"
+			message: '#^Variable \$content in empty\(\) always exists and is always falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: core/Tracker/Cache.php
 
 		-
-			message: "#^Method Piwik\\\\Tracker\\\\Db\\:\\:query\\(\\) has invalid return type Piwik\\\\Tracker\\\\PDOStatement\\.$#"
+			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: core/Tracker/Config/ThirdPartyCookies.php
+
+		-
+			message: '#^Method Piwik\\Tracker\\Db\:\:query\(\) has invalid return type Piwik\\Tracker\\PDOStatement\.$#'
+			identifier: class.notFound
 			count: 1
 			path: core/Tracker/Db.php
 
 		-
-			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Mysqli\\:\\:prepare\\(\\) is unused\\.$#"
+			message: '#^Call to function is_array\(\) with non\-empty\-array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/Tracker/Db/Mysqli.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\|bool and null will always evaluate to false\\.$#"
+			message: '#^Method Piwik\\Tracker\\Db\\Mysqli\:\:prepare\(\) is unused\.$#'
+			identifier: method.unused
 			count: 1
 			path: core/Tracker/Db/Mysqli.php
 
 		-
-			message: "#^Variable \\$timer in isset\\(\\) always exists and is not nullable\\.$#"
+			message: '#^Strict comparison using \=\=\= between array\|bool and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: core/Tracker/Db/Mysqli.php
+
+		-
+			message: '#^Variable \$timer in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
 			count: 4
 			path: core/Tracker/Db/Mysqli.php
 
 		-
-			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Pdo\\\\Mysql\\:\\:lastInsertId\\(\\) should return int but returns string\\|false\\.$#"
+			message: '#^Method Piwik\\Tracker\\Db\\Pdo\\Mysql\:\:lastInsertId\(\) should return int but returns string\|false\.$#'
+			identifier: return.type
 			count: 1
 			path: core/Tracker/Db/Pdo/Mysql.php
 
 		-
-			message: "#^Parameter \\#2 \\$errno of method Piwik\\\\Tracker\\\\Db\\\\Pdo\\\\Mysql\\:\\:isErrNo\\(\\) expects string, int given\\.$#"
+			message: '#^Parameter \#2 \$errno of method Piwik\\Tracker\\Db\\Pdo\\Mysql\:\:isErrNo\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Tracker/Db/Pdo/Mysql.php
 
 		-
-			message: "#^Variable \\$timer in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 2
+			message: '#^Variable \$timer in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
 			path: core/Tracker/Db/Pdo/Mysql.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Tracker\\\\Action\\:\\:getEventAction\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Tracker\\Action\:\:getEventAction\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Tracker/GoalManager.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Tracker\\\\Action\\:\\:getEventCategory\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Tracker\\Action\:\:getEventCategory\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Tracker/GoalManager.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Tracker\\\\Action\\:\\:getEventName\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Tracker\\Action\:\:getEventName\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Tracker/GoalManager.php
 
 		-
-			message: "#^Method Piwik\\\\Tracker\\\\GoalManager\\:\\:getRevenue\\(\\) should return float\\|int but returns string\\.$#"
+			message: '#^Method Piwik\\Tracker\\GoalManager\:\:getRevenue\(\) should return float\|int but returns string\.$#'
+			identifier: return.type
 			count: 1
 			path: core/Tracker/GoalManager.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with Piwik\\\\Tracker\\\\ScheduledTasksRunner will always evaluate to false\\.$#"
+			message: '#^Call to function is_null\(\) with Piwik\\Tracker\\ScheduledTasksRunner will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/Tracker/Handler.php
 
 		-
-			message: "#^Elseif branch is unreachable because previous condition is always true\\.$#"
+			message: '#^Call to function is_null\(\) with null will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/Tracker/Handler/Factory.php
 
 		-
-			message: "#^Instanceof between \\*NEVER\\* and Piwik\\\\Tracker\\\\Handler will always evaluate to false\\.$#"
+			message: '#^Instanceof between \*NEVER\* and Piwik\\Tracker\\Handler will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
 			count: 1
 			path: core/Tracker/Handler/Factory.php
 
 		-
-			message: "#^Method Piwik\\\\Tracker\\\\LogTable\\:\\:getLinkTableToBeAbleToJoinOnVisit\\(\\) should return string but empty return statement found\\.$#"
+			message: '#^Method Piwik\\Tracker\\LogTable\:\:getLinkTableToBeAbleToJoinOnVisit\(\) should return string but empty return statement found\.$#'
+			identifier: return.empty
 			count: 1
 			path: core/Tracker/LogTable.php
 
 		-
-			message: "#^Comparison operation \"\\>\" between int\\<1, max\\> and 0 is always true\\.$#"
+			message: '#^Comparison operation "\>" between int\<1, max\> and 0 is always true\.$#'
+			identifier: greater.alwaysTrue
 			count: 1
 			path: core/Tracker/Model.php
 
 		-
-			message: "#^Parameter \\#3 \\$urlPrefix of method Piwik\\\\Tracker\\\\Model\\:\\:insertNewAction\\(\\) expects string, int given\\.$#"
+			message: '#^Parameter \#3 \$urlPrefix of method Piwik\\Tracker\\Model\:\:insertNewAction\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Tracker/Model.php
 
 		-
-			message: "#^Variable \\$parametersToExclude in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Strict comparison using \!\=\= between int and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: core/Tracker/PageUrl.php
 
 		-
-			message: "#^Negated boolean expression is always true\\.$#"
+			message: '#^Variable \$parametersToExclude in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: core/Tracker/PageUrl.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
 			count: 1
 			path: core/Tracker/Request.php
 
 		-
-			message: "#^Parameter \\#1 \\$login of method Piwik\\\\Auth\\:\\:setLogin\\(\\) expects string, null given\\.$#"
+			message: '#^Parameter \#1 \$login of method Piwik\\Auth\:\:setLogin\(\) expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Tracker/Request.php
 
 		-
-			message: "#^Parameter \\#1 \\$password of method Piwik\\\\Auth\\:\\:setPassword\\(\\) expects string, null given\\.$#"
+			message: '#^Parameter \#1 \$password of method Piwik\\Auth\:\:setPassword\(\) expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Tracker/Request.php
 
 		-
-			message: "#^Parameter \\#1 \\$passwordHash of method Piwik\\\\Auth\\:\\:setPasswordHash\\(\\) expects string, null given\\.$#"
+			message: '#^Parameter \#1 \$passwordHash of method Piwik\\Auth\:\:setPasswordHash\(\) expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Tracker/Request.php
 
 		-
-			message: "#^Variable \\$access in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Variable \$access in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: core/Tracker/Request.php
 
 		-
-			message: "#^Variable \\$idVisitor might not be defined\\.$#"
+			message: '#^Call to function is_array\(\) with array\<Piwik\\Tracker\\Request\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/Tracker/RequestSet.php
+
+		-
+			message: '#^Call to function is_null\(\) with array\<Piwik\\Tracker\\Request\> will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: core/Tracker/RequestSet.php
+
+		-
+			message: '#^Call to function is_null\(\) with string will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: core/Tracker/RequestSet.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: core/Tracker/RequestSet.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
 			count: 2
-			path: core/Tracker/Request.php
-
-		-
-			message: "#^Call to function is_null\\(\\) with array\\<Piwik\\\\Tracker\\\\Request\\> will always evaluate to false\\.$#"
-			count: 1
 			path: core/Tracker/RequestSet.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
-			count: 1
-			path: core/Tracker/RequestSet.php
-
-		-
-			message: "#^Negated boolean expression is always true\\.$#"
-			count: 1
-			path: core/Tracker/RequestSet.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 2
-			path: core/Tracker/RequestSet.php
-
-		-
-			message: "#^Offset 'mime' on array\\{0\\: int\\<0, max\\>, 1\\: int\\<0, max\\>, 2\\: int, 3\\: string, mime\\: string, channels\\?\\: int, bits\\?\\: int\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			message: '#^Offset ''mime'' on array\{0\: int\<0, max\>, 1\: int\<0, max\>, 2\: int, 3\: string, mime\: string, channels\?\: int, bits\?\: int\} in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
 			count: 1
 			path: core/Tracker/Response.php
 
 		-
-			message: "#^Comparison operation \"\\<\" between \\(array\\|float\\|int\\) and int\\<1, max\\> results in an error\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int\<1, max\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Tracker/ScheduledTasksRunner.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int\\<1, max\\> given\\.$#"
-			count: 1
-			path: core/Tracker/ScheduledTasksRunner.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
 			count: 1
 			path: core/Tracker/TableLogAction.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with true will always evaluate to false\\.$#"
+			message: '#^Call to function is_array\(\) with non\-empty\-array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/Tracker/TrackerCodeGenerator.php
 
 		-
-			message: "#^Offset 'httpsPiwikUrl' does not exist on array\\{idSite\\: int, piwikUrl\\: string, options\\: string, optionsBeforeTrackerUrl\\: '', protocol\\: '//'\\|'https\\://', loadAsync\\: true, trackNoScript\\: bool, matomoJsFilename\\: mixed, \\.\\.\\.\\}\\.$#"
+			message: '#^Call to function is_array\(\) with true will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/Tracker/TrackerCodeGenerator.php
 
 		-
-			message: "#^Offset 'httpsPiwikUrl' on array\\{idSite\\: int, piwikUrl\\: string, options\\: string, optionsBeforeTrackerUrl\\: '', protocol\\: '//'\\|'https\\://', loadAsync\\: true, trackNoScript\\: bool, matomoJsFilename\\: mixed, \\.\\.\\.\\} in empty\\(\\) does not exist\\.$#"
+			message: '#^Offset ''httpsPiwikUrl'' does not exist on array\{idSite\: int, piwikUrl\: string, options\: string, optionsBeforeTrackerUrl\: '''', protocol\: ''//''\|''https\://'', loadAsync\: true, trackNoScript\: bool, matomoJsFilename\: mixed, \.\.\.\}\.$#'
+			identifier: offsetAccess.notFound
 			count: 1
 			path: core/Tracker/TrackerCodeGenerator.php
 
 		-
-			message: "#^Parameter \\#2 \\$string of function explode expects string, true given\\.$#"
+			message: '#^Offset ''httpsPiwikUrl'' on array\{idSite\: int, piwikUrl\: string, options\: string, optionsBeforeTrackerUrl\: '''', protocol\: ''//''\|''https\://'', loadAsync\: true, trackNoScript\: bool, matomoJsFilename\: mixed, \.\.\.\} in empty\(\) does not exist\.$#'
+			identifier: empty.offset
 			count: 1
 			path: core/Tracker/TrackerCodeGenerator.php
 
 		-
-			message: "#^Instanceof between \\*NEVER\\* and Piwik\\\\Tracker\\\\VisitInterface will always evaluate to false\\.$#"
+			message: '#^Parameter \#2 \$string of function explode expects string, true given\.$#'
+			identifier: argument.type
+			count: 1
+			path: core/Tracker/TrackerCodeGenerator.php
+
+		-
+			message: '#^Instanceof between \*NEVER\* and Piwik\\Tracker\\VisitInterface will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
 			count: 1
 			path: core/Tracker/Visit/Factory.php
 
 		-
-			message: "#^Variable \\$visit in isset\\(\\) always exists and is always null\\.$#"
+			message: '#^Variable \$visit in isset\(\) always exists and is always null\.$#'
+			identifier: isset.variable
 			count: 1
 			path: core/Tracker/Visit/Factory.php
 
 		-
-			message: "#^Property Piwik\\\\Tracker\\\\Visitor\\:\\:\\$previousVisitProperties \\(Piwik\\\\Tracker\\\\Visit\\\\VisitProperties\\) in empty\\(\\) is not falsy\\.$#"
+			message: '#^Property Piwik\\Tracker\\Visitor\:\:\$previousVisitProperties \(Piwik\\Tracker\\Visit\\VisitProperties\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
 			count: 1
 			path: core/Tracker/Visitor.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with array will always evaluate to false\\.$#"
+			message: '#^Call to function is_null\(\) with array will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: core/Tracker/VisitorRecognizer.php
 
 		-
-			message: "#^Variable \\$translationId on left side of \\?\\? always exists and is not nullable\\.$#"
+			message: '#^PHPDoc tag @return has invalid value \(array\( datetimeMin, datetimeMax \)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 411 on line 8$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: core/Tracker/VisitorRecognizer.php
+
+		-
+			message: '#^Variable \$translationId on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.variable
 			count: 1
 			path: core/Translation/Translator.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, bool given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, bool given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/UpdateCheck.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int\\<1, max\\> given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int\<1, max\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/UpdateCheck.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\<int\\>\\|int and false will always evaluate to false\\.$#"
+			message: '#^PHPDoc tag @return has invalid value \(array\( componentName \=\> array\( file1 \=\> version1, \[\.\.\.\]\), \[\.\.\.\]\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 509 on line 9$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: core/Updater.php
+
+		-
+			message: '#^PHPDoc tag @return has invalid value \(array\( componentName \=\> array\( file1 \=\> version1, \[\.\.\.\]\), \[\.\.\.\]\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 97 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: core/Updater.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between array\<int\>\|int and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 2
 			path: core/Updater/Migration/Db/Factory.php
 
 		-
-			message: "#^Dead catch \\- Exception is never thrown in the try block\\.$#"
+			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
 			count: 1
 			path: core/Updates/1.1.php
 
 		-
-			message: "#^Parameter \\#2 \\$errorCodesToIgnore of method Piwik\\\\Updater\\\\Migration\\\\Db\\\\Factory\\:\\:sql\\(\\) expects array\\<int\\>\\|int, string given\\.$#"
+			message: '#^Parameter \#2 \$errorCodesToIgnore of method Piwik\\Updater\\Migration\\Db\\Factory\:\:sql\(\) expects array\<int\>\|int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Updates/1.4-rc1.php
 
 		-
-			message: "#^Parameter \\#2 \\$errorCodesToIgnore of method Piwik\\\\Updater\\\\Migration\\\\Db\\\\Factory\\:\\:sql\\(\\) expects array\\<int\\>\\|int, string given\\.$#"
+			message: '#^Parameter \#2 \$errorCodesToIgnore of method Piwik\\Updater\\Migration\\Db\\Factory\:\:sql\(\) expects array\<int\>\|int, string given\.$#'
+			identifier: argument.type
 			count: 3
 			path: core/Updates/2.0-a13.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:insert\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:insert\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Updates/2.0.4-b5.php
 
 		-
-			message: "#^Dead catch \\- Exception is never thrown in the try block\\.$#"
+			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
 			count: 1
 			path: core/Updates/2.0.4-b5.php
 
 		-
-			message: "#^Binary operation \"\\+\" between string and 1 results in an error\\.$#"
+			message: '#^Binary operation "\+" between string and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: core/Updates/2.1.1-b11.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:fetchCol\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:fetchCol\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Updates/2.1.1-b11.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:fetchCol\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:fetchCol\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Updates/2.9.0-b1.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:closeConnection\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:closeConnection\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/Updates/3.6.0-b4.php
 
 		-
-			message: "#^Property Piwik\\\\Updates\\\\Updates_4_1_2_b1\\:\\:\\$migration is never read, only written\\.$#"
+			message: '#^Property Piwik\\Updates\\Updates_4_1_2_b1\:\:\$migration is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: core/Updates/4.1.2-b1.php
 
 		-
-			message: "#^Property Piwik\\\\Updates\\\\Updates_5_2_0_b6\\:\\:\\$migration is never read, only written\\.$#"
+			message: '#^Property Piwik\\Updates\\Updates_5_2_0_b6\:\:\$migration is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: core/Updates/5.2.0-b6.php
 
 		-
-			message: "#^Property Piwik\\\\Updates\\\\Updates_5_3_0_rc1\\:\\:\\$migration is never read, only written\\.$#"
+			message: '#^Property Piwik\\Updates\\Updates_5_3_0_rc1\:\:\$migration is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: core/Updates/5.3.0-rc1.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between string and false will always evaluate to false\\.$#"
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/Url.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/UrlHelper.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Strict comparison using \=\=\= between string and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: core/UrlHelper.php
+
+		-
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/Validators/IpRanges.php
 
 		-
-			message: "#^Call to an undefined method Twig\\\\Node\\\\Node\\:\\:getKeyValuePairs\\(\\)\\.$#"
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: core/Validators/WhitelistedValue.php
+
+		-
+			message: '#^Call to an undefined method Twig\\Node\\Node\:\:getKeyValuePairs\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: core/View/MethodCallExpression.php
 
 		-
-			message: "#^Property Piwik\\\\View\\\\UIControl\\:\\:\\$htmlAttributes \\(string\\) does not accept default value of type array\\.$#"
+			message: '#^Property Piwik\\View\\UIControl\:\:\$htmlAttributes \(string\) does not accept default value of type array\.$#'
+			identifier: property.defaultValue
 			count: 1
 			path: core/View/UIControl.php
 
 		-
-			message: "#^Property Piwik\\\\ViewDataTable\\\\Config\\:\\:\\$onlineGuideUrl \\(string\\) does not accept default value of type false\\.$#"
+			message: '#^Property Piwik\\ViewDataTable\\Config\:\:\$onlineGuideUrl \(string\) does not accept default value of type false\.$#'
+			identifier: property.defaultValue
 			count: 1
 			path: core/ViewDataTable/Config.php
 
 		-
-			message: "#^Method Piwik\\\\ViewDataTable\\\\Factory\\:\\:createViewDataTableInstance\\(\\) should return Piwik\\\\Plugin\\\\ViewDataTable but returns Piwik\\\\View\\\\ViewInterface\\.$#"
+			message: '#^Method Piwik\\ViewDataTable\\Factory\:\:createViewDataTableInstance\(\) should return Piwik\\Plugin\\ViewDataTable but returns Piwik\\View\\ViewInterface\.$#'
+			identifier: return.type
 			count: 1
 			path: core/ViewDataTable/Factory.php
 
 		-
-			message: "#^Static property Piwik\\\\ViewDataTable\\\\Factory\\:\\:\\$defaultViewTypes is never read, only written\\.$#"
+			message: '#^Static property Piwik\\ViewDataTable\\Factory\:\:\$defaultViewTypes is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: core/ViewDataTable/Factory.php
 
 		-
-			message: "#^Variable \\$report in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Variable \$report in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 2
 			path: core/ViewDataTable/Factory.php
 
 		-
-			message: "#^Method Piwik\\\\ViewDataTable\\\\Manager\\:\\:getFooterIconFor\\(\\) should return array but empty return statement found\\.$#"
+			message: '#^Method Piwik\\ViewDataTable\\Manager\:\:getFooterIconFor\(\) should return array but empty return statement found\.$#'
+			identifier: return.empty
 			count: 1
 			path: core/ViewDataTable/Manager.php
 
 		-
-			message: "#^Unsafe call to private method Piwik\\\\ViewDataTable\\\\Manager\\:\\:getFooterIconFor\\(\\) through static\\:\\:\\.$#"
+			message: '#^Unsafe call to private method Piwik\\ViewDataTable\\Manager\:\:getFooterIconFor\(\) through static\:\:\.$#'
+			identifier: staticClassAccess.privateMethod
 			count: 9
 			path: core/ViewDataTable/Manager.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
 			count: 1
 			path: core/ViewDataTable/Request.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between mixed and 0 will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between mixed and 0 will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: core/ViewDataTable/Request.php
 
 		-
-			message: "#^Property Piwik\\\\ViewDataTable\\\\RequestConfig\\:\\:\\$filter_excludelowpop_value \\(Closure\\|string\\) does not accept default value of type false\\.$#"
+			message: '#^Property Piwik\\ViewDataTable\\RequestConfig\:\:\$filter_excludelowpop_value \(Closure\|string\) does not accept default value of type false\.$#'
+			identifier: property.defaultValue
 			count: 1
 			path: core/ViewDataTable/RequestConfig.php
 
 		-
-			message: "#^Property Piwik\\\\ViewDataTable\\\\RequestConfig\\:\\:\\$pivotBy \\(string\\) does not accept default value of type false\\.$#"
+			message: '#^Property Piwik\\ViewDataTable\\RequestConfig\:\:\$pivotBy \(string\) does not accept default value of type false\.$#'
+			identifier: property.defaultValue
 			count: 1
 			path: core/ViewDataTable/RequestConfig.php
 
 		-
-			message: "#^Property Piwik\\\\ViewDataTable\\\\RequestConfig\\:\\:\\$pivotByColumn \\(string\\) does not accept default value of type false\\.$#"
+			message: '#^Property Piwik\\ViewDataTable\\RequestConfig\:\:\$pivotByColumn \(string\) does not accept default value of type false\.$#'
+			identifier: property.defaultValue
 			count: 1
 			path: core/ViewDataTable/RequestConfig.php
 
 		-
-			message: "#^Property Piwik\\\\ViewDataTable\\\\RequestConfig\\:\\:\\$pivotByColumnLimit \\(int\\) does not accept default value of type false\\.$#"
+			message: '#^Property Piwik\\ViewDataTable\\RequestConfig\:\:\$pivotByColumnLimit \(int\) does not accept default value of type false\.$#'
+			identifier: property.defaultValue
 			count: 1
 			path: core/ViewDataTable/RequestConfig.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^Call to function is_numeric\(\) with int will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: core/Visualization/Sparkline.php
+
+		-
+			message: '#^Instanceof between Davaxi\\Sparkline and Davaxi\\Sparkline will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: core/Visualization/Sparkline.php
+
+		-
+			message: '#^Path in require_once\(\) "/var/www/html/\.\./\.\./autoload\.php" is not a file or it does not exist\.$#'
+			identifier: requireOnce.fileNotFound
+			count: 1
+			path: core/bootstrap.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: core/dispatch.php
 
 		-
-			message: "#^Parameter \\#1 \\$environment of class Piwik\\\\Application\\\\Environment constructor expects string, null given\\.$#"
+			message: '#^Parameter \#1 \$environment of class Piwik\\Application\\Environment constructor expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: core/dispatch.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(mixed\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/AIAgents/Reports/Get.php
+
+		-
+			message: '#^Call to function is_array\(\) with non\-empty\-array\<string\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: plugins/API/API.php
 
 		-
-			message: "#^Cannot access offset mixed on int\\.$#"
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(mixed\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: plugins/API/API.php
+
+		-
+			message: '#^Variable \$idSites in empty\(\) always exists and is always falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: plugins/API/API.php
+
+		-
+			message: '#^Cannot access offset mixed on int\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
 			path: plugins/API/Filter/DataComparisonFilter.php
 
 		-
-			message: "#^Parameter \\#3 \\$segmentCount of static method Piwik\\\\Plugins\\\\API\\\\Filter\\\\DataComparisonFilter\\:\\:getIndividualComparisonRowIndices\\(\\) expects null, int\\<0, max\\> given\\.$#"
+			message: '#^Parameter \#3 \$segmentCount of static method Piwik\\Plugins\\API\\Filter\\DataComparisonFilter\:\:getIndividualComparisonRowIndices\(\) expects null, int\<0, max\> given\.$#'
+			identifier: argument.type
 			count: 2
 			path: plugins/API/Filter/DataComparisonFilter.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\API\\\\Filter\\\\DataComparisonFilter\\:\\:\\$compareDates \\(array\\<string\\>\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Property Piwik\\Plugins\\API\\Filter\\DataComparisonFilter\:\:\$compareDates \(array\<string\>\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: plugins/API/Filter/DataComparisonFilter.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\API\\\\Filter\\\\DataComparisonFilter\\:\\:\\$comparePeriods \\(array\\<string\\>\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Property Piwik\\Plugins\\API\\Filter\\DataComparisonFilter\:\:\$comparePeriods \(array\<string\>\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: plugins/API/Filter/DataComparisonFilter.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\API\\\\Filter\\\\DataComparisonFilter\\:\\:\\$compareSegments \\(array\\<string\\>\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Property Piwik\\Plugins\\API\\Filter\\DataComparisonFilter\:\:\$compareSegments \(array\<string\>\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: plugins/API/Filter/DataComparisonFilter.php
 
 		-
-			message: "#^Ternary operator condition is always false\\.$#"
+			message: '#^Ternary operator condition is always false\.$#'
+			identifier: ternary.alwaysFalse
 			count: 1
 			path: plugins/API/Filter/DataComparisonFilter.php
 
 		-
-			message: "#^Ternary operator condition is always true\\.$#"
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
 			count: 2
 			path: plugins/API/Filter/DataComparisonFilter.php
 
 		-
-			message: "#^Variable \\$compareTable in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Variable \$compareTable in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/API/Filter/DataComparisonFilter.php
 
 		-
-			message: "#^Variable \\$comparisonTable in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Variable \$comparisonTable in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/API/Filter/DataComparisonFilter.php
 
 		-
-			message: "#^Parameter \\#3 \\$rootCompareTable of method Piwik\\\\Plugins\\\\API\\\\Filter\\\\DataComparisonFilter\\\\ComparisonRowGenerator\\:\\:compareTable\\(\\) expects Piwik\\\\DataTable\\|null, Piwik\\\\DataTable\\\\DataTableInterface\\|null given\\.$#"
+			message: '#^Offset int\<0, max\> on non\-empty\-list\<Piwik\\DataTable\|Piwik\\DataTable\\Map\> in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.offset
 			count: 1
 			path: plugins/API/Filter/DataComparisonFilter/ComparisonRowGenerator.php
 
 		-
-			message: "#^Parameter \\#4 \\$compareTable of method Piwik\\\\Plugins\\\\API\\\\Filter\\\\DataComparisonFilter\\\\ComparisonRowGenerator\\:\\:compareTable\\(\\) expects Piwik\\\\DataTable\\|null, Piwik\\\\DataTable\\\\DataTableInterface\\|null given\\.$#"
+			message: '#^Parameter \#3 \$rootCompareTable of method Piwik\\Plugins\\API\\Filter\\DataComparisonFilter\\ComparisonRowGenerator\:\:compareTable\(\) expects Piwik\\DataTable\|null, Piwik\\DataTable\\DataTableInterface\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/API/Filter/DataComparisonFilter/ComparisonRowGenerator.php
 
 		-
-			message: "#^Variable \\$period in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Parameter \#4 \$compareTable of method Piwik\\Plugins\\API\\Filter\\DataComparisonFilter\\ComparisonRowGenerator\:\:compareTable\(\) expects Piwik\\DataTable\|null, Piwik\\DataTable\\DataTableInterface\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/API/Filter/DataComparisonFilter/ComparisonRowGenerator.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Variable \$period in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: plugins/API/Filter/DataComparisonFilter/ComparisonRowGenerator.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/API/ProcessedReport.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/API/Reports/Get.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: plugins/API/Reports/Get.php
+
+		-
+			message: '#^Call to function is_array\(\) with non\-empty\-array\<string, mixed\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: plugins/API/RowEvolution.php
 
 		-
-			message: "#^Variable \\$compare might not be defined\\.$#"
-			count: 1
-			path: plugins/API/SegmentMetadata.php
+			message: '#^Call to method Piwik\\Plugins\\API\\RowEvolution\:\:checkDataTableInstance\(\) with Piwik\\DataTable will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 2
+			path: plugins/API/RowEvolution.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: plugins/API/RowEvolution.php
+
+		-
+			message: '#^Instanceof between Piwik\\DataTable and Piwik\\DataTable will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: plugins/Actions/API.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: plugins/Actions/Actions/ActionSiteSearch.php
 
 		-
-			message: "#^Variable \\$categoryParameterRaw might not be defined\\.$#"
+			message: '#^Variable \$categoryParameterRaw might not be defined\.$#'
+			identifier: variable.undefined
 			count: 1
 			path: plugins/Actions/Actions/ActionSiteSearch.php
 
 		-
-			message: "#^Variable \\$keywordParameterRaw might not be defined\\.$#"
+			message: '#^Variable \$keywordParameterRaw might not be defined\.$#'
+			identifier: variable.undefined
 			count: 1
 			path: plugins/Actions/Actions/ActionSiteSearch.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with Piwik\\\\DataTable\\\\Row will always evaluate to false\\.$#"
+			message: '#^Call to function is_null\(\) with Piwik\\DataTable\\Row will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 2
 			path: plugins/Actions/ArchivingHelper.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Piwik\\\\DataTable\\\\Row\\:\\:setColumn\\(\\) expects string, int given\\.$#"
+			message: '#^Loose comparison using \=\= between int and ''__mtm_ranking_query…'' will always evaluate to false\.$#'
+			identifier: equal.alwaysFalse
 			count: 1
 			path: plugins/Actions/ArchivingHelper.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Method Piwik\\Plugins\\Actions\\ArchivingHelper\:\:getCachedActionRowKey\(\) never returns string so it can be removed from the return type\.$#'
+			identifier: return.unusedType
 			count: 1
 			path: plugins/Actions/ArchivingHelper.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between non\\-empty\\-string and false will always evaluate to false\\.$#"
+			message: '#^Parameter \#1 \$name of method Piwik\\DataTable\\Row\:\:setColumn\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Actions/ArchivingHelper.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between non\\-empty\\-string and null will always evaluate to false\\.$#"
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Actions/ArchivingHelper.php
 
 		-
-			message: "#^Empty array passed to foreach\\.$#"
+			message: '#^Strict comparison using \=\=\= between non\-empty\-string and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: plugins/Actions/ArchivingHelper.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between non\-empty\-string and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: plugins/Actions/ArchivingHelper.php
+
+		-
+			message: '#^Empty array passed to foreach\.$#'
+			identifier: foreach.emptyArray
 			count: 1
 			path: plugins/Actions/Columns/ActionType.php
 
 		-
-			message: "#^Parameter \\#1 \\$idSite of method Piwik\\\\Plugins\\\\Actions\\\\RecordBuilders\\\\ActionReports\\:\\:getGoalsForSite\\(\\) expects string, int given\\.$#"
+			message: '#^Instanceof between Piwik\\DataTable and Piwik\\DataTable will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: plugins/Actions/Columns/Metrics/AveragePageGenerationTime.php
+
+		-
+			message: '#^Parameter \#1 \$idSite of method Piwik\\Plugins\\Actions\\RecordBuilders\\ActionReports\:\:getGoalsForSite\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Actions/RecordBuilders/ActionReports.php
 
 		-
-			message: "#^Variable \\$action in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Strict comparison using \!\=\= between Piwik\\Tracker\\Action and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: plugins/Actions/Tracker/ActionsRequestProcessor.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^Variable \$action in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: plugins/Actions/Tracker/ActionsRequestProcessor.php
+
+		-
+			message: '#^Call to function is_array\(\) with array\<mixed, mixed\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: plugins/Actions/VisitorDetails.php
 
 		-
-			message: "#^Parameter \\#1 \\$array of function reset is passed by reference, so it expects variables only\\.$#"
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: plugins/Actions/VisitorDetails.php
+
+		-
+			message: '#^Parameter \#1 \$array \(array\{\}\) to function array_filter is empty, call has no effect\.$#'
+			identifier: arrayFilter.empty
+			count: 1
+			path: plugins/Actions/VisitorDetails.php
+
+		-
+			message: '#^Method Piwik\\Plugins\\Annotations\\API\:\:add\(\) should return array\{id\: int, idNote\: int, idsite\: int, date\: string, note\: string, starred\: int, user\: string, canEditOrDelete\: bool\} but returns array\{id\: int, idsite\: int, date\: string, note\: string, starred\: int, user\: string\}\.$#'
+			identifier: return.type
+			count: 1
+			path: plugins/Annotations/API.php
+
+		-
+			message: '#^Method Piwik\\Plugins\\Annotations\\API\:\:get\(\) should return array\{id\: int, idNote\: int, idsite\: int, date\: string, note\: string, starred\: int, user\: string, canEditOrDelete\: bool\} but returns array\{id\: int, idsite\: int, date\: string, note\: string, starred\: int, user\: string\}\.$#'
+			identifier: return.type
+			count: 1
+			path: plugins/Annotations/API.php
+
+		-
+			message: '#^Method Piwik\\Plugins\\Annotations\\API\:\:getAll\(\) should return array\<int, array\<int, array\{id\: int, idNote\: int, idsite\: int, date\: string, note\: string, starred\: int, user\: string, canEditOrDelete\: bool\}\>\> but returns array\<int, list\<array\{id\: int, idsite\: int, date\: string, note\: string, starred\: int, user\: string\}\>\>\.$#'
+			identifier: return.type
+			count: 1
+			path: plugins/Annotations/API.php
+
+		-
+			message: '#^Method Piwik\\Plugins\\Annotations\\API\:\:save\(\) should return array\{id\: int, idNote\: int, idsite\: int, date\: string, note\: string, starred\: int, user\: string, canEditOrDelete\: bool\} but returns array\{id\: int, idsite\: int, date\: string, note\: string, starred\: int, user\: string\}\.$#'
+			identifier: return.type
+			count: 1
+			path: plugins/Annotations/API.php
+
+		-
+			message: '#^Parameter \#1 \$array of function reset is passed by reference, so it expects variables only\.$#'
+			identifier: argument.byRef
 			count: 1
 			path: plugins/Annotations/Controller.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with Piwik\\\\Plugins\\\\BulkTracking\\\\Tracker\\\\Requests will always evaluate to false\\.$#"
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/BotTracking/API.php
+
+		-
+			message: '#^Instanceof between Piwik\\DataTable and Piwik\\DataTable will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: plugins/BotTracking/API.php
+
+		-
+			message: '#^Parameter &\$glossaryItems by\-ref type of method Piwik\\Plugins\\BotTracking\\BotTracking\:\:addGlossaryItems\(\) expects array\<string, array\{title\: string, entries\: array\<int, array\<string, string\>\>\}\>, non\-empty\-array\<string, array\{title\?\: string, entries\: array\<int, array\<string, string\>\>\}\> given\.$#'
+			identifier: parameterByRef.type
+			count: 1
+			path: plugins/BotTracking/BotTracking.php
+
+		-
+			message: '#^Instanceof between Piwik\\DataTable and Piwik\\DataTable will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: plugins/BotTracking/DataTable/FavouredPagesScorer.php
+
+		-
+			message: '#^Parameter &\$tables by\-ref type of method Piwik\\Plugins\\BotTracking\\RecordBuilders\\AIChatbotReports\:\:populateNumerics\(\) expects array\<string, Piwik\\DataTable\>, array\<string, int\|Piwik\\DataTable\> given\.$#'
+			identifier: parameterByRef.type
+			count: 7
+			path: plugins/BotTracking/RecordBuilders/AIChatbotReports.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:configureView\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/AbstractAIChatbotContentUrlReport.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/AbstractAIChatbotContentUrlReport.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:configureView\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/AbstractAIChatbotFavouredPagesReport.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/AbstractAIChatbotFavouredPagesReport.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:configureView\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/AbstractAIChatbotsRealTimeReport.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/AbstractAIChatbotsRealTimeReport.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/Get.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:configureView\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/GetAIChatbotBrokenContent.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/GetAIChatbotBrokenContent.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:configureView\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/GetAIChatbotRequests.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/GetAIChatbotRequests.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/GetDocumentUrlsForAIChatbot.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/BotTracking/Reports/GetPageUrlsForAIChatbot.php
+
+		-
+			message: '#^Call to function is_null\(\) with Piwik\\Plugins\\BulkTracking\\Tracker\\Requests will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: plugins/BulkTracking/BulkTracking.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
 			count: 1
 			path: plugins/BulkTracking/BulkTracking.php
 
 		-
-			message: "#^Parameter \\#1 \\$login of method Piwik\\\\Auth\\:\\:setLogin\\(\\) expects string, null given\\.$#"
+			message: '#^Parameter \#1 \$login of method Piwik\\Auth\:\:setLogin\(\) expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/BulkTracking/Tracker/Handler.php
 
 		-
-			message: "#^Parameter \\#1 \\$password of method Piwik\\\\Auth\\:\\:setPassword\\(\\) expects string, null given\\.$#"
+			message: '#^Parameter \#1 \$password of method Piwik\\Auth\:\:setPassword\(\) expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/BulkTracking/Tracker/Handler.php
 
 		-
-			message: "#^Parameter \\#1 \\$passwordHash of method Piwik\\\\Auth\\:\\:setPasswordHash\\(\\) expects string, null given\\.$#"
+			message: '#^Parameter \#1 \$passwordHash of method Piwik\\Auth\:\:setPasswordHash\(\) expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/BulkTracking/Tracker/Handler.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
 			count: 1
 			path: plugins/Contents/RecordBuilders/ContentRecords.php
 
 		-
-			message: "#^Variable \\$subLabel in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Variable \$subLabel in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/Contents/RecordBuilders/ContentRecords.php
 
 		-
-			message: "#^Expression in empty\\(\\) is not falsy\\.$#"
+			message: '#^Call to function property_exists\(\) with Piwik\\ViewDataTable\\Config and ''selectable_columns'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/Contents/Reports/Base.php
+
+		-
+			message: '#^Expression in empty\(\) is not falsy\.$#'
+			identifier: empty.expr
 			count: 1
 			path: plugins/CoreAdminHome/Commands/ConfigDelete.php
 
 		-
-			message: "#^Offset 'key' on array\\{section\\: mixed, key\\: mixed, value\\?\\: mixed\\} in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Offset ''key'' on array\{section\: mixed, key\: mixed, value\?\: mixed\} in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.offset
 			count: 1
 			path: plugins/CoreAdminHome/Commands/ConfigDelete.php
 
 		-
-			message: "#^Offset 'section' on array\\{section\\: mixed, key\\?\\: mixed, value\\?\\: mixed\\} in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Offset ''section'' on array\{section\: mixed, key\?\: mixed, value\?\: mixed\} in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.offset
 			count: 1
 			path: plugins/CoreAdminHome/Commands/ConfigDelete.php
 
 		-
-			message: "#^Variable \\$options in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Variable \$options in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/CoreAdminHome/Commands/ConfigDelete.php
 
 		-
-			message: "#^Offset 'section' on array\\{section\\: mixed, key\\?\\: mixed\\} in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Offset ''section'' on array\{section\: mixed, key\?\: mixed\} in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.offset
 			count: 1
 			path: plugins/CoreAdminHome/Commands/ConfigGet.php
 
 		-
-			message: "#^Variable \\$options in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Variable \$options in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/CoreAdminHome/Commands/ConfigGet.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\CoreAdminHome\\\\Commands\\\\DeleteLogsData\\:\\:\\$rawLogDao is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\CoreAdminHome\\Commands\\DeleteLogsData\:\:\$rawLogDao is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/CoreAdminHome/Commands/DeleteLogsData.php
 
 		-
-			message: "#^Parameter \\#3 \\$default of method Piwik\\\\Plugin\\\\ConsoleCommand\\:\\:addOptionalArgument\\(\\) expects null, string given\\.$#"
+			message: '#^Parameter \#3 \$default of method Piwik\\Plugin\\ConsoleCommand\:\:addOptionalArgument\(\) expects null, string given\.$#'
+			identifier: argument.type
 			count: 2
 			path: plugins/CoreAdminHome/Commands/PurgeBrokenArchiveData.php
 
 		-
-			message: "#^Ternary operator condition is always true\\.$#"
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
 			count: 1
 			path: plugins/CoreAdminHome/Commands/PurgeBrokenArchiveData.php
 
 		-
-			message: "#^Parameter \\#3 \\$default of method Piwik\\\\Plugin\\\\ConsoleCommand\\:\\:addOptionalArgument\\(\\) expects null, array\\<int, mixed\\> given\\.$#"
+			message: '#^Parameter \#3 \$default of method Piwik\\Plugin\\ConsoleCommand\:\:addOptionalArgument\(\) expects null, array\<int, mixed\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/CoreAdminHome/Commands/PurgeOldArchiveData.php
 
 		-
-			message: "#^Ternary operator condition is always true\\.$#"
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
 			count: 2
 			path: plugins/CoreAdminHome/Commands/PurgeOldArchiveData.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
+			message: '#^Call to function is_array\(\) with string will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: plugins/CoreAdminHome/Commands/SetConfig/ConfigSettingManipulation.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\CoreAdminHome\\\\Controller\\:\\:\\$translator is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\CoreAdminHome\\Controller\:\:\$translator is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/CoreAdminHome/Controller.php
 
 		-
-			message: "#^Left side of && is always true\\.$#"
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
 			path: plugins/CoreAdminHome/CustomLogo.php
 
 		-
-			message: "#^Parameter \\#1 \\$width of function imagecreatetruecolor expects int, float given\\.$#"
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
 			count: 1
 			path: plugins/CoreAdminHome/CustomLogo.php
 
 		-
-			message: "#^Parameter \\#7 \\$dst_width of function imagecopyresampled expects int, float given\\.$#"
+			message: '#^Parameter \#1 \$width of function imagecreatetruecolor expects int\<1, max\>, float given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/CoreAdminHome/CustomLogo.php
 
 		-
-			message: "#^Unsafe call to private method Piwik\\\\Plugins\\\\CoreAdminHome\\\\CustomLogo\\:\\:logoExists\\(\\) through static\\:\\:\\.$#"
+			message: '#^Parameter \#7 \$dst_width of function imagecopyresampled expects int, float given\.$#'
+			identifier: argument.type
+			count: 1
+			path: plugins/CoreAdminHome/CustomLogo.php
+
+		-
+			message: '#^Unsafe call to private method Piwik\\Plugins\\CoreAdminHome\\CustomLogo\:\:logoExists\(\) through static\:\:\.$#'
+			identifier: staticClassAccess.privateMethod
 			count: 5
 			path: plugins/CoreAdminHome/CustomLogo.php
 
 		-
-			message: "#^Parameter \\#1 \\$idSegments of method Piwik\\\\CronArchive\\\\ArchiveFilter\\:\\:setSegmentsToForceFromSegmentIds\\(\\) expects array\\<int\\>, array\\<int, string\\> given\\.$#"
+			message: '#^Parameter \#1 \$idSegments of method Piwik\\CronArchive\\ArchiveFilter\:\:setSegmentsToForceFromSegmentIds\(\) expects array\<int\>, list\<string\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/CoreConsole/Commands/CoreArchiver.php
 
 		-
-			message: "#^Variable \\$dimension in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Expression "\$validate\(\$documentation\)" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
 			count: 1
 			path: plugins/CoreConsole/Commands/GenerateReport.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^Variable \$dimension in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: plugins/CoreConsole/Commands/GenerateReport.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: plugins/CoreHome/Columns/Metrics/EvolutionMetric.php
 
 		-
-			message: "#^Parameter \\#1 \\$sqlFilterValue of method Piwik\\\\Plugin\\\\Segment\\:\\:setSqlFilterValue\\(\\) expects array\\|string, Closure given\\.$#"
+			message: '#^Parameter \#1 \$sqlFilterValue of method Piwik\\Plugin\\Segment\:\:setSqlFilterValue\(\) expects array\|string, Closure given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/CoreHome/Columns/VisitorDaysSinceFirst.php
 
 		-
-			message: "#^Property Piwik\\\\Columns\\\\Dimension\\:\\:\\$sqlFilterValue \\(array\\|string\\) does not accept Closure\\.$#"
+			message: '#^Property Piwik\\Columns\\Dimension\:\:\$sqlFilterValue \(array\|string\) does not accept Closure\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: plugins/CoreHome/Columns/VisitorReturning.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: plugins/CoreHome/Controller.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\CoreHome\\\\Controller\\:\\:\\$translator is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\CoreHome\\Controller\:\:\$translator is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/CoreHome/Controller.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(mixed\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: plugins/CoreHome/DataTableRowAction/RowEvolution.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
+			message: '#^Instanceof between Piwik\\DataTable\\Map and Piwik\\DataTable\\DataTableInterface will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 1
 			path: plugins/CoreHome/DataTableRowAction/RowEvolution.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:getServerVersion\\(\\)\\.$#"
+			message: '#^Instanceof between Piwik\\Date and Piwik\\Date will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: plugins/CoreHome/DataTableRowAction/RowEvolution.php
+
+		-
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(mixed\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: plugins/CoreHome/DataTableRowAction/RowEvolution.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: plugins/CoreHome/DataTableRowAction/RowEvolution.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between array\|int\|Piwik\\Date\|string and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: plugins/CoreHome/DataTableRowAction/RowEvolution.php
+
+		-
+			message: '#^Parameter \#3 \$url of method Piwik\\Menu\\MenuAbstract\:\:addItem\(\) expects array\<string, bool\|float\|int\|string\>\|string, array\<string, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: plugins/CoreHome/Menu.php
+
+		-
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:getServerVersion\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/CoreHome/Widgets/GetSystemSummary.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\CoreHome\\\\Widgets\\\\GetSystemSummary\\:\\:\\$pluginManager is never read, only written\\.$#"
+			message: '#^Parameter \#1 \$array \(array\{Piwik\\Plugins\\CoreHome\\SystemSummary\\Item, Piwik\\Plugins\\CoreHome\\SystemSummary\\Item, Piwik\\Plugins\\CoreHome\\SystemSummary\\Item\}\) to function array_filter does not contain falsy values, the array will always stay the same\.$#'
+			identifier: arrayFilter.same
 			count: 1
 			path: plugins/CoreHome/Widgets/GetSystemSummary.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\CoreHome\\\\Widgets\\\\GetSystemSummary\\:\\:\\$storedSegmentService is never read, only written\\.$#"
+			message: '#^Parameter \#1 \$array \(non\-empty\-list\<Piwik\\Plugins\\CoreHome\\SystemSummary\\Item\>\) to function array_filter does not contain falsy values, the array will always stay the same\.$#'
+			identifier: arrayFilter.same
 			count: 1
 			path: plugins/CoreHome/Widgets/GetSystemSummary.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Property Piwik\\Plugins\\CoreHome\\Widgets\\GetSystemSummary\:\:\$pluginManager is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: plugins/CoreHome/Widgets/GetSystemSummary.php
+
+		-
+			message: '#^Property Piwik\\Plugins\\CoreHome\\Widgets\\GetSystemSummary\:\:\$storedSegmentService is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: plugins/CoreHome/Widgets/GetSystemSummary.php
+
+		-
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
 			count: 1
 			path: plugins/CorePluginsAdmin/Controller.php
 
 		-
-			message: "#^Unsafe call to private method Piwik\\\\Plugins\\\\CorePluginsAdmin\\\\Controller\\:\\:dieIfPluginsAdminIsDisabled\\(\\) through static\\:\\:\\.$#"
+			message: '#^Unsafe call to private method Piwik\\Plugins\\CorePluginsAdmin\\Controller\:\:dieIfPluginsAdminIsDisabled\(\) through static\:\:\.$#'
+			identifier: staticClassAccess.privateMethod
 			count: 1
 			path: plugins/CorePluginsAdmin/Controller.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/CorePluginsAdmin/Model/TagManagerTeaser.php
 
 		-
-			message: "#^Variable \\$plugin in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Variable \$plugin in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/CorePluginsAdmin/PluginInstaller.php
 
 		-
-			message: "#^Variable \\$setting in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^PHPDoc tag @throws has invalid value \(Exception;\)\: Unexpected token ";", expected TOKEN_HORIZONTAL_WS at offset 172 on line 4$#'
+			identifier: phpDoc.parseError
 			count: 1
 			path: plugins/CorePluginsAdmin/SettingsMetadata.php
 
 		-
-			message: "#^Parameter \\#1 \\$https of method Piwik\\\\Plugins\\\\CoreUpdater\\\\Updater\\:\\:updatePiwik\\(\\) expects bool, int given\\.$#"
+			message: '#^Variable \$setting in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: plugins/CorePluginsAdmin/SettingsMetadata.php
+
+		-
+			message: '#^Parameter \#1 \$https of method Piwik\\Plugins\\CoreUpdater\\Updater\:\:updatePiwik\(\) expects bool, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/CoreUpdater/Controller.php
 
 		-
-			message: "#^Property Piwik\\\\View\\\\OneClickDone\\:\\:\\$httpsFail \\(bool\\) does not accept int\\.$#"
+			message: '#^Property Piwik\\View\\OneClickDone\:\:\$httpsFail \(bool\) does not accept int\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: plugins/CoreUpdater/Controller.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
 			count: 1
 			path: plugins/CoreUpdater/Controller.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:getServerVersion\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:getServerVersion\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/CoreUpdater/ReleaseChannel.php
 
 		-
-			message: "#^Class Piwik\\\\Plugins\\\\Marketplace\\\\Api\\\\Exception referenced with incorrect case\\: Piwik\\\\Plugins\\\\Marketplace\\\\API\\\\Exception\\.$#"
+			message: '#^Class Piwik\\Plugins\\Marketplace\\Api\\Exception referenced with incorrect case\: Piwik\\Plugins\\Marketplace\\API\\Exception\.$#'
+			identifier: class.nameCase
 			count: 1
 			path: plugins/CoreUpdater/Updater.php
 
 		-
-			message: "#^Parameter \\#1 \\$exception of class Piwik\\\\Plugins\\\\CoreUpdater\\\\UpdaterException constructor expects Exception, Throwable given\\.$#"
+			message: '#^Parameter \#1 \$exception of class Piwik\\Plugins\\CoreUpdater\\UpdaterException constructor expects Exception, Throwable given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/CoreUpdater/Updater.php
 
 		-
-			message: "#^Variable \\$comparisonTable in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Variable \$comparisonTable in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/CoreVisualizations/JqplotDataGenerator.php
 
 		-
-			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
+			message: '#^Strict comparison using \!\=\= between string and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: plugins/CoreVisualizations/JqplotDataGenerator/Evolution.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\CoreVisualizations\\\\Metrics\\\\Formatter\\\\Numeric\\:\\:getPrettyNumber\\(\\) should return string but returns float\\.$#"
+			message: '#^Method Piwik\\Plugins\\CoreVisualizations\\Metrics\\Formatter\\Numeric\:\:getPrettyNumber\(\) should return string but returns float\.$#'
+			identifier: return.type
 			count: 1
 			path: plugins/CoreVisualizations/Metrics/Formatter/Numeric.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\CoreVisualizations\\\\Metrics\\\\Formatter\\\\Numeric\\:\\:getPrettyPercentFromQuotient\\(\\) should return string but returns float\\.$#"
+			message: '#^Method Piwik\\Plugins\\CoreVisualizations\\Metrics\\Formatter\\Numeric\:\:getPrettyPercentFromQuotient\(\) should return string but returns float\.$#'
+			identifier: return.type
 			count: 1
 			path: plugins/CoreVisualizations/Metrics/Formatter/Numeric.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\CoreVisualizations\\\\Metrics\\\\Formatter\\\\Numeric\\:\\:getPrettyTimeFromSeconds\\(\\) should return string but returns float\\|int\\.$#"
+			message: '#^Method Piwik\\Plugins\\CoreVisualizations\\Metrics\\Formatter\\Numeric\:\:getPrettyTimeFromSeconds\(\) should return string but returns float\|int\.$#'
+			identifier: return.type
 			count: 1
 			path: plugins/CoreVisualizations/Metrics/Formatter/Numeric.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^Call to function is_array\(\) with non\-empty\-list\<int\|string\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/CoreVisualizations/Visualizations/Cloud.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Graph.php
 
 		-
-			message: "#^Instanceof between Piwik\\\\DataTable and Piwik\\\\DataTable\\\\Map will always evaluate to false\\.$#"
+			message: '#^Instanceof between Piwik\\DataTable and Piwik\\DataTable\\Map will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Graph.php
 
 		-
-			message: "#^Property Piwik\\\\Plugin\\\\Visualization\\:\\:\\$report \\(Piwik\\\\Plugin\\\\Report\\) in empty\\(\\) is not falsy\\.$#"
+			message: '#^Call to Piwik\\Plugin\\Visualization\:\:afterGenericFiltersAreAppliedToLoadedDataTable\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/CoreVisualizations/Visualizations/HtmlTable.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Visualization\:\:beforeGenericFiltersAreAppliedToLoadedDataTable\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/CoreVisualizations/Visualizations/HtmlTable.php
+
+		-
+			message: '#^Property Piwik\\Plugin\\Visualization\:\:\$report \(Piwik\\Plugin\\Report\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
 			count: 2
 			path: plugins/CoreVisualizations/Visualizations/HtmlTable.php
 
 		-
-			message: "#^Property Piwik\\\\ViewDataTable\\\\RequestConfig\\:\\:\\$filter_excludelowpop_value \\(Closure\\|string\\) does not accept false\\.$#"
+			message: '#^Property Piwik\\ViewDataTable\\RequestConfig\:\:\$filter_excludelowpop_value \(Closure\|string\) does not accept false\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/HtmlTable/RequestConfig.php
 
 		-
-			message: "#^Parameter \\#2 \\$lastN of static method Piwik\\\\Period\\\\Range\\:\\:getRelativeToEndDate\\(\\) expects int, string given\\.$#"
+			message: '#^Parameter \#2 \$lastN of static method Piwik\\Period\\Range\:\:getRelativeToEndDate\(\) expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/JqplotGraph/Evolution.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\DataTable\\\\DataTableInterface\\:\\:getMetadata\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\DataTable\\DataTableInterface\:\:getMetadata\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Sparkline.php
 
 		-
-			message: "#^Instanceof between Piwik\\\\DataTable\\|null and Piwik\\\\DataTable\\\\Map will always evaluate to false\\.$#"
+			message: '#^Instanceof between Piwik\\DataTable\|null and Piwik\\DataTable\\Map will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Sparkline.php
 
 		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			message: '#^Call to function is_array\(\) with non\-empty\-array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Sparklines.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Sparklines.php
 
 		-
-			message: "#^Parameter \\#3 \\$description of method Piwik\\\\Plugins\\\\CoreVisualizations\\\\Visualizations\\\\Sparklines\\\\Config\\:\\:addSparkline\\(\\) expects array\\|string, null given\\.$#"
+			message: '#^Parameter \#3 \$description of method Piwik\\Plugins\\CoreVisualizations\\Visualizations\\Sparklines\\Config\:\:addSparkline\(\) expects array\|string, null given\.$#'
+			identifier: argument.type
 			count: 2
 			path: plugins/CoreVisualizations/Visualizations/Sparklines.php
 
 		-
-			message: "#^Parameter \\#8 \\$seriesIndices of method Piwik\\\\Plugins\\\\CoreVisualizations\\\\Visualizations\\\\Sparklines\\\\Config\\:\\:addSparkline\\(\\) expects int\\|null, array\\<int\\<0, max\\>, int\\> given\\.$#"
+			message: '#^Parameter \#8 \$seriesIndices of method Piwik\\Plugins\\CoreVisualizations\\Visualizations\\Sparklines\\Config\:\:addSparkline\(\) expects int\|null, list\<int\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Sparklines.php
 
 		-
-			message: "#^Variable \\$segmentPretty might not be defined\\.$#"
+			message: '#^Variable \$segmentPretty might not be defined\.$#'
+			identifier: variable.undefined
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Sparklines.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with Piwik\\\\Site will always evaluate to false\\.$#"
+			message: '#^Call to function is_array\(\) with non\-empty\-array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
 
 		-
-			message: "#^Offset 'group' on array\\{value\\: mixed, description\\: mixed, column\\: mixed\\} in isset\\(\\) does not exist\\.$#"
+			message: '#^Call to function is_null\(\) with Piwik\\Site will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
+			message: '#^Offset ''group'' on array\{value\: mixed, description\: mixed, column\: mixed\} in isset\(\) does not exist\.$#'
+			identifier: isset.offset
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\|string and null will always evaluate to false\\.$#"
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\CoreVue\\\\Commands\\\\Build\\:\\:buildFiles\\(\\) should return int but returns bool\\.$#"
+			message: '#^Strict comparison using \=\=\= between array\|string and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
+
+		-
+			message: '#^Method Piwik\\Plugins\\CoreVue\\Commands\\Build\:\:buildFiles\(\) should return int but returns bool\.$#'
+			identifier: return.type
 			count: 1
 			path: plugins/CoreVue/Commands/Build.php
 
 		-
-			message: "#^Parameter \\#3 \\$default of method Piwik\\\\Plugin\\\\ConsoleCommand\\:\\:addOptionalArgument\\(\\) expects null, array given\\.$#"
+			message: '#^Parameter \#3 \$default of method Piwik\\Plugin\\ConsoleCommand\:\:addOptionalArgument\(\) expects null, array given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/CoreVue/Commands/Build.php
 
 		-
-			message: "#^Variable \\$action in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Call to function is_array\(\) with non\-empty\-array\<int, array\{dimension\?\: mixed, pattern\?\: mixed\}\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/CustomDimensions/API.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/CustomDimensions/CustomDimensions.php
+
+		-
+			message: '#^Variable \$action in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 2
 			path: plugins/CustomDimensions/Dimension/Extraction.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\CustomDimensions\\\\Dimension\\\\Index\\:\\:getConfiguration\\(\\) is unused\\.$#"
+			message: '#^Method Piwik\\Plugins\\CustomDimensions\\Dimension\\Index\:\:getConfiguration\(\) is unused\.$#'
+			identifier: method.unused
 			count: 1
 			path: plugins/CustomDimensions/Dimension/Index.php
 
 		-
-			message: "#^Parameter \\#3 \\$additionalSelects of method Piwik\\\\DataAccess\\\\LogAggregator\\:\\:queryConversionsByDimension\\(\\) expects array, false given\\.$#"
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
+			count: 1
+			path: plugins/CustomDimensions/GetCustomDimension.php
+
+		-
+			message: '#^Parameter \#3 \$additionalSelects of method Piwik\\DataAccess\\LogAggregator\:\:queryConversionsByDimension\(\) expects array, false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/CustomDimensions/RecordBuilders/CustomDimension.php
 
 		-
-			message: "#^Variable \\$value in isset\\(\\) always exists and is not nullable\\.$#"
+			message: '#^Variable \$value in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
 			count: 1
 			path: plugins/CustomDimensions/RecordBuilders/CustomDimension.php
 
 		-
-			message: "#^Variable \\$action in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Variable \$action in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 2
 			path: plugins/CustomDimensions/Tracker/CustomDimensionsRequestProcessor.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$action\\.$#"
-			count: 1
-			path: plugins/Dashboard/API.php
-
-		-
-			message: "#^Parameter \\#1 \\$sqlFilterValue of method Piwik\\\\Plugin\\\\Segment\\:\\:setSqlFilterValue\\(\\) expects array\\|string, Closure given\\.$#"
+			message: '#^Parameter \#1 \$sqlFilterValue of method Piwik\\Plugin\\Segment\:\:setSqlFilterValue\(\) expects array\|string, Closure given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/DevicesDetection/Columns/BrowserName.php
 
 		-
-			message: "#^Parameter \\#1 \\$sqlFilterValue of method Piwik\\\\Plugin\\\\Segment\\:\\:setSqlFilterValue\\(\\) expects array\\|string, Closure given\\.$#"
+			message: '#^Parameter \#1 \$sqlFilterValue of method Piwik\\Plugin\\Segment\:\:setSqlFilterValue\(\) expects array\|string, Closure given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/DevicesDetection/Columns/Os.php
 
 		-
-			message: "#^Variable \\$label in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: plugins/DevicesDetection/Settings/OnlyMajorVersions.php
+
+		-
+			message: '#^Variable \$label in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/DevicesDetection/functions.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:getServerVersion\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:getServerVersion\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/Diagnostics/Commands/ArchivingInstanceStatistics.php
 
 		-
-			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\:\\:fetch\\(\\)\\.$#"
+			message: '#^Call to function is_array\(\) with array\{array\<Piwik\\Plugins\\Diagnostics\\Diagnostic\\DiagnosticResult\>\} will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/Diagnostics/Commands/ArchivingMetrics.php
+
+		-
+			message: '#^Call to an undefined method Symfony\\Component\\Console\\Output\\OutputInterface\:\:fetch\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/Diagnostics/Commands/ArchivingStatus.php
 
 		-
-			message: "#^Negated boolean expression is always true\\.$#"
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
 			count: 1
 			path: plugins/Diagnostics/Commands/Run.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\ArchiveInvalidationsInformational\\:\\:\\$translator is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\Diagnostics\\Diagnostic\\ArchiveInvalidationsInformational\:\:\$translator is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/ArchiveInvalidationsInformational.php
 
 		-
-			message: "#^Parameter \\#2 \\$comment of static method Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\DiagnosticResult\\:\\:informationalResult\\(\\) expects string, bool given\\.$#"
-			count: 4
-			path: plugins/Diagnostics/Diagnostic/ConfigInformational.php
-
-		-
-			message: "#^Parameter \\#2 \\$comment of static method Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\DiagnosticResult\\:\\:informationalResult\\(\\) expects string, false given\\.$#"
+			message: '#^Loose comparison using \!\= between ''/var/www/html'' and ''/var/www/html'' will always evaluate to false\.$#'
+			identifier: notEqual.alwaysFalse
 			count: 2
 			path: plugins/Diagnostics/Diagnostic/ConfigInformational.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\ConfigInformational\\:\\:\\$translator is never read, only written\\.$#"
+			message: '#^Parameter \#2 \$comment of static method Piwik\\Plugins\\Diagnostics\\Diagnostic\\DiagnosticResult\:\:informationalResult\(\) expects string, bool given\.$#'
+			identifier: argument.type
+			count: 4
+			path: plugins/Diagnostics/Diagnostic/ConfigInformational.php
+
+		-
+			message: '#^Parameter \#2 \$comment of static method Piwik\\Plugins\\Diagnostics\\Diagnostic\\DiagnosticResult\:\:informationalResult\(\) expects string, false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: plugins/Diagnostics/Diagnostic/ConfigInformational.php
+
+		-
+			message: '#^Property Piwik\\Plugins\\Diagnostics\\Diagnostic\\ConfigInformational\:\:\$translator is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/ConfigInformational.php
 
 		-
-			message: "#^Binary operation \"\\-\" between int\\<1, max\\> and non\\-falsy\\-string results in an error\\.$#"
+			message: '#^Binary operation "\-" between int\<1, max\> and non\-falsy\-string results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/CronArchivingCheck.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:getServerVersion\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:getServerVersion\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/DatabaseInformational.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\DatabaseInformational\\:\\:\\$translator is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\Diagnostics\\Diagnostic\\DatabaseInformational\:\:\$translator is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/DatabaseInformational.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between string and false will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between string and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/DiagnosticResult.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between string and true will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between string and true will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/DiagnosticResult.php
 
 		-
-			message: "#^Parameter \\#2 \\$comment of static method Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\DiagnosticResult\\:\\:informationalResult\\(\\) expects string, bool given\\.$#"
+			message: '#^Parameter \#2 \$comment of static method Piwik\\Plugins\\Diagnostics\\Diagnostic\\DiagnosticResult\:\:informationalResult\(\) expects string, bool given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/MatomoInformational.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\MatomoInformational\\:\\:\\$translator is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\Diagnostics\\Diagnostic\\MatomoInformational\:\:\$translator is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/MatomoInformational.php
 
 		-
-			message: "#^Parameter \\#2 \\$comment of static method Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\DiagnosticResult\\:\\:informationalResult\\(\\) expects string, bool given\\.$#"
+			message: '#^Parameter \#2 \$comment of static method Piwik\\Plugins\\Diagnostics\\Diagnostic\\DiagnosticResult\:\:informationalResult\(\) expects string, bool given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/PhpInformational.php
 
 		-
-			message: "#^Parameter \\#2 \\$comment of static method Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\DiagnosticResult\\:\\:informationalResult\\(\\) expects string, int\\<1, max\\> given\\.$#"
+			message: '#^Parameter \#2 \$comment of static method Piwik\\Plugins\\Diagnostics\\Diagnostic\\DiagnosticResult\:\:informationalResult\(\) expects string, int\<1, max\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/PhpInformational.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
 			count: 3
 			path: plugins/Diagnostics/Diagnostic/PhpInformational.php
 
 		-
-			message: "#^Variable \\$disabled_functions in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Variable \$disabled_functions in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/PhpInformational.php
 
 		-
-			message: "#^Parameter \\#2 \\$parameters of static method Piwik\\\\Db\\:\\:fetchOne\\(\\) expects array, string given\\.$#"
+			message: '#^Parameter \#2 \$parameters of static method Piwik\\Db\:\:fetchOne\(\) expects array, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/ReportInformational.php
 
 		-
-			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, string given\\.$#"
+			message: '#^Parameter \#2 \$timestamp of function date expects int\|null, string given\.$#'
+			identifier: argument.type
 			count: 2
 			path: plugins/Diagnostics/Diagnostic/ReportInformational.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\ReportInformational\\:\\:\\$translator is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\Diagnostics\\Diagnostic\\ReportInformational\:\:\$translator is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/ReportInformational.php
 
 		-
-			message: "#^Parameter \\#1 \\$version1 of function version_compare expects string, int given\\.$#"
+			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/RequiredPhpSetting.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\UserInformational\\:\\:\\$translator is never read, only written\\.$#"
+			message: '#^Parameter \#1 \$version1 of function version_compare expects string, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: plugins/Diagnostics/Diagnostic/RequiredPhpSetting.php
+
+		-
+			message: '#^Property Piwik\\Plugins\\Diagnostics\\Diagnostic\\UserInformational\:\:\$translator is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/UserInformational.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between false and float\\|int will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between false and float\|int will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: plugins/Ecommerce/Columns/BaseConversion.php
 
 		-
-			message: "#^Parameter \\#3 \\$escapeComment of static method Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\DiagnosticResult\\:\\:informationalResult\\(\\) expects bool, string given\\.$#"
+			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: plugins/Ecommerce/Settings/OrderIdAnonymization.php
+
+		-
+			message: '#^Call to function is_array\(\) with array\<mixed, mixed\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/Ecommerce/VisitorDetails.php
+
+		-
+			message: '#^Call to function property_exists\(\) with Piwik\\ViewDataTable\\Config and ''selectable_columns'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/Events/Reports/Base.php
+
+		-
+			message: '#^Parameter \#3 \$escapeComment of static method Piwik\\Plugins\\Diagnostics\\Diagnostic\\DiagnosticResult\:\:informationalResult\(\) expects bool, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/ExamplePlugin/Diagnostic/ExampleCheck.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/ExamplePlugin/RecordBuilders/ExampleMetric2.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between false and string will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between false and string will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: plugins/ExampleTracker/Columns/ExampleActionDimension.php
 
 		-
-			message: "#^Property Piwik\\\\Notification\\:\\:\\$flags \\(int\\) does not accept null\\.$#"
+			message: '#^Property Piwik\\Notification\:\:\$flags \(int\) does not accept null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: plugins/ExampleUI/Controller.php
 
 		-
-			message: "#^Dead catch \\- Exception is never thrown in the try block\\.$#"
+			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
 			count: 1
 			path: plugins/FeatureFlags/Storage/ConfigFeatureFlagStorage.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
 			count: 1
 			path: plugins/Feedback/Feedback.php
 
 		-
-			message: "#^Parameter \\#2 \\$parameters of static method Piwik\\\\Db\\:\\:query\\(\\) expects array, string given\\.$#"
+			message: '#^Parameter \#2 \$parameters of static method Piwik\\Db\:\:query\(\) expects array, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/GeoIp2/Commands/ConvertRegionCodesToIso.php
 
 		-
-			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, string\\|false given\\.$#"
+			message: '#^Parameter \#2 \$timestamp of function date expects int\|null, string\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/GeoIp2/Commands/ConvertRegionCodesToIso.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, true given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, true given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/GeoIp2/Commands/ConvertRegionCodesToIso.php
 
 		-
-			message: "#^Parameter \\#3 \\$isContinuation of static method Piwik\\\\Http\\:\\:downloadChunk\\(\\) expects bool, int given\\.$#"
+			message: '#^Parameter \#3 \$isContinuation of static method Piwik\\Http\:\:downloadChunk\(\) expects bool, int given\.$#'
+			identifier: argument.type
 			count: 2
 			path: plugins/GeoIp2/Controller.php
 
 		-
-			message: "#^Call to an undefined method Matomo\\\\Decompress\\\\DecompressInterface\\:\\:extractInString\\(\\)\\.$#"
+			message: '#^Call to an undefined method Matomo\\Decompress\\DecompressInterface\:\:extractInString\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/GeoIp2/GeoIP2AutoUpdater.php
 
 		-
-			message: "#^Call to an undefined method Matomo\\\\Decompress\\\\DecompressInterface\\:\\:listContent\\(\\)\\.$#"
+			message: '#^Call to an undefined method Matomo\\Decompress\\DecompressInterface\:\:listContent\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/GeoIp2/GeoIP2AutoUpdater.php
 
 		-
-			message: "#^Parameter \\#2 \\$code of class Exception constructor expects int, string given\\.$#"
+			message: '#^Call to preg_quote\(\) is missing delimiter / to be effective\.$#'
+			identifier: argument.invalidPregQuote
 			count: 1
 			path: plugins/GeoIp2/GeoIP2AutoUpdater.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
+			message: '#^Parameter \#2 \$code of class Exception constructor expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/GeoIp2/GeoIP2AutoUpdater.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, true given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: plugins/GeoIp2/GeoIP2AutoUpdater.php
+
+		-
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, true given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/GeoIp2/GeoIp2.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with array will always evaluate to false\\.$#"
+			message: '#^Call to function is_null\(\) with array will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: plugins/GeoIp2/LocationProvider/GeoIp2.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int\\<1, max\\> given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int\<1, max\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/GeoIp2/LocationProvider/GeoIp2.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Piwik\\\\DataTable\\\\Row\\:\\:deleteColumn\\(\\) expects string, int given\\.$#"
+			message: '#^PHPDoc tag @var with type Piwik\\DataTable\|Piwik\\DataTable\\Map is not subtype of native type null\.$#'
+			identifier: varTag.nativeType
 			count: 1
 			path: plugins/Goals/API.php
 
 		-
-			message: "#^Parameter \\#1 \\$oldName of method Piwik\\\\DataTable\\\\Row\\:\\:renameColumn\\(\\) expects string, int given\\.$#"
+			message: '#^Parameter \#1 \$name of method Piwik\\DataTable\\Row\:\:deleteColumn\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Goals/API.php
 
 		-
-			message: "#^Variable \\$table in isset\\(\\) always exists and is not nullable\\.$#"
+			message: '#^Parameter \#1 \$oldName of method Piwik\\DataTable\\Row\:\:renameColumn\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Goals/API.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\Goals\\\\Commands\\\\CalculateConversionPages\\:\\:getDateRangeToCalculate\\(\\) never returns null so it can be removed from the return type\\.$#"
+			message: '#^Variable \$table in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: plugins/Goals/API.php
+
+		-
+			message: '#^Method Piwik\\Plugins\\Goals\\Commands\\CalculateConversionPages\:\:getDateRangeToCalculate\(\) never returns null so it can be removed from the return type\.$#'
+			identifier: return.unusedType
 			count: 1
 			path: plugins/Goals/Commands/CalculateConversionPages.php
 
 		-
-			message: "#^Parameter \\#1 \\$idGoal of method Piwik\\\\Plugins\\\\Goals\\\\Model\\:\\:doesGoalExist\\(\\) expects int, string given\\.$#"
+			message: '#^Parameter \#1 \$idGoal of method Piwik\\Plugins\\Goals\\Model\:\:doesGoalExist\(\) expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Goals/Commands/CalculateConversionPages.php
 
 		-
-			message: "#^Parameter \\#1 \\$idsite of class Piwik\\\\Site constructor expects int, string given\\.$#"
+			message: '#^Parameter \#1 \$idsite of class Piwik\\Site constructor expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Goals/Commands/CalculateConversionPages.php
 
 		-
-			message: "#^Variable \\$site in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/Goals/Controller.php
+
+		-
+			message: '#^Variable \$site in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/Goals/DataTable/Filter/CalculateConversionPageRate.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Goals\\\\Pages\\:\\:\\$conversions is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\Goals\\Pages\:\:\$conversions is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/Goals/Pages.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\|Zend_Db_Statement and false will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between array\|Zend_Db_Statement and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: plugins/Goals/RecordBuilders/GeneralGoalsRecords.php
 
 		-
-			message: "#^Parameter \\#3 \\$columnToSortByBeforeTruncation of method Piwik\\\\ArchiveProcessor\\\\RecordBuilder\\:\\:__construct\\(\\) expects string\\|null, int given\\.$#"
+			message: '#^Parameter \#3 \$columnToSortByBeforeTruncation of method Piwik\\ArchiveProcessor\\RecordBuilder\:\:__construct\(\) expects string\|null, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Goals/RecordBuilders/ProductRecord.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between string\\|null and false will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \!\=\= between Zend_Db_Statement and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: plugins/Goals/RecordBuilders/ProductRecord.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Strict comparison using \=\=\= between string\|null and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: plugins/Goals/RecordBuilders/ProductRecord.php
+
+		-
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
 			count: 1
 			path: plugins/Goals/Tracker/GoalsRequestProcessor.php
 
 		-
-			message: "#^Parameter \\#2 \\$lastN of static method Piwik\\\\Period\\\\Range\\:\\:getRelativeToEndDate\\(\\) expects int, string given\\.$#"
+			message: '#^Call to function is_array\(\) with array\<mixed, mixed\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/Goals/VisitorDetails.php
+
+		-
+			message: '#^Parameter \#2 \$lastN of static method Piwik\\Period\\Range\:\:getRelativeToEndDate\(\) expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/ImageGraph/ImageGraph.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\ImageGraph\\\\StaticGraph\\:\\:getRenderedImage\\(\\) should return resource but returns GdImage\\.$#"
+			message: '#^Method Piwik\\Plugins\\ImageGraph\\StaticGraph\:\:getRenderedImage\(\) should return resource but returns GdImage\.$#'
+			identifier: return.type
 			count: 1
 			path: plugins/ImageGraph/StaticGraph.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
 			count: 1
 			path: plugins/ImageGraph/StaticGraph.php
 
 		-
-			message: "#^Parameter \\#2 \\$Weight of method CpChart\\\\Data\\:\\:setSerieWeight\\(\\) expects int, float given\\.$#"
+			message: '#^Parameter \#2 \$Weight of method CpChart\\Data\:\:setSerieWeight\(\) expects int, float given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/ImageGraph/StaticGraph/GridGraph.php
 
 		-
-			message: "#^Parameter \\#3 \\$length of function substr expects int\\|null, float given\\.$#"
+			message: '#^Parameter \#3 \$length of function substr expects int\|null, float given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/ImageGraph/StaticGraph/GridGraph.php
 
 		-
-			message: "#^Variable \\$bulletWidth might not be defined\\.$#"
+			message: '#^Variable \$bulletWidth might not be defined\.$#'
+			identifier: variable.undefined
 			count: 2
 			path: plugins/ImageGraph/StaticGraph/GridGraph.php
 
 		-
-			message: "#^Variable \\$iconOffsetAboveLabelSymmetryAxis might not be defined\\.$#"
+			message: '#^Variable \$iconOffsetAboveLabelSymmetryAxis might not be defined\.$#'
+			identifier: variable.undefined
 			count: 1
 			path: plugins/ImageGraph/StaticGraph/GridGraph.php
 
 		-
-			message: "#^Constructor of class Piwik\\\\Plugins\\\\Insights\\\\DataTable\\\\Filter\\\\ExcludeLowValue has an unused parameter \\$table\\.$#"
+			message: '#^Constructor of class Piwik\\Plugins\\Insights\\DataTable\\Filter\\ExcludeLowValue has an unused parameter \$table\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: plugins/Insights/DataTable/Filter/ExcludeLowValue.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Loose comparison using \=\= between 0 and 0 will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
 			count: 1
 			path: plugins/Insights/DataTable/Filter/Insight.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between float\\|int and false will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between float\|int and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: plugins/Insights/DataTable/Filter/Insight.php
 
 		-
-			message: "#^Constructor of class Piwik\\\\Plugins\\\\Insights\\\\DataTable\\\\Filter\\\\Limit has an unused parameter \\$table\\.$#"
+			message: '#^Constructor of class Piwik\\Plugins\\Insights\\DataTable\\Filter\\Limit has an unused parameter \$table\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: plugins/Insights/DataTable/Filter/Limit.php
 
 		-
-			message: "#^Constructor of class Piwik\\\\Plugins\\\\Insights\\\\DataTable\\\\Filter\\\\MinGrowth has an unused parameter \\$table\\.$#"
+			message: '#^Constructor of class Piwik\\Plugins\\Insights\\DataTable\\Filter\\MinGrowth has an unused parameter \$table\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: plugins/Insights/DataTable/Filter/MinGrowth.php
 
 		-
-			message: "#^Constructor of class Piwik\\\\Plugins\\\\Insights\\\\DataTable\\\\Filter\\\\OrderBy has an unused parameter \\$table\\.$#"
+			message: '#^Constructor of class Piwik\\Plugins\\Insights\\DataTable\\Filter\\OrderBy has an unused parameter \$table\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: plugins/Insights/DataTable/Filter/OrderBy.php
 
 		-
-			message: "#^Property Piwik\\\\ViewDataTable\\\\RequestConfig\\:\\:\\$pivotBy \\(string\\) does not accept false\\.$#"
+			message: '#^Property Piwik\\ViewDataTable\\RequestConfig\:\:\$pivotBy \(string\) does not accept false\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: plugins/Insights/Visualizations/Insight/RequestConfig.php
 
 		-
-			message: "#^Property Piwik\\\\ViewDataTable\\\\RequestConfig\\:\\:\\$pivotByColumn \\(string\\) does not accept false\\.$#"
+			message: '#^Property Piwik\\ViewDataTable\\RequestConfig\:\:\$pivotByColumn \(string\) does not accept false\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: plugins/Insights/Visualizations/Insight/RequestConfig.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Db\\|Piwik\\\\Db\\\\AdapterInterface\\|Piwik\\\\Tracker\\\\Db\\:\\:checkClientVersion\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:checkClientVersion\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/Installation/Controller.php
 
 		-
-			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			message: '#^Expression on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.expr
 			count: 1
 			path: plugins/Installation/Controller.php
 
 		-
-			message: "#^Call to an undefined method HTML_QuickForm2_Container\\:\\:createDatabaseObject\\(\\)\\.$#"
+			message: '#^Call to an undefined method HTML_QuickForm2_Container\:\:createDatabaseObject\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/Installation/FormDatabaseSetup.php
 
 		-
-			message: "#^Call to an undefined method HTML_QuickForm2_Node\\:\\:loadOptions\\(\\)\\.$#"
+			message: '#^Call to an undefined method HTML_QuickForm2_Node\:\:loadOptions\(\)\.$#'
+			identifier: method.notFound
 			count: 2
 			path: plugins/Installation/FormDatabaseSetup.php
 
 		-
-			message: "#^Call to an undefined method HTML_QuickForm2_Node\\:\\:loadOptions\\(\\)\\.$#"
+			message: '#^Call to an undefined method HTML_QuickForm2_Node\:\:loadOptions\(\)\.$#'
+			identifier: method.notFound
 			count: 2
 			path: plugins/Installation/FormFirstWebsiteSetup.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
+			message: '#^Instanceof between Exception and Exception will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 1
 			path: plugins/Installation/Installation.php
 
 		-
-			message: "#^Parameter \\#1 \\$request of static method Piwik\\\\API\\\\Request\\:\\:isApiRequest\\(\\) expects array, null given\\.$#"
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
 			count: 1
 			path: plugins/Installation/Installation.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
+			message: '#^Parameter \#1 \$request of static method Piwik\\API\\Request\:\:isApiRequest\(\) expects array, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Installation/Installation.php
 
 		-
-			message: "#^Right side of \\|\\| is always true\\.$#"
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
 			count: 1
 			path: plugins/Installation/Installation.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
+			message: '#^Right side of \|\| is always true\.$#'
+			identifier: booleanOr.rightAlwaysTrue
+			count: 1
+			path: plugins/Installation/Installation.php
+
+		-
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Installation/Onboarding.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(mixed\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Parameter \#3 \$translations of method Piwik\\Plugins\\Intl\\Commands\\GenerateIntl\:\:fetchLanguageData\(\) expects array\{Intl\: array\<string, string\>\}, array\{\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: plugins/Intl/Commands/GenerateIntl.php
+
+		-
+			message: '#^Parameter &\$translations by\-ref type of method Piwik\\Plugins\\Intl\\Commands\\GenerateIntl\:\:fetchCalendarData\(\) expects array\{Intl\: array\<string, string\>\}, array\{Intl\: non\-empty\-array\<string, mixed\>\} given\.$#'
+			identifier: parameterByRef.type
+			count: 4
+			path: plugins/Intl/Commands/GenerateIntl.php
+
+		-
+			message: '#^Parameter &\$translations by\-ref type of method Piwik\\Plugins\\Intl\\Commands\\GenerateIntl\:\:fetchCurrencyData\(\) expects array\{Intl\: array\<string, string\>\}, array\{Intl\: non\-empty\-array\<string, mixed\>\} given\.$#'
+			identifier: parameterByRef.type
+			count: 4
+			path: plugins/Intl/Commands/GenerateIntl.php
+
+		-
+			message: '#^Parameter &\$translations by\-ref type of method Piwik\\Plugins\\Intl\\Commands\\GenerateIntl\:\:fetchListingLayouts\(\) expects array\{Intl\: array\<string, string\>\}, array\{Intl\: non\-empty\-array\<string, mixed\>\} given\.$#'
+			identifier: parameterByRef.type
+			count: 8
+			path: plugins/Intl/Commands/GenerateIntl.php
+
+		-
+			message: '#^Parameter &\$translations by\-ref type of method Piwik\\Plugins\\Intl\\Commands\\GenerateIntl\:\:fetchNumberFormattingData\(\) expects array\{Intl\: array\<string, string\>\}, array\{Intl\: non\-empty\-array\<string, mixed\>\} given\.$#'
+			identifier: parameterByRef.type
+			count: 12
+			path: plugins/Intl/Commands/GenerateIntl.php
+
+		-
+			message: '#^Parameter &\$translations by\-ref type of method Piwik\\Plugins\\Intl\\Commands\\GenerateIntl\:\:fetchTimeZoneData\(\) expects array\{Intl\: array\<string, string\>\}, array\{Intl\: non\-empty\-array\<string, mixed\>\} given\.$#'
+			identifier: parameterByRef.type
+			count: 1
+			path: plugins/Intl/Commands/GenerateIntl.php
+
+		-
+			message: '#^Parameter &\$translations by\-ref type of method Piwik\\Plugins\\Intl\\Commands\\GenerateIntl\:\:fetchUnitData\(\) expects array\{Intl\: array\<string, string\>\}, array\{Intl\: non\-empty\-array\<string, mixed\>\} given\.$#'
+			identifier: parameterByRef.type
+			count: 17
+			path: plugins/Intl/Commands/GenerateIntl.php
+
+		-
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(mixed\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/LanguagesManager/API.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$arrays of function array_merge expects array, string given\\.$#"
+			message: '#^Parameter &\$languages by\-ref type of method Piwik\\Plugins\\LanguagesManager\\API\:\:enableDevelopmentLanguageInDevEnvironment\(\) expects list\<string\>, array\<int\<0, max\>, string\> given\.$#'
+			identifier: parameterByRef.type
+			count: 1
+			path: plugins/LanguagesManager/API.php
+
+		-
+			message: '#^Parameter &\$languages by\-ref type of method Piwik\\Plugins\\LanguagesManager\\API\:\:enableDevelopmentLanguageInDevEnvironment\(\) expects list\<string\>, non\-empty\-array\<int\<0, max\>, string\> given\.$#'
+			identifier: parameterByRef.type
+			count: 1
+			path: plugins/LanguagesManager/API.php
+
+		-
+			message: '#^Parameter \#1 \.\.\.\$arrays of function array_merge expects array, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/LanguagesManager/Commands/PluginsWithTranslations.php
 
 		-
-			message: "#^Parameter \\#5 \\$tooltip of method Piwik\\\\Menu\\\\MenuTop\\:\\:addHtml\\(\\) expects string, false given\\.$#"
+			message: '#^Parameter \#1 \$array \(list\<string\>\) of array_values is already a list, call has no effect\.$#'
+			identifier: arrayValues.list
+			count: 1
+			path: plugins/LanguagesManager/Commands/SetTranslations.php
+
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 3
+			path: plugins/LanguagesManager/LanguagesManager.php
+
+		-
+			message: '#^Parameter \#5 \$tooltip of method Piwik\\Menu\\MenuTop\:\:addHtml\(\) expects string, false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/LanguagesManager/Menu.php
 
 		-
-			message: "#^Parameter \\#2 \\$return of function var_export expects bool, int given\\.$#"
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
+			count: 1
+			path: plugins/LanguagesManager/TranslationWriter/Filter/EmptyTranslations.php
+
+		-
+			message: '#^Parameter \#2 \$return of function var_export expects bool, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/LanguagesManager/TranslationWriter/Writer.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: '#^Call to function is_array\(\) with list\<int\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/Live/API.php
+
+		-
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 1
+			path: plugins/Live/Model.php
+
+		-
+			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: plugins/Live/Settings/VisitorLogDisabled.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
 			count: 1
 			path: plugins/Live/VisitorDetails.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\Live\\\\VisitorDetails\\:\\:getAdditionalUrlsForSite\\(\\) should return array\\<int, array\\<string\\>\\> but returns array\\<string\\>\\.$#"
+			message: '#^Method Piwik\\Plugins\\Live\\VisitorDetails\:\:getAdditionalUrlsForSite\(\) should return array\<int, array\<string\>\> but returns array\<string\>\.$#'
+			identifier: return.type
 			count: 1
 			path: plugins/Live/VisitorDetails.php
 
 		-
-			message: "#^Offset 'type' on array in isset\\(\\) always exists and is not nullable\\.$#"
+			message: '#^Offset ''type'' on non\-empty\-array in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
 			count: 1
 			path: plugins/Live/VisitorDetails.php
 
 		-
-			message: "#^Elseif branch is unreachable because previous condition is always true\\.$#"
+			message: '#^Call to function is_null\(\) with null will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: plugins/Live/VisitorFactory.php
 
 		-
-			message: "#^Instanceof between \\*NEVER\\* and Piwik\\\\Plugins\\\\Live\\\\VisitorInterface will always evaluate to false\\.$#"
+			message: '#^Instanceof between \*NEVER\* and Piwik\\Plugins\\Live\\VisitorInterface will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
 			count: 1
 			path: plugins/Live/VisitorFactory.php
 
 		-
-			message: "#^Parameter \\#2 \\$login of class Piwik\\\\AuthResult constructor expects string, null given\\.$#"
+			message: '#^Parameter \#2 \$login of class Piwik\\AuthResult constructor expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Login/Auth.php
 
 		-
-			message: "#^Parameter \\#3 \\$tokenAuth of class Piwik\\\\AuthResult constructor expects string, null given\\.$#"
+			message: '#^Parameter \#3 \$tokenAuth of class Piwik\\AuthResult constructor expects string, null given\.$#'
+			identifier: argument.type
 			count: 2
 			path: plugins/Login/Auth.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between string and null will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between string and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: plugins/Login/Auth.php
 
 		-
-			message: "#^Access to an undefined property Piwik\\\\Plugins\\\\PrivacyManager\\\\SystemSettings\\:\\:\\$blacklistedBruteForceIps\\.$#"
+			message: '#^Access to an undefined property Piwik\\Plugins\\PrivacyManager\\SystemSettings\:\:\$blacklistedBruteForceIps\.$#'
+			identifier: property.notFound
 			count: 1
 			path: plugins/Login/Controller.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\Login\\\\Controller\\:\\:resetPasswordFirstStep\\(\\) should return array but returns null\\.$#"
+			message: '#^Method Piwik\\Plugins\\Login\\Controller\:\:resetPasswordFirstStep\(\) should return array but returns null\.$#'
+			identifier: return.type
 			count: 2
 			path: plugins/Login/Controller.php
 
 		-
-			message: "#^Parameter \\#1 \\$login of method Piwik\\\\Auth\\:\\:setLogin\\(\\) expects string, null given\\.$#"
+			message: '#^Parameter \#1 \$login of method Piwik\\Auth\:\:setLogin\(\) expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Login/Login.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int\\|null given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Login/Model.php
 
 		-
-			message: "#^Parameter \\#2 \\$password of method Piwik\\\\Plugins\\\\UsersManager\\\\UserUpdater\\:\\:updateUserWithoutCurrentPassword\\(\\) expects bool, string given\\.$#"
+			message: '#^Parameter \#2 \$password of method Piwik\\Plugins\\UsersManager\\UserUpdater\:\:updateUserWithoutCurrentPassword\(\) expects bool, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Login/PasswordResetter.php
 
 		-
-			message: "#^Parameter \\#1 \\$passwordHash of method Piwik\\\\Auth\\:\\:setPasswordHash\\(\\) expects string, null given\\.$#"
+			message: '#^Parameter \#1 \$passwordHash of method Piwik\\Auth\:\:setPasswordHash\(\) expects string, null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/Login/PasswordVerifier.php
 
 		-
-			message: "#^Binary operation \"\\+\" between int\\<1, max\\> and string results in an error\\.$#"
+			message: '#^Binary operation "\+" between int\<1, max\> and string results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: plugins/Login/SessionInitializer.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Login\\\\SessionInitializer\\:\\:\\$usersManagerAPI is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\Login\\SessionInitializer\:\:\$usersManagerAPI is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/Login/SessionInitializer.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
 			count: 2
 			path: plugins/Login/SystemSettings.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Marketplace\\\\Environment\\:\\:\\$releaseChannel \\(Piwik\\\\Plugins\\\\CoreUpdater\\\\ReleaseChannel\\) does not accept Piwik\\\\UpdateCheck\\\\ReleaseChannel\\.$#"
+			message: '#^Property Piwik\\Plugins\\Marketplace\\Environment\:\:\$releaseChannel \(Piwik\\Plugins\\CoreUpdater\\ReleaseChannel\) does not accept Piwik\\UpdateCheck\\ReleaseChannel\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: plugins/Marketplace/Environment.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Marketplace\\\\Environment\\:\\:\\$releaseChannel \\(Piwik\\\\Plugins\\\\CoreUpdater\\\\ReleaseChannel\\) in empty\\(\\) is not falsy\\.$#"
+			message: '#^Property Piwik\\Plugins\\Marketplace\\Environment\:\:\$releaseChannel \(Piwik\\Plugins\\CoreUpdater\\ReleaseChannel\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
 			count: 2
 			path: plugins/Marketplace/Environment.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
 			count: 1
 			path: plugins/Marketplace/Environment.php
 
 		-
-			message: "#^Left side of && is always true\\.$#"
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
 			path: plugins/Marketplace/Plugins/InvalidLicenses.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\MobileMessaging\\\\Diagnostic\\\\MobileMessagingInformational\\:\\:\\$translator is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\MobileMessaging\\Diagnostic\\MobileMessagingInformational\:\:\$translator is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/MobileMessaging/Diagnostic/MobileMessagingInformational.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, bool given\\.$#"
+			message: '#^Method Piwik\\Plugins\\MobileMessaging\\Model\:\:getPhoneNumbers\(\) should return array\<string, array\{verified\: bool, verificationCode\: string\|null, verificationTries\: int, verificationTime\: int\|null, requestTime\: int\}\> but returns array\<string, array\{verified\: bool, verificationTries\: int, verificationTime\: int\|null, requestTime\: int\}\>\.$#'
+			identifier: return.type
 			count: 1
 			path: plugins/MobileMessaging/Model.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between 1 and string\\|false will always evaluate to false\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, bool given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/MobileMessaging/Model.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between true and string\\|false will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between 1 and string\|false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: plugins/MobileMessaging/Model.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function preg_replace_callback expects callable\\(array\\<int\\|string, string\\>\\)\\: string, Closure\\(mixed\\)\\: float given\\.$#"
+			message: '#^Strict comparison using \=\=\= between true and string\|false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: plugins/MobileMessaging/Model.php
+
+		-
+			message: '#^Parameter \#2 \$callback of function preg_replace_callback expects callable\(array\<string\>\)\: string, Closure\(mixed\)\: float given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/MobileMessaging/ReportRenderer/Sms.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\MobileMessaging\\\\SMSProvider\\\\StubbedProvider\\:\\:getCreditLeft\\(\\) should return string but returns int\\.$#"
+			message: '#^Method Piwik\\Plugins\\MobileMessaging\\SMSProvider\\StubbedProvider\:\:getCreditLeft\(\) should return string but returns int\.$#'
+			identifier: return.type
 			count: 1
 			path: plugins/MobileMessaging/SMSProvider/StubbedProvider.php
 
 		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			message: '#^Class Piwik\\Plugins\\Monolog\\Formatter\\ConsoleFormatter extends @final class Symfony\\Bridge\\Monolog\\Formatter\\ConsoleFormatter\.$#'
+			identifier: class.extendsFinalByPhpDoc
+			count: 1
+			path: plugins/Monolog/Formatter/ConsoleFormatter.php
+
+		-
+			message: '#^Variable \$parts in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: plugins/Monolog/Handler/WebNotificationHandler.php
+
+		-
+			message: '#^Instanceof between Exception and Exception will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 2
 			path: plugins/Monolog/Processor/ExceptionToTextProcessor.php
 
 		-
-			message: "#^Property Piwik\\\\Plugin\\\\Report\\:\\:\\$dimension \\(Piwik\\\\Columns\\\\Dimension\\) does not accept null\\.$#"
+			message: '#^Call to function is_array\(\) with array\<string, mixed\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/MultiSites/Dashboard.php
+
+		-
+			message: '#^Call to method Piwik\\DataTable\\Row\:\:setColumn\(\) on a separate line has no effect\.$#'
+			identifier: method.resultUnused
+			count: 1
+			path: plugins/MultiSites/Dashboard.php
+
+		-
+			message: '#^Instanceof between Piwik\\DataTable and Piwik\\DataTable will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: plugins/PagePerformance/Columns/Metrics/AveragePerformanceMetric.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
 			count: 1
 			path: plugins/PagePerformance/Reports/Get.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Plugin\\\\Dimension\\\\ActionDimension\\:\\:getRequestParam\\(\\)\\.$#"
+			message: '#^Property Piwik\\Plugin\\Report\:\:\$dimension \(Piwik\\Columns\\Dimension\) does not accept null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: plugins/PagePerformance/Reports/Get.php
+
+		-
+			message: '#^Call to an undefined method Piwik\\Plugin\\Dimension\\ActionDimension\:\:getRequestParam\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/PagePerformance/Tracker/PerformanceDataProcessor.php
 
 		-
-			message: "#^Binary operation \"\\+\" between non\\-falsy\\-string and int results in an error\\.$#"
+			message: '#^Call to function is_a\(\) with arguments class\-string\<Piwik\\Policy\\CompliancePolicy\>, ''Piwik\\\\Policy\\\\CompliancePolicy'' and true will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/PrivacyManager/API.php
+
+		-
+			message: '#^Binary operation "\+" between non\-falsy\-string and int results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: plugins/PrivacyManager/Controller.php
 
 		-
-			message: "#^Parameter \\#2 \\$comment of static method Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\DiagnosticResult\\:\\:informationalResult\\(\\) expects string, bool given\\.$#"
+			message: '#^Parameter \#2 \$comment of static method Piwik\\Plugins\\Diagnostics\\Diagnostic\\DiagnosticResult\:\:informationalResult\(\) expects string, bool given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/PrivacyManager/Diagnostic/PrivacyInformational.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\PrivacyManager\\\\Diagnostic\\\\PrivacyInformational\\:\\:\\$translator is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\PrivacyManager\\Diagnostic\\PrivacyInformational\:\:\$translator is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/PrivacyManager/Diagnostic/PrivacyInformational.php
 
 		-
-			message: "#^If condition is always false\\.$#"
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
 			count: 1
 			path: plugins/PrivacyManager/DoNotTrackHeaderChecker.php
 
 		-
-			message: "#^Parameter \\#2 \\$first of static method Piwik\\\\Db\\:\\:segmentedFetchFirst\\(\\) expects int, string given\\.$#"
+			message: '#^Parameter \#2 \$first of static method Piwik\\Db\:\:segmentedFetchFirst\(\) expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/PrivacyManager/LogDataPurger.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with non\\-falsy\\-string will always evaluate to false\\.$#"
+			message: '#^Call to function is_array\(\) with non\-falsy\-string will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: plugins/PrivacyManager/Model/DataSubjects.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
 			count: 1
 			path: plugins/PrivacyManager/Model/LogDataAnonymizations.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
+			message: '#^Method Piwik\\Plugins\\PrivacyManager\\PrivacyManager\:\:registerEvents\(\) should return array\<string, array\{function\: string, after\?\: bool, before\?\: bool\}\|string\> but returns array\{''AssetManager\.getStylesheetFiles''\: ''getStylesheetFiles'', ''Tracker\.setTrackerCacheGeneral''\: ''setTrackerCacheGene…'', ''Tracker\.Cache\.getSiteAttributes''\: ''setTrackerCacheSite…'', ''Tracker\.isExcludedVisit''\: array\{mixed, ''checkHeaderInTracker''\}, ''Tracker\.setVisitorIp''\: array\{mixed, ''setVisitorIpAddress''\}, ''Installation\.defaultSettingsForm\.init''\: ''installationFormInit'', ''Installation\.defaultSettingsForm\.submit''\: ''installationFormSub…'', ''Translate\.getClientSideTranslationKeys''\: ''getClientSideTransl…'', \.\.\.\}\.$#'
+			identifier: return.type
+			count: 1
+			path: plugins/PrivacyManager/PrivacyManager.php
+
+		-
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 5
 			path: plugins/PrivacyManager/PrivacyManager.php
 
 		-
-			message: "#^Variable \\$dataTable in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Variable \$dataTable in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/PrivacyManager/PrivacyManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$reportDateYear of static method Piwik\\\\Plugins\\\\PrivacyManager\\\\ReportsPurger\\:\\:shouldReportBePurged\\(\\) expects int, string given\\.$#"
+			message: '#^Parameter \#1 \$reportDateYear of static method Piwik\\Plugins\\PrivacyManager\\ReportsPurger\:\:shouldReportBePurged\(\) expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/PrivacyManager/ReportsPurger.php
 
 		-
-			message: "#^Parameter \\#2 \\$reportDateMonth of static method Piwik\\\\Plugins\\\\PrivacyManager\\\\ReportsPurger\\:\\:shouldReportBePurged\\(\\) expects int, string given\\.$#"
+			message: '#^Parameter \#2 \$reportDateMonth of static method Piwik\\Plugins\\PrivacyManager\\ReportsPurger\:\:shouldReportBePurged\(\) expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/PrivacyManager/ReportsPurger.php
 
 		-
-			message: "#^Parameter \\#3 \\$last of static method Piwik\\\\Db\\:\\:segmentedFetchAll\\(\\) expects int, string given\\.$#"
+			message: '#^Parameter \#3 \$last of static method Piwik\\Db\:\:segmentedFetchAll\(\) expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/PrivacyManager/ReportsPurger.php
 
 		-
-			message: "#^Parameter \\#3 \\$last of static method Piwik\\\\Db\\:\\:segmentedFetchOne\\(\\) expects int, string given\\.$#"
+			message: '#^Parameter \#3 \$last of static method Piwik\\Db\:\:segmentedFetchOne\(\) expects int, string given\.$#'
+			identifier: argument.type
 			count: 2
 			path: plugins/PrivacyManager/ReportsPurger.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\ProfessionalServices\\\\Widgets\\\\PromoServices\\:\\:\\$advertising is never read, only written\\.$#"
+			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: plugins/PrivacyManager/Settings/CampaignParameterValuesMasked.php
+
+		-
+			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: plugins/PrivacyManager/Settings/CompliancePolicyEnforcedSetting.php
+
+		-
+			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: plugins/PrivacyManager/Settings/IPAnonymisation.php
+
+		-
+			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: plugins/PrivacyManager/Settings/IpAddressMaskLength.php
+
+		-
+			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: plugins/PrivacyManager/Settings/ReferrerAnonymisation.php
+
+		-
+			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: plugins/PrivacyManager/Settings/ReportRetention.php
+
+		-
+			message: '#^Property Piwik\\Plugins\\ProfessionalServices\\Widgets\\PromoServices\:\:\$advertising is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/ProfessionalServices/Widgets/PromoServices.php
 
 		-
-			message: "#^Variable \\$requestedColumns in empty\\(\\) is never defined\\.$#"
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/Referrers/AIAssistant.php
+
+		-
+			message: '#^Call to function is_array\(\) with non\-empty\-array\<string\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/Referrers/AIAssistant.php
+
+		-
+			message: '#^Variable \$requestedColumns in empty\(\) is never defined\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/Referrers/API.php
 
 		-
-			message: "#^Offset 'referer_keyword' on array\\{referer_type\\: 1\\|3, referer_name\\: mixed, referer_keyword\\: '', referer_url\\: string\\} in empty\\(\\) always exists and is always falsy\\.$#"
+			message: '#^Call to function is_string\(\) with non\-falsy\-string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: plugins/Referrers/Columns/Base.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\Referrers\\\\Columns\\\\Metrics\\\\VisitorsFromReferrerPercent\\:\\:getTranslatedName\\(\\) should return string but returns null\\.$#"
+			message: '#^Loose comparison using \=\= between 1\|3 and 6 will always evaluate to false\.$#'
+			identifier: equal.alwaysFalse
+			count: 1
+			path: plugins/Referrers/Columns/Base.php
+
+		-
+			message: '#^Offset ''referer_keyword'' on array\{referer_type\: 1\|3, referer_name\: mixed, referer_keyword\: '''', referer_url\: string\} in empty\(\) always exists and is always falsy\.$#'
+			identifier: empty.offset
+			count: 1
+			path: plugins/Referrers/Columns/Base.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: plugins/Referrers/Columns/Base.php
+
+		-
+			message: '#^Method Piwik\\Plugins\\Referrers\\Columns\\Metrics\\VisitorsFromReferrerPercent\:\:getTranslatedName\(\) should return string but returns null\.$#'
+			identifier: return.type
 			count: 1
 			path: plugins/Referrers/Columns/Metrics/VisitorsFromReferrerPercent.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/Referrers/Controller.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
 			count: 1
 			path: plugins/Referrers/DataTable/Filter/SetGetReferrerTypeSubtables.php
 
 		-
-			message: "#^Variable \\$domain on left side of \\?\\? always exists and is not nullable\\.$#"
+			message: '#^Instanceof between Piwik\\Plugins\\SEO\\Metric\\Metric and Piwik\\Plugins\\SEO\\Metric\\Metric will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: plugins/SEO/API.php
+
+		-
+			message: '#^Variable \$domain on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.variable
 			count: 1
 			path: plugins/SEO/Metric/DomainAge.php
 
 		-
-			message: "#^Variable \\$domain on left side of \\?\\? always exists and is not nullable\\.$#"
+			message: '#^Variable \$domain on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.variable
 			count: 1
 			path: plugins/SEO/Metric/ProviderCache.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\ScheduledReports\\\\ReportEmailGenerator\\\\AttachedFileReportEmailGenerator\\:\\:\\$piwikUrl is never read, only written\\.$#"
+			message: '#^Method Piwik\\Plugins\\ScheduledReports\\API\:\:validateIdSegment\(\) never assigns false to &\$idSegment so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: plugins/ScheduledReports/API.php
+
+		-
+			message: '#^Parameter &\$idSegment by\-ref type of method Piwik\\Plugins\\ScheduledReports\\API\:\:validateCommonReportAttributes\(\) expects int\|false\|null, int\|string\|false\|null given\.$#'
+			identifier: parameterByRef.type
+			count: 1
+			path: plugins/ScheduledReports/API.php
+
+		-
+			message: '#^Property Piwik\\Plugins\\ScheduledReports\\ReportEmailGenerator\\AttachedFileReportEmailGenerator\:\:\$piwikUrl is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/ScheduledReports/ReportEmailGenerator/AttachedFileReportEmailGenerator.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\DataTable\\\\Renderer\\:\\:setRenderImageInline\\(\\)\\.$#"
+			message: '#^Call to an undefined method Piwik\\DataTable\\Renderer\:\:setRenderImageInline\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/ScheduledReports/ScheduledReports.php
 
 		-
-			message: "#^Variable \\$endDate in empty\\(\\) always exists and is not falsy\\.$#"
+			message: '#^Parameter &\$segments by\-ref type of method Piwik\\Plugins\\SegmentEditor\\SegmentEditor\:\:getKnownSegmentsToArchiveForSite\(\) expects array\<string\>, array given\.$#'
+			identifier: parameterByRef.type
+			count: 2
+			path: plugins/SegmentEditor/SegmentEditor.php
+
+		-
+			message: '#^Variable \$endDate in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
 			count: 1
 			path: plugins/SegmentEditor/SegmentEditor.php
 
 		-
-			message: "#^Parameter \\#14 \\$excludedQueryParams of method Piwik\\\\Tracker\\\\TrackerCodeGenerator\\:\\:generate\\(\\) expects bool, string given\\.$#"
+			message: '#^Call to function is_string\(\) with non\-falsy\-string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: plugins/SitesManager/API.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Parameter \#14 \$excludedQueryParams of method Piwik\\Tracker\\TrackerCodeGenerator\:\:generate\(\) expects bool, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: plugins/SitesManager/API.php
+
+		-
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
 			count: 2
 			path: plugins/SitesManager/API.php
 
 		-
-			message: "#^Variable \\$id_val might not be defined\\.$#"
+			message: '#^Variable \$id_val might not be defined\.$#'
+			identifier: variable.undefined
 			count: 1
 			path: plugins/SitesManager/Model.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: plugins/SitesManager/Settings/FilterPIIParameters.php
+
+		-
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/SitesManager/SitesManager.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/SitesManager/SitesManager.php
 
 		-
-			message: "#^Parameter \\#3 \\$default of method Piwik\\\\Plugin\\\\ConsoleCommand\\:\\:addOptionalArgument\\(\\) expects null, string given\\.$#"
+			message: '#^Parameter \#3 \$default of method Piwik\\Plugin\\ConsoleCommand\:\:addOptionalArgument\(\) expects null, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/TestRunner/Commands/CodeCoverage.php
 
 		-
-			message: "#^Parameter \\#3 \\$default of method Piwik\\\\Plugin\\\\ConsoleCommand\\:\\:addOptionalArgument\\(\\) expects null, array\\<int, string\\> given\\.$#"
+			message: '#^Parameter \#3 \$default of method Piwik\\Plugin\\ConsoleCommand\:\:addOptionalArgument\(\) expects null, array\<int, string\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/TestRunner/Commands/SyncScreenshots.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/TestRunner/Commands/TestsRun.php
 
 		-
-			message: "#^Parameter \\#3 \\$default of method Piwik\\\\Plugin\\\\ConsoleCommand\\:\\:addOptionalArgument\\(\\) expects null, array given\\.$#"
+			message: '#^Parameter \#3 \$default of method Piwik\\Plugin\\ConsoleCommand\:\:addOptionalArgument\(\) expects null, array given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/TestRunner/Commands/TestsRun.php
 
 		-
-			message: "#^Parameter \\#3 \\$default of method Piwik\\\\Plugin\\\\ConsoleCommand\\:\\:addOptionalArgument\\(\\) expects null, array given\\.$#"
+			message: '#^Parameter \#3 \$default of method Piwik\\Plugin\\ConsoleCommand\:\:addOptionalArgument\(\) expects null, array given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/TestRunner/Commands/TestsRunUI.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Tour\\\\Engagement\\\\ChallengeCustomLogo\\:\\:\\$finder is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\Tour\\Engagement\\ChallengeCustomLogo\:\:\$finder is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/Tour/Engagement/ChallengeCustomLogo.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\Tour\\\\Engagement\\\\ChallengeSetupConsentManager\\:\\:isDisabled\\(\\) should return false but returns bool\\.$#"
+			message: '#^Method Piwik\\Plugins\\Tour\\Engagement\\ChallengeSetupConsentManager\:\:isDisabled\(\) should return false but returns bool\.$#'
+			identifier: return.type
 			count: 1
 			path: plugins/Tour/Engagement/ChallengeSetupConsentManager.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Tour\\\\Engagement\\\\ChallengeSetupConsentManager\\:\\:\\$detectedContentManager \\(Piwik\\\\Plugins\\\\SitesManager\\\\SiteContentDetection\\\\ConsentManagerDetectionAbstract\\|null\\) does not accept Piwik\\\\Plugins\\\\SitesManager\\\\SiteContentDetection\\\\SiteContentDetectionAbstract\\|null\\.$#"
+			message: '#^Property Piwik\\Plugins\\Tour\\Engagement\\ChallengeSetupConsentManager\:\:\$detectedContentManager \(Piwik\\Plugins\\SitesManager\\SiteContentDetection\\ConsentManagerDetectionAbstract\|null\) does not accept Piwik\\Plugins\\SitesManager\\SiteContentDetection\\SiteContentDetectionAbstract\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: plugins/Tour/Engagement/ChallengeSetupConsentManager.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\Tour\\\\Engagement\\\\Challenges\\:\\:\\$finder is never read, only written\\.$#"
+			message: '#^Property Piwik\\Plugins\\Tour\\Engagement\\Challenges\:\:\$finder is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: plugins/Tour/Engagement/Challenges.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\TwoFactorAuth\\\\Controller\\:\\:setupTwoFactorAuth\\(\\) should return string but empty return statement found\\.$#"
+			message: '#^Method Piwik\\Plugins\\TwoFactorAuth\\Controller\:\:setupTwoFactorAuth\(\) should return string but empty return statement found\.$#'
+			identifier: return.empty
 			count: 1
 			path: plugins/TwoFactorAuth/Controller.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
 			count: 1
 			path: plugins/TwoFactorAuth/Controller.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function str_pad expects string, \\(float\\|int\\) given\\.$#"
+			message: '#^Parameter \#1 \$string of function str_pad expects string, \(float\|int\) given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/TwoFactorAuth/Dao/RecoveryCodeStaticGenerator.php
 
 		-
-			message: "#^Parameter \\#1 \\$sqlFilterValue of method Piwik\\\\Plugin\\\\Segment\\:\\:setSqlFilterValue\\(\\) expects array\\|string, Closure given\\.$#"
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/TwoFactorAuth/TwoFactorAuthentication.php
+
+		-
+			message: '#^Offset 0 on non\-empty\-list\<string\> in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: plugins/UserCountry/API.php
+
+		-
+			message: '#^Parameter \#1 \$sqlFilterValue of method Piwik\\Plugin\\Segment\:\:setSqlFilterValue\(\) expects array\|string, Closure given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/UserCountry/Columns/Country.php
 
 		-
-			message: "#^If condition is always false\\.$#"
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
 			count: 1
 			path: plugins/UserCountry/Controller.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with array will always evaluate to false\\.$#"
+			message: '#^Call to function is_null\(\) with array will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: plugins/UserCountry/LocationProvider.php
 
 		-
-			message: "#^Call to function is_string\\(\\) with false will always evaluate to false\\.$#"
+			message: '#^Call to function is_string\(\) with false will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: plugins/UserCountry/LocationProvider.php
 
 		-
-			message: "#^Function Piwik\\\\Plugins\\\\UserCountry\\\\getPrettyCityName\\(\\) never returns false so it can be removed from the return type\\.$#"
+			message: '#^PHPDoc tag @return has invalid value \(false\.\)\: Unexpected token "\.", expected TOKEN_HORIZONTAL_WS at offset 158 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: plugins/UserCountry/LocationProvider/DisabledProvider.php
+
+		-
+			message: '#^Function Piwik\\Plugins\\UserCountry\\getPrettyCityName\(\) never returns false so it can be removed from the return type\.$#'
+			identifier: return.unusedType
 			count: 1
 			path: plugins/UserCountry/functions.php
 
 		-
-			message: "#^Function Piwik\\\\Plugins\\\\UserCountry\\\\getPrettyRegionName\\(\\) never returns false so it can be removed from the return type\\.$#"
+			message: '#^Function Piwik\\Plugins\\UserCountry\\getPrettyRegionName\(\) never returns false so it can be removed from the return type\.$#'
+			identifier: return.unusedType
 			count: 1
 			path: plugins/UserCountry/functions.php
 
 		-
-			message: "#^Argument of an invalid type Zend_Db_Statement supplied for foreach, only iterables are supported\\.$#"
+			message: '#^Argument of an invalid type Zend_Db_Statement supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: plugins/UserId/RecordBuilders/Users.php
 
 		-
-			message: "#^Property Piwik\\\\ViewDataTable\\\\RequestConfig\\:\\:\\$filter_excludelowpop_value \\(Closure\\|string\\) does not accept 2\\.$#"
+			message: '#^Property Piwik\\ViewDataTable\\RequestConfig\:\:\$filter_excludelowpop_value \(Closure\|string\) does not accept 2\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: plugins/UserId/Reports/GetUsers.php
 
 		-
-			message: "#^If condition is always false\\.$#"
+			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: plugins/UserId/Settings/UserIdDisabled.php
+
+		-
+			message: '#^Call to function is_array\(\) with array\{login\: string, password\: string, email\: string, twofactor_secret\: string, superuser_access\: int\|string, date_registered\: string\|null, ts_password_modified\: string\|null, idchange_last_viewed\: int\|string\|null, \.\.\.\} will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/UsersManager/API.php
+
+		-
+			message: '#^Call to function is_array\(\) with non\-empty\-list\<int\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/UsersManager/API.php
+
+		-
+			message: '#^Loose comparison using \!\= between 9 and 9 will always evaluate to false\.$#'
+			identifier: notEqual.alwaysFalse
 			count: 1
 			path: plugins/UsersManager/Controller.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\UsersManager\\\\Controller\\:\\:getIgnoreCookieSalt\\(\\) is unused\\.$#"
+			message: '#^Method Piwik\\Plugins\\UsersManager\\Controller\:\:getIgnoreCookieSalt\(\) is unused\.$#'
+			identifier: method.unused
 			count: 1
 			path: plugins/UsersManager/Controller.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\UsersManager\\\\Controller\\:\\:noAdminAccessToWebsite\\(\\) is unused\\.$#"
+			message: '#^Method Piwik\\Plugins\\UsersManager\\Controller\:\:noAdminAccessToWebsite\(\) is unused\.$#'
+			identifier: method.unused
 			count: 1
 			path: plugins/UsersManager/Controller.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/UsersManager/NewsletterSignup.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\UsersManager\\\\Sql\\\\UserTableFilter\\:\\:\\$filterByRoleSite \\(int\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Property Piwik\\Plugins\\UsersManager\\Sql\\UserTableFilter\:\:\$filterByRoleSite \(int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: plugins/UsersManager/Sql/UserTableFilter.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
 			count: 1
 			path: plugins/UsersManager/Sql/UserTableFilter.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(lowercase\\-string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(lowercase\-string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/UsersManager/SystemSettings.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
+			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/UsersManager/TokenNotifications/TokenNotifierTask.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\UsersManager\\\\UserAccessFilter\\:\\:\\$idSitesWithAdmin \\(array\\) in isset\\(\\) is not nullable\\.$#"
+			message: '#^Property Piwik\\Plugins\\UsersManager\\UserAccessFilter\:\:\$idSitesWithAdmin \(array\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
 			count: 1
 			path: plugins/UsersManager/UserAccessFilter.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
 			count: 1
 			path: plugins/UsersManager/UserLoginHelper.php
 
 		-
-			message: "#^Parameter \\#1 \\$view of method Piwik\\\\Plugins\\\\VisitFrequency\\\\Reports\\\\Get\\:\\:addSparklineColumns\\(\\) expects Piwik\\\\Plugins\\\\CoreVisualizations\\\\Visualizations\\\\Sparklines, Piwik\\\\Plugin\\\\ViewDataTable given\\.$#"
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
 			count: 1
 			path: plugins/VisitFrequency/Reports/Get.php
 
 		-
-			message: "#^Call to an undefined method Piwik\\\\Archive\\\\ArchiveQuery\\:\\:getParams\\(\\)\\.$#"
+			message: '#^Parameter \#1 \$view of method Piwik\\Plugins\\VisitFrequency\\Reports\\Get\:\:addSparklineColumns\(\) expects Piwik\\Plugins\\CoreVisualizations\\Visualizations\\Sparklines, Piwik\\Plugin\\ViewDataTable given\.$#'
+			identifier: argument.type
+			count: 1
+			path: plugins/VisitFrequency/Reports/Get.php
+
+		-
+			message: '#^Call to an undefined method Piwik\\Archive\\ArchiveQuery\:\:getParams\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: plugins/VisitTime/API.php
 
 		-
-			message: "#^Parameter \\#3 \\$pad_string of function str_pad expects string, int given\\.$#"
+			message: '#^Parameter \#3 \$pad_string of function str_pad expects string, int given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/VisitTime/DataTable/Filter/AddSegmentByLabelInUTC.php
 
 		-
-			message: "#^Parameter \\#1 \\$label of method Piwik\\\\DataTable\\:\\:getRowFromLabel\\(\\) expects string, int\\<0, 23\\> given\\.$#"
+			message: '#^Parameter \#1 \$label of method Piwik\\DataTable\:\:getRowFromLabel\(\) expects string, int\<0, 23\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: plugins/VisitTime/RecordBuilders/Base.php
 
 		-
-			message: "#^Function Piwik\\\\Plugins\\\\VisitTime\\\\dayOfWeekFromDate\\(\\) should return int but returns string\\.$#"
+			message: '#^Function Piwik\\Plugins\\VisitTime\\dayOfWeekFromDate\(\) should return int but returns string\.$#'
+			identifier: return.type
 			count: 1
 			path: plugins/VisitTime/functions.php
 
 		-
-			message: "#^Comparison operation \"\\=\\=\" between \\(array\\|float\\|int\\) and 0 results in an error\\.$#"
+			message: '#^Parameter \#1 \$array \(array\{''nb_uniq_visitors'', ''nb_users'', ''nb_visits'', ''nb_actions'', ''nb_visits_converted'', ''bounce_count'', ''sum_visit_length'', ''max_actions''\}\|array\{''nb_visits'', ''nb_actions'', ''nb_visits_converted'', ''bounce_count'', ''sum_visit_length'', ''max_actions''\}\) of array_values is already a list, call has no effect\.$#'
+			identifier: arrayValues.list
+			count: 1
+			path: plugins/VisitsSummary/API.php
+
+		-
+			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'
+			identifier: staticMethod.resultUnused
 			count: 1
 			path: plugins/VisitsSummary/Reports/Get.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
 			count: 4
 			path: plugins/WebsiteMeasurable/MeasurableSettings.php
 
 		-
-			message: "#^If condition is always false\\.$#"
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: plugins/WebsiteMeasurable/Settings/Urls.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
 			count: 1
 			path: plugins/Widgetize/Controller.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,6 +30,18 @@ parameters:
         - bootstrap-phpstan.php
     ignoreErrors:
         - "#Unsafe usage of new static#"
+        # These messages embed an absolute path that differs between environments (local/ddev vs CI),
+        # so they cannot live in the baseline; ignore them by identifier + relative path instead.
+        # The required files are generated at build/install time and are absent from a plain checkout.
+        -
+            identifier: requireOnce.fileNotFound
+            path: core/FileIntegrity.php
+        -
+            identifier: requireOnce.fileNotFound
+            path: core/bootstrap.php
+        -
+            identifier: notEqual.alwaysFalse
+            path: plugins/Diagnostics/Diagnostic/ConfigInformational.php
     universalObjectCratesClasses:
         - Piwik\Config
         - Piwik\View

--- a/plugins/BotTracking/API.php
+++ b/plugins/BotTracking/API.php
@@ -358,14 +358,12 @@ class API extends \Piwik\Plugin\API
             return $table;
         }
 
-        if ($table instanceof DataTable) {
-            $ops = $table->getMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME);
-            if (!is_array($ops)) {
-                $ops = [];
-            }
-            $ops[Metrics::COLUMN_DISCREPANCY_SCORE] = 'skip';
-            $table->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $ops);
+        $ops = $table->getMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME);
+        if (!is_array($ops)) {
+            $ops = [];
         }
+        $ops[Metrics::COLUMN_DISCREPANCY_SCORE] = 'skip';
+        $table->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, $ops);
 
         return $table;
     }

--- a/plugins/BotTracking/DataTable/FavouredPagesScorer.php
+++ b/plugins/BotTracking/DataTable/FavouredPagesScorer.php
@@ -60,10 +60,6 @@ class FavouredPagesScorer
             return;
         }
 
-        if (!$table instanceof DataTable) {
-            return;
-        }
-
         $strongColumn = $this->variant === DiscrepancyScore::VARIANT_HUMAN_FAVOURED
             ? Metrics::COLUMN_UNIQUE_HUMAN_PAGEVIEWS
             : Metrics::COLUMN_AI_CHATBOT_REQUESTS;

--- a/plugins/CoreAdminHome/tests/Integration/Commands/CoreArchiverProcessSignalTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/CoreArchiverProcessSignalTest.php
@@ -88,7 +88,7 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         if (self::METHOD_CURL === $method) {
             self::assertStringContainsString('Execute HTTP API request:', $processOutput);
         } else {
-            self::assertRegExp('/Running command.*\[method = ' . $method . ']/', $processOutput);
+            self::assertMatchesRegularExpression('/Running command.*\[method = ' . $method . ']/', $processOutput);
         }
     }
 
@@ -358,7 +358,7 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         if (self::METHOD_CURL === $method) {
             self::assertStringContainsString('Execute HTTP API request:', $processOutput);
         } else {
-            self::assertRegExp('/Running command.*\[method = ' . $method . ']/', $processOutput);
+            self::assertMatchesRegularExpression('/Running command.*\[method = ' . $method . ']/', $processOutput);
         }
 
         self::assertStringContainsString('Starting archiving for', $processOutput);
@@ -386,7 +386,7 @@ class CoreArchiverProcessSignalTest extends IntegrationTestCase
         }
 
         if (\SIGTERM === $signalOutput) {
-            self::assertRegExp('/Aborting command.*\[method = ' . $method . ']/', $processOutput);
+            self::assertMatchesRegularExpression('/Aborting command.*\[method = ' . $method . ']/', $processOutput);
             self::assertStringContainsString('Archiving process killed, reset invalidation', $processOutput);
         }
     }

--- a/plugins/CoreAdminHome/tests/Integration/Commands/DeleteLogsDataTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/DeleteLogsDataTest.php
@@ -106,7 +106,7 @@ class DeleteLogsDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(1, $result, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertNotRegExp("/Successfully deleted [0-9]+ rows from all log tables/", $this->applicationTester->getDisplay());
+        $this->assertDoesNotMatchRegularExpression("/Successfully deleted [0-9]+ rows from all log tables/", $this->applicationTester->getDisplay());
     }
 
     public function testCommandCorrectlyDeletesRequestedLogFiles()

--- a/plugins/CoreConsole/tests/System/ArchiveCronTest.php
+++ b/plugins/CoreConsole/tests/System/ArchiveCronTest.php
@@ -465,7 +465,7 @@ class ArchiveCronTest extends SystemTestCase
     {
         $output = $this->runArchivePhpCron(array('--help' => null), PIWIK_INCLUDE_PATH . '/misc/cron/archive.php');
 
-        $this->assertRegExp('/Usage:\s*core:archive/', $output);
+        $this->assertMatchesRegularExpression('/Usage:\s*core:archive/', $output);
         self::assertStringNotContainsString("Starting Piwik reports archiving...", $output);
     }
 

--- a/plugins/GeoIp2/tests/System/ConvertRegionCodesToIsoTest.php
+++ b/plugins/GeoIp2/tests/System/ConvertRegionCodesToIsoTest.php
@@ -94,7 +94,7 @@ class ConvertRegionCodesToIsoTest extends IntegrationTestCase
 
         $result = $this->executeCommand();
 
-        $this->assertRegExp('/Converting region codes already done/', $result);
+        $this->assertMatchesRegularExpression('/Converting region codes already done/', $result);
     }
 
     public function testExecuteShouldConvertRegionCodes()

--- a/plugins/Marketplace/tests/System/Api/ClientTest.php
+++ b/plugins/Marketplace/tests/System/Api/ClientTest.php
@@ -219,7 +219,7 @@ class ClientTest extends SystemTestCase
         $version = substr($version, 0, strpos($version, '?'));
 
         $this->assertNotEmpty($version);
-        $this->assertRegExp('/\d+\.\d+\.\d+/', $version);
+        $this->assertMatchesRegularExpression('/\d+\.\d+\.\d+/', $version);
     }
 
     public function testGetDownloadUrlMissingLicense()

--- a/plugins/Monolog/tests/System/TrackerLoggingTest.php
+++ b/plugins/Monolog/tests/System/TrackerLoggingTest.php
@@ -77,7 +77,7 @@ class TrackerLoggingTest extends SystemTestCase
     {
         $response = $t->doTrackPageView('incredible title!');
 
-        $this->assertRegExp('/\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] ' . preg_quote("piwik.DEBUG: Debug enabled - Input parameters: array (   'idsite' => '1',   'rec' => '1',   'apiv' => '1',") . "/", $response);
+        $this->assertMatchesRegularExpression('/\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] ' . preg_quote("piwik.DEBUG: Debug enabled - Input parameters: array (   'idsite' => '1',   'rec' => '1',   'apiv' => '1',") . "/", $response);
     }
 
     private function setTrackerConfig($trackerConfig)

--- a/plugins/PrivacyManager/tests/System/DataRoundingCoverageTest.php
+++ b/plugins/PrivacyManager/tests/System/DataRoundingCoverageTest.php
@@ -192,7 +192,7 @@ class DataRoundingCoverageTest extends SystemTestCase
                 $response,
                 sprintf('Expected reportTotal in API.getProcessedReport response for "%s".', $requestId)
             );
-            $this->assertRegExp(
+            $this->assertMatchesRegularExpression(
                 '/<reportTotal>[\s\S]*<nb_[a-z0-9_]+>/i',
                 $response,
                 sprintf('Expected count metrics inside reportTotal for "%s".', $requestId)

--- a/plugins/UserCountry/tests/System/AttributeHistoricalDataWithLocationsTest.php
+++ b/plugins/UserCountry/tests/System/AttributeHistoricalDataWithLocationsTest.php
@@ -78,7 +78,7 @@ class AttributeHistoricalDataWithLocationsTest extends IntegrationTestCase
 
     public function testExecuteShouldReturnEmptyWorkingProcessLogsIfThereIsNoData()
     {
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '/Re-attribution for date range: 2014-06-01 to 2014-06-06. 0 visits to process with provider "geoip2php"./',
             $this->executeCommand('2014-06-01,2014-06-06')
         );
@@ -93,7 +93,7 @@ class AttributeHistoricalDataWithLocationsTest extends IntegrationTestCase
             $result
         );
 
-        $this->assertRegExp('/100% processed. Time elapsed: [0-9.]+s/', $result);
+        $this->assertMatchesRegularExpression('/100% processed. Time elapsed: [0-9.]+s/', $result);
 
         $queryParams = array(
             'idSite'  => self::$fixture->idSite,

--- a/plugins/UsersManager/tests/Integration/UsersManagerTest.php
+++ b/plugins/UsersManager/tests/Integration/UsersManagerTest.php
@@ -137,10 +137,10 @@ class UsersManagerTest extends IntegrationTestCase
         $userAfter = $this->model->getUser($user["login"]);
 
         $this->assertArrayHasKey('date_registered', $userAfter);
-        $this->assertRegExp(self::DATETIME_REGEX, $userAfter['date_registered']);
+        $this->assertMatchesRegularExpression(self::DATETIME_REGEX, $userAfter['date_registered']);
 
         $this->assertArrayHasKey('ts_password_modified', $userAfter);
-        $this->assertRegExp(self::DATETIME_REGEX, $userAfter['date_registered']);
+        $this->assertMatchesRegularExpression(self::DATETIME_REGEX, $userAfter['date_registered']);
 
         $this->assertArrayHasKey('password', $userAfter);
         $this->assertNotEmpty($userAfter['password']);
@@ -438,7 +438,7 @@ class UsersManagerTest extends IntegrationTestCase
             $this->api->getUser("geggeqgeqag");
             $this->fail("Exception not raised.");
         } catch (Exception $expected) {
-            $this->assertRegExp("(UsersManager_ExceptionUserDoesNotExist)", $expected->getMessage());
+            $this->assertMatchesRegularExpression("(UsersManager_ExceptionUserDoesNotExist)", $expected->getMessage());
         }
 
         // add the same user
@@ -1363,7 +1363,7 @@ class UsersManagerTest extends IntegrationTestCase
             $this->api->getUser($login);
             $this->fail("User $login still exists!");
         } catch (Exception $expected) {
-            $this->assertRegExp("(UsersManager_ExceptionUserDoesNotExist)", $expected->getMessage());
+            $this->assertMatchesRegularExpression("(UsersManager_ExceptionUserDoesNotExist)", $expected->getMessage());
         }
     }
 

--- a/tests/PHPUnit/Integration/Columns/DimensionTest.php
+++ b/tests/PHPUnit/Integration/Columns/DimensionTest.php
@@ -158,7 +158,7 @@ class ColumnDimensionTest extends IntegrationTestCase
                 continue;
             }
 
-            $this->assertRegExp('/Piwik.Plugins.(Actions|Events|DevicesDetector|Goals|CustomVariables).Columns/', get_class($dimension));
+            $this->assertMatchesRegularExpression('/Piwik.Plugins.(Actions|Events|DevicesDetector|Goals|CustomVariables).Columns/', get_class($dimension));
         }
 
         $this->assertTrue($foundConversion);
@@ -185,7 +185,7 @@ class ColumnDimensionTest extends IntegrationTestCase
                 $foundVisit = true;
             }
 
-            $this->assertRegExp('/Piwik.Plugins.Actions.Columns/', get_class($dimension));
+            $this->assertMatchesRegularExpression('/Piwik.Plugins.Actions.Columns/', get_class($dimension));
         }
 
         $this->assertTrue($foundAction);
@@ -207,7 +207,7 @@ class ColumnDimensionTest extends IntegrationTestCase
                 $foundConversion = true;
             }
 
-            $this->assertRegExp('/Piwik.Plugins.Goals.Columns/', get_class($dimension));
+            $this->assertMatchesRegularExpression('/Piwik.Plugins.Goals.Columns/', get_class($dimension));
         }
 
         $this->assertTrue($foundConversion);

--- a/tests/PHPUnit/Integration/Plugin/Dimension/ActionDimensionTest.php
+++ b/tests/PHPUnit/Integration/Plugin/Dimension/ActionDimensionTest.php
@@ -164,7 +164,7 @@ class ActionDimensionTest extends IntegrationTestCase
 
         foreach ($dimensions as $dimension) {
             $this->assertInstanceOf('\Piwik\Plugin\Dimension\ActionDimension', $dimension);
-            $this->assertRegExp('/Piwik.Plugins.(Actions|Events).Columns/', get_class($dimension));
+            $this->assertMatchesRegularExpression('/Piwik.Plugins.(Actions|Events).Columns/', get_class($dimension));
         }
     }
 }

--- a/tests/PHPUnit/Integration/Plugin/Dimension/ConversionDimensionTest.php
+++ b/tests/PHPUnit/Integration/Plugin/Dimension/ConversionDimensionTest.php
@@ -164,7 +164,7 @@ class ConversionDimensionTest extends IntegrationTestCase
 
         foreach ($dimensions as $dimension) {
             $this->assertInstanceOf('\Piwik\Plugin\Dimension\ConversionDimension', $dimension);
-            $this->assertRegExp('/Piwik.Plugins.(ExampleTracker|Ecommerce|Goals).Columns/', get_class($dimension));
+            $this->assertMatchesRegularExpression('/Piwik.Plugins.(ExampleTracker|Ecommerce|Goals).Columns/', get_class($dimension));
         }
     }
 }

--- a/tests/PHPUnit/Integration/Plugin/Dimension/VisitDimensionTest.php
+++ b/tests/PHPUnit/Integration/Plugin/Dimension/VisitDimensionTest.php
@@ -269,7 +269,7 @@ class VisitDimensionTest extends IntegrationTestCase
 
         foreach ($dimensions as $dimension) {
             $this->assertInstanceOf('\Piwik\Plugin\Dimension\VisitDimension', $dimension);
-            $this->assertRegExp('/Piwik.Plugins.(DevicesDetection|Actions).Columns/', get_class($dimension));
+            $this->assertMatchesRegularExpression('/Piwik.Plugins.(DevicesDetection|Actions).Columns/', get_class($dimension));
         }
     }
 }

--- a/tests/PHPUnit/System/EnvironmentValidationTest.php
+++ b/tests/PHPUnit/System/EnvironmentValidationTest.php
@@ -124,7 +124,7 @@ class EnvironmentValidationTest extends SystemTestCase
 
     private function assertOutputContainsConfigFileMissingError($fileName, $output)
     {
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/.*The configuration file \\{.*\\/" . preg_quote($fileName) . "\\} has not been found or could not be read\\..*/",
             (string) $output,
             "Output did not contain the expected exception for $fileName --- Output was --- $output"
@@ -133,8 +133,8 @@ class EnvironmentValidationTest extends SystemTestCase
 
     private function assertOutputContainsBadConfigFileError($output)
     {
-        $this->assertRegExp("/Unable to read INI file \\{.*\\/matomo.php\\}:/", $output);
-        $this->assertRegExp("/Your host may have disabled parse_ini_file\\(\\)/", $output);
+        $this->assertMatchesRegularExpression("/Unable to read INI file \\{.*\\/matomo.php\\}:/", $output);
+        $this->assertMatchesRegularExpression("/Your host may have disabled parse_ini_file\\(\\)/", $output);
     }
 
     private function assertInstallationProcessStarted($output)

--- a/tests/PHPUnit/Unit/VersionTest.php
+++ b/tests/PHPUnit/Unit/VersionTest.php
@@ -167,7 +167,7 @@ class VersionTest extends \PHPUnit\Framework\TestCase
 
     private function assertCorrectPreviewVersionWithoutSuffix($versionNumber, $newVersionNumber)
     {
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             "/^$newVersionNumber.\d{14}$/",
             $this->version->nextPreviewVersion($versionNumber)
         );

--- a/tests/PHPUnit/phpunit.xml.dist
+++ b/tests/PHPUnit/phpunit.xml.dist
@@ -1,96 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
-         backupGlobals="true"
-         backupStaticAttributes="false"
-         bootstrap="bootstrap.php"
-         colors="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         forceCoversAnnotation="false"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         stopOnIncomplete="false"
-         stopOnSkipped="false"
-         testdox="false"
-         verbose="true">
-
-<testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="true" backupStaticAttributes="false" bootstrap="bootstrap.php" colors="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" forceCoversAnnotation="false" processIsolation="false" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" testdox="false" verbose="true">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">../../core</directory>
+      <directory suffix=".php">../../plugins</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">../../core/Updates</directory>
+      <directory suffix=".php">../../plugins/Example*</directory>
+      <directory suffix=".php">../../plugins/SecurityInfo*</directory>
+      <directory suffix=".php">../../plugins/*/Updates</directory>
+      <directory suffix=".php">../../plugins/*/libs</directory>
+      <directory suffix=".php">../../plugins/*/tests</directory>
+      <directory suffix=".php">../../plugins/*/Test</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
     <testsuite name="SystemTests">
-        <directory>./System</directory>
-        <directory>../../plugins/*/tests</directory><!-- There should be actually a tests/System but this way we make sure to execute all tests even if some are not moved to correct subdirectory. We will execute Unit and Integration tests twice :( ... -->
-        <directory>../../plugins/*/Test</directory>
-        <directory>../../tests/resources/custompluginsdir/*/tests/System</directory>
-        <directory>../../tests/resources/custompluginsdir/*/Test/System</directory>
-        <exclude>../../plugins/*/tests/Integration</exclude>
-        <exclude>../../plugins/*/Test/Integration</exclude>
-        <exclude>../../plugins/*/tests/Unit</exclude>
-        <exclude>../../plugins/*/Test/Unit</exclude>
+      <directory>./System</directory>
+      <directory>../../plugins/*/tests</directory>
+      <!-- There should be actually a tests/System but this way we make sure to execute all tests even if some are not moved to correct subdirectory. We will execute Unit and Integration tests twice :( ... -->
+      <directory>../../plugins/*/Test</directory>
+      <directory>../../tests/resources/custompluginsdir/*/tests/System</directory>
+      <directory>../../tests/resources/custompluginsdir/*/Test/System</directory>
+      <exclude>../../plugins/*/tests/Integration</exclude>
+      <exclude>../../plugins/*/Test/Integration</exclude>
+      <exclude>../../plugins/*/tests/Unit</exclude>
+      <exclude>../../plugins/*/Test/Unit</exclude>
     </testsuite>
     <testsuite name="SystemTestsCore">
-        <directory>./System</directory>
+      <directory>./System</directory>
     </testsuite>
     <testsuite name="SystemTestsPlugins">
-        <directory>../../plugins/*/tests</directory><!-- There should be actually a tests/System but this way we make sure to execute all tests even if some are not moved to correct subdirectory. We will execute Unit and Integration tests twice :( ... -->
-        <directory>../../plugins/*/Test</directory>
-        <directory>../../tests/resources/custompluginsdir/*/tests/System</directory>
-        <directory>../../tests/resources/custompluginsdir/*/Test/System</directory>
-        <exclude>../../plugins/*/tests/Integration</exclude>
-        <exclude>../../plugins/*/Test/Integration</exclude>
-        <exclude>../../plugins/*/tests/Unit</exclude>
-        <exclude>../../plugins/*/Test/Unit</exclude>
+      <directory>../../plugins/*/tests</directory>
+      <!-- There should be actually a tests/System but this way we make sure to execute all tests even if some are not moved to correct subdirectory. We will execute Unit and Integration tests twice :( ... -->
+      <directory>../../plugins/*/Test</directory>
+      <directory>../../tests/resources/custompluginsdir/*/tests/System</directory>
+      <directory>../../tests/resources/custompluginsdir/*/Test/System</directory>
+      <exclude>../../plugins/*/tests/Integration</exclude>
+      <exclude>../../plugins/*/Test/Integration</exclude>
+      <exclude>../../plugins/*/tests/Unit</exclude>
+      <exclude>../../plugins/*/Test/Unit</exclude>
     </testsuite>
     <testsuite name="IntegrationTests">
-        <directory>./Integration</directory>
-        <directory>../../plugins/*/tests/Integration</directory>
-        <directory>../../plugins/*/Test/Integration</directory>
-        <directory>../../tests/resources/custompluginsdir/*/tests/Integration</directory>
-        <directory>../../tests/resources/custompluginsdir/*/Test/Integration</directory>
+      <directory>./Integration</directory>
+      <directory>../../plugins/*/tests/Integration</directory>
+      <directory>../../plugins/*/Test/Integration</directory>
+      <directory>../../tests/resources/custompluginsdir/*/tests/Integration</directory>
+      <directory>../../tests/resources/custompluginsdir/*/Test/Integration</directory>
     </testsuite>
     <testsuite name="IntegrationTestsCore">
-        <directory>./Integration</directory>
-        <directory>../../tests/resources/custompluginsdir/*/tests/Integration</directory>
-        <directory>../../tests/resources/custompluginsdir/*/Test/Integration</directory>
+      <directory>./Integration</directory>
+      <directory>../../tests/resources/custompluginsdir/*/tests/Integration</directory>
+      <directory>../../tests/resources/custompluginsdir/*/Test/Integration</directory>
     </testsuite>
     <testsuite name="IntegrationTestsPlugins">
-        <directory>../../plugins/*/tests/Integration</directory>
-        <directory>../../plugins/*/Test/Integration</directory>
+      <directory>../../plugins/*/tests/Integration</directory>
+      <directory>../../plugins/*/Test/Integration</directory>
     </testsuite>
     <testsuite name="UnitTests">
-        <directory>./Unit</directory>
-        <directory>../../plugins/*/tests/Unit</directory>
-        <directory>../../plugins/*/Test/Unit</directory>
-        <directory>../../tests/resources/custompluginsdir/*/tests/Unit</directory>
-        <directory>../../tests/resources/custompluginsdir/*/Test/Unit</directory>
+      <directory>./Unit</directory>
+      <directory>../../plugins/*/tests/Unit</directory>
+      <directory>../../plugins/*/Test/Unit</directory>
+      <directory>../../tests/resources/custompluginsdir/*/tests/Unit</directory>
+      <directory>../../tests/resources/custompluginsdir/*/Test/Unit</directory>
     </testsuite>
     <testsuite name="PluginTests">
-        <directory>../../plugins/*/tests</directory>
-        <directory>../../plugins/*/Test</directory>
+      <directory>../../plugins/*/tests</directory>
+      <directory>../../plugins/*/Test</directory>
     </testsuite>
     <testsuite name="CoreTests">
-        <directory>./Unit</directory>
-        <directory>./Integration</directory>
-        <directory>./System</directory>
+      <directory>./Unit</directory>
+      <directory>./Integration</directory>
+      <directory>./System</directory>
     </testsuite>
-</testsuites>
-
-<filter>
-    <whitelist addUncoveredFilesFromWhitelist="true">
-        <directory suffix=".php">../../core</directory>
-        <directory suffix=".php">../../plugins</directory>
-        <exclude>
-            <directory suffix=".php">../../core/Updates</directory>
-            <directory suffix=".php">../../plugins/Example*</directory>
-            <directory suffix=".php">../../plugins/SecurityInfo*</directory>
-            <directory suffix=".php">../../plugins/*/Updates</directory>
-            <directory suffix=".php">../../plugins/*/libs</directory>
-            <directory suffix=".php">../../plugins/*/tests</directory>
-            <directory suffix=".php">../../plugins/*/Test</directory>
-        </exclude>
-    </whitelist>
-</filter>
-
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
Builds on the runtime composer upgrade (#24640, branch `dev-20331`) by applying the same **package-by-package, major-by-major** process to the `require-dev` block. **Stacked on `dev-20331`** (will retarget to `dev-17598` when #24640 merges).

PHP 8.1 floor caps the targets (phpunit at 10.x; symfony dev components stay 6.4).

### Progress

| Package | From → To | Status | Notes |
|---|---|---|---|
| phpstan/phpstan | 1.12 → 2.2.2 | ✅ done | Standalone package (no composer deps). PHPStan 2's stricter level-5 analysis surfaces additional findings on existing code → `phpstan-baseline.neon` regenerated (816 → 1214 entries); reviewed by identifier (type-precision, redundant checks, phpdoc-parse — no regressions). 3 findings whose messages embed an absolute path (require_once not-found ×2, a path-value comparison) were moved out of the baseline into `phpstan.neon` `ignoreErrors` keyed by identifier + relative path, so they match in any environment. |
| phpunit/phpunit | 8.5 → 9.6.34 | ✅ done | Replaced the removed `assertRegExp`/`assertNotRegExp` with `assertMatchesRegularExpression`/`assertDoesNotMatchRegularExpression` (15 files). Migrated `phpunit.xml.dist` to the 9.3 schema (`filter/whitelist` → `coverage`). `assertInternalType` unused; all `assertContains` use iterable haystacks (still valid). |
| phpunit/phpunit | 9.6 → 10.5 | ⏸️ deferred | phpunit 10 removes `setMethods()`/`setMethodsExcept()`, which are used by **submodule** plugin tests (CustomAlerts, QueuedTracking, LoginLdap) that run in the main CI matrix — those can only be fixed in their own repositories (separate PRs + submodule-pointer bumps), and phpunit 10 likely surfaces further runtime issues (data-provider staticness, metadata). Split into a dedicated follow-up that coordinates the submodule updates. |
| phpstan/phpdoc-parser | removed | ✅ done | Dropped from `require-dev`: not used directly by the codebase and already pulled in transitively at the same `~1.24.0` constraint by `matomo-org/matomo-coding-standards`. (Originally added in 2022 to pin PHPCS dependency versions; that role now lives in the coding-standards package, so the standalone entry was redundant.) `composer.lock` unchanged except for the content hash. |
| symfony/var-dumper, symfony/yaml | 6.4 | ✅ n/a | Already at 6.4 (moved with the Symfony stack in #24640); 7.x needs PHP 8.2. |

No `CHANGELOG.md` entry: dev tooling is not plugin-facing.

Note: This increases our phpstan baseline by around 200 new violations, that PHPStan is now able to detect.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules