### PR TITLE
Docblock quality fixes (chunk 19)

### DIFF
--- a/core/Archive/DataTableFactory.php
+++ b/core/Archive/DataTableFactory.php
@@ -318,7 +318,7 @@ class DataTableFactory
     }
 
     /**
-     * Creates a Set from an array index.
+     * Creates a DataTable\Map from an array index.
      *
      * @param array $index @see DataCollection
      * @param array $resultIndices @see make

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -53,7 +53,7 @@ class CliMulti
 
     /**
      * If set it will issue at most concurrentProcessesLimit requests
-     * @var int
+     * @var int|null
      */
     private $concurrentProcessesLimit = null;
 
@@ -72,14 +72,14 @@ class CliMulti
     /**
      * Only used when doing synchronous curl requests.
      *
-     * @var string
+     * @var string|null
      */
     private $urlToPiwik = null;
 
     private $phpCliOptions = '';
 
     /**
-     * @var callable
+     * @var callable|null
      */
     private $onProcessFinish = null;
 

--- a/core/Config/IniFileChain.php
+++ b/core/Config/IniFileChain.php
@@ -135,7 +135,7 @@ class IniFileChain
      * all default setting files), it is not written to the user settings file.
      *
      * @param string $header The header of the INI output.
-     * @return string The dumped INI contents.
+     * @return string|null The dumped INI contents, or null if there are no changes to write.
      */
     public function dumpChanges($header = '')
     {

--- a/core/CronArchive/Performance/Logger.php
+++ b/core/CronArchive/Performance/Logger.php
@@ -29,7 +29,7 @@ class Logger
     private $logger;
 
     /**
-     * @var int
+     * @var string|false
      */
     private $archivingRunId;
 

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -301,7 +301,7 @@ class QueueConsumer
             && empty($invalidationsToExcludeInBatch)
         ) { // no invalidated archive left
             /**
-             * This event is triggered immediately after the cron archiving process starts archiving data for a single
+             * This event is triggered immediately after the cron archiving process finishes archiving data for a single
              * site.
              *
              * Note: multiple archiving processes can post this event.

--- a/core/DataAccess/ArchivingDbAdapter.php
+++ b/core/DataAccess/ArchivingDbAdapter.php
@@ -28,7 +28,7 @@ class ArchivingDbAdapter
     private $logger;
 
     /**
-     * @var int
+     * @var float
      */
     private $maxExecutionTime;
 

--- a/core/Metrics/Sorter.php
+++ b/core/Metrics/Sorter.php
@@ -134,7 +134,7 @@ class Sorter
      * Detect the column to be used for sorting
      *
      * @param string|int $columnToSort  column name or column id
-     * @return int
+     * @return string|int
      */
     public function getPrimaryColumnToSort(DataTable $table, $columnToSort)
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2883,10 +2883,6 @@ parameters:
 			count: 1
 			path: plugins/Goals/API.php
 
-		-
-			message: "#^Property Piwik\\\\Plugins\\\\Goals\\\\Columns\\\\Metrics\\\\GoalSpecificProcessedMetric\\:\\:\\$idSite \\(int\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: plugins/Goals/Columns/Metrics/GoalSpecificProcessedMetric.php
 
 		-
 			message: "#^Method Piwik\\\\Plugins\\\\Goals\\\\Commands\\\\CalculateConversionPages\\:\\:getDateRangeToCalculate\\(\\) never returns array\\<Piwik\\\\Date\\> so it can be removed from the return type\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -316,10 +316,6 @@ parameters:
 			count: 1
 			path: core/Changes/Model.php
 
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: core/CliMulti.php
 
 		-
 			message: "#^Variable \\$response in empty\\(\\) always exists and is always falsy\\.$#"
@@ -371,10 +367,6 @@ parameters:
 			count: 1
 			path: core/Concurrency/DistributedList.php
 
-		-
-			message: "#^Method Piwik\\\\Config\\\\IniFileChain\\:\\:dumpChanges\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: core/Config/IniFileChain.php
 
 		-
 			message: "#^Parameter \\#2 \\$data of method Matomo\\\\Cache\\\\Backend\\\\File\\:\\:doSave\\(\\) expects string, array\\<string, mixed\\> given\\.$#"
@@ -522,10 +514,6 @@ parameters:
 			count: 1
 			path: core/DataAccess/ArchivingDbAdapter.php
 
-		-
-			message: "#^Property Piwik\\\\DataAccess\\\\ArchivingDbAdapter\\:\\:\\$maxExecutionTime \\(int\\) does not accept float\\.$#"
-			count: 1
-			path: core/DataAccess/ArchivingDbAdapter.php
 
 		-
 			message: "#^PHPDoc tag @throws has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 89$#"
@@ -824,10 +812,6 @@ parameters:
 			count: 3
 			path: core/Mail/EmailStyles.php
 
-		-
-			message: "#^Method Piwik\\\\Metrics\\\\Sorter\\:\\:getPrimaryColumnToSort\\(\\) should return int but returns string\\.$#"
-			count: 1
-			path: core/Metrics/Sorter.php
 
 		-
 			message: "#^Parameter \\#1 \\$default of static method Piwik\\\\Url\\:\\:getCurrentHost\\(\\) expects string, null given\\.$#"
@@ -1894,6 +1878,7 @@ parameters:
 			count: 2
 			path: core/ViewDataTable/Factory.php
 
+
 		-
 			message: "#^Method Piwik\\\\ViewDataTable\\\\Manager\\:\\:getFooterIconFor\\(\\) should return array but empty return statement found\\.$#"
 			count: 1
@@ -2329,10 +2314,6 @@ parameters:
 			count: 1
 			path: plugins/CoreHome/Columns/Metrics/EvolutionMetric.php
 
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\CoreHome\\\\Columns\\\\VisitGoalBuyer\\:\\:onExistingVisit\\(\\) should return int but returns false\\.$#"
-			count: 1
-			path: plugins/CoreHome/Columns/VisitGoalBuyer.php
 
 		-
 			message: "#^Method Piwik\\\\Plugins\\\\CoreHome\\\\Columns\\\\VisitTotalTime\\:\\:onConvertedVisit\\(\\) should return int but returns false\\.$#"

--- a/plugins/CoreAdminHome/Commands/InvalidateReportData.php
+++ b/plugins/CoreAdminHome/Commands/InvalidateReportData.php
@@ -374,8 +374,6 @@ class InvalidateReportData extends ConsoleCommand
      * If no segment is provided, a list of all segments available for the provided sites will be returned (including all visits segment)
      *
      * @param array<int> $idSites
-     *
-     * @return array<string>
      */
     private function getSegmentsToInvalidateFor(array $idSites): array
     {

--- a/plugins/CoreHome/Columns/VisitGoalBuyer.php
+++ b/plugins/CoreHome/Columns/VisitGoalBuyer.php
@@ -82,7 +82,7 @@ class VisitGoalBuyer extends VisitDimension
 
     /**
      * @param Action|null $action
-     * @return int
+     * @return int|false
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/Goals/Columns/Metrics/GoalSpecificProcessedMetric.php
+++ b/plugins/Goals/Columns/Metrics/GoalSpecificProcessedMetric.php
@@ -31,7 +31,7 @@ abstract class GoalSpecificProcessedMetric extends ProcessedMetric
     /**
      * The ID of the site the goal belongs to.
      *
-     * @var int
+     * @var int|null
      */
     protected $idSite;
 

--- a/plugins/UserCountry/Columns/City.php
+++ b/plugins/UserCountry/Columns/City.php
@@ -44,7 +44,7 @@ class City extends Base
 
     /**
      * @param Action|null $action
-     * @return int
+     * @return string|false
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/UserCountry/Columns/Country.php
+++ b/plugins/UserCountry/Columns/Country.php
@@ -101,7 +101,7 @@ class Country extends Base
 
     /**
      * @param Action|null $action
-     * @return int
+     * @return string|false
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/UserCountry/Columns/Latitude.php
+++ b/plugins/UserCountry/Columns/Latitude.php
@@ -51,7 +51,7 @@ class Latitude extends Base
 
     /**
      * @param Action|null $action
-     * @return int
+     * @return string|false
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/UserCountry/Columns/Longitude.php
+++ b/plugins/UserCountry/Columns/Longitude.php
@@ -46,7 +46,7 @@ class Longitude extends Base
 
     /**
      * @param Action|null $action
-     * @return int
+     * @return string|false
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/UserCountry/Columns/Region.php
+++ b/plugins/UserCountry/Columns/Region.php
@@ -49,7 +49,7 @@ class Region extends Base
 
     /**
      * @param Action|null $action
-     * @return int
+     * @return string|false
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {


### PR DESCRIPTION
## Description

Continues the docblock quality cleanup series (chunk 19). Fixes 15 existing docblocks across `core/` and `plugins/` where the PHPDoc did not match the actual code behavior. Documentation-only — no code behavior changes.

**Core:**
- `core/Archive/DataTableFactory.php` — `createDataTableMapFromArray()` summary said "Creates a Set" (stale class name); it returns a `DataTable\Map`.
- `core/CliMulti.php` — `$concurrentProcessesLimit`, `$urlToPiwik`, `$onProcessFinish` default to `null` and are guarded, so their `@var` gain `|null`.
- `core/Config/IniFileChain.php` — `dumpChanges()` returns `null` when there are no changes, so `@return` → `string|null`.
- `core/CronArchive/Performance/Logger.php` — `$archivingRunId` comes from `getRequestVar('runid', false)` (string or `false`), so `@var int` → `string|false`.
- `core/CronArchive/QueueConsumer.php` — the `CronArchive.archiveSingleSite.finish` event doc wrongly said the process "starts" archiving (copied from the `.start` event); it fires when archiving finishes.
- `core/DataAccess/ArchivingDbAdapter.php` — `$maxExecutionTime` is assigned `(float) …`, so `@var int` → `float`.
- `core/Metrics/Sorter.php` — `getPrimaryColumnToSort()` commonly returns a string column name, so `@return int` → `string|int`.

**Plugins:**
- `plugins/CoreAdminHome/Commands/InvalidateReportData.php` — `getSegmentsToInvalidateFor()` has a native `: array` return and returned an associative detail-array, so the inaccurate `@return array<string>` was removed.
- `plugins/CoreHome/Columns/VisitGoalBuyer.php` — `onExistingVisit()` returns `false` on the fall-through, so `@return int` → `int|false`.
- `plugins/Goals/Columns/Metrics/GoalSpecificProcessedMetric.php` — `$idSite` is nullable (constructor `int|null`, guarded with `isset()`), so `@var int` → `int|null`.
- `plugins/UserCountry/Columns/City.php`, `Country.php`, `Latitude.php`, `Longitude.php`, `Region.php` — each `onExistingVisit()` returns `getUrlOverrideValueIfAllowed()` (a request-var string or `false`), so `@return int` → `string|false`.

Several type corrections resolved now-obsolete `phpstan-baseline.neon` entries (CliMulti, IniFileChain, ArchivingDbAdapter, Sorter, VisitGoalBuyer, GoalSpecificProcessedMetric); each removal was confirmed via a full-project PHPStan run reporting them as "not matched", with a follow-up full run coming back clean.

## Review

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Also reviewed locally with `codex review` before opening this PR.

## Refs

n/a

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
