### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -706,12 +706,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/referrer-spam-list.git",
-                "reference": "ce5222bb6f1604ec8fa92003656e05fbd087d36b"
+                "reference": "f63abf1648c13d8f6094cbb017061b2a4e11cff8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/ce5222bb6f1604ec8fa92003656e05fbd087d36b",
-                "reference": "ce5222bb6f1604ec8fa92003656e05fbd087d36b",
+                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/f63abf1648c13d8f6094cbb017061b2a4e11cff8",
+                "reference": "f63abf1648c13d8f6094cbb017061b2a4e11cff8",
                 "shasum": ""
             },
             "replace": {
@@ -729,7 +729,7 @@
                 "issues": "https://github.com/matomo-org/referrer-spam-list/issues",
                 "source": "https://github.com/matomo-org/referrer-spam-list/tree/master"
             },
-            "time": "2026-05-31T20:47:25+00:00"
+            "time": "2026-06-15T23:44:33+00:00"
         },
         {
             "name": "matomo/searchengine-and-social-list",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
                                                      Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading matomo/referrer-spam-list (dev-master ce5222b => dev-master f63abf1)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downloading matomo/referrer-spam-list (dev-master f63abf1)
  - Upgrading matomo/referrer-spam-list (dev-master ce5222b => dev-master f63abf1): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
54 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Found 14 ignored security vulnerability advisories affecting 1 package.
Run "composer audit" for a full list of advisories.
```
