### PR TITLE
Fix stale/incomplete PHPDoc in core and plugin classes (batch 13)

### DIFF
--- a/core/Access/CapabilitiesProvider.php
+++ b/core/Access/CapabilitiesProvider.php
@@ -39,7 +39,7 @@ class CapabilitiesProvider
              *         $capabilities[] = new MyNewCapability();
              *     }
              *
-             * @param Capability[] $reports An array of reports
+             * @param Capability[] $capabilities An array of capabilities
              * @internal
              */
             Piwik::postEvent('Access.Capability.addCapabilities', array(&$capabilities));
@@ -58,7 +58,7 @@ class CapabilitiesProvider
              *         }
              *     }
              *
-             * @param Capability[] $reports An array of reports
+             * @param Capability[] $capabilities An array of capabilities
              * @internal
              */
             Piwik::postEvent('Access.Capability.filterCapabilities', array(&$capabilities));

--- a/core/DataTable/Filter/PivotByDimension.php
+++ b/core/DataTable/Filter/PivotByDimension.php
@@ -74,7 +74,7 @@ class PivotByDimension extends BaseFilter
      * is used to determine if we can pivot the report and used to fetch intersected tables
      * by segment.
      *
-     * @var Report
+     * @var Report|null
      */
     private $pivotDimensionReport;
 
@@ -112,7 +112,7 @@ class PivotByDimension extends BaseFilter
      * Metadata for the segment of the dimension of the report being pivoted. When
      * fetching intersected tables by segment, this is the segment used.
      *
-     * @var Segment
+     * @var Segment|null
      */
     private $thisReportDimensionSegment;
 

--- a/core/DataTable/Manager.php
+++ b/core/DataTable/Manager.php
@@ -14,7 +14,7 @@ use Piwik\Common;
 use Piwik\DataTable;
 
 /**
- * The DataTable_Manager registers all the instantiated DataTable and provides an
+ * The DataTable\Manager registers all the instantiated DataTable and provides an
  * easy way to access them. This is used to store all the DataTable during the archiving process.
  * At the end of archiving, the ArchiveProcessor will read the stored datatable and record them in the DB.
  */

--- a/core/Db/Adapter/Mysqli.php
+++ b/core/Db/Adapter/Mysqli.php
@@ -199,6 +199,7 @@ class Mysqli extends Zend_Db_Adapter_Mysqli implements AdapterInterface
      * Test error number
      *
      * @param Exception $e
+     * @param \mysqli|null $connection
      * @param string $errno
      * @return bool
      */

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -62,7 +62,7 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     /**
      * Returns connection handle
      *
-     * @return resource
+     * @return \PDO
      */
     public function getConnection()
     {
@@ -273,7 +273,7 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     /**
      * Retrieve client version in PHP style
      *
-     * @return string
+     * @return string|null
      */
     public function getClientVersion()
     {

--- a/core/Plugin/ArchivedMetric.php
+++ b/core/Plugin/ArchivedMetric.php
@@ -32,7 +32,7 @@ class ArchivedMetric extends Metric
     public const AGGREGATION_COUNT_WITH_NUMERIC_VALUE_PREFIX = 'nb_with_';
 
     /**
-     * @var string
+     * @var string|false
      */
     private $aggregation;
 

--- a/core/Plugin/ComponentFactory.php
+++ b/core/Plugin/ComponentFactory.php
@@ -84,7 +84,7 @@ class ComponentFactory
      *
      * @param string $componentTypeClass The fully qualified class name of the component type, eg,
      *                                   `"Piwik\Plugin\Report"`.
-     * @param string $pluginName|false The name of the plugin the component is expected to belong to,
+     * @param string|false $pluginName The name of the plugin the component is expected to belong to,
      *                                 eg, `'DevicesDetection'`.
      * @param callable $predicate
      *

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -621,15 +621,6 @@ parameters:
 			count: 1
 			path: core/DataTable/Filter/PivotByDimension.php
 
-		-
-			message: "#^Property Piwik\\\\DataTable\\\\Filter\\\\PivotByDimension\\:\\:\\$pivotDimensionReport \\(Piwik\\\\Plugin\\\\Report\\) in empty\\(\\) is not falsy\\.$#"
-			count: 1
-			path: core/DataTable/Filter/PivotByDimension.php
-
-		-
-			message: "#^Property Piwik\\\\DataTable\\\\Filter\\\\PivotByDimension\\:\\:\\$thisReportDimensionSegment \\(Piwik\\\\Plugin\\\\Segment\\) in empty\\(\\) is not falsy\\.$#"
-			count: 1
-			path: core/DataTable/Filter/PivotByDimension.php
 
 		-
 			message: "#^Parameter \\$doSortBySecondaryColumn of method Piwik\\\\DataTable\\\\Filter\\\\Sort\\:\\:__construct\\(\\) has invalid type Piwik\\\\DataTable\\\\Filter\\\\callback\\.$#"
@@ -731,10 +722,6 @@ parameters:
 			count: 1
 			path: core/Db/Adapter/Pdo/Mysql.php
 
-		-
-			message: "#^Method Piwik\\\\Db\\\\Adapter\\\\Pdo\\\\Mysql\\:\\:getClientVersion\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: core/Db/Adapter/Pdo/Mysql.php
 
 		-
 			message: "#^Parameter \\#2 \\$errno of method Piwik\\\\Db\\\\Adapter\\\\Pdo\\\\Mysql\\:\\:isErrNo\\(\\) expects string, int given\\.$#"
@@ -2381,10 +2368,6 @@ parameters:
 			count: 1
 			path: plugins/CoreHome/Controller.php
 
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\\\Piwik\\\\View \\(the popover_rowevolution template\\)\\)\\: Unexpected token \"\\(\", expected variable at offset 117$#"
-			count: 1
-			path: plugins/CoreHome/DataTableRowAction/RowEvolution.php
 
 		-
 			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(mixed\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
@@ -2536,10 +2519,6 @@ parameters:
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Graph.php
 
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\CoreVisualizations\\\\Visualizations\\\\HtmlTable\\:\\:getCellHtmlAttributes\\(\\) should return array but returns null\\.$#"
-			count: 1
-			path: plugins/CoreVisualizations/Visualizations/HtmlTable.php
 
 		-
 			message: "#^Property Piwik\\\\Plugin\\\\Visualization\\:\\:\\$report \\(Piwik\\\\Plugin\\\\Report\\) in empty\\(\\) is not falsy\\.$#"
@@ -3643,10 +3622,6 @@ parameters:
 			count: 1
 			path: plugins/UsersManager/NewsletterSignup.php
 
-		-
-			message: "#^PHPDoc tag @return with type mixed is not subtype of native type array\\.$#"
-			count: 1
-			path: plugins/UsersManager/Repository/UserRepository.php
 
 		-
 			message: "#^Property Piwik\\\\Plugins\\\\UsersManager\\\\Sql\\\\UserTableFilter\\:\\:\\$filterByRole \\(string\\) does not accept null\\.$#"

--- a/plugins/Actions/Actions/ActionSiteSearch.php
+++ b/plugins/Actions/Actions/ActionSiteSearch.php
@@ -20,8 +20,7 @@ use Piwik\UrlHelper;
  * This class represents a search on the site.
  * - Its name is the search keyword
  * - by default the URL is not recorded (since it's not used)
- * - tracks site search result count and site search category as custom variables
- *
+ * - tracks site search result count and site search category
  */
 class ActionSiteSearch extends Action
 {

--- a/plugins/CoreHome/DataTableRowAction/RowEvolution.php
+++ b/plugins/CoreHome/DataTableRowAction/RowEvolution.php
@@ -172,7 +172,7 @@ class RowEvolution
     /**
      * Render the popover
      * @param \Piwik\Plugins\CoreHome\Controller $controller
-     * @param \Piwik\View (the popover_rowevolution template)
+     * @param \Piwik\View $view the popover_rowevolution template
      * @return string
      */
     public function renderPopover($controller, $view)

--- a/plugins/CorePluginsAdmin/CorePluginsAdmin.php
+++ b/plugins/CorePluginsAdmin/CorePluginsAdmin.php
@@ -46,9 +46,9 @@ class CorePluginsAdmin extends Plugin
     }
 
     /**
-     * Remove any changes from a plugin that has been uninstalled
+     * Remove any changes from a plugin that has been deactivated
      *
-     * @param string $pluginName The name of the plugin that was uninstalled
+     * @param string $pluginName The name of the plugin that was deactivated
      */
     public function removePluginChanges(string $pluginName)
     {

--- a/plugins/CoreVisualizations/Visualizations/HtmlTable.php
+++ b/plugins/CoreVisualizations/Visualizations/HtmlTable.php
@@ -261,7 +261,7 @@ class HtmlTable extends Visualization
      * Override to compute a custom cell HTML attributes (such as style).
      *
      * @param $column
-     * @return array Array of name => value pairs.
+     * @return array|null Array of name => value pairs, or null if no custom attributes.
      */
     public function getCellHtmlAttributes(Row $row, $column)
     {

--- a/plugins/CustomDimensions/Dao/LogTable.php
+++ b/plugins/CustomDimensions/Dao/LogTable.php
@@ -45,7 +45,7 @@ class LogTable
     }
 
     /**
-     * @see getHighestCustomDimensionIndex()
+     * @see getInstalledIndexes()
      * @return int
      */
     public function getNumInstalledIndexes()

--- a/plugins/CustomJsTracker/TrackerUpdater.php
+++ b/plugins/CustomJsTracker/TrackerUpdater.php
@@ -40,7 +40,7 @@ class TrackerUpdater
     private $trackerFiles = array();
 
     /**
-     * @param string|null $fromFile If null then the minified JS tracker file in /js fill be used
+     * @param string|null $fromFile If null then the minified JS tracker file in /js will be used
      * @param string|null $toFile If null then the minified JS tracker will be updated.
      */
     public function __construct($fromFile = null, $toFile = null)

--- a/plugins/Monolog/Formatter/LineMessageFormatter.php
+++ b/plugins/Monolog/Formatter/LineMessageFormatter.php
@@ -17,7 +17,7 @@ use Monolog\Formatter\FormatterInterface;
 class LineMessageFormatter implements FormatterInterface
 {
     /**
-     * The log message format string that turns a tag name, date-time and message into
+     * The log message format string that turns a tag name, date-time, level, trace and message into
      * one string to log.
      *
      * @var string

--- a/plugins/UsersManager/Repository/UserRepository.php
+++ b/plugins/UsersManager/Repository/UserRepository.php
@@ -240,7 +240,7 @@ class UserRepository
 
     /**
      * @param array $users
-     * @return mixed
+     * @return array
      * @throws \Exception
      */
     public function enrichUsers(array $users): array


### PR DESCRIPTION
## Description

Continues the docblock-quality cleanup pass across `core/` and `plugins/` (excluding `@api`-marked classes/methods and submodules). This batch covers 15 files.

**Core:**
- `core/Db/Adapter/Pdo/Mysql.php`: `getConnection()` returns the PDO connection object (not a `resource`); `getClientVersion()` can return `null`.
- `core/Access/CapabilitiesProvider.php`: both `addCapabilities`/`filterCapabilities` event docblocks documented `@param Capability[] $reports` but post `$capabilities`.
- `core/DataTable/Manager.php`: class docblock referenced the old `DataTable_Manager` name.
- `core/Plugin/ComponentFactory.php`: `getComponentIf()` had a malformed `@param string $pluginName|false`.
- `core/Plugin/ArchivedMetric.php`: `$aggregation` defaults to `false`, so its `@var` is `string|false`.
- `core/Db/Adapter/Mysqli.php`: `isMysqliErrorNumber()` skipped documenting its middle `$connection` param.
- `core/DataTable/Filter/PivotByDimension.php`: `$pivotDimensionReport` (from `Report::getForDimension()`, which returns `Report|null`) and `$thisReportDimensionSegment` (set conditionally) are nullable; both `@var` corrected.

**Plugins:**
- `plugins/CoreVisualizations/Visualizations/HtmlTable.php`: `getCellHtmlAttributes()` returns `null` in the base class, so `@return` is `array|null`.
- `plugins/CoreHome/DataTableRowAction/RowEvolution.php`: `renderPopover()`'s `@param` omitted the `$view` variable name.
- `plugins/CorePluginsAdmin/CorePluginsAdmin.php`: `removePluginChanges()` is a `pluginDeactivated` handler ("uninstalled" → "deactivated").
- `plugins/CustomDimensions/Dao/LogTable.php`: `getNumInstalledIndexes()`'s `@see` pointed at a nonexistent `getHighestCustomDimensionIndex()`.
- `plugins/CustomJsTracker/TrackerUpdater.php`: constructor docblock typo ("fill" → "will").
- `plugins/Actions/Actions/ActionSiteSearch.php`: class docblock claimed search count/category are stored as custom variables (no longer true).
- `plugins/Monolog/Formatter/LineMessageFormatter.php`: `$logMessageFormat` also incorporates the level and trace placeholders.
- `plugins/UsersManager/Repository/UserRepository.php`: `enrichUsers()`'s `@return mixed` contradicted its native `: array` return.

Each fix was verified against the actual method body/callers before being applied. Several corrections resolved now-obsolete `phpstan-baseline.neon` entries (2 for `PivotByDimension`), each confirmed via a full-project PHPStan run.

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Also reviewed locally with `codex review` before opening this PR.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
