### PR TITLE
UI Test - Select XSS goal metric in goals row-evolution

### DIFF
--- a/plugins/Goals/tests/UI/Goals_spec.js
+++ b/plugins/Goals/tests/UI/Goals_spec.js
@@ -140,7 +140,13 @@ describe("Goals", function () {
         await page.waitForSelector('.ui-dialog');
         await page.waitForNetworkIdle();
 
-        const series = await page.waitForSelector('[data-name="series3"]');
+        // Select the metric whose label contains an XSS payload (the goal name),
+        // so this screenshot keeps guarding against XSS regressions in row evolution.
+        // Selecting by label (not by color-slot index like series3) is stable even
+        // when metric/series colors are reordered.
+        const series = await page.waitForXPath(
+            '//span[contains(@class, "evolution-graph-colors") and contains(., "_Vue.h.constructor")]'
+        );
         await series.click();
 
         await page.waitForTimeout(250); // rendering

--- a/plugins/Goals/tests/UI/expected-screenshots/Goals_action_goals_row_evolution.png
+++ b/plugins/Goals/tests/UI/expected-screenshots/Goals_action_goals_row_evolution.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:775f4981a0958b51f8006ba1ddb2c255ad4a5e19cd2b5232610f598f2eae7b7a
-size 74252
+oid sha256:8b55c2a6710b274bcb401ac3a71f64941f093726fff241ed50b354658e76039f
+size 77481


### PR DESCRIPTION
### Description

The test picked the row-evolution metric via `[data-name="series3"]`, but that attribute is a color slot (`series{{ i % seriesColorCount }}`), not a metric identifier. The row-evolution color change shifted that mapping in #24733, so series3 moved off the XSS-named goal's conversion rate onto "Revenue per Visit", dropping the XSS coverage.

Select the metric by its XSS payload label instead, so the screenshot keeps guarding against XSS regressions in row evolution regardless of series/color ordering. Also update the expected screenshot.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)