### PR TITLE
Add ReportHeaderRedesign feature flag

### DIFF
--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -22,6 +22,8 @@ use Piwik\Piwik;
 use Piwik\Plugin\ArchivedMetric;
 use Piwik\Plugin\ComputedMetric;
 use Piwik\Plugin\ThemeStyles;
+use Piwik\Plugins\CoreHome\FeatureFlags\ReportHeaderRedesign;
+use Piwik\Plugins\FeatureFlags\FeatureFlagManager;
 use Piwik\Plugins\SegmentEditor\Settings\LimitSegments;
 use Piwik\Segment\SegmentsList;
 use Piwik\SettingsPiwik;
@@ -53,7 +55,20 @@ class CoreHome extends \Piwik\Plugin
             'Request.dispatchCoreAndPluginUpdatesScreen' => ['function' => 'checkAllowedIpsOnAuthentication', 'before' => true],
             'Tracker.setTrackerCacheGeneral'             => 'setTrackerCacheGeneral',
             'Segment.filterSegments'                     => 'filterSegments',
+            'Template.bodyClass'                         => 'addBodyClass',
         );
+    }
+
+    public function addBodyClass(&$out, $type)
+    {
+        $featureFlagManager = StaticContainer::get(FeatureFlagManager::class);
+
+        // The report header redesign moves widget controls and report actions to a shared
+        // top-right header. It is gated app-wide by this flag so later tickets can scope
+        // CSS/JS with `body.report-header-redesign-enabled` across every report surface.
+        if ($featureFlagManager->isFeatureActive(ReportHeaderRedesign::class)) {
+            $out .= ' report-header-redesign-enabled';
+        }
     }
 
     public function isTrackerPlugin()

--- a/plugins/CoreHome/FeatureFlags/ReportHeaderRedesign.php
+++ b/plugins/CoreHome/FeatureFlags/ReportHeaderRedesign.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\CoreHome\FeatureFlags;
+
+use Piwik\Plugins\FeatureFlags\FeatureFlagInterface;
+
+class ReportHeaderRedesign implements FeatureFlagInterface
+{
+    public function getName(): string
+    {
+        return 'ReportHeaderRedesign';
+    }
+}


### PR DESCRIPTION
### Description

Introduce the ReportHeaderRedesign feature flag (CoreHome) to gate the upcoming "move widget and report actions to the top-right" work behind a single switch, so later tickets can merge to 5.x-dev dark.

CoreHome now handles Template.bodyClass and appends the `report-header-redesign-enabled` body class app-wide when the flag is active, giving CSS/JS one global hook to scope the new header layout.

The flag defaults to disabled and is wired into nothing yet, so the UI is unchanged whether it is on or off.

issue dev-20441

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)