### PR TITLE
Fix stale/inaccurate PHPDoc in core/Access, Application, Archive classes

### DIFF
--- a/core/Access/RolesProvider.php
+++ b/core/Access/RolesProvider.php
@@ -53,7 +53,6 @@ class RolesProvider
     }
 
     /**
-     * @param $roleId
      * @throws Exception
      */
     public function checkValidRole(string $roleId): void

--- a/core/Application/Environment.php
+++ b/core/Application/Environment.php
@@ -166,7 +166,7 @@ class Environment
      * Returns the kernel global GlobalSettingsProvider object. Derived classes can override this method
      * to provide a different implementation.
      *
-     * @return null|GlobalSettingsProvider
+     * @return GlobalSettingsProvider
      */
     protected function getGlobalSettings()
     {

--- a/core/Application/Kernel/EnvironmentValidator.php
+++ b/core/Application/Kernel/EnvironmentValidator.php
@@ -65,7 +65,7 @@ class EnvironmentValidator
     }
 
     /**
-     * @param $path
+     * @param string $path
      * @param bool $startInstaller
      * @throws \Exception
      */
@@ -101,7 +101,7 @@ class EnvironmentValidator
     }
 
     /**
-     * @param $exception
+     * @param NotYetInstalledException $exception
      */
     private function startInstallation($exception)
     {
@@ -117,7 +117,7 @@ class EnvironmentValidator
     }
 
     /**
-     * @param $path
+     * @param string $path
      * @return string
      */
     private function getMessageWhenFileExistsButNotReadable($path)
@@ -137,7 +137,7 @@ class EnvironmentValidator
     }
 
     /**
-     * @param $path
+     * @param string $path
      * @return string
      */
     private function getSpecificMessageWhetherFileExistsOrNot($path)

--- a/core/Application/Kernel/PluginList.php
+++ b/core/Application/Kernel/PluginList.php
@@ -101,7 +101,7 @@ class PluginList
      * Sorts an array of plugins in the order they should be loaded. We cannot use DI here as DI is not initialized
      * at this stage.
      *
-     * @params string[] $plugins
+     * @param string[] $plugins
      * @return list<string>
      */
     public function sortPlugins(array $plugins)
@@ -141,7 +141,7 @@ class PluginList
      *
      * @param string[] $plugins
      * @param array[] $pluginJsonCache  For internal testing only
-     * @return \string[]
+     * @return string[]
      */
     public function sortPluginsAndRespectDependencies(array $plugins, $pluginJsonCache = array())
     {

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -235,7 +235,7 @@ class ArchiveInvalidator
     }
 
     /**
-     * @param $id
+     * @param string $id
      * @return bool true if a record was deleted, false otherwise.
      * @throws \Zend_Db_Statement_Exception
      */
@@ -262,9 +262,12 @@ class ArchiveInvalidator
      * @param int[] $idSites
      * @param Date[]|string[] $dates
      * @param string $period
+     * @param Segment|null $segment The segment to restrict invalidation to, or null for no segment.
+     * @param bool $cascadeDown Whether to also invalidate child periods (eg, the days within an invalidated month).
      * @param bool $forceInvalidateNonexistentRanges set true to force inserting rows for ranges in archive_invalidations
      * @param null|string $name null to make sure every plugin is archived when this invalidation is processed by core:archive,
      *                          or a plugin name to only archive the specific plugin.
+     * @param bool $ignorePurgeLogDataDate If true, invalidate dates even if they are older than the configured log deletion date.
      * @param bool $doNotCreateInvalidations If true, archives will only be marked as invalid, but no archive_invalidation record will be created
      * @return InvalidationResult
      * @throws \Exception
@@ -432,9 +435,10 @@ class ArchiveInvalidator
 
     /**
      * @param int[] $idSites
-     * @param Date[] $dates
+     * @param array<array{0: Date, 1: Date}> $dates Array of [startDate, endDate] pairs.
+     * @param Segment|null $segment The segment to restrict invalidation to, or null for no segment.
      * @param null|string $name null to make sure every plugin is archived when this invalidation is processed by core:archive,
-     * *                          or a plugin name to only archive the specific plugin.
+     *                          or a plugin name to only archive the specific plugin.
      * @return InvalidationResult
      * @throws \Exception
      */
@@ -534,7 +538,7 @@ class ArchiveInvalidator
      * archiving data in the past, you may want to call this method to remove any pending invalidations if, for example,
      * your plugin is deactivated or a report deleted.
      *
-     * @param int|int[] $idSite one or more site IDs or 'all' for all site IDs
+     * @param int|int[]|string $idSite one or more site IDs or 'all' for all site IDs
      * @param string $plugin
      * @param string|null $report
      */
@@ -552,7 +556,6 @@ class ArchiveInvalidator
      * since adding invalidations can take a long time and delay UI response times.
      *
      * @param int|int[]|'all' $idSites
-     * @param string|int $pluginName
      * @param string|null $report
      */
     public function scheduleReArchiving(
@@ -725,7 +728,9 @@ class ArchiveInvalidator
     }
 
     /**
-     * @param Date[] $dates
+     * @param Date[]|string[] $dates
+     * @param string $period
+     * @param bool $ignorePurgeLogDataDate
      * @return \Piwik\Date[]
      */
     private function removeDatesThatHaveBeenPurged($dates, $period, InvalidationResult $invalidationInfo, $ignorePurgeLogDataDate)

--- a/core/Archive/ArchivePurger.php
+++ b/core/Archive/ArchivePurger.php
@@ -55,7 +55,7 @@ class ArchivePurger
     /**
      * Date to use for 'today'. Exists so tests can override this value.
      *
-     * @var $today
+     * @var Date
      */
     private $today;
 
@@ -314,7 +314,6 @@ class ArchivePurger
     /**
      * Deleting "Custom Date Range" reports after 1 day, since they can be re-processed and would take up un-necessary space.
      *
-     * @param $date Date
      * @return int The total number of rows deleted from both the numeric & blob table.
      */
     public function purgeArchivesWithPeriodRange(Date $date)
@@ -348,7 +347,7 @@ class ArchivePurger
     /**
      * Deletes by batches Archive IDs in the specified month,
      *
-     * @param $idArchivesToDelete
+     * @param array $idArchivesToDelete
      * @return int Number of rows deleted from both numeric + blob table.
      */
     protected function deleteArchiveIds(Date $date, $idArchivesToDelete): int
@@ -369,9 +368,9 @@ class ArchivePurger
     }
 
     /**
-     * Returns a timestamp indicating outdated archives older than this timestamp (processed before) can be purged.
+     * Returns a date time string; outdated archives processed before this date time can be purged.
      *
-     * @return int|bool  Outdated archives older than this timestamp should be purged
+     * @return string
      */
     protected function getOldestTemporaryArchiveToKeepThreshold()
     {

--- a/core/Archive/ArchiveQuery.php
+++ b/core/Archive/ArchiveQuery.php
@@ -26,8 +26,8 @@ interface ArchiveQuery
     public function getDataTableFromNumeric($names);
 
     /**
-     * @param $names
-     * @return mixed
+     * @param string|string[] $names
+     * @return DataTable|DataTable\Map
      */
     public function getDataTableFromNumericAndMergeChildren($names);
 

--- a/core/Archive/ArchiveQueryFactory.php
+++ b/core/Archive/ArchiveQueryFactory.php
@@ -64,8 +64,8 @@ class ArchiveQueryFactory
      * Parses the site ID string provided in the 'idSite' query parameter to a list of
      * website IDs.
      *
-     * @param string $idSites the value of the 'idSite' query parameter
-     * @param bool $_restrictSitesToLogin
+     * @param string|int|array $idSites the value of the 'idSite' query parameter
+     * @param string|null|false $_restrictSitesToLogin
      * @return array an array containing three elements:
      *     - an array of website IDs
      *     - string timezone to use (or false to use no timezone) when creating periods.
@@ -91,7 +91,7 @@ class ArchiveQueryFactory
      *
      * @param string $strDate the value of the 'date' query parameter
      * @param string $strPeriod the value of the 'period' query parameter
-     * @param string $timezone the timezone to use when constructing periods.
+     * @param string|false $timezone the timezone to use when constructing periods.
      * @return array an array containing two elements:
      *     - the list of period objects to query archive data for
      *     - true if the request was for multiple periods (ie, two months, two weeks, etc.), false if otherwise.
@@ -116,7 +116,7 @@ class ArchiveQueryFactory
     /**
      * Parses the segment query parameter into a Segment object.
      *
-     * @param string $strSegment the value of the 'segment' query parameter.
+     * @param string|false $strSegment the value of the 'segment' query parameter.
      * @param int[] $websiteIds the list of sites being queried.
      * @param Period[] $allPeriods list of all periods
      * @return Segment

--- a/core/Archive/DataCollection.php
+++ b/core/Archive/DataCollection.php
@@ -164,7 +164,7 @@ class DataCollection
      * @param int           $idSite
      * @param string        $period eg, '2012-01-01,2012-01-31'
      * @param string        $name   eg 'nb_visits'
-     * @param string        $value  eg 5
+     * @param mixed         $value  eg 5, or a serialized blob string
      * @param array|null    $meta   Optional metadata to add to the row
      */
     public function set($idSite, $period, $name, $value, ?array $meta = null)
@@ -189,7 +189,7 @@ class DataCollection
      * @param int $idSite
      * @param string $period eg, '2012-01-01,2012-01-31'
      * @param string $name The metadata name.
-     * @param mixed $value The metadata name.
+     * @param mixed $value The metadata value.
      */
     public function addMetadata($idSite, $period, $name, $value)
     {

--- a/core/Archive/DataTableFactory.php
+++ b/core/Archive/DataTableFactory.php
@@ -56,7 +56,7 @@ class DataTableFactory
      * The maximum number of subtable levels to create when creating an expanded
      * DataTable.
      *
-     * @var int
+     * @var int|null
      */
     private $maxSubtableDepth = null;
 
@@ -138,7 +138,7 @@ class DataTableFactory
      * Tells the factory instance to create a DataTable using a blob with the
      * supplied subtable ID.
      *
-     * @param int $idSubtable An in-database subtable ID.
+     * @param int|null $idSubtable An in-database subtable ID.
      * @throws \Exception
      */
     public function useSubtable($idSubtable)
@@ -478,7 +478,7 @@ class DataTableFactory
     }
 
     /**
-     * @param $data
+     * @param array $data
      * @return DataTable\Simple
      */
     private function makeFromMetricsArray($data, $keyMetadata)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -176,22 +176,7 @@ parameters:
 			path: core/Application/Environment.php
 
 		-
-			message: "#^Method Piwik\\\\Application\\\\Kernel\\\\PluginList\\:\\:sortPluginsAndRespectDependencies\\(\\) has invalid return type string\\.$#"
-			count: 1
-			path: core/Application/Kernel/PluginList.php
-
-		-
-			message: "#^Method Piwik\\\\Application\\\\Kernel\\\\PluginList\\:\\:sortPluginsAndRespectDependencies\\(\\) should return array\\<string\\> but returns array\\<string\\>\\.$#"
-			count: 1
-			path: core/Application/Kernel/PluginList.php
-
-		-
 			message: "#^Method Piwik\\\\Archive\\\\ArchiveInvalidator\\:\\:getSegmentArchiving\\(\\) is unused\\.$#"
-			count: 1
-			path: core/Archive/ArchiveInvalidator.php
-
-		-
-			message: "#^PHPDoc tag @param for parameter \\$pluginName with type int\\|string is not subtype of native type string\\|null\\.$#"
 			count: 1
 			path: core/Archive/ArchiveInvalidator.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -211,21 +211,6 @@ parameters:
 			path: core/Archive/ArchiveInvalidator.php
 
 		-
-			message: "#^Method Piwik\\\\Archive\\\\ArchivePurger\\:\\:getOldestTemporaryArchiveToKeepThreshold\\(\\) should return bool\\|int but returns string\\.$#"
-			count: 2
-			path: core/Archive/ArchivePurger.php
-
-		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\$today\\)\\: Unexpected token \"\\$today\", expected type at offset 96$#"
-			count: 1
-			path: core/Archive/ArchivePurger.php
-
-		-
-			message: "#^Parameter \\#3 \\$oldestToKeep of method Piwik\\\\DataAccess\\\\Model\\:\\:getArchiveIdsForSegments\\(\\) expects string, bool\\|int given\\.$#"
-			count: 1
-			path: core/Archive/ArchivePurger.php
-
-		-
 			message: "#^Property Piwik\\\\Archive\\\\ArchivePurger\\:\\:\\$today is never read, only written\\.$#"
 			count: 1
 			path: core/Archive/ArchivePurger.php


### PR DESCRIPTION
## Summary

Part of an ongoing pass to fix PHPDoc comments across `core/` and `plugins/` (excluding `@api`-tagged classes/methods and `API.php` classes) that no longer match the actual code behavior, or whose `@param`/`@return` annotations are wrong/incomplete.

This PR covers:
- `core/Access/RolesProvider.php`: removed a redundant untyped `@param` tag.
- `core/Application/Environment.php`: fixed `getGlobalSettings()`'s return type — it always returns a `GlobalSettingsProvider` and is consumed via a non-nullable param, so the documented `null` case was never valid.
- `core/Application/Kernel/EnvironmentValidator.php`: added missing types on several untyped params.
- `core/Application/Kernel/PluginList.php`: fixed an invalid `@params` tag (should be `@param`) and a stray backslash in `@return \string[]`.
- `core/Archive/ArchiveInvalidator.php`: completed several methods' `@param` lists (1-3 params were undocumented each), fixed `$dates`/`$idSite`/`$pluginName` type mismatches.
- `core/Archive/ArchivePurger.php`: `getOldestTemporaryArchiveToKeepThreshold()` always returns a date time string, not an int/bool timestamp as documented; also fixed an invalid `@var $today` tag and a misordered `@param $date Date` tag.
- `core/Archive/ArchiveQuery.php`: fixed a vague `@param`/`@return mixed` on `getDataTableFromNumericAndMergeChildren()`.
- `core/Archive/ArchiveQueryFactory.php`: widened param types to match `Archive::build()`'s actual accepted types.
- `core/Archive/DataCollection.php`: fixed a copy-pasted `@param` description (`addMetadata()`'s `$value` was documented as "The metadata name.") and a wrong `string`-only type for a param that can hold numeric or blob values.
- `core/Archive/DataTableFactory.php`: fixed two params/property documented as non-nullable that are actually nullable.

Several `phpstan-baseline.neon` entries were removed because these fixes resolved real, previously-suppressed PHPStan findings.

`core/Access/Role/Write.php`, `core/Application/EnvironmentManipulator.php`, `core/Application/Kernel/GlobalSettingsProvider.php`, `core/Archive.php` (class-level `@api`, out of scope), `core/Archive/ArchiveInvalidator/InvalidationResult.php`, `core/Archive/ArchiveState.php`, `core/Archive/Chunk.php`, and `core/Archive/Parameters.php` needed no changes.


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules