### PR TITLE
Harden request handling in the Login controller

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -404,7 +404,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                 if (
                     !empty($host) && !empty($currentHost) && $host == $currentHost && Url::isValidHost($host)
                 ) {
-                    $urlToRedirect = $redirect;
+                    // rebuild the url from its parsed parts, consistent with the handling of the url parameter above
+                    $urlToRedirect = (strpos($redirect, '//') === 0 ? '//' : '') . UrlHelper::getParseUrlReverse(parse_url($redirect));
                 }
             }
         }
@@ -679,7 +680,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $request = Request::fromRequest();
 
         $token = $request->getStringParameter('token');
-        $form = $request->getStringParameter('invitation_form', '');
+        // the invitation form is only processed when submitted via POST
+        $form = Request::fromPost()->getStringParameter('invitation_form', '');
 
         $settings = new SystemSettings();
         $termsAndConditionUrl = $settings->termsAndConditionUrl->getValue();
@@ -699,9 +701,10 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         // if form was sent
         if (!empty($form)) {
             $error = null;
-            $password = $request->getStringParameter('password', '');
-            $passwordConfirmation = $request->getStringParameter('passwordConfirmation', '');
-            $conditionCheck = $request->getBoolParameter('conditionCheck', false);
+            $postRequest = Request::fromPost();
+            $password = $postRequest->getStringParameter('password', '');
+            $passwordConfirmation = $postRequest->getStringParameter('passwordConfirmation', '');
+            $conditionCheck = $postRequest->getBoolParameter('conditionCheck', false);
 
             if (empty($password)) {
                 $error = Piwik::translate('Login_PasswordRequired');

--- a/plugins/Login/tests/Integration/ControllerTest.php
+++ b/plugins/Login/tests/Integration/ControllerTest.php
@@ -10,11 +10,16 @@
 namespace Piwik\Plugins\Login\tests\Integration;
 
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Auth;
+use Piwik\Common;
+use Piwik\Config;
 use Piwik\Plugins\Login\Controller;
+use Piwik\Plugins\Login\PasswordResetter;
 use Piwik\Nonce;
 use Piwik\Auth\PasswordStrength;
 use Piwik\Date;
 use Piwik\Plugins\UsersManager\Model;
+use Piwik\Session\SessionInitializer;
 
 /**
  * @group Login
@@ -115,5 +120,66 @@ class ControllerTest extends IntegrationTestCase
 
         $response = $this->controller->acceptInvitation();
         $this->assertStringNotContainsString('General_PasswordStrengthValidationFailed', $response);
+    }
+
+    public function testAcceptInvitationIsOnlyProcessedForPostRequest()
+    {
+        [$userEmail, $token] = $this->generateTestUser();
+
+        // provide a complete, valid acceptance form, but through GET instead of POST
+        $_GET['token'] = $token;
+        $_GET['password'] = 'Password111!';
+        $_GET['passwordConfirmation'] = 'Password111!';
+        $_GET['email'] = $userEmail;
+        $_GET['invitation_form'] = 'Confirm';
+        $_GET['conditionCheck'] = true;
+
+        try {
+            $response = $this->controller->acceptInvitation();
+        } finally {
+            foreach (['token', 'password', 'passwordConfirmation', 'email', 'invitation_form', 'conditionCheck'] as $key) {
+                unset($_GET[$key]);
+            }
+        }
+
+        // the form is only processed for POST requests, so the user must still be pending
+        $this->assertTrue((new Model())->isPendingUser('test'));
+        // and the set password form is rendered again instead
+        $this->assertStringContainsString('invitation_form', $response);
+    }
+
+    public function testAuthenticateAndRedirectRebuildsFormRedirectUrl()
+    {
+        $host = 'localhost';
+        $_SERVER['HTTP_HOST'] = $host;
+        $_SESSION = [];
+        Config::getInstance()->General['trusted_hosts'] = [$host];
+
+        // the redirect url is rebuilt from its parsed parts, so special characters in the user info part
+        // are escaped instead of being passed through verbatim
+        $_POST['form_redirect'] = 'http://foo\\@' . $host . '/?module=CoreHome';
+
+        $controller = new Controller(
+            $this->createMock(PasswordResetter::class),
+            $this->createMock(Auth::class),
+            $this->createMock(SessionInitializer::class),
+            $passwordVerify = null,
+            $bruteForceDetection = null,
+            $systemSettings = null,
+            new PasswordStrength(true)
+        );
+
+        $method = new \ReflectionMethod(Controller::class, 'authenticateAndRedirect');
+        $method->setAccessible(true);
+
+        try {
+            $method->invoke($controller, 'test', 'Password111!');
+            $this->fail('Expected a redirect to be triggered');
+        } catch (\Exception $e) {
+            $redirectUrl = Common::$headersSentInTests['Location'] ?? '';
+            // the backslash in the user info part must be escaped rather than passed through verbatim
+            $this->assertStringNotContainsString('foo\\@' . $host, $redirectUrl);
+            $this->assertStringContainsString('foo%5C@' . $host, $redirectUrl);
+        }
     }
 }

--- a/plugins/Login/tests/Integration/ControllerTest.php
+++ b/plugins/Login/tests/Integration/ControllerTest.php
@@ -151,6 +151,12 @@ class ControllerTest extends IntegrationTestCase
     public function testAuthenticateAndRedirectRebuildsFormRedirectUrl()
     {
         $host = 'localhost';
+
+        // remember the process-global state we are about to mutate, so it can be restored afterwards
+        $previousHttpHost = $_SERVER['HTTP_HOST'] ?? null;
+        $previousSession = $_SESSION ?? null;
+        $previousTrustedHosts = Config::getInstance()->General['trusted_hosts'] ?? null;
+
         $_SERVER['HTTP_HOST'] = $host;
         $_SESSION = [];
         Config::getInstance()->General['trusted_hosts'] = [$host];
@@ -180,6 +186,14 @@ class ControllerTest extends IntegrationTestCase
             // the backslash in the user info part must be escaped rather than passed through verbatim
             $this->assertStringNotContainsString('foo\\@' . $host, $redirectUrl);
             $this->assertStringContainsString('foo%5C@' . $host, $redirectUrl);
+        } finally {
+            if (null === $previousHttpHost) {
+                unset($_SERVER['HTTP_HOST']);
+            } else {
+                $_SERVER['HTTP_HOST'] = $previousHttpHost;
+            }
+            $_SESSION = $previousSession ?? [];
+            Config::getInstance()->General['trusted_hosts'] = $previousTrustedHosts;
         }
     }
 }


### PR DESCRIPTION
## Description

Some small hardening improvements around request handling in the Login controller:

- The `form_redirect` fallback URL is now rebuilt from its parsed parts before being used, consistent with how the `url` parameter is already handled in the same method. This keeps redirect-target handling uniform across both code paths.
- The invitation acceptance form is now only processed when it is actually submitted via `POST`. The form values are read from the POST request accordingly.

Both changes come with integration test coverage.

## Review

- [ ] Functional review done
- [ ] Usability review done (is anything confusing, is any text potentially misleading)
- [ ] Security review done ([OWASP Top 10](https://owasp.org/www-project-top-ten/), [secure coding guidelines](https://developer.matomo.org/guides/security-how-to))
- [ ] Code review done
- [ ] Tests were added if useful/possible
- [ ] Reviewed for breaking changes
- [ ] Developer changelog updated if useful/necessary
- [ ] Documentation added if useful/necessary


### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
