### PR TITLE
Resolve user logins to their stored form in UsersManager checks

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1297,10 +1297,10 @@ class API extends \Piwik\Plugin\API
      */
     public function addCapabilities(string $userLogin, $capabilities, $idSites): void
     {
+        $userLogin = $this->getCanonicalLogin($userLogin);
+
         $this->executeConcurrencySafe($userLogin, function () use ($userLogin, $capabilities, $idSites) {
             $idSites = $this->getIdSitesCheckAdminAccess($idSites);
-
-            $userLogin = $this->getCanonicalLogin($userLogin);
 
             if (strtolower($userLogin) === 'anonymous') {
                 throw new Exception(Piwik::translate("UsersManager_ExceptionAnonymousNoCapabilities"));

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -242,6 +242,8 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasSuperUserAccessOrIsTheUser($userLogin);
 
+        $userLogin = $this->getCanonicalLogin($userLogin);
+
         if (!$this->model->userExists($userLogin)) {
             throw new Exception('User does not exist: ' . $userLogin);
         }

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1186,6 +1186,8 @@ class API extends \Piwik\Plugin\API
     ): void {
         UsersManager::dieIfUsersAdminIsDisabled();
 
+        $userLogin = $this->getCanonicalLogin($userLogin);
+
         if ($access != 'noaccess') {
             $this->checkAccessType($access);
         }
@@ -1297,6 +1299,8 @@ class API extends \Piwik\Plugin\API
     {
         $this->executeConcurrencySafe($userLogin, function () use ($userLogin, $capabilities, $idSites) {
             $idSites = $this->getIdSitesCheckAdminAccess($idSites);
+
+            $userLogin = $this->getCanonicalLogin($userLogin);
 
             if (strtolower($userLogin) === 'anonymous') {
                 throw new Exception(Piwik::translate("UsersManager_ExceptionAnonymousNoCapabilities"));
@@ -1471,6 +1475,8 @@ class API extends \Piwik\Plugin\API
 
     private function checkUserIsNotAnonymous(string $userLogin): void
     {
+        $userLogin = $this->getCanonicalLogin($userLogin);
+
         if (strtolower($userLogin) === 'anonymous') {
             throw new Exception(Piwik::translate("UsersManager_ExceptionEditAnonymous"));
         }
@@ -1597,6 +1603,24 @@ class API extends \Piwik\Plugin\API
         if (!$userExists) {
             throw new Exception(Piwik::translate("UsersManager_ExceptionUserDoesNotExist", $userLogin));
         }
+    }
+
+    /**
+     * Resolves the given login to the exact login stored in the database.
+     *
+     * Logins are matched case- and accent-insensitively by the database collation, so different
+     * representations of a login can refer to the same stored user. Checks that treat a specific
+     * login specially (such as the reserved anonymous user) must therefore be based on the resolved
+     * login rather than the raw request value, otherwise an equivalent representation of the login
+     * would not be recognised.
+     *
+     * @return string The stored login if a matching user exists, otherwise the given login unchanged.
+     */
+    private function getCanonicalLogin(string $userLogin): string
+    {
+        $user = $this->model->getUser($userLogin);
+
+        return $user['login'] ?? $userLogin;
     }
 
     /**

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -19,6 +19,7 @@ use Piwik\Common;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
+use Piwik\DbHelper;
 use Piwik\EventDispatcher;
 use Piwik\Mail;
 use Piwik\NoAccessException;
@@ -395,6 +396,16 @@ class APITest extends IntegrationTestCase
     {
         $this->expectExceptionMessage('userlogin: General_ValidatorErrorEmptyValue');
         $this->api->logoutUser('');
+    }
+
+    public function testLogoutUserCollationEquivalentAnonymousLoginShouldFail()
+    {
+        DbHelper::createAnonymousUser();
+
+        // "anonymoüs" is a distinct byte string from "anonymous" but resolves to the reserved
+        // anonymous user under the database collation, so it must be treated as anonymous.
+        $this->expectExceptionMessage('UsersManager_ExceptionEditAnonymous');
+        $this->api->logoutUser('anonymoüs');
     }
 
     public function testLogoutUserDeleteSessionUserShouldNotThrowErrorIfNoSessionExists()
@@ -1213,6 +1224,29 @@ class APITest extends IntegrationTestCase
         $this->expectExceptionMessage('UsersManager_ExceptionAnonymousAccessNotPossible');
 
         $this->api->setUserAccess('anonymous', 'write', [1]);
+    }
+
+    public function testSetUserAccessCannotSetAdminToAnonymousUsingCollationEquivalentLogin()
+    {
+        DbHelper::createAnonymousUser();
+
+        // "anonymoüs" is a distinct byte string from "anonymous", but the database matches logins
+        // case- and accent-insensitively, so it resolves to the reserved anonymous user. The
+        // anonymous restriction must still apply.
+        $collationEquivalentLogin = 'anonymoüs';
+
+        try {
+            $this->api->setUserAccess($collationEquivalentLogin, 'admin', [1]);
+            self::fail('Expected UsersManager_ExceptionAnonymousAccessNotPossible to be thrown');
+        } catch (\Exception $e) {
+            self::assertStringContainsString('UsersManager_ExceptionAnonymousAccessNotPossible', $e->getMessage());
+        }
+
+        // no access row must have been created for either representation of the anonymous login
+        $access = $this->model->getSitesAccessFromUser('anonymous');
+        self::assertSame([], $access);
+        $access = $this->model->getSitesAccessFromUser($collationEquivalentLogin);
+        self::assertSame([], $access);
     }
 
     public function testSetUserAccessCannotSetViewToAnonymousWithoutPassword()

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -233,6 +233,17 @@ class APITest extends IntegrationTestCase
         self::assertEquals('5', $siteId);
     }
 
+    public function testSetUserPreferenceStoresPreferenceUnderStoredLoginWhenUsingCollationEquivalentLogin()
+    {
+        // "userLogín" is a distinct byte string from the stored "userLogin", but the database matches
+        // logins case- and accent-insensitively, so it resolves to the same user. The preference must
+        // be stored under the stored login rather than the raw request value.
+        $this->api->setUserPreference('userLogín', API::PREFERENCE_DEFAULT_REPORT, 5);
+
+        $settingsStore = StaticContainer::get(UserScopedSettingsAccessManager::class);
+        self::assertEquals(5, $settingsStore->get('UsersManager', $this->login, API::PREFERENCE_DEFAULT_REPORT, false));
+    }
+
     public function testSetUserPreferenceWritesLegacyOptionForIsLdapUserCompatibility()
     {
         $this->api->setUserPreference($this->login, 'isLDAPUser', 1);


### PR DESCRIPTION
## Description

Logins are matched case- and accent-insensitively by the database collation, so several representations of the same login (differing only in case or accented characters) all resolve to a single stored user. A few `UsersManager` checks that special-case particular logins compared the raw request value directly, which is not consistent with how the login is later resolved against the database.

This adds a small `getCanonicalLogin()` helper that resolves a provided login to the exact login stored in the database, and uses it so the affected checks operate on the resolved login rather than the raw request value.

## Changes

- Add a `getCanonicalLogin()` helper in `Piwik\Plugins\UsersManager\API`.
- Use it in `setUserAccess()`, `addCapabilities()` and `checkUserIsNotAnonymous()` so these checks are based on the actual stored login.
- Add integration tests covering these paths.

## Review

- [ ] Functional review
- [ ] Code style / static analysis (PHPCS + PHPStan pass locally)
- [ ] Tests pass

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
