### PR TITLE
Docblock quality fixes (chunk 20)

### DIFF
--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -106,7 +106,7 @@ class ArchiveProcessor
     private $params;
 
     /**
-     * @var int
+     * @var int|false
      */
     private $numberOfVisits = false;
 

--- a/core/Settings/Storage/Factory.php
+++ b/core/Settings/Storage/Factory.php
@@ -44,7 +44,7 @@ class Factory
 
     /**
      * @param string $section
-     * @return mixed
+     * @return Storage
      */
     public function getConfigStorage($section)
     {

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -857,7 +857,7 @@ class GoalManager
      * @param string $hook
      * @param Visitor $visitor
      * @param Action|null $action
-     * @param array|null $valuesToUpdate If null, $this->visitorInfo will be updated
+     * @param array|null $valuesToUpdate
      *
      * @return array|null The updated $valuesToUpdate or null if no $valuesToUpdate given
      */

--- a/core/Tracker/Settings.php
+++ b/core/Tracker/Settings.php
@@ -22,7 +22,7 @@ class Settings // TODO: merge w/ visitor recognizer or make it it's own service.
 
     /**
      * If `true`, the config ID for a visitor will be the same no matter what site is being tracked.
-     * If `false, the config ID will be different.
+     * If `false`, the config ID will be different.
      *
      * @var bool
      */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -175,15 +175,7 @@ parameters:
 			count: 1
 			path: core/ArchiveProcessor.php
 
-		-
-			message: "#^Property Piwik\\\\ArchiveProcessor\\:\\:\\$numberOfVisits \\(int\\) does not accept default value of type false\\.$#"
-			count: 1
-			path: core/ArchiveProcessor.php
 
-		-
-			message: "#^Strict comparison using \\=\\=\\= between int and false will always evaluate to false\\.$#"
-			count: 1
-			path: core/ArchiveProcessor.php
 
 		-
 			message: "#^Left side of && is always true\\.$#"
@@ -2008,35 +2000,8 @@ parameters:
 			count: 1
 			path: plugins/Actions/Columns/ActionType.php
 
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Actions\\\\Columns\\\\VisitTotalActions\\:\\:onExistingVisit\\(\\) should return int but returns false\\.$#"
-			count: 2
-			path: plugins/Actions/Columns/VisitTotalActions.php
 
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Actions\\\\Columns\\\\VisitTotalActions\\:\\:onExistingVisit\\(\\) should return int but returns string\\.$#"
-			count: 2
-			path: plugins/Actions/Columns/VisitTotalActions.php
 
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Actions\\\\Columns\\\\VisitTotalInteractions\\:\\:onExistingVisit\\(\\) should return int but returns false\\.$#"
-			count: 1
-			path: plugins/Actions/Columns/VisitTotalInteractions.php
-
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Actions\\\\Columns\\\\VisitTotalInteractions\\:\\:onExistingVisit\\(\\) should return int but returns string\\.$#"
-			count: 1
-			path: plugins/Actions/Columns/VisitTotalInteractions.php
-
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Actions\\\\Columns\\\\VisitTotalSearches\\:\\:onExistingVisit\\(\\) should return int but returns false\\.$#"
-			count: 1
-			path: plugins/Actions/Columns/VisitTotalSearches.php
-
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Actions\\\\Columns\\\\VisitTotalSearches\\:\\:onExistingVisit\\(\\) should return int but returns string\\.$#"
-			count: 1
-			path: plugins/Actions/Columns/VisitTotalSearches.php
 
 		-
 			message: "#^Parameter \\#1 \\$idSite of method Piwik\\\\Plugins\\\\Actions\\\\RecordBuilders\\\\ActionReports\\:\\:getGoalsForSite\\(\\) expects string, int given\\.$#"
@@ -2203,10 +2168,6 @@ parameters:
 			count: 1
 			path: plugins/CoreHome/Columns/Metrics/EvolutionMetric.php
 
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\CoreHome\\\\Columns\\\\VisitTotalTime\\:\\:onConvertedVisit\\(\\) should return int but returns false\\.$#"
-			count: 1
-			path: plugins/CoreHome/Columns/VisitTotalTime.php
 
 		-
 			message: "#^Parameter \\#1 \\$sqlFilterValue of method Piwik\\\\Plugin\\\\Segment\\:\\:setSqlFilterValue\\(\\) expects array\\|string, Closure given\\.$#"
@@ -2623,15 +2584,6 @@ parameters:
 			count: 1
 			path: plugins/Ecommerce/Columns/BaseConversion.php
 
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Events\\\\Columns\\\\TotalEvents\\:\\:onExistingVisit\\(\\) should return int but returns false\\.$#"
-			count: 1
-			path: plugins/Events/Columns/TotalEvents.php
-
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Events\\\\Columns\\\\TotalEvents\\:\\:onExistingVisit\\(\\) should return int but returns string\\.$#"
-			count: 1
-			path: plugins/Events/Columns/TotalEvents.php
 
 		-
 			message: "#^Parameter \\#3 \\$escapeComment of static method Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\DiagnosticResult\\:\\:informationalResult\\(\\) expects bool, string given\\.$#"
@@ -3158,10 +3110,6 @@ parameters:
 			count: 1
 			path: plugins/PrivacyManager/Model/LogDataAnonymizations.php
 
-		-
-			message: "#^Call to function is_null\\(\\) with Piwik\\\\DataTable\\\\DataTableInterface will always evaluate to false\\.$#"
-			count: 1
-			path: plugins/PrivacyManager/PrivacyManager.php
 
 		-
 			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
@@ -3170,8 +3118,9 @@ parameters:
 
 		-
 			message: "#^Variable \\$dataTable in empty\\(\\) always exists and is not falsy\\.$#"
-			count: 2
+			count: 1
 			path: plugins/PrivacyManager/PrivacyManager.php
+
 
 		-
 			message: "#^Parameter \\#1 \\$reportDateYear of static method Piwik\\\\Plugins\\\\PrivacyManager\\\\ReportsPurger\\:\\:shouldReportBePurged\\(\\) expects int, string given\\.$#"

--- a/plugins/Actions/Columns/ExitPageTitle.php
+++ b/plugins/Actions/Columns/ExitPageTitle.php
@@ -56,7 +56,7 @@ class ExitPageTitle extends VisitDimension
 
     /**
      * @param Action|null $action
-     * @return int|bool
+     * @return int|false|null
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/Actions/Columns/VisitTotalActions.php
+++ b/plugins/Actions/Columns/VisitTotalActions.php
@@ -76,7 +76,7 @@ class VisitTotalActions extends VisitDimension
 
     /**
      * @param Action|null $action
-     * @return int
+     * @return string|false
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/Actions/Columns/VisitTotalInteractions.php
+++ b/plugins/Actions/Columns/VisitTotalInteractions.php
@@ -47,7 +47,7 @@ class VisitTotalInteractions extends VisitDimension
 
     /**
      * @param Action|null $action
-     * @return int
+     * @return string|false
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/Actions/Columns/VisitTotalSearches.php
+++ b/plugins/Actions/Columns/VisitTotalSearches.php
@@ -43,7 +43,7 @@ class VisitTotalSearches extends VisitDimension
 
     /**
      * @param Action|null $action
-     * @return int
+     * @return string|false
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/CoreHome/Columns/VisitTotalTime.php
+++ b/plugins/CoreHome/Columns/VisitTotalTime.php
@@ -51,7 +51,7 @@ class VisitTotalTime extends VisitDimension
 
     /**
      * @param Action|null $action
-     * @return int
+     * @return int|false
      */
     public function onConvertedVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -88,7 +88,7 @@ class Controller extends \Piwik\Plugin\Controller
     }
 
     /**
-     * Return the base.less compiled to css
+     * Return the compiled JavaScript for the updater screen.
      *
      * @return string
      */

--- a/plugins/Events/Columns/TotalEvents.php
+++ b/plugins/Events/Columns/TotalEvents.php
@@ -43,7 +43,7 @@ class TotalEvents extends VisitDimension
 
     /**
      * @param Action|null $action
-     * @return int
+     * @return string|false
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -540,7 +540,7 @@ class Controller extends ControllerAdmin
     }
 
     /**
-     * Return the base.less compiled to css
+     * Return the compiled JavaScript for the installation screen.
      *
      * @return string
      */

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -564,8 +564,7 @@ class Model
      *                      visitor will be the visitor that appears chronologically later in the
      *                      log_visit table. The previous visitor will be the visitor that appears
      *                      earlier.
-     * @return string The hex visitor ID.
-     * @throws Exception
+     * @return string|false The hex visitor ID, or false if no adjacent visitor exists.
      */
     public function queryAdjacentVisitorId($idSite, $visitorId, $visitLastActionTime, $segment, $getNext)
     {

--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -100,7 +100,7 @@ class PrivacyManager extends Plugin
      * - The data table for this report must either be empty or not have been fetched.
      * - The period of this report is not a multiple period.
      * - The date of this report must be older than the delete_reports_older_than config option.
-     * @param  DataTableInterface $dataTable
+     * @param  DataTableInterface|null $dataTable
      * @return bool
      */
     public static function hasReportBeenPurged($dataTable)
@@ -132,7 +132,7 @@ class PrivacyManager extends Plugin
     }
 
     /**
-     * @param DataTable $dataTable
+     * @param DataTable|null $dataTable
      * @param int|null $logsOlderThan If set, it is assumed that log deletion is enabled with the given amount of days
      * @return bool
      */

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -850,7 +850,7 @@ class Model
          * This event should be used to clean up any data that is related to the now deleted user.
          * The **Dashboard** plugin, for example, uses this event to remove the user's dashboards.
          *
-         * @param string $userLogins The login handle of the deleted user.
+         * @param string $userLogin The login handle of the deleted user.
          */
         try {
             Piwik::postEvent('UsersManager.deleteUser', array($userLogin));


### PR DESCRIPTION
## Description

Continues the docblock quality cleanup series (chunk 20). Fixes 15 existing docblocks across `core/` and `plugins/` where the PHPDoc did not match the actual code behavior. Documentation-only — no code behavior changes.

**Tracker dimension return types** — several `VisitDimension` methods documented `@return int` actually return a SQL-expression string or `false`:
- `plugins/Actions/Columns/VisitTotalInteractions.php`, `VisitTotalActions.php`, `VisitTotalSearches.php`, `plugins/Events/Columns/TotalEvents.php` — `onExistingVisit()` returns `'<col> + 1'` (string) or `false` → `@return string|false`.
- `plugins/CoreHome/Columns/VisitTotalTime.php` — `onConvertedVisit()` returns `false` for unknown visitors → `@return int|false`.
- `plugins/Actions/Columns/ExitPageTitle.php` — `onExistingVisit()` returns `false` or `getIdActionNameForEntryAndExitIds()` (which is `null` for site-search actions) → `@return int|false|null`.

**Core:**
- `core/ArchiveProcessor.php` — `$numberOfVisits` is initialized to `false` and checked `=== false`, so `@var int` → `int|false`.
- `core/Settings/Storage/Factory.php` — `getConfigStorage()` always returns a `Storage` (via `makeStorage()`), so `@return mixed` → `Storage`.
- `core/Tracker/GoalManager.php` — `triggerHookOnDimensions()` `@param` had a stale "If null, $this->visitorInfo will be updated" note (no such property; copied from `Visit`); removed it.
- `core/Tracker/Settings.php` — unbalanced inline-code backtick in a property docblock (`` `false `` → `` `false` ``).

**Plugins:**
- `plugins/CoreUpdater/Controller.php` / `plugins/Installation/Controller.php` — `getUpdaterJs()`/`getInstallationJs()` summaries wrongly said "Return the base.less compiled to css" (copied from the CSS methods); they return compiled JavaScript.
- `plugins/Live/Model.php` — `queryAdjacentVisitorId()` returns `false` when no adjacent visitor exists → `@return string|false`.
- `plugins/PrivacyManager/PrivacyManager.php` — `hasReportBeenPurged()`/`haveLogsBeenPurged()` accept `null` for `$dataTable` (guarded via `is_null`/`empty`) → `@param …|null`.
- `plugins/UsersManager/Model.php` — the `UsersManager.deleteUser` event `@param` name `$userLogins` → `$userLogin` (a single login is posted).

Several type corrections resolved now-obsolete `phpstan-baseline.neon` entries (the four dimension `int`→`string`/`false` pairs, VisitTotalTime, ArchiveProcessor's `$numberOfVisits`, and two PrivacyManager `is_null`/`empty` entries); each removal was confirmed via a full-project PHPStan run reporting them as "not matched" (one `empty()` entry was kept with a reduced count because a short-circuit path is still non-null), with a follow-up full run coming back clean.

## Review

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Also reviewed locally with `codex review` before opening this PR.

## Refs

n/a

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
