### PR TITLE
Docblock quality fixes (chunk 22)

### DIFF
--- a/core/Auth/Password.php
+++ b/core/Auth/Password.php
@@ -84,7 +84,7 @@ class Password
      *
      * Can be used to verify whether a string is compatible with password_hash().
      *
-     * @param string
+     * @param string $hash
      * @return array
      */
     public function info($hash)

--- a/core/Category/Category.php
+++ b/core/Category/Category.php
@@ -28,7 +28,7 @@ class Category
 
     /**
      * The id of the category as specified eg in {@link Piwik\Widget\WidgetConfig::setCategoryId()`} or
-     * {@link Piwik\Report\getCategoryId()}. The id is used as the name in the menu and will be visible in the
+     * {@link Piwik\Plugin\Report::getCategoryId()}. The id is used as the name in the menu and will be visible in the
      * URL.
      *
      * @var string Should be a translation key, eg 'General_Visits'

--- a/core/Category/CategoryList.php
+++ b/core/Category/CategoryList.php
@@ -12,11 +12,9 @@ namespace Piwik\Category;
 use Piwik\Container\StaticContainer;
 
 /**
- * Base type for category. lets you change the name for a categoryId and specify a different order
- * so the category appears eg at a different order in the reporting menu.
+ * Holds the list of categories (with their subcategories) available in the Piwik reporting menu.
  *
- * This class is for now not exposed as public API until needed. Categories of plugins will be automatically
- * displayed in the menu at the very right after all core categories.
+ * This class is for now not exposed as public API until needed.
  */
 class CategoryList
 {

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -1217,8 +1217,8 @@ class LogAggregator
      *
      * Additional data can be selected through the `$additionalSelects` parameter.
      *
-     * _Note: This method will only query the **log_conversion** table. Other tables cannot be joined
-     * using this method._
+     * _Note: By default this method queries the **log_conversion** table, but additional tables can be
+     * joined via the `$extraFrom` parameter._
      *
      * @param array<string>|string $dimensions One or more **SELECT** fields that will be used to group the log_conversion
      *                                 rows by. This parameter determines which **log_conversion** rows will be

--- a/core/DataTable/Map.php
+++ b/core/DataTable/Map.php
@@ -429,7 +429,7 @@ class Map implements DataTableInterface
         if ($firstChild instanceof Map) {
             $result = $firstChild->getEmptyClone();
 
-            /** @var $subDataTableMap Map */
+            /** @var Map $subDataTableMap */
             foreach ($this->getDataTables() as $label => $subDataTableMap) {
                 foreach ($subDataTableMap->getDataTables() as $innerLabel => $subTable) {
                     if (!isset($result->array[$innerLabel])) {

--- a/core/Http/ControllerResolver.php
+++ b/core/Http/ControllerResolver.php
@@ -71,7 +71,7 @@ class ControllerResolver
             return null;
         }
 
-        /** @var $controller Controller */
+        /** @var \Piwik\Plugin\Controller $controller */
         $controller = $this->abstractFactory->make($controllerClass);
 
         $action = $action ?: $controller->getDefaultAction();

--- a/core/Option.php
+++ b/core/Option.php
@@ -151,7 +151,7 @@ class Option
     /**
      * Sets the singleton instance. For testing purposes.
      *
-     * @param mixed
+     * @param mixed $instance
      * @ignore
      */
     public static function setSingletonInstance($instance)

--- a/core/Period.php
+++ b/core/Period.php
@@ -134,7 +134,7 @@ abstract class Period
 
         $periods = $this->getSubperiods();
 
-        /** @var $currentPeriod Period */
+        /** @var Period $currentPeriod */
         $currentPeriod = $periods[0];
         while ($currentPeriod->getNumberOfSubperiods() > 0) {
             $periods       = $currentPeriod->getSubperiods();
@@ -179,7 +179,7 @@ abstract class Period
 
         $periods = $this->getSubperiods();
 
-        /** @var $currentPeriod Period */
+        /** @var Period $currentPeriod */
         $currentPeriod = $periods[count($periods) - 1];
         while ($currentPeriod->getNumberOfSubperiods() > 0) {
             $periods       = $currentPeriod->getSubperiods();

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -597,8 +597,6 @@ class Segment
      * @param int $offset Specified the offset of the first row to return
      * @param bool $forceGroupBy Force the group by and not using a subquery. Note: This may make the query slower see https://github.com/matomo-org/matomo/issues/9200#issuecomment-183641293
      *                           A $groupBy value needs to be set for this to work.
-     * @param int If set to value >= 1 then the Select query (and All inner queries) will be LIMIT'ed by this value.
-     *              Use only when you're not aggregating or it will sample the data.
      * @return array{sql: string, bind: array<scalar>} The entire select query.
      */
     public function getSelectQuery($select, $from, $where = false, $bind = array(), $orderBy = false, $groupBy = false, $limit = 0, $offset = 0, $forceGroupBy = false, bool $withRollup = false)

--- a/core/Tracker/Action.php
+++ b/core/Tracker/Action.php
@@ -176,7 +176,7 @@ abstract class Action
     /**
      * Returns URL of the page currently being tracked, or the file being downloaded, or the outlink being clicked
      *
-     * @return string
+     * @return string|false|null
      */
     public function getActionUrl()
     {

--- a/core/Updater/Migration/Db/Sql.php
+++ b/core/Updater/Migration/Db/Sql.php
@@ -28,7 +28,7 @@ class Sql extends DbMigration
     protected $sql;
 
     /**
-     * @var false|int|array
+     * @var array
      */
     private $errorCodesToIgnore;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -533,11 +533,6 @@ parameters:
 			path: core/DataTable/Map.php
 
 		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\$subDataTableMap Map\\)\\: Unexpected token \"\\$subDataTableMap\", expected type at offset 9$#"
-			count: 1
-			path: core/DataTable/Map.php
-
-		-
 			message: "#^Result of && is always false\\.$#"
 			count: 1
 			path: core/DataTable/Renderer.php
@@ -751,11 +746,6 @@ parameters:
 		-
 			message: "#^PHPDoc tag @param for parameter \\$timezone with type array\\<Piwik\\\\Date\\> is incompatible with native type string\\.$#"
 			count: 1
-			path: core/Period.php
-
-		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\$currentPeriod Period\\)\\: Unexpected token \"\\$currentPeriod\", expected type at offset 9$#"
-			count: 2
 			path: core/Period.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -258,11 +258,6 @@ parameters:
 			path: core/Auth/Password.php
 
 		-
-			message: "#^PHPDoc tag @param has invalid value \\(string\\)\\: Unexpected token \"\\\\n     \\* \", expected variable at offset 193$#"
-			count: 1
-			path: core/Auth/Password.php
-
-		-
 			message: "#^Call to an undefined method Piwik\\\\Db\\\\AdapterInterface\\:\\:fetchAll\\(\\)\\.$#"
 			count: 1
 			path: core/Changes/Model.php
@@ -739,11 +734,6 @@ parameters:
 			path: core/NumberFormatter.php
 
 		-
-			message: "#^PHPDoc tag @param has invalid value \\(mixed\\)\\: Unexpected token \"\\\\n     \\* \", expected variable at offset 88$#"
-			count: 1
-			path: core/Option.php
-
-		-
 			message: "#^PHPDoc tag @param for parameter \\$timezone with type array\\<Piwik\\\\Date\\> is incompatible with native type string\\.$#"
 			count: 1
 			path: core/Period.php
@@ -1145,14 +1135,6 @@ parameters:
 
 		-
 			message: "#^If condition is always false\\.$#"
-			count: 1
-			path: core/Segment.php
-
-		-
-			message: """
-				#^PHPDoc tag @param has invalid value \\(int If set to value \\>\\= 1 then the Select query \\(and All inner queries\\) will be LIMIT'ed by this value\\.
-				             Use only when you're not aggregating or it will sample the data\\.\\)\\: Unexpected token "If", expected variable at offset 1187$#
-			"""
 			count: 1
 			path: core/Segment.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2972,11 +2972,6 @@ parameters:
 			path: plugins/Login/Model.php
 
 		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 171$#"
-			count: 1
-			path: plugins/Login/PasswordResetter.php
-
-		-
 			message: "#^Parameter \\#2 \\$password of method Piwik\\\\Plugins\\\\UsersManager\\\\UserUpdater\\:\\:updateUserWithoutCurrentPassword\\(\\) expects bool, string given\\.$#"
 			count: 1
 			path: plugins/Login/PasswordResetter.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3360,11 +3360,6 @@ parameters:
 			path: plugins/UsersManager/SystemSettings.php
 
 		-
-			message: "#^PHPDoc tag @param has invalid value \\(API\\)\\: Unexpected token \"\\\\n     \", expected variable at offset 21$#"
-			count: 1
-			path: plugins/UsersManager/Tasks.php
-
-		-
 			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
 			count: 1
 			path: plugins/UsersManager/TokenNotifications/TokenNotifierTask.php
@@ -3413,11 +3408,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
 			count: 4
 			path: plugins/WebsiteMeasurable/MeasurableSettings.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(string\\|array urls\\)\\: Unexpected token \"urls\", expected variable at offset 172$#"
-			count: 1
-			path: plugins/WebsiteMeasurable/Settings/Urls.php
 
 		-
 			message: "#^If condition is always false\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -704,11 +704,6 @@ parameters:
 			path: core/FrontController.php
 
 		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\$controller Controller\\)\\: Unexpected token \"\\$controller\", expected type at offset 9$#"
-			count: 1
-			path: core/Http/ControllerResolver.php
-
-		-
 			message: "#^Method Piwik\\\\Log\\:\\:getInstance\\(\\) should return static\\(Piwik\\\\Log\\) but returns Piwik\\\\Log\\.$#"
 			count: 1
 			path: core/Log.php
@@ -2960,11 +2955,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$login of method Piwik\\\\Auth\\:\\:setLogin\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: plugins/Login/Login.php
-
-		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 15$#"
-			count: 1
-			path: plugins/Login/Model.php
 
 		-
 			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int\\|null given\\.$#"

--- a/plugins/BulkTracking/Tracker/Requests.php
+++ b/plugins/BulkTracking/Tracker/Requests.php
@@ -48,7 +48,7 @@ class Requests
     }
 
     /**
-     * @return string
+     * @return string|false
      */
     public function getRawBulkRequest()
     {

--- a/plugins/CoreAdminHome/Commands/InvalidateReportData.php
+++ b/plugins/CoreAdminHome/Commands/InvalidateReportData.php
@@ -26,13 +26,16 @@ use Piwik\Log\LoggerInterface;
 
 /**
  * Provides a simple interface for invalidating report data by date ranges, site IDs and periods.
+ *
+ * @phpstan-import-type StoredSegment from API
  */
 class InvalidateReportData extends ConsoleCommand
 {
     public const ALL_OPTION_VALUE = 'all';
 
     /**
-     * @var null|array<Segment>
+     * @var array<array<string, mixed>>|null
+     * @phpstan-var list<StoredSegment>|null
      */
     private $allSegments = null;
 
@@ -450,7 +453,8 @@ class InvalidateReportData extends ConsoleCommand
     /**
      * @param array<int> $idSites
      *
-     * @return array<Segment>
+     * @return array<array<string, mixed>>
+     * @phpstan-return list<StoredSegment>
      */
     private function getAllSegments(array $idSites): array
     {

--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -223,7 +223,7 @@ class Controller extends ControllerAdmin
     }
 
     /**
-     * Renders and echo's an admin page that lets users generate custom JavaScript
+     * Renders and returns an admin page that lets users generate custom JavaScript
      * tracking code and custom image tracker links.
      */
     public function trackingCodeGenerator()

--- a/plugins/CoreVisualizations/Visualizations/Sparklines.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines.php
@@ -32,7 +32,7 @@ use Piwik\View;
  * the sparklines are shown in one column.
  *
  * The sparklines view currently only supports requesting columns from the same API (the API method of the defining
- * report) via {Sparklines\Config::addSparklineMetric($columns = array('nb_visits', 'nb_unique_visitors'))}.
+ * report) via {Sparklines\Config::addSparklineMetric($columns = array('nb_visits', 'nb_uniq_visitors'))}.
  *
  * Example:
  * $view->config->addSparklineMetric('nb_visits'); // if an array of metrics given, they will be displayed comma separated

--- a/plugins/Login/Model.php
+++ b/plugins/Login/Model.php
@@ -22,7 +22,7 @@ class Model
     public const LAST_LOGIN_COUNTRY_OPTION_PREFIX = 'LoginFromDifferentCountry.lastCountry.';
 
     /**
-     * @var
+     * @var string
      */
     private $tablePrefixed;
 

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -102,7 +102,7 @@ class PasswordResetter
      *
      * Defaults to the `[General] noreply_email_name` INI config option.
      *
-     * @var string
+     * @var string|null
      */
     private $emailFromName;
 
@@ -111,7 +111,7 @@ class PasswordResetter
      *
      * Defaults to the `[General] noreply_email_address` INI config option.
      *
-     * @var
+     * @var string|null
      */
     private $emailFromAddress;
 

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -130,7 +130,7 @@ class DataSubjects
          *     }
          *
          * @param array &$results An array storing the result of how much data was deleted for each plugin.
-         * @param array &$visits An array with multiple visit entries containing an idvisit and idsite each. The data
+         * @param array $visits An array with multiple visit entries containing an idvisit and idsite each. The data
          *                       for these visits is requested to be deleted.
          */
         Piwik::postEvent('PrivacyManager.deleteDataSubjects', [&$results, $visits]);
@@ -469,7 +469,7 @@ class DataSubjects
          *     }
          *
          * @param array &$results An array containing the exported data subjects.
-         * @param array &$visits An array with multiple visit entries containing an idvisit and idsite each. The data
+         * @param array $visits An array with multiple visit entries containing an idvisit and idsite each. The data
          *                       for these visits is requested to be exported.
          */
         Piwik::postEvent('PrivacyManager.exportDataSubjects', [&$results, $visits]);

--- a/plugins/Referrers/SearchEngine.php
+++ b/plugins/Referrers/SearchEngine.php
@@ -186,7 +186,7 @@ class SearchEngine extends Singleton
      *     eg. if the url is "https://www.google.com/partners.html" this will return false,
      *       as the google keyword parameter couldn't be found.
      *
-     * @see unit tests in /tests/core/Common.test.php
+     * @see \Piwik\Plugins\Referrers\tests\Unit\SearchEngineTest
      * @param string $referrerUrl URL referrer URL, eg. $_SERVER['HTTP_REFERER']
      * @return array|bool   false if a keyword couldn't be extracted,
      *                        or array(

--- a/plugins/UsersManager/Tasks.php
+++ b/plugins/UsersManager/Tasks.php
@@ -22,7 +22,7 @@ class Tasks extends \Piwik\Plugin\Tasks
     private $usersModel;
 
     /**
-     * @param API
+     * @var API
      */
     private $usersManagerApi;
 

--- a/plugins/UsersManager/UserAccessFilter.php
+++ b/plugins/UsersManager/UserAccessFilter.php
@@ -15,7 +15,7 @@ use Piwik\Access;
  * This class offers methods to filter a list of users, logins, or anything that is related to users/logins.
  *
  * * By default a super user is allowed to see all users.
- * * A user having admin access is allowed to see all other users that have view or admin access to the same access.
+ * * A user having admin access is allowed to see all other users that have view, write or admin access to the same site.
  * * A user not having any admin access is only allowed to see the own user.
  *
  * The methods in this class make sure to only return the data for logins / users the current user actually has

--- a/plugins/WebsiteMeasurable/Settings/Urls.php
+++ b/plugins/WebsiteMeasurable/Settings/Urls.php
@@ -97,7 +97,7 @@ class Urls extends \Piwik\Settings\Measurable\MeasurableProperty
      * - if the parameter is a string make it an array
      * - remove the trailing slashes if found
      *
-     * @param string|array urls
+     * @param string|array $urls
      * @return array the array of cleaned URLs
      */
     public function cleanParameterUrls($urls)


### PR DESCRIPTION
## Description

Continues the docblock quality cleanup series (chunk 22). Fixes 22 existing docblocks across `core/` and `plugins/` where the PHPDoc did not match the actual code behavior. Documentation-only — no code behavior changes.

A number of these also clear every remaining `PHPDoc tag @var has invalid value` and `PHPDoc tag @param has invalid value` entry from `phpstan-baseline.neon` (9 entries in total): they were malformed annotations PHPStan could not parse — empty types, a type and variable name reversed, a variable name missing its `$`, or an annotation with no variable at all. Correcting each one lets PHPStan parse it, so the corresponding baseline entries were removed.

**Core:**
- `core/Category/Category.php` — `$id` doc referenced `{@link Piwik\Report\getCategoryId()}` (no such symbol); it's `Piwik\Plugin\Report::getCategoryId()`.
- `core/Category/CategoryList.php` — class summary was a verbatim copy of `Category`'s (described a single category); rewritten to describe the list.
- `core/DataAccess/LogAggregator.php` — `queryConversionsByDimension()` note claimed other tables "cannot be joined", but its own `$extraFrom` param merges additional tables into the FROM clause.
- `core/Tracker/Action.php` — `getActionUrl()` returns the nullable/`false` `$actionUrl` (set from `PageUrl::getUrlIfLookValid()`), so `@return` → `string|false|null`.
- `core/Updater/Migration/Db/Sql.php` — `$errorCodesToIgnore` is always an array (constructor normalizes + `array_merge`), so `@var false|int|array` → `array`.
- `core/DataTable/Map.php` — reversed inline `@var $subDataTableMap Map` → `@var Map $subDataTableMap` (unparseable by PHPStan).
- `core/Http/ControllerResolver.php` — reversed inline `@var $controller Controller` → `@var \Piwik\Plugin\Controller $controller` (also made resolvable — `Controller` was unqualified with no matching import).
- `core/Period.php` — two reversed inline `@var $currentPeriod Period` → `@var Period $currentPeriod`.
- `core/Auth/Password.php` — `info()` `@param string` had no variable name → `@param string $hash`.
- `core/Option.php` — `setSingletonInstance()` `@param mixed` had no variable name → `@param mixed $instance`.
- `core/Segment.php` — `getSelectQuery()` carried an orphaned `@param` (no variable name) whose text duplicated the already-documented `$limit` parameter; removed it.

**Plugins:**
- `plugins/CoreAdminHome/Commands/InvalidateReportData.php` — `$allSegments` / `getAllSegments()` were typed `array<Segment>`, but the elements are the associative DB-row arrays returned by `SegmentEditor\API::getAll()` (accessed as `$segment['idsegment']`, `['definition']`, …), not `Piwik\Segment` objects; corrected to `list<StoredSegment>`, reusing the `StoredSegment` shape that `API::getAll()` already declares (`@phpstan-import-type`).
- `plugins/Login/PasswordResetter.php` — `$emailFromName` (`@var string`) and `$emailFromAddress` (empty `@var`) are both assigned only from nullable constructor parameters, so both are `string|null`.
- `plugins/BulkTracking/Tracker/Requests.php` — `getRawBulkRequest()` returns `file_get_contents()` (can be `false`), so `@return string` → `string|false`.
- `plugins/CoreAdminHome/Controller.php` — `trackingCodeGenerator()` "Renders and echo's" but actually `return`s the rendered view.
- `plugins/CoreVisualizations/Visualizations/Sparklines.php` — class-summary example used the non-existent metric `nb_unique_visitors`; corrected to `nb_uniq_visitors`.
- `plugins/PrivacyManager/Model/DataSubjects.php` — the `deleteDataSubjects`/`exportDataSubjects` event docblocks marked `&$visits` by-reference, but `$visits` is posted by value (only `$results` is by-ref).
- `plugins/Referrers/SearchEngine.php` — `@see` pointed at a removed `/tests/core/Common.test.php`; updated to `\Piwik\Plugins\Referrers\tests\Unit\SearchEngineTest`.
- `plugins/UsersManager/UserAccessFilter.php` — class summary said admins see users with "view or admin access to the same access"; the code checks view/write/admin access to the same **site**.
- `plugins/Login/Model.php` — `$tablePrefixed` had an empty `@var`; it is assigned `Common::prefixTable()` (`string`).
- `plugins/UsersManager/Tasks.php` — the `$usersManagerApi` property used `@param API` (a property takes `@var`) → `@var API`.
- `plugins/WebsiteMeasurable/Settings/Urls.php` — `cleanParameterUrls()` `@param string|array urls` was missing the `$` → `@param string|array $urls`.

## Review

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Removed the nine now-obsolete `PHPDoc tag @var/@param has invalid value` entries from `phpstan-baseline.neon` (confirmed by the full run). Also reviewed locally with `codex review` before opening this PR.

## Refs

n/a

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
