### PR TITLE
Fix stale/incomplete PHPDoc in various plugin classes (batch 10)

### DIFF
--- a/core/ReportRenderer/Pdf.php
+++ b/core/ReportRenderer/Pdf.php
@@ -1295,12 +1295,12 @@ class Pdf extends ReportRenderer
     }
 
     /**
-     * Get report attachments, ex. graph images
+     * PDF reports embed graphs directly, so there are never any separate attachments.
      *
      * @param $report
      * @param $processedReports
      * @param $prettyDate
-     * @return array
+     * @return array  Always empty.
      */
     public function getAttachments($report, $processedReports, $prettyDate): array
     {

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -149,7 +149,7 @@ class GoalManager
      * is returned. Otherwise null is returned.
      *
      * @param array $goal
-     * @return bool|null if a goal is matched, a string of the Action URL is returned, or if no goal was matched it returns null
+     * @return string|null The Action URL that triggered the goal, or null if no goal was matched
      */
     public function detectGoalMatch($goal, Action $action, VisitProperties $visitor, Request $request)
     {
@@ -746,12 +746,12 @@ class GoalManager
     }
 
     /**
-     * Helper function used by other record* methods which will INSERT or UPDATE the conversion in the DB
+     * Helper function used by other record* methods which will INSERT the conversion in the DB
      *
      * @param array $conversion
      * @param array $visitInformation
      * @param Action|null $action
-     * @param int|null $convertedGoal
+     * @param array|null $convertedGoal
      * @return bool
      */
     protected function insertNewConversion($conversion, $visitInformation, Request $request, $action, $convertedGoal = null)

--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -120,11 +120,10 @@ class Model
 
 
     /**
-     * Loads the Ecommerce items from the request and records them in the DB
+     * Returns the ecommerce items currently stored in the cart/order for the given visit.
      *
      * @param array $goal
      * @param int   $defaultIdOrder
-     * @throws Exception
      * @return array
      */
     public function getAllItemsCurrentlyInTheCart($goal, $defaultIdOrder)

--- a/core/Tracker/VisitExcluded.php
+++ b/core/Tracker/VisitExcluded.php
@@ -349,13 +349,11 @@ class VisitExcluded
     }
 
     /**
-     * Returns true if the specified user agent should be excluded for the current site or not.
+     * Returns true if the current visit's user agent should be excluded for the current site.
      *
      * Visits whose user agent string contains one of the excluded_user_agents strings for the
      * site being tracked (or one of the global strings) will be excluded. Regular expressions
      * are also supported.
-     *
-     * @internal param string $this ->userAgent The user agent string.
      */
     protected function isUserAgentExcluded(): bool
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1658,10 +1658,6 @@ parameters:
 			count: 1
 			path: core/Tracker/GoalManager.php
 
-		-
-			message: "#^Method Piwik\\\\Tracker\\\\GoalManager\\:\\:detectGoalMatch\\(\\) should return bool\\|null but returns string\\.$#"
-			count: 1
-			path: core/Tracker/GoalManager.php
 
 		-
 			message: "#^Method Piwik\\\\Tracker\\\\GoalManager\\:\\:getRevenue\\(\\) should return float\\|int but returns string\\.$#"
@@ -3478,10 +3474,6 @@ parameters:
 			count: 1
 			path: plugins/Referrers/SearchEngine.php
 
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Referrers\\\\Social\\:\\:getMainUrlFromName\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: plugins/Referrers/Social.php
 
 		-
 			message: "#^Function Piwik\\\\Plugins\\\\Referrers\\\\getReferrerTypeFromShortName\\(\\) should return string but returns int\\.$#"

--- a/plugins/CoreVisualizations/Visualizations/Sparkline.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparkline.php
@@ -29,7 +29,6 @@ class Sparkline extends ViewDataTable
     }
 
     /**
-     * @see ViewDataTable::main()
      * @return mixed
      */
     public function render()

--- a/plugins/CoreVisualizations/Visualizations/Sparklines.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines.php
@@ -65,7 +65,6 @@ class Sparklines extends ViewDataTable
     }
 
     /**
-     * @see ViewDataTable::main()
      * @return mixed
      */
     public function render()

--- a/plugins/Goals/Goals.php
+++ b/plugins/Goals/Goals.php
@@ -271,11 +271,8 @@ class Goals extends \Piwik\Plugin
     }
 
     /**
-     * Returns the Metadata for the Goals plugin API.
-     * The API returns general Goal metrics: conv, conv rate and revenue globally
-     * and for each goal.
-     *
-     * Also, this will update metadata of all other reports that have Goal segmentation
+     * Adds Goal metrics (conversions, conversion rate, revenue) to the metadata of all
+     * other reports that support Goal segmentation.
      */
     public function getReportMetadataEnd(&$reports, $info)
     {

--- a/plugins/Live/Controller.php
+++ b/plugins/Live/Controller.php
@@ -192,7 +192,7 @@ class Controller extends \Piwik\Plugin\Controller
     }
 
     /**
-     * Echo's HTML for visitor profile popup.
+     * Returns the rendered HTML for the visitor profile popup.
      */
     public function getVisitorProfilePopup()
     {

--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -134,7 +134,7 @@ class PrivacyManager extends Plugin
     /**
      * @param DataTable $dataTable
      * @param int|null $logsOlderThan If set, it is assumed that log deletion is enabled with the given amount of days
-     * @return bool|void
+     * @return bool
      */
     public static function haveLogsBeenPurged($dataTable, $logsOlderThan = null)
     {

--- a/plugins/Referrers/Social.php
+++ b/plugins/Referrers/Social.php
@@ -18,7 +18,7 @@ use Piwik\SettingsPiwik;
 use Piwik\Singleton;
 
 /**
- * Contains methods to access search engine definition data.
+ * Contains methods to access social network definition data.
  */
 class Social extends Singleton
 {
@@ -30,9 +30,9 @@ class Social extends Singleton
     protected $definitionList = null;
 
     /**
-     * Returns list of search engines by URL
+     * Returns list of social networks by URL
      *
-     * @return array  Array of ( URL => array( searchEngineName, keywordParameter, path, charset ) )
+     * @return array  Array of ( URL => socialNetworkName )
      */
     public function getDefinitions()
     {
@@ -182,7 +182,7 @@ class Social extends Singleton
      *
      * @param string  $social
      *
-     * @return string
+     * @return string|null
      */
     public function getMainUrlFromName($social)
     {

--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -227,7 +227,7 @@ class SitesManager extends \Piwik\Plugin
     }
 
     /**
-     * Returns whether we should keep URL fragments for a specific site.
+     * Returns the timezone configured for a specific site.
      *
      * @param array $site DB data for the site.
      * @return ?string

--- a/plugins/Transitions/Transitions.php
+++ b/plugins/Transitions/Transitions.php
@@ -73,9 +73,10 @@ class Transitions extends \Piwik\Plugin
     }
 
     /**
-     * Retrieve the period allowed config setting for a site or all sites if null
+     * Retrieve the max period allowed config setting for the given site,
+     * falling back to the general config when no site is given.
      *
-     * @param $idSite
+     * @param int|null $idSite
      */
     public static function getPeriodAllowedConfig($idSite): string
     {

--- a/plugins/UserCountry/LocationProvider.php
+++ b/plugins/UserCountry/LocationProvider.php
@@ -210,7 +210,7 @@ abstract class LocationProvider
     }
 
     /**
-     * Get all lo that are defined by the given plugin.
+     * Get all location providers that are defined by the given plugin.
      *
      * @return LocationProvider[]
      */
@@ -260,8 +260,8 @@ abstract class LocationProvider
      * array(
      *     'geoip2php' => array('id' => 'geoip2php',
      *                          'title' => '...',
-     *                          'desc' => '...',
-     *                          'status' => GeoIp2::BROKEN,
+     *                          'description' => '...',
+     *                          'status' => self::BROKEN,
      *                          'statusMessage' => '...',
      *                          'location' => '...')
      *     'geoip_serverbased' => array(...)

--- a/plugins/UsersManager/UsersManager.php
+++ b/plugins/UsersManager/UsersManager.php
@@ -182,7 +182,9 @@ class UsersManager extends \Piwik\Plugin
     }
 
     /**
-     * Returns true if the password is complex enough (at least 6 characters and max 26 characters)
+     * Returns true if the password string is considered valid. When the credentials sanity check is
+     * disabled, any non-empty password is accepted; otherwise the password must be at least
+     * PASSWORD_MIN_LENGTH characters.
      *
      * @param $input string
      * @return bool

--- a/plugins/VisitsSummary/VisitsSummary.php
+++ b/plugins/VisitsSummary/VisitsSummary.php
@@ -14,11 +14,10 @@ use Piwik\Plugins\CoreHome\Columns\UserId;
 use Piwik\Plugins\VisitsSummary\Reports\Get;
 
 /**
- * Note: This plugin does not hook on Daily and Period Archiving like other Plugins because it reports the
- * very core metrics (visits, actions, visit duration, etc.) which are processed in the Core
- * Day class directly.
- * These metrics can be used by other Plugins so they need to be processed up front.
- *
+ * Note: This plugin does not hook on Daily and Period Archiving like other plugins because it reports the
+ * very core metrics (visits, actions, visit duration, etc.), which are aggregated directly via
+ * LogAggregator/PluginsArchiver ahead of other plugins' archiving.
+ * These metrics can be used by other plugins so they need to be processed up front.
  */
 class VisitsSummary extends \Piwik\Plugin
 {


### PR DESCRIPTION
## Description

Continues the docblock-quality cleanup pass across `core/` and `plugins/` (excluding `@api`-marked classes/methods and submodules). This batch covers 15 non-submodule files.

**Plugin classes:**
- `plugins/VisitsSummary/VisitsSummary.php`: class docblock referenced a "Core Day class" removed years ago; core metrics are now aggregated via `LogAggregator`/`PluginsArchiver`.
- `plugins/Live/Controller.php`: `getVisitorProfilePopup()` returns the rendered HTML, it doesn't echo.
- `plugins/Goals/Goals.php`: `getReportMetadataEnd()` is an `API.getReportMetadata.end` handler that augments other reports' metadata by reference and returns nothing.
- `plugins/UserCountry/LocationProvider.php`: `getLocationProviders()` had a truncated summary; `getAllProviderInfo()`'s example array used a stale `'desc'` key and `GeoIp2::BROKEN`.
- `plugins/PrivacyManager/PrivacyManager.php`: `haveLogsBeenPurged()`'s `@return bool|void` — every path returns bool.
- `plugins/Transitions/Transitions.php`: `getPeriodAllowedConfig()` falls back to the general config when no site is given, not an "all sites" aggregate.
- `plugins/CoreVisualizations/Visualizations/Sparkline.php` + `Sparklines.php`: removed a dangling `@see ViewDataTable::main()` (no such method; the entry point is `render()`).
- `plugins/SitesManager/SitesManager.php`: `getTimezoneFromWebsite()` had a docblock copy-pasted from `shouldKeepURLFragmentsFor()`; it returns the site's timezone.
- `plugins/UsersManager/UsersManager.php`: `isValidPasswordString()` claimed a nonexistent "max 26 characters" limit; it only enforces a minimum length and accepts any non-empty password when the credentials sanity check is disabled.
- `plugins/Referrers/Social.php`: class summary and `getDefinitions()` described "search engines" (copied from `SearchEngine`); this class handles social networks, and `getDefinitions()` returns a `URL => name` map, not a 4-field tuple. `getMainUrlFromName()` returns `null` on no match.

**Core classes:**
- `core/Tracker/Model.php`: `getAllItemsCurrentlyInTheCart()`'s summary was copy-pasted from a record* method; it SELECTs and returns items already in the cart/order.
- `core/Tracker/GoalManager.php`: `detectGoalMatch()`'s `@return` was `bool|null` but it returns the Action URL string (or null); `insertNewConversion()`'s `$convertedGoal` is an array (not `int|null`) and the method only INSERTs.
- `core/Tracker/VisitExcluded.php`: `isUserAgentExcluded()` had a malformed `@internal param` tag documenting a nonexistent parameter.
- `core/ReportRenderer/Pdf.php`: `getAttachments()`'s summary described the HTML renderer's graph-image behavior; the PDF renderer embeds graphs directly and always returns an empty array.

Each fix was verified against the actual method body/callers before being applied. Two return-type corrections (`GoalManager::detectGoalMatch`, `Social::getMainUrlFromName`) each resolved a now-obsolete `phpstan-baseline.neon` entry, confirmed via full-project PHPStan runs.

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Also reviewed locally with `codex review` before pushing.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
