### PR TITLE
Fix double HTML-encoding of download URLs in real-time widget

### DIFF
--- a/plugins/Live/Controller.php
+++ b/plugins/Live/Controller.php
@@ -107,6 +107,7 @@ class Controller extends \Piwik\Plugin\Controller
                 'disable_generic_filters' => 1,
             ]);
             $visitors = $api->process();
+            $this->decodeActionUrls($visitors);
         } catch (\Exception $e) {
             $error = $e->getMessage();
         }
@@ -114,6 +115,36 @@ class Controller extends \Piwik\Plugin\Controller
         $view->visitors = $visitors;
 
         return $this->render($view);
+    }
+
+    /**
+     * The real-time widget template renders action URLs inline instead of going through the
+     * `Live.renderAction` event. As tracked URLs are returned HTML-entity encoded (e.g. `&` as
+     * `&amp;`), they would be escaped a second time when output into the href attribute, resulting
+     * in broken links like `download.pdf?a=b&amp;c=d`. Decode the entities here so the template's
+     * output escaping produces a single, correct encoding - matching VisitorDetails::renderAction().
+     */
+    private function decodeActionUrls(DataTable $visitors): void
+    {
+        foreach ($visitors->getRows() as $visitor) {
+            $actionDetails = $visitor->getColumn('actionDetails');
+
+            if (!is_array($actionDetails)) {
+                continue;
+            }
+
+            foreach ($actionDetails as &$action) {
+                if (
+                    isset($action['type'], $action['url'])
+                    && in_array($action['type'], ['outlink', 'download'], true)
+                ) {
+                    $action['url'] = html_entity_decode($action['url'], ENT_QUOTES, 'UTF-8');
+                }
+            }
+            unset($action);
+
+            $visitor->setColumn('actionDetails', $actionDetails);
+        }
     }
 
     private function setCounters($view)

--- a/plugins/Live/templates/getLastVisitsStart.twig
+++ b/plugins/Live/templates/getLastVisitsStart.twig
@@ -75,7 +75,7 @@
                         {% else %}
 
                             {% if action.url is defined and action.url is not empty %}
-                            <a href="{{ action.url|safelink }}" target="_blank" rel="noreferrer noopener">
+                            <a href="{{ action.url|safelink|e('html_attr') }}" target="_blank" rel="noreferrer noopener">
                             {% endif %}
                                 {% if action.type == 'action' %}
 {# white spacing matters as Chrome tooltip display whitespaces #}

--- a/tests/PHPUnit/Fixtures/UITestFixture.php
+++ b/tests/PHPUnit/Fixtures/UITestFixture.php
@@ -283,6 +283,16 @@ class UITestFixture extends SqlDump
                 $tracker->setUrl('http://realtime-fixture.example.com/page-' . $idx . '-' . $p);
                 self::assertTrue($tracker->doTrackPageView('Page ' . $idx . '-' . $p));
             }
+
+            if (0 === $idx) {
+                $tracker->setForceVisitDateTime(
+                    Date::factory($nowTs - $secondsAgo + $pageCount * 5)->getDatetime()
+                );
+                $tracker->setUrl('http://realtime-fixture.example.com/page-' . $idx . '-0');
+                self::assertTrue(
+                    $tracker->doTrackAction('http://realtime-fixture.example.com/files/download.pdf?a=b&c=d', 'download')
+                );
+            }
         }
 
         self::checkBulkTrackingResponse($tracker->doBulkTrack());

--- a/tests/UI/expected-screenshots/UIIntegrationTest_visitors_realtime_visits.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_visitors_realtime_visits.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3eb850abc9184a47ca8277d6c0e60f69857d297f95fc50caf93cee1774233fad
-size 70137
+oid sha256:ac04ada751b81ce937c7a35f7af507485db91c85dfd253ef8f30c8bdd39d4c19
+size 70215

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -310,6 +310,25 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
 
             expect(await screenshotPageWrap()).to.matchImage('visitors_realtime_visits');
         });
+
+        it('should not double-encode action URLs in the real-time visits widget', async function () {
+            const idSite = testEnvironment.realtimeUiSiteId;
+            const idSiteParams = 'idSite=' + idSite + '&period=year&date=2012-08-09';
+
+            await page.goto("?" + urlBaseGeneric + idSiteParams + "#?" + idSiteParams + "&category=General_Visitors&subcategory=General_RealTime");
+
+            await page.waitForNetworkIdle();
+            await page.waitForSelector('#visitsLive li.visit a[href*="download.pdf"]', { visible: true });
+
+            const href = await page.evaluate(() => {
+                const link = document.querySelector('#visitsLive li.visit a[href*="download.pdf"]');
+                return link ? link.getAttribute('href') : null;
+            });
+
+            expect(href).to.be.a('string');
+            expect(href).to.contain('download.pdf?a=b&c=d');
+            expect(href).to.not.contain('&amp;');
+        });
     });
 
     describe("ActionsPages", function () {


### PR DESCRIPTION
## Description

Fixes [DEV-19990](https://github.com/matomo-org/matomo/issues/24225) — tracked download/outlink URLs containing an `&` are displayed double HTML-encoded in the **Visits in real-time** widget, so clicking the action opens a broken link (`download.pdf?a=b&amp;c=d` instead of `download.pdf?a=b&c=d`). The Visitor Log and Behaviour > Downloads were unaffected.

### Root cause

Tracked URLs are returned HTML-entity encoded by the API (`&` → `&amp;`). The Visitor Log renders each action via the `Live.renderAction` event, where `Live\VisitorDetails::renderAction()` explicitly `html_entity_decode`s download/outlink URLs **before** rendering, so the template re-escapes exactly once.

The real-time widget (`getLastVisitsStart.twig`) iterates `actionDetails` **inline** and never goes through `renderAction`, so the already-encoded `&amp;` was escaped a second time on output → `&amp;amp;` in the href source → the browser navigated to a literal `&amp;`.

### Fix

- `plugins/Live/Controller.php`: decode download/outlink URLs after fetching the visitors, mirroring `VisitorDetails::renderAction()`.
- `plugins/Live/templates/getLastVisitsStart.twig`: escape the href with `e('html_attr')` to match the working `_actionCommon.twig`.

`html_entity_decode` is used (rather than the `rawSafeDecoded`/`decodeLabelSafe` filter) to stay consistent with the Visitor Log: `decodeLabelSafe` additionally `urldecode`s the value, which would turn `%20` into a literal space and corrupt percent-encoded download URLs.

### Tests

Added a regression test: the realtime UI fixture now tracks a download whose URL contains an `&`, and `UIIntegration_spec` asserts the widget links it without double HTML-encoding (`& must not become &amp;`).

> Note: the `visitors_realtime_visits` screenshot changes because the most recent fixture visit now has a download action — the expected image needs regenerating from CI.

### Review notes
- [ ] Functional review


[DEV-19990]: https://innocraft.atlassian.net/browse/DEV-19990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
