### PR TITLE
Fix stale/inaccurate PHPDoc in core/ (Auth, Cache, Columns, Common, Concurrency, Config)

### DIFF
--- a/core/BaseFactory.php
+++ b/core/BaseFactory.php
@@ -27,7 +27,7 @@ abstract class BaseFactory
      * Creates a new instance of a class using a string ID.
      *
      * @param string $classId The ID of the class.
-     * @return object
+     * @return \Piwik\DataTable\Renderer
      * @throws Exception if $classId is invalid.
      */
     public static function factory($classId)

--- a/core/BaseFactory.php
+++ b/core/BaseFactory.php
@@ -27,7 +27,7 @@ abstract class BaseFactory
      * Creates a new instance of a class using a string ID.
      *
      * @param string $classId The ID of the class.
-     * @return \Piwik\DataTable\Renderer
+     * @return object
      * @throws Exception if $classId is invalid.
      */
     public static function factory($classId)

--- a/core/Cache.php
+++ b/core/Cache.php
@@ -63,7 +63,7 @@ class Cache
     }
 
     /**
-     * @param $type
+     * @param string $type
      * @return \Matomo\Cache\Backend
      */
     public static function buildBackend($type)

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -182,7 +182,7 @@ class CliMulti
     /**
      * Ok, this sounds weird. Why should we care about ssl certificates when we are in CLI mode? It is needed for
      * our simple fallback mode for Windows where we initiate HTTP requests instead of CLI.
-     * @param $acceptInvalidSSLCertificate
+     * @param bool $acceptInvalidSSLCertificate
      */
     public function setAcceptInvalidSSLCertificate($acceptInvalidSSLCertificate)
     {
@@ -190,7 +190,7 @@ class CliMulti
     }
 
     /**
-     * @param $limit int Maximum count of requests to issue in parallel
+     * @param int $limit Maximum count of requests to issue in parallel
      */
     public function setConcurrentProcessesLimit($limit)
     {

--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -189,7 +189,7 @@ class Process
     /**
      * Tests only
      * @internal
-     * @param $content
+     * @param string|int $content
      */
     public function writePidFileContent($content)
     {

--- a/core/Columns/DimensionsProvider.php
+++ b/core/Columns/DimensionsProvider.php
@@ -15,7 +15,7 @@ use Piwik\Cache as PiwikCache;
 class DimensionsProvider
 {
     /**
-     * @param $dimensionId
+     * @param string $dimensionId
      * @return ?Dimension
      */
     public function factory($dimensionId)

--- a/core/Columns/Updater.php
+++ b/core/Columns/Updater.php
@@ -160,6 +160,7 @@ class Updater extends \Piwik\Updates
     /**
      * @param ActionDimension|ConversionDimension|VisitDimension $dimension
      * @param string $componentPrefix
+     * @param array $existingColumnsInDb
      * @return array
      */
     private function getUpdatesForDimension(PiwikUpdater $updater, $dimension, $componentPrefix, $existingColumnsInDb)

--- a/core/Common.php
+++ b/core/Common.php
@@ -212,7 +212,7 @@ class Common
      * If you are wanting to use the pid to check if the process is running eg using `ps`, then you also have to use
      * getmypid directly.
      *
-     * @return int|null
+     * @return int|false
      */
     public static function getProcessId()
     {
@@ -382,7 +382,7 @@ class Common
     /**
      * Sanitize a single input value and removes line breaks, tabs and null characters.
      *
-     * @param string $value
+     * @param string|null $value
      * @return string  sanitized input
      */
     public static function sanitizeInputValue($value)
@@ -460,7 +460,7 @@ class Common
     }
 
     /**
-     * @param string $value
+     * @param string|null $value
      * @return string Line breaks and line carriage removed
      */
     public static function sanitizeLineBreaks($value)
@@ -720,7 +720,7 @@ class Common
     /**
      * Converts a User ID string to the Visitor ID Binary representation.
      *
-     * @param $userId
+     * @param string $userId
      * @return string
      */
     public static function convertUserIdToVisitorIdBin($userId)
@@ -1256,7 +1256,7 @@ class Common
     }
 
     /**
-     * @param $validLanguages
+     * @param array $validLanguages
      * @return array
      */
     protected static function checkValidLanguagesIsSet($validLanguages)

--- a/core/Concurrency/LockBackend.php
+++ b/core/Concurrency/LockBackend.php
@@ -14,7 +14,7 @@ interface LockBackend
     /**
      * Returns lock keys matching a pattern.
      *
-     * @param $pattern
+     * @param string $pattern
      * @return string[]
      */
     public function getKeysMatchingPattern($pattern);
@@ -22,37 +22,37 @@ interface LockBackend
     /**
      * Set a key value if the key is not already set.
      *
-     * @param $lockKey
-     * @param $lockValue
-     * @param $ttlInSeconds
-     * @return mixed
+     * @param string $lockKey
+     * @param string $lockValue
+     * @param int $ttlInSeconds
+     * @return bool
      */
     public function setIfNotExists($lockKey, $lockValue, $ttlInSeconds);
 
     /**
      * Get the lock value for a key if any.
      *
-     * @param $lockKey
-     * @return mixed
+     * @param string $lockKey
+     * @return string|false
      */
     public function get($lockKey);
 
     /**
      * Delete the lock with key = $lockKey if the lock has the given value.
      *
-     * @param $lockKey
-     * @param $lockValue
-     * @return mixed
+     * @param string $lockKey
+     * @param string $lockValue
+     * @return bool
      */
     public function deleteIfKeyHasValue($lockKey, $lockValue);
 
     /**
      * Update expiration for a lock if the lock with the specified key has the given value.
      *
-     * @param $lockKey
-     * @param $lockValue
-     * @param $ttlInSeconds
-     * @return mixed
+     * @param string $lockKey
+     * @param string $lockValue
+     * @param int $ttlInSeconds
+     * @return bool
      */
     public function expireIfKeyHasValue($lockKey, $lockValue, $ttlInSeconds);
 }

--- a/core/Config.php
+++ b/core/Config.php
@@ -197,8 +197,7 @@ class Config
     }
 
     /**
-     * @param $general
-     * @return mixed
+     * @return array
      */
     private function getDatatableRowLimits()
     {

--- a/core/Config/Cache.php
+++ b/core/Config/Cache.php
@@ -15,7 +15,8 @@ use Piwik\Piwik;
 use Piwik\Url;
 
 /**
- * Exception thrown when the config file doesn't exist.
+ * File cache backend for tracker config data, keyed by the current (trusted) hostname since the
+ * config is not loaded yet when this cache is used.
  */
 class Cache extends File
 {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -521,11 +521,6 @@ parameters:
 			path: core/Columns/Updater.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
-			count: 1
-			path: core/Common.php
-
-		-
 			message: "#^Comparison operation \"\\<\" between int\\<2, 3\\> and 2 is always false\\.$#"
 			count: 1
 			path: core/Common.php


### PR DESCRIPTION
## Summary

Part of an ongoing pass to fix PHPDoc comments across `core/` and `plugins/` (excluding `@api`-tagged classes/methods and `API.php` classes) that no longer match the actual code behavior, or whose `@param`/`@return` annotations are wrong/incomplete.

This PR covers:
- `core/BaseFactory.php`: `factory()` was documented as always returning a `\Piwik\DataTable\Renderer`, but this is a generic base class meant to be extended by many different factory types.
- `core/Cache.php`: added a missing param type on `buildBackend()`.
- `core/CliMulti.php` / `core/CliMulti/Process.php`: fixed an untyped param, a misordered `@param $limit int ...` tag (type after the variable name), and added a missing type.
- `core/Columns/DimensionsProvider.php`: added a missing param type on `factory()`.
- `core/Columns/Updater.php`: added a missing `@param` on `getUpdatesForDimension()`.
- `core/Common.php`: `getProcessId()` can return `false` (from `getmypid()`) but was documented as `int|null` (a case that never occurs); `sanitizeInputValue()`/`sanitizeLineBreaks()` both explicitly handle a `null` input internally but were documented as accepting only `string`; added two missing param types.
- `core/Concurrency/LockBackend.php`: the entire interface was fully untyped (bare `@param $x`, `@return mixed`) despite the implementation and callers consistently using string/int/bool.
- `core/Config.php`: `getDatatableRowLimits()` takes no parameters, but its docblock still documented a `$general` param that no longer exists.
- `core/Config/Cache.php`: the class docblock said "Exception thrown when the config file doesn't exist" — copy-pasted from the neighboring `ConfigNotFoundException` class, but this class is a file cache backend, not an exception.

One `phpstan-baseline.neon` entry was removed because the `Common.php` fix resolved a real, previously-suppressed PHPStan finding.

Many files in this range were skipped because they are `@api`-tagged (whole class or whole interface): `core/Auth.php`, `core/Auth/Password.php`, `core/Auth/PasswordStrength.php`, `core/AuthResult.php`, `core/Category/Subcategory.php`, `core/Columns/ComputedMetricFactory.php`, `core/Columns/Dimension.php`, `core/Columns/DimensionMetricFactory.php`, `core/Columns/DimensionSegmentFactory.php`, `core/Columns/Discriminator.php`, `core/Columns/Join.php`, `core/Columns/Join/ActionNameJoin.php`, `core/Columns/Join/GoalNameJoin.php`, `core/Columns/Join/SiteNameJoin.php`, `core/Columns/MetricsList.php`. Many other files needed no changes (already accurate/well-documented, or had no docblocks to begin with).


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules