### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -706,12 +706,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/referrer-spam-list.git",
-                "reference": "f63abf1648c13d8f6094cbb017061b2a4e11cff8"
+                "reference": "d94fc55b2bcd0a4f36fd32e8b4430ff5fd60d23d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/f63abf1648c13d8f6094cbb017061b2a4e11cff8",
-                "reference": "f63abf1648c13d8f6094cbb017061b2a4e11cff8",
+                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/d94fc55b2bcd0a4f36fd32e8b4430ff5fd60d23d",
+                "reference": "d94fc55b2bcd0a4f36fd32e8b4430ff5fd60d23d",
                 "shasum": ""
             },
             "replace": {
@@ -729,7 +729,7 @@
                 "issues": "https://github.com/matomo-org/referrer-spam-list/issues",
                 "source": "https://github.com/matomo-org/referrer-spam-list/tree/master"
             },
-            "time": "2026-06-15T23:44:33+00:00"
+            "time": "2026-06-25T20:01:36+00:00"
         },
         {
             "name": "matomo/searchengine-and-social-list",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
                                                      Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading matomo/referrer-spam-list (dev-master f63abf1 => dev-master d94fc55)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downloading matomo/referrer-spam-list (dev-master d94fc55)
  - Upgrading matomo/referrer-spam-list (dev-master f63abf1 => dev-master d94fc55): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
54 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Found 14 ignored security vulnerability advisories affecting 1 package.
Run "composer audit" for a full list of advisories.
```
