### PR TITLE
Restore submodule UI tests in plugin matrix

### DIFF
--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -355,14 +355,7 @@ jobs:
 
           plugins=$(find plugins -mindepth 2 -path '*/tests/UI/*_spec.js' \
             ! -path '*/node_modules/*' ! -path '*/vendor/*' \
-            | awk -F/ '{print $2}' | sort -u \
-            | while read -r plugin; do
-                [ -n "$plugin" ] || continue
-
-                if [ ! -e "plugins/$plugin/.git" ]; then
-                  printf '%s\n' "$plugin"
-                fi
-              done)
+            | awk -F/ '{print $2}' | sort -u)
 
           matrix=$(printf '%s\n' "$plugins" \
             | jq -Rsc 'split("\n") | map(select(length>0) | {plugin: .}) | {include: .}')

--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -389,6 +389,11 @@ jobs:
           # Persisted so github-action-tests' own `git lfs pull --exclude=` stays scoped too
           git config lfs.fetchinclude "plugins/$PLUGIN/tests/UI/expected-screenshots/*"
           git lfs pull --include "plugins/$PLUGIN/tests/UI/expected-screenshots/*" --exclude=
+
+          # Submodule plugins store expected screenshots in their own repo's LFS.
+          if [ -e "plugins/$PLUGIN/.git" ]; then
+            git -C "plugins/$PLUGIN" lfs pull --include "tests/UI/expected-screenshots/*" --exclude=
+          fi
       - name: running tests
         uses: matomo-org/github-action-tests@main
         with:


### PR DESCRIPTION
### Description

_Won't be able to merge until [https://github.com/matomo-org/tag-manager/pull/1135 is merged] and submodules updated._

When splitting up UI tests I incorrectly prevented sub module UI tests from running.

I've added them back in.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
