### PR TITLE
Auto-retry flaky preview builds up to 3 times before notifying Slack

### DIFF
--- a/.github/workflows/preview-retry-handler.yml
+++ b/.github/workflows/preview-retry-handler.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
   retry_or_notify:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     # Only act on scheduled runs that ended in failure. Manual dispatches
     # of the preview build stay opt-in (no auto-retry, no Slack ping) so
     # engineers can experiment without triggering alerts.
@@ -35,9 +36,11 @@ jobs:
       SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
       SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
       SOURCE_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+      HANDLER_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CORE_ALERT_WEBHOOK_URL }}
     steps:
       - name: Retry failed jobs (attempts 1 and 2 of 3)
+        id: retry
         if: ${{ github.event.workflow_run.run_attempt < 3 }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -45,16 +48,42 @@ jobs:
           echo "Preview build attempt $SOURCE_ATTEMPT of 3 failed. Re-running failed jobs on run $SOURCE_RUN_ID..."
           gh run rerun "$SOURCE_RUN_ID" --failed --repo "${{ github.repository }}"
 
-      - name: Notify Slack after final attempt
-        if: ${{ github.event.workflow_run.run_attempt >= 3 && env.SLACK_WEBHOOK_URL != '' }}
+      # Ping Slack when either the source has hit its 3rd failed attempt OR
+      # the retry step above blew up (rate limit, permission edge, network).
+      # Without the failure() branch, a broken retry would leave the day's
+      # preview build silently unreleased and no one would know.
+      - name: Notify Slack on final failure or broken retry
+        if: |
+          always() &&
+          env.SLACK_WEBHOOK_URL != '' &&
+          (
+            github.event.workflow_run.run_attempt >= 3 ||
+            steps.retry.outcome == 'failure'
+          )
         run: |
+          if [ "${{ steps.retry.outcome }}" = "failure" ]; then
+            HEADLINE="*Preview build retry mechanism failed on attempt $SOURCE_ATTEMPT of 3*"
+            DETAIL="The auto-retry step could not re-run the failed jobs, so the preview build stopped here."
+            TRAILER="\nSource run: ${SOURCE_RUN_URL}\nHandler run (has the retry-step logs): ${HANDLER_RUN_URL}"
+          else
+            HEADLINE="*Preview build has failed for today after 3 attempts!*"
+            DETAIL="<${SOURCE_RUN_URL}|The automated preview build> failed on three consecutive attempts."
+            TRAILER=""
+          fi
+
           PAYLOAD=$(cat <<EOF
-          {"text":"*Preview build has failed for today after 3 attempts!*\n<${SOURCE_RUN_URL}|The automated preview build> failed 3 times in a row.\n*Impact:* Cloud might not get the latest build in the next deployment cycle, so customers may not receive the newest fixes.\nPlease investigate — this is unlikely to be flakiness alone."}
+          {"text":"${HEADLINE}\n${DETAIL}\n*Impact:* Cloud might not get the latest build in the next deployment cycle, so customers may not receive the newest fixes.${TRAILER}"}
           EOF
           )
           curl --fail-with-body -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
 
       - name: Skip Slack notification when webhook is missing
-        if: ${{ github.event.workflow_run.run_attempt >= 3 && env.SLACK_WEBHOOK_URL == '' }}
+        if: |
+          always() &&
+          env.SLACK_WEBHOOK_URL == '' &&
+          (
+            github.event.workflow_run.run_attempt >= 3 ||
+            steps.retry.outcome == 'failure'
+          )
         run: |
           echo "Info: SLACK_CORE_ALERT_WEBHOOK_URL is not configured. Skipping failure notification."

--- a/.github/workflows/preview-retry-handler.yml
+++ b/.github/workflows/preview-retry-handler.yml
@@ -1,0 +1,60 @@
+# Retry / notify handler for the "Build preview release" workflow.
+#
+# The nightly preview build occasionally fails on flaky UI/system tests.
+# Historically every failure fired a Slack alert, and an engineer had to
+# hand-rerun the job. This handler absorbs up to two flaky failures by
+# re-running only the failed jobs, and only pings Slack once the run has
+# failed three times.
+#
+# It has to live in its own workflow (not as a job inside
+# release-preview.yml) because GitHub refuses to rerun a workflow while any
+# of its jobs are still running — a `workflow_run: completed` listener sees
+# the run as complete and is allowed to rerun it.
+
+name: Preview release — retry or notify
+
+on:
+  workflow_run:
+    workflows: ["Build preview release"]
+    types: [completed]
+
+permissions:
+  actions: write   # required to call `gh run rerun`
+  contents: read
+
+jobs:
+  retry_or_notify:
+    runs-on: ubuntu-24.04
+    # Only act on scheduled runs that ended in failure. Manual dispatches
+    # of the preview build stay opt-in (no auto-retry, no Slack ping) so
+    # engineers can experiment without triggering alerts.
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'schedule'
+    env:
+      SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+      SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+      SOURCE_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CORE_ALERT_WEBHOOK_URL }}
+    steps:
+      - name: Retry failed jobs (attempts 1 and 2 of 3)
+        if: ${{ github.event.workflow_run.run_attempt < 3 }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Preview build attempt $SOURCE_ATTEMPT of 3 failed. Re-running failed jobs on run $SOURCE_RUN_ID..."
+          gh run rerun "$SOURCE_RUN_ID" --failed --repo "${{ github.repository }}"
+
+      - name: Notify Slack after final attempt
+        if: ${{ github.event.workflow_run.run_attempt >= 3 && env.SLACK_WEBHOOK_URL != '' }}
+        run: |
+          PAYLOAD=$(cat <<EOF
+          {"text":"*Preview build has failed for today after 3 attempts!*\n<${SOURCE_RUN_URL}|The automated preview build> failed 3 times in a row.\n*Impact:* Cloud might not get the latest build in the next deployment cycle, so customers may not receive the newest fixes.\nPlease investigate — this is unlikely to be flakiness alone."}
+          EOF
+          )
+          curl --fail-with-body -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
+
+      - name: Skip Slack notification when webhook is missing
+        if: ${{ github.event.workflow_run.run_attempt >= 3 && env.SLACK_WEBHOOK_URL == '' }}
+        run: |
+          echo "Info: SLACK_CORE_ALERT_WEBHOOK_URL is not configured. Skipping failure notification."

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -174,33 +174,7 @@ jobs:
       GPG_CERTIFICATE: ${{ secrets.GPG_CERTIFICATE }}
       GPG_CERTIFICATE_PASS: ${{ secrets.GPG_CERTIFICATE_PASS }}
 
-  notify_slack_on_failure:
-    runs-on: ubuntu-24.04
-    needs: [prepare_preview_version, run_matomo_tests, release_preview_version]
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CORE_ALERT_WEBHOOK_URL }}
-    if: |
-      always() &&
-      github.event_name == 'schedule' &&
-      (
-        needs.prepare_preview_version.result == 'failure' ||
-        needs.run_matomo_tests.result == 'failure' ||
-        needs.release_preview_version.result == 'failure'
-      )
-    steps:
-      - name: Notify Slack on failure
-        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
-        env:
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          PAYLOAD=$(cat <<EOF
-          {"text":"*Preview build has failed for today!*\n<${RUN_URL}|The automated preview build> failed to run.\n*Impact:* Cloud might not get the latest build in the next deployment cycle, so customers may not receive the newest fixes.\nPlease investigate and re-run the build if this was flaky until it passes."}
-          EOF
-          )
-
-          curl --fail-with-body -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
-
-      - name: Skip Slack notification when webhook is missing
-        if: ${{ env.SLACK_WEBHOOK_URL == '' }}
-        run: |
-          echo "Info: SLACK_CORE_ALERT_WEBHOOK_URL is not configured. Skipping failure notification."
+  # Slack notifications on failure are handled by the separate
+  # preview-retry-handler.yml workflow, which listens for the completion of
+  # this workflow, auto-reruns failed jobs on attempts 1 and 2, and only
+  # pings Slack after the third failed attempt.

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,5 +1,10 @@
 # Matomo release action for automated PREVIEW releases
 #
+# Slack notifications on failure and automatic retries live in the
+# separate preview-retry-handler.yml workflow, which reacts to this
+# workflow's completion. Attempts 1 and 2 get rerun automatically;
+# only the third failure pings Slack.
+#
 # Required GitHub secrets:
 #
 # GPG_CERTIFICATE  |  ASCII armored or Base64 encoded GPG certificate that is used to create the signatures for the archives
@@ -173,8 +178,3 @@ jobs:
       RELEASE_PASSWORD: ${{ secrets.RELEASE_PASSWORD }}
       GPG_CERTIFICATE: ${{ secrets.GPG_CERTIFICATE }}
       GPG_CERTIFICATE_PASS: ${{ secrets.GPG_CERTIFICATE_PASS }}
-
-  # Slack notifications on failure are handled by the separate
-  # preview-retry-handler.yml workflow, which listens for the completion of
-  # this workflow, auto-reruns failed jobs on attempts 1 and 2, and only
-  # pings Slack after the third failed attempt.


### PR DESCRIPTION
## Description

The nightly `release-preview.yml` build currently pings Slack on every failed run, and an engineer has to hand-rerun the workflow. Most of these failures are flaky UI/system tests (visible in PR CI runs), and the CI/UI suite is being reworked for Matomo 6 anyway. To cut interruptions, this PR makes the preview build absorb up to two flaky retries and only alert Slack once the run has failed three times.

### How it works

1. `release-preview.yml` no longer has its inline `notify_slack_on_failure` job (removed) — a pointer comment replaces it.
2. A new `preview-retry-handler.yml` listens on `workflow_run: completed` for **Build preview release**. When a scheduled preview run finishes in `failure`:
   - **Attempt 1 or 2** → the handler calls `gh run rerun <source_run_id> --failed`, which reruns only the failed jobs (and their dependents). `github.run_attempt` on the source increments to 2, then 3.
   - **Attempt 3** → the handler POSTs the (slightly reworded) failure message to `SLACK_CORE_ALERT_WEBHOOK_URL`.

The handler had to be a separate workflow: an inline retry job inside the same workflow hits `gh run rerun … cannot be rerun; This workflow is already running` because GitHub won't rerun a workflow while any of its jobs are still active. A `workflow_run: completed` listener sees the source run as `completed` and is allowed to rerun it.

The handler ignores manual dispatches (`github.event.workflow_run.event == 'schedule'`), so engineers testing the preview build with `workflow_dispatch` never auto-retry or ping Slack.

### Verification

Because the real workflow builds and releases Matomo, I proved the mechanism on my fork (`caddoo/matomo`) without invoking any build or Slack webhook. The `workflow_run` auto-trigger itself is standard GitHub behavior (well-documented and requires the handler on the default branch — which it will be once this PR merges), so I verified the two pieces that actually matter:

- **`gh run rerun --failed` bumps `github.run_attempt`** on a completed run — exactly what the handler will do from the outside once the source is complete.
- **The `run_attempt < 3` / `>= 3` branching** switches between rerun and notify correctly.

A throwaway test workflow (fake failing job + a decision step mirroring the handler's `if:` gates) was pushed to my fork, then I invoked `gh run rerun --failed` twice from a local shell. All three attempts landed on the same run: [caddoo/matomo run 28639454480](https://github.com/caddoo/matomo/actions/runs/28639454480).

| Attempt | `run_attempt` | Decision the handler logic printed |
|---:|---:|:--|
| 1 | 1 | `DECISION: RERUN — the real handler would call: gh run rerun <run_id> --failed` |
| 2 | 2 | `DECISION: RERUN — the real handler would call: gh run rerun <run_id> --failed` |
| 3 | 3 | `DECISION: NOTIFY SLACK — attempt 3 is the third and final attempt; the real handler would POST to Slack now.` |

Direct log links:

- Attempt 1 decision log: https://github.com/caddoo/matomo/actions/runs/28639454480/attempts/1
- Attempt 2 decision log: https://github.com/caddoo/matomo/actions/runs/28639454480/attempts/2
- Attempt 3 decision log: https://github.com/caddoo/matomo/actions/runs/28639454480/attempts/3

The `SLACK_CORE_ALERT_WEBHOOK_URL` secret was never referenced during verification — the third-attempt step in the test workflow only echoed the decision string; no `curl` to Slack was ever made. The throwaway branch and test workflow file have already been deleted from the fork.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)