### PR TITLE
Allow filtering website by siteId when granting user access #24685

### DIFF
--- a/plugins/SitesManager/Model.php
+++ b/plugins/SitesManager/Model.php
@@ -410,13 +410,6 @@ class Model
 
         $bind = self::getPatternMatchSqlBind($pattern);
 
-        // Also match the idsite
-        $where = '';
-        if (is_numeric($pattern)) {
-            $bind[] = $pattern;
-            $where  = 'OR s.idsite = ?';
-        }
-
         $typeWhere = '';
         if (!empty($siteTypesToExclude)) {
             $bind = array_merge($bind, $siteTypesToExclude);
@@ -425,8 +418,7 @@ class Model
 
         $query = "SELECT *
                   FROM " . $this->table . " s
-                  WHERE ( " . self::getPatternMatchSqlQuery('s') . "
-                          $where ) $typeWhere
+                  WHERE ( " . self::getPatternMatchSqlQuery('s') . " ) $typeWhere
                      AND idsite in ($ids_str)";
 
         if ($limit && intval($limit) > 0) {
@@ -441,12 +433,15 @@ class Model
 
     public static function getPatternMatchSqlQuery($table)
     {
-        return "($table.name like ? OR $table.main_url like ? OR $table.group like ?)";
+        if (!in_array($table, ['s', 'site', 'a', 'access'])) {
+            $table = 's';
+        }
+        return "($table.name like ? OR $table.main_url like ? OR $table.group like ? OR $table.idsite = ?)";
     }
 
     public static function getPatternMatchSqlBind($pattern)
     {
-        return array('%' . $pattern . '%', 'http%' . $pattern . '%', '%' . $pattern . '%');
+        return array('%' . $pattern . '%', 'http%' . $pattern . '%', '%' . $pattern . '%', (int)$pattern);
     }
 
     /**


### PR DESCRIPTION
Fixes #24685
This is the Matomo 5 version of the GH-24685 issue

Description
Fixes an issue where admins could not search or filter websites by
`siteId` when editing a user's permissions in the UsersManager.

How it works
Updated `getPatternMatchSqlQuery` and `getPatternMatchSqlBind` in
`plugins/SitesManager/Model.php` to include an exact match for `idsite = ?`.
Since site IDs in Matomo always start from 1, searching for non-numeric
string patterns (e.g. "my-site") will safely cast to 0. This ensures that
non-numeric searches yield no matches for `idsite`, preventing false
positives while allowing exact ID matches to work perfectly.

Testing
Manually tested the string-to-int casting edge cases in PHP to guarantee
that non-numeric and literal "0" inputs safely evaluate to 0 without
matching any valid site IDs.

Checklist
[✔] I have understood, reviewed, and tested all AI outputs before use
[✔] All AI instructions respect security, IP, and privacy rules
Review
[ ✔] Functional review done
[ ✔] Potential edge cases thought about (behaviour of the code with
strange input, with strange internal state or possible interactions with
other Matomo subsystems)
[ ✔] Usability review done (is anything maybe unclear or think about
anything that would cause people to reach out to support)
[ ✔] Security review done
 Wording review done
[✔ ] Code review done
 Tests were added if useful/possible
[ ✔] Reviewed for breaking changes