### PR TITLE
Fix goal regex patterns corrupted by erroneous urldecode (+ turned into space)

### DIFF
--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -221,10 +221,8 @@ class API extends \Piwik\Plugin\API
         $patternType = Common::unsanitizeInputValue($patternType);
 
         $this->checkPatternIsValid($patternType, $pattern, $matchAttribute);
-        $name = $this->checkName($name);
         $pattern = $this->checkPattern($pattern, $matchAttribute);
         $patternType = $this->checkPatternType($patternType, $matchAttribute);
-        $description = $this->checkDescription($description);
 
         $revenue = Common::forceDotAsSeparatorForDecimalPoint((float)$revenue);
 
@@ -293,8 +291,6 @@ class API extends \Piwik\Plugin\API
 
         $patternType = Common::unsanitizeInputValue($patternType);
 
-        $name = $this->checkName($name);
-        $description = $this->checkDescription($description);
         $patternType = $this->checkPatternType($patternType, $matchAttribute);
         $pattern = $this->checkPattern($pattern, $matchAttribute);
         $this->checkPatternIsValid($patternType, $pattern, $matchAttribute);
@@ -365,16 +361,6 @@ class API extends \Piwik\Plugin\API
         }
     }
 
-    private function checkName(string $name): string
-    {
-        return urldecode($name);
-    }
-
-    private function checkDescription(string $description): string
-    {
-        return urldecode($description);
-    }
-
     /**
      * @param string|null $patternType
      * @param string $matchAttribute
@@ -413,7 +399,7 @@ class API extends \Piwik\Plugin\API
             throw new \Exception("Invalid pattern for match attribute '$matchAttribute'. (got '$pattern', expected numeric value).");
         }
 
-        return urldecode($pattern);
+        return $pattern;
     }
 
     /**

--- a/plugins/Goals/tests/Integration/APITest.php
+++ b/plugins/Goals/tests/Integration/APITest.php
@@ -104,6 +104,32 @@ class APITest extends IntegrationTestCase
         $this->assertGoal($idGoal, 'MyName', '', 'title', 'rere(.*)', 'regex', 1, 50, 1);
     }
 
+    public function testAddGoalShouldPreservePlusCharacterInRegexPattern()
+    {
+        // see DEV-18306: a "+" must not be turned into a space when saving a goal
+        $idGoal = $this->api->addGoal($this->idSite, 'MyName', 'url', '\/one_\d+\.php$', 'regex');
+
+        $this->assertGoal($idGoal, 'MyName', '', 'url', '\/one_\d+\.php$', 'regex');
+    }
+
+    public function testAddGoalShouldPreservePlusCharacterInNameAndDescription()
+    {
+        // see DEV-18306: a "+" must not be turned into a space when saving a goal
+        $idGoal = $this->api->addGoal($this->idSite, 'My + Name', 'title', 'a+b', 'contains', false, false, false, 'desc + text');
+
+        $this->assertGoal($idGoal, 'My + Name', 'desc + text', 'title', 'a+b', 'contains');
+    }
+
+    public function testUpdateGoalShouldPreservePlusCharacterInRegexPattern()
+    {
+        // see DEV-18306: a "+" must not be turned into a space when updating a goal
+        $idGoal = $this->api->addGoal($this->idSite, 'MyName', 'title', 'rere(.*)', 'regex');
+
+        $this->api->updateGoal($this->idSite, $idGoal, 'My + Name', 'title', '(?!Postuler$).+', 'regex', false, false, false, 'desc + text');
+
+        $this->assertGoal($idGoal, 'My + Name', 'desc + text', 'title', '(?!Postuler$).+', 'regex');
+    }
+
     public function testAddGoalShouldThrowExceptionIfPatternTypeIsInvalid()
     {
         $this->expectException(\Exception::class);

--- a/plugins/Goals/tests/Integration/APITest.php
+++ b/plugins/Goals/tests/Integration/APITest.php
@@ -106,7 +106,7 @@ class APITest extends IntegrationTestCase
 
     public function testAddGoalShouldPreservePlusCharacterInRegexPattern()
     {
-        // see DEV-18306: a "+" must not be turned into a space when saving a goal
+        // a "+" must not be turned into a space when saving a goal
         $idGoal = $this->api->addGoal($this->idSite, 'MyName', 'url', '\/one_\d+\.php$', 'regex');
 
         $this->assertGoal($idGoal, 'MyName', '', 'url', '\/one_\d+\.php$', 'regex');
@@ -114,7 +114,7 @@ class APITest extends IntegrationTestCase
 
     public function testAddGoalShouldPreservePlusCharacterInNameAndDescription()
     {
-        // see DEV-18306: a "+" must not be turned into a space when saving a goal
+        // a "+" must not be turned into a space when saving a goal
         $idGoal = $this->api->addGoal($this->idSite, 'My + Name', 'title', 'a+b', 'contains', false, false, false, 'desc + text');
 
         $this->assertGoal($idGoal, 'My + Name', 'desc + text', 'title', 'a+b', 'contains');
@@ -122,7 +122,7 @@ class APITest extends IntegrationTestCase
 
     public function testUpdateGoalShouldPreservePlusCharacterInRegexPattern()
     {
-        // see DEV-18306: a "+" must not be turned into a space when updating a goal
+        // a "+" must not be turned into a space when updating a goal
         $idGoal = $this->api->addGoal($this->idSite, 'MyName', 'title', 'rere(.*)', 'regex');
 
         $this->api->updateGoal($this->idSite, $idGoal, 'My + Name', 'title', '(?!Postuler$).+', 'regex', false, false, false, 'desc + text');


### PR DESCRIPTION
## Description

Fixes DEV-18306.

Saving a Goal whose pattern, name or description contains a `+` corrupted the value: the `+` was turned into a space. For regex goals this silently changed the semantics (e.g. `.+` "one or more" became `.` followed by a space), causing expected conversions to be missed and reporting to be inaccurate. Reported by multiple Cloud customers.

### Root cause

`plugins/Goals/API.php` called `urldecode()` on the `pattern`, `name` and `description` parameters in `checkPattern()`, `checkName()` and `checkDescription()` — **after** PHP / the request framework had already URL-decoded the request parameters. Since `+` means a space in `application/x-www-form-urlencoded`, this double-decode converted a literal `+` into a space.

These `urldecode()` calls are legacy leftovers from ~2012 when the old JS client URL-encoded values before sending. The current Vue client sends the raw value, so the extra decode is pure corruption.

### Changes

- Remove the `urldecode()` call from `checkPattern()` (the numeric validation is kept).
- Remove the now no-op `checkName()` / `checkDescription()` methods and use the parameters directly.
- Add regression tests in `plugins/Goals/tests/Integration/APITest.php` covering `+` in patterns, names and descriptions for both `addGoal` and `updateGoal`.

### Notes

- **Forward-only fix.** Goals already saved with a `+` corrupted into a space cannot be auto-recovered (a stored space is indistinguishable from an originally-typed space), so no data migration is included. Affected goals need to be re-saved.
- Scope is limited to the Goals plugin; no other feature shares this code path.

## Review

- [ ] Functional review
- [x] Code review

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
