### PR TITLE
Docblock quality fixes (chunk 18)

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -36,7 +36,7 @@ use Piwik\Session\SessionAuth;
  *                          Super user access is required to set some configuration options.
  *                          All other options are specific to the user or to a website.
  *
- * Access is granted per website. Uses with access for a website can view all
+ * Access is granted per website. Users with access for a website can view all
  * data associated with that website.
  *
  */
@@ -73,7 +73,7 @@ class Access
     protected $hasSuperUserAccess = false;
 
     /**
-     * Authentification object (see Auth)
+     * Authentication object (see Auth)
      *
      * @var Auth
      */

--- a/core/DataTable/Renderer.php
+++ b/core/DataTable/Renderer.php
@@ -66,7 +66,7 @@ abstract class Renderer extends BaseFactory
 
     /**
      * The current idSite
-     * @var int
+     * @var int|string
      */
     public $idSite = 'all';
 

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -561,7 +561,7 @@ class Mysql implements SchemaInterface
     /**
      * Create database
      *
-     * @param string $dbName Name of the database to create
+     * @param string|null $dbName Name of the database to create
      */
     public function createDatabase($dbName = null)
     {

--- a/core/DbHelper.php
+++ b/core/DbHelper.php
@@ -30,7 +30,7 @@ class DbHelper
     }
 
     /**
-     * Returns `true` if a table in the database, `false` if otherwise.
+     * Returns `true` if a table exists in the database, `false` if otherwise.
      *
      * @param string $tableName The name of the table to check for. Must be prefixed.
      *                          Avoid using user input, as the variable will be used in a query unescaped.

--- a/core/NumberFormatter.php
+++ b/core/NumberFormatter.php
@@ -35,8 +35,6 @@ class NumberFormatter
      * that gets needed characters (ie, NumberFormatSource). The default implementation
      * can use the Translator. This will make it easier to unit test NumberFormatter,
      * w/o needing the Piwik Environment.
-     *
-     * @return NumberFormatter
      */
     public function __construct(Translator $translator)
     {
@@ -193,6 +191,7 @@ class NumberFormatter
      * @see \Piwik\NumberFormatter::format()
      *
      * @param string|int|float $value
+     * @param string $currency
      * @return mixed|string
      */
     public function formatCurrencyCompact($value, $currency)

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -751,9 +751,9 @@ class Piwik
     }
 
     /**
-     * Returns `true` if the login is valid.
+     * Checks that the login string is valid.
      *
-     * _Warning: does not check if the login already exists! You must use UsersManager_API->userExists as well._
+     * _Warning: does not check if the login already exists! You must use UsersManager\API->userExists as well._
      *
      * @param string $userLogin
      * @throws Exception

--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -137,7 +137,7 @@ abstract class ControllerAdmin extends Controller
     }
 
     /**
-     * Calls {@link setBasicVariablesView()} and {@link setBasicVariablesAdminView()}
+     * Calls {@link setBasicVariablesNoneAdminView()} and {@link setBasicVariablesAdminView()}
      * using the supplied view.
      *
      * @param View $view

--- a/core/Plugin/SettingsProvider.php
+++ b/core/Plugin/SettingsProvider.php
@@ -39,7 +39,7 @@ class SettingsProvider
     }
 
     /**
-     * Get user settings implemented by a specific plugin (if implemented by this plugin).
+     * Get system settings implemented by a specific plugin (if implemented by this plugin).
      */
     public function getSystemSettings(string $pluginName): ?SystemSettings
     {

--- a/core/Scheduler/Schedule/Daily.php
+++ b/core/Scheduler/Schedule/Daily.php
@@ -19,7 +19,7 @@ use Exception;
 class Daily extends Schedule
 {
     /**
-     * @see ScheduledTime::getRescheduledTime
+     * @see Schedule::getRescheduledTime
      * @return int
      */
     public function getRescheduledTime()
@@ -44,7 +44,7 @@ class Daily extends Schedule
     }
 
     /**
-     * @see ScheduledTime::setDay
+     * @see Schedule::setDay
      * @param int $_day
      * @throws \Exception
      * @ignore

--- a/core/Scheduler/Schedule/Hourly.php
+++ b/core/Scheduler/Schedule/Hourly.php
@@ -19,7 +19,7 @@ use Exception;
 class Hourly extends Schedule
 {
     /**
-     * @see ScheduledTime::getRescheduledTime
+     * @see Schedule::getRescheduledTime
      * @return int
      */
     public function getRescheduledTime()
@@ -39,7 +39,7 @@ class Hourly extends Schedule
     }
 
     /**
-     * @see ScheduledTime::setHour
+     * @see Schedule::setHour
      * @param int $_hour
      * @throws \Exception
      * @return int
@@ -50,7 +50,7 @@ class Hourly extends Schedule
     }
 
     /**
-     * @see ScheduledTime::setDay
+     * @see Schedule::setDay
      * @param int $_day
      * @throws \Exception
      * @return int

--- a/core/Scheduler/Schedule/Weekly.php
+++ b/core/Scheduler/Schedule/Weekly.php
@@ -19,7 +19,7 @@ use Exception;
 class Weekly extends Schedule
 {
     /**
-     * @see ScheduledTime::getRescheduledTime
+     * @see Schedule::getRescheduledTime
      * @return int
      */
     public function getRescheduledTime()

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -345,13 +345,11 @@ class SettingsPiwik
     }
 
     /**
-     * Returns true if the Piwik server appears to be working.
+     * Checks whether the Piwik server appears to be working.
      *
      * If the Piwik server is in an error state (eg. some directories are not writable and Piwik displays error message),
      * or if the Piwik server is "offline",
-     * this will return false..
-     *
-     * @throws Exception
+     * this will throw an exception.
      */
     public static function checkPiwikServerWorking(string $piwikServerUrl, bool $acceptInvalidSSLCertificates = false): void
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -628,10 +628,6 @@ parameters:
 			count: 1
 			path: core/DataTable/Map.php
 
-		-
-			message: "#^Property Piwik\\\\DataTable\\\\Renderer\\:\\:\\$idSite \\(int\\) does not accept default value of type string\\.$#"
-			count: 1
-			path: core/DataTable/Renderer.php
 
 		-
 			message: "#^Result of && is always false\\.$#"
@@ -2124,10 +2120,6 @@ parameters:
 			count: 1
 			path: plugins/Actions/Columns/ActionType.php
 
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Actions\\\\Columns\\\\ExitPageUrl\\:\\:onExistingVisit\\(\\) should return int but returns false\\.$#"
-			count: 1
-			path: plugins/Actions/Columns/ExitPageUrl.php
 
 		-
 			message: "#^Method Piwik\\\\Plugins\\\\Actions\\\\Columns\\\\VisitTotalActions\\:\\:onExistingVisit\\(\\) should return int but returns false\\.$#"
@@ -2571,10 +2563,6 @@ parameters:
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
 
-		-
-			message: "#^Property Piwik\\\\Plugins\\\\CoreVisualizations\\\\Visualizations\\\\Sparklines\\\\Config\\:\\:\\$title_attributes \\(string\\) does not accept default value of type array\\.$#"
-			count: 1
-			path: plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
 
 		-
 			message: "#^Result of && is always false\\.$#"
@@ -2957,10 +2945,6 @@ parameters:
 			count: 1
 			path: plugins/Goals/RecordBuilders/ProductRecord.php
 
-		-
-			message: "#^Property Piwik\\\\Plugins\\\\CoreVisualizations\\\\Visualizations\\\\Sparklines\\\\Config\\:\\:\\$title_attributes \\(string\\) does not accept array\\<string, string\\>\\.$#"
-			count: 1
-			path: plugins/Goals/Reports/Get.php
 
 		-
 			message: "#^Right side of && is always true\\.$#"

--- a/plugins/Actions/Columns/ExitPageUrl.php
+++ b/plugins/Actions/Columns/ExitPageUrl.php
@@ -63,7 +63,7 @@ class ExitPageUrl extends VisitDimension
 
     /**
      * @param Action|null $action
-     * @return int
+     * @return int|false
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/CoreVisualizations/Visualizations/HtmlTable/Config.php
+++ b/plugins/CoreVisualizations/Visualizations/HtmlTable/Config.php
@@ -12,7 +12,7 @@ namespace Piwik\Plugins\CoreVisualizations\Visualizations\HtmlTable;
 use Piwik\ViewDataTable\Config as VisualizationConfig;
 
 /**
- * DataTable Visualization that derives from HtmlTable and sets show_extra_columns to true.
+ * Configuration for the HtmlTable visualization.
  */
 class Config extends VisualizationConfig
 {

--- a/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
@@ -44,7 +44,7 @@ class Config extends \Piwik\ViewDataTable\Config
 
     /**
      * Adds possibility to set html attributes on the sparklines title / headline.
-     * @var string
+     * @var array
      */
     public $title_attributes = array();
 
@@ -56,7 +56,7 @@ class Config extends \Piwik\ViewDataTable\Config
     /**
      * If supplied, this function is used to compute the evolution percent displayed next to non-comparison sparkline views.
      *
-     * The function is passed three parameters:
+     * The function is passed two parameters:
      * - an array mapping column names with column values ['column' => 123]
      * - an array of \Piwik\Plugin\Metrics objects available for the report - useful for formatting values
      *


### PR DESCRIPTION
## Description

Continues the docblock quality cleanup series (chunk 18). Fixes 15 existing docblocks across `core/` and `plugins/` where the PHPDoc did not match the actual code behavior. Documentation-only — no code behavior changes.

**Core:**
- `core/Access.php` — class docblock typos ("Uses with access" → "Users with access"; "Authentification" → "Authentication").
- `core/DataTable/Renderer.php` — `$idSite` defaults to the string `'all'`, so `@var int` → `int|string`.
- `core/Db/Schema/Mysql.php` — `createDatabase()` `$dbName` defaults to `null` (handled via `is_null`), so `@param` → `string|null`.
- `core/DbHelper.php` — `tableExists()` summary was missing its verb ("if a table in the database" → "if a table exists in the database").
- `core/NumberFormatter.php` — removed a bogus `@return NumberFormatter` on the constructor; documented the missing `$currency` param on `formatCurrencyCompact()`.
- `core/Piwik.php` — `checkValidLoginString()` is `void` and throws (not "Returns `true`"); fixed stale `UsersManager_API` → `UsersManager\API` reference.
- `core/Plugin/ControllerAdmin.php` — `{@link setBasicVariablesView()}` → `{@link setBasicVariablesNoneAdminView()}` (the method actually called).
- `core/Plugin/SettingsProvider.php` — `getSystemSettings()` summary said "user settings" (copy-paste) → "system settings".
- `core/Scheduler/Schedule/Daily.php` / `Hourly.php` / `Weekly.php` — stale `@see ScheduledTime::…` references (old class name) → `@see Schedule::…`.
- `core/SettingsPiwik.php` — `checkPiwikServerWorking()` is `void` and throws on failure; summary no longer claims it "Returns true"/"returns false".

**Plugins:**
- `plugins/Actions/Columns/ExitPageUrl.php` — `onExistingVisit()` returns `false` (empty action / falsy id), so `@return int` → `int|false`.
- `plugins/CoreVisualizations/Visualizations/HtmlTable/Config.php` — class doc was copy-pasted from `AllColumns` ("sets show_extra_columns to true"), which this config does not do.
- `plugins/CoreVisualizations/Visualizations/Sparklines/Config.php` — `$title_attributes` is an array (`@var string` → `array`); the evolution callback is passed two parameters, not three.

Several type corrections resolved now-obsolete `phpstan-baseline.neon` entries (Renderer `$idSite`, ExitPageUrl return, and the `title_attributes` assignments in `Sparklines/Config.php` and `Goals/Reports/Get.php` — 4 entries total); each removal was confirmed via a full-project PHPStan run reporting them as "not matched", with a follow-up full run coming back clean.

## Review

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Also reviewed locally with `codex review` before opening this PR.

## Refs

n/a

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
