### PR TITLE
Isolate password verification from the shared authentication object

### DIFF
--- a/plugins/API/tests/Integration/APITest.php
+++ b/plugins/API/tests/Integration/APITest.php
@@ -393,14 +393,18 @@ class APITest extends IntegrationTestCase
 
     private function createSecondUserTokenWithViewAccessToSite1(): string
     {
-        return Access::doAsSuperUser(function () {
+        Access::doAsSuperUser(function () {
             $api = UsersManagerAPI::getInstance();
             if (!$api->userExists('bulk_viewer')) {
                 $api->addUser('bulk_viewer', 'BulkViewer!2026abc', 'bulk_viewer@example.test');
             }
             $api->setUserAccess('bulk_viewer', 'view', [1]);
-            return $api->createAppSpecificTokenAuth('bulk_viewer', 'BulkViewer!2026abc', 'bulk viewer token');
         });
+
+        // the token is created from an unauthenticated request using the user's credentials
+        $this->setAnonymousContext();
+
+        return UsersManagerAPI::getInstance()->createAppSpecificTokenAuth('bulk_viewer', 'BulkViewer!2026abc', 'bulk viewer token');
     }
 
     public function testArchiveReportsAllowsViewAccessForNonBulkRootApiMethod()

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -135,7 +135,7 @@ class Login extends \Piwik\Plugin
     /**
      * @return void
      */
-    public function onFailedLoginRecordAttempt()
+    public function onFailedLoginRecordAttempt($login = null)
     {
         // we're always making sure on any success or failed login to check if user is actually allowed to log in
         // in case for some reason it forgot to run the check
@@ -147,7 +147,8 @@ class Login extends \Piwik\Plugin
         // time frame
         $bruteForce = StaticContainer::get('Piwik\Plugins\Login\Security\BruteForceDetection');
         if ($bruteForce->isEnabled() && !$this->hasAddedFailedAttempt) {
-            $login = $this->getUsernameUsedInPasswordLogin();
+            // prefer the login the attempt was made for; otherwise derive it from the request
+            $login = empty($login) ? $this->getUsernameUsedInPasswordLogin() : $this->normalizeUserLogin($login);
             $bruteForce->addFailedAttempt(IP::getIpFromHeader(), $login);
             // we make sure to log max one failed login attempt per request... otherwise we might log 3 or many more
             // if eg API is called etc.

--- a/plugins/Login/PasswordVerifier.php
+++ b/plugins/Login/PasswordVerifier.php
@@ -60,8 +60,9 @@ class PasswordVerifier
          */
         Piwik::postEvent('Login.beforeLoginCheckAllowed');
 
+        // Use an isolated copy so the check does not mutate the shared auth object.
         /** @var \Piwik\Auth $authAdapter */
-        $authAdapter = StaticContainer::get('Piwik\Auth');
+        $authAdapter = clone StaticContainer::get('Piwik\Auth');
         $authAdapter->setLogin($userLogin);
         $authAdapter->setPasswordHash(null);// ensure authentication happens on password
         $authAdapter->setPassword($password);
@@ -76,7 +77,7 @@ class PasswordVerifier
          * @ignore
          * @internal
          */
-        Piwik::postEvent('Login.recordFailedLoginAttempt');
+        Piwik::postEvent('Login.recordFailedLoginAttempt', [$userLogin]);
         return false;
     }
 

--- a/plugins/Login/tests/Integration/CreateAppSpecificTokenAuthBruteForceTest.php
+++ b/plugins/Login/tests/Integration/CreateAppSpecificTokenAuthBruteForceTest.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\Login\tests\Integration;
 
+use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\Container\StaticContainer;
 use Piwik\NoAccessException;
@@ -118,6 +119,7 @@ class CreateAppSpecificTokenAuthBruteForceTest extends IntegrationTestCase
 
     public function testCreateAppSpecificTokenAuthCreatesTokenUsingEmailWhenUserNotBlocked(): void
     {
+        $this->setAnonymousUser();
         $token = Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
             'userLogin' => $this->userEmail,
             'passwordConfirmation' => $this->userPassword,
@@ -142,6 +144,57 @@ class CreateAppSpecificTokenAuthBruteForceTest extends IntegrationTestCase
 
         $plugin = new LoginPlugin();
         $plugin->beforeLoginCheckBruteForce();
+    }
+
+    public function testCreateAppSpecificTokenAuthRecordsFailedAttemptForTheTargetLogin(): void
+    {
+        // an unauthenticated request creating a token by credentials
+        $this->setAnonymousUser();
+
+        try {
+            Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
+                'userLogin' => $this->userLogin,
+                'passwordConfirmation' => 'wrongPassword123!',
+                'description' => 'wrong password test',
+            ]);
+            $this->fail('expected an exception for the wrong password');
+        } catch (\Exception $e) {
+            // expected: password is not correct
+        }
+
+        $recordedLogins = array_column($this->bruteForceDetection->getAll(), 'login');
+        $this->assertContains($this->userLogin, $recordedLogins);
+    }
+
+    public function testCreateAppSpecificTokenAuthRecordsFailedAttemptForTheTargetLoginWhenGivenAnEmail(): void
+    {
+        $this->setAnonymousUser();
+
+        try {
+            Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
+                'userLogin' => $this->userEmail,
+                'passwordConfirmation' => 'wrongPassword123!',
+                'description' => 'wrong password test',
+            ]);
+            $this->fail('expected an exception for the wrong password');
+        } catch (\Exception $e) {
+            // expected: password is not correct
+        }
+
+        // the email is normalized to the login, matching the brute-force check
+        $recordedLogins = array_column($this->bruteForceDetection->getAll(), 'login');
+        $this->assertContains($this->userLogin, $recordedLogins);
+    }
+
+    private function setAnonymousUser(): void
+    {
+        $auth = StaticContainer::get('Piwik\Auth');
+        $auth->setLogin('anonymous');
+        $auth->setTokenAuth('anonymous');
+        $auth->setPasswordHash(null);
+
+        Access::getInstance()->setSuperUserAccess(false);
+        Access::getInstance()->reloadAccess($auth);
     }
 
     private function blockLogin(string $userLogin): void

--- a/plugins/Login/tests/Integration/PasswordVerifierAuthStateTest.php
+++ b/plugins/Login/tests/Integration/PasswordVerifierAuthStateTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Login\tests\Integration;
+
+use Piwik\Access;
+use Piwik\Container\StaticContainer;
+use Piwik\Plugins\Login\PasswordVerifier;
+use Piwik\Plugins\UsersManager\API as UsersAPI;
+use Piwik\Plugins\UsersManager\UserUpdater;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * Verifies that checking a password does not change the current authentication state.
+ *
+ * @group Login
+ */
+class PasswordVerifierAuthStateTest extends IntegrationTestCase
+{
+    private const OTHER_USER = 'anothersuperuser';
+    private const OTHER_USER_PASSWORD = '123abcDk3_l3';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        UsersAPI::getInstance()->addUser(self::OTHER_USER, self::OTHER_USER_PASSWORD, self::OTHER_USER . '@matomo.org');
+        (new UserUpdater())->setSuperUserAccessWithoutCurrentPassword(self::OTHER_USER, true);
+    }
+
+    public function testCheckingAPasswordDoesNotChangeTheAuthenticatedUser()
+    {
+        $this->authenticateAsAnonymous();
+        $this->assertFalse(Access::getInstance()->hasSuperUserAccess());
+        $this->assertNull(Access::getInstance()->getLogin());
+
+        // Check another user's password.
+        $isCorrect = StaticContainer::get(PasswordVerifier::class)
+            ->isPasswordCorrect(self::OTHER_USER, self::OTHER_USER_PASSWORD);
+        $this->assertTrue($isCorrect);
+
+        // The current user must be unchanged afterwards.
+        Access::getInstance()->reloadAccess();
+
+        $this->assertFalse(Access::getInstance()->hasSuperUserAccess());
+        $this->assertNull(Access::getInstance()->getLogin());
+    }
+
+    private function authenticateAsAnonymous(): void
+    {
+        Access::getInstance()->setSuperUserAccess(false);
+
+        /** @var \Piwik\Auth $auth */
+        $auth = StaticContainer::get('Piwik\Auth');
+        $auth->setLogin('anonymous');
+        $auth->setTokenAuth('anonymous');
+        $auth->setPasswordHash(null);
+
+        Access::getInstance()->reloadAccess($auth);
+    }
+}

--- a/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
@@ -85,6 +85,9 @@ class TwoFactorAuthTest extends IntegrationTestCase
         $this->bruteForceDetection->deleteAll();
 
         unset($_GET['authCode']);
+
+        // default to an unauthenticated request; tests that need a specific user set it explicitly
+        $this->setCurrentUser('anonymous');
     }
 
     public function tearDown(): void
@@ -339,6 +342,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
 
     public function testOnDeleteUserRemovesAllRecoveryCodesWhenUsingTwoFa()
     {
+        Access::getInstance()->setSuperUserAccess(true);
         $this->assertNotEmpty($this->dao->getAllRecoveryCodesForLogin($this->userWith2Fa));
         Request::processRequest('UsersManager.deleteUser', array(
             'userLogin' => $this->userWith2Fa,
@@ -348,6 +352,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
 
     public function testOnDeleteUserDoesNotFailToDeleteUserNotUsingTwoFa()
     {
+        Access::getInstance()->setSuperUserAccess(true);
         $this->expectNotToPerformAssertions();
         Request::processRequest('UsersManager.deleteUser', array(
             'userLogin' => $this->userWithout2Fa,

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\UsersManager;
 use DeviceDetector\DeviceDetector;
 use Exception;
 use Piwik\Access;
+use Piwik\API\Request as ApiRequest;
 use Piwik\Access\CapabilitiesProvider;
 use Piwik\Access\Role\Admin;
 use Piwik\Access\RolesProvider;
@@ -1546,12 +1547,27 @@ class API extends \Piwik\Plugin\API
         $expireHours = 0,
         bool $secureOnly = false
     ) {
+        // Only allowed as a top-level request, not nested within another API request.
+        if (ApiRequest::isRootRequestApiRequest() && !ApiRequest::isCurrentApiRequestTheRootApiRequest()) {
+            throw new Exception(Piwik::translate('UsersManager_ExceptionCreateTokenAuthWithinNestedRequest'));
+        }
+
         $user = $this->model->getUser($userLogin);
         if (empty($user) && Piwik::isValidEmailString($userLogin)) {
             $user = $this->model->getUserByEmail($userLogin);
             if (!empty($user['login'])) {
                 $userLogin = $user['login'];
             }
+        }
+
+        // A logged-in user may only create a token for their own account. Creating a token
+        // for a different account requires that account's credentials via an anonymous request.
+        $currentLogin = Piwik::getCurrentUserLogin();
+        if (
+            strtolower((string) $currentLogin) !== 'anonymous'
+            && ($user['login'] ?? $userLogin) !== $currentLogin
+        ) {
+            throw new Exception(Piwik::translate('UsersManager_ExceptionCreateTokenAuthForOtherUser'));
         }
 
         if (empty($user) || !$this->passwordVerifier->isPasswordCorrect($userLogin, $passwordConfirmation)) {

--- a/plugins/UsersManager/lang/en.json
+++ b/plugins/UsersManager/lang/en.json
@@ -43,6 +43,8 @@
         "EmailYourAdministrator": "%1$sE-mail your administrator about this problem%2$s.",
         "EnterUsernameOrEmail": "Enter a username or email address",
         "ExceptionAccessValues": "The parameter access must have one of the following values: [ %1$s ], '%2$s' given.",
+        "ExceptionCreateTokenAuthForOtherUser": "You can only create an authentication token for your own account.",
+        "ExceptionCreateTokenAuthWithinNestedRequest": "This method cannot be called from within another API request.",
         "ExceptionNoRoleSet": "No role is set but one of these needs to be set: %s",
         "ExceptionMultipleRoleSet": "Only one role can be set but multiple have been set. Use only one of: %s",
         "ExceptionAnonymousNoCapabilities": "You cannot grant any capability to the 'anonymous' user.",

--- a/plugins/UsersManager/tests/Integration/CreateAppSpecificTokenAuthSelfOnlyTest.php
+++ b/plugins/UsersManager/tests/Integration/CreateAppSpecificTokenAuthSelfOnlyTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\tests\Integration;
+
+use Exception;
+use Piwik\Plugins\UsersManager\API as UsersAPI;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group UsersManager
+ */
+class CreateAppSpecificTokenAuthSelfOnlyTest extends IntegrationTestCase
+{
+    private const PASSWORD = '123abcDk3_l3';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        FakeAccess::clearAccess(true);
+        UsersAPI::getInstance()->addUser('actor', self::PASSWORD, 'actor@matomo.org');
+        UsersAPI::getInstance()->addUser('victim', self::PASSWORD, 'victim@matomo.org');
+    }
+
+    public function provideContainerConfig()
+    {
+        return ['Piwik\Access' => new FakeAccess()];
+    }
+
+    public function testLoggedInUserCannotCreateTokenForAnotherUser()
+    {
+        FakeAccess::clearAccess(false, [], [], 'actor');
+
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('UsersManager_ExceptionCreateTokenAuthForOtherUser');
+
+        UsersAPI::getInstance()->createAppSpecificTokenAuth('victim', self::PASSWORD, 'x');
+    }
+
+    public function testLoggedInUserCanCreateTokenForThemselves()
+    {
+        FakeAccess::clearAccess(false, [], [], 'actor');
+
+        $token = UsersAPI::getInstance()->createAppSpecificTokenAuth('actor', self::PASSWORD, 'x');
+
+        self::assertNotEmpty($token);
+    }
+
+    public function testSuperUserCannotCreateTokenForAnotherUserWhileLoggedIn()
+    {
+        FakeAccess::clearAccess(true, [], [], 'admin');
+
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('UsersManager_ExceptionCreateTokenAuthForOtherUser');
+
+        UsersAPI::getInstance()->createAppSpecificTokenAuth('victim', self::PASSWORD, 'x');
+    }
+
+    public function testAnonymousCanCreateTokenForTheCredentialOwner()
+    {
+        FakeAccess::clearAccess(false, [], [], 'anonymous');
+
+        $token = UsersAPI::getInstance()->createAppSpecificTokenAuth('victim', self::PASSWORD, 'x');
+
+        self::assertNotEmpty($token);
+    }
+}

--- a/plugins/UsersManager/tests/Integration/CreateAppSpecificTokenAuthTest.php
+++ b/plugins/UsersManager/tests/Integration/CreateAppSpecificTokenAuthTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UsersManager\tests\Integration;
+
+use Piwik\Access;
+use Piwik\API\Request as ApiRequest;
+use Piwik\Container\StaticContainer;
+use Piwik\Plugins\UsersManager\API as UsersAPI;
+use Piwik\Plugins\UsersManager\Model;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group UsersManager
+ */
+class CreateAppSpecificTokenAuthTest extends IntegrationTestCase
+{
+    private const LOGIN = 'sometokenuser';
+    private const PASSWORD = '123abcDk3_l3';
+
+    /**
+     * @var Model
+     */
+    private $model;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->model = new Model();
+        UsersAPI::getInstance()->addUser(self::LOGIN, self::PASSWORD, self::LOGIN . '@matomo.org');
+    }
+
+    public function tearDown(): void
+    {
+        ApiRequest::setIsRootRequestApiRequest(null);
+        parent::tearDown();
+    }
+
+    public function testCreateAppSpecificTokenAuthIsRejectedAsAChildOfAnApiRequest()
+    {
+        // Make the bulk request's children count as nested API requests.
+        ApiRequest::setIsRootRequestApiRequest('API.getBulkRequest');
+
+        $result = ApiRequest::processRequest('API.getBulkRequest', [
+            'urls' => [
+                'method=UsersManager.createAppSpecificTokenAuth'
+                    . '&userLogin=' . self::LOGIN
+                    . '&passwordConfirmation=' . urlencode(self::PASSWORD)
+                    . '&description=test',
+            ],
+        ]);
+
+        $this->assertSame('error', $result[0]['result'] ?? null);
+        // No token may have been created for the user.
+        $this->assertEmpty($this->model->getAllNonSystemTokensForLogin(self::LOGIN));
+    }
+
+    public function testCreateAppSpecificTokenAuthWorksAsATopLevelRequest()
+    {
+        $this->setAnonymousUser();
+        $token = UsersAPI::getInstance()->createAppSpecificTokenAuth(self::LOGIN, self::PASSWORD, 'test');
+
+        $this->assertNotEmpty($token);
+        $this->assertNotEmpty($this->model->getAllNonSystemTokensForLogin(self::LOGIN));
+    }
+
+    private function setAnonymousUser(): void
+    {
+        $auth = StaticContainer::get('Piwik\Auth');
+        $auth->setLogin('anonymous');
+        $auth->setTokenAuth('anonymous');
+        $auth->setPasswordHash(null);
+
+        Access::getInstance()->setSuperUserAccess(false);
+        Access::getInstance()->reloadAccess($auth);
+    }
+}

--- a/plugins/UsersManager/tests/System/ApiTest.php
+++ b/plugins/UsersManager/tests/System/ApiTest.php
@@ -9,6 +9,8 @@
 
 namespace Piwik\Plugins\UsersManager\tests\System;
 
+use Piwik\Access;
+use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\API\Request;
 use Piwik\Piwik;
@@ -45,6 +47,19 @@ class ApiTest extends SystemTestCase
 
         $this->api = API::getInstance();
         $this->model = new Model();
+
+        Access::getInstance()->setSuperUserAccess(true);
+    }
+
+    private function setAnonymousUser(): void
+    {
+        $auth = StaticContainer::get('Piwik\Auth');
+        $auth->setLogin('anonymous');
+        $auth->setTokenAuth('anonymous');
+        $auth->setPasswordHash(null);
+
+        Access::getInstance()->setSuperUserAccess(false);
+        Access::getInstance()->reloadAccess($auth);
     }
 
     /**
@@ -136,6 +151,7 @@ class ApiTest extends SystemTestCase
         $this->api->updateUser('login6', $password);
         API::$UPDATE_USER_REQUIRE_PASSWORD_CONFIRMATION = true;
         $this->model->deleteAllTokensForUser('login6');
+        $this->setAnonymousUser();
         $token = $this->api->createAppSpecificTokenAuth('login6', $password, 'test');
         $this->assertMd5($token);
 
@@ -146,6 +162,7 @@ class ApiTest extends SystemTestCase
     public function testCreateAppSpecificTokenAuth()
     {
         $this->model->deleteAllTokensForUser('login1');
+        $this->setAnonymousUser();
         $token = $this->api->createAppSpecificTokenAuth('login1', 'password', 'test');
         $this->assertMd5($token);
 
@@ -156,6 +173,7 @@ class ApiTest extends SystemTestCase
     public function testCreateAppSpecificTokenAuthCanLoginByEmail()
     {
         $this->model->deleteAllTokensForUser('login1');
+        $this->setAnonymousUser();
         $token = $this->api->createAppSpecificTokenAuth('login1@example.com', 'password', 'test');
         $this->assertMd5($token);
 
@@ -169,6 +187,7 @@ class ApiTest extends SystemTestCase
         $this->expectExceptionMessage('The current password you entered is not correct.');
 
         $this->model->deleteAllTokensForUser('login1');
+        $this->setAnonymousUser();
         $this->api->createAppSpecificTokenAuth('login1', 'foooooo', 'test');
     }
 
@@ -178,6 +197,7 @@ class ApiTest extends SystemTestCase
 
         $expiryDate = (new \DateTime())->modify('+1 day');
 
+        $this->setAnonymousUser();
         $token = $this->api->createAppSpecificTokenAuth('login1', 'password', 'test', $expiryDate->format('Y-m-d H:i:s'));
         $this->assertMd5($token);
 
@@ -192,6 +212,7 @@ class ApiTest extends SystemTestCase
     {
         $expireInHours = 48;
         $this->model->deleteAllTokensForUser('login1');
+        $this->setAnonymousUser();
         $token = $this->api->createAppSpecificTokenAuth('login1', 'password', 'test', null, $expireInHours);
         $this->assertMd5($token);
 

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -20,6 +20,8 @@ use Piwik\Scheduler\Schedule\Schedule;
 use Piwik\Scheduler\Task;
 use Piwik\Scheduler\Timetable;
 use Piwik\SettingsPiwik;
+use Piwik\Access;
+use Piwik\Container\StaticContainer;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -82,12 +84,22 @@ class TrackerTest extends IntegrationTestCase
     {
         \Piwik\Filesystem::deleteAllCacheOnUpdate();
 
+        // a token is created from an unauthenticated request by providing the credentials
+        $auth = StaticContainer::get('Piwik\Auth');
+        $auth->setLogin('anonymous');
+        $auth->setTokenAuth('anonymous');
+        $auth->setPasswordHash(null);
+        Access::getInstance()->setSuperUserAccess(false);
+        Access::getInstance()->reloadAccess($auth);
+
         $token = Request::processRequest('UsersManager.createAppSpecificTokenAuth', [
             'userLogin'            => Fixture::ADMIN_USER_LOGIN,
             'passwordConfirmation' => Fixture::ADMIN_USER_PASSWORD,
             'description'          => 'secure one',
             'secureOnly'           => true,
         ]);
+
+        Access::getInstance()->setSuperUserAccess(true);
 
         $this->issueBulkTrackingRequest($token, true, 2, 0);
     }


### PR DESCRIPTION
### Summary

Hardening around `UsersManager.createAppSpecificTokenAuth` and the shared authentication state:

- **Isolated password verification** — `PasswordVerifier::isPasswordCorrect()` now verifies against a copy of the shared `Piwik\Auth` object, so a password check has no lasting effect on the shared authentication state that is reused during a request. All callers only use the boolean result.
- **No nested creation** — `createAppSpecificTokenAuth` is only allowed as a top-level request and is rejected when it runs as a child of another API request (e.g. within a bulk request).
- **Correct failed-attempt attribution** — a failed password verification records the brute-force attempt against the login it was made for, instead of deriving it from the shared authentication state.
- **Self-service only** — a logged-in user may only create an app-specific token for their own account. Creating a token for a different account requires providing that account's credentials via an unauthenticated request; there is no exception for super users.

### Tests

- `PasswordVerifierAuthStateTest` — verifying a password does not change the current authentication state.
- `CreateAppSpecificTokenAuthTest` — rejected inside a nested (bulk) request; still works as a top-level request.
- `CreateAppSpecificTokenAuthBruteForceTest` — a failed attempt is recorded against the target login (by login and by email).
- `CreateAppSpecificTokenAuthSelfOnlyTest` — a logged-in user (including a super user) cannot create a token for another account; creating one for the own account and the unauthenticated credentials flow still work.

### Notes

- A companion change is required in the `LoginLdap` submodule, whose tests create tokens for other users from a super-user context and need the same unauthenticated-context adjustment.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules



Backport of #24821.
