### PR TITLE
Docblock quality fixes (chunk 14)

### DIFF
--- a/core/DataArray.php
+++ b/core/DataArray.php
@@ -302,7 +302,7 @@ class DataArray
      *
      * @param $label
      * @param $row
-     * @throws Exception if the the data row contains non numeric values
+     * @throws Exception if the data row contains non numeric values
      */
     public function sumMetrics($label, $row)
     {

--- a/core/ReportRenderer.php
+++ b/core/ReportRenderer.php
@@ -131,7 +131,7 @@ abstract class ReportRenderer extends BaseFactory
 
     /**
      * Render the provided report.
-     * Multiple calls to this method before calling outputRendering appends each report content.
+     * Multiple calls to this method before calling getRenderedReport appends each report content.
      *
      * @param array $processedReport @see API::getProcessedReport()
      */

--- a/core/ReportRenderer/Csv.php
+++ b/core/ReportRenderer/Csv.php
@@ -104,7 +104,7 @@ class Csv extends ReportRenderer
 
     /**
      * Render the provided report.
-     * Multiple calls to this method before calling outputRendering appends each report content.
+     * Multiple calls to this method before calling getRenderedReport appends each report content.
      *
      * @param array $processedReport @see API::getProcessedReport()
      */

--- a/core/Scheduler/Scheduler.php
+++ b/core/Scheduler/Scheduler.php
@@ -301,8 +301,8 @@ class Scheduler
      * @param string $className The name of the class that contains the scheduled task method.
      * @param string $methodName The name of the scheduled task method.
      * @param string|null $methodParameter Optional method parameter.
-     * @return mixed int|bool The time in milliseconds when the scheduled task will be executed
-     *                        next or false if it is not scheduled to run.
+     * @return int|false The time (in seconds since the Unix epoch) when the scheduled task will be
+     *                   executed next, or false if it is not scheduled to run.
      */
     public function getScheduledTimeForMethod($className, $methodName, $methodParameter = null)
     {

--- a/core/SettingsServer.php
+++ b/core/SettingsServer.php
@@ -198,7 +198,7 @@ class SettingsServer
      * Prior to PHP 5.2.1, or on Windows, --enable-memory-limit is not a
      * compile-time default, so ini_get('memory_limit') may return false.
      *
-     * @return int|bool  memory limit in megabytes, or false if there is no limit
+     * @return int|float|string|false  memory limit in megabytes, or false if there is no limit
      */
     public static function getMemoryLimitValue()
     {
@@ -213,7 +213,7 @@ class SettingsServer
     /**
      * Get php post_max_size (in Megabytes)
      *
-     * @return int|bool  max upload size in megabytes, or false if there is no limit
+     * @return int|float|string|false  max upload size in megabytes, or false if there is no limit
      */
     public static function getPostMaxUploadSize()
     {
@@ -228,7 +228,7 @@ class SettingsServer
     /**
      * @see https://www.php.net/manual/en/faq.using.php#faq.using.shorthandbytes
      * @param $value
-     * @return false|float|int
+     * @return false|float|int|string
      */
     private static function getMegaBytesFromShorthandByte($value)
     {

--- a/core/Tracker/Cache.php
+++ b/core/Tracker/Cache.php
@@ -258,7 +258,7 @@ class Cache
     /**
      * Delete existing Tracker cache
      *
-     * @param string|int $idSite (website ID of the site to clear cache for
+     * @param string|int $idSite website ID of the site to clear cache for
      */
     public static function deleteCacheWebsiteAttributes($idSite)
     {

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -576,7 +576,7 @@ class Request
     }
 
     /**
-     * Returns true if the timestamp is valid ie. timestamp is sometime in the last 10 years and is not in the future.
+     * Returns true if the timestamp is valid ie. timestamp is sometime in the last 20 years and is not in the future.
      *
      * @param $time int Timestamp to test
      * @param $now int Current timestamp

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -466,7 +466,7 @@ class Visit implements VisitInterface
     /**
      * @param VisitDimension[] $dimensions
      * @param string $hook
-     * @param array|null $valuesToUpdate If null, $this->visitorInfo will be updated
+     * @param array|null $valuesToUpdate If null, $this->visitProperties will be updated
      *
      * @return array|null The updated $valuesToUpdate or null if no $valuesToUpdate given
      */

--- a/core/ViewDataTable/Manager.php
+++ b/core/ViewDataTable/Manager.php
@@ -32,7 +32,7 @@ class Manager
     /**
      * Returns the viewDataTable IDs of a visualization's class lineage.
      *
-     * @see self::getVisualizationClassLineage
+     * @see \Piwik\Common::getClassLineage
      *
      * @param string $klass The visualization class.
      *

--- a/plugins/API/DataTable/MergeDataTables.php
+++ b/plugins/API/DataTable/MergeDataTables.php
@@ -28,8 +28,8 @@ class MergeDataTables
      * Merge the columns of two data tables. Only takes into consideration the first row of each table.
      * Manipulates the first table.
      *
-     * @param DataTable|DataTable\Map $table1 The table to eventually filter.
-     * @param DataTable|DataTable\Map $table2 Whether to delete rows with no visits or not.
+     * @param DataTable|DataTable\Map $table1 The table that is manipulated in place and receives the merged columns.
+     * @param DataTable|DataTable\Map $table2 The table whose (first row's) columns are merged into $table1.
      */
     public function mergeDataTables($table1, $table2)
     {

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -127,7 +127,7 @@ class ProcessedReport
     }
 
     /**
-     * Verfies whether the given report exists for the given site.
+     * Verifies whether the given report exists for the given site.
      *
      * @param int $idSite
      * @param string $apiMethodUniqueId  For example 'MultiSites_getAll'
@@ -142,7 +142,7 @@ class ProcessedReport
     }
 
     /**
-     * Verfies whether the given metric belongs to the given report.
+     * Verifies whether the given metric belongs to the given report.
      *
      * @param int $idSite
      * @param string $metric     For example 'nb_visits'

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -31,7 +31,7 @@ use Piwik\Plugins\PrivacyManager\Config as PrivacyManagerConfig;
  * This RequestProcessor exposes the following metadata for the **CoreHome** plugin:
  *
  * * **visitorId**: A hash that identifies the current visitor being tracked. This value is
- *                  calculated using the Piwik\Tracker\Settings;:getConfigId() method.
+ *                  calculated using the Piwik\Tracker\Settings::getConfigId() method.
  *
  *                  Set in `processRequestParams()`.
  *

--- a/plugins/Installation/FormDatabaseSetup.php
+++ b/plugins/Installation/FormDatabaseSetup.php
@@ -136,8 +136,7 @@ class FormDatabaseSetup extends QuickForm2
     /**
      * Creates database object based on form data.
      *
-     * @throws Exception|Zend_Db_Adapter_Exception
-     * @return array The database connection info. Can be passed into Piwik::createDatabaseObject.
+     * @return array The database connection info. Can be passed into Db::createDatabaseObject.
      */
     public function createDatabaseObject()
     {

--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -142,7 +142,7 @@ class Auth implements \Piwik\Auth
     /**
      * Returns the login of the user being authenticated.
      *
-     * @return string
+     * @return ?string
      */
     public function getLogin()
     {
@@ -162,7 +162,7 @@ class Auth implements \Piwik\Auth
     /**
      * Returns the secret used to calculate a user's token auth.
      *
-     * @return string
+     * @return ?string
      */
     public function getTokenAuthSecret()
     {

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -129,7 +129,7 @@ class DataSubjects
          *         $result['myplugin'] = $numDeletes;
          *     }
          *
-         * @param array &$results An array storing the result of how much data was deleted for .
+         * @param array &$results An array storing the result of how much data was deleted for each plugin.
          * @param array &$visits An array with multiple visit entries containing an idvisit and idsite each. The data
          *                       for these visits is requested to be deleted.
          */


### PR DESCRIPTION
## Description

Continues the docblock quality cleanup series (chunk 14). This chunk fixes 15 existing docblocks across `core/` and `plugins/` where the PHPDoc did not match the actual code behavior. Changes are documentation-only — no code behavior changes.

Fixes in this chunk:

- **core/DataArray.php** — remove duplicated word ("the the") in `sumMetrics()` `@throws` text.
- **core/ReportRenderer.php** / **core/ReportRenderer/Csv.php** — correct a stale method reference (`outputRendering` → `getRenderedReport`, the method that actually exists).
- **core/Scheduler/Scheduler.php** — `getScheduledTimeForMethod()` returned a malformed `@return mixed int|bool ... milliseconds`; the value is a Unix timestamp in seconds or `false`, now documented as `int|false`.
- **core/SettingsServer.php** — `getMemoryLimitValue()` / `getPostMaxUploadSize()` (and the shared `getMegaBytesFromShorthandByte()` helper) can return `int`, `float`, a numeric `string` (the `M`/`m` shorthand branch) or `false`; return docs corrected accordingly.
- **core/Tracker/Cache.php** — remove a stray unclosed parenthesis in a `@param` description.
- **core/Tracker/Request.php** — `isTimestampValid()` summary said "last 10 years" but the code allows the last 20 years.
- **core/Tracker/Visit.php** — `triggerHookOnDimensions()` referenced a non-existent `$this->visitorInfo`; the code updates `$this->visitProperties`.
- **core/ViewDataTable/Manager.php** — fix a stale `@see self::getVisualizationClassLineage` (no such method) → `\Piwik\Common::getClassLineage`.
- **plugins/API/DataTable/MergeDataTables.php** — `$table1`/`$table2` `@param` descriptions were stale copy-paste ("Whether to delete rows with no visits or not."); corrected to describe the merge.
- **plugins/API/ProcessedReport.php** — fix "Verfies" → "Verifies" typo in two method summaries.
- **plugins/CoreHome/Tracker/VisitRequestProcessor.php** — fix a broken scope-resolution reference (`Settings;:getConfigId()` → `Settings::getConfigId()`).
- **plugins/Installation/FormDatabaseSetup.php** — `@return` referenced a non-existent `Piwik::createDatabaseObject`; the method lives on `Db`.
- **plugins/Login/Auth.php** — `getLogin()` / `getTokenAuthSecret()` can return `null` (matching the `\Piwik\Auth` interface); return type corrected to `?string`.
- **plugins/PrivacyManager/Model/DataSubjects.php** — complete a truncated `@param` description ("for ." → "for each plugin.") in the `PrivacyManager.deleteDataSubjects` event docblock.

## Review

PHPStan (full run) and PHPCS pass. A local review pass was also run before opening this PR.

## Refs

n/a

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
