### PR TITLE
Align TSV report renderer name handling with CSV renderer

### DIFF
--- a/core/ReportRenderer/Tsv.php
+++ b/core/ReportRenderer/Tsv.php
@@ -120,8 +120,7 @@ class Tsv extends ReportRenderer
             $reportData = Piwik::translate('CoreHome_ThereIsNoDataForThisReport');
         }
 
-        $replaceBySpace = array( $tsvRenderer->separator);
-        $reportName = str_replace($replaceBySpace, " ", $processedReport['metadata']['name']);
+        $reportName = $tsvRenderer->formatValue($processedReport['metadata']['name']);
         $this->rendered .= implode(
             '',
             array(

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_schedrep_in_tsv__ScheduledReports.generateReport_week.original.tsv
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_schedrep_in_tsv__ScheduledReports.generateReport_week.original.tsv
@@ -511,11 +511,11 @@ label	nb_conversions
 121-364 days	0
 365+ days	0
 
-Goal title match, triggered ONCE
+"Goal title match, triggered ONCE"
 nb_conversions	nb_visits_converted	revenue	conversion_rate
 1	1	$10	20%
 
-title match, triggered ONCE - Visits to Conversion
+"title match, triggered ONCE - Visits to Conversion"
 label	nb_conversions
 1 visit	1
 2 visits	0
@@ -531,7 +531,7 @@ label	nb_conversions
 51-100 visits	0
 101+ visits	0
 
-title match, triggered ONCE - Days to Conversion
+"title match, triggered ONCE - Days to Conversion"
 label	nb_conversions
 0 days	1
 1 day	0

--- a/tests/PHPUnit/Unit/ReportRenderer/TsvTest.php
+++ b/tests/PHPUnit/Unit/ReportRenderer/TsvTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\ReportRenderer;
+
+use Piwik\DataTable;
+use Piwik\ReportRenderer\Tsv;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group Core
+ */
+class TsvTest extends TestCase
+{
+    private function buildProcessedReport(string $name): array
+    {
+        $table = new DataTable();
+        $table->addRowsFromSimpleArray([
+            ['label' => 'row', 'nb_conversions' => 1],
+        ]);
+
+        return [
+            'reportData' => $table,
+            'metadata'   => [
+                'uniqueId' => 'Goals_get',
+                'name'     => $name,
+            ],
+        ];
+    }
+
+    /**
+     * The report-name line must be neutralized the same way the CSV renderer
+     * neutralizes it, so a name carrying control characters or a leading
+     * formula character cannot split the output into a new, executable record.
+     */
+    public function testRenderReportNeutralizesReportNameLineBreaksAndFormulas()
+    {
+        $renderer = new Tsv();
+        $renderer->renderReport($this->buildProcessedReport("Goal A\r\n=FORMULA_MARKER"));
+
+        $rendered = $renderer->getRenderedReport();
+        $firstLine = strtok($rendered, "\n");
+
+        // The whole report name is wrapped in quotes, so the embedded line
+        // break and the leading formula character stay inside a single field
+        // instead of forming a new, executable record. (A vulnerable renderer
+        // would emit a bare "Goal A" line followed by an unquoted "=..." record.)
+        self::assertSame('"Goal A ', $firstLine);
+        self::assertStringContainsString('"Goal A ' . "\n" . '=FORMULA_MARKER"', $rendered);
+
+        // The raw CR is replaced rather than carried through to the output.
+        self::assertStringNotContainsString("\r", $rendered);
+    }
+
+    public function testRenderReportLeavesPlainReportNameUnquoted()
+    {
+        $renderer = new Tsv();
+        $renderer->renderReport($this->buildProcessedReport('Visits Summary'));
+
+        $rendered = $renderer->getRenderedReport();
+
+        self::assertSame('Visits Summary', strtok($rendered, "\n"));
+    }
+}


### PR DESCRIPTION
### Description

The TSV report renderer formatted the per-report name line differently from the CSV renderer, only collapsing the column separator. Route the report name through the renderer's formatValue() so both formats apply the same consistent value formatting and quoting.

Add a unit test covering the report-name line formatting.
### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
