### PR TITLE
add test coverage for campaign & AI assistant filtering

### DIFF
--- a/plugins/Goals/tests/System/GoalsEcommerceTest.php
+++ b/plugins/Goals/tests/System/GoalsEcommerceTest.php
@@ -9,7 +9,12 @@
 
 namespace Piwik\Plugins\Goals\tests\System;
 
+use Piwik\API\Request;
+use Piwik\Common;
+use Piwik\DataTable;
+use Piwik\Date;
 use Piwik\Tests\Fixtures\ThreeGoalsOnePageview;
+use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Fixtures\TwoSitesEcommerceOrderWithItems;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
@@ -31,6 +36,66 @@ class GoalsEcommerceTest extends SystemTestCase
     public function testApi($api, $params)
     {
         $this->runApiTests($api, $params);
+    }
+
+    public function testMonthlySalesByReferrerTypeKeepsAIAssistantConversionsAttributedToCampaign(): void
+    {
+        $this->trackAIAssistantEcommerceOrder('2011-06-03 10:00:00', 'ai-campaign-order-1', 100, 'http://chatgpt.com');
+        $this->trackAIAssistantEcommerceOrder('2011-06-05 10:00:00', 'ai-campaign-order-2', 200, 'http://chatgpt.com');
+        $this->trackAIAssistantEcommerceOrder('2011-06-05 11:00:00', 'ai-campaign-order-3', 40, 'http://chatgpt.com');
+        $this->trackAIAssistantEcommerceOrder('2011-06-03 11:00:00', 'ai-attributed-order-1', 50);
+        $this->trackAIAssistantEcommerceOrder('2011-06-05 12:00:00', 'ai-attributed-order-2', 60);
+
+        $report = Request::processRequest('Referrers.getReferrerType', [
+            'idSite' => self::$fixture->idSite,
+            'period' => 'month',
+            'date' => '2011-06-01',
+            'idGoal' => 'ecommerceOrder',
+            // Load-bearing request params: the two goal filters materialise the
+            // goal_ecommerceOrder_* columns asserted below, and _setReferrerTypeLabel=0
+            // keeps the row labels as the numeric referrer-type ids matched by the
+            // Common::REFERRER_TYPE_* constants in assertSalesByReferrerType(). Do not drop them.
+            'filter_update_columns_when_show_all_goals' => 'ecommerceOrder',
+            'filter_show_goal_columns_process_goals' => 'ecommerceOrder',
+            'apiModule' => 'Referrers',
+            'apiAction' => 'getReferrerType',
+            '_setReferrerTypeLabel' => 0,
+            'format_metrics' => 0,
+        ]);
+
+        $this->assertInstanceOf(DataTable::class, $report);
+        $this->assertSalesByReferrerType($report);
+    }
+
+    private function assertSalesByReferrerType(DataTable $report): void
+    {
+        $campaignRow = $report->getRowFromLabel(Common::REFERRER_TYPE_CAMPAIGN);
+        $aiAssistantRow = $report->getRowFromLabel(Common::REFERRER_TYPE_AI_ASSISTANT);
+
+        $this->assertNotFalse($campaignRow);
+        $this->assertNotFalse($aiAssistantRow);
+
+        $this->assertSame(3, (int) $campaignRow->getColumn('goal_ecommerceOrder_nb_conversions'), 'Campaign ecommerce orders');
+        $this->assertSame(340.0, (float) $campaignRow->getColumn('goal_ecommerceOrder_revenue'), 'Campaign ecommerce revenue');
+
+        $this->assertSame(2, (int) $aiAssistantRow->getColumn('goal_ecommerceOrder_nb_conversions'), 'AI Assistant ecommerce orders');
+        $this->assertSame(110.0, (float) $aiAssistantRow->getColumn('goal_ecommerceOrder_revenue'), 'AI Assistant ecommerce revenue');
+    }
+
+    private function trackAIAssistantEcommerceOrder(string $dateTime, string $orderId, float $revenue, ?string $campaignName = null): void
+    {
+        $tracker = Fixture::getTracker(self::$fixture->idSite, $dateTime, $defaultInit = true);
+        $tracker->setNewVisitorId();
+        $tracker->setUrl('http://example.org/landing?utm_source=chatgpt.com');
+        Fixture::checkResponse($tracker->doTrackPageView('AI landing page'));
+
+        $tracker->setForceVisitDateTime(Date::factory($dateTime)->addHour(0.1)->getDatetime());
+
+        if ($campaignName !== null) {
+            $tracker->setCustomTrackingParameter('_rcn', $campaignName);
+        }
+
+        Fixture::checkResponse($tracker->doTrackEcommerceOrder($orderId, $revenue));
     }
 
     public function getApiForTesting()

--- a/plugins/Goals/tests/System/GoalsEcommerceTest.php
+++ b/plugins/Goals/tests/System/GoalsEcommerceTest.php
@@ -38,7 +38,7 @@ class GoalsEcommerceTest extends SystemTestCase
         $this->runApiTests($api, $params);
     }
 
-    public function testMonthlySalesByReferrerTypeKeepsAIAssistantConversionsAttributedToCampaign(): void
+    public function testSalesByReferrerTypeSeparatesAIAssistantAndCampaignEcommerceOrders(): void
     {
         $this->trackAIAssistantEcommerceOrder('2011-06-03 10:00:00', 'ai-campaign-order-1', 100, 'http://chatgpt.com');
         $this->trackAIAssistantEcommerceOrder('2011-06-05 10:00:00', 'ai-campaign-order-2', 200, 'http://chatgpt.com');


### PR DESCRIPTION
### Description

Adds test coverage for the fix introduced in the following PR https://github.com/matomo-org/matomo/pull/24534

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
