### PR TITLE
Fix aggregation of archives spanning multiple sites for the same period

### DIFF
--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -420,12 +420,12 @@ class ArchiveProcessor
                 }
             },
             null,
-            function (string $period, int $tableId): void {
+            function (string $sitePeriod, int $tableId): void {
                 StaticContainer::get(LoggerInterface::class)->info(
-                    'Unexpected state when aggregating DataTable, unknown period/table ID combination encountered: {period} - {tableId}.'
+                    'Unexpected state when aggregating DataTable, unknown site/period/table ID combination encountered: {sitePeriod} - {tableId}.'
                     . ' This either means the SQL to order blobs is behaving incorrectly or the blob data is corrupt in some way.',
                     [
-                        'period' => $period,
+                        'sitePeriod' => $sitePeriod,
                         'tableId' => $tableId,
                     ]
                 );

--- a/core/ArchiveProcessor/BlobTableAggregator.php
+++ b/core/ArchiveProcessor/BlobTableAggregator.php
@@ -21,10 +21,12 @@ use Piwik\DataTable\Row;
 final class BlobTableAggregator
 {
     /**
-     * @param iterable<array{name: string, date1: string, date2: string, value: string}> $archiveDataRows
+     * @param iterable<array{idsite: int|string, name: string, date1: string, date2: string, value: string}> $archiveDataRows
      * @param callable(DataTable):void $renameColumnsCallback
-     * @param callable(array{name: string, date1: string, date2: string, value: string}):bool|null $shouldIncludeRow
-     * @param callable(string, int):void|null $onMissingParentTable
+     * @param callable(array{idsite: int|string, name: string, date1: string, date2: string, value: string}):bool|null $shouldIncludeRow
+     * @param callable(string, int):void|null $onMissingParentTable Called with the site/period key of the orphaned
+     *                                                              subtable blob (see {@link self::getSitePeriodKey()})
+     *                                                              and the subtable ID it references.
      * @return array{0: DataTable, 1: bool}
      */
     public static function aggregateBlobRows(
@@ -35,8 +37,10 @@ final class BlobTableAggregator
         ?callable $shouldIncludeRow = null,
         ?callable $onMissingParentTable = null
     ): array {
-        // maps period & subtable ID in database to the Row instance in $result that subtable should be added to
-        // [$row['date1'].','.$row['date2']][$tableId] = $row in $result
+        // maps site, period & subtable ID in database to the Row instance in $result that subtable should be added to.
+        // the site is part of the key because an archive query can span multiple sites for the same period
+        // (eg for roll-up day archives) and each site's blobs use their own subtable ID space.
+        // [$row['idsite'].'|'.$row['date1'].','.$row['date2']][$tableId] = $row in $result
         $tableIdToResultRowMapping = [];
         $result = new DataTable();
         $hasRows = false;
@@ -51,7 +55,7 @@ final class BlobTableAggregator
             }
 
             $hasRows = true;
-            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
+            $sitePeriod = self::getSitePeriodKey($archiveDataRow);
             $tableId = $archiveDataRow['name'] === $recordName
                 ? null
                 : self::parseSubtableIdFromBlobName($archiveDataRow['name']);
@@ -63,14 +67,14 @@ final class BlobTableAggregator
 
             if ($tableId === null) {
                 $tableToAddTo = $result;
-            } elseif (empty($tableIdToResultRowMapping[$period][$tableId])) {
+            } elseif (empty($tableIdToResultRowMapping[$sitePeriod][$tableId])) {
                 if ($onMissingParentTable !== null) {
-                    $onMissingParentTable($period, $tableId);
+                    $onMissingParentTable($sitePeriod, $tableId);
                 }
                 Common::destroy($blobTable);
                 continue;
             } else {
-                $rowToAddTo = $tableIdToResultRowMapping[$period][$tableId];
+                $rowToAddTo = $tableIdToResultRowMapping[$sitePeriod][$tableId];
                 if (!$rowToAddTo->getIdSubDataTable()) {
                     $newTable = new DataTable();
                     if (!empty($columnsAggregationOperation)) {
@@ -93,7 +97,7 @@ final class BlobTableAggregator
 
                 $rowToAddTo = $tableToAddTo->getRowFromLabel($label);
                 if ($rowToAddTo instanceof Row) {
-                    $tableIdToResultRowMapping[$period][$subtableId] = $rowToAddTo;
+                    $tableIdToResultRowMapping[$sitePeriod][$subtableId] = $rowToAddTo;
                 }
             }
 
@@ -101,6 +105,16 @@ final class BlobTableAggregator
         }
 
         return [$result, $hasRows];
+    }
+
+    /**
+     * Returns a key uniquely identifying the site and period an archive data row belongs to.
+     *
+     * @param array{idsite: int|string, date1: string, date2: string} $archiveDataRow
+     */
+    public static function getSitePeriodKey(array $archiveDataRow): string
+    {
+        return $archiveDataRow['idsite'] . '|' . $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
     }
 
     public static function parseSubtableIdFromBlobName(string $recordName): ?int

--- a/core/ArchiveProcessor/RecordBuilder.php
+++ b/core/ArchiveProcessor/RecordBuilder.php
@@ -350,18 +350,18 @@ abstract class RecordBuilder
         $flatColumnToSortByBeforeTruncation = $flatRecord->getColumnToSortByBeforeTruncation() ?? $this->columnToSortByBeforeTruncation;
         $flatMaxRowsInTable = $flatRecord->getMaxRowsInTable() ?? $this->maxRowsInTable;
 
-        [$flatTable, $hasFlatSourceData, $periodsWithFlatRecord] = $this->aggregateRootDataTableFromBlobs(
+        [$flatTable, $hasFlatSourceData, $sitePeriodsWithFlatRecord] = $this->aggregateRootDataTableFromBlobs(
             $archiveProcessor,
             $flatRecordName,
             $flatColumnAggregationOps,
             $flatColumnToRenameAfterAggregation
         );
         $allSubperiodKeys = $this->getAllSubperiodKeys($archiveProcessor);
-        $periodsWithoutFlatRecord = array_diff_key($allSubperiodKeys, $periodsWithFlatRecord);
+        $sitePeriodsWithoutFlatRecord = array_diff_key($allSubperiodKeys, $sitePeriodsWithFlatRecord);
 
         $hasLegacyFallbackData = false;
         $legacyReducerCallback = $hierarchicalRecord->getLegacyHierarchyToFlatReducerCallback();
-        if (!empty($periodsWithoutFlatRecord) && is_callable($legacyReducerCallback)) {
+        if (!empty($sitePeriodsWithoutFlatRecord) && is_callable($legacyReducerCallback)) {
             $hasLegacyFallbackData = $this->aggregateLegacyHierarchyPeriodsIntoFlatTable(
                 $archiveProcessor,
                 $hierarchicalRecord->getName(),
@@ -370,7 +370,7 @@ abstract class RecordBuilder
                 $hierarchicalRecord,
                 $columnAggregationOps,
                 $columnToRenameAfterAggregation,
-                $periodsWithoutFlatRecord
+                $sitePeriodsWithoutFlatRecord
             );
         }
 
@@ -430,21 +430,21 @@ abstract class RecordBuilder
         Record $hierarchicalRecord,
         ?array $columnsAggregationOperation,
         ?array $columnsToRenameAfterAggregation,
-        ?array $periodsToInclude
+        ?array $sitePeriodsToInclude
     ): bool {
-        $currentPeriod = null;
-        $currentPeriodRows = [];
+        $currentSitePeriod = null;
+        $currentSitePeriodRows = [];
         $hasRows = false;
 
         foreach ($this->querySingleBlobRows($archiveProcessor, $recordName) as $archiveDataRow) {
-            $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
-            if ($periodsToInclude !== null && !isset($periodsToInclude[$period])) {
+            $sitePeriod = BlobTableAggregator::getSitePeriodKey($archiveDataRow);
+            if ($sitePeriodsToInclude !== null && !isset($sitePeriodsToInclude[$sitePeriod])) {
                 continue;
             }
 
-            if ($currentPeriod !== null && $period !== $currentPeriod) {
+            if ($currentSitePeriod !== null && $sitePeriod !== $currentSitePeriod) {
                 $hasRows = $this->reduceLegacyHierarchyPeriodRowsIntoFlatTable(
-                    $currentPeriodRows,
+                    $currentSitePeriodRows,
                     $recordName,
                     $flatTable,
                     $legacyReducerCallback,
@@ -453,16 +453,16 @@ abstract class RecordBuilder
                     $columnsAggregationOperation,
                     $columnsToRenameAfterAggregation
                 ) || $hasRows;
-                $currentPeriodRows = [];
+                $currentSitePeriodRows = [];
             }
 
-            $currentPeriod = $period;
-            $currentPeriodRows[] = $archiveDataRow;
+            $currentSitePeriod = $sitePeriod;
+            $currentSitePeriodRows[] = $archiveDataRow;
         }
 
-        if (!empty($currentPeriodRows)) {
+        if (!empty($currentSitePeriodRows)) {
             $hasRows = $this->reduceLegacyHierarchyPeriodRowsIntoFlatTable(
-                $currentPeriodRows,
+                $currentSitePeriodRows,
                 $recordName,
                 $flatTable,
                 $legacyReducerCallback,
@@ -477,7 +477,7 @@ abstract class RecordBuilder
     }
 
     protected function reduceLegacyHierarchyPeriodRowsIntoFlatTable(
-        array $periodRows,
+        array $sitePeriodRows,
         string $recordName,
         DataTable $flatTable,
         callable $legacyReducerCallback,
@@ -487,7 +487,7 @@ abstract class RecordBuilder
         ?array $columnsToRenameAfterAggregation
     ): bool {
         [$legacyHierarchicalTable, $hasRows] = BlobTableAggregator::aggregateBlobRows(
-            $periodRows,
+            $sitePeriodRows,
             $recordName,
             $columnsAggregationOperation,
             function (DataTable $table) use ($archiveProcessor, $columnsToRenameAfterAggregation): void {
@@ -645,7 +645,9 @@ abstract class RecordBuilder
     }
 
     /**
-     * Aggregates a root blob record while discovering periods that contain the root record in a single pass.
+     * Aggregates a root blob record while discovering the site and period combinations that contain the
+     * root record in a single pass. The combinations are keyed in the same way as
+     * {@link BlobTableAggregator::getSitePeriodKey()}.
      *
      * @return array{0: DataTable, 1: bool, 2: array<string, bool>}
      */
@@ -655,7 +657,7 @@ abstract class RecordBuilder
         ?array $columnsAggregationOperation,
         ?array $columnsToRenameAfterAggregation
     ): array {
-        $periodsWithRootRecord = [];
+        $sitePeriodsWithRootRecord = [];
 
         [$result, $hasRows] = BlobTableAggregator::aggregateBlobRows(
             $this->querySingleBlobRows($archiveProcessor, $recordName),
@@ -664,26 +666,29 @@ abstract class RecordBuilder
             function (DataTable $table) use ($archiveProcessor, $columnsToRenameAfterAggregation): void {
                 $archiveProcessor->renameColumnsAfterAggregation($table, $columnsToRenameAfterAggregation);
             },
-            function (array $archiveDataRow) use (&$periodsWithRootRecord, $recordName): bool {
-                $period = $archiveDataRow['date1'] . ',' . $archiveDataRow['date2'];
+            function (array $archiveDataRow) use (&$sitePeriodsWithRootRecord, $recordName): bool {
+                $sitePeriod = BlobTableAggregator::getSitePeriodKey($archiveDataRow);
                 if ($archiveDataRow['name'] === $recordName) {
-                    $periodsWithRootRecord[$period] = true;
+                    $sitePeriodsWithRootRecord[$sitePeriod] = true;
                     return true;
                 }
 
-                return isset($periodsWithRootRecord[$period]);
+                return isset($sitePeriodsWithRootRecord[$sitePeriod]);
             }
         );
 
-        return [$result, $hasRows, $periodsWithRootRecord];
+        return [$result, $hasRows, $sitePeriodsWithRootRecord];
     }
 
     protected function querySingleBlobRows(ArchiveProcessor $archiveProcessor, string $recordName): iterable
     {
+        // use the same parameters as ArchiveProcessor::getArchive(): a day period has no subperiods, so the
+        // period itself must be queried, and an archive can aggregate the archives of multiple sites for the
+        // same period (eg for roll-up day archives)
         $archive = Archive::factory(
             $archiveProcessor->getParams()->getSegment(),
-            $archiveProcessor->getParams()->getPeriod()->getSubperiods(),
-            [$archiveProcessor->getParams()->getSite()->getId()]
+            $archiveProcessor->getParams()->getSubPeriods(),
+            $archiveProcessor->getParams()->getIdSites()
         );
         if (!method_exists($archive, 'querySingleBlob')) {
             return [];
@@ -692,11 +697,24 @@ abstract class RecordBuilder
         return $archive->querySingleBlob($recordName);
     }
 
+    /**
+     * Returns one entry per site and subperiod combination the archive being built aggregates over,
+     * keyed in the same way as {@link BlobTableAggregator::getSitePeriodKey()}.
+     *
+     * @return array<string, bool>
+     */
     protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
     {
         $result = [];
-        foreach ($archiveProcessor->getParams()->getPeriod()->getSubperiods() as $period) {
-            $result[$period->getDateStart()->toString() . ',' . $period->getDateEnd()->toString()] = true;
+        foreach ($archiveProcessor->getParams()->getIdSites() as $idSite) {
+            foreach ($archiveProcessor->getParams()->getSubPeriods() as $period) {
+                $key = BlobTableAggregator::getSitePeriodKey([
+                    'idsite' => $idSite,
+                    'date1' => $period->getDateStart()->toString(),
+                    'date2' => $period->getDateEnd()->toString(),
+                ]);
+                $result[$key] = true;
+            }
         }
 
         return $result;

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -618,7 +618,7 @@ class ArchiveSelector
 
         $archiveIdsPerMonth = self::getArchiveIdsByYearMonth($archiveIds);
 
-        $periodsSeen = [];
+        $sitePeriodsSeen = [];
 
         // $yearMonth = "2022-11",
         foreach ($archiveIdsPerMonth as $yearMonth => $ids) {
@@ -649,12 +649,12 @@ class ArchiveSelector
                     continue;
                 }
 
-                // only use the first period/blob name combination seen (since we order by ts_archived descending)
-                if (!empty($periodsSeen[$period][$recordName])) {
+                // only use the first site/period/blob name combination seen (since we order by ts_archived descending)
+                if (!empty($sitePeriodsSeen[$row['idsite']][$period][$recordName])) {
                     continue;
                 }
 
-                $periodsSeen[$period][$recordName] = true;
+                $sitePeriodsSeen[$row['idsite']][$period][$recordName] = true;
 
                 $row['value'] = ArchiveSelector::uncompress($row['value']);
                 if ($chunk->isRecordNameAChunk($row['name'])) {
@@ -662,6 +662,7 @@ class ArchiveSelector
                     $blobs = Common::safe_unserialize($row['value']);
                     if (!is_array($blobs)) {
                         yield $row;
+                        continue;
                     }
 
                     ksort($blobs);
@@ -688,8 +689,8 @@ class ArchiveSelector
      *
      * @param array $recordNames The list of records to look for.
      * @param string|int $idSubtable The idSubtable to look for or 'all' to load all of them.
-     * @param boolean $orderBySubtableId If true, orders the result set by start date ascending, subtable ID
-     *                                   ascending and ts_archived descending. Only applied if loading all
+     * @param boolean $orderBySubtableId If true, orders the result set by start date ascending, site ID ascending,
+     *                                   subtable ID ascending and ts_archived descending. Only applied if loading all
      *                                   subtables for a single record.
      *
      *                                   This parameter is used when aggregating blob data for a single record
@@ -724,6 +725,7 @@ class ArchiveSelector
                 $idSubtableAsInt = self::getExtractIdSubtableFromBlobNameSql($chunk, $name);
 
                 $orderBy = "ORDER BY date1 ASC, " . // ordering by date just so column order in tests will be predictable
+                    " idsite ASC, " . // an archive query can span multiple sites for the same period, so keep each site's rows together
                     " $idSubtableAsInt ASC,
                   ts_archived DESC"; // ascending order so we use the latest data found
             }

--- a/plugins/Actions/tests/System/MixedArchivingAggregationTest.php
+++ b/plugins/Actions/tests/System/MixedArchivingAggregationTest.php
@@ -15,6 +15,7 @@ use Piwik\Config;
 use Piwik\DataTable;
 use Piwik\Db;
 use Piwik\Metrics;
+use Piwik\Piwik;
 use Piwik\Plugins\Actions\Archiver;
 use Piwik\Plugins\Actions\ArchivingHelper;
 use Piwik\Tests\Framework\Fixture;
@@ -167,6 +168,262 @@ class MixedArchivingAggregationTest extends IntegrationTestCase
         );
     }
 
+    public function testDayArchiveAggregatingMultipleSitesWorksWithFlatFirstEnabled()
+    {
+        [$childSiteA, $childSiteB, $multiSite] = $this->setUpMultiSiteDayAggregation();
+
+        $config = Config::getInstance();
+        $configKeys = [
+            'datatable_archiving_maximum_rows_actions_flat',
+            'datatable_archiving_maximum_rows_actions',
+            'datatable_archiving_maximum_rows_subtable_actions',
+            'archiving_ranking_query_row_limit',
+        ];
+        $configBackup = $this->backupGeneralConfig($configKeys);
+
+        try {
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50000;
+            $config->General['datatable_archiving_maximum_rows_actions'] = 50000;
+            $config->General['datatable_archiving_maximum_rows_subtable_actions'] = 50000;
+            $config->General['archiving_ranking_query_row_limit'] = 100000;
+
+            // archive the child sites' days first, so the multi-site day archive can aggregate them
+            Archive::build($childSiteA, 'day', '2026-03-02')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+            Archive::build($childSiteB, 'day', '2026-03-02')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+
+            $archive = Archive::build($multiSite, 'day', '2026-03-02');
+            $flatUrls = $archive->getDataTable(Archiver::PAGE_URLS_FLAT_RECORD_NAME);
+            $hierarchicalUrls = $archive->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        $flatExport = $this->exportFlatTableValues($flatUrls);
+
+        $expectedHits = [
+            '/a' => 3,
+            '/b' => 1,
+            '/c' => 3,
+        ];
+        $actualHits = array_map(function (array $columns) {
+            return (int) $columns[Metrics::INDEX_PAGE_NB_HITS];
+        }, $flatExport['rows']);
+        $this->assertSame($expectedHits, $actualHits);
+
+        // the hierarchy export uses json encoded path segments as labels
+        $expectedHierarchyExport = $flatExport;
+        $expectedHierarchyExport['rows'] = [];
+        foreach ($flatExport['rows'] as $label => $columns) {
+            $expectedHierarchyExport['rows'][json_encode([$label])] = $columns;
+        }
+
+        $this->assertSame(
+            $expectedHierarchyExport,
+            $this->exportHierarchyTableValues($hierarchicalUrls)
+        );
+    }
+
+    public function testWeekArchiveAggregatingMultipleSitesWorksWithFlatFirstEnabled()
+    {
+        [$childSiteA, $childSiteB, $multiSite] = $this->setUpMultiSiteDayAggregation();
+
+        $config = Config::getInstance();
+        $configKeys = [
+            'datatable_archiving_maximum_rows_actions_flat',
+            'datatable_archiving_maximum_rows_actions',
+            'datatable_archiving_maximum_rows_subtable_actions',
+            'archiving_ranking_query_row_limit',
+        ];
+        $configBackup = $this->backupGeneralConfig($configKeys);
+
+        try {
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50000;
+            $config->General['datatable_archiving_maximum_rows_actions'] = 50000;
+            $config->General['datatable_archiving_maximum_rows_subtable_actions'] = 50000;
+            $config->General['archiving_ranking_query_row_limit'] = 100000;
+
+            // archive the child sites' days first, so the multi-site week archive can aggregate the
+            // day archives of every site within the week
+            Archive::build($childSiteA, 'day', '2026-03-02')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+            Archive::build($childSiteB, 'day', '2026-03-02')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+
+            $archive = Archive::build($multiSite, 'week', '2026-03-02');
+            $flatUrls = $archive->getDataTable(Archiver::PAGE_URLS_FLAT_RECORD_NAME);
+            $hierarchicalUrls = $archive->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        $expectedHits = [
+            '/a' => 3,
+            '/b' => 1,
+            '/c' => 3,
+        ];
+        $actualHits = array_map(function (array $columns) {
+            return (int) $columns[Metrics::INDEX_PAGE_NB_HITS];
+        }, $this->exportFlatTableValues($flatUrls)['rows']);
+        $this->assertSame($expectedHits, $actualHits);
+
+        $this->assertSame(
+            [
+                '["\/a"]' => 3,
+                '["\/b"]' => 1,
+                '["\/c"]' => 3,
+            ],
+            $this->exportHierarchyHits($hierarchicalUrls)
+        );
+    }
+
+    public function testDayArchiveAggregatingMultipleSitesAggregatesAllSitesWithLegacyArchiving()
+    {
+        // nested paths ensure the day archives contain subtables, whose IDs overlap between the sites
+        [$childSiteA, $childSiteB, $multiSite] = $this->setUpMultiSiteDayAggregation([
+            'siteA' => [
+                '/blog/post1' => 1,
+                '/shop/shoes/nike' => 2,
+            ],
+            'siteB' => [
+                '/shop/shoes/adidas' => 3,
+                '/shop/shoes/nike' => 1,
+            ],
+        ]);
+
+        $config = Config::getInstance();
+        $configBackup = $this->backupGeneralConfig(['datatable_archiving_maximum_rows_actions_flat']);
+
+        try {
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 0;
+
+            // archive the child sites' days first, so the multi-site day archive can aggregate them
+            $childHitsA = $this->exportHierarchyHits(
+                Archive::build($childSiteA, 'day', '2026-03-02')->getDataTableExpanded(Archiver::PAGE_URLS_RECORD_NAME)
+            );
+            $childHitsB = $this->exportHierarchyHits(
+                Archive::build($childSiteB, 'day', '2026-03-02')->getDataTableExpanded(Archiver::PAGE_URLS_RECORD_NAME)
+            );
+
+            $hierarchicalUrls = Archive::build($multiSite, 'day', '2026-03-02')->getDataTableExpanded(Archiver::PAGE_URLS_RECORD_NAME);
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        $multiSiteHits = $this->exportHierarchyHits($hierarchicalUrls);
+
+        // the multi-site day archive must contain the label-wise sum of both child day archives
+        $expectedHits = $childHitsA;
+        foreach ($childHitsB as $label => $hits) {
+            $expectedHits[$label] = ($expectedHits[$label] ?? 0) + $hits;
+        }
+        ksort($expectedHits);
+
+        $this->assertCount(3, $childHitsA + $childHitsB);
+        $this->assertSame(7, array_sum($multiSiteHits));
+        $this->assertSame($expectedHits, $multiSiteHits);
+    }
+
+    public function testDayArchiveAggregatingMultipleSitesFallsBackToLegacyChildDayArchives()
+    {
+        [$childSiteA, $childSiteB, $multiSite] = $this->setUpMultiSiteDayAggregation();
+
+        $config = Config::getInstance();
+        $configBackup = $this->backupGeneralConfig(['datatable_archiving_maximum_rows_actions_flat']);
+
+        try {
+            // one child day archive contains flat records, the other one was archived without flat-first
+            // archiving, so aggregating the multi-site day archive needs to combine both variants
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50000;
+            Archive::build($childSiteA, 'day', '2026-03-02')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 0;
+            Archive::build($childSiteB, 'day', '2026-03-02')->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+
+            $config->General['datatable_archiving_maximum_rows_actions_flat'] = 50000;
+            $archive = Archive::build($multiSite, 'day', '2026-03-02');
+            $flatUrls = $archive->getDataTable(Archiver::PAGE_URLS_FLAT_RECORD_NAME);
+            $hierarchicalUrls = $archive->getDataTable(Archiver::PAGE_URLS_RECORD_NAME);
+        } finally {
+            $this->restoreGeneralConfig($configBackup);
+        }
+
+        $this->assertDayArchiveRecordNames(
+            $childSiteA,
+            '2026-03-02',
+            [Archiver::PAGE_URLS_RECORD_NAME, Archiver::PAGE_URLS_FLAT_RECORD_NAME],
+            []
+        );
+        $this->assertDayArchiveRecordNames(
+            $childSiteB,
+            '2026-03-02',
+            [Archiver::PAGE_URLS_RECORD_NAME],
+            [Archiver::PAGE_URLS_FLAT_RECORD_NAME]
+        );
+
+        $expectedHits = [
+            '/a' => 3,
+            '/b' => 1,
+            '/c' => 3,
+        ];
+        $actualHits = array_map(function (array $columns) {
+            return (int) $columns[Metrics::INDEX_PAGE_NB_HITS];
+        }, $this->exportFlatTableValues($flatUrls)['rows']);
+        $this->assertSame($expectedHits, $actualHits);
+
+        $this->assertSame(
+            [
+                '["\/a"]' => 3,
+                '["\/b"]' => 1,
+                '["\/c"]' => 3,
+            ],
+            $this->exportHierarchyHits($hierarchicalUrls)
+        );
+    }
+
+    /**
+     * Simulates a site whose archives aggregate the day archives of other sites (as e.g. RollUpReporting does),
+     * resulting in a day archive that is aggregated from multiple reports instead of raw log data.
+     *
+     * @param array{siteA: array<string, int>, siteB: array<string, int>}|null $urlHitsPerSite
+     * @return int[] the two child site ids and the multi-site id
+     */
+    private function setUpMultiSiteDayAggregation(?array $urlHitsPerSite = null): array
+    {
+        $childSiteA = Fixture::createWebsite('2026-03-01 00:00:00');
+        $childSiteB = Fixture::createWebsite('2026-03-01 00:00:00');
+        $multiSite = Fixture::createWebsite('2026-03-01 00:00:00');
+
+        Piwik::addAction('ArchiveProcessor.Parameters.getIdSites', function (&$idSites) use ($multiSite, $childSiteA, $childSiteB) {
+            if (reset($idSites) == $multiSite) {
+                $idSites = [$childSiteA, $childSiteB];
+            }
+        });
+
+        // the multi-site has no visits of its own, so archiving needs to be forced for it
+        Piwik::addAction('Archiving.getIdSitesToArchiveWhenNoVisits', function (&$idSites) use ($multiSite) {
+            $idSites[] = $multiSite;
+        });
+
+        $this->trackUrlHits($childSiteA, '2026-03-02', $urlHitsPerSite['siteA'] ?? [
+            '/a' => 2,
+            '/b' => 1,
+        ]);
+        $this->trackUrlHits($childSiteB, '2026-03-02', $urlHitsPerSite['siteB'] ?? [
+            '/a' => 1,
+            '/c' => 3,
+        ]);
+
+        return [$childSiteA, $childSiteB, $multiSite];
+    }
+
+    /**
+     * @return array<string, int> nb_hits by flattened label
+     */
+    private function exportHierarchyHits(DataTable $hierarchicalTable): array
+    {
+        return array_map(function (array $columns) {
+            return (int) $columns[Metrics::INDEX_PAGE_NB_HITS];
+        }, $this->exportHierarchyTableValues($hierarchicalTable)['rows']);
+    }
+
     public function testDayFlatAndHierarchyStayInParityWhenHostsDifferButPathsMatch()
     {
         $idSite = Fixture::createWebsite('2026-02-10 00:00:00');
@@ -265,7 +522,7 @@ class MixedArchivingAggregationTest extends IntegrationTestCase
 
     private function assertDayArchiveRecordNames(int $idSite, string $day, array $expectedPresent, array $expectedAbsent): void
     {
-        $table = Common::prefixTable('archive_blob_2026_01');
+        $table = Common::prefixTable('archive_blob_' . str_replace('-', '_', substr($day, 0, 7)));
         $names = Db::fetchAll(
             "SELECT DISTINCT name
              FROM $table

--- a/plugins/Actions/tests/Unit/ActionReportsTest.php
+++ b/plugins/Actions/tests/Unit/ActionReportsTest.php
@@ -81,12 +81,14 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
 
             $rowsByRecordName = [
                 $flatRecordName => [[
+                    'idsite' => 1,
                     'date1' => '2026-01-01',
                     'date2' => '2026-01-01',
                     'name' => $flatRecordName,
                     'value' => $flatPeriodTable,
                 ]],
                 $hierarchicalRecordName => [[
+                    'idsite' => 1,
                     'date1' => '2026-01-02',
                     'date2' => '2026-01-02',
                     'name' => $hierarchicalRecordName,
@@ -177,12 +179,14 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
 
             $rowsByRecordName = [
                 $flatRecordName => [[
+                    'idsite' => 1,
                     'date1' => '2026-01-01',
                     'date2' => '2026-01-01',
                     'name' => $flatRecordName,
                     'value' => $flatPeriodTable,
                 ]],
                 $hierarchicalRecordName => [[
+                    'idsite' => 1,
                     'date1' => '2026-01-02',
                     'date2' => '2026-01-02',
                     'name' => $hierarchicalRecordName,
@@ -614,9 +618,21 @@ class ActionReportsTest extends \PHPUnit\Framework\TestCase
                 return $this->period;
             }
 
+            public function getSubPeriods(): array
+            {
+                // unlike the real Parameters::getSubPeriods() this fake does not special-case
+                // day periods, so it must only be used with non-day periods
+                return $this->period->getSubperiods();
+            }
+
             public function getSite(): object
             {
                 return $this->site;
+            }
+
+            public function getIdSites(): array
+            {
+                return [$this->site->getId()];
             }
 
             public function getSegment()

--- a/tests/PHPUnit/Unit/ArchiveProcessor/BlobTableAggregatorTest.php
+++ b/tests/PHPUnit/Unit/ArchiveProcessor/BlobTableAggregatorTest.php
@@ -55,6 +55,7 @@ class BlobTableAggregatorTest extends TestCase
             $this->makeTableWithSubtable('parent', 'child', 5)
         );
         $rows[] = [
+            'idsite' => 1,
             'name' => 'Test_record_999',
             'date1' => '2020-01-02',
             'date2' => '2020-01-02',
@@ -69,17 +70,63 @@ class BlobTableAggregatorTest extends TestCase
             function (DataTable $table): void {
             },
             null,
-            function (string $period, int $tableId) use (&$missingParents): void {
-                $missingParents[] = [$period, $tableId];
+            function (string $sitePeriod, int $tableId) use (&$missingParents): void {
+                $missingParents[] = [$sitePeriod, $tableId];
             }
         );
 
         $this->assertTrue($hasRows);
-        $this->assertContains(['2020-01-02,2020-01-02', 999], $missingParents);
+        $this->assertContains(['1|2020-01-02,2020-01-02', 999], $missingParents);
         $this->assertGreaterThan(0, $result->getRowsCount());
         $rows = $result->getRows();
         $row = reset($rows);
         $this->assertInstanceOf(Row::class, $row);
+    }
+
+    public function testAggregateBlobRowsKeepsSubtableIdSpacesOfMultipleSitesSeparate(): void
+    {
+        // both sites use the same period and overlapping subtable IDs, but for different parent rows
+        $siteOneRows = $this->makeArchiveDataRowsForPeriod(
+            'Test_record',
+            '2020-01-01',
+            $this->makeTableWithSubtable('shop', 'shoes', 3),
+            $idSite = 1
+        );
+        $siteTwoRows = $this->makeArchiveDataRowsForPeriod(
+            'Test_record',
+            '2020-01-01',
+            $this->makeTableWithSubtable('blog', 'article', 7),
+            $idSite = 2
+        );
+
+        // order the rows by subtable ID first, like the SQL used to fetch blob rows would when not
+        // ordering by site: both root records first, then the subtable blobs of both sites
+        $rows = [$siteOneRows[0], $siteTwoRows[0], $siteOneRows[1], $siteTwoRows[1]];
+
+        [$result, $hasRows] = BlobTableAggregator::aggregateBlobRows(
+            $rows,
+            'Test_record',
+            null,
+            function (DataTable $table): void {
+            }
+        );
+
+        $this->assertTrue($hasRows);
+        $this->assertSame(2, $result->getRowsCount());
+
+        $shopRow = $result->getRowFromLabel('shop');
+        $this->assertInstanceOf(Row::class, $shopRow);
+        $shopSubtable = $shopRow->getSubtable();
+        $this->assertInstanceOf(DataTable::class, $shopSubtable);
+        $this->assertInstanceOf(Row::class, $shopSubtable->getRowFromLabel('shoes'));
+        $this->assertFalse($shopSubtable->getRowFromLabel('article'));
+
+        $blogRow = $result->getRowFromLabel('blog');
+        $this->assertInstanceOf(Row::class, $blogRow);
+        $blogSubtable = $blogRow->getSubtable();
+        $this->assertInstanceOf(DataTable::class, $blogSubtable);
+        $this->assertInstanceOf(Row::class, $blogSubtable->getRowFromLabel('article'));
+        $this->assertFalse($blogSubtable->getRowFromLabel('shoes'));
     }
 
     private function makeSimpleTable(string $label, int $nbVisits): DataTable
@@ -103,17 +150,22 @@ class BlobTableAggregatorTest extends TestCase
     }
 
     /**
-     * @return array<int, array{name: string, date1: string, date2: string, value: string}>
+     * Returns one archive data row per serialized blob, starting with the root record (stored
+     * at key 0) followed by the subtable blobs ordered by their subtable ID, like the SQL used
+     * to fetch blob rows would return them for a single site.
+     *
+     * @return array<int, array{idsite: int, name: string, date1: string, date2: string, value: string}>
      */
-    private function makeArchiveDataRowsForPeriod(string $recordName, string $date, DataTable $table): array
+    private function makeArchiveDataRowsForPeriod(string $recordName, string $date, DataTable $table, int $idSite = 1): array
     {
         $rows = [];
         $serialized = $table->getSerialized();
-        $rootKey = array_key_first($serialized);
+        ksort($serialized);
 
         foreach ($serialized as $key => $value) {
-            $name = $key === $rootKey ? $recordName : $recordName . '_' . $key;
+            $name = $key === 0 ? $recordName : $recordName . '_' . $key;
             $rows[] = [
+                'idsite' => $idSite,
                 'name' => $name,
                 'date1' => $date,
                 'date2' => $date,

--- a/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
+++ b/tests/PHPUnit/Unit/ArchiveProcessor/RecordBuilderTest.php
@@ -618,7 +618,7 @@ class RecordBuilderTest extends TestCase
                 $table = new DataTable();
                 if ($recordName === 'TestPlugin_flat') {
                     $table->addRowFromSimpleArray(['label' => '/flat-path', 'nb_visits' => 5]);
-                    return [$table, true, ['2020-03-04,2020-03-04' => true]];
+                    return [$table, true, ['1|2020-03-04,2020-03-04' => true]];
                 }
 
                 return [$table, false, []];
@@ -626,7 +626,7 @@ class RecordBuilderTest extends TestCase
 
             protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
             {
-                return ['2020-03-04,2020-03-04' => true];
+                return ['1|2020-03-04,2020-03-04' => true];
             }
         };
 
@@ -689,7 +689,7 @@ class RecordBuilderTest extends TestCase
                 if ($recordName === 'TestPlugin_flat') {
                     $table->addRowFromSimpleArray(['label' => '/flat-path-a', 'nb_visits' => 5]);
                     $table->addRowFromSimpleArray(['label' => '/flat-path-b', 'nb_visits' => 3]);
-                    return [$table, true, ['2020-03-04,2020-03-04' => true]];
+                    return [$table, true, ['1|2020-03-04,2020-03-04' => true]];
                 }
 
                 return [$table, false, []];
@@ -697,7 +697,7 @@ class RecordBuilderTest extends TestCase
 
             protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
             {
-                return ['2020-03-04,2020-03-04' => true];
+                return ['1|2020-03-04,2020-03-04' => true];
             }
         };
 
@@ -765,6 +765,7 @@ class RecordBuilderTest extends TestCase
 
                 return [[
                     'name' => 'TestPlugin_flat',
+                    'idsite' => 1,
                     'date1' => '2020-03-04',
                     'date2' => '2020-03-04',
                     'value' => $this->flatRootBlob,
@@ -773,7 +774,7 @@ class RecordBuilderTest extends TestCase
 
             protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
             {
-                return ['2020-03-04,2020-03-04' => true];
+                return ['1|2020-03-04,2020-03-04' => true];
             }
         };
 
@@ -829,7 +830,7 @@ class RecordBuilderTest extends TestCase
                 $table = new DataTable();
                 if ($recordName === 'TestPlugin_flat') {
                     $table->addRowFromSimpleArray(['label' => '/flat-path', 'nb_visits' => 5]);
-                    return [$table, true, ['2020-03-04,2020-03-04' => true]];
+                    return [$table, true, ['1|2020-03-04,2020-03-04' => true]];
                 }
 
                 return [$table, false, []];
@@ -845,6 +846,7 @@ class RecordBuilderTest extends TestCase
                 $legacyTable->addRowFromSimpleArray(['label' => '/legacy-path', 'nb_visits' => 7]);
 
                 yield [
+                    'idsite' => 1,
                     'date1' => '2020-03-05',
                     'date2' => '2020-03-05',
                     'name' => 'TestPlugin_hierarchy',
@@ -855,8 +857,8 @@ class RecordBuilderTest extends TestCase
             protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
             {
                 return [
-                    '2020-03-04,2020-03-04' => true,
-                    '2020-03-05,2020-03-05' => true,
+                    '1|2020-03-04,2020-03-04' => true,
+                    '1|2020-03-05,2020-03-05' => true,
                 ];
             }
         };
@@ -923,7 +925,7 @@ class RecordBuilderTest extends TestCase
                     $table->addRowFromSimpleArray(['label' => '/flat-path-b', 'nb_visits' => 3]);
                     $table->addSummaryRow(new Row([Row::COLUMNS => ['label' => '-1', 'nb_visits' => 2]]));
 
-                    return [$table, true, ['2020-03-04,2020-03-04' => true]];
+                    return [$table, true, ['1|2020-03-04,2020-03-04' => true]];
                 }
 
                 return [$table, false, []];
@@ -931,7 +933,7 @@ class RecordBuilderTest extends TestCase
 
             protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
             {
-                return ['2020-03-04,2020-03-04' => true];
+                return ['1|2020-03-04,2020-03-04' => true];
             }
 
             protected function beforeInsertBuiltFromFlatHierarchyRecord(
@@ -1004,7 +1006,7 @@ class RecordBuilderTest extends TestCase
                 $table = new DataTable();
                 if ($recordName === 'TestPlugin_flat') {
                     $table->addRowFromSimpleArray(['label' => '/flat-path', 'nb_visits' => 5]);
-                    return [$table, true, ['2020-03-04,2020-03-04' => true]];
+                    return [$table, true, ['1|2020-03-04,2020-03-04' => true]];
                 }
 
                 return [$table, false, []];
@@ -1023,6 +1025,7 @@ class RecordBuilderTest extends TestCase
                 $legacyTableB->addRowFromSimpleArray(['label' => '/legacy-path-b', 'nb_visits' => 3]);
 
                 yield [
+                    'idsite' => 1,
                     'date1' => '2020-03-05',
                     'date2' => '2020-03-05',
                     'name' => 'TestPlugin_hierarchy',
@@ -1030,6 +1033,7 @@ class RecordBuilderTest extends TestCase
                 ];
 
                 yield [
+                    'idsite' => 1,
                     'date1' => '2020-03-06',
                     'date2' => '2020-03-06',
                     'name' => 'TestPlugin_hierarchy',
@@ -1040,9 +1044,9 @@ class RecordBuilderTest extends TestCase
             protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
             {
                 return [
-                    '2020-03-04,2020-03-04' => true,
-                    '2020-03-05,2020-03-05' => true,
-                    '2020-03-06,2020-03-06' => true,
+                    '1|2020-03-04,2020-03-04' => true,
+                    '1|2020-03-05,2020-03-05' => true,
+                    '1|2020-03-06,2020-03-06' => true,
                 ];
             }
         };
@@ -1132,7 +1136,7 @@ class RecordBuilderTest extends TestCase
 
             protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
             {
-                return ['2020-03-04,2020-03-04' => true];
+                return ['1|2020-03-04,2020-03-04' => true];
             }
         };
 
@@ -1246,8 +1250,8 @@ class RecordBuilderTest extends TestCase
             protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
             {
                 return [
-                    '2020-03-05,2020-03-05' => true,
-                    '2020-03-06,2020-03-06' => true,
+                    '1|2020-03-05,2020-03-05' => true,
+                    '1|2020-03-06,2020-03-06' => true,
                 ];
             }
         };
@@ -1313,7 +1317,7 @@ class RecordBuilderTest extends TestCase
                     // Period 03-04 already has a flat record with paths overlapping the legacy hierarchy.
                     $table->addRowFromSimpleArray(['label' => '/products/shoes', 'nb_visits' => 10]);
                     $table->addRowFromSimpleArray(['label' => '/contact', 'nb_visits' => 2]);
-                    return [$table, true, ['2020-03-04,2020-03-04' => true]];
+                    return [$table, true, ['1|2020-03-04,2020-03-04' => true]];
                 }
                 return [$table, false, []];
             }
@@ -1341,8 +1345,8 @@ class RecordBuilderTest extends TestCase
             protected function getAllSubperiodKeys(ArchiveProcessor $archiveProcessor): array
             {
                 return [
-                    '2020-03-04,2020-03-04' => true,
-                    '2020-03-05,2020-03-05' => true,
+                    '1|2020-03-04,2020-03-04' => true,
+                    '1|2020-03-05,2020-03-05' => true,
                 ];
             }
         };
@@ -1820,7 +1824,7 @@ class RecordBuilderTest extends TestCase
      * spec), subtable blobs named $recordName_<id>. Root is yielded first so consumers can rely
      * on parent-before-child ordering, mirroring how ArchiveSelector orders rows.
      *
-     * @return iterable<array{name: string, date1: string, date2: string, value: string}>
+     * @return iterable<array{idsite: int, name: string, date1: string, date2: string, value: string}>
      */
     public static function serializeToArchiveRows(string $recordName, string $date, DataTable $table): iterable
     {
@@ -1828,6 +1832,7 @@ class RecordBuilderTest extends TestCase
         ksort($serialized);
         foreach ($serialized as $key => $value) {
             yield [
+                'idsite' => 1,
                 'name' => $key === 0 ? $recordName : $recordName . '_' . $key,
                 'date1' => $date,
                 'date2' => $date,


### PR DESCRIPTION
### Description

Archiving failed with `Uncaught exception: Error: Call to a member function getLabel() on false in core/Archive.php:837` when a day archive aggregates the day archives of multiple sites (e.g. a RollUpReporting roll-up site with `force_aggregate_raw_data_for_day = 0`) while flat-first Actions archiving (`datatable_archiving_maximum_rows_actions_flat > 0`) is enabled.

Investigating the crash surfaced two more defects on the same multi-site aggregation path, one of them predating flat-first archiving:

1. **Crash (flat-first, since 5.12.0):** `RecordBuilder::querySingleBlobRows()` built its `Archive` query from `getPeriod()->getSubperiods()` — which is empty for day periods — and from only the archived site's ID. `Archive::getPeriodLabel()` then calls `reset([])->getLabel()`. Fixed by using the same parameters as `ArchiveProcessor::getArchive()`: `Parameters::getSubPeriods()` (day-safe) and `Parameters::getIdSites()`.
2. **Silent data loss (since 5.0.0):** `ArchiveSelector::querySingleBlob()` deduplicated blob rows by (period, record name) only. When multiple sites share the same period in one archive query, all but one site's blobs were discarded — this affected the legacy (non-flat) aggregation path for every plugin as well. Fixed by including `idsite` in the dedup key and in the ORDER BY, keeping each site's rows together.
3. **Cross-site subtable collisions:** `BlobTableAggregator` mapped subtable IDs per period only, although every site's archive uses its own subtable ID space, so subtable blobs of one site could be attached to rows of another site. Fixed by keying the mapping (and the flat/legacy period discovery in `RecordBuilder`) per site and period via the new `BlobTableAggregator::getSitePeriodKey()` helper.

These paths only trigger when a plugin routes a day archive through multi-report aggregation (via the `ArchiveProcessor.Parameters.getIdSites` event, as RollUpReporting does); plain single-site setups are unaffected and behave identically before and after this change (`getIdSites()` returns one site, `getSubPeriods()` equals `getSubperiods()` for non-day periods).

Notes:
* Behavior change for non-day multi-site archives: the flat-first blob query now reads the child sites' day archives instead of the roll-up site's own day archives, restoring parity with the legacy path (`ArchiveProcessor::getArchive()` has always done this).
* The row shape/key format of the protected `RecordBuilder::querySingleBlobRows()` / `getAllSubperiodKeys()` changes. These helpers were only introduced with flat-first archiving in 5.12.0 and are not public plugin API; a sweep of all marketplace, InnoCraft and cloud plugins found no plugin overriding or calling them (or any other API touched here), so this is not called out in the changelog.
* The corrupt-chunk handling fix in `ArchiveSelector::querySingleBlob()` (missing `continue` after `yield`, previously a `TypeError`) has no dedicated test, as crafting a corrupt chunk fixture would need to bypass the archive writer.
* Chunked blobs in multi-site queries have no dedicated test either; the chunk expansion preserves `idsite` for every expanded row, so the site-qualified keying applies to them unchanged.

### Test coverage

* `MixedArchivingAggregationTest`: new tests for multi-site day archives with flat-first enabled (reproduces the reported crash and stack trace exactly), with legacy hierarchical archiving (reproduces the data loss, including cross-site subtable aggregation of overlapping subtable IDs), with mixed flat/legacy child day archives, and for a multi-site week archive with flat-first enabled.
* `BlobTableAggregatorTest`: new unit test for overlapping subtable ID spaces of multiple sites in the same period.
* All new tests were verified to fail without the fix (two crash with the reported error, the legacy test loses one site's data, the unit test cross-attaches subtables).

### Review

Please pay extra attention to:
* The ORDER BY change in `ArchiveSelector::getSqlTemplateToFetchArchiveData()` (`idsite` added between `date1` and the subtable ID) — single-site queries are unaffected, but all `querySingleBlob()` consumers rely on this ordering.
* The site-qualified key format change of the protected `RecordBuilder` methods (see changelog entry) with regard to a potential 5.x backport, where the silent contract change for third-party `RecordBuilder` subclasses weighs heavier than in a major release.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules




Backport of #24832.
