### PR TITLE
Reject conflicting authentication parameters in nested bulk API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This is the Developer Changelog for Matomo platform developers. All changes in o
 
 The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)** lets you see more details about any Matomo release, such as the list of new guides and FAQs, security fixes, and links to all closed issues.
 
+## Matomo 5.13.0
+
+### HTTP API
+* `API.getBulkRequest` now validates the authentication parameters of each nested request URL against
+  the outer request. Within a browser session a nested request may change neither the session flag
+  (`force_api_session`) nor the acting user (`token_auth`); outside a session a nested request may still
+  authenticate with its own `token_auth`, but may not change the session flag. A nested request whose
+  parameters conflict with the outer request's authentication context aborts the whole bulk request.
+
 ## Matomo 5.12.0
 
 ### JavaScript Tracker

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -28,6 +28,7 @@ use Piwik\Piwik;
 use Piwik\Plugin\SettingsProvider;
 use Piwik\Plugins\API\DataTable\MergeDataTables;
 use Piwik\Plugins\CorePluginsAdmin\SettingsMetadata;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Segment;
 use Piwik\Site;
 use Piwik\Translation\Translator;
@@ -575,9 +576,17 @@ class API extends \Piwik\Plugin\API
         $queryParameters = $request->getParameters();
         unset($queryParameters['urls']);
 
+        $authToken = StaticContainer::get(AuthenticationToken::class);
+        $rootIsSessionToken = $authToken->isSessionToken();
+        $rootTokenAuth = $authToken->getAuthToken();
+
         $result = [];
         foreach ($urls as $url) {
-            $params = \Piwik\Request::fromQueryString($url)->getParameters();
+            $nestedRequest = \Piwik\Request::fromQueryString($url);
+
+            $this->checkNestedRequestAuthMatchesRoot($nestedRequest, $rootIsSessionToken, $rootTokenAuth);
+
+            $params = $nestedRequest->getParameters();
             $params['format'] = 'json';
 
             $params += $queryParameters;
@@ -595,6 +604,42 @@ class API extends \Piwik\Plugin\API
             $result[] = json_decode($req->process(), true);
         }
         return $result;
+    }
+
+    /**
+     * A bulk sub-request runs inside the authentication context that was established for the outer
+     * request, so it must not redefine that context. Within a browser session a sub-request may
+     * change neither the session flag nor the acting user; outside a session it may still not
+     * change the session flag, but it may supply its own token_auth to authenticate that single
+     * call. Any attempt to change the established context is treated as a conflicting set of
+     * authentication parameters and aborts the whole bulk request.
+     *
+     * @param \Piwik\Request $nestedRequest The bulk sub-request to validate against the root context.
+     * @param bool $rootIsSessionToken Whether the outer request authenticated via a session token.
+     * @param string $rootTokenAuth The token the outer request authenticated with.
+     */
+    private function checkNestedRequestAuthMatchesRoot(
+        \Piwik\Request $nestedRequest,
+        bool $rootIsSessionToken,
+        #[\SensitiveParameter]
+        string $rootTokenAuth
+    ): void {
+        $params = $nestedRequest->getParameters();
+
+        if (
+            array_key_exists('force_api_session', $params)
+            && $nestedRequest->getBoolParameter('force_api_session', false) !== $rootIsSessionToken
+        ) {
+            throw new BadRequestException(Piwik::translate('General_ConflictingAuthenticationParametersProvided'));
+        }
+
+        if (
+            $rootIsSessionToken
+            && array_key_exists('token_auth', $params)
+            && $nestedRequest->getStringParameter('token_auth', '') !== $rootTokenAuth
+        ) {
+            throw new BadRequestException(Piwik::translate('General_ConflictingAuthenticationParametersProvided'));
+        }
     }
 
     /**

--- a/plugins/API/tests/Integration/APITest.php
+++ b/plugins/API/tests/Integration/APITest.php
@@ -21,7 +21,9 @@ use Piwik\Piwik;
 use Piwik\Plugins\API\API;
 use Piwik\Plugins\API\BulkRequestLimit;
 use Piwik\Plugins\CoreAdminHome\API as CoreAdminHomeAPI;
+use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\UsersManager\Model as UsersManagerModel;
+use Piwik\Request\AuthenticationToken;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -198,6 +200,207 @@ class APITest extends IntegrationTestCase
         $response = $this->getBulkRequestAsRootApiRequest([$this->makeArchiveReportsBulkUrl(1, Fixture::getTokenAuth())]);
         $this->assertCount(1, $response);
         $this->assertResponseIsSuccess($response[0]);
+    }
+
+    /**
+     * In a session, a nested force_api_session differing from the root aborts the whole bulk request.
+     */
+    public function testGetBulkRequestSessionRootRejectsNestedForceApiSessionDowngrade()
+    {
+        $this->enterSessionRootScope();
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage(Piwik::translate('General_ConflictingAuthenticationParametersProvided'));
+
+        try {
+            $this->getBulkRequestAsRootApiRequest([
+                $this->makeBulkUrl(['method' => 'VisitsSummary.get', 'idSite' => 1, 'period' => 'day', 'date' => '2012-01-01', 'force_api_session' => 0]),
+            ]);
+        } finally {
+            $this->leaveRootScope();
+        }
+    }
+
+    /**
+     * In a session, a nested token_auth differing from the root aborts the request, even when it
+     * also downgrades force_api_session.
+     */
+    public function testGetBulkRequestSessionRootRejectsNestedDifferentTokenAuthWithDowngrade()
+    {
+        $this->enterSessionRootScope();
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage(Piwik::translate('General_ConflictingAuthenticationParametersProvided'));
+
+        try {
+            $this->getBulkRequestAsRootApiRequest([
+                $this->makeBulkUrl(['method' => 'VisitsSummary.get', 'idSite' => 1, 'period' => 'day', 'date' => '2012-01-01', 'token_auth' => 'aDifferentToken', 'force_api_session' => 0]),
+            ]);
+        } finally {
+            $this->leaveRootScope();
+        }
+    }
+
+    /**
+     * In a session, a nested token_auth differing from the root aborts the request on its own.
+     */
+    public function testGetBulkRequestSessionRootRejectsNestedDifferentTokenAuthWithoutDowngrade()
+    {
+        $this->enterSessionRootScope();
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage(Piwik::translate('General_ConflictingAuthenticationParametersProvided'));
+
+        try {
+            $this->getBulkRequestAsRootApiRequest([
+                $this->makeBulkUrl(['method' => 'VisitsSummary.get', 'idSite' => 1, 'period' => 'day', 'date' => '2012-01-01', 'token_auth' => 'aDifferentToken']),
+            ]);
+        } finally {
+            $this->leaveRootScope();
+        }
+    }
+
+    /**
+     * With a real-token (non-session) root, a nested force_api_session aborts the whole bulk request.
+     */
+    public function testGetBulkRequestRealTokenRootRejectsNestedForceApiSessionUpgrade()
+    {
+        $this->enterRealTokenRootScope();
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage(Piwik::translate('General_ConflictingAuthenticationParametersProvided'));
+
+        try {
+            $this->getBulkRequestAsRootApiRequest([
+                $this->makeBulkUrl(['method' => 'VisitsSummary.get', 'idSite' => 1, 'period' => 'day', 'date' => '2012-01-01', 'force_api_session' => 1]),
+            ]);
+        } finally {
+            $this->leaveRootScope();
+        }
+    }
+
+    /**
+     * With an anonymous (non-session) root, a nested force_api_session aborts the whole bulk request.
+     */
+    public function testGetBulkRequestAnonymousRootRejectsNestedForceApiSessionUpgrade()
+    {
+        $this->enterAnonymousRootScope();
+
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage(Piwik::translate('General_ConflictingAuthenticationParametersProvided'));
+
+        try {
+            $this->getBulkRequestAsRootApiRequest([
+                $this->makeBulkUrl(['method' => 'VisitsSummary.get', 'idSite' => 1, 'period' => 'day', 'date' => '2012-01-01', 'token_auth' => 'aDifferentToken', 'force_api_session' => 1]),
+            ]);
+        } finally {
+            $this->leaveRootScope();
+        }
+    }
+
+    /**
+     * A session root allows a nested sub-request that carries no auth params (inherits the root).
+     */
+    public function testGetBulkRequestSessionRootAllowsInheritedNestedAuth()
+    {
+        $this->enterSessionRootScope();
+
+        try {
+            $response = $this->getBulkRequestAsRootApiRequest([
+                $this->makeBulkUrl(['method' => 'VisitsSummary.get', 'idSite' => 1, 'period' => 'day', 'date' => '2012-01-01']),
+            ]);
+            $this->assertCount(1, $response);
+            $this->assertResponseIsSuccess($response[0]);
+        } finally {
+            $this->leaveRootScope();
+        }
+    }
+
+    /**
+     * A session root allows a nested sub-request that repeats the root's own token_auth and
+     * force_api_session.
+     */
+    public function testGetBulkRequestSessionRootAllowsMatchingNestedAuth()
+    {
+        $this->enterSessionRootScope();
+
+        try {
+            $response = $this->getBulkRequestAsRootApiRequest([
+                $this->makeBulkUrl(['method' => 'VisitsSummary.get', 'idSite' => 1, 'period' => 'day', 'date' => '2012-01-01', 'token_auth' => Fixture::getTokenAuth(), 'force_api_session' => 1]),
+            ]);
+            $this->assertCount(1, $response);
+            $this->assertResponseIsSuccess($response[0]);
+        } finally {
+            $this->leaveRootScope();
+        }
+    }
+
+    /**
+     * Outside a session, a nested sub-request may authenticate with its own token_auth and then runs
+     * under that identity (here a view-only user, so only site 1), not the root's.
+     */
+    public function testGetBulkRequestRealTokenRootAllowsNestedDifferentTokenAuth()
+    {
+        $secondToken = $this->createSecondUserTokenWithViewAccessToSite1();
+        $this->enterRealTokenRootScope();
+
+        try {
+            $response = $this->getBulkRequestAsRootApiRequest([
+                $this->makeBulkUrl(['method' => 'SitesManager.getSitesIdWithAtLeastViewAccess', 'token_auth' => $secondToken]),
+            ]);
+            $this->assertCount(1, $response);
+            // the sub-request ran as the view-only user (site 1 only), not the super user root
+            $this->assertEquals([1], $response[0]);
+        } finally {
+            $this->leaveRootScope();
+        }
+    }
+
+    private function makeBulkUrl(array $params): string
+    {
+        return rawurlencode(http_build_query($params, '', '&', PHP_QUERY_RFC3986));
+    }
+
+    private function enterSessionRootScope(): void
+    {
+        $_POST['token_auth'] = Fixture::getTokenAuth();
+        $_POST['force_api_session'] = 1;
+        StaticContainer::getContainer()->set(AuthenticationToken::class, new AuthenticationToken());
+        $this->setSuperUserContext();
+    }
+
+    private function enterRealTokenRootScope(): void
+    {
+        $_POST['token_auth'] = Fixture::getTokenAuth();
+        unset($_POST['force_api_session']);
+        StaticContainer::getContainer()->set(AuthenticationToken::class, new AuthenticationToken());
+        $this->setSuperUserContext();
+    }
+
+    private function enterAnonymousRootScope(): void
+    {
+        unset($_POST['token_auth'], $_POST['force_api_session']);
+        StaticContainer::getContainer()->set(AuthenticationToken::class, new AuthenticationToken());
+        $this->setAnonymousContext();
+    }
+
+    private function leaveRootScope(): void
+    {
+        unset($_POST['token_auth'], $_POST['force_api_session']);
+        StaticContainer::getContainer()->set(AuthenticationToken::class, new AuthenticationToken());
+        $this->setAnonymousContext();
+    }
+
+    private function createSecondUserTokenWithViewAccessToSite1(): string
+    {
+        return Access::doAsSuperUser(function () {
+            $api = UsersManagerAPI::getInstance();
+            if (!$api->userExists('bulk_viewer')) {
+                $api->addUser('bulk_viewer', 'BulkViewer!2026abc', 'bulk_viewer@example.test');
+            }
+            $api->setUserAccess('bulk_viewer', 'view', [1]);
+            return $api->createAppSpecificTokenAuth('bulk_viewer', 'BulkViewer!2026abc', 'bulk viewer token');
+        });
     }
 
     public function testArchiveReportsAllowsViewAccessForNonBulkRootApiMethod()


### PR DESCRIPTION
## Summary

A bulk API request (`API.getBulkRequest`) runs each nested sub-request inside the authentication context established by the outer request. Until now a nested sub-request URL could carry its own `token_auth` / `force_api_session`, and those values could differ from the outer request's — silently changing the authentication context the sub-request ran under.

## Changes

`getBulkRequest` now captures the outer request's authentication context once (session flag + token) and validates every nested sub-request against it:

- **In a browser session**, a nested sub-request may not change the session flag (`force_api_session`) nor the acting user (`token_auth`).
- **Outside a session**, a nested sub-request may still not change the session flag, but it may supply its own `token_auth` to authenticate that single call (per-URL authentication).
- Inherited (absent) parameters remain allowed.

Any attempt to change the established context is treated as a conflicting set of authentication parameters and aborts the whole bulk request (`BadRequestException`, reusing the existing `General_ConflictingAuthenticationParametersProvided` message).

Integration tests in `plugins/API/tests/Integration/APITest.php` cover session / real-token / anonymous root scopes for both the rejected and the allowed combinations.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules



Backport of #24799.
