### PR TITLE
Tracker: json_encode setDomains/setCookieDomain values in generated JS snippet

### DIFF
--- a/core/Tracker/TrackerCodeGenerator.php
+++ b/core/Tracker/TrackerCodeGenerator.php
@@ -313,11 +313,13 @@ class TrackerCodeGenerator
         }
         $options = '';
         if ($mergeSubdomains && !empty($firstHost)) {
-            $options .= '  _paq.push(["setCookieDomain", "*.' . $firstHost . '"]);' . "\n";
+            $options .= '  _paq.push(["setCookieDomain", ' . json_encode('*.' . $firstHost, JSON_UNESCAPED_SLASHES) . ']);' . "\n";
         }
         if ($mergeAliasUrls && !empty($websiteHosts)) {
-            $urls = '["*.' . implode('","*.', $websiteHosts) . '"]';
-            $options .= '  _paq.push(["setDomains", ' . $urls . ']);' . "\n";
+            $urls = array_map(static function ($host) {
+                return '*.' . $host;
+            }, $websiteHosts);
+            $options .= '  _paq.push(["setDomains", ' . json_encode($urls, JSON_UNESCAPED_SLASHES) . ']);' . "\n";
         }
         return $options;
     }


### PR DESCRIPTION
### Summary

`TrackerCodeGenerator::getJavascriptTagOptions()` builds the cross-domain `setDomains` array and the `setCookieDomain` value by raw string concatenation (`implode()` / `.`), while the rest of the same class already `json_encode`s every interpolated value — e.g. `setCustomVariable` (json_encode), `setExcludedQueryParams`, `setExcludedReferrers`, campaign params, etc.

This PR makes the encoding consistent so the aliased site URL/host values are emitted as properly-escaped JS string literals.

```php
// before
$options .= '  _paq.push(["setCookieDomain", "*.' . $firstHost . '"]);' . "\n";
$urls = '["*.' . implode('","*.', $websiteHosts) . '"]';
$options .= '  _paq.push(["setDomains", ' . $urls . ']);' . "\n";

// after
$options .= '  _paq.push(["setCookieDomain", ' . json_encode('*.' . $firstHost, JSON_UNESCAPED_SLASHES) . ']);' . "\n";
$urls = array_map(static function ($host) {
    return '*.' . $host;
}, $websiteHosts);
$options .= '  _paq.push(["setDomains", ' . json_encode($urls, JSON_UNESCAPED_SLASHES) . ']);' . "\n";
```

### Why

A site's aliased URLs feed `$websiteHosts`/`$firstHost`. If an alias path contains a quote or bracket, the current concatenation reflects it verbatim into the snippet rather than escaping it, so the value can break out of the JS array/string literal. Routing these through `json_encode` (as the rest of the generator already does) guarantees valid, escaped output.

This is a code-quality / hardening cleanup, not a security report — setting alias URLs requires site-configuration rights and the snippet is rendered as inert text in Matomo, so it does not cross a privilege/trust boundary. Filing here for public tracking as suggested by the security team.

### Compatibility

`JSON_UNESCAPED_SLASHES` keeps the output byte-identical to the previous concatenation for normal hostnames and URL paths (which contain `/`), so the existing expected snippets in `TrackerCodeGeneratorTest` are unchanged — e.g.:

```
_paq.push(["setCookieDomain", "*.localhost"]);
_paq.push(["setDomains", ["*.localhost/piwik","*.another-domain/piwik","*.another-domain/piwik"]]);
```

### Test

- `core/Tracker/TrackerCodeGenerator.php` only.
- Existing `tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php` covers this output and asserts the snippets above; behaviour is preserved for valid input.

### Review notes

- [ ] I have checked there is no existing PR for this
- [ ] This is a single, self-contained change with no behaviour change for valid input

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules