### PR TITLE
Apply the table search filter after multi-dimension labels are combined in flattened reports

### DIFF
--- a/core/API/DataTableManipulator/Flattener.php
+++ b/core/API/DataTableManipulator/Flattener.php
@@ -251,7 +251,7 @@ class Flattener extends DataTableManipulator
     }
 
     /**
-     * Remove the flat parameter from the subtable request
+     * Remove the flat & filter_pattern parameters from the subtable request
      *
      * @param array $request
      * @return array
@@ -259,6 +259,12 @@ class Flattener extends DataTableManipulator
     protected function manipulateSubtableRequest($request)
     {
         unset($request['flat']);
+
+        // don't apply the search pattern while subtables are loaded, otherwise rows are filtered on
+        // their child label before the parent label parts are combined into the final flattened label.
+        // that would drop rows whose match only appears in a parent label. instead we let the pattern
+        // run once on the flattened table (via the generic filters applied after flattening).
+        unset($request['filter_pattern']);
 
         return $request;
     }

--- a/plugins/Referrers/tests/System/ApiTest.php
+++ b/plugins/Referrers/tests/System/ApiTest.php
@@ -368,6 +368,44 @@ class ApiTest extends SystemTestCase
         $this->assertEquals(2, $visits->getFirstRow()->getColumn('nb_actions'));
     }
 
+    public function testCampaignReportFlatSearchMatchesTermFoundOnlyInCampaignNameLabel()
+    {
+        // Regression test for a flattened Campaign report (Campaign name + Keyword). When searching
+        // a flattened report, the search term must be matched against the combined "campaign - keyword"
+        // label, not against the keyword subtable before the campaign name is prepended. Otherwise a
+        // term that only appears in the campaign name portion returns no results even though it is
+        // clearly visible in the table.
+        $dateTime = '2015-01-11';
+        $idSite = self::$fixture->idSite;
+
+        $t = Fixture::getTracker($idSite, $dateTime . ' 00:01:02', $defaultInit = true);
+
+        // campaign whose NAME contains "barbagianni" but whose keyword does not
+        $t->setUrl('http://piwik.net/?pk_campaign=pixelfed-barbagianni&pk_keyword=link-homepage');
+        $t->doTrackPageView('Homepage');
+
+        // an unrelated campaign, so the search actually has to filter a row out
+        $t->setForceNewVisit(true);
+        $t->setUrl('http://piwik.net/?pk_campaign=romatoday-camposecco&pk_keyword=escursione-camposecco');
+        $t->doTrackPageView('Homepage');
+
+        /** @var DataTable $report */
+        $report = Request::processRequest('Referrers.getCampaigns', [
+            'idSite'         => $idSite,
+            'period'         => 'day',
+            'date'           => $dateTime,
+            'flat'           => 1,
+            'filter_pattern' => 'barbagianni',
+        ]);
+
+        $this->assertCount(1, $report->getRows());
+
+        $label = $report->getFirstRow()->getColumn('label');
+        $this->assertStringContainsString('barbagianni', $label);
+        $this->assertStringContainsString('link-homepage', $label);
+        $this->assertEquals(1, $report->getFirstRow()->getColumn('nb_visits'));
+    }
+
     public static function getOutputPrefix()
     {
         return '';


### PR DESCRIPTION
### Description

**Problem**

When a report is displayed flat and a search term is entered, rows could be missing even though the searched value is clearly visible in the table. This was reproducible on the Campaign report, which combines two label levels (campaign name + keyword): searching for a term that appears only in the campaign-name part of the combined label returned no results, while a term present in the keyword part worked.

**Root cause**

For a flattened report whose subtables are loaded through a separate API action (e.g. `Referrers.getCampaigns` → `getKeywordsFromCampaignId`), the flattener loads each subtable via a nested API request. That request still carried `filter_pattern`, so the search filter ran against the child (keyword) label **before** the parent (campaign) label was prepended to form the final combined label. Rows whose match only appeared in the parent portion were therefore removed before the combined label existed.

**Changes**

- `core/API/DataTableManipulator/Flattener.php`: strip `filter_pattern` from subtable-load requests so the search filter is applied only once, on the fully combined flattened table. This mirrors the existing handling of `filter_pattern_recursive` and is scoped to the flattener so that totals and label-navigation behaviour (which use the shared base manipulator) are unaffected.
- Updated the `manipulateSubtableRequest()` docblock accordingly.

**Tests / validation**

- Added a system test in `plugins/Referrers/tests/System/ApiTest.php` that tracks a campaign whose name contains a term absent from its keyword, requests the flattened Campaign report with that term as the search pattern, and asserts the combined row is returned. Verified it fails before the change (0 rows) and passes after (1 row).
- `plugins/Referrers/tests/System/ApiTest.php` (full): passes.
- `tests/PHPUnit/System/FlattenReportsTest.php`: passes (existing flatten and recursive-search cases unaffected).
- `tests/PHPUnit/System/TrackCustomVariablesAndCampaignsForceUsingVisitIdNotHeuristicsTest.php`: passes (non-flat Campaign report unaffected).
- PHPCS and PHPStan clean on the changed files.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)