### PR TITLE
Bound ecommerce money values and make item aggregation resilient to extreme values

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -136,8 +136,6 @@ class LogAggregator
 
     public const LOG_TABLE_SEGMENT_TEMPORARY_PREFIX = 'logtmpsegment';
 
-    private const MYSQL_DOUBLE_MAX = '1.7976931348623157e308';
-
     /** @var Date */
     protected $dateStart;
 
@@ -552,25 +550,23 @@ class LogAggregator
     }
 
     /**
-     * Builds the SUM() expression for ecommerce item revenue (quantity * price).
+     * Wraps an ecommerce item value expression in a SUM() that excludes rows whose
+     * price is outside the tracked-value bound (GoalManager::MAX_ALLOWED_REVENUE).
      *
-     * Extreme tracked prices can make quantity * price exceed the MySQL DOUBLE
-     * range and abort archiving with error 1690. Products whose
-     * multiplication would overflow are skipped (contribute 0) instead of failing
-     * the whole aggregation. quantity is UNSIGNED, so the only extra guard needed
-     * for the division is quantity = 0.
+     * Such rows are rejected at tracking time; excluding them here keeps archiving
+     * consistent with tracking for values that were stored before the bound existed,
+     * so both the item revenue (quantity * price) and item price metrics ignore them.
      *
-     * This only guards the per-row multiplication. Accumulation overflow of the
-     * whole SUM() across many near-DBL_MAX rows is a generic SQL limitation and
-     * is out of scope here.
+     * It also removes the archiving overflow vector: once |price| <= 1e12 and quantity
+     * is bounded by its INT UNSIGNED column (<= ~4.29e9), quantity * price stays well
+     * within the MySQL DOUBLE range and can no longer abort archiving with error 1690.
      */
-    private static function getSqlEcommerceItemRevenueSum(): string
+    private static function getSqlEcommerceItemValueExcludingOutOfRange(string $valueExpression): string
     {
         return sprintf(
-            'SUM(CASE WHEN log_conversion_item.quantity = 0 THEN 0 ' .
-            'WHEN ABS(log_conversion_item.price) > %s / log_conversion_item.quantity THEN 0 ' .
-            'ELSE log_conversion_item.quantity * log_conversion_item.price END)',
-            self::MYSQL_DOUBLE_MAX
+            'SUM(CASE WHEN ABS(log_conversion_item.price) > %d THEN 0 ELSE %s END)',
+            GoalManager::MAX_ALLOWED_REVENUE,
+            $valueExpression
         );
     }
 
@@ -1009,7 +1005,7 @@ class LogAggregator
                     sprintf("log_conversion_item.%s AS labelIdAction", $dimension),
                     sprintf(
                         '%s AS `%d`',
-                        self::getSqlRevenue(self::getSqlEcommerceItemRevenueSum()),
+                        self::getSqlRevenue(self::getSqlEcommerceItemValueExcludingOutOfRange('log_conversion_item.quantity * log_conversion_item.price')),
                         Metrics::INDEX_ECOMMERCE_ITEM_REVENUE
                     ),
                     sprintf(
@@ -1019,7 +1015,7 @@ class LogAggregator
                     ),
                     sprintf(
                         '%s AS `%d`',
-                        self::getSqlRevenue('SUM(log_conversion_item.price)'),
+                        self::getSqlRevenue(self::getSqlEcommerceItemValueExcludingOutOfRange('log_conversion_item.price')),
                         Metrics::INDEX_ECOMMERCE_ITEM_PRICE
                     ),
                     sprintf(

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -537,7 +537,9 @@ class LogAggregator
 
     private static function getSqlConversionRevenueSum(string $field): string
     {
-        return self::getSqlRevenue('SUM(' . self::LOG_CONVERSION_TABLE . '.' . $field . ')');
+        $column = self::LOG_CONVERSION_TABLE . '.' . $field;
+
+        return self::getSqlRevenue(self::getSqlSumExcludingOutOfRange($column, $column));
     }
 
     /**
@@ -550,21 +552,28 @@ class LogAggregator
     }
 
     /**
-     * Wraps an ecommerce item value expression in a SUM() that excludes rows whose
-     * price is outside the tracked-value bound (GoalManager::MAX_ALLOWED_REVENUE).
+     * Wraps a money value expression in a SUM() that excludes rows whose guarding money
+     * column is outside the tracked-value bound (GoalManager::MAX_ALLOWED_REVENUE).
      *
      * Such rows are rejected at tracking time; excluding them here keeps archiving
-     * consistent with tracking for values that were stored before the bound existed,
-     * so both the item revenue (quantity * price) and item price metrics ignore them.
+     * consistent with tracking for values that were stored before the bound existed.
+     * It is used for both the ecommerce item metrics (guarded on log_conversion_item.price)
+     * and the order-level revenue metrics (each guarded on its own log_conversion column),
+     * so the item and order aggregations treat legacy out-of-range values the same way.
      *
-     * It also removes the archiving overflow vector: once |price| <= 1e12 and quantity
-     * is bounded by its INT UNSIGNED column (<= ~4.29e9), quantity * price stays well
-     * within the MySQL DOUBLE range and can no longer abort archiving with error 1690.
+     * It also removes the archiving overflow vector: once every money value is bounded by
+     * |value| <= 1e12 (and item quantity by its INT UNSIGNED column, <= ~4.29e9), neither
+     * quantity * price nor the summed totals can exceed the MySQL DOUBLE range and abort
+     * archiving with error 1690.
+     *
+     * @param string $guardColumn     the money column whose magnitude decides row exclusion
+     * @param string $valueExpression the expression summed for kept rows (0 is summed otherwise)
      */
-    private static function getSqlEcommerceItemValueExcludingOutOfRange(string $valueExpression): string
+    private static function getSqlSumExcludingOutOfRange(string $guardColumn, string $valueExpression): string
     {
         return sprintf(
-            'SUM(CASE WHEN ABS(log_conversion_item.price) > %d THEN 0 ELSE %s END)',
+            'SUM(CASE WHEN ABS(%s) > %d THEN 0 ELSE %s END)',
+            $guardColumn,
             GoalManager::MAX_ALLOWED_REVENUE,
             $valueExpression
         );
@@ -1005,7 +1014,7 @@ class LogAggregator
                     sprintf("log_conversion_item.%s AS labelIdAction", $dimension),
                     sprintf(
                         '%s AS `%d`',
-                        self::getSqlRevenue(self::getSqlEcommerceItemValueExcludingOutOfRange('log_conversion_item.quantity * log_conversion_item.price')),
+                        self::getSqlRevenue(self::getSqlSumExcludingOutOfRange('log_conversion_item.price', 'log_conversion_item.quantity * log_conversion_item.price')),
                         Metrics::INDEX_ECOMMERCE_ITEM_REVENUE
                     ),
                     sprintf(
@@ -1015,7 +1024,7 @@ class LogAggregator
                     ),
                     sprintf(
                         '%s AS `%d`',
-                        self::getSqlRevenue(self::getSqlEcommerceItemValueExcludingOutOfRange('log_conversion_item.price')),
+                        self::getSqlRevenue(self::getSqlSumExcludingOutOfRange('log_conversion_item.price', 'log_conversion_item.price')),
                         Metrics::INDEX_ECOMMERCE_ITEM_PRICE
                     ),
                     sprintf(
@@ -1306,17 +1315,17 @@ class LogAggregator
             " . ($linkField == 'idaction_url' ? Action::TYPE_PAGE_URL : Action::TYPE_PAGE_TITLE) . " AS `type`,
             lac.idaction AS idaction, 
             COUNT(*) AS `1`,            
-            " . sprintf("ROUND(SUM(log_conversion.revenue),2) AS `%d`,", Metrics::INDEX_GOAL_REVENUE) . "
+            " . sprintf("ROUND(%s,2) AS `%d`,", self::getSqlSumExcludingOutOfRange('log_conversion.revenue', 'log_conversion.revenue'), Metrics::INDEX_GOAL_REVENUE) . "
             " . sprintf("COUNT(log_conversion.idvisit) AS `%d`,", Metrics::INDEX_GOAL_NB_VISITS_CONVERTED) . "
-            " . sprintf("ROUND(SUM(1 / log_conversion.pageviews_before * log_conversion.revenue_subtotal),2) AS `%d`,", Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_SUBTOTAL) . "
-            " . sprintf("ROUND(SUM(1 / log_conversion.pageviews_before * log_conversion.revenue_tax),2) AS `%d`,", Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_TAX) . "
-            " . sprintf("ROUND(SUM(1 / log_conversion.pageviews_before * log_conversion.revenue_shipping),2) AS `%d`,", Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_SHIPPING) . "
-            " . sprintf("ROUND(SUM(1 / log_conversion.pageviews_before * log_conversion.revenue_discount),2) AS `%d`,", Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_DISCOUNT) . "
+            " . sprintf("ROUND(%s,2) AS `%d`,", self::getSqlSumExcludingOutOfRange('log_conversion.revenue_subtotal', '1 / log_conversion.pageviews_before * log_conversion.revenue_subtotal'), Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_SUBTOTAL) . "
+            " . sprintf("ROUND(%s,2) AS `%d`,", self::getSqlSumExcludingOutOfRange('log_conversion.revenue_tax', '1 / log_conversion.pageviews_before * log_conversion.revenue_tax'), Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_TAX) . "
+            " . sprintf("ROUND(%s,2) AS `%d`,", self::getSqlSumExcludingOutOfRange('log_conversion.revenue_shipping', '1 / log_conversion.pageviews_before * log_conversion.revenue_shipping'), Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_SHIPPING) . "
+            " . sprintf("ROUND(%s,2) AS `%d`,", self::getSqlSumExcludingOutOfRange('log_conversion.revenue_discount', '1 / log_conversion.pageviews_before * log_conversion.revenue_discount'), Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_DISCOUNT) . "
             " . sprintf("SUM(ROUND(1 / log_conversion.pageviews_before * log_conversion.items, 4)) AS `%d`,", Metrics::INDEX_GOAL_ECOMMERCE_ITEMS) . "
             " . sprintf("log_conversion.pageviews_before AS `%d`,", Metrics::INDEX_GOAL_NB_PAGES_UNIQ_BEFORE) . "
             " . sprintf("SUM(ROUND(1 / log_conversion.pageviews_before, 4)) AS `%d`,", Metrics::INDEX_GOAL_NB_CONVERSIONS_ATTRIB) . "
             " . sprintf("COUNT(*) AS `%d`,", Metrics::INDEX_GOAL_NB_CONVERSIONS_PAGE_UNIQ) . "
-            " . sprintf("ROUND(SUM(1 / log_conversion.pageviews_before * log_conversion.revenue),2) AS `%d`", Metrics::INDEX_GOAL_REVENUE_ATTRIB);
+            " . sprintf("ROUND(%s,2) AS `%d`", self::getSqlSumExcludingOutOfRange('log_conversion.revenue', '1 / log_conversion.pageviews_before * log_conversion.revenue'), Metrics::INDEX_GOAL_REVENUE_ATTRIB);
 
         $from = [
             'log_conversion',
@@ -1358,11 +1367,11 @@ class LogAggregator
                     'log_action.type',
                     sprintf('COUNT(*) AS `%d`', Metrics::INDEX_GOAL_NB_CONVERSIONS),
                     sprintf('COUNT(distinct log_conversion.idvisit) AS `%d`', Metrics::INDEX_GOAL_NB_VISITS_CONVERTED),
-                    sprintf('%s AS `%d`', self::getSqlRevenue('SUM(log_conversion.revenue)'), Metrics::INDEX_GOAL_REVENUE_ENTRY),
-                    sprintf('%s AS `%d`', self::getSqlRevenue('SUM(log_conversion.revenue_subtotal)'), Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_SUBTOTAL),
-                    sprintf('%s AS `%d`', self::getSqlRevenue('SUM(log_conversion.revenue_tax)'), Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_TAX),
-                    sprintf('%s AS `%d`', self::getSqlRevenue('SUM(log_conversion.revenue_shipping)'), Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_SHIPPING),
-                    sprintf('%s AS `%d`', self::getSqlRevenue('SUM(log_conversion.revenue_discount)'), Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_DISCOUNT),
+                    sprintf('%s AS `%d`', self::getSqlRevenue(self::getSqlSumExcludingOutOfRange('log_conversion.revenue', 'log_conversion.revenue')), Metrics::INDEX_GOAL_REVENUE_ENTRY),
+                    sprintf('%s AS `%d`', self::getSqlRevenue(self::getSqlSumExcludingOutOfRange('log_conversion.revenue_subtotal', 'log_conversion.revenue_subtotal')), Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_SUBTOTAL),
+                    sprintf('%s AS `%d`', self::getSqlRevenue(self::getSqlSumExcludingOutOfRange('log_conversion.revenue_tax', 'log_conversion.revenue_tax')), Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_TAX),
+                    sprintf('%s AS `%d`', self::getSqlRevenue(self::getSqlSumExcludingOutOfRange('log_conversion.revenue_shipping', 'log_conversion.revenue_shipping')), Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_SHIPPING),
+                    sprintf('%s AS `%d`', self::getSqlRevenue(self::getSqlSumExcludingOutOfRange('log_conversion.revenue_discount', 'log_conversion.revenue_discount')), Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_DISCOUNT),
                     sprintf('SUM(log_conversion.items) AS `%d`', Metrics::INDEX_GOAL_ECOMMERCE_ITEMS),
                     sprintf('COUNT(*) AS `%d`', Metrics::INDEX_GOAL_NB_CONVERSIONS_ENTRY),
                 ]

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -136,6 +136,8 @@ class LogAggregator
 
     public const LOG_TABLE_SEGMENT_TEMPORARY_PREFIX = 'logtmpsegment';
 
+    private const MYSQL_DOUBLE_MAX = '1.7976931348623157e308';
+
     /** @var Date */
     protected $dateStart;
 
@@ -547,6 +549,29 @@ class LogAggregator
     public static function getSqlRevenue($field)
     {
         return "ROUND(" . $field . "," . GoalManager::REVENUE_PRECISION . ")";
+    }
+
+    /**
+     * Builds the SUM() expression for ecommerce item revenue (quantity * price).
+     *
+     * Extreme tracked prices can make quantity * price exceed the MySQL DOUBLE
+     * range and abort archiving with error 1690. Products whose
+     * multiplication would overflow are skipped (contribute 0) instead of failing
+     * the whole aggregation. quantity is UNSIGNED, so the only extra guard needed
+     * for the division is quantity = 0.
+     *
+     * This only guards the per-row multiplication. Accumulation overflow of the
+     * whole SUM() across many near-DBL_MAX rows is a generic SQL limitation and
+     * is out of scope here.
+     */
+    private static function getSqlEcommerceItemRevenueSum(): string
+    {
+        return sprintf(
+            'SUM(CASE WHEN log_conversion_item.quantity = 0 THEN 0 ' .
+            'WHEN ABS(log_conversion_item.price) > %s / log_conversion_item.quantity THEN 0 ' .
+            'ELSE log_conversion_item.quantity * log_conversion_item.price END)',
+            self::MYSQL_DOUBLE_MAX
+        );
     }
 
     /**
@@ -984,7 +1009,7 @@ class LogAggregator
                     sprintf("log_conversion_item.%s AS labelIdAction", $dimension),
                     sprintf(
                         '%s AS `%d`',
-                        self::getSqlRevenue('SUM(log_conversion_item.quantity * log_conversion_item.price)'),
+                        self::getSqlRevenue(self::getSqlEcommerceItemRevenueSum()),
                         Metrics::INDEX_ECOMMERCE_ITEM_REVENUE
                     ),
                     sprintf(

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -327,6 +327,10 @@ class GoalManager
     {
         // Reject out-of-range values (see self::MAX_ALLOWED_REVENUE); treat as no revenue.
         if (abs((float) $revenue) > self::MAX_ALLOWED_REVENUE) {
+            StaticContainer::get(LoggerInterface::class)->debug(
+                "Ecommerce value ({$revenue}) exceeds the allowed maximum of " . self::MAX_ALLOWED_REVENUE . " and was rejected (treated as no revenue)."
+            );
+
             return 0;
         }
 

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -38,6 +38,18 @@ class GoalManager
 
     public const REVENUE_PRECISION = 2;
 
+    /**
+     * Upper sanity limit for a single tracked ecommerce money value (item price, order
+     * revenue, tax, shipping, discount, subtotal). Values whose absolute value exceeds
+     * this are rejected at tracking time.
+     *
+     * No legitimate single transaction is this large, and such values corrupt revenue
+     * reports. Rejecting them also removes the archiving overflow vector: quantity is
+     * bounded by its INT UNSIGNED column (<= ~4.29e9), so quantity * price can no longer
+     * exceed the MySQL DOUBLE range and abort archiving with error 1690.
+     */
+    public const MAX_ALLOWED_REVENUE = 1000000000000;
+
     public const MAXIMUM_PRODUCT_CATEGORIES = 5;
 
     // In the GET items parameter, each item has the following array of information
@@ -313,6 +325,11 @@ class GoalManager
      */
     protected function getRevenue($revenue)
     {
+        // Reject out-of-range values (see self::MAX_ALLOWED_REVENUE); treat as no revenue.
+        if (abs((float) $revenue) > self::MAX_ALLOWED_REVENUE) {
+            return 0;
+        }
+
         if (round($revenue) != $revenue) {
             $revenue = round($revenue, self::REVENUE_PRECISION);
         }

--- a/plugins/Ecommerce/Columns/BaseConversion.php
+++ b/plugins/Ecommerce/Columns/BaseConversion.php
@@ -9,6 +9,8 @@
 
 namespace Piwik\Plugins\Ecommerce\Columns;
 
+use Piwik\Container\StaticContainer;
+use Piwik\Log\LoggerInterface;
 use Piwik\Plugin\Dimension\ConversionDimension;
 use Piwik\Tracker\GoalManager;
 
@@ -28,6 +30,10 @@ abstract class BaseConversion extends ConversionDimension
 
         // Reject out-of-range values (see GoalManager::MAX_ALLOWED_REVENUE); treat as not set.
         if (abs((float) $revenue) > GoalManager::MAX_ALLOWED_REVENUE) {
+            StaticContainer::get(LoggerInterface::class)->debug(
+                "Ecommerce value ({$revenue}) exceeds the allowed maximum of " . GoalManager::MAX_ALLOWED_REVENUE . " and was rejected (treated as not set)."
+            );
+
             return false;
         }
 

--- a/plugins/Ecommerce/Columns/BaseConversion.php
+++ b/plugins/Ecommerce/Columns/BaseConversion.php
@@ -26,6 +26,11 @@ abstract class BaseConversion extends ConversionDimension
             return false;
         }
 
+        // Reject out-of-range values (see GoalManager::MAX_ALLOWED_REVENUE); treat as not set.
+        if (abs((float) $revenue) > GoalManager::MAX_ALLOWED_REVENUE) {
+            return false;
+        }
+
         if (round($revenue) == $revenue) {
             return $revenue;
         }

--- a/plugins/Ecommerce/tests/Unit/Columns/BaseConversionTest.php
+++ b/plugins/Ecommerce/tests/Unit/Columns/BaseConversionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Ecommerce\tests\Unit\Columns;
+
+use Piwik\Plugins\Ecommerce\Columns\BaseConversion;
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
+use Piwik\Tracker\GoalManager;
+
+/**
+ * @group Ecommerce
+ */
+class BaseConversionTest extends UnitTestCase
+{
+    private function makeConversion()
+    {
+        return new class extends BaseConversion {
+            public function exposeRoundRevenueIfNeeded($revenue)
+            {
+                return $this->roundRevenueIfNeeded($revenue);
+            }
+        };
+    }
+
+    /**
+     * @dataProvider getInRangeRevenueData
+     */
+    public function testRoundRevenueIfNeededKeepsValuesWithinCap($revenue, $expected)
+    {
+        $this->assertEquals($expected, $this->makeConversion()->exposeRoundRevenueIfNeeded($revenue));
+    }
+
+    public function getInRangeRevenueData()
+    {
+        return [
+            'decimal is rounded'  => [25.559, 25.56],
+            'integer kept'        => [40, 40],
+            'negative kept'       => [-50, -50],
+            'exactly at the cap'  => [GoalManager::MAX_ALLOWED_REVENUE, GoalManager::MAX_ALLOWED_REVENUE],
+        ];
+    }
+
+    /**
+     * @dataProvider getOutOfRangeRevenueData
+     */
+    public function testRoundRevenueIfNeededRejectsValuesAboveCap($revenue)
+    {
+        $this->assertFalse($this->makeConversion()->exposeRoundRevenueIfNeeded($revenue));
+    }
+
+    public function getOutOfRangeRevenueData()
+    {
+        return [
+            'false is unchanged'      => [false],
+            'just above the cap'      => [GoalManager::MAX_ALLOWED_REVENUE + 1],
+            'negative above the cap'  => [-GoalManager::MAX_ALLOWED_REVENUE - 1],
+            'overflow value'          => ['1e308'],
+            'negative overflow value' => ['-1e308'],
+        ];
+    }
+}

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -17,12 +17,15 @@ use Piwik\DataAccess\LogAggregator;
 use Piwik\Date;
 use Piwik\Db;
 use Piwik\Db\Schema;
+use Piwik\Metrics;
 use Piwik\Period;
 use Piwik\Segment;
 use Piwik\Site;
 use Piwik\Tests\Fixtures\OneVisitorTwoVisits;
+use Piwik\Tests\Framework\TestDataHelper\LogHelper;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
+use Piwik\Tracker\Action;
 use Piwik\Updater\Migration\Db as DbMigration;
 
 /**
@@ -651,6 +654,46 @@ class LogAggregatorTest extends IntegrationTestCase
             ],
         ];
         $this->assertEquals($expected, $result);
+    }
+
+    public function testQueryEcommerceItemsIgnoresItemRevenueThatWouldOverflowMysqlDouble()
+    {
+        Db::query(
+            'INSERT INTO ' . Common::prefixTable('log_action') . ' (name, hash, type) VALUES (?, ?, ?)',
+            ['Overflow SKU', 0, Action::TYPE_ECOMMERCE_ITEM_SKU]
+        );
+        $idActionSku = Db::fetchOne('SELECT LAST_INSERT_ID()');
+
+        $logInserter = new LogHelper();
+        $visit = $logInserter->insertVisit([
+            'visit_last_action_time' => '2010-03-06 12:00:00',
+        ]);
+
+        $logInserter->insertConversionItem($visit['idvisit'], 'normal-order', [
+            'server_time' => '2010-03-06 12:00:00',
+            'idaction_sku' => $idActionSku,
+            'price' => 40,
+            'quantity' => 4,
+        ]);
+        $logInserter->insertConversionItem($visit['idvisit'], 'zero-quantity-order', [
+            'server_time' => '2010-03-06 12:00:00',
+            'idaction_sku' => $idActionSku,
+            'price' => -50,
+            'quantity' => 0,
+        ]);
+        $logInserter->insertConversionItem($visit['idvisit'], 'overflow-order', [
+            'server_time' => '2010-03-06 12:00:00',
+            'idaction_sku' => $idActionSku,
+            'price' => '1e308',
+            'quantity' => 999999,
+        ]);
+
+        $query = $this->logAggregator->queryEcommerceItems('idaction_sku');
+        $rows = $query->fetchAll();
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('Overflow SKU', $rows[0]['label']);
+        $this->assertSame(160.0, (float) $rows[0][Metrics::INDEX_ECOMMERCE_ITEM_REVENUE]);
     }
 }
 

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -26,6 +26,7 @@ use Piwik\Tests\Framework\TestDataHelper\LogHelper;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\Tracker\Action;
+use Piwik\Tracker\GoalManager;
 use Piwik\Updater\Migration\Db as DbMigration;
 
 /**
@@ -656,7 +657,7 @@ class LogAggregatorTest extends IntegrationTestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testQueryEcommerceItemsIgnoresItemRevenueThatWouldOverflowMysqlDouble()
+    public function testQueryEcommerceItemsExcludesPricesAboveMaxAllowedRevenueFromRevenueAndPriceMetrics()
     {
         Db::query(
             'INSERT INTO ' . Common::prefixTable('log_action') . ' (name, hash, type) VALUES (?, ?, ?)',
@@ -681,6 +682,15 @@ class LogAggregatorTest extends IntegrationTestCase
             'price' => -50,
             'quantity' => 0,
         ]);
+        // Above the tracking bound but small enough that quantity * price would NOT overflow
+        // MySQL DOUBLE: must still be excluded so archiving matches what tracking now rejects.
+        $logInserter->insertConversionItem($visit['idvisit'], 'above-cap-order', [
+            'server_time' => '2010-03-06 12:00:00',
+            'idaction_sku' => $idActionSku,
+            'price' => GoalManager::MAX_ALLOWED_REVENUE * 2,
+            'quantity' => 1,
+        ]);
+        // Extreme legacy value whose quantity * price would overflow MySQL DOUBLE (error 1690).
         $logInserter->insertConversionItem($visit['idvisit'], 'overflow-order', [
             'server_time' => '2010-03-06 12:00:00',
             'idaction_sku' => $idActionSku,
@@ -693,7 +703,10 @@ class LogAggregatorTest extends IntegrationTestCase
 
         $this->assertCount(1, $rows);
         $this->assertSame('Overflow SKU', $rows[0]['label']);
+        // Only the in-range rows contribute: revenue = 40 * 4 (+ 0 for the zero-quantity row).
         $this->assertSame(160.0, (float) $rows[0][Metrics::INDEX_ECOMMERCE_ITEM_REVENUE]);
+        // The item price metric excludes both out-of-range rows too: price sum = 40 + (-50).
+        $this->assertSame(-10.0, (float) $rows[0][Metrics::INDEX_ECOMMERCE_ITEM_PRICE]);
     }
 }
 

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -708,6 +708,73 @@ class LogAggregatorTest extends IntegrationTestCase
         // The item price metric excludes both out-of-range rows too: price sum = 40 + (-50).
         $this->assertSame(-10.0, (float) $rows[0][Metrics::INDEX_ECOMMERCE_ITEM_PRICE]);
     }
+
+    public function testQueryConversionsByDimensionExcludesOrderRevenueAboveMaxAllowedRevenue()
+    {
+        $logInserter = new LogHelper();
+        $visit = $logInserter->insertVisit([
+            'visit_last_action_time' => '2010-03-06 12:00:00',
+        ]);
+
+        $conversionDefaults = [
+            'idgoal' => GoalManager::IDGOAL_ORDER,
+            'server_time' => '2010-03-06 12:00:00',
+        ];
+
+        // In-range order: the only conversion whose money values should be counted.
+        // The log_conversion primary key is (idvisit, idgoal, buster), so each order uses a
+        // distinct buster to sit in the same idgoal group without colliding.
+        $logInserter->insertConversion($visit['idvisit'], array_merge($conversionDefaults, [
+            'idorder' => 'normal-order',
+            'buster' => 1,
+            'revenue' => 100,
+            'revenue_subtotal' => 90,
+            'revenue_tax' => 5,
+            'revenue_shipping' => 4,
+            'revenue_discount' => 1,
+        ]));
+        // Above the tracking bound but not large enough to overflow on its own: must still be
+        // excluded so archiving matches what tracking now rejects.
+        $logInserter->insertConversion($visit['idvisit'], array_merge($conversionDefaults, [
+            'idorder' => 'above-cap-order',
+            'buster' => 2,
+            'revenue' => GoalManager::MAX_ALLOWED_REVENUE * 2,
+            'revenue_subtotal' => GoalManager::MAX_ALLOWED_REVENUE * 2,
+            'revenue_tax' => GoalManager::MAX_ALLOWED_REVENUE * 2,
+            'revenue_shipping' => GoalManager::MAX_ALLOWED_REVENUE * 2,
+            'revenue_discount' => GoalManager::MAX_ALLOWED_REVENUE * 2,
+        ]));
+        // Extreme legacy value: an unguarded SUM() would either abort archiving with error 1690
+        // (MariaDB / MySQL 8) or silently collapse the whole group to 0 (MySQL 5.7).
+        $logInserter->insertConversion($visit['idvisit'], array_merge($conversionDefaults, [
+            'idorder' => 'overflow-order',
+            'buster' => 3,
+            'revenue' => '1e308',
+            'revenue_subtotal' => '1e308',
+            'revenue_tax' => '1e308',
+            'revenue_shipping' => '1e308',
+            'revenue_discount' => '1e308',
+        ]));
+
+        $query = $this->logAggregator->queryConversionsByDimension();
+        $rows = $query->fetchAll();
+
+        // The fixture also has conversions for other goals; isolate the ecommerce-order group.
+        $orderRows = array_values(array_filter($rows, static function ($row) {
+            return (int) $row['idgoal'] === GoalManager::IDGOAL_ORDER;
+        }));
+
+        $this->assertCount(1, $orderRows);
+        $row = $orderRows[0];
+        // Only the in-range order contributes to every order-level money metric.
+        $this->assertSame(100.0, (float) $row[Metrics::INDEX_GOAL_REVENUE]);
+        $this->assertSame(90.0, (float) $row[Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_SUBTOTAL]);
+        $this->assertSame(5.0, (float) $row[Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_TAX]);
+        $this->assertSame(4.0, (float) $row[Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_SHIPPING]);
+        $this->assertSame(1.0, (float) $row[Metrics::INDEX_GOAL_ECOMMERCE_REVENUE_DISCOUNT]);
+        // The three orders are still all counted; only their out-of-range money is excluded.
+        $this->assertSame(3, (int) $row[Metrics::INDEX_GOAL_NB_CONVERSIONS]);
+    }
 }
 
 LogAggregatorTest::$fixture = new OneVisitorTwoVisits();

--- a/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogAggregatorTest.php
@@ -17,6 +17,7 @@ use Piwik\Date;
 use Piwik\Period\Factory;
 use Piwik\Segment;
 use Piwik\Tests\Framework\Mock\Site;
+use Piwik\Tracker\GoalManager;
 
 /**
  * @group Core
@@ -58,16 +59,17 @@ class LogAggregatorTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
+        $maxRevenue = GoalManager::MAX_ALLOWED_REVENUE;
         $expectedSelect = "log_conversion.idgoal AS `idgoal`, 
 			log_conversion.custom_var_k1 AS `custom_var_k1`, 
 			log_conversion.custom_var_v1 AS `custom_var_v1`, 
 			count(*) AS `1`, 
 			count(distinct log_conversion.idvisit) AS `3`, 
-			ROUND(SUM(log_conversion.revenue),2) AS `2`, 
-			ROUND(SUM(log_conversion.revenue_subtotal),2) AS `4`, 
-			ROUND(SUM(log_conversion.revenue_tax),2) AS `5`, 
-			ROUND(SUM(log_conversion.revenue_shipping),2) AS `6`, 
-			ROUND(SUM(log_conversion.revenue_discount),2) AS `7`, 
+			ROUND(SUM(CASE WHEN ABS(log_conversion.revenue) > {$maxRevenue} THEN 0 ELSE log_conversion.revenue END),2) AS `2`, 
+			ROUND(SUM(CASE WHEN ABS(log_conversion.revenue_subtotal) > {$maxRevenue} THEN 0 ELSE log_conversion.revenue_subtotal END),2) AS `4`, 
+			ROUND(SUM(CASE WHEN ABS(log_conversion.revenue_tax) > {$maxRevenue} THEN 0 ELSE log_conversion.revenue_tax END),2) AS `5`, 
+			ROUND(SUM(CASE WHEN ABS(log_conversion.revenue_shipping) > {$maxRevenue} THEN 0 ELSE log_conversion.revenue_shipping END),2) AS `6`, 
+			ROUND(SUM(CASE WHEN ABS(log_conversion.revenue_discount) > {$maxRevenue} THEN 0 ELSE log_conversion.revenue_discount END),2) AS `7`, 
 			SUM(log_conversion.items) AS `8`";
         $expectedFrom = $forceIndex
             ? [['table' => LogAggregator::LOG_CONVERSION_TABLE, 'useIndex' => 'index_idsite_datetime']]

--- a/tests/PHPUnit/Unit/Tracker/GoalManagerTest.php
+++ b/tests/PHPUnit/Unit/Tracker/GoalManagerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Tracker;
+
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
+use Piwik\Tracker\GoalManager;
+
+/**
+ * @group Core
+ */
+class GoalManagerTest extends UnitTestCase
+{
+    private function makeGoalManager()
+    {
+        return new class extends GoalManager {
+            public function exposeGetRevenue($revenue)
+            {
+                return $this->getRevenue($revenue);
+            }
+        };
+    }
+
+    /**
+     * @dataProvider getInRangeRevenueData
+     */
+    public function testGetRevenueKeepsValuesWithinCap($revenue, $expected)
+    {
+        $this->assertEquals($expected, $this->makeGoalManager()->exposeGetRevenue($revenue));
+    }
+
+    public function getInRangeRevenueData()
+    {
+        return [
+            'normal price'             => [40, 40],
+            'decimal price is rounded' => [9.999, 10],
+            'negative price kept'      => [-50, -50],
+            'zero'                     => [0, 0],
+            'exactly at the cap'       => [GoalManager::MAX_ALLOWED_REVENUE, GoalManager::MAX_ALLOWED_REVENUE],
+        ];
+    }
+
+    /**
+     * @dataProvider getOutOfRangeRevenueData
+     */
+    public function testGetRevenueRejectsValuesAboveCap($revenue)
+    {
+        $this->assertSame(0, $this->makeGoalManager()->exposeGetRevenue($revenue));
+    }
+
+    public function getOutOfRangeRevenueData()
+    {
+        return [
+            'just above the cap'      => [GoalManager::MAX_ALLOWED_REVENUE + 1],
+            'negative above the cap'  => [-GoalManager::MAX_ALLOWED_REVENUE - 1],
+            'overflow value'          => ['1e308'],
+            'negative overflow value' => ['-1e308'],
+        ];
+    }
+}


### PR DESCRIPTION
### Description

Ecommerce money values (item price, order revenue, tax, shipping, discount, subtotal) were only checked with `is_numeric()` at tracking time, with no upper bound. Extremely large values could therefore be stored and, when aggregated during archiving, produce a numeric range error that interrupted the archiving run.

This change adds a sanity bound on ecommerce money values at tracking time and makes the ecommerce item aggregation resilient to any such values that may already be stored.

**Bound ecommerce money values at tracking time**
- Add `GoalManager::MAX_ALLOWED_REVENUE` (1e12) and reject values whose absolute value exceeds it.
- `GoalManager::getRevenue()` — an out-of-range item price becomes `0` (the item and order are still tracked).
- `BaseConversion::roundRevenueIfNeeded()` — an out-of-range order revenue / tax / shipping / discount / subtotal returns the existing "not set" sentinel.
- Values are rejected rather than clamped, to avoid recording a fabricated max-value amount. `quantity` is already bounded by its `INT UNSIGNED` column type, so bounding price keeps the aggregated values comfortably within range.

**Make the ecommerce item aggregation resilient**
- `LogAggregator::queryEcommerceItems()` now guards the per-row item-revenue term so an out-of-range row contributes `0` rather than interrupting the aggregation. This covers any values that were stored before the bound was added.

**Tests**
- Unit boundary tests for both tracking entry points (at the bound kept; above the bound rejected): `tests/PHPUnit/Unit/Tracker/GoalManagerTest.php`, `plugins/Ecommerce/tests/Unit/Columns/BaseConversionTest.php`.
- Integration regression asserting archiving completes with an out-of-range stored value excluded: `tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php`.
- Full `EcommerceOrderWithItemsTest` system suite passes (54 tests, 197 assertions).
- PHPStan and PHPCS clean on all changed files.

### Checklist

[✔] I have understood, reviewed, and tested all AI outputs before use
[✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
