### PR TITLE
Fix flaky SegmentSelectorEditorTest (reload timeout)

### DIFF
--- a/plugins/SegmentEditor/tests/UI/SegmentSelectorEditor_spec.js
+++ b/plugins/SegmentEditor/tests/UI/SegmentSelectorEditor_spec.js
@@ -358,6 +358,11 @@ describe("SegmentSelectorEditorTest", function () {
     });
 
     it("should keep the updated segment name after page reload", async function() {
+        // Reloading re-archives the applied segment (its "is not" definition matches every
+        // visit) and takes ~228s on CI; give this one reload headroom so the 240s default
+        // doesn't abort it mid-flight and cascade into the delete tests (see #24482).
+        this.timeout(360000);
+
         await page.reload();
         await page.waitForSelector('.segmentationContainer .title');
         await page.waitForFunction(() => {

--- a/plugins/SegmentEditor/tests/UI/SegmentSelectorEditor_spec.js
+++ b/plugins/SegmentEditor/tests/UI/SegmentSelectorEditor_spec.js
@@ -310,9 +310,14 @@ describe("SegmentSelectorEditorTest", function () {
         await page.type('input.edit_segment_name', 'edited segment');
         await (await page.jQuery('.segmentRow0 .segment-or:first')).click(); // click somewhere else to save new name
 
-        await selectFieldValue('.segmentRow0 .segment-row:first .metricMatchBlock', 'Is not');
-        await selectFieldValue('.segmentRow0 .segment-row:last .metricMatchBlock', 'Is not');
-        await selectFieldValue('.segmentRow1 .segment-row .metricMatchBlock', 'Is not');
+        // Use "Is" (equals a value nothing has) so the applied segment matches zero visits.
+        // With "Is not" it matched every visit, so the reload below re-archived the whole
+        // 2012 year (~228s) and tipped over Mocha's 240s timeout, cascading into the delete
+        // tests (see #24482). "Is" still changes the definition, so the confirmation modal
+        // this test checks for still fires.
+        await selectFieldValue('.segmentRow0 .segment-row:first .metricMatchBlock', 'Is');
+        await selectFieldValue('.segmentRow0 .segment-row:last .metricMatchBlock', 'Is');
+        await selectFieldValue('.segmentRow1 .segment-row .metricMatchBlock', 'Is');
 
         for (let i = 0; i < 3; i += 1) {
           await page.waitForTimeout(200);
@@ -358,11 +363,6 @@ describe("SegmentSelectorEditorTest", function () {
     });
 
     it("should keep the updated segment name after page reload", async function() {
-        // Reloading re-archives the applied segment (its "is not" definition matches every
-        // visit) and takes ~228s on CI; give this one reload headroom so the 240s default
-        // doesn't abort it mid-flight and cascade into the delete tests (see #24482).
-        this.timeout(360000);
-
         await page.reload();
         await page.waitForSelector('.segmentationContainer .title');
         await page.waitForFunction(() => {

--- a/plugins/SegmentEditor/tests/UI/expected-screenshots/SegmentSelectorEditorTest_autocomplete_capitalized.png
+++ b/plugins/SegmentEditor/tests/UI/expected-screenshots/SegmentSelectorEditorTest_autocomplete_capitalized.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c8ef4d0765dee83d553ba9a0b818ebb0f8877b4c5dff722f474bc87fbec25557
-size 59438
+oid sha256:e1b7074c5fbb5e1ecf79fd4895e806552357f2cc2bd0957c91860bdac4b9f0cb
+size 58798

--- a/plugins/SegmentEditor/tests/UI/expected-screenshots/SegmentSelectorEditorTest_autocomplete_lowercase.png
+++ b/plugins/SegmentEditor/tests/UI/expected-screenshots/SegmentSelectorEditorTest_autocomplete_lowercase.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f4b33548903f20a6848ea7e021955ca9bff8478015795553bc15cb1a6c5b465e
-size 59421
+oid sha256:6132591c15e7f2fef1129fb634adfc62d81da5ab6642218ccd55f0a60361e0a9
+size 58793

--- a/plugins/SegmentEditor/tests/UI/expected-screenshots/SegmentSelectorEditorTest_autocomplete_uppercase.png
+++ b/plugins/SegmentEditor/tests/UI/expected-screenshots/SegmentSelectorEditorTest_autocomplete_uppercase.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a7d367bf6e17fb7375dba443d3237b8d57b9d160c5ae59880b09b9ea5514af8
-size 59449
+oid sha256:878bee32da1d3203b94a4c35f941e5234b62de7f2b8b9b04ea7f891c1ed3cf12
+size 58879


### PR DESCRIPTION
### Description
DEV-20222
Fixes [#24482](https://github.com/matomo-org/matomo/issues/24482)

SegmentSelectorEditorTest fails intermittently. The `should keep the updated segment name after page reload` test reloads the page with the just-edited "edited segment" applied. That segment's definition was three "Is not" conditions on values that don't exist in the fixture, so it matched every visit — and the reload re-archived a full year of data (~228s on CI). That's just under Mocha's 240s timeout, so on a slightly slower runner it tips over: the reload gets killed mid-flight and cascades into the delete tests, so the segment never actually gets deleted. That's what produces the deleted.png and enabled_create_realtime_segments_saved.png diffs in the issue.

The fix removes the slow archive at its source instead of just tolerating it: it flips those three operators from "Is not" to "Is" (equals a value nothing has), so the applied segment now matches zero visits and the reload archives near-instantly. Locally the reload test drops from ~228s to ~2.3s.

This keeps the test's coverage intact:

The change is still a definition change, so the confirmation modal that should show a confirmation modal when changing segment definition checks for still fires.
The reload test only asserts that the segment's name and values survive a reload — it never asserts on archived report data — so a zero-match segment tests exactly what it did before.
Archiving stays enabled everywhere else, so complex_segment (which renders real report data) is unaffected.
I went with this over widening the timeout because a bigger timeout only tolerates the expensive archive (and the flake can resurface elsewhere), whereas this eliminates it; and over disabling archiving via config, because that needs a fragile set of global overrides restored in a finally, versus a one-word change here.

#### Screenshots
Three screenshots are regenerated — autocomplete_lowercase, autocomplete_uppercase, autocomplete_capitalized — because they capture the open editor and the operator dropdowns now read "Is" instead of "Is not". No behavioural coverage changes.

### Testing
Re-ran the UI-plugins (SegmentEditor) suite: the reload test went from ~228s to ~2.3s, and the only screenshot changes are the three autocomplete_* operator-text diffs.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
