### PR TITLE
Fix stale/inaccurate PHPDoc in core/Cookie, CronArchive, DataAccess

### DIFF
--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -134,7 +134,7 @@ class Cookie
      * @param string $Domain
      * @param bool $Secure
      * @param bool $HTTPOnly
-     * @param string $sameSite
+     * @param string|bool|null $sameSite
      */
     protected function setCookie($Name, $Value, $Expires, $Path = '', $Domain = '', $Secure = false, $HTTPOnly = false, $sameSite = false)
     {
@@ -193,7 +193,7 @@ class Cookie
      * Saves the cookie (set the Cookie header).
      * You have to call this method before sending any text to the browser or you would get the
      * "Header already sent" error.
-     * @param string $sameSite Value for SameSite cookie property
+     * @param string|null $sameSite Value for SameSite cookie property
      */
     public function save($sameSite = null)
     {
@@ -348,7 +348,7 @@ class Cookie
      * A cookie has to stay small and its size shouldn't increase over time!
      *
      * @param string $name Name of the value to save; the name will be used to retrieve this value
-     * @param string|number $value Value to save. If null, entry will be deleted from cookie.
+     * @param string|int|float|null $value Value to save. If null, entry will be deleted from cookie.
      */
     public function set($name, $value)
     {
@@ -375,7 +375,7 @@ class Cookie
     /**
      * Returns the value defined by $name from the cookie.
      *
-     * @param string|integer Index name of the value to return
+     * @param string|int $name Index name of the value to return
      * @return mixed  The value if found, false if the value is not found
      */
     public function get($name)
@@ -422,7 +422,7 @@ class Cookie
      * Escape values from the cookie before sending them back to the client
      * (when using the get() method).
      *
-     * @param string $value Value to be escaped
+     * @param mixed $value Value to be escaped
      * @return mixed  The value once cleaned.
      */
     protected static function escapeValue($value)
@@ -480,7 +480,7 @@ class Cookie
 
     /**
      *  extend Cookie by timestamp or sting like + 30 years, + 10 months, default 2 years
-     * @param $time
+     * @param int|string|null $time
      * @return string
      */
     public function formatExpireTime($time = null)

--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -129,7 +129,7 @@ class Cookie
      *
      * @param string $Name Name of cookie
      * @param string $Value Value of cookie
-     * @param int|string $Expires Time the cookie expires
+     * @param int|string|null $Expires Time the cookie expires
      * @param string $Path
      * @param string $Domain
      * @param bool $Secure

--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -134,7 +134,7 @@ class Cookie
      * @param string $Domain
      * @param bool $Secure
      * @param bool $HTTPOnly
-     * @param string|bool|null $sameSite
+     * @param string|false|null $sameSite
      */
     protected function setCookie($Name, $Value, $Expires, $Path = '', $Domain = '', $Secure = false, $HTTPOnly = false, $sameSite = false)
     {

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -793,7 +793,8 @@ class CronArchive
      * @param string $idSite
      * @param string $period
      * @param string $date
-     * @param bool|false $segment
+     * @param string|false $segment
+     * @param string|null $plugin
      * @return string
      */
     private function getVisitsRequestUrl($idSite, $period, $date, $segment = false, $plugin = null)
@@ -904,7 +905,7 @@ class CronArchive
 
     /**
      * @internal
-     * @param $api
+     * @param CoreAdminHomeAPI $api
      */
     public function setApiToInvalidateArchivedReport($api)
     {
@@ -1164,7 +1165,8 @@ class CronArchive
      *
      * Note: this method should only be used in the context of invalidation.
      *
-     * @params Parameters $params The parameters for the archive we want to invalidate.
+     * @param Parameters $params The parameters for the archive we want to invalidate.
+     * @param bool $doNotIncludeTtlInExistingArchiveCheck
      */
     private function canWeSkipInvalidatingBecauseThereIsAUsablePeriod(Parameters $params, $doNotIncludeTtlInExistingArchiveCheck = false): bool
     {
@@ -1412,7 +1414,7 @@ class CronArchive
     }
 
     /**
-     * @return false|string
+     * @return string|int|false
      */
     private function getLastSuccessRunTimestamp()
     {
@@ -1427,7 +1429,7 @@ class CronArchive
     }
 
     /**
-     * @param $idSite
+     * @param int|string $idSite
      * @return array of date strings
      */
     private function getCustomDateRangeToPreProcess($idSite)
@@ -1498,7 +1500,7 @@ class CronArchive
     }
 
     /**
-     * @param $url
+     * @param string $url
      * @return string
      */
     private function makeRequestUrl($url)

--- a/core/CronArchive/ArchiveFilter.php
+++ b/core/CronArchive/ArchiveFilter.php
@@ -157,7 +157,7 @@ class ArchiveFilter
     }
 
     /**
-     * @return null
+     * @return string[]|null
      */
     public function getSegmentsToForce()
     {
@@ -198,7 +198,7 @@ class ArchiveFilter
     }
 
     /**
-     * @return false|string
+     * @return Date[]|false
      */
     public function getRestrictToDateRange()
     {

--- a/core/CronArchive/SharedSiteIds.php
+++ b/core/CronArchive/SharedSiteIds.php
@@ -170,7 +170,7 @@ class SharedSiteIds
     /**
      * Get the next site id that needs to be processed or null if all site ids where processed.
      *
-     * @return int|null
+     * @return int|string|null
      */
     public function getNextSiteId()
     {

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -61,7 +61,6 @@ class ArchiveSelector
      *               - the ts_archived for the latest usable archive
      *               - the doneFlag value for the latest archive
      *               - existing records contained in partial archives, if applicable
-     * @throws Exception
      */
     public static function getArchiveIdAndVisits(ArchiveProcessor\Parameters $params, $minDatetimeArchiveProcessedUTC = false, $includeInvalidated = null)
     {

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -49,14 +49,18 @@ class ArchiveSelector
     }
 
     /**
-     * @param bool $minDatetimeArchiveProcessedUTC deprecated. Will be removed in Matomo 4.
-     * @return array An array with four values:
-     *               - the latest archive ID or false if none
+     * @param bool|string|Date|null $minDatetimeArchiveProcessedUTC deprecated. Will be removed in Matomo 4.
+     * @param bool|null $includeInvalidated true to include archives that are DONE_INVALIDATED, false if only DONE_OK,
+     *                                      null to determine automatically based on $params.
+     * @return array An array with the following values:
+     *               - the latest archive ID(s) or false if none
      *               - the latest visits value for the latest archive, regardless of whether the archive is invalidated or not
      *               - the latest visits converted value for the latest archive, regardless of whether the archive is invalidated or not
      *               - whether there is an archive that exists or not. if this is true and the latest archive is false, it means
      *                 the archive found was not usable (for example, it was invalidated and we are not looking for invalidated archives)
      *               - the ts_archived for the latest usable archive
+     *               - the doneFlag value for the latest archive
+     *               - existing records contained in partial archives, if applicable
      * @throws Exception
      */
     public static function getArchiveIdAndVisits(ArchiveProcessor\Parameters $params, $minDatetimeArchiveProcessedUTC = false, $includeInvalidated = null)
@@ -510,8 +514,9 @@ class ArchiveSelector
      * - the ts_archived for the latest idarchive
      * - the doneFlag value for the latest archive
      *
-     * @param $results
-     * @param $doneFlags
+     * @param array $results
+     * @param array $requestedPluginDoneFlags
+     * @param string $allPluginsDoneFlag
      * @return array
      */
     private static function findArchiveDataWithLatestTsArchived($results, $requestedPluginDoneFlags, $allPluginsDoneFlag)

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -49,7 +49,7 @@ class ArchiveSelector
     }
 
     /**
-     * @param bool|string|Date|null $minDatetimeArchiveProcessedUTC deprecated. Will be removed in Matomo 4.
+     * @param false|int|string|Date|null $minDatetimeArchiveProcessedUTC deprecated. Will be removed in Matomo 4.
      * @param bool|null $includeInvalidated true to include archives that are DONE_INVALIDATED, false if only DONE_OK,
      *                                      null to determine automatically based on $params.
      * @return array An array with the following values:

--- a/core/DataAccess/ArchiveTableCreator.php
+++ b/core/DataAccess/ArchiveTableCreator.php
@@ -144,7 +144,8 @@ class ArchiveTableCreator
     /**
      * Returns all table names archive_*
      *
-     * @param string $type The type of table to return. Either `self::NUMERIC_TABLE` or `self::BLOB_TABLE`.
+     * @param string|null $type The type of table to return. Either `self::NUMERIC_TABLE` or `self::BLOB_TABLE`,
+     *                           or null to return both.
      * @param bool   $forceReload
      * @return array
      */

--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -62,7 +62,8 @@ class ArchiveWriter
     public const DONE_INVALIDATED = 4;
 
     /**
-     * Flag indicating that the archive is
+     * Flag indicating that the archive only contains data for a single requested plugin/report rather
+     * than the full set of reports for the period.
      *
      * @var int
      */

--- a/core/DataAccess/ArchivingDbAdapter.php
+++ b/core/DataAccess/ArchivingDbAdapter.php
@@ -96,7 +96,7 @@ class ArchivingDbAdapter
      * Test error number
      *
      * @param Exception $e
-     * @param string $errno
+     * @param int|string $errno
      * @return bool
      */
     public function isErrNo($e, $errno)

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -1226,6 +1226,7 @@ class LogAggregator
      * @param false|string $where An optional SQL expression used in the SQL's **WHERE** clause.
      * @param array $additionalSelects Additional SELECT fields that are not included in the group by
      *                                 clause. These can be aggregate expressions, eg, `SUM(somecol)`.
+     * @param array $extraFrom Additional tables/joins to merge into the FROM clause alongside log_conversion.
      * @param RankingQuery|null|false $rankingQuery
      * @param bool $rankingQueryGenerate if `true`, generates a SQL query / bind array pair and returns it. If false, the
      *                                   ranking query SQL will be immediately executed and the results returned.

--- a/core/DataAccess/LogQueryBuilder.php
+++ b/core/DataAccess/LogQueryBuilder.php
@@ -37,7 +37,8 @@ class LogQueryBuilder
 
     /**
      * Forces to use a subselect when generating the query.
-     * @var string
+     *
+     * @param string $innerGroupBy
      */
     public function forceInnerGroupBySubselect($innerGroupBy)
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -456,21 +456,6 @@ parameters:
 			path: core/Container/IniConfigDefinitionSource.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with float\\|int\\|string will always evaluate to false\\.$#"
-			count: 1
-			path: core/Cookie.php
-
-		-
-			message: "#^Default value of the parameter \\#8 \\$sameSite \\(false\\) of method Piwik\\\\Cookie\\:\\:setCookie\\(\\) is incompatible with type string\\.$#"
-			count: 1
-			path: core/Cookie.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(string\\|integer Index name of the value to return\\)\\: Unexpected token \"Index\", expected variable at offset 99$#"
-			count: 1
-			path: core/Cookie.php
-
-		-
 			message: "#^Property Piwik\\\\Cookie\\:\\:\\$keyStore \\(string\\) does not accept default value of type false\\.$#"
 			count: 1
 			path: core/Cookie.php
@@ -501,16 +486,6 @@ parameters:
 			path: core/CronArchive.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function urlencode expects string, true given\\.$#"
-			count: 1
-			path: core/CronArchive.php
-
-		-
-			message: "#^Parameter \\#2 \\$minDatetimeArchiveProcessedUTC of static method Piwik\\\\DataAccess\\\\ArchiveSelector\\:\\:getArchiveIdAndVisits\\(\\) expects bool, Piwik\\\\Date\\|null given\\.$#"
-			count: 1
-			path: core/CronArchive.php
-
-		-
 			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int\\<1, max\\> given\\.$#"
 			count: 3
 			path: core/CronArchive.php
@@ -527,11 +502,6 @@ parameters:
 
 		-
 			message: "#^Method Piwik\\\\CronArchive\\\\ArchiveFilter\\:\\:getPeriodsToProcess\\(\\) is unused\\.$#"
-			count: 1
-			path: core/CronArchive/ArchiveFilter.php
-
-		-
-			message: "#^Method Piwik\\\\CronArchive\\\\ArchiveFilter\\:\\:getRestrictToDateRange\\(\\) should return string\\|false but returns array\\<Piwik\\\\Date\\>\\.$#"
 			count: 1
 			path: core/CronArchive/ArchiveFilter.php
 
@@ -571,11 +541,6 @@ parameters:
 			path: core/CronArchive/QueueConsumer.php
 
 		-
-			message: "#^Parameter \\#2 \\$minDatetimeArchiveProcessedUTC of static method Piwik\\\\DataAccess\\\\ArchiveSelector\\:\\:getArchiveIdAndVisits\\(\\) expects bool, Piwik\\\\Date given\\.$#"
-			count: 1
-			path: core/CronArchive/QueueConsumer.php
-
-		-
 			message: "#^Property Piwik\\\\CronArchive\\\\QueueConsumer\\:\\:\\$idSite \\(int\\) does not accept null\\.$#"
 			count: 2
 			path: core/CronArchive/QueueConsumer.php
@@ -601,11 +566,6 @@ parameters:
 			path: core/CronArchive/SharedSiteIds.php
 
 		-
-			message: "#^Call to function is_object\\(\\) with true will always evaluate to false\\.$#"
-			count: 1
-			path: core/DataAccess/ArchiveSelector.php
-
-		-
 			message: "#^Call to method fetch\\(\\) on an unknown class Piwik\\\\Tracker\\\\PDOStatement\\.$#"
 			count: 1
 			path: core/DataAccess/ArchiveSelector.php
@@ -626,11 +586,6 @@ parameters:
 			path: core/DataAccess/ArchiveSelector.php
 
 		-
-			message: "#^Parameter \\#1 \\$dateString of static method Piwik\\\\Date\\:\\:factory\\(\\) expects int\\|Piwik\\\\Date\\|string, true given\\.$#"
-			count: 1
-			path: core/DataAccess/ArchiveSelector.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between int\\|string and null will always evaluate to false\\.$#"
 			count: 1
 			path: core/DataAccess/ArchiveSelector.php
@@ -638,11 +593,6 @@ parameters:
 		-
 			message: "#^If condition is always true\\.$#"
 			count: 1
-			path: core/DataAccess/ArchivingDbAdapter.php
-
-		-
-			message: "#^Parameter \\#2 \\$errno of method Piwik\\\\DataAccess\\\\ArchivingDbAdapter\\:\\:isErrNo\\(\\) expects string, int given\\.$#"
-			count: 2
 			path: core/DataAccess/ArchivingDbAdapter.php
 
 		-
@@ -657,16 +607,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @throws has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 89$#"
-			count: 1
-			path: core/DataAccess/LogQueryBuilder.php
-
-		-
-			message: "#^PHPDoc tag @var above a method has no effect\\.$#"
-			count: 1
-			path: core/DataAccess/LogQueryBuilder.php
-
-		-
-			message: "#^PHPDoc tag @var does not specify variable name\\.$#"
 			count: 1
 			path: core/DataAccess/LogQueryBuilder.php
 
@@ -3692,11 +3632,6 @@ parameters:
 			message: "#^Call to an undefined method Piwik\\\\DataTable\\\\Renderer\\:\\:setRenderImageInline\\(\\)\\.$#"
 			count: 1
 			path: plugins/ScheduledReports/ScheduledReports.php
-
-		-
-			message: "#^Parameter \\#2 \\$minDatetimeArchiveProcessedUTC of static method Piwik\\\\DataAccess\\\\ArchiveSelector\\:\\:getArchiveIdAndVisits\\(\\) expects bool, null given\\.$#"
-			count: 1
-			path: plugins/SegmentEditor/SegmentEditor.php
 
 		-
 			message: "#^Variable \\$endDate in empty\\(\\) always exists and is not falsy\\.$#"


### PR DESCRIPTION
## Summary

Part of an ongoing pass to fix PHPDoc comments across `core/` and `plugins/` (excluding `@api`-tagged classes/methods and `API.php` classes) that no longer match the actual code behavior, or whose `@param`/`@return` annotations are wrong/incomplete.

This PR covers:
- `core/Cookie.php`: `setCookie()`/`save()`'s `$sameSite` params default to `false`/`null` but were typed as always `string`; `set()`'s `$value` used the non-standard "number" alias and didn't allow the `null` case the method explicitly handles; `get()`'s `@param` tag was missing the `$name` token entirely (malformed); `escapeValue()` forwards to a mixed-accepting sanitizer but was typed `string`; `formatExpireTime()`'s `$time` was completely untyped despite three distinct handled types.
- `core/CronArchive.php`: `getVisitsRequestUrl()` was missing a param entirely and used a nonsensical `bool|false` type; an `@params` (plural) typo; a couple of untyped params; `getLastSuccessRunTimestamp()`'s return type was missing a real case.
- `core/CronArchive/ArchiveFilter.php`: `getSegmentsToForce()` was documented as always `null` but returns an array once set; `getRestrictToDateRange()` was documented as `false|string` but actually returns an array of `Date` objects.
- `core/CronArchive/SharedSiteIds.php`: `getNextSiteId()`'s return type was `int|null` but site IDs read back from the persisted queue are strings.
- `core/DataAccess/ArchiveSelector.php`: `getArchiveIdAndVisits()`'s date param was typed `bool` though it's actually a date string/`Date`/`null`; an undocumented param that materially changes behavior; a return array documented with 4 keys when it actually has 7; a stale `@param` on a private helper referencing a local variable that isn't even a real parameter.
- `core/DataAccess/ArchiveTableCreator.php`: a `null`-accepting param typed as non-nullable `string`.
- `core/DataAccess/ArchiveWriter.php`: a constant's docblock description was truncated mid-sentence.
- `core/DataAccess/ArchivingDbAdapter.php`: `isErrNo()`'s `$errno` typed `string` though callers pass int constants.
- `core/DataAccess/LogAggregator.php`: `queryConversionsByDimension()` skipped documenting a parameter in the middle of its signature.
- `core/DataAccess/LogQueryBuilder.php`: a method's docblock used `@var` (a property tag) instead of `@param`/description, left over from a copy-paste.

Several `phpstan-baseline.neon` entries were removed because these fixes resolved real, previously-suppressed PHPStan findings — including ones in files outside this PR's diff (`core/CronArchive/QueueConsumer.php`, `plugins/SegmentEditor/SegmentEditor.php`) that call the fixed methods.

The DataAccess file findings were located with the help of a research pass; each finding was independently re-verified against the actual code before being applied.

## Test plan
- [x] Full-project `phpcbf` + `phpcs` run (not just changed files) — clean
- [x] Full-project `phpstan` run (not just changed files) — clean, no new baseline entries needed
- No behavior change intended; docblock-only fixes

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules