### PR TITLE
Require a valid 2FA code to disable your own two-factor authentication

### DIFF
--- a/plugins/TwoFactorAuth/Controller.php
+++ b/plugins/TwoFactorAuth/Controller.php
@@ -12,7 +12,6 @@ namespace Piwik\Plugins\TwoFactorAuth;
 use Piwik\Access;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
-use Piwik\IP;
 use Piwik\Nonce;
 use Piwik\Piwik;
 use Piwik\Plugins\Login\PasswordVerifier;
@@ -104,14 +103,7 @@ class Controller extends \Piwik\Plugin\Controller
                     Url::redirectToUrl(Url::getCurrentUrl());
                 } else {
                     $messageNoAccess = Piwik::translate('TwoFactorAuth_InvalidAuthCode');
-                    try {
-                        $bruteForce = StaticContainer::get('Piwik\Plugins\Login\Security\BruteForceDetection');
-                        if ($bruteForce->isEnabled()) {
-                            $bruteForce->addFailedAttempt(IP::getIpFromHeader(), Piwik::getCurrentUserLogin());
-                        }
-                    } catch (Exception $e) {
-                        // ignore error eg if login plugin is disabled
-                    }
+                    $this->twoFa->recordFailedAuthAttempt(Piwik::getCurrentUserLogin());
                 }
             }
         }

--- a/plugins/TwoFactorAuth/Controller.php
+++ b/plugins/TwoFactorAuth/Controller.php
@@ -149,26 +149,58 @@ class Controller extends \Piwik\Plugin\Controller
             throw new Exception('Two-factor authentication cannot be disabled as it is enforced');
         }
 
-        $nonce = Common::getRequestVar('disableNonce', null, 'string');
+        $nonce = Common::getRequestVar('disableNonce', '', 'string');
         $params = array('module' => 'TwoFactorAuth', 'action' => 'disableTwoFactorAuth', 'disableNonce' => $nonce);
 
-        if ($this->passwordVerify->requirePasswordVerifiedRecently($params)) {
-            Nonce::checkNonce(self::DISABLE_2FA_NONCE, $nonce);
-
-            $this->twoFa->disable2FAforUser(Piwik::getCurrentUserLogin());
-            $this->passwordVerify->forgetVerifiedPassword();
-
-            $container = StaticContainer::getContainer();
-            $email = $container->make(TwoFactorAuthDisabledEmail::class, array(
-                'login' => Piwik::getCurrentUserLogin(),
-                'emailAddress' => Piwik::getCurrentUserEmail(),
-            ));
-            $email->safeSend();
-
-            $this->redirectToIndex('UsersManager', 'userSecurity', null, null, null, array(
-                'disableNonce' => false,
-            ));
+        if (!$this->passwordVerify->requirePasswordVerifiedRecently($params)) {
+            // redirected to confirm the password first
+            return;
         }
+
+        // On top of the password, a valid 2FA code is required to disable 2FA. The nonce is only consumed once
+        // 2FA is actually turned off, so it stays valid while the auth code is being entered.
+        if (!Nonce::verifyNonce(self::DISABLE_2FA_NONCE, $nonce)) {
+            throw new Exception(Piwik::translate('General_ExceptionSecurityCheckFailed'));
+        }
+
+        $login = Piwik::getCurrentUserLogin();
+        $authCode = Common::getRequestVar('authCode', '', 'string');
+        $accessErrorString = null;
+
+        if ($authCode !== '') {
+            $authCode = str_replace('-', '', $authCode);
+            $authCode = strtoupper($authCode); // recovery codes are stored upper case, app codes are only numbers
+            $authCode = trim($authCode);
+
+            if ($this->twoFa->validateAuthCode($login, $authCode)) {
+                Nonce::discardNonce(self::DISABLE_2FA_NONCE);
+
+                $this->twoFa->disable2FAforUser($login);
+                $this->passwordVerify->forgetVerifiedPassword();
+
+                $container = StaticContainer::getContainer();
+                $email = $container->make(TwoFactorAuthDisabledEmail::class, array(
+                    'login' => $login,
+                    'emailAddress' => Piwik::getCurrentUserEmail(),
+                ));
+                $email->safeSend();
+
+                $this->redirectToIndex('UsersManager', 'userSecurity', null, null, null, array(
+                    'disableNonce' => false,
+                ));
+                return;
+            }
+
+            $accessErrorString = Piwik::translate('TwoFactorAuth_InvalidAuthCode');
+            $this->twoFa->recordFailedAuthAttempt($login);
+        }
+
+        $view = new View('@TwoFactorAuth/disableTwoFactorAuth');
+        $this->setBasicVariablesView($view);
+        $view->AccessErrorString = $accessErrorString;
+        $view->disableNonce = $nonce;
+
+        return $view->render();
     }
 
     private function make2faSession()

--- a/plugins/TwoFactorAuth/TwoFactorAuth.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuth.php
@@ -15,7 +15,6 @@ use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Exception\NoPrivilegesException;
 use Piwik\FrontController;
-use Piwik\IP;
 use Piwik\Piwik;
 use Piwik\Plugins\Login\Controller as LoginController;
 use Piwik\Request\AuthenticationToken;
@@ -157,7 +156,7 @@ class TwoFactorAuth extends \Piwik\Plugin
                     $sessionFingerprint = new SessionFingerprint();
                     $sessionFingerprint->setTwoFactorAuthenticationVerified($login);
                 } else {
-                    $this->recordFailedTwoFactorAttempt($login);
+                    $twoFa->recordFailedAuthAttempt($login);
                 }
             }
         }
@@ -197,11 +196,11 @@ class TwoFactorAuth extends \Piwik\Plugin
                 // we only return an error when the login/password combo was correct. otherwise you could brute force
                 // auth tokens
                 if (!$authCode) {
-                    $this->recordFailedTwoFactorAttempt($login);
+                    $twoFa->recordFailedAuthAttempt($login);
                     throw new NoPrivilegesException(Piwik::translate('TwoFactorAuth_MissingAuthCodeAPI'));
                 }
                 if (!$twoFa->validateAuthCode($login, $authCode)) {
-                    $this->recordFailedTwoFactorAttempt($login);
+                    $twoFa->recordFailedAuthAttempt($login);
                     throw new NoPrivilegesException(Piwik::translate('TwoFactorAuth_InvalidAuthCode'));
                 }
             } elseif (
@@ -210,21 +209,6 @@ class TwoFactorAuth extends \Piwik\Plugin
             ) {
                 throw new Exception(Piwik::translate('TwoFactorAuth_RequiredAuthCodeNotConfiguredAPI'));
             }
-        }
-    }
-
-    /**
-     * Records a failed login attempt so the existing brute-force protection can engage.
-     */
-    private function recordFailedTwoFactorAttempt(string $login): void
-    {
-        try {
-            $bruteForce = StaticContainer::get('Piwik\Plugins\Login\Security\BruteForceDetection');
-            if ($bruteForce->isEnabled()) {
-                $bruteForce->addFailedAttempt(IP::getIpFromHeader(), $login);
-            }
-        } catch (Exception $e) {
-            // ignore error eg if login plugin is disabled
         }
     }
 

--- a/plugins/TwoFactorAuth/TwoFactorAuthentication.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuthentication.php
@@ -10,7 +10,9 @@
 namespace Piwik\Plugins\TwoFactorAuth;
 
 use Piwik\Common;
+use Piwik\Container\StaticContainer;
 use Piwik\Db;
+use Piwik\IP;
 use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugins\TwoFactorAuth\Dao\RecoveryCodeDao;
@@ -273,5 +275,20 @@ class TwoFactorAuthentication
     private function makeAuthenticator(): \TwoFactorAuthenticator
     {
         return new \TwoFactorAuthenticator();
+    }
+
+    /**
+     * Records a failed attempt for the brute force detection, if the Login plugin is available and enabled.
+     */
+    public function recordFailedAuthAttempt(string $login): void
+    {
+        try {
+            $bruteForce = StaticContainer::get('Piwik\Plugins\Login\Security\BruteForceDetection');
+            if ($bruteForce->isEnabled()) {
+                $bruteForce->addFailedAttempt(IP::getIpFromHeader(), $login);
+            }
+        } catch (Exception $e) {
+            // ignore error eg if login plugin is disabled
+        }
     }
 }

--- a/plugins/TwoFactorAuth/lang/en.json
+++ b/plugins/TwoFactorAuth/lang/en.json
@@ -32,6 +32,7 @@
         "DisableTwoFA": "Turn off two-factor authentication",
         "EnableTwoFA": "Turn on two-factor authentication",
         "ConfirmDisableTwoFA": "Turn off two-factor authentication for your account? This will lower your account security.",
+        "ConfirmDisableTwoFAAuthCode": "To turn off two-factor authentication, enter the code from your authentication app or one of your recovery codes.",
         "VerifyAuthCodeIntro": "Please enter the six-digit code from your OTP app below to confirm you have set up on your device.",
         "VerifyAuthCodeHelp": "Please enter the six-digit code generated on your mobile device after scanning the barcode.",
         "Your2FaAuthSecret": "Your two-factor authentication secret",

--- a/plugins/TwoFactorAuth/templates/disableTwoFactorAuth.twig
+++ b/plugins/TwoFactorAuth/templates/disableTwoFactorAuth.twig
@@ -1,0 +1,46 @@
+{% extends '@Login/loginLayout.twig' %}
+
+{% set title %}{{ 'TwoFactorAuth_DisableTwoFA'|translate }}{% endset %}
+
+{% block loginContent %}
+    <div class="contentForm loginForm disableTwoFactorAuthForm">
+        {% embed 'contentBlock.twig' with {'title': ('TwoFactorAuth_DisableTwoFA'|translate)} %}
+        {% block content %}
+
+            <div class="message_container">
+                {% if AccessErrorString %}
+                    <div vue-entry="CoreHome.Notification"
+                         noclear="true"
+                         context="error">
+                        <strong>{{ 'General_Error'|translate }}</strong>: {{ AccessErrorString|raw }}<br/>
+                    </div>
+                {% endif %}
+            </div>
+
+            <p>{{ 'TwoFactorAuth_ConfirmDisableTwoFAAuthCode'|translate }}</p>
+
+            <form action="{{ linkTo({'module': 'TwoFactorAuth', 'action': 'disableTwoFactorAuth'}) }}" method="post">
+                <div class="row">
+                    <div class="col s12 input-field">
+                        <input type="hidden" name="disableNonce" value="{{ disableNonce }}"/>
+                        <input type="text" placeholder="" name="authCode" id="disable_2fa_authcode" class="input" value=""
+                               autocomplete="one-time-code" autocorrect="off" autocapitalize="none" spellcheck="false"
+                               tabindex="20" autofocus />
+                        <label for="disable_2fa_authcode">
+                            <i class="icon-locked icon"></i> {{ 'TwoFactorAuth_AuthenticationCode'|translate }}
+                        </label>
+                    </div>
+                </div>
+
+                <div class="row actions">
+                    <div class="col s12">
+                        <input class="submit btn" id="disable_2fa_submit" type="submit"
+                               value="{{ 'General_Confirm'|translate }}" tabindex="100"/>
+                    </div>
+                </div>
+            </form>
+
+        {% endblock %}
+        {% endembed %}
+    </div>
+{% endblock %}

--- a/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
@@ -13,8 +13,10 @@ use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\Auth;
 use Piwik\AuthResult;
+use Piwik\Nonce;
 use Piwik\Session\SessionFingerprint;
 use Piwik\Container\StaticContainer;
+use Piwik\Plugins\Login\PasswordVerifier;
 use Piwik\Plugins\Login\Security\BruteForceDetection;
 use Piwik\Plugins\TwoFactorAuth\Dao\RecoveryCodeDao;
 use Piwik\Plugins\TwoFactorAuth\Dao\TwoFaSecretRandomGenerator;
@@ -91,6 +93,108 @@ class TwoFactorAuthTest extends IntegrationTestCase
     {
         $this->bruteForceDetection->deleteAll();
         unset($_GET['authCode'], $_GET['module'], $_GET['action']);
+        unset($_POST['authCode'], $_POST['disableNonce']);
+    }
+
+    public function testDisableTwoFactorAuthRendersAuthCodeFormWhenPasswordVerifiedButNoAuthCodeProvided()
+    {
+        $nonce = $this->setUpVerifiedDisableFlow($this->userWith2Fa);
+        $_POST['disableNonce'] = $nonce;
+
+        $result = StaticContainer::get(Controller::class)->disableTwoFactorAuth();
+
+        // the auth code form is shown and 2fa stays enabled until a valid code is provided
+        $this->assertStringContainsString('disable_2fa_authcode', $result);
+        $this->assertTrue(TwoFactorAuthentication::isUserUsingTwoFactorAuthentication($this->userWith2Fa));
+    }
+
+    public function testDisableTwoFactorAuthRejectsInvalidAuthCodeAndKeeps2FaEnabled()
+    {
+        $this->assertCount(0, $this->bruteForceDetection->getAll());
+
+        $nonce = $this->setUpVerifiedDisableFlow($this->userWith2Fa);
+        $_POST['disableNonce'] = $nonce;
+        $_POST['authCode'] = '000000';
+
+        $result = StaticContainer::get(Controller::class)->disableTwoFactorAuth();
+
+        $this->assertStringContainsString('disable_2fa_authcode', $result);
+        $this->assertStringContainsString('TwoFactorAuth_InvalidAuthCode', $result);
+        $this->assertTrue(TwoFactorAuthentication::isUserUsingTwoFactorAuthentication($this->userWith2Fa));
+
+        // an invalid code is treated as a failed authentication attempt
+        $attempts = $this->bruteForceDetection->getAll();
+        $this->assertCount(1, $attempts);
+        $this->assertSame($this->userWith2Fa, $attempts[0]['login']);
+    }
+
+    public function testDisableTwoFactorAuthDisables2FaWhenValidAuthCodeProvided()
+    {
+        $nonce = $this->setUpVerifiedDisableFlow($this->userWith2Fa);
+        $_POST['disableNonce'] = $nonce;
+        $_POST['authCode'] = $this->generateValidAuthCode($this->user2faSecret);
+
+        try {
+            StaticContainer::get(Controller::class)->disableTwoFactorAuth();
+        } catch (\Exception $e) {
+            // the redirect after disabling becomes an exception in CLI mode
+        }
+
+        $this->assertFalse(TwoFactorAuthentication::isUserUsingTwoFactorAuthentication($this->userWith2Fa));
+    }
+
+    public function testDisableTwoFactorAuthDisables2FaWhenValidRecoveryCodeProvided()
+    {
+        $recoveryCode = $this->dao->getAllRecoveryCodesForLogin($this->userWith2Fa)[0];
+
+        $nonce = $this->setUpVerifiedDisableFlow($this->userWith2Fa);
+        $_POST['disableNonce'] = $nonce;
+        $_POST['authCode'] = $recoveryCode;
+
+        try {
+            StaticContainer::get(Controller::class)->disableTwoFactorAuth();
+        } catch (\Exception $e) {
+            // the redirect after disabling becomes an exception in CLI mode
+        }
+
+        $this->assertFalse(TwoFactorAuthentication::isUserUsingTwoFactorAuthentication($this->userWith2Fa));
+    }
+
+    public function testDisableTwoFactorAuthThrowsWhenNonceIsInvalidEvenWhenPasswordVerified()
+    {
+        $this->setUpVerifiedDisableFlow($this->userWith2Fa);
+        $_POST['disableNonce'] = 'not-a-valid-nonce';
+        $_POST['authCode'] = $this->generateValidAuthCode($this->user2faSecret);
+
+        try {
+            StaticContainer::get(Controller::class)->disableTwoFactorAuth();
+            $this->fail('Expected a security check exception to be thrown for the invalid nonce');
+        } catch (\Exception $e) {
+            $this->assertStringContainsString('General_ExceptionSecurityCheckFailed', $e->getMessage());
+        }
+
+        // 2fa must remain enabled when the nonce is invalid
+        $this->assertTrue(TwoFactorAuthentication::isUserUsingTwoFactorAuthentication($this->userWith2Fa));
+    }
+
+    /**
+     * Puts the session into the state right before the auth code confirmation: 2FA verified on login and the
+     * password verified recently. Returns a valid disable nonce.
+     */
+    private function setUpVerifiedDisableFlow(string $login): string
+    {
+        $this->setCurrentUser($login);
+
+        $fingerprint = new SessionFingerprint();
+        $fingerprint->initialize($login, $login . '-token');
+        $fingerprint->setTwoFactorAuthenticationVerified($login);
+
+        $verifier = new PasswordVerifier();
+        $verifier->setDisableRedirect();
+        $verifier->requirePasswordVerifiedRecently(['module' => 'TwoFactorAuth', 'action' => 'disableTwoFactorAuth']);
+        $verifier->setPasswordVerifiedCorrectly($login);
+
+        return Nonce::getNonce(Controller::DISABLE_2FA_NONCE);
     }
 
     public function testLoginTwoFactorAuthRequiresFreshLoginWhenCurrentUserDoesNotMatchPendingSessionUser()

--- a/plugins/TwoFactorAuth/tests/UI/TwoFactorAuth_spec.js
+++ b/plugins/TwoFactorAuth/tests/UI/TwoFactorAuth_spec.js
@@ -183,7 +183,7 @@ describe("TwoFactorAuth", function () {
         expect(await modal.screenshot()).to.matchImage('usersettings_twofa_disable_step1');
     });
 
-    it('should be possible to disable two factor step 2 confirmed', async function () {
+    it('should be possible to disable two factor step 2 confirm password', async function () {
         await selectModalButton('Yes');
 
         const element = await page.waitForSelector('.loginSection', {visible: true});
@@ -191,8 +191,27 @@ describe("TwoFactorAuth", function () {
         expect(await element.screenshot()).to.matchImage('usersettings_twofa_disable_step2');
     });
 
-    it('should be possible to disable two factor step 3 verified', async function () {
+    it('should ask for the auth code after confirming the password', async function () {
         await confirmPassword();
+        const element = await page.waitForSelector('.disableTwoFactorAuthForm', {visible: true});
+        await page.waitForTimeout(150);
+        expect(await element.screenshot()).to.matchImage('usersettings_twofa_disable_authcode');
+    });
+
+    it('should show an error when providing a wrong auth code while disabling', async function () {
+        await page.type('#disable_2fa_authcode', '555555');
+        await page.click('#disable_2fa_submit');
+        await page.waitForNetworkIdle();
+        const element = await page.waitForSelector('.loginSection', {visible: true});
+        await page.waitForTimeout(150);
+        expect(await element.screenshot()).to.matchImage('usersettings_twofa_disable_authcode_wrong');
+    });
+
+    it('should be possible to disable two factor step 3 verified', async function () {
+        // 123456 is a valid recovery code for this user (see fixture)
+        await page.type('#disable_2fa_authcode', '123456');
+        await page.click('#disable_2fa_submit');
+        await page.waitForNetworkIdle();
         await page.waitForSelector('.userSettings2FA');
         const elem = await page.$('.userSettings2FA');
         expect(await elem.screenshot()).to.matchImage('usersettings_twofa_disable_step3');

--- a/plugins/TwoFactorAuth/tests/UI/expected-screenshots/TwoFactorAuth_usersettings_twofa_disable_authcode.png
+++ b/plugins/TwoFactorAuth/tests/UI/expected-screenshots/TwoFactorAuth_usersettings_twofa_disable_authcode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89783e5d7ae901b24724f76104e9293557e7d1169313b5f4d41e7a8d0a1d09ca
+size 19624

--- a/plugins/TwoFactorAuth/tests/UI/expected-screenshots/TwoFactorAuth_usersettings_twofa_disable_authcode_wrong.png
+++ b/plugins/TwoFactorAuth/tests/UI/expected-screenshots/TwoFactorAuth_usersettings_twofa_disable_authcode_wrong.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f90d2baa7c1af7b922e293f5ddc556bea7e2eac72d655e5adfac71be7ea87828
+size 28051


### PR DESCRIPTION
### Description

Disabling two-factor authentication for your own account previously only required re-confirming your password. This PR additionally requires a valid **2FA code** (an authentication-app code or one of your recovery codes) before 2FA can be turned off.

This protects against an attacker who has learned the account password or hijacked an already authenticated session but does not have access to the configured 2FA device.

#### Behaviour
- After the existing password confirmation, `TwoFactorAuth\Controller::disableTwoFactorAuth()` now renders an auth-code confirmation screen. 2FA is only turned off once a valid code (TOTP or recovery code) is provided.
- Invalid codes re-prompt with an error and are recorded as failed attempts for the existing brute-force detection.
- The disable nonce protects the whole flow and is only consumed once 2FA is actually turned off, so it stays valid across the extra step (verified, not consumed, while rendering/rejecting).
- The enforced-2FA and "not verified" guards are unchanged.

#### Refactor (separate commit)
- The duplicated brute-force recording logic (inline in the login controller and a private helper in the `TwoFactorAuth` plugin class) was consolidated into a single `TwoFactorAuthentication::recordFailedAuthAttempt()` method, and all call sites route through it.

### Review

- Enforcement is server-side; the new screen is a plain Twig form using the login layout, consistent with the adjacent confirm-password screen.
- New integration tests cover: form shown / 2FA kept enabled when no code is provided, invalid code rejected + brute-force attempt recorded, disable succeeds with a valid TOTP code, disable succeeds with a valid recovery code, and invalid-nonce rejection.
- The UI spec exercises the auth-code screen, the wrong-code error, and successful disable.

> [!NOTE]
> Two new UI screenshot baselines (`usersettings_twofa_disable_authcode`, `usersettings_twofa_disable_authcode_wrong`) were generated locally; if the CI screenshot job reports a diff they should be re-synced from the CI artifacts.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
