### PR TITLE
add nodata banner message to realtime ai report page

### DIFF
--- a/plugins/BotTracking/Widgets/NoRecentRequests.php
+++ b/plugins/BotTracking/Widgets/NoRecentRequests.php
@@ -22,9 +22,8 @@ class NoRecentRequests extends Widget
     }
 
     /**
-     * Shared config for the "no recent AI bot requests" message. It tops the Overview and Content
-     * Requests pages as its own widget (see {@see NoRecentRequestsContentRequests}); the
-     * showNoRecentRequestsMessage middleware hides it once recent requests exist.
+     * Shared config for the "no recent AI bot requests" message. It tops each AI Chatbots page as
+     * its own widget; the showNoRecentRequestsMessage middleware hides it once recent requests exist.
      */
     public static function configureMessageWidget(WidgetConfig $config, string $subcategoryId, string $action): void
     {

--- a/plugins/BotTracking/Widgets/NoRecentRequestsRealtime.php
+++ b/plugins/BotTracking/Widgets/NoRecentRequestsRealtime.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\BotTracking\Widgets;
+
+use Piwik\Widget\Widget;
+use Piwik\Widget\WidgetConfig;
+
+/**
+ * Places the "no recent AI bot requests" message on the Real-time page too, so it matches the
+ * Overview when nothing has been tracked recently. A distinct action gives it its own widget id.
+ */
+class NoRecentRequestsRealtime extends Widget
+{
+    public static function configure(WidgetConfig $config)
+    {
+        NoRecentRequests::configureMessageWidget(
+            $config,
+            'BotTracking_AIChatbotsRealtime',
+            'noRecentRequestsMessageRealtime'
+        );
+    }
+}

--- a/plugins/BotTracking/tests/UI/BotTrackingSiteWithoutData_spec.js
+++ b/plugins/BotTracking/tests/UI/BotTrackingSiteWithoutData_spec.js
@@ -13,6 +13,7 @@ describe('BotTrackingSiteWithoutData', function () {
     const generalParams = 'idSite=1&period=day&date=today';
     const urlBase = `module=CoreHome&action=index&${generalParams}`;
     const urlOverview = `?${urlBase}#?${generalParams}&category=General_AIAssistants&subcategory=BotTracking_AIChatbotsOverview`;
+    const urlRealtime = `?${urlBase}#?${generalParams}&category=General_AIAssistants&subcategory=BotTracking_AIChatbotsRealtime`;
     const urlContentRequests = `?${urlBase}#?${generalParams}&category=General_AIAssistants&subcategory=BotTracking_AIChatbotsContentRequests`;
 
     before(function () {
@@ -39,6 +40,19 @@ describe('BotTrackingSiteWithoutData', function () {
 
     it('should show the same message on the Content Requests page', async function () {
         await page.goto(urlContentRequests);
+        await page.waitForSelector('.bot-tracking-no-recent-requests-message');
+
+        const notification = await page.$('.bot-tracking-no-recent-requests-message');
+
+        expect(await notification.getProperty('textContent')).to.match(/No data collected/i);
+
+        // Back to the overview so the click-through flow below starts from the same place.
+        await page.goto(urlOverview);
+        await page.waitForSelector('.bot-tracking-no-recent-requests-message');
+    });
+
+    it('should show the same message on the Real-time page', async function () {
+        await page.goto(urlRealtime);
         await page.waitForSelector('.bot-tracking-no-recent-requests-message');
 
         const notification = await page.$('.bot-tracking-no-recent-requests-message');

--- a/tests/PHPUnit/Integration/WidgetsListTest.php
+++ b/tests/PHPUnit/Integration/WidgetsListTest.php
@@ -51,7 +51,7 @@ class WidgetsListTest extends IntegrationTestCase
             'Referrers_Referrers' => 11,
             'About Matomo' => 11,
             'Marketplace_Marketplace' => 3,
-            'General_AIAssistants' => 16,
+            'General_AIAssistants' => 17,
 
             // widgets provided by Professional Services plugin for plugin promos
             'ProfessionalServices_PromoAbTesting' => 1,

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getReportPagesMetadata.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getReportPagesMetadata.xml
@@ -279,6 +279,26 @@
 		</subcategory>
 		<widgets>
 			<row>
+				<name>AI Chatbots - No Recent Requests</name>
+				<module>BotTracking</module>
+				<action>noRecentRequestsMessageRealtime</action>
+				<order>0</order>
+				<parameters>
+					<module>BotTracking</module>
+					<action>noRecentRequestsMessageRealtime</action>
+				</parameters>
+				<uniqueId>widgetBotTrackingnoRecentRequestsMessageRealtime</uniqueId>
+				<isWide>1</isWide>
+				<middlewareParameters>
+					<module>BotTracking</module>
+					<action>showNoRecentRequestsMessage</action>
+				</middlewareParameters>
+				<clientComponent>
+					<plugin>BotTracking</plugin>
+					<name>NoRecentRequestsWidget</name>
+				</clientComponent>
+			</row>
+			<row>
 				<name>AI Chatbots - Last 30 Minutes</name>
 				<module>BotTracking</module>
 				<action>getAIChatbotsRealTime</action>


### PR DESCRIPTION
### Description

The new realtime AI assistants report page is missing the "no data" banner that shows on other AI assistant pages when there is no data present. This PR adds it.
 
### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
