### PR TITLE
goal segment comparisons display original selected range

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/JqplotGraph/Evolution.php
+++ b/plugins/CoreVisualizations/Visualizations/JqplotGraph/Evolution.php
@@ -46,7 +46,9 @@ class Evolution extends JqplotGraph
 
     public function beforeLoadDataTable()
     {
-        if (!$this->isComparing()) {
+        $isComparingDatesOrPeriods = $this->isComparingDatesOrPeriods();
+
+        if (!$this->isComparing() || !$isComparingDatesOrPeriods) {
             $this->calculateEvolutionDateRange();
         }
 
@@ -73,7 +75,7 @@ class Evolution extends JqplotGraph
 
         $this->config->custom_parameters['columns'] = $this->config->columns_to_display;
 
-        if ($this->isComparing()) {
+        if ($this->isComparing() && $isComparingDatesOrPeriods) {
             $this->config->show_limit_control = false; // since we always show the evolution over the period, there's no point in changing the limit
             $this->config->show_periods = false; // the periods can't be changed as they are always fixed when comparing
 
@@ -94,6 +96,14 @@ class Evolution extends JqplotGraph
                 true
             );
         }
+    }
+
+    private function isComparingDatesOrPeriods(): bool
+    {
+        $comparePeriods = Common::getRequestVar('comparePeriods', [], 'array');
+        $compareDates = Common::getRequestVar('compareDates', [], 'array');
+
+        return !empty($comparePeriods) || !empty($compareDates);
     }
 
     public function afterAllFiltersAreApplied()

--- a/plugins/CoreVisualizations/tests/Integration/EvolutionPeriodSelectorTest.php
+++ b/plugins/CoreVisualizations/tests/Integration/EvolutionPeriodSelectorTest.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\CoreVisualizations\tests\Integration;
 use Piwik\Date;
 use Piwik\Period;
 use Piwik\Plugins\CoreVisualizations\Visualizations\EvolutionPeriodSelector;
+use Piwik\Plugins\CoreVisualizations\Visualizations\JqplotGraph\Evolution as EvolutionGraph;
 use Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines\Config;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
@@ -46,6 +47,9 @@ class EvolutionPeriodSelectorTest extends IntegrationTestCase
         unset($_GET['period']);
         unset($_GET['idSite']);
         unset($_GET['date']);
+        unset($_GET['compareSegments']);
+        unset($_GET['comparePeriods']);
+        unset($_GET['compareDates']);
         parent::tearDown();
     }
 
@@ -252,6 +256,45 @@ class EvolutionPeriodSelectorTest extends IntegrationTestCase
             'period' => 'week','date' => $year->getRangeString(),
             'comparePeriods' => ['week', 'week'], 'compareDates' => [$largeRangePrevious->getRangeString(), $mediumRangePrevious->getRangeString()],
         ], $year, [$largeRangePrevious, $mediumRangePrevious]);
+    }
+
+    public function testEvolutionGraphKeepsLastPeriodsWhenOnlyComparingSegments()
+    {
+        $_GET['period'] = 'day';
+        $_GET['date'] = '2022-05-02';
+        $_GET['idSite'] = 1;
+        $_GET['compareSegments'] = ['countryCode==nz'];
+
+        $view = new EvolutionGraph('VisitsSummary.getEvolutionGraph', 'VisitsSummary.get');
+        $view->beforeLoadDataTable();
+
+        $this->assertSame(
+            '2022-04-03,2022-05-02',
+            $view->requestConfig->request_parameters_to_modify['date']
+        );
+    }
+
+    public function testEvolutionGraphKeepsSelectedRangeWhenComparingDates()
+    {
+        $_GET['period'] = 'day';
+        $_GET['date'] = '2022-05-02';
+        $_GET['idSite'] = 1;
+        $_GET['compareDates'] = ['2022-05-01'];
+        $_GET['comparePeriods'] = ['day'];
+
+        $view = new EvolutionGraph('VisitsSummary.getEvolutionGraph', 'VisitsSummary.get');
+        $view->beforeLoadDataTable();
+
+        $this->assertSame('day', $view->requestConfig->request_parameters_to_modify['period']);
+        $this->assertSame(
+            '2022-05-02,2022-05-02',
+            $view->requestConfig->request_parameters_to_modify['date']
+        );
+        $this->assertSame(['day'], $view->requestConfig->request_parameters_to_modify['comparePeriods']);
+        $this->assertSame(
+            ['2022-05-01,2022-05-01'],
+            $view->requestConfig->request_parameters_to_modify['compareDates']
+        );
     }
 
     private function assertHighestPeriodInCommon($expected, $originalPeriod, $comparePeriods)

--- a/tests/UI/expected-screenshots/Comparison_visits_overview_widget_compareperiod_year.png
+++ b/tests/UI/expected-screenshots/Comparison_visits_overview_widget_compareperiod_year.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6b7fbdd216c3bff5163f95b2981cd011ae8ce9ff85b812f6d21fb43dfd0840f
-size 160579
+oid sha256:4d35c5f59383d557bf7e31ec4c7fb001a2265bbbc875de32cddbe54bc33e4864
+size 156375


### PR DESCRIPTION
### Description

When viewing a graph for a goal, comparing two segments without comparing period ranges will now correctly use the selected period. Previously the comparison would default to showing one day's worth of data.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
