### PR TITLE
Docblock quality chunk 24: correct stale @return/@param/@var types

### DIFF
--- a/core/Db/Schema.php
+++ b/core/Db/Schema.php
@@ -274,7 +274,7 @@ class Schema extends Singleton
      * Tables will only be optimized if the `[General] enable_sql_optimize_queries` INI config option is
      * set to **1**.
      *
-     * @param string|array $tables The name of the table to optimize or an array of tables to optimize.
+     * @param array $tables The name of the table to optimize or an array of tables to optimize.
      *                             Table names must be prefixed (see {@link Piwik\Common::prefixTable()}).
      * @param bool $force If true, the `OPTIMIZE TABLE` query will be run even if InnoDB tables are being used.
      */

--- a/core/FileIntegrity.php
+++ b/core/FileIntegrity.php
@@ -457,7 +457,7 @@ class FileIntegrity
      *
      * @param $directory
      * @param $directories
-     * @return string
+     * @return string|null
      */
     protected static function getDirectoryParentFromList($directory, $directories)
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -175,8 +175,6 @@ parameters:
 			count: 1
 			path: core/ArchiveProcessor.php
 
-
-
 		-
 			message: "#^Left side of && is always true\\.$#"
 			count: 1
@@ -582,7 +580,6 @@ parameters:
 			count: 1
 			path: core/Db/Adapter/Pdo/Mysql.php
 
-
 		-
 			message: "#^Call to function is_null\\(\\) with mixed will always evaluate to false\\.$#"
 			count: 1
@@ -600,11 +597,6 @@ parameters:
 
 		-
 			message: "#^Method Piwik\\\\Db\\\\SchemaInterface\\:\\:dropDatabase\\(\\) invoked with 1 parameter, 0 required\\.$#"
-			count: 1
-			path: core/Db/Schema.php
-
-		-
-			message: "#^PHPDoc tag @param for parameter \\$tables with type array\\|string is not subtype of native type array\\.$#"
 			count: 1
 			path: core/Db/Schema.php
 
@@ -632,11 +624,6 @@ parameters:
 			message: "#^Right side of && is always false\\.$#"
 			count: 1
 			path: core/ExceptionHandler.php
-
-		-
-			message: "#^Method Piwik\\\\FileIntegrity\\:\\:getDirectoryParentFromList\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: core/FileIntegrity.php
 
 		-
 			message: "#^Method Piwik\\\\Filesystem\\:\\:getFileSize\\(\\) should return float\\|null but empty return statement found\\.$#"
@@ -1774,26 +1761,6 @@ parameters:
 			path: plugins/API/Filter/DataComparisonFilter.php
 
 		-
-			message: "#^Cannot call method getBoolParameter\\(\\) on array\\.$#"
-			count: 1
-			path: plugins/API/Filter/DataComparisonFilter.php
-
-		-
-			message: "#^Cannot call method getIntegerParameter\\(\\) on array\\.$#"
-			count: 3
-			path: plugins/API/Filter/DataComparisonFilter.php
-
-		-
-			message: "#^Cannot call method getJsonParameter\\(\\) on array\\.$#"
-			count: 1
-			path: plugins/API/Filter/DataComparisonFilter.php
-
-		-
-			message: "#^Cannot call method getStringParameter\\(\\) on array\\.$#"
-			count: 12
-			path: plugins/API/Filter/DataComparisonFilter.php
-
-		-
 			message: "#^Parameter \\#3 \\$segmentCount of static method Piwik\\\\Plugins\\\\API\\\\Filter\\\\DataComparisonFilter\\:\\:getIndividualComparisonRowIndices\\(\\) expects null, int\\<0, max\\> given\\.$#"
 			count: 2
 			path: plugins/API/Filter/DataComparisonFilter.php
@@ -1810,11 +1777,6 @@ parameters:
 
 		-
 			message: "#^Property Piwik\\\\Plugins\\\\API\\\\Filter\\\\DataComparisonFilter\\:\\:\\$compareSegments \\(array\\<string\\>\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: plugins/API/Filter/DataComparisonFilter.php
-
-		-
-			message: "#^Property Piwik\\\\Plugins\\\\API\\\\Filter\\\\DataComparisonFilter\\:\\:\\$request \\(array\\) does not accept Piwik\\\\Request\\.$#"
 			count: 1
 			path: plugins/API/Filter/DataComparisonFilter.php
 
@@ -1864,16 +1826,6 @@ parameters:
 			path: plugins/API/SegmentMetadata.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\API\\\\WidgetMetadata\\:\\:buildCategoryMetadata\\(\\) should return array but returns null\\.$#"
-			count: 1
-			path: plugins/API/WidgetMetadata.php
-
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\API\\\\WidgetMetadata\\:\\:buildSubcategoryMetadata\\(\\) should return array but returns null\\.$#"
-			count: 1
-			path: plugins/API/WidgetMetadata.php
-
-		-
 			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: plugins/Actions/Actions/ActionSiteSearch.php
@@ -1917,9 +1869,6 @@ parameters:
 			message: "#^Empty array passed to foreach\\.$#"
 			count: 1
 			path: plugins/Actions/Columns/ActionType.php
-
-
-
 
 		-
 			message: "#^Parameter \\#1 \\$idSite of method Piwik\\\\Plugins\\\\Actions\\\\RecordBuilders\\\\ActionReports\\:\\:getGoalsForSite\\(\\) expects string, int given\\.$#"
@@ -2007,11 +1956,6 @@ parameters:
 			path: plugins/CoreAdminHome/Commands/ConfigGet.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\CoreAdminHome\\\\Commands\\\\DeleteLogsData\\:\\:getDateRangeToDeleteFrom\\(\\) should return array\\<Piwik\\\\Date\\> but returns array\\<int, string\\>\\.$#"
-			count: 1
-			path: plugins/CoreAdminHome/Commands/DeleteLogsData.php
-
-		-
 			message: "#^Property Piwik\\\\Plugins\\\\CoreAdminHome\\\\Commands\\\\DeleteLogsData\\:\\:\\$rawLogDao is never read, only written\\.$#"
 			count: 1
 			path: plugins/CoreAdminHome/Commands/DeleteLogsData.php
@@ -2085,7 +2029,6 @@ parameters:
 			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: plugins/CoreHome/Columns/Metrics/EvolutionMetric.php
-
 
 		-
 			message: "#^Parameter \\#1 \\$sqlFilterValue of method Piwik\\\\Plugin\\\\Segment\\:\\:setSqlFilterValue\\(\\) expects array\\|string, Closure given\\.$#"
@@ -2463,15 +2406,9 @@ parameters:
 			path: plugins/Diagnostics/Diagnostic/UserInformational.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\Ecommerce\\\\Columns\\\\BaseConversion\\:\\:roundRevenueIfNeeded\\(\\) should return float\\|int but returns false\\.$#"
-			count: 1
-			path: plugins/Ecommerce/Columns/BaseConversion.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between false and float\\|int will always evaluate to false\\.$#"
 			count: 1
 			path: plugins/Ecommerce/Columns/BaseConversion.php
-
 
 		-
 			message: "#^Parameter \\#3 \\$escapeComment of static method Piwik\\\\Plugins\\\\Diagnostics\\\\Diagnostic\\\\DiagnosticResult\\:\\:informationalResult\\(\\) expects bool, string given\\.$#"
@@ -2492,11 +2429,6 @@ parameters:
 			message: "#^Property Piwik\\\\Notification\\:\\:\\$flags \\(int\\) does not accept null\\.$#"
 			count: 1
 			path: plugins/ExampleUI/Controller.php
-
-		-
-			message: "#^Property Piwik\\\\Plugins\\\\FeatureFlags\\\\FeatureFlagManager\\:\\:\\$logger \\(Piwik\\\\Log\\\\Logger\\) does not accept Piwik\\\\Log\\\\LoggerInterface\\.$#"
-			count: 1
-			path: plugins/FeatureFlags/FeatureFlagManager.php
 
 		-
 			message: "#^Dead catch \\- Exception is never thrown in the try block\\.$#"
@@ -2564,16 +2496,6 @@ parameters:
 			path: plugins/GeoIp2/LocationProvider/GeoIp2.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\GeoIp2\\\\LocationProvider\\\\GeoIp2\\\\ServerModule\\:\\:getLocation\\(\\) should return array but returns false\\.$#"
-			count: 1
-			path: plugins/GeoIp2/LocationProvider/GeoIp2/ServerModule.php
-
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\GeoIp2\\\\LocationProvider\\\\GeoIp2\\\\ServerModule\\:\\:isWorking\\(\\) should return bool but returns string\\.$#"
-			count: 1
-			path: plugins/GeoIp2/LocationProvider/GeoIp2/ServerModule.php
-
-		-
 			message: "#^Parameter \\#1 \\$name of method Piwik\\\\DataTable\\\\Row\\:\\:deleteColumn\\(\\) expects string, int given\\.$#"
 			count: 1
 			path: plugins/Goals/API.php
@@ -2589,17 +2511,7 @@ parameters:
 			path: plugins/Goals/API.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\Goals\\\\Commands\\\\CalculateConversionPages\\:\\:getDateRangeToCalculate\\(\\) never returns array\\<Piwik\\\\Date\\> so it can be removed from the return type\\.$#"
-			count: 1
-			path: plugins/Goals/Commands/CalculateConversionPages.php
-
-		-
 			message: "#^Method Piwik\\\\Plugins\\\\Goals\\\\Commands\\\\CalculateConversionPages\\:\\:getDateRangeToCalculate\\(\\) never returns null so it can be removed from the return type\\.$#"
-			count: 1
-			path: plugins/Goals/Commands/CalculateConversionPages.php
-
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\Goals\\\\Commands\\\\CalculateConversionPages\\:\\:getDateRangeToCalculate\\(\\) should return array\\<Piwik\\\\Date\\>\\|null but returns array\\<int, string\\>\\.$#"
 			count: 1
 			path: plugins/Goals/Commands/CalculateConversionPages.php
 
@@ -2785,11 +2697,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$return of function var_export expects bool, int given\\.$#"
-			count: 1
-			path: plugins/LanguagesManager/TranslationWriter/Writer.php
-
-		-
-			message: "#^Property Piwik\\\\Plugins\\\\LanguagesManager\\\\TranslationWriter\\\\Writer\\:\\:\\$validationMessage \\(string\\|null\\) does not accept array\\.$#"
 			count: 1
 			path: plugins/LanguagesManager/TranslationWriter/Writer.php
 
@@ -2983,7 +2890,6 @@ parameters:
 			count: 1
 			path: plugins/PrivacyManager/Model/LogDataAnonymizations.php
 
-
 		-
 			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
 			count: 5
@@ -2993,7 +2899,6 @@ parameters:
 			message: "#^Variable \\$dataTable in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: plugins/PrivacyManager/PrivacyManager.php
-
 
 		-
 			message: "#^Parameter \\#1 \\$reportDateYear of static method Piwik\\\\Plugins\\\\PrivacyManager\\\\ReportsPurger\\:\\:shouldReportBePurged\\(\\) expects int, string given\\.$#"
@@ -3030,7 +2935,6 @@ parameters:
 			count: 1
 			path: plugins/Referrers/Columns/Base.php
 
-
 		-
 			message: "#^Method Piwik\\\\Plugins\\\\Referrers\\\\Columns\\\\Metrics\\\\VisitorsFromReferrerPercent\\:\\:getTranslatedName\\(\\) should return string but returns null\\.$#"
 			count: 1
@@ -3040,11 +2944,6 @@ parameters:
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: plugins/Referrers/DataTable/Filter/SetGetReferrerTypeSubtables.php
-
-		-
-			message: "#^Function Piwik\\\\Plugins\\\\Referrers\\\\getReferrerTypeFromShortName\\(\\) should return string but returns int\\.$#"
-			count: 1
-			path: plugins/Referrers/functions.php
 
 		-
 			message: "#^Variable \\$domain on left side of \\?\\? always exists and is not nullable\\.$#"
@@ -3167,11 +3066,6 @@ parameters:
 			path: plugins/UserCountry/Columns/Country.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\UserCountry\\\\Commands\\\\AttributeHistoricalDataWithLocations\\:\\:\\$processedPercent \\(int\\) does not accept float\\.$#"
-			count: 1
-			path: plugins/UserCountry/Commands/AttributeHistoricalDataWithLocations.php
-
-		-
 			message: "#^If condition is always false\\.$#"
 			count: 1
 			path: plugins/UserCountry/Controller.php
@@ -3222,24 +3116,9 @@ parameters:
 			path: plugins/UsersManager/Controller.php
 
 		-
-			message: "#^Property Piwik\\\\Plugins\\\\UsersManager\\\\Emails\\\\UserInviteEmail\\:\\:\\$invitedUser \\(object\\) does not accept array\\.$#"
-			count: 1
-			path: plugins/UsersManager/Emails/UserInviteEmail.php
-
-		-
 			message: "#^Parameter \\#2 \\$value of static method Piwik\\\\Option\\:\\:set\\(\\) expects string, int given\\.$#"
 			count: 1
 			path: plugins/UsersManager/NewsletterSignup.php
-
-		-
-			message: "#^Property Piwik\\\\Plugins\\\\UsersManager\\\\Sql\\\\UserTableFilter\\:\\:\\$filterByRole \\(string\\) does not accept null\\.$#"
-			count: 1
-			path: plugins/UsersManager/Sql/UserTableFilter.php
-
-		-
-			message: "#^Property Piwik\\\\Plugins\\\\UsersManager\\\\Sql\\\\UserTableFilter\\:\\:\\$filterByRole \\(string\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: plugins/UsersManager/Sql/UserTableFilter.php
 
 		-
 			message: "#^Property Piwik\\\\Plugins\\\\UsersManager\\\\Sql\\\\UserTableFilter\\:\\:\\$filterByRoleSite \\(int\\) in isset\\(\\) is not nullable\\.$#"

--- a/plugins/API/Filter/DataComparisonFilter.php
+++ b/plugins/API/Filter/DataComparisonFilter.php
@@ -66,7 +66,7 @@ use Piwik\Site;
 class DataComparisonFilter
 {
     /**
-     * @var array
+     * @var \Piwik\Request
      */
     private $request;
 

--- a/plugins/API/WidgetMetadata.php
+++ b/plugins/API/WidgetMetadata.php
@@ -189,7 +189,7 @@ class WidgetMetadata
 
     /**
      * @param Category|null $category
-     * @return array
+     * @return array|null
      */
     private function buildCategoryMetadata($category)
     {
@@ -210,7 +210,7 @@ class WidgetMetadata
 
     /**
      * @param Subcategory|null $subcategory
-     * @return array
+     * @return array|null
      */
     private function buildSubcategoryMetadata($subcategory)
     {

--- a/plugins/CoreAdminHome/Commands/DeleteLogsData.php
+++ b/plugins/CoreAdminHome/Commands/DeleteLogsData.php
@@ -110,7 +110,7 @@ class DeleteLogsData extends ConsoleCommand
     }
 
     /**
-     * @return Date[]
+     * @return string[]
      */
     private function getDateRangeToDeleteFrom()
     {

--- a/plugins/Ecommerce/Columns/BaseConversion.php
+++ b/plugins/Ecommerce/Columns/BaseConversion.php
@@ -18,7 +18,7 @@ abstract class BaseConversion extends ConversionDimension
      * Returns rounded decimal revenue, or if revenue is integer, then returns as is.
      *
      * @param int|float $revenue
-     * @return int|float
+     * @return int|float|false
      */
     protected function roundRevenueIfNeeded($revenue)
     {

--- a/plugins/FeatureFlags/FeatureFlagManager.php
+++ b/plugins/FeatureFlags/FeatureFlagManager.php
@@ -10,7 +10,6 @@
 namespace Piwik\Plugins\FeatureFlags;
 
 use Piwik\Container\StaticContainer;
-use Piwik\Log\Logger;
 use Piwik\Log\LoggerInterface;
 
 class FeatureFlagManager
@@ -21,7 +20,7 @@ class FeatureFlagManager
     private $storages;
 
     /**
-     * @var Logger
+     * @var LoggerInterface
      */
     private $logger;
 

--- a/plugins/GeoIp2/LocationProvider/GeoIp2/ServerModule.php
+++ b/plugins/GeoIp2/LocationProvider/GeoIp2/ServerModule.php
@@ -60,7 +60,7 @@ class ServerModule extends GeoIp2
      * information will not be available to Piwik.
      *
      * @param array $info Must have an 'ip' field.
-     * @return array
+     * @return array|false
      */
     public function getLocation($info)
     {
@@ -178,7 +178,7 @@ class ServerModule extends GeoIp2
     /**
      * Returns true if the MMDB_ADDR server variable is defined.
      *
-     * @return bool
+     * @return bool|string
      */
     public function isWorking()
     {

--- a/plugins/Goals/Commands/CalculateConversionPages.php
+++ b/plugins/Goals/Commands/CalculateConversionPages.php
@@ -127,7 +127,7 @@ class CalculateConversionPages extends ConsoleCommand
     /**
      * Validate dates parameter
      *
-     * @return Date[]
+     * @return string[]
      */
     private function getDateRangeToCalculate(string $dates): ?array
     {

--- a/plugins/LanguagesManager/TranslationWriter/Writer.php
+++ b/plugins/LanguagesManager/TranslationWriter/Writer.php
@@ -53,7 +53,7 @@ class Writer
     /**
      * Message why validation failed
      *
-     * @var string|null
+     * @var string|array|null
      */
     protected $validationMessage = null;
 

--- a/plugins/Referrers/functions.php
+++ b/plugins/Referrers/functions.php
@@ -72,7 +72,7 @@ function getReferrerTypeLabel($label)
 /**
  * Works in both directions
  * @param string|int $name
- * @return string
+ * @return string|int
  */
 function getReferrerTypeFromShortName($name)
 {

--- a/plugins/UserCountry/Commands/AttributeHistoricalDataWithLocations.php
+++ b/plugins/UserCountry/Commands/AttributeHistoricalDataWithLocations.php
@@ -56,7 +56,7 @@ class AttributeHistoricalDataWithLocations extends ConsoleCommand
     private $percentStep;
 
     /**
-     * @var int
+     * @var float
      */
     private $processedPercent = 0;
 

--- a/plugins/UsersManager/Emails/UserInviteEmail.php
+++ b/plugins/UsersManager/Emails/UserInviteEmail.php
@@ -21,7 +21,7 @@ class UserInviteEmail extends Mail
     private $currentUser;
 
     /**
-     * @var object
+     * @var array
      */
     private $invitedUser;
 

--- a/plugins/UsersManager/Sql/UserTableFilter.php
+++ b/plugins/UsersManager/Sql/UserTableFilter.php
@@ -15,7 +15,7 @@ use Piwik\Piwik;
 class UserTableFilter
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $filterByRole;
 


### PR DESCRIPTION
## Description

Docblock quality cleanup series (chunk 24). Corrects `@return`/`@param`/`@var` docblocks that no longer match the code's actual behaviour, each of which was masking a `phpstan-baseline.neon` entry. Documentation-only — no code behaviour changes.

All fixes were triaged conservatively: only cases where the code's actual value is clearly the intended behaviour and the docblock is simply stale/too-narrow are included. Cases where a caller might just be passing an incorrect type, where the mismatch stems from a native type declaration (a code change), where the class/method is `@api`, or where widening would cascade new errors, were deliberately excluded. Every change was verified with a full-project phpstan run showing no new errors.

**`@return` corrections:**
- `core/FileIntegrity.php` — `getDirectoryParentFromList()` returns `null` when no parent is found → `string` → `string|null`.
- `plugins/API/WidgetMetadata.php` — `buildCategoryMetadata()` / `buildSubcategoryMetadata()` return `null` when the (sub)category is not set → `array` → `array|null`.
- `plugins/CoreAdminHome/Commands/DeleteLogsData.php` & `plugins/Goals/Commands/CalculateConversionPages.php` — both convert their `Date` objects to datetime strings via `getDatetime()` before returning → `Date[]` → `string[]`.
- `plugins/Ecommerce/Columns/BaseConversion.php` — `roundRevenueIfNeeded()` returns `false` when passed `false` → `int|float` → `int|float|false`.
- `plugins/GeoIp2/LocationProvider/GeoIp2/ServerModule.php` — `getLocation()` returns `false` when no fallback resolves the location (`array` → `array|false`); `isWorking()` returns a translated error string when the server var is missing (`bool` → `bool|string`).
- `plugins/Referrers/functions.php` — `getReferrerTypeFromShortName()` "works in both directions" and returns the numeric referrer-type constant via `array_search` → `string` → `string|int`.

**`@var` corrections:**
- `plugins/API/Filter/DataComparisonFilter.php` — `$request` holds a `\Piwik\Request` (used as one), not an `array`.
- `plugins/UsersManager/Emails/UserInviteEmail.php` — `$invitedUser` is an `array` (documented `@param array`, accessed by key), not an `object`.
- `plugins/FeatureFlags/FeatureFlagManager.php` — `$logger` is the injected `LoggerInterface`, not the concrete `Logger` (removes the now-unused import).
- `plugins/LanguagesManager/TranslationWriter/Writer.php` — `$validationMessage` can be an `array` (from `$validator->getMessage()`) → `string|null` → `string|array|null`.
- `plugins/UserCountry/Commands/AttributeHistoricalDataWithLocations.php` — `$processedPercent` is assigned `ceil(...)` (float) → `int` → `float`.
- `plugins/UsersManager/Sql/UserTableFilter.php` — `$filterByRole` is assigned `null` and guarded with `isset()` → `string` → `string|null`.

**`@param` correction:**
- `core/Db/Schema.php` — `optimizeTables()` has a native `array $tables` parameter, so the `@param string|array` docblock was not a subtype of it → `@param array`.

## Review

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Removed the 22 now-obsolete `phpstan-baseline.neon` entries the corrections resolved (confirmed by the full run reporting them as no-longer-matched; several corrections cleared more than one entry, e.g. fixing `DataComparisonFilter::$request` also cleared four downstream "Cannot call method … on array" entries). Also reviewed locally with `codex review` before opening this PR.

## Refs

n/a

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
