### PR TITLE
Fix stale/incomplete PHPDoc in core and plugin classes (batch 11)

### DIFF
--- a/core/Archive/ArchivePurger.php
+++ b/core/Archive/ArchivePurger.php
@@ -88,7 +88,7 @@ class ArchivePurger
      * table that stores data for `$date`.
      *
      * @param Date $date The date identifying the archive table.
-     * @return int The total number of archive rows deleted (from both the blog & numeric tables).
+     * @return int The total number of archive rows deleted (from both the blob & numeric tables).
      */
     public function purgeInvalidatedArchivesFrom(Date $date)
     {

--- a/core/Archive/ArchiveState.php
+++ b/core/Archive/ArchiveState.php
@@ -23,7 +23,7 @@ class ArchiveState
     public const INVALIDATED = 'invalidated';
 
     /**
-     * @param array{date1: string, date2: string, idsite: string, ts_archived: string} $archiveData
+     * @param array<array{date1: string, date2: string, idsite: string, ts_archived: string}> $archiveData
      * @param array<string, array<int>> $archiveIds archives ids indexed by period
      * @param array<int, array<string, array<int, int>>> $archiveStates archive states indexed by site and period
      */

--- a/core/Archive/DataTableFactory.php
+++ b/core/Archive/DataTableFactory.php
@@ -15,7 +15,7 @@ use Piwik\Segment;
 use Piwik\Site;
 
 /**
- * Creates a DataTable or Set instance based on an array
+ * Creates a DataTable or DataTable\Map instance based on an array
  * index created by DataCollection.
  *
  * This class is only used by DataCollection.
@@ -157,12 +157,13 @@ class DataTableFactory
     }
 
     /**
-     * Creates a DataTable|Set instance using an index of
+     * Creates a DataTable|DataTable\Map instance using an index of
      * archive data.
      *
      * @param array $index @see DataCollection
      * @param array $resultIndices an array mapping metadata names with pretty metadata
      *                             labels.
+     * @param array|null $keyMetadata
      * @return DataTable|DataTable\Map
      */
     public function make($index, $resultIndices, $keyMetadata = null)
@@ -229,7 +230,7 @@ class DataTableFactory
     }
 
     /**
-     * Creates a DataTable|Set instance using an array
+     * Creates a DataTable|DataTable\Map instance using an array
      * of blobs.
      *
      * If only one record is being queried, a single DataTable will

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -359,7 +359,7 @@ class PluginsArchiver
          *
          * @param \Piwik\Plugin\Archiver &$archiver The newly created plugin archiver instance.
          * @param string $pluginName The name of plugin of which archiver instance was created.
-         * @param array $this->params Array containing archive parameters (Site, Period, Date and Segment)
+         * @param Parameters $params Object containing archive parameters (Site, Period, Date and Segment)
          * @param bool false This parameter is deprecated and will be removed.
          */
         Piwik::postEvent('Archiving.makeNewArchiverObject', array($archiver, $pluginName, $this->params, false));

--- a/core/Period/Factory.php
+++ b/core/Period/Factory.php
@@ -66,8 +66,7 @@ abstract class Factory
      *
      * @param string $period `"day"`, `"week"`, `"month"`, `"year"`, `"range"`.
      * @param Date|string $date A date within the period or the range of dates.
-     * @param Date|string $timezone Optional timezone that will be used only when $period is 'range' or $date is 'last|previous'
-     * @throws Exception If `$strPeriod` is invalid or $date is invalid.
+     * @param string $timezone Optional timezone that will be used only when $period is 'range' or $date is 'last|previous'
      * @return \Piwik\Period
      */
     public static function build($period, $date, $timezone = 'UTC')

--- a/core/Period/Year.php
+++ b/core/Period/Year.php
@@ -71,7 +71,7 @@ class Year extends Period
     }
 
     /**
-     * Returns the current period as a string
+     * Returns a list of strings representing the current period (one date per month).
      *
      * @param string $format
      * @return array

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -636,7 +636,7 @@ class Manager
      * @param string $componentName     The name of the component you want to look for. In case you request a
      *                                  component named 'Menu' it'll look for a file named 'Menu.php' within the
      *                                  root of all plugin folders that implement a class named
-     *                                  Piwik\Plugin\$PluginName\Menu.
+     *                                  Piwik\Plugins\$PluginName\Menu.
      * @param string $expectedSubclass  If not empty, a check will be performed whether a found file extends the
      *                                  given subclass. If the requested file exists but does not extend this class
      *                                  a warning will be shown to advice a developer to extend this certain class.
@@ -1049,7 +1049,8 @@ class Manager
     }
 
     /**
-     * Returns an array containing the plugins class names (eg. 'UserCountry' and NOT 'UserCountry')
+     * Returns an array containing the names of all loaded plugins (eg. 'UserCountry' and NOT the
+     * fully qualified class name '\Piwik\Plugins\UserCountry\UserCountry').
      *
      * @return list<string>
      */

--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -629,7 +629,8 @@ class Visualization extends ViewDataTable
     }
 
     /**
-     * Return true if the config for the plug is disabled
+     * Returns true if a segment is applied to the request but segment archiving is disabled for the
+     * requested plugin/module.
      * @return bool
      */
 

--- a/core/Tracker/Db/Mysqli.php
+++ b/core/Tracker/Db/Mysqli.php
@@ -437,8 +437,6 @@ class Mysqli extends Db
     /**
      * Commit Transaction
      * @param $xid
-     * @throws DbException
-     * @internal param TransactionID $string from beginTransaction
      */
     public function commit($xid)
     {
@@ -458,8 +456,6 @@ class Mysqli extends Db
     /**
      * Rollback Transaction
      * @param $xid
-     * @throws DbException
-     * @internal param TransactionID $string from beginTransaction
      */
     public function rollBack($xid)
     {

--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -191,8 +191,7 @@ class Mysql extends Db
      *
      * @param string $sql An SQL SELECT statement.
      * @param mixed $bind Data to bind into SELECT placeholders.
-     * @throws \Piwik\Tracker\Db\DbException
-     * @return string
+     * @return array|false
      */
     public function fetchCol($sql, $bind = array())
     {
@@ -381,8 +380,6 @@ class Mysql extends Db
     /**
      * Commit Transaction
      * @param $xid
-     * @throws DbException
-     * @internal param TransactionID $string from beginTransaction
      */
     public function commit($xid)
     {
@@ -400,8 +397,6 @@ class Mysql extends Db
     /**
      * Rollback Transaction
      * @param $xid
-     * @throws DbException
-     * @internal param TransactionID $string from beginTransaction
      */
     public function rollBack($xid)
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -150,25 +150,6 @@ parameters:
 			count: 1
 			path: core/Archive/ArchivePurger.php
 
-		-
-			message: "#^Offset 'date1' does not exist on string\\.$#"
-			count: 1
-			path: core/Archive/ArchiveState.php
-
-		-
-			message: "#^Offset 'date2' does not exist on string\\.$#"
-			count: 2
-			path: core/Archive/ArchiveState.php
-
-		-
-			message: "#^Offset 'idsite' does not exist on string\\.$#"
-			count: 1
-			path: core/Archive/ArchiveState.php
-
-		-
-			message: "#^Offset 'ts_archived' does not exist on string\\.$#"
-			count: 1
-			path: core/Archive/ArchiveState.php
 
 		-
 			message: "#^Parameter \\#3 \\$archiveIdsFlipped of method Piwik\\\\Archive\\\\ArchiveState\\:\\:checkArchiveStates\\(\\) expects array\\<string, array\\<int, bool\\>\\>, array\\<string, array\\<int, \\(int\\|string\\)\\>\\> given\\.$#"
@@ -1613,15 +1594,6 @@ parameters:
 			count: 1
 			path: core/Tracker/Db/Pdo/Mysql.php
 
-		-
-			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Pdo\\\\Mysql\\:\\:fetchCol\\(\\) should return string but returns array\\|false\\.$#"
-			count: 1
-			path: core/Tracker/Db/Pdo/Mysql.php
-
-		-
-			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Pdo\\\\Mysql\\:\\:fetchCol\\(\\) should return string but returns false\\.$#"
-			count: 1
-			path: core/Tracker/Db/Pdo/Mysql.php
 
 		-
 			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Pdo\\\\Mysql\\:\\:lastInsertId\\(\\) should return int but returns string\\|false\\.$#"
@@ -3523,10 +3495,6 @@ parameters:
 			count: 2
 			path: plugins/SitesManager/API.php
 
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(string Date to set as creation date\\.\\)\\: Unexpected token \"Date\", expected variable at offset 154$#"
-			count: 1
-			path: plugins/SitesManager/Model.php
 
 		-
 			message: "#^Variable \\$id_val might not be defined\\.$#"

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -165,7 +165,7 @@ class VisitRequestProcessor extends RequestProcessor
     }
 
     /**
-     * Determines if the tracker if the current action should be treated as the start of a new visit or
+     * Determines if the current action should be treated as the start of a new visit or
      * an action in an existing visit.
      *
      * Note: public only for tests.
@@ -217,7 +217,7 @@ class VisitRequestProcessor extends RequestProcessor
     }
 
     /**
-     * Returns true if the last action was done during the last 30 minutes
+     * Returns true if the last action was done within the standard visit length.
      * @return bool
      */
     protected function isLastActionInTheSameVisit(VisitProperties $visitProperties, Request $request, $lastKnownVisit)

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -37,13 +37,13 @@ class Model
      * @param $period
      * @param $date
      * @param $segment
+     * @param $offset
      * @param $limit
      * @param $visitorId
      * @param $minTimestamp
      * @param $filterSortOrder
      * @param $checkforMoreEntries
      * @return array
-     * @throws Exception
      */
     public function queryLogVisits($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder, $checkforMoreEntries = false)
     {

--- a/plugins/SegmentEditor/Model.php
+++ b/plugins/SegmentEditor/Model.php
@@ -42,7 +42,7 @@ class Model
     }
 
     /**
-     * Returns all stored segments.
+     * Returns all segments that are enabled for auto archiving.
      *
      * @param bool|int $idSite Whether to return stored segments for a specific idSite, or segments that are available
      *                         for all sites. If supplied, must be a valid site ID.
@@ -131,11 +131,10 @@ class Model
     }
 
     /**
-     * Gets a list of segments that have been deleted in the last week and therefore may have orphaned archives.
+     * Gets a list of segments that have been deleted on or after the given date and therefore may have orphaned archives.
      * @param Date $date Segments deleted on or after this date will be returned.
      * @return array of segments. The segments are only populated with the fields needed for archive invalidation
      * (e.g. definition, enable_only_idsite).
-     * @throws \Exception
      */
     public function getSegmentsDeletedSince(Date $date)
     {

--- a/plugins/SitesManager/Model.php
+++ b/plugins/SitesManager/Model.php
@@ -302,10 +302,9 @@ class Model
     }
 
     /**
-     * Returns the list of alias URLs registered for the given idSite.
-     * The website ID must be valid when calling this method!
+     * Returns all known URLs (main and alias) for all sites, each row containing idsite and url.
      *
-     * @return array list of alias URLs
+     * @return array list of URLs
      */
     public function getAllKnownUrlsForAllSites()
     {
@@ -344,8 +343,8 @@ class Model
     /**
      * Updates the field ts_created for the specified websites.
      *
-     * @param $idSites int[] Id Site to update ts_created
-     * @param string Date to set as creation date.
+     * @param int[] $idSites Site IDs whose ts_created may be updated.
+     * @param string $minDateSql The minimum creation date; sites with a later ts_created are lowered to this value.
      *
      * @ignore
      */

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -29,16 +29,7 @@ use Piwik\Validators\CharacterLength;
 use Piwik\Validators\NotEmpty;
 
 /**
- * The UsersManager API lets you Manage Users and their permissions to access specific websites.
- *
- * You can create users via "addUser", update existing users via "updateUser" and delete users via "deleteUser".
- * There are many ways to list users based on their login "getUser" and "getUsers", their email "getUserByEmail",
- * or which users have permission (view or admin) to access the specified websites "getUsersWithSiteAccess".
- *
- * Existing Permissions are listed given a login via "getSitesAccessFromUser", or a website ID via "getUsersAccessFromSite",
- * or you can list all users and websites for a given permission via "getUsersSitesFromAccess". Permissions are set and updated
- * via the method "setUserAccess".
- * See also the documentation about <a href='https://matomo.org/docs/manage-users/' rel='noreferrer' target='_blank'>Managing Users</a> in Piwik.
+ * Persists and reads users, their auth tokens and their site access from the database backend.
  *
  * @phpstan-type UserRow array{
  *     login: string,
@@ -440,7 +431,7 @@ class Model
      * @param string|null $tokenAuth    The token auth string
      * @param bool $isTokenSecured      True if the token was sent via a secure mechanism (POST request, Auth header)
      *
-     * @return array|bool               An array representing the token record, or null if not found
+     * @return array|bool               An array representing the token record, or false if not found
      * @throws \Exception
      */
     private function getTokenByTokenAuthIfNotExpired(


### PR DESCRIPTION
## Description

Continues the docblock-quality cleanup pass across `core/` and `plugins/` (excluding `@api`-marked classes/methods and submodules). This batch covers 15 files.

**Core:**
- `core/Plugin/Manager.php`: `getLoadedPluginsName()` had a self-contradictory example ("'UserCountry' and NOT 'UserCountry'") and returns plugin names, not class names; `findComponents()` referenced the nonexistent namespace `Piwik\Plugin\$PluginName` (should be `Piwik\Plugins\`).
- `core/Plugin/Visualization.php`: `hasReportSegmentDisabled()`'s summary was garbled ("config for the plug") and inaccurate.
- `core/Period/Factory.php`: `build()`'s `$timezone` is a string, not `Date|string`; removed a stale `@throws` referencing a nonexistent `$strPeriod`.
- `core/Period/Year.php`: `toString()`'s summary claimed a string return but it returns an array.
- `core/Archive/ArchivePurger.php`: "blog" → "blob" typo in a `@return`.
- `core/Archive/DataTableFactory.php`: replaced the legacy "Set" term (now `DataTable\Map`) and documented `make()`'s `$keyMetadata`.
- `core/Archive/ArchiveState.php`: `$archiveData` is a list of row arrays, so the `@param` shape was corrected to `array<array{...}>`.
- `core/ArchiveProcessor/PluginsArchiver.php`: the `Archiving.makeNewArchiverObject` event passes a `Parameters` object, not `array $this->params`.
- `core/Tracker/Db/Mysqli.php` + `core/Tracker/Db/Pdo/Mysql.php`: removed malformed `@internal param ... $string` tags documenting a nonexistent param; `Pdo\Mysql::fetchCol()` returns `array|false`, not `string`.

**Plugins:**
- `plugins/CoreHome/Tracker/VisitRequestProcessor.php`: fixed a duplicated-word typo in `isVisitNew()` and a stale hardcoded "30 minutes" claim (the code uses the configurable visit length).
- `plugins/Live/Model.php`: `queryLogVisits()` docblock was missing `$offset`, misaligning the params.
- `plugins/SegmentEditor/Model.php`: `getSegmentsToAutoArchive()` returns only auto-archive-enabled segments (not "all"); `getSegmentsDeletedSince()` uses the given date, not "the last week".
- `plugins/UsersManager/Model.php`: class docblock was copied from the API class; `getTokenByTokenAuthIfNotExpired()` returns `false` (not `null`) when not found.
- `plugins/SitesManager/Model.php`: `getAllKnownUrlsForAllSites()` docblock was copy-pasted from an alias-URL getter; fixed the malformed `@param` on `updateSiteCreatedTime()`.

Each fix was verified against the actual method body/callers before being applied. Several corrections resolved now-obsolete `phpstan-baseline.neon` entries (7 total: 4 in ArchiveState, 2 fetchCol return-type, 1 SitesManager malformed `@param`), each confirmed via a full-project PHPStan run.

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Also reviewed locally with `codex review` before opening this PR.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
