### PR TITLE
Docblock quality fixes (chunk 21)

### DIFF
--- a/core/Archive/DataCollection.php
+++ b/core/Archive/DataCollection.php
@@ -107,7 +107,7 @@ class DataCollection
      * @param array $sitesId @see $this->sitesId
      * @param \Piwik\Period[] $periods @see $this->periods
      * @param \Piwik\Segment $segment @see $this->segment
-     * @param array $defaultRow @see $this->defaultRow
+     * @param array|null $defaultRow @see $this->defaultRow
      */
     public function __construct($dataNames, $dataType, $sitesId, $periods, $segment, $defaultRow = null)
     {

--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -187,7 +187,8 @@ class Process
     }
 
     /**
-     * Tests only
+     * Writes the given content to the process' PID file.
+     *
      * @internal
      * @param string|int $content
      */

--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -84,9 +84,9 @@ class Cookie
      * exists already.
      *
      * @param string $cookieName cookie Name
-     * @param int|string $expire The timestamp after which the cookie will expire, eg time() + 86400;
+     * @param int|string|null $expire The timestamp after which the cookie will expire, eg time() + 86400;
      *                                  use 0 (int zero) to expire cookie at end of browser session
-     * @param string $path The path on the server in which the cookie will be available on.
+     * @param string|null $path The path on the server in which the cookie will be available on.
      * @param bool|string $keyStore Will be used to store several bits of data (eg. one array per website)
      */
     public function __construct($cookieName, $expire = null, $path = null, $keyStore = false)

--- a/core/DataAccess/LogQueryBuilder.php
+++ b/core/DataAccess/LogQueryBuilder.php
@@ -25,7 +25,7 @@ class LogQueryBuilder
     private $logTableProvider;
 
     /**
-     * Forces to use a subselect when generating the query. Set value to `false` to force not using a subselect.
+     * Forces to use a subselect when generating the query. Set value to the FORCE_INNER_GROUP_BY_NO_SUBSELECT constant to force not using a subselect.
      * @var string
      */
     private $forcedInnerGroupBy = '';

--- a/core/Db/Adapter/Mysqli.php
+++ b/core/Db/Adapter/Mysqli.php
@@ -187,7 +187,7 @@ class Mysqli extends Zend_Db_Adapter_Mysqli implements AdapterInterface
      * Test error number
      *
      * @param Exception $e
-     * @param string $errno
+     * @param string|int $errno
      * @return bool
      */
     public function isErrNo($e, $errno)
@@ -200,7 +200,7 @@ class Mysqli extends Zend_Db_Adapter_Mysqli implements AdapterInterface
      *
      * @param Exception $e
      * @param \mysqli|null $connection
-     * @param string $errno
+     * @param string|int $errno
      * @return bool
      */
     public static function isMysqliErrorNumber($e, $connection, $errno)

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -216,7 +216,7 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * Test error number
      *
      * @param Exception $e
-     * @param string $errno
+     * @param string|int $errno
      * @return bool
      */
     public function isErrNo($e, $errno)
@@ -229,7 +229,7 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * Test error number
      *
      * @param Exception $e
-     * @param string $errno
+     * @param string|int $errno
      * @return bool
      */
     public static function isPdoErrorNumber($e, $errno)

--- a/core/Db/Schema/Tidb.php
+++ b/core/Db/Schema/Tidb.php
@@ -10,7 +10,7 @@
 namespace Piwik\Db\Schema;
 
 /**
- * Mariadb schema
+ * TiDB schema
  */
 class Tidb extends Mysql
 {

--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -568,7 +568,7 @@ class Filesystem
     }
 
     /**
-     * Check if the filesystem is case sensitive by writing a temporary file
+     * Check if the filesystem is case insensitive by writing a temporary file
      */
     public static function isFileSystemCaseInsensitive(): bool
     {

--- a/core/Period/Factory.php
+++ b/core/Period/Factory.php
@@ -62,8 +62,6 @@ abstract class Factory
     /**
      * Creates a new Period instance with a period ID and {@link Date} instance.
      *
-     * _Note: This method cannot create {@link Period\Range} periods._
-     *
      * @param string $period `"day"`, `"week"`, `"month"`, `"year"`, `"range"`.
      * @param Date|string $date A date within the period or the range of dates.
      * @param string $timezone Optional timezone that will be used only when $period is 'range' or $date is 'last|previous'

--- a/core/Tracker/Db.php
+++ b/core/Tracker/Db.php
@@ -229,7 +229,7 @@ abstract class Db implements TransactionalDatabaseInterface
      * Test error number
      *
      * @param Exception $e
-     * @param string $errno
+     * @param string|int $errno
      * @return bool  True if error number matches; false otherwise
      */
     abstract public function isErrNo($e, $errno);

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -56,7 +56,7 @@ class Request
      * whatever they want in this array, and other RequestProcessors can modify these
      * values to change tracker behavior.
      *
-     * @var string[][]
+     * @var array<string, array<string, mixed>> Keyed by plugin name, then metadata key.
      */
     private $requestMetadata = array();
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -625,10 +625,6 @@ parameters:
 			count: 1
 			path: core/Db/Adapter/Pdo/Mysql.php
 
-		-
-			message: "#^Parameter \\#2 \\$errno of method Piwik\\\\Db\\\\Adapter\\\\Pdo\\\\Mysql\\:\\:isErrNo\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: core/Db/Adapter/Pdo/Mysql.php
 
 		-
 			message: "#^Call to function is_null\\(\\) with mixed will always evaluate to false\\.$#"
@@ -3208,15 +3204,6 @@ parameters:
 			count: 1
 			path: plugins/Referrers/Columns/Base.php
 
-		-
-			message: "#^PHPDoc type bool of property Piwik\\\\Plugins\\\\Referrers\\\\Columns\\\\Campaign\\:\\:\\$nameSingular is not covariant with PHPDoc type string of overridden property Piwik\\\\Columns\\\\Dimension\\:\\:\\$nameSingular\\.$#"
-			count: 1
-			path: plugins/Referrers/Columns/Campaign.php
-
-		-
-			message: "#^Property Piwik\\\\Plugins\\\\Referrers\\\\Columns\\\\Campaign\\:\\:\\$nameSingular \\(bool\\) does not accept default value of type string\\.$#"
-			count: 1
-			path: plugins/Referrers/Columns/Campaign.php
 
 		-
 			message: "#^Method Piwik\\\\Plugins\\\\Referrers\\\\Columns\\\\Metrics\\\\VisitorsFromReferrerPercent\\:\\:getTranslatedName\\(\\) should return string but returns null\\.$#"

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -950,7 +950,7 @@ class ArchivingHelper
      *
      * @param string $name action name
      * @param int $type action type
-     * @param int $urlPrefix url prefix (only used for TYPE_PAGE_URL)
+     * @param int|null $urlPrefix url prefix (only used for TYPE_PAGE_URL)
      * @return array of exploded elements from $name
      */
     public static function getActionExplodedNames($name, $type, $urlPrefix = null)
@@ -1021,7 +1021,7 @@ class ArchivingHelper
     }
 
     /**
-     * Get cached action row by id & type. If $idAction is set to -1, the 'Others' row
+     * Get cached action row by id & type. If $idAction is set to RankingQuery::LABEL_SUMMARY_ROW, the 'Others' row
      * for the specific action type will be returned.
      *
      * @param int $idAction

--- a/plugins/CoreVisualizations/JqplotDataGenerator.php
+++ b/plugins/CoreVisualizations/JqplotDataGenerator.php
@@ -77,7 +77,7 @@ class JqplotDataGenerator
      * Generates JSON graph data and returns it.
      *
      * @param DataTable|DataTable\Map $dataTable
-     * @return string
+     * @return array
      */
     public function generate($dataTable)
     {

--- a/plugins/Referrers/Columns/Campaign.php
+++ b/plugins/Referrers/Columns/Campaign.php
@@ -17,12 +17,6 @@ use Piwik\Tracker\Visitor;
 
 class Campaign extends Base
 {
-    /**
-     * Obtained from the `[Tracker] create_new_visit_when_campaign_changes` INI config option.
-     * If true, will create new visits when campaign name changes.
-     *
-     * @var bool
-     */
     protected $nameSingular = 'Referrers_ColumnCampaign';
 
     /**

--- a/plugins/SegmentEditor/Model.php
+++ b/plugins/SegmentEditor/Model.php
@@ -85,8 +85,8 @@ class Model
     /**
      * Returns all stored segments that are available for the given site and login.
      *
-     * @param  string $userLogin
      * @param  int    $idSite Whether to return stored segments for a specific idSite, or all of them. If supplied, must be a valid site ID.
+     * @param  string $userLogin
      * @return array
      */
     public function getAllSegmentsForSite($idSite, $userLogin)


### PR DESCRIPTION
## Description

Continues the docblock quality cleanup series (chunk 21). Fixes 15 existing docblocks across `core/` and `plugins/` where the PHPDoc did not match the actual code behavior. Documentation-only — no code behavior changes.

**Core:**
- `core/Db/Schema/Tidb.php` — class summary was "Mariadb schema" (copy-paste); it's the TiDB schema.
- `core/Tracker/Db.php`, `core/Db/Adapter/Mysqli.php`, `core/Db/Adapter/Pdo/Mysql.php` — `isErrNo()`/`isMysqliErrorNumber()`/`isPdoErrorNumber()` receive an int error code (callers pass e.g. `2006`), matching the `AdapterInterface` contract, so `@param string $errno` → `string|int`.
- `core/Cookie.php` — constructor `$expire` and `$path` default to `null`, so `@param` → `int|string|null` / `string|null`.
- `core/Filesystem.php` — `isFileSystemCaseInsensitive()` summary said it checks "case sensitive" (inverted; it returns true when insensitive).
- `core/CliMulti/Process.php` — `writePidFileContent()` was marked "Tests only" but is used in production (`startProcess()`/`markAsNotStarted()`); replaced with an accurate summary.
- `core/Period/Factory.php` — `build()` note falsely claimed it "cannot create Range periods"; it does (for `'range'`/multiple-period dates).
- `core/Tracker/Request.php` — `$requestMetadata` stores arbitrary values (bool/object/array) keyed by plugin name then key, not `string[][]`; `@var array<string, array<string, mixed>>`.
- `core/DataAccess/LogQueryBuilder.php` — `$forcedInnerGroupBy` doc said set to `false` to disable subselect; the trigger is the `FORCE_INNER_GROUP_BY_NO_SUBSELECT` constant.
- `core/Archive/DataCollection.php` — constructor `$defaultRow` defaults to `null` (`=== null` branch), so `@param` → `array|null`.

**Plugins:**
- `plugins/Referrers/Columns/Campaign.php` — a misplaced `@var bool` docblock (describing a config flag) sat on the string `$nameSingular` property; removed it.
- `plugins/SegmentEditor/Model.php` — `getAllSegmentsForSite($idSite, $userLogin)` had its two `@param` lines in reversed order.
- `plugins/Actions/ArchivingHelper.php` — `getCachedActionRow` doc said the `-1` sentinel returns the 'Others' row (it's `RankingQuery::LABEL_SUMMARY_ROW`); `getActionExplodedNames` `$urlPrefix` defaults to `null` (`int|null`).
- `plugins/CoreVisualizations/JqplotDataGenerator.php` — `generate()` returns the `Chart::render()` array, not a `string`.

Several type corrections resolved now-obsolete `phpstan-baseline.neon` entries (the `Db\Adapter\Pdo\Mysql::isErrNo` call site and the two `Campaign::$nameSingular` `@var bool` entries); each removal was confirmed via a full-project PHPStan run reporting them as "not matched", with a follow-up full run coming back clean.

## Review

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Also reviewed locally with `codex review` before opening this PR.

## Refs

n/a

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
