### PR TITLE
Fix flaky Dashboard_dashboard5 UI test caused by ellipsis truncation boundary

### DIFF
--- a/plugins/Dashboard/tests/UI/Dashboard_spec.js
+++ b/plugins/Dashboard/tests/UI/Dashboard_spec.js
@@ -74,7 +74,14 @@ describe("Dashboard", function () {
     await page.waitForNetworkIdle();
 
     pageWrap = await page.$('.pageWrap');
-    expect(await pageWrap.screenshot()).to.matchImage('dashboard5');
+    // A report label (e.g. "Provence-Alpes-Côte-d'Azur, France" in the Region widget) sits right on the
+    // CSS text-overflow:ellipsis truncation boundary. Headless Chrome's sub-pixel text layout is not fully
+    // deterministic, so it occasionally truncates one character earlier ("Fr…" vs "Fra…"). Allow a tiny
+    // difference so this purely cosmetic variance doesn't make the test flaky.
+    expect(await pageWrap.screenshot()).to.matchImage({
+      imageName: 'dashboard5',
+      comparisonThreshold: 0.001
+    });
   });
 
   it("should display dashboard correctly on a mobile phone", async function () {


### PR DESCRIPTION
### Description

`Dashboard_dashboard5` intermittently fails because a report label in the
Region widget ("Provence-Alpes-Côte-d'Azur, France") sits exactly on the CSS
`text-overflow: ellipsis` truncation boundary. Headless Chrome's sub-pixel text
layout isn't fully deterministic, so the label occasionally truncates one
character earlier (`…, Fr…` vs `…, Fra…`). Since the assertion ran with
zero tolerance, that single-character flip fails the whole screenshot.

This regressed after #24774, whose `Math.round($(column).outerWidth())` change
(dataTable.js) stabilized several tables but relocated the rounding boundary for
this widget onto an `x.5` value, making the derived label width jitter by 1px.

Perfect pixel-determinism for ellipsis truncation isn't achievable across
headless-Chrome runs, so this adds a small `comparisonThreshold: 0.001` to the
`dashboard5` assertion — the same approach already used in the UsersManager,
Referrers, and PivotByDimension specs. The change is scoped to the test only;
no production layout code is touched.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)