### PR TITLE
Persist ViewDataTable settings per container so container-widget graph settings survive reload

### DIFF
--- a/core/ViewDataTable/Manager.php
+++ b/core/ViewDataTable/Manager.php
@@ -282,7 +282,7 @@ class Manager
      */
     public static function saveViewDataTableParameters($login, $controllerAction, $parametersToOverride, $containerId = null)
     {
-        $params = self::getViewDataTableParameters($login, $controllerAction);
+        $params = self::getViewDataTableParameters($login, $controllerAction, $containerId);
 
         self::unsetComparisonParams($params);
 

--- a/tests/PHPUnit/Integration/ViewDataTable/ManagerTest.php
+++ b/tests/PHPUnit/Integration/ViewDataTable/ManagerTest.php
@@ -162,6 +162,50 @@ class ManagerTest extends IntegrationTestCase
         $this->assertNotEmpty(ViewDataTableManager::getViewDataTableParameters('mylogin3', 'API.get5'));
     }
 
+    public function testSaveViewDataTableParametersWithContainerIdMergesWithExistingContainerParameters()
+    {
+        $login       = 'mylogin';
+        $method      = 'VisitsSummary.get';
+        $containerId = 'VisitOverviewWithGraph';
+
+        // widgets within a container persist their settings as partial updates, one request at a time
+        ViewDataTableManager::saveViewDataTableParameters($login, $method, array('columns' => array('nb_visits', 'nb_uniq_visitors')), $containerId);
+        ViewDataTableManager::saveViewDataTableParameters($login, $method, array('flat' => '1'), $containerId);
+
+        // the earlier container setting must not be lost by the later save
+        $storedParams = ViewDataTableManager::getViewDataTableParameters($login, $method, $containerId);
+        $this->assertEquals(array('columns' => array('nb_visits', 'nb_uniq_visitors'), 'flat' => '1'), $storedParams);
+    }
+
+    public function testSaveViewDataTableParametersWithContainerIdDoesNotOverwriteNonContainerParameters()
+    {
+        $login       = 'mylogin';
+        $method      = 'VisitsSummary.get';
+        $containerId = 'VisitOverviewWithGraph';
+
+        // the same report can be shown both standalone and inside a container
+        ViewDataTableManager::saveViewDataTableParameters($login, $method, array('columns' => array('nb_visits')));
+        ViewDataTableManager::saveViewDataTableParameters($login, $method, array('columns' => array('nb_uniq_visitors')), $containerId);
+
+        // container settings are stored separately and neither side clobbers the other
+        $this->assertEquals(array('columns' => array('nb_visits')), ViewDataTableManager::getViewDataTableParameters($login, $method));
+        $this->assertEquals(array('columns' => array('nb_uniq_visitors')), ViewDataTableManager::getViewDataTableParameters($login, $method, $containerId));
+    }
+
+    public function testSaveViewDataTableParametersWithContainerIdDoesNotSeedFromNonContainerParameters()
+    {
+        $login       = 'mylogin';
+        $method      = 'VisitsSummary.get';
+        $containerId = 'VisitOverviewWithGraph';
+
+        // pre-existing standalone report settings must not leak into a fresh container save
+        ViewDataTableManager::saveViewDataTableParameters($login, $method, array('flat' => '1'));
+        ViewDataTableManager::saveViewDataTableParameters($login, $method, array('columns' => array('nb_visits')), $containerId);
+
+        $storedParams = ViewDataTableManager::getViewDataTableParameters($login, $method, $containerId);
+        $this->assertEquals(array('columns' => array('nb_visits')), $storedParams);
+    }
+
     private function addParameters()
     {
         $login  = 'mylogin';


### PR DESCRIPTION
### Description

Fixes #21944

Graph and table settings for widgets rendered inside a widget container (a "widget wrapper for multiple widgets") were lost after a dashboard reload. For example, adding extra metrics to the graph in **Visits Overview (with graph)** reverted to the default metric selection on reload. The same applied to other bundled containers such as **Goals Overview**, **Ecommerce Overview**, and the individual **Goal_&lt;idGoal&gt;** overview widgets, and to any third-party container whose child widgets have persisted `ViewDataTable` settings.

**Root cause**

`Piwik\ViewDataTable\Manager::saveViewDataTableParameters()` loaded the existing saved parameters **without** the `containerId`, but persisted them **with** the `containerId`:

- it read the standalone report's parameters (the non-container option key), and
- it wrote to the container-scoped option key.

The UI persists most view settings as *partial* updates — the series picker sends `columns`/`columns_to_display`/`rows`/`rows_to_display`, footer toggles send a single key (e.g. `flat`), and visualization switches send only `viewDataTable`. Because each container save re-read the non-container key instead of the container key, every save (a) seeded the container settings from the standalone report and (b) discarded any settings previously saved for that container. As a result only the keys present in the most recent request survived a reload; everything else fell back to defaults.

**Changes**

- `core/ViewDataTable/Manager.php`: load the existing parameters using the same `containerId` that is used to persist them, so a container save merges with the settings already stored for that container. Container settings now stay isolated from the standalone report's settings in both directions.

The non-container path is unchanged: the controller defaults `containerId` to an empty string and the option-key builder ignores empty container ids, so saves without a container behave exactly as before.

**Tests**

- `tests/PHPUnit/Integration/ViewDataTable/ManagerTest.php`: added regression coverage that
  - successive partial saves under the same `containerId` accumulate/merge instead of overwriting each other,
  - container settings and standalone report settings for the same login/action do not clobber one another, and
  - a container save does not seed from the standalone report's settings.

**Validation run locally**

- `tests:run --file=tests/PHPUnit/Integration/ViewDataTable/ManagerTest.php` → 11/11 pass; two of the new tests fail against the unpatched code (bug reproduced) and pass after the fix.
- PHPStan (both changed files) → clean.
- PHPCS (both changed files) → clean.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
