### PR TITLE
Docblock quality chunk 25: mark nullable/widened property @var types

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -53,14 +53,14 @@ class Access
     /**
      * Login of the current user
      *
-     * @var string
+     * @var string|null
      */
     protected $login = null;
 
     /**
      * token_auth of the current user
      *
-     * @var string
+     * @var string|null
      */
     protected $token_auth = null;
 

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -69,7 +69,7 @@ class ArchiveInvalidator
     private $model;
 
     /**
-     * @var SegmentArchiving
+     * @var SegmentArchiving|null
      */
     private $segmentArchiving;
 

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -96,7 +96,7 @@ class ArchiveProcessor
     private $logAggregator;
 
     /**
-     * @var Archive
+     * @var \Piwik\Archive\ArchiveQuery|null
      */
     public $archive = null;
 

--- a/core/CronArchive/ArchiveFilter.php
+++ b/core/CronArchive/ArchiveFilter.php
@@ -31,7 +31,7 @@ class ArchiveFilter
      * If supplied, archiving will be launched only for periods that fall within this date range. For example,
      * `"2012-01-01,2012-03-15"` would result in January 2012, February 2012 being archived but not April 2012.
      *
-     * @var Date[]
+     * @var Date[]|false
      */
     private $restrictToDateRange = false;
 
@@ -211,7 +211,7 @@ class ArchiveFilter
     public function setRestrictToDateRange($restrictToDateRange)
     {
         if (empty($restrictToDateRange)) {
-            $this->restrictToDateRange = $restrictToDateRange;
+            $this->restrictToDateRange = false;
             return;
         }
 

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -77,7 +77,7 @@ class QueueConsumer
     private $periodIdsToLabels;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $idSite;
 

--- a/core/Plugin/LogTablesProvider.php
+++ b/core/Plugin/LogTablesProvider.php
@@ -22,7 +22,7 @@ class LogTablesProvider
     private $pluginManager;
 
     /**
-     * @var LogTable[]
+     * @var LogTable[]|null
      */
     private $tablesCache;
 

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -35,7 +35,7 @@ use Piwik\Log\LoggerInterface;
 class Tracker
 {
     /**
-     * @var Db
+     * @var Db|null
      */
     private static $db = null;
 

--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -23,7 +23,7 @@ use Piwik\Tracker\Db\DbException;
 class Mysql extends Db
 {
     /**
-     * @var PDO
+     * @var PDO|null
      */
     protected $connection = null;
 

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -60,7 +60,7 @@ class Visit implements VisitInterface
     protected $requestProcessors;
 
     /**
-     * @var VisitProperties
+     * @var VisitProperties|null
      */
     protected $visitProperties;
 

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -65,7 +65,7 @@ class VisitorRecognizer
     private $eventDispatcher;
 
     /**
-     * @var array
+     * @var array|false
      */
     private $visitRow;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,21 +91,6 @@ parameters:
 			path: core/Access.php
 
 		-
-			message: "#^Property Piwik\\\\Access\\:\\:\\$login \\(string\\) does not accept null\\.$#"
-			count: 3
-			path: core/Access.php
-
-		-
-			message: "#^Property Piwik\\\\Access\\:\\:\\$login \\(string\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: core/Access.php
-
-		-
-			message: "#^Property Piwik\\\\Access\\:\\:\\$token_auth \\(string\\) does not accept null\\.$#"
-			count: 1
-			path: core/Access.php
-
-		-
 			message: "#^If condition is always true\\.$#"
 			count: 6
 			path: core/Application/Environment.php
@@ -122,16 +107,6 @@ parameters:
 
 		-
 			message: "#^Property Piwik\\\\Archive\\\\ArchiveInvalidator\\:\\:\\$allIdSitesCache is never written, only read\\.$#"
-			count: 1
-			path: core/Archive/ArchiveInvalidator.php
-
-		-
-			message: "#^Property Piwik\\\\Archive\\\\ArchiveInvalidator\\:\\:\\$segmentArchiving \\(Piwik\\\\CronArchive\\\\SegmentArchiving\\) does not accept null\\.$#"
-			count: 1
-			path: core/Archive/ArchiveInvalidator.php
-
-		-
-			message: "#^Property Piwik\\\\Archive\\\\ArchiveInvalidator\\:\\:\\$segmentArchiving \\(Piwik\\\\CronArchive\\\\SegmentArchiving\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: core/Archive/ArchiveInvalidator.php
 
@@ -164,16 +139,6 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between array and false will always evaluate to false\\.$#"
 			count: 1
 			path: core/Archive/DataTableFactory.php
-
-		-
-			message: "#^Property Piwik\\\\ArchiveProcessor\\:\\:\\$archive \\(Piwik\\\\Archive\\) does not accept Piwik\\\\Archive\\\\ArchiveQuery\\.$#"
-			count: 1
-			path: core/ArchiveProcessor.php
-
-		-
-			message: "#^Property Piwik\\\\ArchiveProcessor\\:\\:\\$archive \\(Piwik\\\\Archive\\) in empty\\(\\) is not falsy\\.$#"
-			count: 1
-			path: core/ArchiveProcessor.php
 
 		-
 			message: "#^Left side of && is always true\\.$#"
@@ -346,16 +311,6 @@ parameters:
 			path: core/CronArchive/ArchiveFilter.php
 
 		-
-			message: "#^Property Piwik\\\\CronArchive\\\\ArchiveFilter\\:\\:\\$restrictToDateRange \\(array\\<Piwik\\\\Date\\>\\) does not accept default value of type false\\.$#"
-			count: 1
-			path: core/CronArchive/ArchiveFilter.php
-
-		-
-			message: "#^Property Piwik\\\\CronArchive\\\\ArchiveFilter\\:\\:\\$restrictToDateRange \\(array\\<Piwik\\\\Date\\>\\) does not accept string\\|false\\.$#"
-			count: 1
-			path: core/CronArchive/ArchiveFilter.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: core/CronArchive/Performance/Logger.php
@@ -368,11 +323,6 @@ parameters:
 		-
 			message: "#^Method Piwik\\\\CronArchive\\\\QueueConsumer\\:\\:isArchiveNonSegmentAndInProgressArchiveSegment\\(\\) is unused\\.$#"
 			count: 1
-			path: core/CronArchive/QueueConsumer.php
-
-		-
-			message: "#^Property Piwik\\\\CronArchive\\\\QueueConsumer\\:\\:\\$idSite \\(int\\) does not accept null\\.$#"
-			count: 2
 			path: core/CronArchive/QueueConsumer.php
 
 		-
@@ -802,16 +752,6 @@ parameters:
 
 		-
 			message: "#^Method Piwik\\\\Plugin\\\\LogTablesProvider\\:\\:getLogTable\\(\\) should return Piwik\\\\Tracker\\\\LogTable\\|null but return statement is missing\\.$#"
-			count: 1
-			path: core/Plugin/LogTablesProvider.php
-
-		-
-			message: "#^Property Piwik\\\\Plugin\\\\LogTablesProvider\\:\\:\\$tablesCache \\(array\\<Piwik\\\\Tracker\\\\LogTable\\>\\) does not accept null\\.$#"
-			count: 1
-			path: core/Plugin/LogTablesProvider.php
-
-		-
-			message: "#^Property Piwik\\\\Plugin\\\\LogTablesProvider\\:\\:\\$tablesCache \\(array\\<Piwik\\\\Tracker\\\\LogTable\\>\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: core/Plugin/LogTablesProvider.php
 
@@ -1286,18 +1226,8 @@ parameters:
 			path: core/Tracker.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with Piwik\\\\Db will always evaluate to false\\.$#"
-			count: 3
-			path: core/Tracker.php
-
-		-
 			message: "#^Parameter \\#2 \\$options of function json_encode expects int, true given\\.$#"
 			count: 1
-			path: core/Tracker.php
-
-		-
-			message: "#^Static property Piwik\\\\Tracker\\:\\:\\$db \\(Piwik\\\\Db\\) does not accept null\\.$#"
-			count: 2
 			path: core/Tracker.php
 
 		-
@@ -1356,11 +1286,6 @@ parameters:
 			path: core/Tracker/Db/Mysqli.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with PDO will always evaluate to false\\.$#"
-			count: 1
-			path: core/Tracker/Db/Pdo/Mysql.php
-
-		-
 			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Pdo\\\\Mysql\\:\\:beginTransaction\\(\\) should return string\\|null but empty return statement found\\.$#"
 			count: 1
 			path: core/Tracker/Db/Pdo/Mysql.php
@@ -1378,11 +1303,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$errno of method Piwik\\\\Tracker\\\\Db\\\\Pdo\\\\Mysql\\:\\:isErrNo\\(\\) expects string, int given\\.$#"
 			count: 1
-			path: core/Tracker/Db/Pdo/Mysql.php
-
-		-
-			message: "#^Property Piwik\\\\Tracker\\\\Db\\\\Pdo\\\\Mysql\\:\\:\\$connection \\(PDO\\) does not accept null\\.$#"
-			count: 2
 			path: core/Tracker/Db/Pdo/Mysql.php
 
 		-
@@ -1536,11 +1456,6 @@ parameters:
 			path: core/Tracker/TrackerCodeGenerator.php
 
 		-
-			message: "#^Property Piwik\\\\Tracker\\\\Visit\\:\\:\\$visitProperties \\(Piwik\\\\Tracker\\\\Visit\\\\VisitProperties\\) does not accept null\\.$#"
-			count: 1
-			path: core/Tracker/Visit.php
-
-		-
 			message: "#^Instanceof between \\*NEVER\\* and Piwik\\\\Tracker\\\\VisitInterface will always evaluate to false\\.$#"
 			count: 1
 			path: core/Tracker/Visit/Factory.php
@@ -1557,11 +1472,6 @@ parameters:
 
 		-
 			message: "#^Call to function is_null\\(\\) with array will always evaluate to false\\.$#"
-			count: 1
-			path: core/Tracker/VisitorRecognizer.php
-
-		-
-			message: "#^Property Piwik\\\\Tracker\\\\VisitorRecognizer\\:\\:\\$visitRow \\(array\\) does not accept false\\.$#"
 			count: 1
 			path: core/Tracker/VisitorRecognizer.php
 


### PR DESCRIPTION
## Description

Docblock quality cleanup series (chunk 25). Corrects property `@var` docblocks that were too narrow: each property is legitimately assigned `null`/`false`/a wider type by the class's own code (constructor defaults, disconnect resets, lazy-init sentinels), but the `@var` omitted it. Documentation-only, with one small behaviour-preserving normalization (`ArchiveFilter`, see below).

Each correction removes the corresponding `phpstan-baseline.neon` entry. In several cases making the property nullable also **removed** previously-baselined "pointless `is_null()` / `empty()` check" entries, because the code's existing null-guards became justified once the type reflected reality.

Only properties whose value is assigned by the class itself are included — nothing where an external caller might just be passing an incorrect type. Every change was verified against a full-project phpstan run showing **no new errors** (nullable widening can cascade "possibly null" errors at usage sites; none did here).

**Fixes:**
- `core/Access.php` — `$login` / `$token_auth` default to `null` and are `isset()`-guarded → `string` → `string|null`.
- `core/Archive/ArchiveInvalidator.php` — `$segmentArchiving` is `null` in the constructor and lazily instantiated (guarded with `empty()`) → `SegmentArchiving|null`.
- `core/ArchiveProcessor.php` — `$archive` defaults to `null` and holds an `ArchiveQuery` (`Archive::build()` returns the interface), so the concrete non-null `Archive` type was wrong → `\Piwik\Archive\ArchiveQuery|null`.
- `core/CronArchive/ArchiveFilter.php` — `$restrictToDateRange` is documented `Date[]|false` by its getter, but the setter stored the raw empty input (so an empty-string argument was kept as a `string`). The empty branch now stores `false`, so the property is only ever a parsed `Date[]` or `false`; `@var` corrected to `Date[]|false`. All reads guard with `!empty()` before array access, so this is behaviour-preserving.
- `core/CronArchive/QueueConsumer.php` — `$idSite` is explicitly assigned `null` → `int|null`.
- `core/Plugin/LogTablesProvider.php` — `$tablesCache` uses `null` as its uninitialised-cache sentinel (guarded with `isset()`) → `LogTable[]|null`.
- `core/Tracker.php` — static `$db` defaults to `null` and is reset to `null` on disconnect → `Db|null`.
- `core/Tracker/Db/Pdo/Mysql.php` — `$connection` defaults to `null` and is reset to `null` on disconnect → `PDO|null`.
- `core/Tracker/Visit.php` — `$visitProperties` is `null` in the constructor before a `VisitProperties` instance is set → `VisitProperties|null`.
- `core/Tracker/VisitorRecognizer.php` — `$visitRow` is assigned `false` as the no-matching-visitor sentinel → `array|false`.

## Review

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Removed the 18 now-obsolete `phpstan-baseline.neon` entries the corrections resolved (confirmed by the full run reporting them as no-longer-matched). Also reviewed locally with `codex review` before opening this PR.

## Refs

n/a

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
