### PR TITLE
Clean up PHPStan level 0 and level 2 violations from the PHPStan 2 upgrade

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -165,7 +165,7 @@ class Request
      *
      * @param $module
      * @param $action
-     * @return array( $module, $action )
+     * @return array [$module, $action]
      * @ignore
      */
     public static function getRenamedModuleAndAction($module, $action)

--- a/core/Console.php
+++ b/core/Console.php
@@ -19,7 +19,6 @@ use Piwik\Plugins\Monolog\Handler\FailureLogMessageDetector;
 use Piwik\Log\LoggerInterface;
 use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -175,7 +174,6 @@ class Console extends Application
         } elseif (!is_subclass_of($command, 'Piwik\Plugin\ConsoleCommand')) {
             Log::warning(sprintf('Cannot add command %s, class does not extend Piwik\Plugin\ConsoleCommand', $command));
         } else {
-            /** @var Command $commandInstance */
             $commandInstance = new $command();
 
             // do not add the command if it already exists; this way we can add the command ourselves in tests

--- a/core/FileIntegrity.php
+++ b/core/FileIntegrity.php
@@ -18,7 +18,7 @@ class FileIntegrity
     /**
      * Get file integrity information
      *
-     * @return array(bool $success, array $messages)
+     * @return array [bool $success, array $messages]
      */
     public static function getFileIntegrityInformation()
     {

--- a/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
+++ b/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
@@ -53,7 +53,6 @@ trait PolicyComparisonTrait
      */
     protected static function getStrictestValueFromArray(array $policies)
     {
-        /** @var callable-string */
         $callback = [__CLASS__, 'compareValuesHandleNull'];
 
         return array_reduce($policies, $callback);

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -230,7 +230,7 @@ class VisitorRecognizer
      *
      * The returned value is the window range (Min, max) that the matched visitor should fall within
      *
-     * @return array( datetimeMin, datetimeMax )
+     * @return array [datetimeMin, datetimeMax]
      */
     protected function getWindowLookupThisVisit(Request $request)
     {

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -190,7 +190,7 @@ class Updater
      *                                    must be upgraded.
      *
      *                                    Example: `array('core' => '2.11.0')`
-     * @return array( componentName => array( file1 => version1, [...]), [...])
+     * @return array Map of componentName => [file1 => version1, ...]
      */
     public function getComponentsWithUpdateFile($componentsToCheck)
     {
@@ -341,7 +341,7 @@ class Updater
     /**
      * Construct list of update files for the outdated components
      *
-     * @return array( componentName => array( file1 => version1, [...]), [...])
+     * @return array Map of componentName => [file1 => version1, ...]
      */
     private function loadComponentsWithUpdateFile()
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -127,12 +127,6 @@ parameters:
 			path: core/API/Request.php
 
 		-
-			message: '#^PHPDoc tag @return has invalid value \(array\( \$module, \$action \)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 207 on line 7$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: core/API/Request.php
-
-		-
 			message: '#^Parameter \#2 \$columnToFilter of class Piwik\\DataTable\\Filter\\Pattern constructor expects string, array given\.$#'
 			identifier: argument.type
 			count: 1
@@ -425,12 +419,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: core/Config/IniFileChain.php
-
-		-
-			message: '#^PHPDoc tag @var with type Symfony\\Component\\Console\\Command\\Command is not subtype of native type Piwik\\Plugin\\ConsoleCommand\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: core/Console.php
 
 		-
 			message: '#^Strict comparison using \=\=\= between null and null will always evaluate to true\.$#'
@@ -899,12 +887,6 @@ parameters:
 			identifier: booleanAnd.rightAlwaysFalse
 			count: 1
 			path: core/ExceptionHandler.php
-
-		-
-			message: '#^PHPDoc tag @return has invalid value \(array\(bool \$success, array \$messages\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 69 on line 4$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: core/FileIntegrity.php
 
 		-
 			message: '#^Strict comparison using \!\=\= between string and false will always evaluate to true\.$#'
@@ -1867,12 +1849,6 @@ parameters:
 			path: core/Tracker/Cache.php
 
 		-
-			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: core/Tracker/Config/ThirdPartyCookies.php
-
-		-
 			message: '#^Method Piwik\\Tracker\\Db\:\:query\(\) has invalid return type Piwik\\Tracker\\PDOStatement\.$#'
 			identifier: class.notFound
 			count: 1
@@ -2125,12 +2101,6 @@ parameters:
 			path: core/Tracker/VisitorRecognizer.php
 
 		-
-			message: '#^PHPDoc tag @return has invalid value \(array\( datetimeMin, datetimeMax \)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 411 on line 8$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: core/Tracker/VisitorRecognizer.php
-
-		-
 			message: '#^Variable \$translationId on left side of \?\? always exists and is not nullable\.$#'
 			identifier: nullCoalesce.variable
 			count: 1
@@ -2147,18 +2117,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: core/UpdateCheck.php
-
-		-
-			message: '#^PHPDoc tag @return has invalid value \(array\( componentName \=\> array\( file1 \=\> version1, \[\.\.\.\]\), \[\.\.\.\]\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 509 on line 9$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: core/Updater.php
-
-		-
-			message: '#^PHPDoc tag @return has invalid value \(array\( componentName \=\> array\( file1 \=\> version1, \[\.\.\.\]\), \[\.\.\.\]\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 97 on line 4$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: core/Updater.php
 
 		-
 			message: '#^Strict comparison using \=\=\= between array\<int\>\|int and false will always evaluate to false\.$#'
@@ -3055,12 +3013,6 @@ parameters:
 			path: plugins/CorePluginsAdmin/PluginInstaller.php
 
 		-
-			message: '#^PHPDoc tag @throws has invalid value \(Exception;\)\: Unexpected token ";", expected TOKEN_HORIZONTAL_WS at offset 172 on line 4$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: plugins/CorePluginsAdmin/SettingsMetadata.php
-
-		-
 			message: '#^Variable \$setting in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
@@ -3325,12 +3277,6 @@ parameters:
 			path: plugins/DevicesDetection/Columns/Os.php
 
 		-
-			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: plugins/DevicesDetection/Settings/OnlyMajorVersions.php
-
-		-
 			message: '#^Variable \$label in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
@@ -3493,12 +3439,6 @@ parameters:
 			path: plugins/Ecommerce/Columns/BaseConversion.php
 
 		-
-			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: plugins/Ecommerce/Settings/OrderIdAnonymization.php
-
-		-
 			message: '#^Call to function is_array\(\) with array\<mixed, mixed\> will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
@@ -3619,12 +3559,6 @@ parameters:
 			path: plugins/GeoIp2/LocationProvider/GeoIp2.php
 
 		-
-			message: '#^PHPDoc tag @var with type Piwik\\DataTable\|Piwik\\DataTable\\Map is not subtype of native type null\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: plugins/Goals/API.php
-
-		-
 			message: '#^Parameter \#1 \$name of method Piwik\\DataTable\\Row\:\:deleteColumn\(\) expects string, int given\.$#'
 			identifier: argument.type
 			count: 1
@@ -3633,12 +3567,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$oldName of method Piwik\\DataTable\\Row\:\:renameColumn\(\) expects string, int given\.$#'
 			identifier: argument.type
-			count: 1
-			path: plugins/Goals/API.php
-
-		-
-			message: '#^Variable \$table in isset\(\) always exists and is not nullable\.$#'
-			identifier: isset.variable
 			count: 1
 			path: plugins/Goals/API.php
 
@@ -3979,12 +3907,6 @@ parameters:
 			path: plugins/Live/Model.php
 
 		-
-			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: plugins/Live/Settings/VisitorLogDisabled.php
-
-		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 1
@@ -4291,42 +4213,6 @@ parameters:
 			path: plugins/PrivacyManager/ReportsPurger.php
 
 		-
-			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: plugins/PrivacyManager/Settings/CampaignParameterValuesMasked.php
-
-		-
-			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: plugins/PrivacyManager/Settings/CompliancePolicyEnforcedSetting.php
-
-		-
-			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: plugins/PrivacyManager/Settings/IPAnonymisation.php
-
-		-
-			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: plugins/PrivacyManager/Settings/IpAddressMaskLength.php
-
-		-
-			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: plugins/PrivacyManager/Settings/ReferrerAnonymisation.php
-
-		-
-			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: plugins/PrivacyManager/Settings/ReportRetention.php
-
-		-
 			message: '#^Property Piwik\\Plugins\\ProfessionalServices\\Widgets\\PromoServices\:\:\$advertising is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
@@ -4471,12 +4357,6 @@ parameters:
 			path: plugins/SitesManager/Model.php
 
 		-
-			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: plugins/SitesManager/Settings/FilterPIIParameters.php
-
-		-
 			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
 			identifier: argument.type
 			count: 1
@@ -4597,12 +4477,6 @@ parameters:
 			path: plugins/UserCountry/LocationProvider.php
 
 		-
-			message: '#^PHPDoc tag @return has invalid value \(false\.\)\: Unexpected token "\.", expected TOKEN_HORIZONTAL_WS at offset 158 on line 5$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: plugins/UserCountry/LocationProvider/DisabledProvider.php
-
-		-
 			message: '#^Function Piwik\\Plugins\\UserCountry\\getPrettyCityName\(\) never returns false so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
@@ -4625,12 +4499,6 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: plugins/UserId/Reports/GetUsers.php
-
-		-
-			message: '#^PHPDoc tag @var with type callable\-string is not subtype of native type array\{class\-string&literal\-string, ''compareValuesHandle…''\}\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: plugins/UserId/Settings/UserIdDisabled.php
 
 		-
 			message: '#^Call to function is_array\(\) with array\{login\: string, password\: string, email\: string, twofactor_secret\: string, superuser_access\: int\|string, date_registered\: string\|null, ts_password_modified\: string\|null, idchange_last_viewed\: int\|string\|null, \.\.\.\} will always evaluate to true\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -973,12 +973,6 @@ parameters:
 			path: core/Log.php
 
 		-
-			message: '#^Class Piwik\\Log\\Logger extends @final class Monolog\\Logger\.$#'
-			identifier: class.extendsFinalByPhpDoc
-			count: 1
-			path: core/Log/Logger.php
-
-		-
 			message: '#^Property Piwik\\LogDeleter\:\:\$logTablesProvider is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
@@ -4157,12 +4151,6 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: plugins/MobileMessaging/SMSProvider/StubbedProvider.php
-
-		-
-			message: '#^Class Piwik\\Plugins\\Monolog\\Formatter\\ConsoleFormatter extends @final class Symfony\\Bridge\\Monolog\\Formatter\\ConsoleFormatter\.$#'
-			identifier: class.extendsFinalByPhpDoc
-			count: 1
-			path: plugins/Monolog/Formatter/ConsoleFormatter.php
 
 		-
 			message: '#^Variable \$parts in empty\(\) always exists and is not falsy\.$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,6 +30,18 @@ parameters:
         - bootstrap-phpstan.php
     ignoreErrors:
         - "#Unsafe usage of new static#"
+        # Monolog\Logger and Symfony's ConsoleFormatter are marked @final only via
+        # a docblock annotation, not the final keyword. Both are extended on purpose:
+        # Piwik\Log\Logger is a proxy that adds Matomo's logger interface, and
+        # ConsoleFormatter augments the console output with %extra.*% placeholders.
+        # These are deliberate, long-standing integrations rather than accidental
+        # subclassing, so the soft-final hint is intentionally overridden here.
+        -
+            identifier: class.extendsFinalByPhpDoc
+            path: core/Log/Logger.php
+        -
+            identifier: class.extendsFinalByPhpDoc
+            path: plugins/Monolog/Formatter/ConsoleFormatter.php
         # These messages embed an absolute path that differs between environments (local/ddev vs CI),
         # so they cannot live in the baseline; ignore them by identifier + relative path instead.
         # The required files are generated at build/install time and are absent from a plain checkout.

--- a/plugins/CorePluginsAdmin/SettingsMetadata.php
+++ b/plugins/CorePluginsAdmin/SettingsMetadata.php
@@ -26,7 +26,7 @@ class SettingsMetadata
     /**
      * @param Settings[]  $settingsInstances
      * @param array $settingValues   array('pluginName' => array('settingName' => 'settingValue'))
-     * @throws Exception;
+     * @throws Exception
      */
     public function setPluginSettings($settingsInstances, $settingValues)
     {

--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -667,7 +667,6 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        /** @var DataTable|DataTable\Map $table */
         $table = null;
 
         $segments = array(

--- a/plugins/UserCountry/LocationProvider/DisabledProvider.php
+++ b/plugins/UserCountry/LocationProvider/DisabledProvider.php
@@ -26,7 +26,7 @@ class DisabledProvider extends LocationProvider
      * Guesses a visitor's location using a visitor's browser language.
      *
      * @param array $info Contains 'ip' & 'lang' keys.
-     * @return false.
+     * @return false
      */
     public function getLocation($info)
     {


### PR DESCRIPTION
## Summary

Follow-up to the PHPStan 1 → 2 upgrade (#24649). PHPStan 2's stricter analysis surfaced additional findings that were captured wholesale in `phpstan-baseline.neon`. This PR clears the low-level, fully-resolvable ones so they don't sit in the debt-burndown baseline.

At **level 0** the whole codebase has exactly two findings; at **level 2** the only *newly-added* findings are docblock-only. Both groups are addressed here.

### Level 0 — `class.extendsFinalByPhpDoc` (2)
`Piwik\Log\Logger` extends `Monolog\Logger` and `Monolog\Formatter\ConsoleFormatter` extends Symfony's `ConsoleFormatter`. Both parents are marked `@final` via a **docblock annotation only** (not the `final` keyword), and both are deliberate, long-standing integrations. Moved out of the baseline into documented `ignoreErrors` entries in `phpstan.neon` explaining why the soft-final hint is intentionally overridden.

### Level 2 — docblock-only, fixed at the source
- **`phpDoc.parseError` (7):** rewrote non-standard `@return`/`@throws` tags (`array( ... )` pseudo-syntax, trailing punctuation) into valid PHPDoc, keeping the structural hint as description text.
- **`varTag.nativeType`:** removed `@var` tags that contradict the native type —
  - `PolicyComparisonTrait`: value is a callable *array*, not a `callable-string` (one line, fixes every Settings class using the trait);
  - `Console`: PHPStan already infers the narrower `ConsoleCommand`, so the widening `@var Command` and its now-unused import are dropped;
  - `Goals/API`: dropped the `@var` on a `$table = null` init — this also corrected the variable's type so a previously-baselined `isset.variable` finding no longer fires (also removed from the baseline).

Corresponding baseline entries removed in each case.

## Test plan
- `ddev exec phpstan analyse -c phpstan.neon` → `[OK] No errors`
- Clean level-0 run: 0 `class.extendsFinalByPhpDoc`
- Clean level-2 run: 0 `phpDoc.parseError`, 0 `varTag.nativeType`, no new errors introduced
- `phpcs --standard=Matomo` (errors only) on changed files: clean

## Notes
No behaviour change — all edits are docblocks, a redundant `@var`/import, and PHPStan config/baseline. Not user-facing; no changelog entry.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
