### PR TITLE
Serve flat Actions reports from the pre-flattened archive record

### DIFF
--- a/plugins/Actions/API.php
+++ b/plugins/Actions/API.php
@@ -119,7 +119,18 @@ class API extends \Piwik\Plugin\API
     ) {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $dataTable = Archive::createDataTableFromArchive('Actions_actions_url', $idSite, $period, $date, $segment, $expanded, $flat, $idSubtable, $depth);
+        $dataTable = $this->createActionsTableFromArchive(
+            Archiver::PAGE_URLS_RECORD_NAME,
+            Archiver::PAGE_URLS_FLAT_RECORD_NAME,
+            $idSite,
+            $period,
+            $date,
+            $segment,
+            $expanded,
+            $idSubtable,
+            $depth,
+            $flat
+        );
 
         $this->filterActionsDataTable($dataTable, Action::TYPE_PAGE_URL);
 
@@ -335,7 +346,18 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $dataTable = Archive::createDataTableFromArchive('Actions_actions', $idSite, $period, $date, $segment, $expanded, $flat, $idSubtable);
+        $dataTable = $this->createActionsTableFromArchive(
+            Archiver::PAGE_TITLES_RECORD_NAME,
+            Archiver::PAGE_TITLES_FLAT_RECORD_NAME,
+            $idSite,
+            $period,
+            $date,
+            $segment,
+            $expanded,
+            $idSubtable,
+            null,
+            $flat
+        );
 
         $this->filterActionsDataTable($dataTable, Action::TYPE_PAGE_TITLE);
 
@@ -799,6 +821,174 @@ class API extends \Piwik\Plugin\API
             $table = call_user_func_array('\Piwik\Archive::createDataTableFromArchive', $callBackParameters);
             return $this->doFilterPageDatatableSearch($callBackParameters, $table, $searchTree);
         }
+    }
+
+    /**
+     * Reads the pre-flattened archive record directly for top-level flat requests when flat-first
+     * archiving is enabled, avoiding loading the hierarchy and collapsing it again at request time.
+     * Otherwise (and for subtable drill-downs) reads the hierarchical record as before.
+     *
+     * @param int|string|int[] $idSite
+     * @param string|null|false $segment
+     * @param int|null|false $idSubtable
+     * @param int|null|false $depth
+     * @return DataTable|DataTable\Map
+     */
+    private function createActionsTableFromArchive(
+        string $hierarchicalRecord,
+        string $flatRecord,
+        $idSite,
+        string $period,
+        string $date,
+        $segment,
+        bool $expanded,
+        $idSubtable,
+        $depth,
+        bool $flat
+    ) {
+        $useFlatRecord = $flat && empty($idSubtable) && ArchivingHelper::isFlatArchivingEnabled();
+
+        if (!$useFlatRecord) {
+            return Archive::createDataTableFromArchive($hierarchicalRecord, $idSite, $period, $date, $segment, $expanded, $flat, $idSubtable, $depth);
+        }
+
+        // Read the flat record as-is: no expansion (which the flat flag would force) is needed,
+        // and the request-level flat=1 still drives the Actions filter and request-time Flattener.
+        $flatTable = Archive::createDataTableFromArchive($flatRecord, $idSite, $period, $date, $segment, false, false, null, null);
+
+        // Match the hierarchical record's column order so exports stay identical.
+        $this->reorderFlatRowColumnsToHierarchicalOrder($flatTable);
+
+        if (!$this->flatResultHasEmptyTable($flatTable)) {
+            return $flatTable;
+        }
+
+        // Some periods are empty. Read the hierarchical record unexpanded (top-level only, no
+        // subtable loading, so cheap) to tell a genuinely empty period apart from one archived
+        // before flat-first was enabled (which has no flat record but does have hierarchical data).
+        $hierarchicalTop = Archive::createDataTableFromArchive($hierarchicalRecord, $idSite, $period, $date, $segment, false, false, null, null);
+
+        if (!$this->hasRecoverableHierarchicalData($flatTable, $hierarchicalTop)) {
+            return $flatTable;
+        }
+
+        // At least one empty period predates flat-first and still holds hierarchical data; rebuild
+        // those periods from the fully expanded hierarchical record (the request-time Flattener then
+        // flattens them), keeping the flat rows for every period that has a flat record.
+        $hierarchicalTable = Archive::createDataTableFromArchive($hierarchicalRecord, $idSite, $period, $date, $segment, true, true, null, $depth);
+
+        return $this->replaceEmptyFlatTablesWithHierarchical($flatTable, $hierarchicalTable);
+    }
+
+    /**
+     * Moves the leading metrics to the front in the order the hierarchical record uses (the flat
+     * record appends nb_uniq_visitors instead of keeping it second); other columns keep their order.
+     *
+     * @param DataTable|DataTable\Map $table
+     */
+    private function reorderFlatRowColumnsToHierarchicalOrder($table): void
+    {
+        $leadingColumns = ArchivingHelper::getHierarchyRowColumnOrder();
+
+        $table->filter(function (DataTable $dataTable) use ($leadingColumns) {
+            foreach ($dataTable->getRows() as $row) {
+                $columns = $row->getColumns();
+
+                $ordered = [];
+                if (array_key_exists('label', $columns)) {
+                    $ordered['label'] = $columns['label'];
+                }
+                foreach ($leadingColumns as $index) {
+                    if (array_key_exists($index, $columns)) {
+                        $ordered[$index] = $columns[$index];
+                    }
+                }
+                foreach ($columns as $index => $value) {
+                    if (!array_key_exists($index, $ordered)) {
+                        $ordered[$index] = $value;
+                    }
+                }
+
+                $row->setColumns($ordered);
+            }
+        });
+    }
+
+    /**
+     * True if any leaf table is empty, i.e. a period whose flat record is not archived yet.
+     *
+     * @param DataTable|DataTable\Map $table
+     */
+    private function flatResultHasEmptyTable($table): bool
+    {
+        if ($table instanceof DataTable\Map) {
+            foreach ($table->getDataTables() as $child) {
+                if ($this->flatResultHasEmptyTable($child)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return $table->getRowsCount() === 0;
+    }
+
+    /**
+     * True if any empty flat leaf has a non-empty hierarchical counterpart, i.e. a period that
+     * predates flat-first and still holds hierarchical data worth recovering. A genuinely empty
+     * period is empty in both records, so it does not trigger the expensive expanded read.
+     *
+     * @param DataTable|DataTable\Map $flatTable
+     * @param DataTable|DataTable\Map $hierarchicalTable Read unexpanded (top-level rows only).
+     */
+    private function hasRecoverableHierarchicalData($flatTable, $hierarchicalTable): bool
+    {
+        if ($flatTable instanceof DataTable\Map && $hierarchicalTable instanceof DataTable\Map) {
+            $hierarchicalChildren = $hierarchicalTable->getDataTables();
+            foreach ($flatTable->getDataTables() as $label => $flatChild) {
+                if (!array_key_exists($label, $hierarchicalChildren)) {
+                    continue;
+                }
+                if ($this->hasRecoverableHierarchicalData($flatChild, $hierarchicalChildren[$label])) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($flatTable instanceof DataTable && $hierarchicalTable instanceof DataTable) {
+            return $flatTable->getRowsCount() === 0 && $hierarchicalTable->getRowsCount() > 0;
+        }
+
+        return false;
+    }
+
+    /**
+     * Replaces each empty leaf table in the flat result with the matching hierarchical table, so a
+     * result spanning the flat-first enablement date mixes both sources correctly.
+     *
+     * @param DataTable|DataTable\Map $flatTable
+     * @param DataTable|DataTable\Map $hierarchicalTable
+     * @return DataTable|DataTable\Map
+     */
+    private function replaceEmptyFlatTablesWithHierarchical($flatTable, $hierarchicalTable)
+    {
+        if ($flatTable instanceof DataTable\Map && $hierarchicalTable instanceof DataTable\Map) {
+            $hierarchicalChildren = $hierarchicalTable->getDataTables();
+            foreach ($flatTable->getDataTables() as $label => $flatChild) {
+                if (!array_key_exists($label, $hierarchicalChildren)) {
+                    continue;
+                }
+                $flatTable->addTable($this->replaceEmptyFlatTablesWithHierarchical($flatChild, $hierarchicalChildren[$label]), $label);
+            }
+            return $flatTable;
+        }
+
+        if ($flatTable instanceof DataTable && $flatTable->getRowsCount() === 0) {
+            return $hierarchicalTable;
+        }
+
+        return $flatTable;
     }
 
     /**

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -598,6 +598,32 @@ class ArchivingHelper
     protected static $defaultActionNameWhenNotDefined = null;
     protected static $defaultActionUrlWhenNotDefined = null;
 
+    /**
+     * Whether flat-first archiving is enabled, i.e. page URL/title reports are archived in a flat
+     * form (and the hierarchy rebuilt from it) rather than hierarchically only.
+     */
+    public static function isFlatArchivingEnabled(): bool
+    {
+        return (int) (Config::getInstance()->General['datatable_archiving_maximum_rows_actions_flat'] ?? 0) > 0;
+    }
+
+    /**
+     * Leading metric columns of a hierarchical action row, in their canonical order. This is the
+     * order the hierarchical record (and therefore the report output and its exports) uses, so the
+     * flat record's rows are reordered to match it when served directly.
+     *
+     * @return int[]
+     */
+    public static function getHierarchyRowColumnOrder(): array
+    {
+        return [
+            PiwikMetrics::INDEX_NB_VISITS,
+            PiwikMetrics::INDEX_NB_UNIQ_VISITORS,
+            PiwikMetrics::INDEX_PAGE_NB_HITS,
+            PiwikMetrics::INDEX_PAGE_SUM_TIME_SPENT,
+        ];
+    }
+
     public static function reloadConfig()
     {
         // for BC, we read the old style delimiter first (see #1067)

--- a/plugins/Actions/RecordBuilders/ActionReports.php
+++ b/plugins/Actions/RecordBuilders/ActionReports.php
@@ -42,6 +42,8 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
     public function getRecordMetadata(ArchiveProcessor $archiveProcessor): array
     {
+        ArchivingHelper::reloadConfig();
+
         $pageUrlsRecord = Record::make(Record::TYPE_BLOB, Archiver::PAGE_URLS_RECORD_NAME)
             ->setBlobColumnAggregationOps(Metrics::getColumnsAggregationOperation());
         $pageTitlesRecord = Record::make(Record::TYPE_BLOB, Archiver::PAGE_TITLES_RECORD_NAME)
@@ -334,8 +336,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
     private function isFlatArchivingEnabled(): bool
     {
-        ArchivingHelper::reloadConfig();
-        return ArchivingHelper::$maximumRowsInDataTableFlat > 0;
+        return ArchivingHelper::isFlatArchivingEnabled();
     }
 
     private function setHierarchyBuiltFromFlatRecord(
@@ -365,12 +366,7 @@ class ActionReports extends ArchiveProcessor\RecordBuilder
 
     private function getDefaultHierarchyRowColumns(): array
     {
-        return [
-            PiwikMetrics::INDEX_NB_VISITS => 0,
-            PiwikMetrics::INDEX_NB_UNIQ_VISITORS => 0,
-            PiwikMetrics::INDEX_PAGE_NB_HITS => 0,
-            PiwikMetrics::INDEX_PAGE_SUM_TIME_SPENT => 0,
-        ];
+        return array_fill_keys(ArchivingHelper::getHierarchyRowColumnOrder(), 0);
     }
 
     private function aggregateLegacyHierarchical(ArchiveProcessor $archiveProcessor): array

--- a/plugins/Actions/tests/System/MixedArchivingAggregationTest.php
+++ b/plugins/Actions/tests/System/MixedArchivingAggregationTest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\Actions\tests\System;
 
+use Piwik\API\Request as ApiRequest;
 use Piwik\Archive;
 use Piwik\Common;
 use Piwik\Config;
@@ -215,10 +216,334 @@ class MixedArchivingAggregationTest extends IntegrationTestCase
         $this->assertSame(2, $hierarchicalRows[0][Metrics::INDEX_PAGE_NB_HITS]);
     }
 
+    public function testFlatPageReportsAreUnchangedWhetherServedFromFlatBlobOrHierarchy()
+    {
+        $siteId = Fixture::createWebsite('2026-03-01 00:00:00');
+        $this->trackUrlHits($siteId, '2026-03-02', [
+            '/shop/shoes/nike' => 5,
+            '/shop/shoes/adidas' => 3,
+            '/about' => 2,
+        ]);
+
+        $config = Config::getInstance();
+        $configBackup = $this->backupGeneralConfig([
+            'datatable_archiving_maximum_rows_actions_flat',
+            'datatable_archiving_maximum_rows_actions',
+            'datatable_archiving_maximum_rows_subtable_actions',
+            'archiving_ranking_query_row_limit',
+        ]);
+
+        try {
+            $config->General['datatable_archiving_maximum_rows_actions'] = 50000;
+            $config->General['datatable_archiving_maximum_rows_subtable_actions'] = 50000;
+            $config->General['archiving_ranking_query_row_limit'] = 100000;
+
+            // Archive with flat-first enabled: both the flat and the hierarchical record are stored.
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50000;
+            Archive::build($siteId, 'day', '2026-03-02')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+
+            // Retrieval served directly from the flat record (new behavior).
+            $flatUrls = $this->requestFlatReportRows('Actions.getPageUrls', $siteId, '2026-03-02');
+            $flatTitles = $this->requestFlatReportRows('Actions.getPageTitles', $siteId, '2026-03-02');
+
+            // Previous behavior: flattened from the hierarchical record, same archive (flat-first
+            // gate turned off for the request only, no re-archiving).
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 0;
+            $hierarchyUrls = $this->requestFlatReportRows('Actions.getPageUrls', $siteId, '2026-03-02');
+            $hierarchyTitles = $this->requestFlatReportRows('Actions.getPageTitles', $siteId, '2026-03-02');
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        $this->assertContains('/shop/shoes/nike', array_map([$this, 'extractRowLabel'], $flatUrls));
+
+        // Identical row data from either record; compared as a set because the tie-break order of
+        // equal-valued rows is not a guaranteed contract (PHP's sort is order dependent for ties).
+        $this->assertSame($hierarchyUrls, $flatUrls);
+        $this->assertSame($hierarchyTitles, $flatTitles);
+    }
+
+    public function testFlatPageReportsAreUnchangedUnderTruncationWhetherServedFromFlatBlobOrHierarchy()
+    {
+        $siteId = Fixture::createWebsite('2026-03-03 00:00:00');
+        $this->trackUrlHits($siteId, '2026-03-04', [
+            '/shop/shoes/nike' => 9,
+            '/shop/shoes/adidas' => 7,
+            '/shop/shoes/puma' => 5,
+            '/about' => 3,
+            '/contact' => 1,
+        ]);
+
+        $config = Config::getInstance();
+        $configBackup = $this->backupGeneralConfig([
+            'datatable_archiving_maximum_rows_actions_flat',
+            'datatable_archiving_maximum_rows_actions',
+            'datatable_archiving_maximum_rows_subtable_actions',
+            'archiving_ranking_query_row_limit',
+        ]);
+
+        try {
+            $config->General['datatable_archiving_maximum_rows_actions'] = 50000;
+            $config->General['datatable_archiving_maximum_rows_subtable_actions'] = 50000;
+            $config->General['archiving_ranking_query_row_limit'] = 100000;
+
+            // Archive with flat-first enabled and a small flat cap, so the flat record itself is
+            // truncated and gets a summary ("Others") row; the hierarchical record is rebuilt from
+            // this already-capped flat record, so both serving paths must agree on the capped set.
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 2;
+            Archive::build($siteId, 'day', '2026-03-04')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+
+            // Retrieval served directly from the flat record (new behavior).
+            $flatUrlsXml = $this->requestFlatReport('Actions.getPageUrls', $siteId, '2026-03-04');
+            $flatUrls = $this->requestFlatReportRows('Actions.getPageUrls', $siteId, '2026-03-04');
+            $flatTitles = $this->requestFlatReportRows('Actions.getPageTitles', $siteId, '2026-03-04');
+
+            // Previous behavior: flattened from the hierarchical record, same archive (flat-first
+            // gate turned off for the request only, no re-archiving).
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 0;
+            $hierarchyUrls = $this->requestFlatReportRows('Actions.getPageUrls', $siteId, '2026-03-04');
+            $hierarchyTitles = $this->requestFlatReportRows('Actions.getPageTitles', $siteId, '2026-03-04');
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        // The truncated flat report includes a summary ("Others") row for the rows that did not
+        // fit within the cap.
+        $this->assertStringContainsString('<is_summary>1</is_summary>', $flatUrlsXml);
+
+        // Identical row data from either record; compared as a set because the tie-break order of
+        // equal-valued rows is not a guaranteed contract (PHP's sort is order dependent for ties).
+        $this->assertSame($hierarchyUrls, $flatUrls);
+        $this->assertSame($hierarchyTitles, $flatTitles);
+    }
+
+    public function testFlatEntryPagesReportListsOnlyActualEntryPagesWhenServedFromFlatBlob()
+    {
+        $siteId = Fixture::createWebsite('2026-03-05 00:00:00');
+        // A single visit walks /shop/shoes/nike (entry) -> /shop/shoes/adidas -> /about, so only
+        // /shop/shoes/nike is ever an entry page.
+        $this->trackUrlHits($siteId, '2026-03-06', [
+            '/shop/shoes/nike' => 5,
+            '/shop/shoes/adidas' => 3,
+            '/about' => 2,
+        ]);
+
+        $config = Config::getInstance();
+        $configBackup = $this->backupGeneralConfig([
+            'datatable_archiving_maximum_rows_actions_flat',
+            'datatable_archiving_maximum_rows_actions',
+            'datatable_archiving_maximum_rows_subtable_actions',
+            'archiving_ranking_query_row_limit',
+        ]);
+
+        try {
+            $config->General['datatable_archiving_maximum_rows_actions'] = 50000;
+            $config->General['datatable_archiving_maximum_rows_subtable_actions'] = 50000;
+            $config->General['archiving_ranking_query_row_limit'] = 100000;
+
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50000;
+            Archive::build($siteId, 'day', '2026-03-06')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+
+            $flatEntryLabels = array_map(
+                [$this, 'extractRowLabel'],
+                $this->requestFlatReportRows('Actions.getEntryPageUrls', $siteId, '2026-03-06')
+            );
+
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 0;
+            $hierarchyEntryLabels = array_map(
+                [$this, 'extractRowLabel'],
+                $this->requestFlatReportRows('Actions.getEntryPageUrls', $siteId, '2026-03-06')
+            );
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        // From the flat record the report lists only real entry pages. The hierarchical path also
+        // surfaces non-entry leaves sharing a folder with an entry page (the folder-level filter
+        // runs before flattening), which the flat record correctly excludes.
+        $this->assertContains('/shop/shoes/nike', $flatEntryLabels);
+        $this->assertNotContains('/shop/shoes/adidas', $flatEntryLabels);
+        $this->assertContains('/shop/shoes/adidas', $hierarchyEntryLabels);
+    }
+
+    public function testFlatExitPagesReportListsOnlyActualExitPagesWhenServedFromFlatBlob()
+    {
+        $siteId = Fixture::createWebsite('2026-03-07 00:00:00');
+        // A single visit walks /about -> /shop/shoes/nike -> /shop/shoes/adidas (exit), so only
+        // /shop/shoes/adidas is ever an exit page.
+        $this->trackUrlHits($siteId, '2026-03-08', [
+            '/about' => 2,
+            '/shop/shoes/nike' => 5,
+            '/shop/shoes/adidas' => 3,
+        ]);
+
+        $config = Config::getInstance();
+        $configBackup = $this->backupGeneralConfig([
+            'datatable_archiving_maximum_rows_actions_flat',
+            'datatable_archiving_maximum_rows_actions',
+            'datatable_archiving_maximum_rows_subtable_actions',
+            'archiving_ranking_query_row_limit',
+        ]);
+
+        try {
+            $config->General['datatable_archiving_maximum_rows_actions'] = 50000;
+            $config->General['datatable_archiving_maximum_rows_subtable_actions'] = 50000;
+            $config->General['archiving_ranking_query_row_limit'] = 100000;
+
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50000;
+            Archive::build($siteId, 'day', '2026-03-08')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+
+            $flatExitLabels = array_map(
+                [$this, 'extractRowLabel'],
+                $this->requestFlatReportRows('Actions.getExitPageUrls', $siteId, '2026-03-08')
+            );
+
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 0;
+            $hierarchyExitLabels = array_map(
+                [$this, 'extractRowLabel'],
+                $this->requestFlatReportRows('Actions.getExitPageUrls', $siteId, '2026-03-08')
+            );
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        // From the flat record the report lists only real exit pages. The hierarchical path also
+        // surfaces non-exit leaves sharing a folder with an exit page (the folder-level filter runs
+        // before flattening), which the flat record correctly excludes.
+        $this->assertContains('/shop/shoes/adidas', $flatExitLabels);
+        $this->assertNotContains('/shop/shoes/nike', $flatExitLabels);
+        $this->assertContains('/shop/shoes/nike', $hierarchyExitLabels);
+    }
+
+    public function testFlatRequestFallsBackToHierarchyWhenFlatRecordIsMissing()
+    {
+        $siteId = Fixture::createWebsite('2026-03-10 00:00:00');
+        $this->trackUrlHits($siteId, '2026-03-11', [
+            '/shop/shoes/nike' => 5,
+            '/shop/shoes/adidas' => 3,
+            '/about' => 2,
+        ]);
+
+        $config = Config::getInstance();
+        $configBackup = $this->backupGeneralConfig([
+            'datatable_archiving_maximum_rows_actions_flat',
+            'datatable_archiving_maximum_rows_actions',
+            'datatable_archiving_maximum_rows_subtable_actions',
+            'archiving_ranking_query_row_limit',
+        ]);
+
+        try {
+            $config->General['datatable_archiving_maximum_rows_actions'] = 50000;
+            $config->General['datatable_archiving_maximum_rows_subtable_actions'] = 50000;
+            $config->General['archiving_ranking_query_row_limit'] = 100000;
+
+            // Archive while flat-first is disabled: only the hierarchical record is stored and the
+            // archive is marked done, so enabling flat-first later will not add the flat record.
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 0;
+            Archive::build($siteId, 'day', '2026-03-11')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+            $legacyUrls = $this->requestFlatReport('Actions.getPageUrls', $siteId, '2026-03-11');
+
+            // Enable flat-first without re-archiving. The flat record is absent, so the request must
+            // fall back to the hierarchical record instead of returning an empty report.
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50000;
+            $fallbackUrls = $this->requestFlatReport('Actions.getPageUrls', $siteId, '2026-03-11');
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        $this->assertStringContainsString('/shop/shoes/nike', $fallbackUrls);
+        $this->assertSame($legacyUrls, $fallbackUrls);
+    }
+
+    public function testFlatRangeRequestMixesFlatRecordAndHierarchicalFallbackPerPeriod()
+    {
+        $siteId = Fixture::createWebsite('2026-04-01 00:00:00');
+        $this->trackUrlHits($siteId, '2026-04-06', [
+            '/shop/shoes/nike' => 5,
+            '/about' => 2,
+        ]);
+        $this->trackUrlHits($siteId, '2026-04-07', [
+            '/shop/shoes/adidas' => 4,
+            '/contact' => 1,
+        ]);
+
+        $config = Config::getInstance();
+        $configBackup = $this->backupGeneralConfig([
+            'datatable_archiving_maximum_rows_actions_flat',
+            'datatable_archiving_maximum_rows_actions',
+            'datatable_archiving_maximum_rows_subtable_actions',
+            'archiving_ranking_query_row_limit',
+        ]);
+
+        try {
+            $config->General['datatable_archiving_maximum_rows_actions'] = 50000;
+            $config->General['datatable_archiving_maximum_rows_subtable_actions'] = 50000;
+            $config->General['archiving_ranking_query_row_limit'] = 100000;
+
+            // Day 1 archived with flat-first enabled -> has a flat record.
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50000;
+            Archive::build($siteId, 'day', '2026-04-06')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+
+            // Day 2 archived before flat-first -> hierarchical record only.
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 0;
+            Archive::build($siteId, 'day', '2026-04-07')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+            $hierarchyRows = $this->requestFlatReportRows('Actions.getPageUrls', $siteId, '2026-04-06,2026-04-07');
+
+            // With flat-first enabled the range Map mixes day 1 (from the flat record) with day 2
+            // (recovered from the hierarchical record), and must equal the pure-hierarchical result.
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50000;
+            $mixedRows = $this->requestFlatReportRows('Actions.getPageUrls', $siteId, '2026-04-06,2026-04-07');
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        $labels = array_map([$this, 'extractRowLabel'], $mixedRows);
+        $this->assertContains('/shop/shoes/nike', $labels);
+        $this->assertContains('/shop/shoes/adidas', $labels);
+        $this->assertSame($hierarchyRows, $mixedRows);
+    }
+
     protected static function configureFixture($fixture)
     {
         parent::configureFixture($fixture);
         $fixture->createSuperUser = true;
+    }
+
+    private function requestFlatReport(string $method, int $idSite, string $date): string
+    {
+        return ApiRequest::processRequest($method, [
+            'idSite'       => $idSite,
+            'period'       => 'day',
+            'date'         => $date,
+            'flat'         => 1,
+            'filter_limit' => -1,
+            'format'       => 'xml',
+        ]);
+    }
+
+    /**
+     * Returns the flat report's `<row>` blocks sorted so two runs can be compared independently
+     * of the tie-break order of equal-valued rows.
+     *
+     * @return string[]
+     */
+    private function requestFlatReportRows(string $method, int $idSite, string $date): array
+    {
+        $xml = $this->requestFlatReport($method, $idSite, $date);
+        preg_match_all('#<row>.*?</row>#s', $xml, $matches);
+        $rows = $matches[0];
+        sort($rows);
+
+        return $rows;
+    }
+
+    private function extractRowLabel(string $rowXml): string
+    {
+        if (preg_match('#<label>(.*?)</label>#s', $rowXml, $matches)) {
+            return $matches[1];
+        }
+
+        return '';
     }
 
     private function trackUrlHits(int $idSite, string $day, array $urlHits): void


### PR DESCRIPTION
## Description

Follow-up to the flat-first archiving rollout. When a page-based Actions report is requested in flat mode (`flat=1`, either explicitly or as a report default) and flat-first archiving is enabled (`datatable_archiving_maximum_rows_actions_flat > 0`), the report is now served directly from the pre-flattened archive record (`Actions_actions_url_flat` / `Actions_actions_flat`) instead of loading the full hierarchy, force-expanding every subtable, and flattening it again at request time.

Applies to Page URLs, Page Titles and their Entry/Exit variants. Subtable drill-downs keep using the hierarchical record. When flat-first archiving is disabled (the default), behaviour is unchanged.

## Details

- **Retrieval**: `Actions.API::getPageUrls` / `getPageTitles` read the flat record directly for top-level flat requests; entry/exit variants inherit this via delegation.
- **Fallback**: periods archived before flat-first was enabled have no flat record. Those fall back to the hierarchical record, using a cheap *unexpanded* read to distinguish a genuinely empty period from one that predates flat-first, so a sparse/empty period in a multi-period range does not drag the whole range onto the expensive expanded path.
- **Output parity**: flat rows are reordered to the hierarchical record's column order so report data, sorting, filtering, pagination and exports remain byte-identical (guarded by the existing `BlobReportLimitingTest` flattening expectations).
- **Shared helpers**: the flat-first gate and the canonical column order are centralised in `ArchivingHelper` and reused by both the archiver and the API.

## Behaviour change (intentional)

Entry/Exit reports served from the flat record now filter **strictly per page**. Previously, hierarchical flat mode also surfaced non-entry leaves that merely shared a folder with an entry page (the folder-level filter ran before flattening while recursive filters were disabled). The flat record correctly lists only pages that were actually an entry/exit page. This is a bug fix.

## Tests

Added `MixedArchivingAggregationTest` coverage: flat-vs-hierarchical parity for page URLs/titles, the corrected entry-pages filtering, the single-period missing-flat-record fallback, and per-period mixing of the flat record with the hierarchical fallback across a date range. The existing byte-identical flat-first flattening guard continues to pass.

## Review notes

- No public API signatures change.
- No archiving-process changes; retrieval only.



### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules



Backport of #24802.
