### PR TITLE
Show Referrers channel-type percentages with enough precision so small non-zero shares are not displayed as 0%

### DIFF
--- a/plugins/PrivacyManager/tests/System/expected/test_DataRoundingCoverage_cnil_enabled_segmented__Referrers.get_year.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_DataRoundingCoverage_cnil_enabled_segmented__Referrers.get_year.xml
@@ -13,10 +13,10 @@
 	<Referrers_distinctWebsites>20</Referrers_distinctWebsites>
 	<Referrers_distinctWebsitesUrls>40</Referrers_distinctWebsitesUrls>
 	<Referrers_distinctCampaigns>10</Referrers_distinctCampaigns>
-	<Referrers_visitorsFromDirectEntry_percent>57%</Referrers_visitorsFromDirectEntry_percent>
-	<Referrers_visitorsFromSearchEngines_percent>14%</Referrers_visitorsFromSearchEngines_percent>
-	<Referrers_visitorsFromAIAssistants_percent>7%</Referrers_visitorsFromAIAssistants_percent>
-	<Referrers_visitorsFromCampaigns_percent>5%</Referrers_visitorsFromCampaigns_percent>
+	<Referrers_visitorsFromDirectEntry_percent>57.01%</Referrers_visitorsFromDirectEntry_percent>
+	<Referrers_visitorsFromSearchEngines_percent>14.25%</Referrers_visitorsFromSearchEngines_percent>
+	<Referrers_visitorsFromAIAssistants_percent>7.13%</Referrers_visitorsFromAIAssistants_percent>
+	<Referrers_visitorsFromCampaigns_percent>4.75%</Referrers_visitorsFromCampaigns_percent>
 	<Referrers_visitorsFromSocialNetworks_percent>0%</Referrers_visitorsFromSocialNetworks_percent>
-	<Referrers_visitorsFromWebsites_percent>17%</Referrers_visitorsFromWebsites_percent>
+	<Referrers_visitorsFromWebsites_percent>16.63%</Referrers_visitorsFromWebsites_percent>
 </result>

--- a/plugins/Referrers/Columns/Metrics/VisitorsFromReferrerPercent.php
+++ b/plugins/Referrers/Columns/Metrics/VisitorsFromReferrerPercent.php
@@ -52,7 +52,9 @@ class VisitorsFromReferrerPercent extends ProcessedMetric
     public function compute(Row $row)
     {
         $columnValue = self::getMetric($row, $this->referrerSourceColumn);
-        $result = Piwik::getQuotientSafe($columnValue, $this->totalVisits, $precision = 2);
+        // Keep enough quotient precision so that very small non-zero shares (e.g. 0.4% -> 0.004)
+        // survive until the formatter applies display rounding, instead of collapsing to 0%.
+        $result = Piwik::getQuotientSafe($columnValue, $this->totalVisits, $precision = 4);
         return $result;
     }
 

--- a/plugins/Referrers/tests/System/expected/test_formattedMetrics__Referrers.get_year.xml
+++ b/plugins/Referrers/tests/System/expected/test_formattedMetrics__Referrers.get_year.xml
@@ -14,9 +14,9 @@
 	<Referrers_distinctWebsitesUrls>10</Referrers_distinctWebsitesUrls>
 	<Referrers_distinctCampaigns>0</Referrers_distinctCampaigns>
 	<Referrers_visitorsFromDirectEntry_percent>0%</Referrers_visitorsFromDirectEntry_percent>
-	<Referrers_visitorsFromSearchEngines_percent>33%</Referrers_visitorsFromSearchEngines_percent>
-	<Referrers_visitorsFromAIAssistants_percent>33%</Referrers_visitorsFromAIAssistants_percent>
+	<Referrers_visitorsFromSearchEngines_percent>33.33%</Referrers_visitorsFromSearchEngines_percent>
+	<Referrers_visitorsFromAIAssistants_percent>33.33%</Referrers_visitorsFromAIAssistants_percent>
 	<Referrers_visitorsFromCampaigns_percent>0%</Referrers_visitorsFromCampaigns_percent>
 	<Referrers_visitorsFromSocialNetworks_percent>0%</Referrers_visitorsFromSocialNetworks_percent>
-	<Referrers_visitorsFromWebsites_percent>33%</Referrers_visitorsFromWebsites_percent>
+	<Referrers_visitorsFromWebsites_percent>33.33%</Referrers_visitorsFromWebsites_percent>
 </result>

--- a/plugins/Referrers/tests/System/expected/test_unformattedMetrics__Referrers.get_year.xml
+++ b/plugins/Referrers/tests/System/expected/test_unformattedMetrics__Referrers.get_year.xml
@@ -14,9 +14,9 @@
 	<Referrers_distinctWebsitesUrls>10</Referrers_distinctWebsitesUrls>
 	<Referrers_distinctCampaigns>0</Referrers_distinctCampaigns>
 	<Referrers_visitorsFromDirectEntry_percent>0</Referrers_visitorsFromDirectEntry_percent>
-	<Referrers_visitorsFromSearchEngines_percent>0.33</Referrers_visitorsFromSearchEngines_percent>
-	<Referrers_visitorsFromAIAssistants_percent>0.33</Referrers_visitorsFromAIAssistants_percent>
+	<Referrers_visitorsFromSearchEngines_percent>0.3333</Referrers_visitorsFromSearchEngines_percent>
+	<Referrers_visitorsFromAIAssistants_percent>0.3333</Referrers_visitorsFromAIAssistants_percent>
 	<Referrers_visitorsFromCampaigns_percent>0</Referrers_visitorsFromCampaigns_percent>
 	<Referrers_visitorsFromSocialNetworks_percent>0</Referrers_visitorsFromSocialNetworks_percent>
-	<Referrers_visitorsFromWebsites_percent>0.33</Referrers_visitorsFromWebsites_percent>
+	<Referrers_visitorsFromWebsites_percent>0.3333</Referrers_visitorsFromWebsites_percent>
 </result>

--- a/plugins/Referrers/tests/UI/expected-screenshots/ReferrersPages_overview.png
+++ b/plugins/Referrers/tests/UI/expected-screenshots/ReferrersPages_overview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88cf8660a92dcdb8c02f7d503801b060475f60cfd3ea7667a1aba507bb659ec6
-size 72495
+oid sha256:dc601cddf9498cf8c42af99d0cbeaa2caab2c148e93fcff56c121eaa72804ea7
+size 74133

--- a/plugins/Referrers/tests/Unit/VisitorsFromReferrerPercentTest.php
+++ b/plugins/Referrers/tests/Unit/VisitorsFromReferrerPercentTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Referrers\tests\Unit;
+
+use Piwik\DataTable\Row;
+use Piwik\Plugins\Referrers\Columns\Metrics\VisitorsFromReferrerPercent;
+
+/**
+ * @group Referrers
+ */
+class VisitorsFromReferrerPercentTest extends \PHPUnit\Framework\TestCase
+{
+    private const SOURCE_COLUMN = 'Referrers_visitorsFromSearchEngines';
+
+    /**
+     * @dataProvider getComputeTestData
+     */
+    public function testComputePreservesPrecisionForSmallShares($visits, $totalVisits, $expectedQuotient)
+    {
+        $metric = new VisitorsFromReferrerPercent('name', self::SOURCE_COLUMN, $totalVisits);
+
+        $row = new Row([Row::COLUMNS => [self::SOURCE_COLUMN => $visits]]);
+
+        $this->assertEqualsWithDelta($expectedQuotient, $metric->compute($row), 1e-9);
+    }
+
+    public function getComputeTestData(): array
+    {
+        return [
+            // A very small but non-zero share (0.4%) must not collapse to 0. This is the
+            // regression this metric fixes: 4 / 1000 = 0.004 used to be rounded to 0.00.
+            'small non-zero share stays non-zero' => [4, 1000, 0.004],
+            'sub-percent share' => [4, 10000, 0.0004],
+            'even third keeps two percent decimals' => [1, 3, 0.3333],
+            'exact share' => [250, 1000, 0.25],
+            'zero visits' => [0, 1000, 0],
+            'zero total avoids division by zero' => [5, 0, 0],
+        ];
+    }
+}

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Referrers.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Referrers.get_month.xml
@@ -13,10 +13,10 @@
 	<Referrers_distinctWebsites>4</Referrers_distinctWebsites>
 	<Referrers_distinctWebsitesUrls>4</Referrers_distinctWebsitesUrls>
 	<Referrers_distinctCampaigns>0</Referrers_distinctCampaigns>
-	<Referrers_visitorsFromDirectEntry_percent>91%</Referrers_visitorsFromDirectEntry_percent>
+	<Referrers_visitorsFromDirectEntry_percent>90.7%</Referrers_visitorsFromDirectEntry_percent>
 	<Referrers_visitorsFromSearchEngines_percent>0%</Referrers_visitorsFromSearchEngines_percent>
 	<Referrers_visitorsFromAIAssistants_percent>0%</Referrers_visitorsFromAIAssistants_percent>
 	<Referrers_visitorsFromCampaigns_percent>0%</Referrers_visitorsFromCampaigns_percent>
 	<Referrers_visitorsFromSocialNetworks_percent>0%</Referrers_visitorsFromSocialNetworks_percent>
-	<Referrers_visitorsFromWebsites_percent>9%</Referrers_visitorsFromWebsites_percent>
+	<Referrers_visitorsFromWebsites_percent>9.3%</Referrers_visitorsFromWebsites_percent>
 </result>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_html_tables_only__ScheduledReports.generateReport_month.original.html
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_html_tables_only__ScheduledReports.generateReport_month.original.html
@@ -5142,7 +5142,7 @@
                                                                 <td style="padding:17px 15px;;font-size: 15px;font-variant-numeric: tabular-nums;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Percent of Visitors from Direct Entry                                                                                                                        </td>
                                             <td style="padding:17px 15px; text-align:right;;font-size: 15px;font-variant-numeric: tabular-nums;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                                                9%
+                                                                                                9.09%
                                                                                     </td>
                                     </tr>
                             
@@ -5166,7 +5166,7 @@
                                                                 <td style="padding:17px 15px;;font-size: 15px;font-variant-numeric: tabular-nums;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Percent of Visitors from Campaigns                                                                                                                        </td>
                                             <td style="padding:17px 15px; text-align:right;;font-size: 15px;font-variant-numeric: tabular-nums;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                                                36%
+                                                                                                36.36%
                                                                                     </td>
                                     </tr>
                             
@@ -5182,7 +5182,7 @@
                                                                 <td style="padding:17px 15px;;font-size: 15px;font-variant-numeric: tabular-nums;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Percent of Visitors from Websites                                                                                                                        </td>
                                             <td style="padding:17px 15px; text-align:right;;font-size: 15px;font-variant-numeric: tabular-nums;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                                                55%
+                                                                                                54.55%
                                                                                     </td>
                                     </tr>
                         </tbody>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_in_csv__ScheduledReports.generateReport_month.original.csv
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_in_csv__ScheduledReports.generateReport_month.original.csv
@@ -320,7 +320,7 @@ avg_time_network,avg_time_server,avg_time_transfer,avg_time_dom_processing,avg_t
 
 Referrers Overview
 Referrers_visitorsFromSearchEngines,Referrers_visitorsFromSocialNetworks,Referrers_visitorsFromAIAssistants,Referrers_visitorsFromDirectEntry,Referrers_visitorsFromWebsites,Referrers_visitorsFromCampaigns,Referrers_distinctSearchEngines,Referrers_distinctSocialNetworks,Referrers_distinctAIAssistants,Referrers_distinctKeywords,Referrers_distinctWebsites,Referrers_distinctCampaigns,Referrers_visitorsFromDirectEntry_percent,Referrers_visitorsFromSearchEngines_percent,Referrers_visitorsFromAIAssistants_percent,Referrers_visitorsFromCampaigns_percent,Referrers_visitorsFromSocialNetworks_percent,Referrers_visitorsFromWebsites_percent
-0,0,0,1,6,4,0,0,0,0,1,1,9%,0%,0%,36%,0%,55%
+0,0,0,1,6,4,0,0,0,0,1,1,9.09%,0%,0%,36.36%,0%,54.55%
 
 Channel Type
 label,nb_visits,nb_actions,nb_actions_per_visit,avg_time_on_site,bounce_rate,revenue

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_in_tsv__ScheduledReports.generateReport_month.original.tsv
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_in_tsv__ScheduledReports.generateReport_month.original.tsv
@@ -320,7 +320,7 @@ avg_time_network	avg_time_server	avg_time_transfer	avg_time_dom_processing	avg_t
 
 Referrers Overview
 Referrers_visitorsFromSearchEngines	Referrers_visitorsFromSocialNetworks	Referrers_visitorsFromAIAssistants	Referrers_visitorsFromDirectEntry	Referrers_visitorsFromWebsites	Referrers_visitorsFromCampaigns	Referrers_distinctSearchEngines	Referrers_distinctSocialNetworks	Referrers_distinctAIAssistants	Referrers_distinctKeywords	Referrers_distinctWebsites	Referrers_distinctCampaigns	Referrers_visitorsFromDirectEntry_percent	Referrers_visitorsFromSearchEngines_percent	Referrers_visitorsFromAIAssistants_percent	Referrers_visitorsFromCampaigns_percent	Referrers_visitorsFromSocialNetworks_percent	Referrers_visitorsFromWebsites_percent
-0	0	0	1	6	4	0	0	0	0	1	1	9%	0%	0%	36%	0%	55%
+0	0	0	1	6	4	0	0	0	0	1	1	9.09%	0%	0%	36.36%	0%	54.55%
 
 Channel Type
 label	nb_visits	nb_actions	nb_actions_per_visit	avg_time_on_site	bounce_rate	revenue

--- a/tests/UI/expected-screenshots/UIIntegrationTest_widgets_listing.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_widgets_listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b72e1aae7e59c3d3dd282fd9a35f315a9e1cd749824298a1d7ff518163305dc
-size 190328
+oid sha256:b30a1740739fd6d054dfd3d48d8f930dfe8eed572e19644f8b45152f3c85368d
+size 190859

--- a/tests/UI/expected-screenshots/UIIntegrationTest_widgets_listing.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_widgets_listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b30a1740739fd6d054dfd3d48d8f930dfe8eed572e19644f8b45152f3c85368d
-size 190859
+oid sha256:9b72e1aae7e59c3d3dd282fd9a35f315a9e1cd749824298a1d7ff518163305dc
+size 190328


### PR DESCRIPTION
### Description

**Problem**

On **Referrers > Overview**, the Channel Types percentages could display a very small but non-zero share as `0%`. For example a channel contributing `0.4%` of visits was shown as `0%`, making it look as though the channel generated no traffic.

refs #21812

**Root cause**

`VisitorsFromReferrerPercent::compute()` rounded the visit-share quotient to 2 decimal places before the value reached the formatter. A `0.4%` share has a quotient of `0.004`, which rounds to `0.00`, so the formatter could only ever render `0%`. The precision was being lost in the calculation step rather than at display time.

**Changes**

- `plugins/Referrers/Columns/Metrics/VisitorsFromReferrerPercent.php`: raise the quotient precision from `2` to `4` in `compute()`, so small non-zero shares survive until the formatter applies display rounding. This matches the precision already used by comparable percentage metrics that format through `getPrettyPercentFromQuotient()` (e.g. `CoreHome\Columns\Metrics\ConversionRate`, `Contents\Columns\Metrics\InteractionRate`, `BotTracking\Columns\Metrics\ClickThroughRate`). Percentages now display with up to two decimal places (e.g. `0.4%`, `57.01%`), and only shares below `0.005%` still round to `0%`.

**Tests / validation**

- Added `plugins/Referrers/tests/Unit/VisitorsFromReferrerPercentTest.php` covering the regression directly: a `4 / 1000` share now computes `0.004` (previously `0`), plus sub-percent, exact-share, zero-visit, and zero-total (division-by-zero) cases.
- Updated the affected system-test expectations, which now show the additional precision:
  - `plugins/Referrers/tests/System/expected/test_formattedMetrics__Referrers.get_year.xml` and `test_unformattedMetrics__Referrers.get_year.xml`
  - `plugins/PrivacyManager/tests/System/expected/test_DataRoundingCoverage_cnil_enabled_segmented__Referrers.get_year.xml`
  - `tests/PHPUnit/System/expected/test_ImportLogs__Referrers.get_month.xml`
  - `tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_schedrep_*` (ScheduledReports HTML/CSV/TSV outputs that embed the Referrers Overview table)
- Updated the UI screenshot baselines that render these percentages.
- Passing locally: `Referrers` unit test (6/6), `Referrers` `ApiTest` (16/16), `PrivacyManager` `DataRoundingCoverageTest` (11/11), core `ImportLogsTest` (10/10), core `TwoVisitorsTwoWebsitesDifferentDaysTest` (16/16).
- PHPCS and PHPStan clean on the changed files.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

