### PR TITLE
Fix Display options label contrast in Dark Mode on scheduled reports edit

### DIFF
--- a/plugins/ScheduledReports/stylesheets/scheduledreports.less
+++ b/plugins/ScheduledReports/stylesheets/scheduledreports.less
@@ -26,7 +26,7 @@
     }
 
     label {
-      color: @color-black-matomo;
+      color: @theme-color-text;
     }
   }
 }


### PR DESCRIPTION
## Summary
- On the Scheduled Reports edit form, the two "Evolution graphs..." radio labels in the Display options section hardcoded `color: @color-black-matomo`, which stayed black in Dark Mode and produced dark text on a dark background.
- Swap to `@theme-color-text` so the labels follow the active theme.

  |          | Before | After |
  | -------- | ------ | ----- |
  | **Dark** |<img width="1200" height="862" alt="dev-20412-dark-before" src="https://github.com/user-attachments/assets/8bfb17ee-3a80-41c3-a87a-ce650f030f9c" /> | <img width="1200" height="862" alt="dev-20412-dark-after" src="https://github.com/user-attachments/assets/edc4548a-6fac-4ce7-bf21-316e81ebaf9a" />|
  | **Light** (unchanged) | <img width="1200" height="862" alt="dev-20412-light-before" src="https://github.com/user-attachments/assets/591c2c1f-8bb5-4149-8bbd-d49a43da36c1" /> |<img width="1200" height="862" alt="dev-20412-light-after" src="https://github.com/user-attachments/assets/b92ba6ed-38bf-43d7-bc80-7a20470fbbff" /> |

Fixes DEV-20412.

## Test plan
- [x] Enable Dark Mode → Scheduled Reports → edit an existing Email Report → scroll to **Display options** → both "Evolution graphs..." labels are legible.
- [x] Switch to Light Mode → labels still legible with the standard text color.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules



Backport of #24812.
