### PR TITLE
Add CSS @container query support to the Less compiler

### DIFF
--- a/.github/scripts/clean-build.sh
+++ b/.github/scripts/clean-build.sh
@@ -207,3 +207,9 @@ done
 
 # Delete DDEV environment files
 rm -rf .ddev
+
+# Delete composer patches: they are build-time inputs (applied to vendor/ during
+# `composer install`) and must not ship in the release. A leftover top-level
+# directory would also break the one-click updater, which checks every shipped
+# root directory is writable on the target install (see CoreUpdater\Updater::checkFolderPermissions).
+rm -rf patches

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "prepend-autoloader": false,
         "sort-packages": true,
         "allow-plugins": {
+            "cweagans/composer-patches": true,
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
@@ -62,6 +63,7 @@
         "php": ">=7.2.5",
         "composer/ca-bundle": "^1.2",
         "composer/semver": "^3.0",
+        "cweagans/composer-patches": "^1.7",
         "davaxi/sparkline": "~2.0",
         "geoip2/geoip2": "^2.8",
         "lox/xhprof": "dev-master",
@@ -121,5 +123,12 @@
     },
     "scripts": {
         "phpstan": "phpstan analyse -c phpstan.neon"
+    },
+    "extra": {
+        "patches": {
+            "wikimedia/less.php": {
+                "Support CSS @container queries": "patches/less-container-query.patch"
+            }
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af8e842d49ff6d4bd3a16a4c5114ab90",
+    "content-hash": "1ebc6a8c0b75825b274a0f446c29e68a",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -154,6 +154,54 @@
                 }
             ],
             "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+            },
+            "time": "2022-12-20T22:53:13+00:00"
         },
         {
             "name": "davaxi/sparkline",
@@ -5698,5 +5746,5 @@
     "platform-overrides": {
         "php": "7.2.9"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/patches/less-container-query.patch
+++ b/patches/less-container-query.patch
@@ -1,0 +1,100 @@
+diff --git a/lib/Less/Parser.php b/lib/Less/Parser.php
+index b05bf14..2e821c8 100644
+--- a/lib/Less/Parser.php
++++ b/lib/Less/Parser.php
+@@ -2207,6 +2207,23 @@ $g = intval( $g );
+ 		}
+ 	}
+ 
++	private function parseContainer() {
++		if ( $this->MatchReg( '/\\G@container/' ) ) {
++			$this->save();
++
++			$features = $this->parseMediaFeatures();
++			$rules = $this->parseBlock();
++
++			if ( $rules === null ) {
++				$this->restore();
++				return;
++			}
++
++			$this->forget();
++			return $this->NewObj( 'Less_Tree_Container', [ $rules, $features, $this->pos, $this->env->currentFileInfo ] );
++		}
++	}
++
+ 	//
+ 	// A CSS Directive
+ 	//
+@@ -2226,7 +2243,8 @@ $g = intval( $g );
+ 
+ 		$value = $this->MatchFuncs( [
+ 			'parseImport',
+-			'parseMedia'
++			'parseMedia',
++			'parseContainer'
+ 		] );
+ 		if ( $value ) {
+ 			return $value;
+diff --git a/lib/Less/Tree/Container.php b/lib/Less/Tree/Container.php
+new file mode 100644
+index 0000000..3745125
+--- /dev/null
++++ b/lib/Less/Tree/Container.php
+@@ -0,0 +1,56 @@
++<?php
++/**
++ * CSS `@container` query.
++ *
++ * Behaves like `@media`, but emits the `@container` at-rule and reuses the
++ * media-query compilation machinery (feature compilation, nesting, strict-math
++ * bypass).
++ *
++ * @private
++ */
++class Less_Tree_Container extends Less_Tree_Media {
++
++	public $type = 'Container';
++
++	/**
++	 * @see Less_Tree::genCSS
++	 */
++	public function genCSS( $output ) {
++		$output->add( '@container ', $this->currentFileInfo, $this->index );
++		$this->features->genCSS( $output );
++		Less_Tree::outputRuleset( $output, $this->rules );
++	}
++
++	/**
++	 * @param Less_Environment $env
++	 * @return Less_Tree_Container|Less_Tree_Ruleset
++	 * @see less-2.5.3.js#Media.prototype.eval
++	 */
++	public function compile( $env ) {
++		$container = new Less_Tree_Container( [], [], $this->index, $this->currentFileInfo );
++
++		$strictMathBypass = false;
++		if ( Less_Parser::$options['strictMath'] === false ) {
++			$strictMathBypass = true;
++			Less_Parser::$options['strictMath'] = true;
++		}
++
++		$container->features = $this->features->compile( $env );
++
++		if ( $strictMathBypass ) {
++			Less_Parser::$options['strictMath'] = false;
++		}
++
++		$env->mediaPath[] = $container;
++		$env->mediaBlocks[] = $container;
++
++		array_unshift( $env->frames, $this->rules[0] );
++		$container->rules = [ $this->rules[0]->compile( $env ) ];
++		array_shift( $env->frames );
++
++		array_pop( $env->mediaPath );
++
++		return !$env->mediaPath ? $container->compileTop( $env ) : $container->compileNested( $env );
++	}
++
++}

--- a/tests/PHPUnit/Unit/AssetManager/LessContainerQueryTest.php
+++ b/tests/PHPUnit/Unit/AssetManager/LessContainerQueryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\AssetManager;
+
+use lessc;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ensures the Less compiler used by Matomo supports CSS container queries
+ * (the `@container` at-rule), which are enabled through a patch applied to
+ * wikimedia/less.php (see patches/less-container-query.patch).
+ */
+class LessContainerQueryTest extends TestCase
+{
+    /**
+     * @group Core
+     */
+    public function testContainerQueryIsCompiled()
+    {
+        $less = <<<'LESS'
+@minWidth: 400px;
+.wrapper {
+  container-type: inline-size;
+}
+@container (min-width: @minWidth) {
+  .card {
+    color: red;
+    .inner { font-weight: bold; }
+  }
+}
+@container sidebar (min-width: 700px) {
+  .card { color: blue; }
+}
+LESS;
+
+        $compiler = new lessc();
+        $compiler->setFormatter('classic');
+        $compiled = $compiler->compile($less);
+
+        // The @container at-rule is preserved (not rewritten to @media).
+        self::assertStringContainsString('@container (min-width: 400px)', $compiled);
+        self::assertStringContainsString('@container sidebar (min-width: 700px)', $compiled);
+
+        // Less features still work inside the query: the variable is resolved
+        // and nested selectors are flattened.
+        self::assertStringContainsString('.card .inner', $compiled);
+
+        // Regular declarations outside the query are unaffected.
+        self::assertStringContainsString('container-type: inline-size', $compiled);
+    }
+}


### PR DESCRIPTION
### Description

Matomo's LESS files are compiled with [`wikimedia/less.php`](https://github.com/wikimedia/less.php), which does not understand the CSS [`@container`](https://developer.mozilla.org/en-US/docs/Web/CSS/@container) at-rule (container queries). 

This PR teaches the compiler to recognise `@container`, so plugins and themes can use container queries in their stylesheets.

## How

Since `vendor/` is not committed (only `composer.lock` is), the dependency is patched at install time via [`cweagans/composer-patches`](https://github.com/cweagans/composer-patches):

- `composer.json` — add `cweagans/composer-patches`, allow the plugin, and register `patches/less-container-query.patch` for `wikimedia/less.php`.
- `patches/less-container-query.patch` — adds a `parseContainer()` method to `Less_Parser` and a new `Less_Tree_Container` tree node. It mirrors the existing `@media` handling and reuses the same compilation machinery (feature compilation, nesting, strict-math bypass), only emitting `@container` instead of `@media`.

## Example

Input:

```less
@minWidth: 400px;
.wrapper { container-type: inline-size; }
@container (min-width: @minWidth) {
  .card {
    color: red;
    .inner { font-weight: bold; }
  }
}
```

Output:

```css
.wrapper { container-type: inline-size; }
@container (min-width: 400px) {
  .card { color: red; }
  .card .inner { font-weight: bold; }
}
```

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
