### PR TITLE
Docblock quality fixes (chunk 16)

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -231,7 +231,7 @@ class Common
     /**
      * Multi-byte strlen() - works with UTF-8
      *
-     * Calls `mb_substr` if available and falls back to `substr` if not.
+     * Calls `mb_strlen` if available and falls back to `strlen` if not.
      *
      * @param string $string
      * @return int

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -49,7 +49,7 @@ class ArchiveSelector
     }
 
     /**
-     * @param false|int|string|Date|null $minDatetimeArchiveProcessedUTC deprecated. Will be removed in Matomo 4.
+     * @param false|int|string|Date|null $minDatetimeArchiveProcessedUTC The minimum ts_archived an archive must have to be considered usable, or false to accept any.
      * @param bool|null $includeInvalidated true to include archives that are DONE_INVALIDATED, false if only DONE_OK,
      *                                      null to determine automatically based on $params.
      * @return array An array with the following values:

--- a/core/Development.php
+++ b/core/Development.php
@@ -59,7 +59,7 @@ class Development
 
     /**
      * Formats a method call depending on the given class/object and method name. It does not perform any checks whether
-     * does actually exists.
+     * the method actually exists.
      *
      * @param string|object $classOrObject
      * @param string $method

--- a/core/Scheduler/Schedule/Schedule.php
+++ b/core/Scheduler/Schedule/Schedule.php
@@ -47,8 +47,7 @@ abstract class Schedule
 
     /**
      * @param $period
-     * @return Daily|Monthly|Weekly
-     * @throws \Exception
+     * @return Daily|Monthly|Weekly|Hourly
      * @ignore
      */
     public static function getScheduledTimeForPeriod($period)

--- a/core/Sequence.php
+++ b/core/Sequence.php
@@ -43,7 +43,7 @@ class Sequence
      * The name of the table or sequence you want to get an id for.
      *
      * @param string $name eg 'archive_numeric_2014_11'
-     * @param AdapterInterface $db You can optionally pass a DB adapter to make it work against another database.
+     * @param AdapterInterface|null $db You can optionally pass a DB adapter to make it work against another database.
      * @param string|null $tablePrefix
      */
     public function __construct($name, $db = null, $tablePrefix = null)

--- a/core/Tracker/Db/Mysqli.php
+++ b/core/Tracker/Db/Mysqli.php
@@ -244,9 +244,7 @@ class Mysqli extends Db
      * @param string $query Query
      * @param array $parameters Parameters to bind
      *
-     * @return array
-     *
-     * @throws DbException if an exception occurred
+     * @return array|false
      */
     public function fetch($query, $parameters = array())
     {
@@ -280,8 +278,7 @@ class Mysqli extends Db
      * @param string $query Query
      * @param array|string $parameters Parameters to bind array('idsite'=> 1)
      *
-     * @return bool|resource  false if failed
-     * @throws DbException  if an exception occurred
+     * @return \mysqli_stmt|false  false if failed
      */
     public function query($query, $parameters = array())
     {

--- a/core/Tracker/FingerprintSalt.php
+++ b/core/Tracker/FingerprintSalt.php
@@ -25,7 +25,7 @@ class FingerprintSalt
 
     public function deleteOldSalts()
     {
-        // we want to make sure to delete salts that were created more than three days ago as they are likely not in
+        // we want to make sure to delete salts that were created more than five days ago as they are likely not in
         // use anymore. We should delete them to ensure the fingerprint is truly random for each day because if we used
         // eg the regular salt then it would technically still be possible to try and regenerate the fingerprint based
         // on certain information.

--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -20,12 +20,11 @@ class Model
     public const CACHE_KEY_INDEX_IDSITE_IDVISITOR_TIME = 'log_visit_has_index_idsite_idvisitor_time';
 
     /**
-     * Write an visit action record to the database
+     * Write a visit action record to the database
      *
      * @param array $visitAction
      *
      * @return int
-     * @throws Db\DbException
      */
     public function createAction($visitAction)
     {

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -162,8 +162,7 @@ class Updater
      * Returns the currently installed version of a Piwik component.
      *
      * @param string $name The component name. Eg, a plugin name, `'core'` or dimension column name.
-     * @return string A semantic version.
-     * @throws \Exception
+     * @return string|false A semantic version, or false if the component version is not recorded yet.
      */
     public function getCurrentComponentVersion($name)
     {

--- a/core/Updater/Migration/Db/CreateTable.php
+++ b/core/Updater/Migration/Db/CreateTable.php
@@ -19,7 +19,7 @@ class CreateTable extends Sql
 {
     /**
      * @param string $table Prefixed table name
-     * @param string|string[] $columnNames array(columnName => columnValue)
+     * @param array $columnNames array(columnName => columnType)
      * @param string|string[] $primaryKey one or multiple columns that define the primary key
      */
     public function __construct($table, $columnNames, $primaryKey)

--- a/core/Updates.php
+++ b/core/Updates.php
@@ -18,7 +18,7 @@ use Piwik\Updater\Migration;
  * SQL queries and/or PHP code to update an environment to a newer version.
  *
  * To create a new update script, create a class that extends `Updates`. Name the class and file
- * after the version, eg, `class Updates_3_0_0` and `3.0.0.php`. Override the {@link getMigrationQueries()}
+ * after the version, eg, `class Updates_3_0_0` and `3.0.0.php`. Override the {@link getMigrations()}
  * method if you need to run SQL queries. Override the {@link doUpdate()} method to do other types
  * of updating, eg, to activate/deactivate plugins or create files.
  *

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -351,15 +351,6 @@ parameters:
 			count: 1
 			path: core/Columns/Updater.php
 
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 2
-			path: core/Columns/Updater.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between false and string will always evaluate to false\\.$#"
-			count: 1
-			path: core/Columns/Updater.php
 
 		-
 			message: "#^Comparison operation \"\\<\" between int\\<2, 3\\> and 2 is always false\\.$#"
@@ -1214,10 +1205,6 @@ parameters:
 			count: 1
 			path: core/Scheduler/Schedule/Monthly.php
 
-		-
-			message: "#^Method Piwik\\\\Scheduler\\\\Schedule\\\\Schedule\\:\\:getScheduledTimeForPeriod\\(\\) should return Piwik\\\\Scheduler\\\\Schedule\\\\Daily\\|Piwik\\\\Scheduler\\\\Schedule\\\\Monthly\\|Piwik\\\\Scheduler\\\\Schedule\\\\Weekly but returns Piwik\\\\Scheduler\\\\Schedule\\\\Hourly\\.$#"
-			count: 1
-			path: core/Scheduler/Schedule/Schedule.php
 
 		-
 			message: "#^Parameter \\#3 \\$sec of function mktime expects int, string given\\.$#"
@@ -1542,10 +1529,6 @@ parameters:
 			count: 1
 			path: core/Tracker/Db/Mysqli.php
 
-		-
-			message: "#^Return type \\(bool\\|resource\\) of method Piwik\\\\Tracker\\\\Db\\\\Mysqli\\:\\:query\\(\\) should be compatible with return type \\(Piwik\\\\Tracker\\\\PDOStatement\\) of method Piwik\\\\Tracker\\\\Db\\:\\:query\\(\\)$#"
-			count: 1
-			path: core/Tracker/Db/Mysqli.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between array\\|bool and null will always evaluate to false\\.$#"
@@ -1784,10 +1767,6 @@ parameters:
 			count: 1
 			path: core/UpdateCheck.php
 
-		-
-			message: "#^Strict comparison using \\=\\=\\= between string and false will always evaluate to false\\.$#"
-			count: 1
-			path: core/Updater.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between array\\<int\\>\\|int and false will always evaluate to false\\.$#"
@@ -2415,10 +2394,6 @@ parameters:
 			count: 1
 			path: plugins/CorePluginsAdmin/SettingsMetadata.php
 
-		-
-			message: "#^Strict comparison using \\=\\=\\= between string and false will always evaluate to false\\.$#"
-			count: 1
-			path: plugins/CoreUpdater/Commands/Update.php
 
 		-
 			message: "#^Parameter \\#1 \\$https of method Piwik\\\\Plugins\\\\CoreUpdater\\\\Updater\\:\\:updatePiwik\\(\\) expects bool, int given\\.$#"
@@ -3102,10 +3077,6 @@ parameters:
 			count: 1
 			path: plugins/LanguagesManager/Commands/PluginsWithTranslations.php
 
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\LanguagesManager\\\\LanguagesManager\\:\\:getLanguageNameForCurrentUser\\(\\) should return string but returns false\\.$#"
-			count: 1
-			path: plugins/LanguagesManager/LanguagesManager.php
 
 		-
 			message: "#^Parameter \\#5 \\$tooltip of method Piwik\\\\Menu\\\\MenuTop\\:\\:addHtml\\(\\) expects string, false given\\.$#"
@@ -3407,10 +3378,6 @@ parameters:
 			count: 1
 			path: plugins/Referrers/DataTable/Filter/SetGetReferrerTypeSubtables.php
 
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Referrers\\\\SearchEngine\\:\\:getBackLinkFromUrlAndKeyword\\(\\) should return string but returns false\\.$#"
-			count: 1
-			path: plugins/Referrers/SearchEngine.php
 
 
 		-

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -31,7 +31,7 @@ use Piwik\Plugins\PrivacyManager\Config as PrivacyManagerConfig;
  * This RequestProcessor exposes the following metadata for the **CoreHome** plugin:
  *
  * * **visitorId**: A hash that identifies the current visitor being tracked. This value is
- *                  calculated using the Piwik\Tracker\Settings;:getConfigId() method.
+ *                  calculated using the Piwik\Tracker\Settings::getConfigId() method.
  *
  *                  Set in `processRequestParams()`.
  *

--- a/plugins/LanguagesManager/LanguagesManager.php
+++ b/plugins/LanguagesManager/LanguagesManager.php
@@ -172,7 +172,7 @@ class LanguagesManager extends \Piwik\Plugin
     }
 
     /**
-     * @return string Full english language string, eg. "French"
+     * @return string|false Full english language string, eg. "French"
      */
     public static function getLanguageNameForCurrentUser()
     {

--- a/plugins/Referrers/SearchEngine.php
+++ b/plugins/Referrers/SearchEngine.php
@@ -427,8 +427,6 @@ class SearchEngine extends Singleton
     /**
      * Return search engine URL by name
      *
-     * @see core/DataFiles/SearchEnginges.php
-     *
      * @param string $name
      * @return string URL
      */
@@ -466,7 +464,7 @@ class SearchEngine extends Singleton
      *
      * @param string $url
      * @return string path
-     * @see plugins/Morpheus/icons/dist/searchEnginges/
+     * @see plugins/Morpheus/icons/dist/searchEngines/
      */
     public function getLogoFromUrl($url)
     {
@@ -482,11 +480,9 @@ class SearchEngine extends Singleton
     /**
      * Return search engine URL for URL and keyword
      *
-     * @see core/DataFiles/SearchEnginges.php
-     *
      * @param string $url Domain name, e.g., search.piwik.org
      * @param string $keyword Keyword, e.g., web+analytics
-     * @return string URL, e.g., https://search.matomo.org/q=web+analytics
+     * @return string|false URL, e.g., https://search.matomo.org/q=web+analytics, or false if the search engine defines no backlink
      */
     public function getBackLinkFromUrlAndKeyword($url, $keyword)
     {

--- a/plugins/UserCountry/LocationProvider.php
+++ b/plugins/UserCountry/LocationProvider.php
@@ -543,7 +543,7 @@ abstract class LocationProvider
      * will return an IPv4 address or IPv6 address.
      *
      * @param  array $info Must have 'ip' key.
-     * @return string|null
+     * @return string
      */
     protected function getIpFromInfo($info)
     {


### PR DESCRIPTION
## Description

Continues the docblock quality cleanup series (chunk 16). Fixes 15 existing docblocks across `core/` and `plugins/` where the PHPDoc did not match the actual code behavior. Documentation-only — no code behavior changes.

**Core:**
- `core/Common.php` — `mb_strlen()` doc referenced `mb_substr`/`substr` (copy-paste); now matches the sibling `mb_strtolower`/`mb_strtoupper` wording.
- `core/DataAccess/ArchiveSelector.php` — `$minDatetimeArchiveProcessedUTC` was labelled "deprecated. Will be removed in Matomo 4" but is actively used; replaced with a real description.
- `core/Development.php` — `formatMethodCall()` summary had a broken sentence ("whether does actually exists").
- `core/Scheduler/Schedule/Schedule.php` — `getScheduledTimeForPeriod()` also returns `Hourly` (PERIOD_HOUR case); added to `@return`.
- `core/Sequence.php` — constructor `$db` defaults to `null`, so `@param` is `AdapterInterface|null`.
- `core/Tracker/Db/Mysqli.php` — `fetch()` can return `false` (`array|false`); `query()` returns the prepared `\mysqli_stmt` or `false` (was `bool|resource`).
- `core/Tracker/FingerprintSalt.php` — `deleteOldSalts()` comment said "three days" but the threshold is 5 days (and the rest of the same comment says "five days").
- `core/Tracker/Model.php` — `createAction()` summary grammar ("an visit" → "a visit").
- `core/Updater.php` — `getCurrentComponentVersion()` returns `false` when the version isn't recorded (`string|false`).
- `core/Updater/Migration/Db/CreateTable.php` — `$columnNames` is always an associative `array` (columnName ⇒ columnType), not `string|string[]`.
- `core/Updates.php` — class doc linked `{@link getMigrationQueries()}` which doesn't exist on this class; the method is `getMigrations()`.

**Plugins:**
- `plugins/CoreHome/Tracker/VisitRequestProcessor.php` — broken scope-resolution reference (`Settings;:getConfigId()` → `Settings::getConfigId()`).
- `plugins/LanguagesManager/LanguagesManager.php` — `getLanguageNameForCurrentUser()` returns `false` when no match (`string|false`).
- `plugins/Referrers/SearchEngine.php` — removed two `@see core/DataFiles/SearchEnginges.php` refs (file doesn't exist), fixed a `searchEnginges` → `searchEngines` path typo, and `getBackLinkFromUrlAndKeyword()` `@return` gains `|false`.
- `plugins/UserCountry/LocationProvider.php` — `getIpFromInfo()` always returns a `string` (both branches; IP source never null), so removed the incorrect `|null`.

Several of the type corrections resolved now-obsolete `phpstan-baseline.neon` entries (Updater + cascading callers `Columns/Updater.php` and `CoreUpdater/Commands/Update.php`, Schedule, Tracker Mysqli `query()`, LanguagesManager, SearchEngine — 8 entries total); each removal was confirmed via a full-project PHPStan run reporting them as "not matched", with a follow-up full run coming back clean.

## Review

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Also reviewed locally with `codex review` before opening this PR.

## Refs

n/a

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
