### PR TITLE
Minor hardening and cleanup improvements

### DIFF
--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -224,7 +224,7 @@ class Cookie
 
         if (
             substr($content, -43, 3) === self::VALUE_SEPARATOR . '_=' &&
-            ($signature === sha1(substr($content, 0, -40) . SettingsPiwik::getSalt()))
+            hash_equals(sha1(substr($content, 0, -40) . SettingsPiwik::getSalt()), $signature)
         ) {
             // strip trailing: VALUE_SEPARATOR '_=' signature"
             return substr($content, 0, -43);

--- a/core/CronArchive/ArchiveFilter.php
+++ b/core/CronArchive/ArchiveFilter.php
@@ -251,14 +251,6 @@ class ArchiveFilter
     /**
      * @return array
      */
-    private function getPeriodsToProcess()
-    {
-        return $this->restrictToPeriods;
-    }
-
-    /**
-     * @return array
-     */
     private function getDefaultPeriodsToProcess()
     {
         return array('day', 'week', 'month', 'year', 'range');

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -459,20 +459,6 @@ class QueueConsumer
         return false;
     }
 
-    private function isArchiveNonSegmentAndInProgressArchiveSegment(array $archiveToProcess, array $archiveBeingProcessed): bool
-    {
-        // archive is for different site/period
-        if (
-            $archiveToProcess['idsite'] != $archiveBeingProcessed['idsite']
-            || $archiveToProcess['periodObj']->getId() != $archiveBeingProcessed['periodObj']->getId()
-            || $archiveToProcess['periodObj']->getDateStart()->toString() != $archiveBeingProcessed['periodObj']->getDateStart()->toString()
-        ) {
-            return false;
-        }
-
-        return empty($archiveToProcess['segment']) && !empty($archiveBeingProcessed['segment']);
-    }
-
     private function detectPluginForArchive(&$archive): void
     {
         $archive['plugin'] = $this->getPluginNameForArchiveIfAny($archive);

--- a/core/ProfessionalServices/Advertising.php
+++ b/core/ProfessionalServices/Advertising.php
@@ -87,26 +87,6 @@ class Advertising
     }
 
     /**
-     * @deprecated
-     * Generates campaign URL parameters that can be used with promoting Professional Support service.
-     *
-     * @param string $campaignName
-     * @param string $campaignMedium
-     * @param string $campaignContent Optional
-     * @return string URL parameters without a leading ? or &
-     */
-    private function getCampaignParametersForPromoUrl($campaignName, $campaignMedium, $campaignContent = '')
-    {
-        $campaignName = sprintf('pk_campaign=%s&pk_medium=%s&pk_source=Matomo_App', $campaignName, $campaignMedium);
-
-        if (!empty($campaignContent)) {
-            $campaignName .= '&pk_content=' . $campaignContent;
-        }
-
-        return $campaignName;
-    }
-
-    /**
      * @param $configGeneralSection
      * @return bool
      */

--- a/core/Updates/2.0.4-b5.php
+++ b/core/Updates/2.0.4-b5.php
@@ -13,6 +13,7 @@ use Piwik\Common;
 use Piwik\Config;
 use Piwik\Date;
 use Piwik\Db;
+use Piwik\Log;
 use Piwik\Plugins\UsersManager\API as UsersManagerApi;
 use Piwik\Updater;
 use Piwik\UpdaterErrorException;
@@ -86,7 +87,9 @@ class Updates_2_0_4_b5 extends Updates
                     'superuser_access' => 1,
                 ));
         } catch (\Exception $e) {
-            echo "There was an issue, but we proceed: " . $e->getMessage();
+            // best effort insert - if it fails we proceed anyway and only log the details server side
+            // instead of writing them to the update output
+            Log::warning('Could not insert super user during 2.0.4-b5 update, proceeding anyway: %s', $e->getMessage());
         }
 
         if (array_key_exists('salt', $superUser)) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4405,12 +4405,6 @@ parameters:
 			path: plugins/UsersManager/Controller.php
 
 		-
-			message: '#^Method Piwik\\Plugins\\UsersManager\\Controller\:\:getIgnoreCookieSalt\(\) is unused\.$#'
-			identifier: method.unused
-			count: 1
-			path: plugins/UsersManager/Controller.php
-
-		-
 			message: '#^Method Piwik\\Plugins\\UsersManager\\Controller\:\:noAdminAccessToWebsite\(\) is unused\.$#'
 			identifier: method.unused
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4405,12 +4405,6 @@ parameters:
 			path: plugins/UsersManager/Controller.php
 
 		-
-			message: '#^Method Piwik\\Plugins\\UsersManager\\Controller\:\:noAdminAccessToWebsite\(\) is unused\.$#'
-			identifier: method.unused
-			count: 1
-			path: plugins/UsersManager/Controller.php
-
-		-
 			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -475,12 +475,6 @@ parameters:
 			path: core/CronArchive.php
 
 		-
-			message: '#^Method Piwik\\CronArchive\\ArchiveFilter\:\:getPeriodsToProcess\(\) is unused\.$#'
-			identifier: method.unused
-			count: 1
-			path: core/CronArchive/ArchiveFilter.php
-
-		-
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
 			count: 1
@@ -489,12 +483,6 @@ parameters:
 		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
-			count: 1
-			path: core/CronArchive/QueueConsumer.php
-
-		-
-			message: '#^Method Piwik\\CronArchive\\QueueConsumer\:\:isArchiveNonSegmentAndInProgressArchiveSegment\(\) is unused\.$#'
-			identifier: method.unused
 			count: 1
 			path: core/CronArchive/QueueConsumer.php
 
@@ -1253,12 +1241,6 @@ parameters:
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: core/Policy/PolicyManager.php
-
-		-
-			message: '#^Method Piwik\\ProfessionalServices\\Advertising\:\:getCampaignParametersForPromoUrl\(\) is unused\.$#'
-			identifier: method.unused
-			count: 1
-			path: core/ProfessionalServices/Advertising.php
 
 		-
 			message: '#^Property Piwik\\ProfessionalServices\\Advertising\:\:\$pluginManager is never read, only written\.$#'
@@ -3161,12 +3143,6 @@ parameters:
 			identifier: empty.variable
 			count: 2
 			path: plugins/CustomDimensions/Dimension/Extraction.php
-
-		-
-			message: '#^Method Piwik\\Plugins\\CustomDimensions\\Dimension\\Index\:\:getConfiguration\(\) is unused\.$#'
-			identifier: method.unused
-			count: 1
-			path: plugins/CustomDimensions/Dimension/Index.php
 
 		-
 			message: '#^Call to Piwik\\Plugin\\Report\:\:init\(\) on a separate line has no effect\.$#'

--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -257,10 +257,13 @@ var broadcast = {
         if (valFromUrl != '' || urlStr.indexOf(paramName + '=') !== -1) {
             // replacing current param=value to newParamValue;
             valFromUrl = getQuotedRegex(valFromUrl);
-            var regToBeReplace = new RegExp(paramName + '=' + valFromUrl, 'ig');
+            // the parameter name is also embedded into the regular expression, so escape it as well to make sure
+            // it is always matched literally
+            var quotedParamName = getQuotedRegex(paramName);
+            var regToBeReplace = new RegExp(quotedParamName + '=' + valFromUrl, 'ig');
             if (newParamValue == '') {
                 // if new value is empty remove leading &, as well
-                regToBeReplace = new RegExp('[\&]?(' + paramName + '|' + encodeURIComponent(paramName) + ')=' + valFromUrl, 'ig');
+                regToBeReplace = new RegExp('[\&]?(' + quotedParamName + '|' + getQuotedRegex(encodeURIComponent(paramName)) + ')=' + valFromUrl, 'ig');
             }
             urlStr = urlStr.replace(regToBeReplace, newParamValue);
         } else if (newParamValue != '') {

--- a/plugins/CustomDimensions/Dimension/Index.php
+++ b/plugins/CustomDimensions/Dimension/Index.php
@@ -11,7 +11,6 @@ namespace Piwik\Plugins\CustomDimensions\Dimension;
 
 use Exception;
 use Piwik\API\Request;
-use Piwik\Plugins\CustomDimensions\Dao\Configuration;
 use Piwik\Plugins\CustomDimensions\Dao\LogTable;
 
 class Index
@@ -43,10 +42,5 @@ class Index
     private function getTracking($scope)
     {
         return new LogTable($scope);
-    }
-
-    private function getConfiguration()
-    {
-        return new Configuration();
     }
 }

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -817,12 +817,4 @@ class Controller extends ControllerAdmin
         $auth->setPassword($newPassword);
         $sessionInitializer->initSession($auth);
     }
-
-    /**
-     * @return string
-     */
-    private function getIgnoreCookieSalt()
-    {
-        return md5(SettingsPiwik::getSalt());
-    }
 }

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -737,18 +737,6 @@ class Controller extends ControllerAdmin
         $this->redirectToIndex('UsersManager', 'userSecurity');
     }
 
-    private function noAdminAccessToWebsite($idSiteSelected, $defaultReportSiteName, $message)
-    {
-        $view = new View('@UsersManager/noWebsiteAdminAccess');
-
-        $view->idSiteSelected = $idSiteSelected;
-        $view->defaultReportSiteName = $defaultReportSiteName;
-        $view->message = $message;
-        $this->setBasicVariablesView($view);
-
-        return $view->render();
-    }
-
     private function processEmailChange($userLogin)
     {
         if (!UsersManager::isUsersAdminEnabled()) {

--- a/plugins/UsersManager/templates/noWebsiteAdminAccess.twig
+++ b/plugins/UsersManager/templates/noWebsiteAdminAccess.twig
@@ -1,9 +1,0 @@
-{% extends '@UsersManager/index.twig' %}
-
-{% block websiteAccessTable %}
-
-    <div class="notification system notification-error">
-        {{ message }}
-    </div>
-
-{% endblock %}


### PR DESCRIPTION
## Description

A set of small, self-contained code hardening and cleanup changes.

### Hardening

- **`core/Cookie.php`** – use `hash_equals()` instead of `===` when comparing the (backward-compatibility only) signed-cookie value, so the comparison runs in constant time.
- **`plugins/CoreHome/javascripts/broadcast.js`** – escape the parameter name (and its URL-encoded form) through the existing `getQuotedRegex()` helper before embedding it into the replacement `RegExp` in `updateParamValue()`. For the regular, hardcoded parameter names this is a no-op; it just makes sure the name is always matched literally (`encodeURIComponent()` can legitimately emit `* ( ) '`, which are regex metacharacters).

### Cleanup

- Remove several unused private methods, together with their now-stale PHPStan baseline entries:
  - `UsersManager\Controller::getIgnoreCookieSalt()`
  - `UsersManager\Controller::noAdminAccessToWebsite()` (and the `noWebsiteAdminAccess` template it rendered, which nothing else referenced)
  - `CronArchive\ArchiveFilter::getPeriodsToProcess()`
  - `CronArchive\QueueConsumer::isArchiveNonSegmentAndInProgressArchiveSegment()`
  - `ProfessionalServices\Advertising::getCampaignParametersForPromoUrl()`
  - `CustomDimensions\Dimension\Index::getConfiguration()` (and its now-unused `Configuration` import)
- **`core/Updates/2.0.4-b5.php`** – log the best-effort super user insert failure via `Log::warning()` instead of echoing the raw exception message into the update output.

### Note on the migration change

`core/Updates/2.0.4-b5.php` already exists on the target branch, and update files are normally treated as immutable. This edit is intentional and safe: it only changes **where** a caught exception is reported (server-side log instead of the update output), does not alter any migration logic or schema, and the insert is best-effort by design.

## Review

- [x] `phpcs` clean on the changed PHP files
- [x] `phpstan` clean on the changed PHP files
- [x] `CookieTest` (unit) green

A backport to `5.x-dev` will follow once this is approved.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
