### PR TITLE
provide cleaner exception messaging for reports disabled by CNIL

### DIFF
--- a/core/Exception/MessageOnlyException.php
+++ b/core/Exception/MessageOnlyException.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Exception;
+
+/**
+ * Marker for exceptions whose message is complete and safe to show without debug context.
+ */
+interface MessageOnlyException
+{
+}

--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -20,6 +20,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\DataTable;
 use Piwik\DataTable\DataTableInterface;
 use Piwik\Date;
+use Piwik\Exception\MessageOnlyException;
 use Piwik\Http\BadRequestException;
 use Piwik\Log;
 use Piwik\Metrics\Formatter\Html as HtmlFormatter;
@@ -207,7 +208,7 @@ class Visualization extends ViewDataTable
                 'ignoreInScreenWriter' => true,
             ]);
 
-            $message = ExceptionToTextProcessor::getMessageAndWholeBacktrace($e);
+            $message = $this->getLoadingErrorMessage($e);
 
             $loadingError = array('message' => $message);
         }
@@ -274,6 +275,15 @@ class Visualization extends ViewDataTable
         }
 
         return $view->render();
+    }
+
+    private function getLoadingErrorMessage(\Exception $exception): string
+    {
+        if ($exception instanceof MessageOnlyException) {
+            return $exception->getMessage();
+        }
+
+        return ExceptionToTextProcessor::getMessageAndWholeBacktrace($exception);
     }
 
     protected function checkRequestIsNotForMultiplePeriods()

--- a/core/Policy/Exceptions/DisabledByCompliancePolicyException.php
+++ b/core/Policy/Exceptions/DisabledByCompliancePolicyException.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Policy\Exceptions;
+
+use Piwik\Exception\MessageOnlyException;
+
+class DisabledByCompliancePolicyException extends \Exception implements MessageOnlyException
+{
+}

--- a/plugins/DevicesDetection/API.php
+++ b/plugins/DevicesDetection/API.php
@@ -10,12 +10,12 @@
 namespace Piwik\Plugins\DevicesDetection;
 
 use DeviceDetector\Parser\Device\AbstractDeviceParser;
-use Exception;
 use Piwik\Archive;
 use Piwik\DataTable;
 use Piwik\Metrics;
 use Piwik\Piwik;
 use DeviceDetector\Parser\Client\Browser as BrowserParser;
+use Piwik\Policy\Exceptions\DisabledByCompliancePolicyException;
 use Piwik\Site;
 
 /**
@@ -154,7 +154,7 @@ class API extends \Piwik\Plugin\API
 
         // show an error only if none of the requested sites is left
         if (count($idSitesFiltered) === 0 && count($idSites) !== count($idSitesFiltered)) {
-            throw new Exception(Piwik::translate('DevicesDetection_DeviceModelReportDisabledByCompliancePolicy'));
+            throw new DisabledByCompliancePolicyException(Piwik::translate('DevicesDetection_DeviceModelReportDisabledByCompliancePolicy'));
         }
 
         $dataTable = $this->getDataTable('DevicesDetection_models', $idSitesFiltered, $period, $date, $segment);

--- a/plugins/DevicesDetection/tests/System/GoalReportForDevicesTest.php
+++ b/plugins/DevicesDetection/tests/System/GoalReportForDevicesTest.php
@@ -9,11 +9,12 @@
 
 namespace Piwik\Plugins\DevicesDetection\tests\System;
 
-use Exception;
 use Piwik\API\Request;
 use Piwik\DataTable;
+use Piwik\Plugins\DevicesDetection\API as DevicesDetectionApi;
 use Piwik\Plugins\DevicesDetection\tests\Fixtures\MultiDeviceGoalConversions;
 use Piwik\Policy\CnilPolicy;
+use Piwik\Policy\Exceptions\DisabledByCompliancePolicyException;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
 /**
@@ -54,6 +55,11 @@ class GoalReportForDevicesTest extends SystemTestCase
         ]);
 
         return array_values($report->getColumn('label'));
+    }
+
+    private function getModelReportForSiteRequest(string $idSite)
+    {
+        return DevicesDetectionApi::getInstance()->getModel($idSite, 'day', self::$fixture->dateTime);
     }
 
     /**
@@ -152,10 +158,10 @@ class GoalReportForDevicesTest extends SystemTestCase
         $this->setSiteCompliancePolicy(self::$fixture->idSite, true);
 
         try {
-            $this->expectException(Exception::class);
+            $this->expectException(DisabledByCompliancePolicyException::class);
             $this->expectExceptionMessage('Device model report is disabled by compliance policy.');
 
-            $this->getModelLabelsForSiteRequest((string) self::$fixture->idSite);
+            $this->getModelReportForSiteRequest((string) self::$fixture->idSite);
         } finally {
             $this->setSiteCompliancePolicy(self::$fixture->idSite, false);
         }
@@ -167,10 +173,10 @@ class GoalReportForDevicesTest extends SystemTestCase
         $this->setSiteCompliancePolicy(self::$fixture->idSite2, true);
 
         try {
-            $this->expectException(Exception::class);
+            $this->expectException(DisabledByCompliancePolicyException::class);
             $this->expectExceptionMessage('Device model report is disabled by compliance policy.');
 
-            $this->getModelLabelsForSiteRequest(self::$fixture->idSite . ',' . self::$fixture->idSite2);
+            $this->getModelReportForSiteRequest(self::$fixture->idSite . ',' . self::$fixture->idSite2);
         } finally {
             $this->setSiteCompliancePolicy(self::$fixture->idSite, false);
             $this->setSiteCompliancePolicy(self::$fixture->idSite2, false);
@@ -183,10 +189,10 @@ class GoalReportForDevicesTest extends SystemTestCase
         $this->setSiteCompliancePolicy(self::$fixture->idSite2, true);
 
         try {
-            $this->expectException(Exception::class);
+            $this->expectException(DisabledByCompliancePolicyException::class);
             $this->expectExceptionMessage('Device model report is disabled by compliance policy.');
 
-            $this->getModelLabelsForSiteRequest('all');
+            $this->getModelReportForSiteRequest('all');
         } finally {
             $this->setSiteCompliancePolicy(self::$fixture->idSite, false);
             $this->setSiteCompliancePolicy(self::$fixture->idSite2, false);

--- a/plugins/Resolution/API.php
+++ b/plugins/Resolution/API.php
@@ -9,10 +9,10 @@
 
 namespace Piwik\Plugins\Resolution;
 
-use Exception;
 use Piwik\Archive;
 use Piwik\DataTable;
 use Piwik\Piwik;
+use Piwik\Policy\Exceptions\DisabledByCompliancePolicyException;
 use Piwik\Site;
 
 /**
@@ -72,7 +72,7 @@ class API extends \Piwik\Plugin\API
 
         // show an error only if none of the requested sites is left
         if (count($idSitesFiltered) === 0 && count($idSites) !== count($idSitesFiltered)) {
-            throw new Exception(Piwik::translate('Resolution_ScreenResolutionReportDisabledByCompliancePolicy'));
+            throw new DisabledByCompliancePolicyException(Piwik::translate('Resolution_ScreenResolutionReportDisabledByCompliancePolicy'));
         }
 
         $dataTable = $this->getDataTable(Archiver::RESOLUTION_RECORD_NAME, $idSitesFiltered, $period, $date, $segment);

--- a/plugins/Resolution/tests/System/ApiTest.php
+++ b/plugins/Resolution/tests/System/ApiTest.php
@@ -9,12 +9,13 @@
 
 namespace Piwik\Plugins\Resolution\tests\System;
 
-use Exception;
 use Piwik\API\Request;
 use Piwik\Config;
 use Piwik\DataTable;
 use Piwik\Plugins\PrivacyManager\FeatureFlags\PrivacyCompliance;
+use Piwik\Plugins\Resolution\API as ResolutionApi;
 use Piwik\Plugins\Resolution\tests\Fixtures\TwoSitesWithResolutions;
+use Piwik\Policy\Exceptions\DisabledByCompliancePolicyException;
 use Piwik\Policy\PolicyManager;
 use Piwik\Policy\CnilPolicy;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
@@ -64,10 +65,10 @@ class ApiTest extends SystemTestCase
         $this->setComplianceFeatureFlag(true);
         PolicyManager::setPolicyActiveStatus(CnilPolicy::class, true, self::$fixture->idSite);
 
-        $this->expectException(Exception::class);
+        $this->expectException(DisabledByCompliancePolicyException::class);
         $this->expectExceptionMessage('Screen resolution report is disabled by compliance policy.');
 
-        $this->getResolutionLabelsForSiteRequest((string) self::$fixture->idSite);
+        $this->getResolutionReportForSiteRequest((string) self::$fixture->idSite);
     }
 
     /**
@@ -84,6 +85,11 @@ class ApiTest extends SystemTestCase
         ]);
 
         return array_values($report->getColumn('label'));
+    }
+
+    private function getResolutionReportForSiteRequest(string $idSite)
+    {
+        return ResolutionApi::getInstance()->getResolution($idSite, 'day', self::$fixture->dateTime);
     }
 
     private function setComplianceFeatureFlag(bool $enableFlag): void

--- a/plugins/Resolution/tests/System/ResolutionReportTest.php
+++ b/plugins/Resolution/tests/System/ResolutionReportTest.php
@@ -9,11 +9,12 @@
 
 namespace Piwik\Plugins\Resolution\tests\System;
 
-use Exception;
 use Piwik\API\Request;
 use Piwik\DataTable;
+use Piwik\Plugins\Resolution\API as ResolutionApi;
 use Piwik\Plugins\Resolution\tests\Fixtures\MultiSiteResolutionReport;
 use Piwik\Policy\CnilPolicy;
+use Piwik\Policy\Exceptions\DisabledByCompliancePolicyException;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
 /**
@@ -53,6 +54,11 @@ class ResolutionReportTest extends SystemTestCase
         ]);
 
         return array_values($report->getColumn('label'));
+    }
+
+    private function getResolutionReportForSiteRequest(string $idSite)
+    {
+        return ResolutionApi::getInstance()->getResolution($idSite, 'day', self::$fixture->dateTime);
     }
 
     /**
@@ -95,10 +101,10 @@ class ResolutionReportTest extends SystemTestCase
         $this->setSiteCompliancePolicy(self::$fixture->idSite, true);
 
         try {
-            $this->expectException(Exception::class);
+            $this->expectException(DisabledByCompliancePolicyException::class);
             $this->expectExceptionMessage('Screen resolution report is disabled by compliance policy.');
 
-            $this->getResolutionLabelsForSiteRequest((string) self::$fixture->idSite);
+            $this->getResolutionReportForSiteRequest((string) self::$fixture->idSite);
         } finally {
             $this->setSiteCompliancePolicy(self::$fixture->idSite, false);
         }


### PR DESCRIPTION
### Description

Adds a new exception type, MessageOnly, which can be used to only show the message of the exception in the UI, rather than the verbose stack trace.

Use the new exception type to provide cleaner  messaging for Device Model and device resolution reports when they are disabled by CNIL policy. 

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
