### PR TITLE
Docblock quality chunk 23: fix structurally broken PHPDoc annotations

### DIFF
--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -207,7 +207,6 @@ class ArchiveSelector
      *                       '2010-01-01' => array(1,2,3)
      *                   )
      *               )
-     * @throws
      */
     public static function getArchiveIds(
         $siteIds,
@@ -257,7 +256,6 @@ class ArchiveSelector
      *                       )
      *                   )
      *               )
-     * @throws
      */
     public static function getArchiveIdsAndStates(
         $siteIds,

--- a/core/DataAccess/LogQueryBuilder.php
+++ b/core/DataAccess/LogQueryBuilder.php
@@ -318,7 +318,6 @@ class LogQueryBuilder
      * @param $where
      * @param $segmentWhere
      * @return string
-     * @throws
      */
     protected function getWhereMatchBoth($where, $segmentWhere)
     {

--- a/core/DataTable/Filter/ColumnCallbackDeleteRow.php
+++ b/core/DataTable/Filter/ColumnCallbackDeleteRow.php
@@ -34,7 +34,7 @@ class ColumnCallbackDeleteRow extends BaseFilter
      * @param DataTable $table The DataTable that will be filtered eventually.
      * @param array|string $columnsToFilter The column or array of columns that should be
      *                                      passed to the callback.
-     * @param callback $function The callback that determines whether a row should be deleted
+     * @param callable $function The callback that determines whether a row should be deleted
      *                           or not. Should return `true` if the row should be deleted.
      * @param array $functionParams deprecated - use an [anonymous function](https://php.net/manual/en/functions.anonymous.php)
      *                              instead.

--- a/core/DataTable/Filter/Sort.php
+++ b/core/DataTable/Filter/Sort.php
@@ -38,7 +38,7 @@ class Sort extends BaseFilter
      * @param string $order order `'asc'` or `'desc'`.
      * @param bool $naturalSort Whether to use a natural sort or not (see {@link https://php.net/natsort}).
      * @param bool $recursiveSort Whether to sort all subtables or not.
-     * @param bool|callback $doSortBySecondaryColumn If true will sort by a secondary column. The column is automatically
+     * @param bool|callable $doSortBySecondaryColumn If true will sort by a secondary column. The column is automatically
      *                                               detected and will be either nb_visits or label, if possible.
      *                                               If callback given it will sort by the column returned by the callback (if any)
      *                                               callback will be called with 2 parameters: primaryColumnToSort and table

--- a/core/Plugin/ViewDataTable.php
+++ b/core/Plugin/ViewDataTable.php
@@ -572,7 +572,6 @@ abstract class ViewDataTable implements ViewInterface
      * Display a meaningful error message when any invalid parameter is being set.
      *
      * @param $overrideParams
-     * @throws
      */
     public function throwWhenSettingNonOverridableParameter($overrideParams)
     {

--- a/core/Tracker/Db.php
+++ b/core/Tracker/Db.php
@@ -164,7 +164,7 @@ abstract class Db implements TransactionalDatabaseInterface
      * @see fetch()
      * @param string $query Query
      * @param array $parameters Parameters to bind
-     * @return
+     * @return array|false
      */
     public function fetchRow($query, $parameters = array())
     {
@@ -191,7 +191,7 @@ abstract class Db implements TransactionalDatabaseInterface
      * @see fetch()
      * @param string $query Query
      * @param array $parameters Parameters to bind
-     * @return
+     * @return array|false
      */
     public function exec($query, $parameters = array())
     {

--- a/core/ViewDataTable/Manager.php
+++ b/core/ViewDataTable/Manager.php
@@ -324,7 +324,6 @@ class Manager
      * Display a meaningful error message when any invalid parameter is being set.
      *
      * @param $params
-     * @throws
      */
     private static function errorWhenSettingNonOverridableParameter($controllerAction, $params)
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1407,16 +1407,6 @@ parameters:
 			path: core/Tracker/Db.php
 
 		-
-			message: "#^PHPDoc tag @return has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 228$#"
-			count: 1
-			path: core/Tracker/Db.php
-
-		-
-			message: "#^PHPDoc tag @return has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 234$#"
-			count: 1
-			path: core/Tracker/Db.php
-
-		-
 			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Mysqli\\:\\:beginTransaction\\(\\) should return string\\|null but empty return statement found\\.$#"
 			count: 1
 			path: core/Tracker/Db/Mysqli.php
@@ -2291,32 +2281,12 @@ parameters:
 			path: plugins/CoreVisualizations/Metrics/Formatter/Numeric.php
 
 		-
-			message: "#^Call to method getName\\(\\) on an unknown class Piwik\\\\Plugins\\\\AbTesting\\\\Columns\\\\Metrics\\\\ProcessedMetric\\.$#"
-			count: 1
-			path: plugins/CoreVisualizations/Visualizations/Graph.php
-
-		-
 			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Graph.php
 
 		-
 			message: "#^Instanceof between Piwik\\\\DataTable and Piwik\\\\DataTable\\\\Map will always evaluate to false\\.$#"
-			count: 1
-			path: plugins/CoreVisualizations/Visualizations/Graph.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$extraProcessedMetrics contains unknown class Piwik\\\\Plugins\\\\AbTesting\\\\Columns\\\\Metrics\\\\ProcessedMetric\\.$#"
-			count: 1
-			path: plugins/CoreVisualizations/Visualizations/Graph.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(Piwik\\\\Plugins\\\\AbTesting\\\\Columns\\\\Metrics\\\\ProcessedMetric\\)\\: mixed\\)\\|null, Closure\\(Piwik\\\\Plugin\\\\Metric\\)\\: string given\\.$#"
-			count: 1
-			path: plugins/CoreVisualizations/Visualizations/Graph.php
-
-		-
-			message: "#^Variable \\$dataTable in PHPDoc tag @var does not match any variable in the foreach loop\\: \\$row$#"
 			count: 1
 			path: plugins/CoreVisualizations/Visualizations/Graph.php
 
@@ -2514,16 +2484,6 @@ parameters:
 			message: "#^Property Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\MatomoInformational\\:\\:\\$translator is never read, only written\\.$#"
 			count: 1
 			path: plugins/Diagnostics/Diagnostic/MatomoInformational.php
-
-		-
-			message: "#^PHPDoc tag @var above a method has no effect\\.$#"
-			count: 1
-			path: plugins/Diagnostics/Diagnostic/PHPBinaryCheck.php
-
-		-
-			message: "#^PHPDoc tag @var does not specify variable name\\.$#"
-			count: 1
-			path: plugins/Diagnostics/Diagnostic/PHPBinaryCheck.php
 
 		-
 			message: "#^Parameter \\#2 \\$comment of static method Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\DiagnosticResult\\:\\:informationalResult\\(\\) expects string, bool given\\.$#"
@@ -3020,11 +2980,6 @@ parameters:
 			message: "#^Left side of && is always true\\.$#"
 			count: 1
 			path: plugins/Marketplace/Plugins/InvalidLicenses.php
-
-		-
-			message: "#^Variable \\$previous in PHPDoc tag @var does not match assigned variable \\$domain\\.$#"
-			count: 1
-			path: plugins/Marketplace/config/config.php
 
 		-
 			message: "#^Property Piwik\\\\Plugins\\\\MobileMessaging\\\\Diagnostic\\\\MobileMessagingInformational\\:\\:\\$translator is never read, only written\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -413,16 +413,6 @@ parameters:
 			path: core/DataAccess/ArchiveSelector.php
 
 		-
-			message: "#^PHPDoc tag @throws has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 1330$#"
-			count: 1
-			path: core/DataAccess/ArchiveSelector.php
-
-		-
-			message: "#^PHPDoc tag @throws has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 733$#"
-			count: 1
-			path: core/DataAccess/ArchiveSelector.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between int\\|string and null will always evaluate to false\\.$#"
 			count: 1
 			path: core/DataAccess/ArchiveSelector.php
@@ -436,11 +426,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$options of function json_encode expects int, true given\\.$#"
 			count: 1
 			path: core/DataAccess/ArchivingDbAdapter.php
-
-		-
-			message: "#^PHPDoc tag @throws has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 89$#"
-			count: 1
-			path: core/DataAccess/LogQueryBuilder.php
 
 		-
 			message: "#^Parameter \\#3 \\$where of method Piwik\\\\DataAccess\\\\LogQueryBuilder\\:\\:buildSelectQuery\\(\\) expects string, false given\\.$#"
@@ -503,11 +488,6 @@ parameters:
 			path: core/DataTable/Filter/ColumnCallbackAddColumnQuotient.php
 
 		-
-			message: "#^Parameter \\$function of method Piwik\\\\DataTable\\\\Filter\\\\ColumnCallbackDeleteRow\\:\\:__construct\\(\\) has invalid type Piwik\\\\DataTable\\\\Filter\\\\callback\\.$#"
-			count: 1
-			path: core/DataTable/Filter/ColumnCallbackDeleteRow.php
-
-		-
 			message: "#^Property Piwik\\\\DataTable\\\\Filter\\\\Pattern\\:\\:\\$patternToSearch is never read, only written\\.$#"
 			count: 1
 			path: core/DataTable/Filter/Pattern.php
@@ -521,11 +501,6 @@ parameters:
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: core/DataTable/Filter/PivotByDimension.php
-
-		-
-			message: "#^Parameter \\$doSortBySecondaryColumn of method Piwik\\\\DataTable\\\\Filter\\\\Sort\\:\\:__construct\\(\\) has invalid type Piwik\\\\DataTable\\\\Filter\\\\callback\\.$#"
-			count: 1
-			path: core/DataTable/Filter/Sort.php
 
 		-
 			message: "#^Instanceof between Piwik\\\\DataTable\\|false and Piwik\\\\DataTable\\\\Map will always evaluate to false\\.$#"
@@ -902,11 +877,6 @@ parameters:
 			message: "#^Property Piwik\\\\Plugin\\\\Report\\:\\:\\$dimension \\(Piwik\\\\Columns\\\\Dimension\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: core/Plugin/Report.php
-
-		-
-			message: "#^PHPDoc tag @throws has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 138$#"
-			count: 1
-			path: core/Plugin/ViewDataTable.php
 
 		-
 			message: "#^Property Piwik\\\\ViewDataTable\\\\RequestConfig\\:\\:\\$filter_excludelowpop_value \\(Closure\\|string\\) in isset\\(\\) is not nullable\\.$#"
@@ -1763,11 +1733,6 @@ parameters:
 
 		-
 			message: "#^Method Piwik\\\\ViewDataTable\\\\Manager\\:\\:getFooterIconFor\\(\\) should return array but empty return statement found\\.$#"
-			count: 1
-			path: core/ViewDataTable/Manager.php
-
-		-
-			message: "#^PHPDoc tag @throws has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 130$#"
 			count: 1
 			path: core/ViewDataTable/Manager.php
 
@@ -3296,11 +3261,6 @@ parameters:
 
 		-
 			message: "#^Method Piwik\\\\Plugins\\\\UsersManager\\\\Controller\\:\\:noAdminAccessToWebsite\\(\\) is unused\\.$#"
-			count: 1
-			path: plugins/UsersManager/Controller.php
-
-		-
-			message: "#^PHPDoc tag @throws has invalid value \\(\\)\\: Unexpected token \"\\\\n     \\* \", expected type at offset 149$#"
 			count: 1
 			path: plugins/UsersManager/Controller.php
 

--- a/plugins/CoreVisualizations/Visualizations/Graph.php
+++ b/plugins/CoreVisualizations/Visualizations/Graph.php
@@ -12,7 +12,7 @@ namespace Piwik\Plugins\CoreVisualizations\Visualizations;
 use Piwik\Common;
 use Piwik\DataTable;
 use Piwik\Plugin\Metric;
-use Piwik\Plugins\AbTesting\Columns\Metrics\ProcessedMetric;
+use Piwik\Plugin\ProcessedMetric;
 use Piwik\Plugins\CoreVisualizations\Metrics\Formatter\Numeric;
 use Piwik\Piwik;
 use Piwik\Plugin\Visualization;
@@ -105,11 +105,10 @@ abstract class Graph extends Visualization
         // collect all selectable rows
         $self = $this;
 
-        $this->dataTable->filter(function ($dataTable) use ($self) {
+        $this->dataTable->filter(function (DataTable $dataTable) use ($self) {
 
             $identifier = $self->config->row_picker_match_rows_by;
 
-            /** @var DataTable $dataTable */
             foreach ($dataTable->getRows() as $row) {
                 $rowLabel = $row->getColumn('label');
                 $rowIdentifier = $row->hasColumn($identifier) ? $row->getColumn($identifier) : $row->getMetadata($identifier);

--- a/plugins/Diagnostics/Diagnostic/PHPBinaryCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PHPBinaryCheck.php
@@ -21,10 +21,6 @@ class PHPBinaryCheck implements Diagnostic
      */
     private $translator;
 
-    /**
-     * @var int
-     */
-
     public function __construct(Translator $translator)
     {
         $this->translator = $translator;

--- a/plugins/Marketplace/config/config.php
+++ b/plugins/Marketplace/config/config.php
@@ -17,8 +17,6 @@ return array(
         return 'https://' . $domain;
     },
     'Piwik\Plugins\Marketplace\Api\Service' => function (Container $c) {
-        /** @var Service $previous */
-
         $domain = $c->get('MarketplaceEndpoint');
 
         $service = new Service($domain);

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -186,7 +186,6 @@ class Controller extends ControllerAdmin
      * Returns the enabled dates that users can select,
      * in their User Settings page "Report date to load by default"
      *
-     * @throws
      * @return array
      */
     protected function getDefaultDates()


### PR DESCRIPTION
## Description

Docblock quality cleanup series (chunk 23). Unlike earlier chunks (which corrected inaccurate `@param`/`@return`/`@var` *types*), this one targets **structurally broken** annotations flagged in `phpstan-baseline.neon` — tags that are malformed, misplaced, reference a variable/class that does not exist, or use an invalid type name. Documentation-only, apart from one tiny, behavior-neutral parameter type-hint (see Graph.php). No functional changes.

Each fix also removes the corresponding `phpstan-baseline.neon` entry (17 entries in total).

**Malformed / misplaced / non-existent-reference tags:**
- `core/Tracker/Db.php` — `fetchRow()` and `exec()` had **empty `@return` tags** PHPStan could not parse. Both are proxies to `fetch()`, which returns a fetched row (assoc array) or `false`, so they now document `@return array|false`.
- `plugins/Diagnostics/Diagnostic/PHPBinaryCheck.php` — a stray `/** @var int */` block with **no variable name** sat above the constructor, documenting no property (PHPStan: "does not specify variable name" + "@var above a method has no effect"). Removed.
- `plugins/Marketplace/config/config.php` — the `Service` factory closure carried `/** @var Service $previous */`, but there is **no `$previous` variable** in the closure (PHPStan: "does not match assigned variable `$domain`"). Removed the orphaned annotation.
- `plugins/CoreVisualizations/Visualizations/Graph.php` — two issues:
  - `$extraProcessedMetrics` was annotated `@var ProcessedMetric[]` via a `use` import pointing at the **non-existent** `Piwik\Plugins\AbTesting\Columns\Metrics\ProcessedMetric`; corrected the import to the real core `Piwik\Plugin\ProcessedMetric` (also clears two dependent baseline entries — a `getName()`-on-unknown-class error and an `array_map` callback-type error).
  - `/** @var DataTable $dataTable */` sat directly above a `foreach`, so PHPStan tied it to the loop variable `$row` instead of the closure parameter it was meant to type. Replaced it with a native `DataTable $dataTable` parameter type-hint on the closure — `DataTable::filter()` (and `Map::filter()`, which forwards to child tables) always passes a `DataTable`, so this is behavior-neutral.

**Invalid `callback` type:**
- `core/DataTable/Filter/ColumnCallbackDeleteRow.php` and `core/DataTable/Filter/Sort.php` — `@param` tags used the removed PHP `callback` pseudo-type, which PHPStan resolves as an unknown class `Piwik\DataTable\Filter\callback`. Both values are invoked / passed through `is_callable()`, so the intended type is `callable`.

**Empty `@throws`:**
- `core/DataAccess/ArchiveSelector.php` (×2), `core/DataAccess/LogQueryBuilder.php`, `core/Plugin/ViewDataTable.php`, `core/ViewDataTable/Manager.php`, `plugins/UsersManager/Controller.php` — six `@throws` tags had no type after them and could not be parsed. An empty `@throws` conveys nothing, so they were removed (valid `@throws` tags in the same files are left untouched).

## Review

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Removed the seventeen now-obsolete `phpstan-baseline.neon` entries (confirmed by the full run reporting them as no-longer-matched). Also reviewed locally with `codex review`.

## Refs

n/a

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
