### PR TITLE
Technical debt chunk 26: explicit null returns for nullable methods

### DIFF
--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -453,7 +453,7 @@ class Filesystem
         }
 
         if (!file_exists($pathToFile)) {
-            return;
+            return null;
         }
 
         $filesize  = filesize($pathToFile);

--- a/core/Plugin/LogTablesProvider.php
+++ b/core/Plugin/LogTablesProvider.php
@@ -52,6 +52,8 @@ class LogTablesProvider
                 return $table;
             }
         }
+
+        return null;
     }
 
     /**

--- a/core/Plugin/WidgetsProvider.php
+++ b/core/Plugin/WidgetsProvider.php
@@ -96,18 +96,18 @@ class WidgetsProvider
     public function factory($module, $action)
     {
         if (empty($module) || empty($action)) {
-            return;
+            return null;
         }
 
         try {
             if (!$this->pluginManager->isPluginActivated($module)) {
-                return;
+                return null;
             }
 
             $plugin = $this->pluginManager->getLoadedPlugin($module);
         } catch (\Exception $e) {
             // we are not allowed to use possible widgets, plugin is not active
-            return;
+            return null;
         }
 
         $widgets = $plugin->findMultipleComponents('Widgets', 'Piwik\\Widget\\Widget');
@@ -119,6 +119,8 @@ class WidgetsProvider
                 return StaticContainer::get($widgetClass);
             }
         }
+
+        return null;
     }
 
     private function getWidgetConfigForClassName($widgetClass)

--- a/core/Session/SessionAuth.php
+++ b/core/Session/SessionAuth.php
@@ -59,7 +59,7 @@ class SessionAuth implements Auth
 
     public function getName()
     {
-        // empty
+        return null;
     }
 
     public function setTokenAuth(
@@ -74,11 +74,13 @@ class SessionAuth implements Auth
         if (isset($this->user['login'])) {
             return $this->user['login'];
         }
+
+        return null;
     }
 
     public function getTokenAuthSecret()
     {
-        // empty
+        return null;
     }
 
     public function setLogin($login)

--- a/core/Settings/Settings.php
+++ b/core/Settings/Settings.php
@@ -72,6 +72,8 @@ abstract class Settings
         if (array_key_exists($name, $this->settings)) {
             return $this->settings[$name];
         }
+
+        return null;
     }
 
     /**

--- a/core/Tracker/Db/Mysqli.php
+++ b/core/Tracker/Db/Mysqli.php
@@ -422,13 +422,15 @@ class Mysqli extends Db
     public function beginTransaction()
     {
         if ($this->activeTransaction !== null) {
-            return;
+            return null;
         }
 
         if ($this->connection->autocommit(false)) {
             $this->activeTransaction = uniqid();
             return $this->activeTransaction;
         }
+
+        return null;
     }
 
     /**

--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -355,7 +355,7 @@ class Mysql extends Db
     public function beginTransaction()
     {
         if ($this->activeTransaction !== null) {
-            return;
+            return null;
         }
 
         try {
@@ -375,6 +375,8 @@ class Mysql extends Db
             $this->activeTransaction = uniqid();
             return $this->activeTransaction;
         }
+
+        return null;
     }
 
     /**

--- a/core/ViewDataTable/Factory.php
+++ b/core/ViewDataTable/Factory.php
@@ -176,7 +176,7 @@ class Factory
     private static function getReport($apiAction)
     {
         if (strpos($apiAction, '.') === false) {
-            return;
+            return null;
         }
 
         list($module, $action) = explode('.', $apiAction);

--- a/core/Visualization/Sparkline.php
+++ b/core/Visualization/Sparkline.php
@@ -264,7 +264,7 @@ class Sparkline implements ViewInterface
     public function render()
     {
         if (!$this->sparkline instanceof \Davaxi\Sparkline) {
-            return;
+            return null;
         }
 
         if (0 === $this->sparkline->getSeriesCount()) {
@@ -275,5 +275,7 @@ class Sparkline implements ViewInterface
 
         $this->sparkline->display();
         $this->sparkline->destroy();
+
+        return null;
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -576,11 +576,6 @@ parameters:
 			path: core/ExceptionHandler.php
 
 		-
-			message: "#^Method Piwik\\\\Filesystem\\:\\:getFileSize\\(\\) should return float\\|null but empty return statement found\\.$#"
-			count: 1
-			path: core/Filesystem.php
-
-		-
 			message: "#^Negated boolean expression is always true\\.$#"
 			count: 1
 			path: core/Filesystem.php
@@ -751,11 +746,6 @@ parameters:
 			path: core/Plugin/LogTablesProvider.php
 
 		-
-			message: "#^Method Piwik\\\\Plugin\\\\LogTablesProvider\\:\\:getLogTable\\(\\) should return Piwik\\\\Tracker\\\\LogTable\\|null but return statement is missing\\.$#"
-			count: 1
-			path: core/Plugin/LogTablesProvider.php
-
-		-
 			message: "#^Right side of \\|\\| is always false\\.$#"
 			count: 1
 			path: core/Plugin/Manager.php
@@ -814,16 +804,6 @@ parameters:
 			message: "#^Ternary operator condition is always true\\.$#"
 			count: 1
 			path: core/Plugin/Visualization.php
-
-		-
-			message: "#^Method Piwik\\\\Plugin\\\\WidgetsProvider\\:\\:factory\\(\\) should return Piwik\\\\Widget\\\\Widget\\|null but empty return statement found\\.$#"
-			count: 3
-			path: core/Plugin/WidgetsProvider.php
-
-		-
-			message: "#^Method Piwik\\\\Plugin\\\\WidgetsProvider\\:\\:factory\\(\\) should return Piwik\\\\Widget\\\\Widget\\|null but return statement is missing\\.$#"
-			count: 1
-			path: core/Plugin/WidgetsProvider.php
 
 		-
 			message: "#^If condition is always true\\.$#"
@@ -1091,21 +1071,6 @@ parameters:
 			path: core/Session/SaveHandler/DbTable.php
 
 		-
-			message: "#^Method Piwik\\\\Session\\\\SessionAuth\\:\\:getLogin\\(\\) should return string\\|null but return statement is missing\\.$#"
-			count: 1
-			path: core/Session/SessionAuth.php
-
-		-
-			message: "#^Method Piwik\\\\Session\\\\SessionAuth\\:\\:getName\\(\\) should return string\\|null but return statement is missing\\.$#"
-			count: 1
-			path: core/Session/SessionAuth.php
-
-		-
-			message: "#^Method Piwik\\\\Session\\\\SessionAuth\\:\\:getTokenAuthSecret\\(\\) should return string\\|null but return statement is missing\\.$#"
-			count: 1
-			path: core/Session/SessionAuth.php
-
-		-
 			message: "#^Parameter \\#2 \\$login of class Piwik\\\\AuthResult constructor expects string, null given\\.$#"
 			count: 1
 			path: core/Session/SessionAuth.php
@@ -1129,11 +1094,6 @@ parameters:
 			message: "#^Property Piwik\\\\Settings\\\\Setting\\:\\:\\$type \\(string\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: core/Settings/Setting.php
-
-		-
-			message: "#^Method Piwik\\\\Settings\\\\Settings\\:\\:getSetting\\(\\) should return Piwik\\\\Settings\\\\Setting\\|null but return statement is missing\\.$#"
-			count: 1
-			path: core/Settings/Settings.php
 
 		-
 			message: "#^Property Piwik\\\\Settings\\\\Storage\\\\Backend\\\\BaseSettingsTable\\:\\:\\$db \\(Piwik\\\\Db\\\\AdapterInterface\\) in isset\\(\\) is not nullable\\.$#"
@@ -1261,16 +1221,6 @@ parameters:
 			path: core/Tracker/Db.php
 
 		-
-			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Mysqli\\:\\:beginTransaction\\(\\) should return string\\|null but empty return statement found\\.$#"
-			count: 1
-			path: core/Tracker/Db/Mysqli.php
-
-		-
-			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Mysqli\\:\\:beginTransaction\\(\\) should return string\\|null but return statement is missing\\.$#"
-			count: 1
-			path: core/Tracker/Db/Mysqli.php
-
-		-
 			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Mysqli\\:\\:prepare\\(\\) is unused\\.$#"
 			count: 1
 			path: core/Tracker/Db/Mysqli.php
@@ -1284,16 +1234,6 @@ parameters:
 			message: "#^Variable \\$timer in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 4
 			path: core/Tracker/Db/Mysqli.php
-
-		-
-			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Pdo\\\\Mysql\\:\\:beginTransaction\\(\\) should return string\\|null but empty return statement found\\.$#"
-			count: 1
-			path: core/Tracker/Db/Pdo/Mysql.php
-
-		-
-			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Pdo\\\\Mysql\\:\\:beginTransaction\\(\\) should return string\\|null but return statement is missing\\.$#"
-			count: 1
-			path: core/Tracker/Db/Pdo/Mysql.php
 
 		-
 			message: "#^Method Piwik\\\\Tracker\\\\Db\\\\Pdo\\\\Mysql\\:\\:lastInsertId\\(\\) should return int but returns string\\|false\\.$#"
@@ -1581,11 +1521,6 @@ parameters:
 			path: core/ViewDataTable/Factory.php
 
 		-
-			message: "#^Method Piwik\\\\ViewDataTable\\\\Factory\\:\\:getReport\\(\\) should return Piwik\\\\Plugin\\\\Report\\|null but empty return statement found\\.$#"
-			count: 1
-			path: core/ViewDataTable/Factory.php
-
-		-
 			message: "#^Static property Piwik\\\\ViewDataTable\\\\Factory\\:\\:\\$defaultViewTypes is never read, only written\\.$#"
 			count: 1
 			path: core/ViewDataTable/Factory.php
@@ -1634,16 +1569,6 @@ parameters:
 			message: "#^Property Piwik\\\\ViewDataTable\\\\RequestConfig\\:\\:\\$pivotByColumnLimit \\(int\\) does not accept default value of type false\\.$#"
 			count: 1
 			path: core/ViewDataTable/RequestConfig.php
-
-		-
-			message: "#^Method Piwik\\\\Visualization\\\\Sparkline\\:\\:render\\(\\) should return string\\|null but empty return statement found\\.$#"
-			count: 1
-			path: core/Visualization/Sparkline.php
-
-		-
-			message: "#^Method Piwik\\\\Visualization\\\\Sparkline\\:\\:render\\(\\) should return string\\|null but return statement is missing\\.$#"
-			count: 1
-			path: core/Visualization/Sparkline.php
 
 		-
 			message: "#^Parameter \\#2 \\$newvalue of function ini_set expects string, int given\\.$#"
@@ -2611,11 +2536,6 @@ parameters:
 			path: plugins/LanguagesManager/TranslationWriter/Writer.php
 
 		-
-			message: "#^Method Piwik\\\\Plugins\\\\Live\\\\Reports\\\\GetLastVisits\\:\\:buildReportMetadata\\(\\) should return array\\|null but return statement is missing\\.$#"
-			count: 1
-			path: plugins/Live/Reports/GetLastVisits.php
-
-		-
 			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: plugins/Live/VisitorDetails.php
@@ -2894,11 +2814,6 @@ parameters:
 			message: "#^Variable \\$id_val might not be defined\\.$#"
 			count: 1
 			path: plugins/SitesManager/Model.php
-
-		-
-			message: "#^Method Piwik\\\\Plugins\\\\SitesManager\\\\SitesManager\\:\\:getTimezoneFromWebsite\\(\\) should return string\\|null but return statement is missing\\.$#"
-			count: 1
-			path: plugins/SitesManager/SitesManager.php
 
 		-
 			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"

--- a/plugins/Live/Reports/GetLastVisits.php
+++ b/plugins/Live/Reports/GetLastVisits.php
@@ -17,5 +17,6 @@ class GetLastVisits extends Base
     public function buildReportMetadata()
     {
         // do not add this report as metadata
+        return null;
     }
 }

--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -237,6 +237,8 @@ class SitesManager extends \Piwik\Plugin
         if (!empty($site['timezone'])) {
             return $site['timezone'];
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Description

Technical-debt cleanup (chunk 26). Resolves the `phpstan-baseline.neon` entries of the form "should return `<nullable type>` but empty return statement found / but return statement is missing".

Each affected method declares a nullable return type (e.g. `string|null`, `Widget|null`, `float|null`) but reached the end of a code path with a bare `return;` or with no `return` at all. PHPStan flags this even though it is harmless at runtime. The fix replaces the bare `return;` with `return null;` (or adds an explicit `return null;` at the fall-through). **Behaviour is unchanged** — a bare/implicit return already yields `null` — so this only makes the declared contract explicit and removes the baseline entries.

**Methods:**
- `core/Filesystem.php` — `getFileSize()` (`float|null`)
- `core/Plugin/LogTablesProvider.php` — `getLogTable()` (`LogTable|null`)
- `core/Plugin/WidgetsProvider.php` — `factory()` (`Widget|null`)
- `core/Session/SessionAuth.php` — `getLogin()` / `getName()` / `getTokenAuthSecret()` (`string|null`, from the `Auth` interface)
- `core/Settings/Settings.php` — `getSetting()` (`Setting|null`)
- `core/Tracker/Db/Mysqli.php` & `core/Tracker/Db/Pdo/Mysql.php` — `beginTransaction()` (`string|null`)
- `core/ViewDataTable/Factory.php` — `getReport()` (`Report|null`)
- `core/Visualization/Sparkline.php` — `render()` (`string|null` — it renders by echoing and returns nothing)
- `plugins/Live/Reports/GetLastVisits.php` — `buildReportMetadata()` (`array|null` — intentionally returns nothing to suppress the report metadata)
- `plugins/SitesManager/SitesManager.php` — `getTimezoneFromWebsite()` (`string|null`)

## Review

Validated with full-project (not just changed-file) runs of `phpcbf`, `phpcs`, and `phpstan` — all clean. Removed the 17 now-obsolete baseline entries the change resolved (confirmed by the full run reporting them as no-longer-matched). Also reviewed locally with `codex review` before opening this PR.

## Refs

n/a

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
