### PR TITLE
update isMajorVersion docblock to be clearer

### DIFF
--- a/core/Updates.php
+++ b/core/Updates.php
@@ -56,11 +56,10 @@ abstract class Updates
     }
 
     /**
-     * Tell the updater that this is a major update.
-     * Leads to a more visible notice.
+     * Tell the updater that this update has major operational impact.
      *
-     * NOTE to release manager: Remember to mention in the Changelog
-     * that this update contains major DB upgrades and will take some time!
+     * This is not tied to semantic major versions. Use it for product-level changes that can
+     * require substantial work or downtime on large instances, such as modifying large db tables.
      *
      * @return bool
      */

--- a/core/Updates.php
+++ b/core/Updates.php
@@ -61,6 +61,9 @@ abstract class Updates
      * This is not tied to semantic major versions. Use it for product-level changes that can
      * require substantial work or downtime on large instances, such as modifying large db tables.
      *
+     * NOTE to release manager: Remember to mention in the Changelog
+     * that this update contains major DB upgrades and will take some time!
+     *
      * @return bool
      */
     public static function isMajorUpdate()


### PR DESCRIPTION
### Description

The current docblock for core/Updates::isMajorVersion() is unclear with regards to its actual purpose, and has been updated to more clearly describe what constitutes a 'major' update.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
