### PR TITLE
Clear dimension column cache when (re)creating tables

### DIFF
--- a/core/Columns/Updater.php
+++ b/core/Columns/Updater.php
@@ -372,6 +372,22 @@ class Updater extends \Piwik\Updates
         $cache->save(self::$cacheId, $changes);
     }
 
+    /**
+     * Invalidate the cached dimension file-change times.
+     *
+     * getAllVersions() short-circuits when the dimension files on disk are unchanged since they
+     * were last cached, treating "files unchanged" as "columns already installed". That assumption
+     * breaks whenever the tables are (re)created independently of the cache — most notably a fresh
+     * install or a test fixture that drops and recreates the database while a warm eager cache
+     * survives on disk. The freshly created log_visit / log_link_visit_action / log_conversion
+     * tables would then never receive their dimension columns. Callers that (re)create the schema
+     * must clear this cache so the column updates are re-evaluated against the new tables.
+     */
+    public static function clearCache()
+    {
+        self::buildCache()->delete(self::$cacheId);
+    }
+
     private static function buildCache()
     {
         return PiwikCache::getEagerCache();

--- a/core/DbHelper.php
+++ b/core/DbHelper.php
@@ -143,6 +143,12 @@ class DbHelper
     public static function createTables()
     {
         Schema::getInstance()->createTables();
+
+        // The tables were just (re)created without their dimension columns (those are added by the
+        // subsequent DB update). Invalidate the cache that would otherwise make Columns\Updater
+        // believe the dimension columns are already installed because the dimension files on disk
+        // are unchanged. See Columns\Updater::clearCache().
+        \Piwik\Columns\Updater::clearCache();
     }
 
     /**


### PR DESCRIPTION
### Description

Running UI tests in sequence intermittently fails during fixture setup with a tracking error, because the freshly created log tables are missing their dimension columns.

`Columns\Updater::getAllVersions()` skips loading all dimensions on every request as a performance optimisation: it caches the dimension files' modification times and short-circuits to "no updates" when they are unchanged. The assumption is *"dimension files unchanged on disk" ⇒ "columns already installed in the DB"*. That assumption breaks whenever the tables are (re)created independently of this cache — most notably a test fixture that drops and recreates the database while a warm eager cache survives on disk.

The base schema only creates a handful of columns per log table (`log_visit` starts with just `idvisit`, `idsite`, `idvisitor`, `visit_last_action_time`, `config_id`, `location_ip`); **every other column — core dimensions like `referer_type`/`config_*` as well as plugin dimensions — is added afterwards by the dimension updater.** So when `getAllVersions()` short-circuits against freshly created tables, none of those columns are installed, and the next tracking request fails. Because the cache is only warmed by a *successful* run's post-setup requests and is not reset when a setup fails, the failure appears intermittently across consecutive runs.

This makes `DbHelper::createTables()` invalidate the cached dimension file-change times so the column updates are re-evaluated against the newly created tables. Only the single `AllDimensionModifyTime` cache key is deleted (rather than a full eager-cache flush) to keep the blast radius minimal — plugin metadata, language lists, etc. in the eager cache are left intact. Every code path that reaches `createTables()` (the installer, test fixtures, and the CI install script) runs the DB update immediately afterwards, which is exactly the re-scan the cleared cache enables.

### Changes

- Add `Columns\Updater::clearCache()`, which invalidates only the `AllDimensionModifyTime` eager-cache key.
- Call it from `DbHelper::createTables()` so any code path that (re)creates the schema re-evaluates the dimension columns against the new tables.

**Note**: we can also convert this to a CI/test only change if wanted.

### How to reproduce / verify

Run a UI spec whose fixture tracks visits (i.e. not the SQL-dump-based `UITestFixture`) **consecutively**, without resetting between runs:

```
ddev matomo:console tests:run-ui OnlyRawDataNotification
```

#### Before this change

```
> ddev matomo:console tests:run-ui OnlyRawDataNotification

... successful run (2 passing)

> ddev matomo:console tests:run-ui OnlyRawDataNotification

    OnlyRawDataNotification
    Setting up fixture Piwik\Tests\Fixtures\OneVisit...
    Dropping database 'matomo_tests'...

    In IsEqual.php line 101:

    [PHPUnit\Framework\ExpectationFailedException]
    Expected GIF beacon, got: <br/>

... failure during setup

> ddev matomo:console tests:run-ui OnlyRawDataNotification

... successful run (2 passing)
```

#### After this change

```
> ddev matomo:console tests:run-ui OnlyRawDataNotification

... successful run (2 passing)
> ddev matomo:console tests:run-ui OnlyRawDataNotification

... successful run (2 passing)
> ddev matomo:console tests:run-ui OnlyRawDataNotification

... successful run (2 passing)
```

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
