### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -706,12 +706,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/referrer-spam-list.git",
-                "reference": "d94fc55b2bcd0a4f36fd32e8b4430ff5fd60d23d"
+                "reference": "4f1c7a8d99be37b0aa19ff93fcd8bd7f2d0bf27e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/d94fc55b2bcd0a4f36fd32e8b4430ff5fd60d23d",
-                "reference": "d94fc55b2bcd0a4f36fd32e8b4430ff5fd60d23d",
+                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/4f1c7a8d99be37b0aa19ff93fcd8bd7f2d0bf27e",
+                "reference": "4f1c7a8d99be37b0aa19ff93fcd8bd7f2d0bf27e",
                 "shasum": ""
             },
             "replace": {
@@ -729,7 +729,7 @@
                 "issues": "https://github.com/matomo-org/referrer-spam-list/issues",
                 "source": "https://github.com/matomo-org/referrer-spam-list/tree/master"
             },
-            "time": "2026-06-25T20:01:36+00:00"
+            "time": "2026-07-01T13:51:06+00:00"
         },
         {
             "name": "matomo/searchengine-and-social-list",
@@ -737,12 +737,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/searchengine-and-social-list.git",
-                "reference": "743a0faff8185340c6db38f3b7f1c13cf168cc5b"
+                "reference": "3b3a82dc83cd146abe17aafe31254de1c25f7844"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/searchengine-and-social-list/zipball/743a0faff8185340c6db38f3b7f1c13cf168cc5b",
-                "reference": "743a0faff8185340c6db38f3b7f1c13cf168cc5b",
+                "url": "https://api.github.com/repos/matomo-org/searchengine-and-social-list/zipball/3b3a82dc83cd146abe17aafe31254de1c25f7844",
+                "reference": "3b3a82dc83cd146abe17aafe31254de1c25f7844",
                 "shasum": ""
             },
             "replace": {
@@ -759,7 +759,7 @@
                 "issues": "https://github.com/matomo-org/searchengine-and-social-list/issues",
                 "source": "https://github.com/matomo-org/searchengine-and-social-list/tree/master"
             },
-            "time": "2025-12-15T20:05:07+00:00"
+            "time": "2026-07-15T21:31:22+00:00"
         },
         {
             "name": "maxmind-db/reader",
@@ -4527,25 +4527,25 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.52",
+            "version": "8.5.53",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1015741814413c156abb0f53d7db7bbd03c6e858"
+                "reference": "17cd4291b0ef645b6d21e5ddb6f497694c5e9bcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1015741814413c156abb0f53d7db7bbd03c6e858",
-                "reference": "1015741814413c156abb0f53d7db7bbd03c6e858",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17cd4291b0ef645b6d21e5ddb6f497694c5e9bcd",
+                "reference": "17cd4291b0ef645b6d21e5ddb6f497694c5e9bcd",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.5.0",
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
@@ -4605,31 +4605,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.52"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.53"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-01-27T05:20:18+00:00"
+            "time": "2026-07-06T14:29:25+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 3 updates, 0 removals
  - Upgrading matomo/referrer-spam-list (dev-master d94fc55 => dev-master 4f1c7a8)
  - Upgrading matomo/searchengine-and-social-list (dev-master 743a0fa => dev-master 3b3a82d)
  - Upgrading phpunit/phpunit (8.5.52 => 8.5.53)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 3 updates, 0 removals
  - Downloading matomo/referrer-spam-list (dev-master 4f1c7a8)
  - Downloading matomo/searchengine-and-social-list (dev-master 3b3a82d)
  - Downloading phpunit/phpunit (8.5.53)
  - Upgrading matomo/referrer-spam-list (dev-master d94fc55 => dev-master 4f1c7a8): Extracting archive
  - Upgrading matomo/searchengine-and-social-list (dev-master 743a0fa => dev-master 3b3a82d): Extracting archive
  - Upgrading phpunit/phpunit (8.5.52 => 8.5.53): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
54 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Found 15 ignored security vulnerability advisories affecting 1 package.
Run "composer audit" for a full list of advisories.
```
