### PR TITLE
DEV-20461 Preserve request_parameters_to_modify in export URL requestParams

### DIFF
--- a/plugins/CoreHome/templates/_dataTableActions.twig
+++ b/plugins/CoreHome/templates/_dataTableActions.twig
@@ -4,7 +4,7 @@
     show-footer-icons="{{ properties.show_footer_icons|json_encode }}"
     footer-icons="{{ footerIcons|json_encode }}"
     report-title="{{ properties.title|json_encode }}"
-    request-params="{{ properties.export_parameters_to_modify|default(properties.request_parameters_to_modify|default({}))|json_encode }}"
+    request-params="{{ (properties.request_parameters_to_modify|default({}))|merge(properties.export_parameters_to_modify|default({}))|json_encode }}"
     api-method-to-request-data-table="{{ properties.apiMethodToRequestDataTable|json_encode }}"
     max-filter-limit="{{ properties.max_export_filter_limit|json_encode }}"
     show-export="{{ properties.show_export|json_encode }}"

--- a/tests/PHPUnit/Integration/CoreHome/RowEvolutionTest.php
+++ b/tests/PHPUnit/Integration/CoreHome/RowEvolutionTest.php
@@ -13,6 +13,7 @@ use Piwik\DataTable\Map;
 use Piwik\Plugins\CoreHome\DataTableRowAction\RowEvolution;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\View;
 
 /**
  * @group CoreHome
@@ -51,6 +52,53 @@ class RowEvolutionTest extends IntegrationTestCase
         $this->assertSame('', $view->requestConfig->request_parameters_to_modify['label']);
         $this->assertSame('@referrer.com', $view->config->export_parameters_to_modify['label']);
         $this->assertFalse($view->config->show_flatten_table_export);
+    }
+
+    /**
+     * A plugin whose report configureView adds an identifier to
+     * request_parameters_to_modify (as plugin-CustomReports does with
+     * idCustomReport) must still see that identifier reach the export URL
+     * even when RowEvolution has populated export_parameters_to_modify['label'].
+     * The _dataTableActions.twig template must merge the two maps, not pick one.
+     */
+    public function testDataTableActionsTemplateMergesRequestAndExportParameters(): void
+    {
+        $view = new View('@CoreHome/_dataTableActions');
+        $view->properties = [
+            // Simulates a plugin's configureView contribution.
+            'request_parameters_to_modify' => ['idDummyReport' => 42, 'label' => ''],
+            // Simulates RowEvolution::getRowEvolutionGraph overriding the label for exports.
+            'export_parameters_to_modify'  => ['label' => '@rowLabel'],
+            'show_footer'                  => true,
+            'show_footer_icons'            => true,
+            'title'                        => '',
+            'apiMethodToRequestDataTable'  => 'Referrers.getWebsites',
+            'max_export_filter_limit'      => 100,
+            'show_export'                  => true,
+            'show_export_as_image_icon'    => false,
+            'hide_annotations_view'        => true,
+            'show_search'                  => false,
+            'report_id'                    => 'test',
+            'show_flatten_table'           => false,
+            'report_supports_flatten'      => false,
+            'show_flatten_table_export'    => false,
+            'show_periods'                 => false,
+            'translations'                 => [],
+        ];
+        $view->footerIcons = [];
+        $view->clientSideParameters = ['viewDataTable' => 'table'];
+        $view->hasMultipleDimensions = false;
+        $view->isDataTableEmpty = false;
+        $view->isComparing = false;
+
+        $html = $view->render();
+
+        $this->assertSame(1, preg_match('/request-params="([^"]*)"/', $html, $matches));
+        $requestParams = json_decode(htmlspecialchars_decode($matches[1]), true);
+
+        $this->assertIsArray($requestParams);
+        $this->assertSame(42, $requestParams['idDummyReport']);
+        $this->assertSame('@rowLabel', $requestParams['label']);
     }
 
     private function setProperty(object $instance, string $propertyName, $value): void


### PR DESCRIPTION
## Summary

Fixes a Custom Reports row-evolution export regression: the export URL was missing the `idCustomReport` parameter, causing "Please specify a value for 'idCustomReport'".

### Root cause

PR #24495 (2026-05-20) changed `plugins/CoreHome/templates/_dataTableActions.twig` to prefer `export_parameters_to_modify` over `request_parameters_to_modify` and set `export_parameters_to_modify['label']` in `RowEvolution::getRowEvolutionGraph`. Because Twig `|default(x)` only falls back to `x` when the primary is empty, and `export_parameters_to_modify` now always has `label`, the fallback never fires. The result: any plugin-added keys in `request_parameters_to_modify` — most visibly `idCustomReport` set by `plugin-CustomReports/GetCustomReport::configureView` — are silently dropped from the export URL passed to the ReportExportPopover.

### Fix

Merge the two maps in `_dataTableActions.twig` instead of replacing. `request_parameters_to_modify` is the base; `export_parameters_to_modify` overrides on shared keys (still lets row evolution override `label`).

Low-risk one-line template change; restores pre-#24495 behaviour for `request_parameters_to_modify` keys while preserving the row-evolution `label` override. Added a Twig-level integration test that emulates a plugin contributing an id-key to `request_parameters_to_modify` and asserts both maps end up in the rendered `request-params` attribute.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)