### PR TITLE
Escape regex metacharacters in JS tracker getCookie()

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2524,7 +2524,11 @@ if (typeof window.Matomo !== 'object') {
                     return 0;
                 }
 
-                var cookiePattern = new RegExp('(^|;)[ ]*' + cookieName + '=([^;]*)'),
+                // escape regular expression metacharacters in the cookie name, otherwise
+                // characters such as '.' would match any character and getCookie could
+                // return the value of a different cookie (see #21998)
+                var escapedCookieName = String(cookieName).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+                    cookiePattern = new RegExp('(^|;)[ ]*' + escapedCookieName + '=([^;]*)'),
                     cookieMatch = cookiePattern.exec(documentAlias.cookie);
 
                 return cookieMatch ? decodeWrapper(cookieMatch[2]) : 0;


### PR DESCRIPTION
### Description

`getCookie()` in the JavaScript tracker builds a `RegExp` by concatenating the cookie name directly into the pattern:

    new RegExp('(^|;)[ ]*' + cookieName + '=([^;]*)')

Any regex metacharacter in the name is therefore interpreted as a pattern. In particular a `.` matches any character, so `getCookie('namespace.abc')` can match an unrelated cookie such as `namespaceEabc` and return the wrong value.

Repro (from the issue):

    this.setSessionCookie('namespaceEabc', 'value1', 1000)
    this.setSessionCookie('namespace.abc', 'value2', 1000)
    this.getCookie('namespace.abc') // returned 'value1', should be 'value2'

This escapes the cookie name before building the pattern, so it is matched literally. Normal cookie names (including Matomo's own `_pk_id.<idsite>.<hash>` style names that contain `.`) are unaffected — verified for the repro case, the literal-name case, dotted Matomo names, and missing cookies.

Only `js/piwik.js` (the source) is changed here — the minified tracker files (`js/piwik.min.js`, `piwik.js`, `matomo.js`) still need to be regenerated with the usual `build js` comment.

fixes #21998

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

> Note: this fix was prepared with AI assistance; the change and its behaviour were reviewed and verified before submission.

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
