### PR TITLE
Fix flaky evolution graph annotation markers

### DIFF
--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -482,7 +482,12 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
 
         it('should load the example ui > evolution graph page correctly', async function () {
             await page.goto("?" + urlBase + "#?" + generalParams + "&category=ExampleUI_UiFramework&subcategory=Evolution%20Graph");
-            await page.waitForSelector('.icon-annotation');
+            await page.waitForNetworkIdle();
+            // the annotation markers are positioned after the graph has rendered, so wait until the
+            // ones that have annotations are actually placed/visible before taking the screenshot
+            await page.waitForFunction(
+              "$('.evolution-annotations > span[data-count!=0]').length > 0 && $('.evolution-annotations > span[data-count!=0]').css('opacity') == 1"
+            );
 
             expect(await screenshotPageWrap()).to.matchImage('exampleui_evolutionGraph');
         });


### PR DESCRIPTION
### Description

The `UIIntegrationTest` screenshot test "should load the example ui > evolution graph page correctly" was flaky: the annotation markers rendered under the evolution graph's x-axis were sometimes missing from the captured screenshot.

| Processed | Expected |
|---|---|
| <img width="1108" height="351" alt="Image" src="https://github.com/user-attachments/assets/b18db7a0-794f-4a83-a507-c36ec1645277" /> |  <img width="1108" height="372" alt="Image" src="https://github.com/user-attachments/assets/b4c6f60a-ed3f-4e4e-a305-f957d91db5f1" /> |

### Fix

Wait for the markers that actually have annotations to be placed and visible
before taking the screenshot:

- `await page.waitForNetworkIdle()` — let the annotations request finish.
- `await page.waitForFunction(...)` — wait until at least one
  `.evolution-annotations > span[data-count!=0]` exists and has `opacity == 1`
  (i.e. it has been positioned against the rendered graph).

This is a test-only change; there are no product code changes.

### Validation

5 times in a row:
- https://github.com/matomo-org/matomo/actions/runs/27818469755/attempts/1
- https://github.com/matomo-org/matomo/actions/runs/27818469755/attempts/2
- https://github.com/matomo-org/matomo/actions/runs/27818469755/attempts/3
- https://github.com/matomo-org/matomo/actions/runs/27818469755/attempts/4
- https://github.com/matomo-org/matomo/actions/runs/27818469755/attempts/5

### Issue

ref #24454
dev-20195

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
