### PR TITLE
Improve Row Evolution modal text contrast in Dark Mode

### DIFF
--- a/plugins/CoreVisualizations/stylesheets/jqplot.less
+++ b/plugins/CoreVisualizations/stylesheets/jqplot.less
@@ -294,4 +294,16 @@ a.rowevolution-startmulti {
   .jqplot-seriespicker-popover p.pickRow:hover {
     background-color: @theme-color-background-tinyContrast;
   }
+
+  .rowevolution table.metrics td.text {
+    color: @theme-color-text-light;
+  }
+
+  .rowevolution table.metrics td.text span.details {
+    color: @theme-color-text;
+  }
+
+  .rowevolution .metric-selectbox select {
+    color: @theme-color-text;
+  }
 });


### PR DESCRIPTION
## Summary
- Overrides the Row Evolution modal metric label and details text colors to use theme tokens when Dark Mode is active
- Light Mode rendering is unchanged

Fixes DEV-20479

### Before / After

|          | Before | After |
| -------- | ------ | ----- |
| **Dark** | <img width="2400" height="1724" alt="tmp-dark-before" src="https://github.com/user-attachments/assets/08d52312-a541-4c8e-82de-ef99ae1d06c5" /> | <img width="2400" height="1724" alt="tmp-dark-after" src="https://github.com/user-attachments/assets/901e79ad-c2ae-437d-8d29-0b9ed93d7cd7" /> |
| **Light** (unchanged) |<img width="2400" height="1724" alt="tmp-light-before" src="https://github.com/user-attachments/assets/404d152b-890a-4b1e-bbaa-74aca8949469" /> | <img width="2400" height="1724" alt="tmp-light-after" src="https://github.com/user-attachments/assets/d30bd78c-bc06-462d-9c0f-6c5f410433cc" /> |

## Test plan
- [ ] Enable Dark Mode via Personal settings
- [ ] Open any Row Evolution modal (e.g. Behaviour → Pages, click a row's Row Evolution action)
- [ ] Metric label and detail text are readable
- [ ] Switch back to Light Mode and confirm rendering is unchanged

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules



Backport of #24813.
