### PR TITLE
Fix stale/inaccurate PHPDoc in core/API/Proxy, ResponseBuilder, Access

### DIFF
--- a/core/API/Proxy.php
+++ b/core/API/Proxy.php
@@ -35,8 +35,6 @@ if (!class_exists('Piwik\API\NoDefaultValue', false)) {
  * and default values.
  * Proxy receives all the API calls requests via call() and forwards them to the right
  * object, with the parameters in the right order.
- *
- * It will also log the performance of API calls (time spent, parameter values, etc.) if logger available
  */
 class Proxy
 {
@@ -81,7 +79,7 @@ class Proxy
      *
      * The method will introspect the methods, their parameters, etc.
      *
-     * @param string $className ModuleName eg. "API"
+     * @param string $className Fully qualified API class name, eg. "\Piwik\Plugins\Referrers\API"
      */
     public function registerClass($className)
     {
@@ -134,6 +132,10 @@ class Proxy
      * Removes docblock annotations and their continuation lines.
      *
      * For example, this removes `@phpstan-type` and the following multiline shape definition.
+     *
+     * @param string|false $doc
+     * @param string $annotationPrefix
+     * @return string|false
      */
     private function removeDocblockAnnotationBlocks($doc, $annotationPrefix)
     {
@@ -181,9 +183,6 @@ class Proxy
      * Will execute $className->$methodName($parametersValues)
      * If any error is detected (wrong number of parameters, method not found, class not found, etc.)
      * it will throw an exception
-     *
-     * It also logs the API calls, with the parameters values, the returned value, the performance, etc.
-     * You can enable logging in config/global.ini.php (log_api_call)
      *
      * @param string $className The class name (eg. API)
      * @param string $methodName The method name
@@ -479,7 +478,7 @@ class Proxy
     /**
      * Returns an array containing the *sanitized* values of the parameters to pass to the method to call
      *
-     * @param array $requiredParameters array of (parameter name, default value)
+     * @param array $requiredParameters array mapping parameter name to ['default' => value, 'type' => type]
      * @param array $parametersRequest
      * @throws Exception
      * @return array values to pass to the function call
@@ -534,7 +533,7 @@ class Proxy
     /**
      * Returns an array containing the values of the parameters to pass to the method to call
      *
-     * @param array $requiredParameters array of (parameter name, default value)
+     * @param array $requiredParameters array mapping parameter name to ['default' => value, 'type' => type]
      * @param \Piwik\Request $request
      * @throws Exception
      * @return array values to pass to the function call
@@ -661,7 +660,7 @@ class Proxy
     }
 
     /**
-     * @param $docComment
+     * @param string|false $docComment
      * @return bool
      */
     public function shouldHideAPIMethod($docComment)

--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -37,6 +37,7 @@ class ResponseBuilder
     /**
      * @param string $outputFormat
      * @param array $request
+     * @param bool|null $shouldPrintBacktrace
      */
     public function __construct($outputFormat, $request = array(), $shouldPrintBacktrace = null)
     {
@@ -153,7 +154,7 @@ class ResponseBuilder
 
     /**
      * @param Exception|\Throwable $e
-     * @return Exception
+     * @return Exception|\Throwable
      */
     private function decorateExceptionWithDebugTrace($e)
     {

--- a/core/Access.php
+++ b/core/Access.php
@@ -448,7 +448,7 @@ class Access
     }
 
     /**
-     * Returns `true` if the current user has admin access to at least one site.
+     * Returns `true` if the current user has write access to at least one site.
      *
      * @return bool
      */
@@ -568,11 +568,11 @@ class Access
     }
 
     /**
-     * This method checks that the user has VIEW or ADMIN access for the given list of websites.
-     * If the user doesn't have VIEW or ADMIN access for at least one website of the list, we throw an exception.
+     * This method checks that the user has WRITE access for the given list of websites.
+     * If the user doesn't have WRITE access for at least one website of the list, we throw an exception.
      *
      * @param int|array|string $idSites List of ID sites to check (integer, array of integers, string comma separated list of integers)
-     * @throws \Piwik\NoAccessException  If for any of the websites the user doesn't have an VIEW or ADMIN access
+     * @throws \Piwik\NoAccessException  If for any of the websites the user doesn't have a WRITE access
      */
     public function checkUserHasWriteAccess($idSites)
     {
@@ -694,7 +694,7 @@ class Access
      * Returns the level of access the current user has to the given site.
      *
      * @param int $idSite The site to check.
-     * @return string The access level, eg, 'view', 'admin', 'noaccess'.
+     * @return string The access level, eg, 'view', 'write', 'admin', 'noaccess'.
      */
     public function getRoleForSite($idSite)
     {
@@ -741,7 +741,7 @@ class Access
      * Throw a NoAccessException with the given message, or a more generic 'You need to log in' message if the
      * user is not currently logged in (e.g. if session has expired).
      *
-     * @param $message
+     * @param string $message
      * @throws NoAccessException
      */
     private function throwNoAccessException($message)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -136,11 +136,6 @@ parameters:
 			path: core/API/Request.php
 
 		-
-			message: "#^Method Piwik\\\\API\\\\ResponseBuilder\\:\\:decorateExceptionWithDebugTrace\\(\\) should return Exception but returns Throwable\\.$#"
-			count: 1
-			path: core/API/ResponseBuilder.php
-
-		-
 			message: "#^Parameter \\#2 \\$columnToFilter of class Piwik\\\\DataTable\\\\Filter\\\\Pattern constructor expects string, array given\\.$#"
 			count: 1
 			path: core/API/ResponseBuilder.php


### PR DESCRIPTION
## Summary

Part of an ongoing pass to fix PHPDoc comments across `core/` and `plugins/` (excluding `@api`-tagged classes/methods and `API.php` classes) that no longer match the actual code behavior, or whose `@param`/`@return` annotations are wrong/incomplete.

This PR covers:
- `core/API/Proxy.php`: removed a stale claim about API-call performance logging via a `log_api_call` config setting that doesn't exist anywhere in the codebase; fixed a misleading `registerClass()` param example; corrected the `$requiredParameters` shape description used by two methods; added missing types on two untyped params.
- `core/API/ResponseBuilder.php`: widened `decorateExceptionWithDebugTrace()`'s return type since it can return the original `Throwable` unchanged, not just `Exception`; documented a previously-untyped constructor param.
- `core/Access.php`: fixed two copy-pasted docblocks — `isUserHasSomeWriteAccess()` was documented as checking "admin access" and `checkUserHasWriteAccess()` was documented as checking "VIEW or ADMIN access", both copied from sibling methods; completed `getRoleForSite()`'s return value example; added a missing param type.

One `phpstan-baseline.neon` entry was removed because the `ResponseBuilder` return type fix resolved a real, previously-suppressed PHPStan finding.

`core/API/NoDefaultValue.php`, `core/API/Request.php` (class-level `@api`, out of scope), `core/Access/CapabilitiesProvider.php`, `core/Access/Capability.php`, `core/Access/Role.php`, `core/Access/Role/Admin.php`, and `core/Access/Role/View.php` needed no changes.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
