### PR TITLE
Improve validation of expiryInDays parameter

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -40,6 +40,7 @@ use Piwik\Tracker\Cache;
 use Piwik\Url;
 use Piwik\Validators\BaseValidator;
 use Piwik\Validators\NotEmpty;
+use Piwik\Validators\NumberRange;
 
 /**
  * The UsersManager API lets you Manage Users and their permissions to access specific websites.
@@ -119,6 +120,9 @@ class API extends \Piwik\Plugin\API
 
     public const PREFERENCE_DEFAULT_REPORT = 'defaultReport';
     public const PREFERENCE_DEFAULT_REPORT_DATE = 'defaultReportDate';
+
+    public const MIN_INVITE_EXPIRY_IN_DAYS = 1;
+    public const MAX_INVITE_EXPIRY_IN_DAYS = 3650;
 
     /**
      * @var API|null
@@ -822,6 +826,10 @@ class API extends \Piwik\Plugin\API
         if (empty($expiryInDays)) {
             $expiryInDays = GeneralConfig::getConfigValue('default_invite_user_token_expiry_days');
         }
+
+        BaseValidator::check(Piwik::translate('UsersManager_ExpiryInDays'), (int) $expiryInDays, [
+            new NumberRange(self::MIN_INVITE_EXPIRY_IN_DAYS, self::MAX_INVITE_EXPIRY_IN_DAYS),
+        ]);
 
         if (empty($initialIdSite)) {
             throw new \Exception(Piwik::translate("UsersManager_AddUserNoInitialAccessError"));
@@ -1704,6 +1712,10 @@ class API extends \Piwik\Plugin\API
             $this->confirmCurrentUserPassword($passwordConfirmation);
         }
 
+        BaseValidator::check(Piwik::translate('UsersManager_ExpiryInDays'), (int) $expiryInDays, [
+            new NumberRange(self::MIN_INVITE_EXPIRY_IN_DAYS, self::MAX_INVITE_EXPIRY_IN_DAYS),
+        ]);
+
         if (!$this->model->isPendingUser($userLogin)) {
             throw new Exception(Piwik::translate('UsersManager_ExceptionUserDoesNotExist', $userLogin));
         }
@@ -1748,6 +1760,10 @@ class API extends \Piwik\Plugin\API
         if (StaticContainer::get(AuthenticationToken::class)->isSessionToken()) {
             $this->confirmCurrentUserPassword($passwordConfirmation);
         }
+
+        BaseValidator::check(Piwik::translate('UsersManager_ExpiryInDays'), (int) $expiryInDays, [
+            new NumberRange(self::MIN_INVITE_EXPIRY_IN_DAYS, self::MAX_INVITE_EXPIRY_IN_DAYS),
+        ]);
 
         if (!$this->model->isPendingUser($userLogin)) {
             throw new Exception(Piwik::translate('UsersManager_ExceptionUserDoesNotExist', $userLogin));

--- a/plugins/UsersManager/Repository/UserRepository.php
+++ b/plugins/UsersManager/Repository/UserRepository.php
@@ -182,15 +182,25 @@ class UserRepository
         $user['invite_status'] = 'active';
 
         if (!empty($user['invite_expired_at'])) {
-            $inviteExpireAt = Date::factory($user['invite_expired_at']);
-            // if token expired
-            if (Date::now()->isLater($inviteExpireAt)) {
+            try {
+                $inviteExpireAt = Date::factory($user['invite_expired_at']);
+            } catch (\Exception $e) {
+                // invite_expired_at is not a valid, in-range date (e.g. corrupted by a bug in the past);
+                // treat the invite as expired instead of letting the exception break the whole user list
+                $inviteExpireAt = null;
                 $user['invite_status'] = 'expired';
             }
-            // if token not expired
-            if (Date::now()->isEarlier($inviteExpireAt)) {
-                $dayLeft = floor(Date::secondsToDays($inviteExpireAt->getTimestamp() - Date::now()->getTimestamp()));
-                $user['invite_status'] = $dayLeft;
+
+            if ($inviteExpireAt) {
+                // if token expired
+                if (Date::now()->isLater($inviteExpireAt)) {
+                    $user['invite_status'] = 'expired';
+                }
+                // if token not expired
+                if (Date::now()->isEarlier($inviteExpireAt)) {
+                    $dayLeft = floor(Date::secondsToDays($inviteExpireAt->getTimestamp() - Date::now()->getTimestamp()));
+                    $user['invite_status'] = $dayLeft;
+                }
             }
         }
 

--- a/plugins/UsersManager/lang/en.json
+++ b/plugins/UsersManager/lang/en.json
@@ -14,6 +14,7 @@
         "AllWebsites": "All websites",
         "LastUsed": "Last used",
         "ExpireDate": "Expire date",
+        "ExpiryInDays": "Expiry in days",
         "TokenExpireDate": "Token expire date",
         "AuthTokens": "Auth tokens",
         "AuthTokenPurpose": "What are you using this token for?",

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -966,6 +966,22 @@ class APITest extends IntegrationTestCase
         self::assertResultCountHeader(5);
     }
 
+    public function testGetUsersPlusRoleDoesNotThrowWhenInviteExpiredAtIsCorrupted()
+    {
+        $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
+        self::assertTrue($this->model->isPendingUser('pendingLoginTest'));
+
+        // simulate a row corrupted by a bug that stored an out-of-range expiry date directly,
+        // bypassing the API validation (eg. from before this validation existed)
+        $this->model->updateUserFields('pendingLoginTest', ['invite_expired_at' => '0000-00-00 00:00:00']);
+
+        $users = $this->api->getUsersPlusRole(1, null, 0, 'pendingLoginTest');
+
+        self::assertCount(1, $users);
+        self::assertEquals('pendingLoginTest', $users[0]['login']);
+        self::assertEquals('expired', $users[0]['invite_status']);
+    }
+
     public function testGetSitesAccessForUserShouldReturnAccessForUser()
     {
         $this->api->setUserAccess('userLogin', 'admin', [1]);
@@ -1591,6 +1607,34 @@ class APITest extends IntegrationTestCase
         self::assertEquals($expiredDays, $diff / 3600 / 24);
     }
 
+    public function testInviteUserFailsWhenExpiryInDaysIsTooHigh()
+    {
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('UsersManager_ExpiryInDays');
+
+        $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1, 99999);
+    }
+
+    public function testInviteUserFailsWhenExpiryInDaysIsNegative()
+    {
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('UsersManager_ExpiryInDays');
+
+        $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1, -5);
+    }
+
+    public function testInviteUserDoesNotCreateUserWhenExpiryInDaysIsTooHigh()
+    {
+        try {
+            $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1, 99999);
+            self::fail('Expected exception was not thrown');
+        } catch (\Exception $e) {
+            // expected, asserted in testInviteUserFailsWhenExpiryInDaysIsTooHigh()
+        }
+
+        self::assertFalse($this->model->isPendingUser('pendingLoginTest'));
+    }
+
     public function testResendInviteAsSuperUser()
     {
         $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
@@ -1617,6 +1661,26 @@ class APITest extends IntegrationTestCase
         self::expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
 
         $this->api->resendInvite('notExistingUser');
+    }
+
+    public function testResendInviteFailsWhenExpiryInDaysIsTooHigh()
+    {
+        $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
+
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('UsersManager_ExpiryInDays');
+
+        $this->api->resendInvite('pendingLoginTest', 99999);
+    }
+
+    public function testGenerateInviteLinkFailsWhenExpiryInDaysIsTooHigh()
+    {
+        $this->api->inviteUser('pendingLoginTest', 'pendingLoginTest@matomo.org', 1);
+
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('UsersManager_ExpiryInDays');
+
+        $this->api->generateInviteLink('pendingLoginTest', 99999);
     }
 
     public function testResendInviteAsInviterWithAdminAccess()


### PR DESCRIPTION
### Description



### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
