### PR TITLE
Adds code to fix comparison row not working for more than 1 dimension, #PG-5296

### DIFF
--- a/plugins/API/Filter/DataComparisonFilter/ComparisonRowGenerator.php
+++ b/plugins/API/Filter/DataComparisonFilter/ComparisonRowGenerator.php
@@ -99,7 +99,14 @@ class ComparisonRowGenerator
         }
 
         foreach ($table->getRows() as $row) {
-            $label = $row->getColumn('label');
+            // when a flattened report is shown with each dimension in a separate column, the visualization
+            // replaces the 'label' column with the first dimension's value and keeps the original combined
+            // label in 'combinedLabel' metadata. The comparison tables are still keyed by the combined label,
+            // so we must match on it - otherwise no row matches and every comparison metric defaults to 0.
+            $label = $row->getMetadata('combinedLabel');
+            if ($label === false) {
+                $label = $row->getColumn('label');
+            }
 
             $compareRow = null;
             if ($compareTable instanceof Simple) {

--- a/plugins/API/tests/Integration/Filter/DataComparisonFilter/ComparisonRowGeneratorTest.php
+++ b/plugins/API/tests/Integration/Filter/DataComparisonFilter/ComparisonRowGeneratorTest.php
@@ -583,6 +583,51 @@ END;
         $this->assertEquals($expectedXml, $xmlContent);
     }
 
+    public function testCompareTablesShouldMatchByCombinedLabelWhenDimensionsShownSeparately()
+    {
+        // When a flattened report is displayed with "show dimensions separately", the visualization
+        // replaces the 'label' column with the first dimension's value (here "google") and keeps the
+        // full flattened label in 'combinedLabel' metadata. Two rows can therefore share the same
+        // 'label' but differ by 'combinedLabel'.
+        $table1 = new DataTable();
+
+        $row1 = new DataTable\Row([DataTable\Row::COLUMNS => ['label' => 'google', 'nb_visits' => 5, 'nb_actions' => 10]]);
+        $row1->setMetadata('combinedLabel', 'google - cpc');
+        $table1->addRow($row1);
+
+        $row2 = new DataTable\Row([DataTable\Row::COLUMNS => ['label' => 'google', 'nb_visits' => 7, 'nb_actions' => 20]]);
+        $row2->setMetadata('combinedLabel', 'google - organic');
+        $table1->addRow($row2);
+
+        // the comparison table is fetched via the raw API and is still keyed by the combined label
+        $table2 = $this->makeTable([
+            ['label' => 'google - cpc', 'nb_visits' => 50, 'nb_actions' => 100],
+            ['label' => 'google - organic', 'nb_visits' => 70, 'nb_actions' => 200],
+        ]);
+
+        $compareMetadata = [
+            'compareSegment' => self::TEST_SEGMENT,
+            'comparePeriod' => 'day',
+            'compareDate' => '2012-03-04',
+        ];
+
+        $comparisonRowGenerator = new ComparisonRowGenerator('reportSegment', false, []);
+        $comparisonRowGenerator->compareTables($compareMetadata, $table1, $table2);
+
+        // each row must be matched to the comparison row sharing its *combined* label, not just "google".
+        // before the fix both rows matched nothing (no "google" row in the comparison table) and every
+        // comparison metric defaulted to 0.
+        $rows = array_values($table1->getRows());
+
+        $comparison1 = $rows[0]->getComparisons()->getFirstRow();
+        $this->assertEquals(50, $comparison1->getColumn('nb_visits'));
+        $this->assertEquals(100, $comparison1->getColumn('nb_actions'));
+
+        $comparison2 = $rows[1]->getComparisons()->getFirstRow();
+        $this->assertEquals(70, $comparison2->getColumn('nb_visits'));
+        $this->assertEquals(200, $comparison2->getColumn('nb_actions'));
+    }
+
     private function makeTable(array $rows)
     {
         $table = new DataTable();


### PR DESCRIPTION
### Description

Adds code to fix comparison row not working for more than 1 dimension, #PG-5296

A customer reported that comparison row shows 0 metric values if using more than 1 dimension and viewing dimensions separately, combined the same report works.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
