### PR TITLE
Docblock quality fixes (chunk 15)

### DIFF
--- a/core/AssetManager.php
+++ b/core/AssetManager.php
@@ -63,7 +63,7 @@ class AssetManager extends Singleton
     private $minimalStylesheetFetcher;
 
     /**
-     * @var Theme
+     * @var Theme|null
      */
     private $theme;
 

--- a/core/AssetManager/UIAssetFetcher.php
+++ b/core/AssetManager/UIAssetFetcher.php
@@ -31,13 +31,13 @@ abstract class UIAssetFetcher
     protected $plugins;
 
     /**
-     * @var Theme
+     * @var Theme|null
      */
     private $theme;
 
     /**
      * @param string[] $plugins
-     * @param Theme $theme
+     * @param Theme|null $theme
      */
     public function __construct($plugins, $theme)
     {
@@ -142,7 +142,7 @@ abstract class UIAssetFetcher
     }
 
     /**
-     * @return Theme
+     * @return Theme|null
      */
     public function getTheme()
     {

--- a/core/CliMulti/CliPhp.php
+++ b/core/CliMulti/CliPhp.php
@@ -103,7 +103,7 @@ class CliPhp
 
     /**
      * @param string $bin PHP binary
-     * @return string
+     * @return string|null
      */
     private function getPhpVersion($bin)
     {

--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -45,7 +45,7 @@ class Cookie
     protected $path = '';
 
     /**
-     * @var string
+     * @var bool|string
      */
     protected $keyStore = false;
 

--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -152,7 +152,7 @@ class ArchiveWriter
      * @param string $name
      * @param string|string[] $values  A blob string or an array of blob strings. If an array
      *                                 is used, the first element in the array will be inserted
-     *                                 with the `$name` name. The others will be splitted into chunks. All subtables
+     *                                 with the `$name` name. The others will be split into chunks. All subtables
      *                                 within one chunk will be serialized as an array where the index is the
      *                                 subtableId.
      */

--- a/core/Plugin/MetadataLoader.php
+++ b/core/Plugin/MetadataLoader.php
@@ -21,7 +21,7 @@ require_once PIWIK_INCLUDE_PATH . '/core/Version.php';
 
 /**
  * Loads plugin metadata found in the following files:
- * - piwik.json
+ * - plugin.json
  */
 class MetadataLoader
 {

--- a/core/Tracker/TableLogAction.php
+++ b/core/Tracker/TableLogAction.php
@@ -168,8 +168,7 @@ class TableLogAction
      * @param string $sqlField
      * @param string $matchType
      * @param string $segmentName
-     * @throws \Exception
-     * @return array|int|string
+     * @return array|int|string|null
      */
     public static function getIdActionFromSegment($valueToMatch, $sqlField, $matchType, $segmentName)
     {

--- a/core/Tracker/Visit/Factory.php
+++ b/core/Tracker/Visit/Factory.php
@@ -17,8 +17,8 @@ use Exception;
 class Factory
 {
     /**
-     * Returns the Tracker_Visit object.
-     * This method can be overwritten to use a different Tracker_Visit object
+     * Returns the Visit object.
+     * This method can be overwritten to use a different Visit object
      *
      * @throws Exception
      * @return \Piwik\Tracker\Visit

--- a/core/Updater/Migration/Db/BatchInsert.php
+++ b/core/Updater/Migration/Db/BatchInsert.php
@@ -13,7 +13,7 @@ use Piwik\Db;
 use Piwik\Updater\Migration;
 
 /**
- * Inserts a new record into an existing table.
+ * Inserts multiple records into an existing table.
  *
  * @see Factory::batchInsert()
  * @see Db\BatchInsert::tableInsertBatch()

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -241,10 +241,6 @@ parameters:
 			count: 1
 			path: core/AssetManager.php
 
-		-
-			message: "#^Parameter \\#3 \\$theme of class Piwik\\\\AssetManager\\\\UIAssetFetcher\\\\StaticUIAssetFetcher constructor expects Piwik\\\\Theme, null given\\.$#"
-			count: 2
-			path: core/AssetManager.php
 
 		-
 			message: "#^Property Piwik\\\\AssetManager\\\\UIAsset\\\\OnDiskUIAsset\\:\\:\\$relativeRootDir \\(string\\) in isset\\(\\) is not nullable\\.$#"
@@ -261,25 +257,13 @@ parameters:
 			count: 1
 			path: core/AssetManager/UIAssetFetcher.php
 
-		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: core/AssetManager/UIAssetFetcher/JScriptUIAssetFetcher.php
 
 		-
 			message: "#^Parameter \\#3 \\$pending of static method Piwik\\\\Piwik\\:\\:postEvent\\(\\) expects bool, null given\\.$#"
 			count: 1
 			path: core/AssetManager/UIAssetFetcher/JScriptUIAssetFetcher.php
 
-		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: core/AssetManager/UIAssetFetcher/StylesheetUIAssetFetcher.php
 
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: core/AssetManager/UIAssetMerger.php
 
 		-
 			message: "#^Parameter \\#3 \\$pending of static method Piwik\\\\Piwik\\:\\:postEvent\\(\\) expects bool, null given\\.$#"
@@ -386,20 +370,6 @@ parameters:
 			count: 1
 			path: core/Container/IniConfigDefinitionSource.php
 
-		-
-			message: "#^Property Piwik\\\\Cookie\\:\\:\\$keyStore \\(string\\) does not accept default value of type false\\.$#"
-			count: 1
-			path: core/Cookie.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between false and string will always evaluate to false\\.$#"
-			count: 1
-			path: core/Cookie.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between string and false will always evaluate to false\\.$#"
-			count: 2
-			path: core/Cookie.php
 
 		-
 			message: "#^Dead catch \\- UnexpectedValueException is never thrown in the try block\\.$#"
@@ -2094,10 +2064,6 @@ parameters:
 			count: 2
 			path: plugins/Actions/ArchivingHelper.php
 
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\\\Piwik\\\\DataTable\\\\Row\\)\\: Unexpected token \"\\\\n     \", expected variable at offset 150$#"
-			count: 1
-			path: plugins/Actions/ArchivingHelper.php
 
 		-
 			message: "#^Parameter \\#1 \\$name of method Piwik\\\\DataTable\\\\Row\\:\\:setColumn\\(\\) expects string, int given\\.$#"
@@ -3317,10 +3283,6 @@ parameters:
 			count: 1
 			path: plugins/PrivacyManager/DoNotTrackHeaderChecker.php
 
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\PrivacyManager\\\\LogDataPurger\\:\\:getDeleteIdVisitOffset\\(\\) should return string but returns false\\.$#"
-			count: 1
-			path: plugins/PrivacyManager/LogDataPurger.php
 
 		-
 			message: "#^Parameter \\#2 \\$first of static method Piwik\\\\Db\\:\\:segmentedFetchFirst\\(\\) expects int, string given\\.$#"

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -1047,7 +1047,7 @@ class ArchivingHelper
      *
      * @param int $idAction
      * @param int $actionType
-     * @param \Piwik\DataTable\Row
+     * @param \Piwik\DataTable\Row|false|null $actionRow
      */
     private static function setCachedActionRow($idAction, $actionType, $actionRow)
     {

--- a/plugins/Actions/Columns/Metrics/AverageTimeOnPage.php
+++ b/plugins/Actions/Columns/Metrics/AverageTimeOnPage.php
@@ -18,9 +18,9 @@ use Piwik\Columns\Dimension;
 /**
  * The average amount of time spent on a page. Calculated as:
  *
- *     sum_time_spent / nb_visits
+ *     sum_time_spent / nb_hits
  *
- * sum_time_spent and nb_visits are calculated by Archiver classes.
+ * sum_time_spent and nb_hits are calculated by Archiver classes.
  */
 class AverageTimeOnPage extends ProcessedMetric
 {

--- a/plugins/GeoIp2/LocationProvider/GeoIp2/Php.php
+++ b/plugins/GeoIp2/LocationProvider/GeoIp2/Php.php
@@ -422,7 +422,7 @@ class Php extends GeoIp2
      * Returns information about this location provider. Contains an id, title & description:
      *
      * array(
-     *     'id' => 'geoip2_php',
+     *     'id' => 'geoip2php',
      *     'title' => '...',
      *     'description' => '...'
      * );

--- a/plugins/Marketplace/Api/Service.php
+++ b/plugins/Marketplace/Api/Service.php
@@ -79,7 +79,7 @@ class Service
      *
      * @param string $url An absolute URL to the marketplace including domain.
      * @param null|string $destinationPath
-     * @param null|int $timeout Defaults to 60 seconds see {@link self::HTTP_REQUEST_METHOD}
+     * @param null|int $timeout Defaults to 60 seconds see {@link self::HTTP_REQUEST_TIMEOUT}
      * @param null|array $postData eg array('email' => 'user@example.org')
      * @param bool $getExtendedInfo Return the extended response info for the HTTP request.
      * @return bool|string Returns the downloaded data or true if a destination path was given.

--- a/plugins/PrivacyManager/LogDataPurger.php
+++ b/plugins/PrivacyManager/LogDataPurger.php
@@ -142,7 +142,7 @@ class LogDataPurger
 
     /**
      * get highest idVisit to delete rows from
-     * @return string
+     * @return string|false
      */
     private function getDeleteIdVisitOffset($deleteLogsOlderThan)
     {

--- a/plugins/UserCountry/VisitorGeolocator.php
+++ b/plugins/UserCountry/VisitorGeolocator.php
@@ -162,7 +162,7 @@ class VisitorGeolocator
     }
 
     /**
-     * Geolcates an existing visit and then updates it if it's current attributes are different than
+     * Geolocates an existing visit and then updates it if its current attributes are different than
      * what was geolocated. Also updates all conversions of a visit.
      *
      * **This method should NOT be used from within the tracker.**


### PR DESCRIPTION
## Description

Continues the docblock quality cleanup series (chunk 15). Fixes 15 existing docblocks across `core/` and `plugins/` where the PHPDoc did not match the actual code behavior. Documentation-only — no code behavior changes.

**Core:**
- `core/Cookie.php` — `$keyStore` defaults to `false`, so its `@var` is `bool|string` (not `string`).
- `core/CliMulti/CliPhp.php` — `getPhpVersion()` returns the `shell_exec()` result or the `null` default, so `@return` is `string|null`.
- `core/DataAccess/ArchiveWriter.php` — `insertBlobRecord()` `@param` prose typo ("splitted" → "split").
- `core/Plugin/MetadataLoader.php` — class doc listed `piwik.json`; the loaded file is `plugin.json` (`PLUGIN_JSON_FILENAME`).
- `core/Tracker/TableLogAction.php` — `getIdActionFromSegment()` can return `null` (the equal/not-equal branch), so `@return` gains `|null`.
- `core/Tracker/Visit/Factory.php` — summary referenced the old-style `Tracker_Visit` class name; the code uses `\Piwik\Tracker\Visit`.
- `core/Updater/Migration/Db/BatchInsert.php` — summary said "Inserts a new record" but it batch-inserts multiple rows.
- `core/AssetManager.php` + `core/AssetManager/UIAssetFetcher.php` — `$theme`/`getTheme()` are nullable (a null theme is passed/stored when no theme is enabled); `@var`/`@param`/`@return` corrected to `Theme|null`.

**Plugins:**
- `plugins/Actions/ArchivingHelper.php` — `setCachedActionRow()` `@param` omitted the variable name and was too narrow; callers pass `false`/`null`/`Row` → `\Piwik\DataTable\Row|false|null $actionRow`.
- `plugins/Actions/Columns/Metrics/AverageTimeOnPage.php` — formula doc said `sum_time_spent / nb_visits`; `compute()` divides by `nb_hits`.
- `plugins/GeoIp2/LocationProvider/GeoIp2/Php.php` — `getInfo()` doc example id `geoip2_php` → `geoip2php` (matches `const ID`).
- `plugins/Marketplace/Api/Service.php` — `download()` `{@link}` referenced a non-existent `HTTP_REQUEST_METHOD`; the constant is `HTTP_REQUEST_TIMEOUT`.
- `plugins/PrivacyManager/LogDataPurger.php` — `getDeleteIdVisitOffset()` returns `false` when there are no visits, so `@return` is `string|false`.
- `plugins/UserCountry/VisitorGeolocator.php` — method summary typos ("Geolcates" → "Geolocates", "it's" → "its").

Several of the type corrections resolved now-obsolete `phpstan-baseline.neon` entries (Cookie, AssetManager + the JScript/Stylesheet fetchers + UIAssetMerger, ArchivingHelper, LogDataPurger); all 9 removals were confirmed via a full-project PHPStan run reporting them as "not matched".

## Review

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Also reviewed locally with `codex review` before opening this PR.

## Refs

n/a

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
