### PR TITLE
Fixing issue where annotations cannot be added/saved when calendar is set to 'range'

### DIFF
--- a/plugins/Annotations/javascripts/annotations.js
+++ b/plugins/Annotations/javascripts/annotations.js
@@ -46,6 +46,8 @@
 
             var ajaxRequest = new ajaxHelper();
             ajaxRequest.addParams(ajaxParams, 'get');
+            // Do not need to include the period parameter as this is not used in the endpoint
+            ajaxRequest.removeDefaultParameter('period');
             ajaxRequest.withTokenInUrl();
             ajaxRequest.setCallback(callback);
             ajaxRequest.setFormat('html');
@@ -69,6 +71,8 @@
 
             var ajaxRequest = new ajaxHelper();
             ajaxRequest.addParams(ajaxParams, 'get');
+            // Do not need to include the period parameter as this is not used in the endpoint
+            ajaxRequest.removeDefaultParameter('period');
             ajaxRequest.withTokenInUrl();
             ajaxRequest.setCallback(callback);
             ajaxRequest.setFormat('html');

--- a/plugins/Annotations/tests/UI/Annotations_spec.js
+++ b/plugins/Annotations/tests/UI/Annotations_spec.js
@@ -34,4 +34,49 @@ describe("Annotations", function () {
 
         expect(await page.screenshotSelector(".isFirstWidgetInPage .annotation-manager")).to.matchImage("added_annotation");
     });
+
+    // Adding an annotation with a range selected used to fail because
+    // the inherited period=range made AjaxHelper reject the single annotation date.
+    it("should add annotation when a date range is selected", async function() {
+        const rangeParams = "idSite=1&period=range&date=2012-03-01,2012-04-01";
+        await page.goto("?module=CoreHome&action=index&" + rangeParams + category);
+        await page.waitForNetworkIdle();
+
+        await page.click(".evolution-annotations span[title^=\"View and add annotations\"]");
+        await page.waitForTimeout(200);
+
+        await page.click(".add-annotation");
+        await page.waitForTimeout(100);
+
+        await page.type(".new-annotation-edit", "range period annotation");
+        await page.click(".new-annotation-save");
+        await page.waitForNetworkIdle();
+
+        // the manager only shows the note if the save succeeded
+        const managerText = await page.evaluate(function () {
+            return document.querySelector(".isFirstWidgetInPage .annotation-manager").innerText;
+        });
+        expect(managerText).to.contain("range period annotation");
+    });
+
+    // Same fix for the edit path: saving an edited annotation also sends a single date.
+    it("should save an edited annotation when a date range is selected", async function() {
+        // still on the range page from the previous test; edit the first annotation
+        const annotation = ".isFirstWidgetInPage .annotation-manager .annotation";
+
+        await page.click(annotation + " .annotation-value .annotation-enter-edit-mode");
+        await page.waitForTimeout(100);
+
+        // change the note text so the save isn't skipped as a no-op
+        await page.click(annotation + " .annotation-edit", { clickCount: 3 });
+        await page.type(annotation + " .annotation-edit", "edited range annotation");
+        await page.click(annotation + " .annotation-edit-mode .annotation-save");
+        await page.waitForNetworkIdle();
+
+        // the manager only shows the new text if the save succeeded
+        const managerText = await page.evaluate(function () {
+            return document.querySelector(".isFirstWidgetInPage .annotation-manager").innerText;
+        });
+        expect(managerText).to.contain("edited range annotation");
+    });
 });

--- a/plugins/Annotations/tests/UI/Annotations_spec.js
+++ b/plugins/Annotations/tests/UI/Annotations_spec.js
@@ -43,10 +43,10 @@ describe("Annotations", function () {
         await page.waitForNetworkIdle();
 
         await page.click(".evolution-annotations span[title^=\"View and add annotations\"]");
-        await page.waitForTimeout(200);
+        await page.waitForSelector(".add-annotation", { visible: true });
 
         await page.click(".add-annotation");
-        await page.waitForTimeout(100);
+        await page.waitForSelector(".new-annotation-edit", { visible: true });
 
         await page.type(".new-annotation-edit", "range period annotation");
         await page.click(".new-annotation-save");
@@ -65,7 +65,7 @@ describe("Annotations", function () {
         const annotation = ".isFirstWidgetInPage .annotation-manager .annotation";
 
         await page.click(annotation + " .annotation-value .annotation-enter-edit-mode");
-        await page.waitForTimeout(100);
+        await page.waitForSelector(annotation + " .annotation-edit", { visible: true });
 
         // change the note text so the save isn't skipped as a no-op
         await page.click(annotation + " .annotation-edit", { clickCount: 3 });


### PR DESCRIPTION
### Description

Fixes: https://github.com/matomo-org/matomo/issues/24654

DEV-20383

This fixes the issue where when creating new or updating annotations, the code includes the `period` parameter for the dates, which the API does not even use. This was causing an issue with our new date validator. 

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
