### PR TITLE
Gate addCapabilities/removeCapabilities behind enable_users_admin

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1306,6 +1306,8 @@ class API extends \Piwik\Plugin\API
      */
     public function addCapabilities(string $userLogin, $capabilities, $idSites): void
     {
+        UsersManager::dieIfUsersAdminIsDisabled();
+
         $userLogin = $this->getCanonicalLogin($userLogin);
 
         $this->executeConcurrencySafe($userLogin, function () use ($userLogin, $capabilities, $idSites) {
@@ -1408,6 +1410,8 @@ class API extends \Piwik\Plugin\API
      */
     public function removeCapabilities(string $userLogin, $capabilities, $idSites): void
     {
+        UsersManager::dieIfUsersAdminIsDisabled();
+
         $this->executeConcurrencySafe($userLogin, function () use ($userLogin, $capabilities, $idSites) {
             $idSites = $this->getIdSitesCheckAdminAccess($idSites);
 

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -176,6 +176,7 @@ class APITest extends IntegrationTestCase
     public function tearDown(): void
     {
         Config::getInstance()->General['enable_update_users_email'] = 1;
+        Config::getInstance()->General['enable_users_admin'] = 1;
 
         parent::tearDown();
     }
@@ -1473,6 +1474,16 @@ class APITest extends IntegrationTestCase
         $this->api->addCapabilities('foobar', [TestCap2::ID], [1]);
     }
 
+    public function testAddCapabilitiesFailsWhenUsersAdminIsDisabled()
+    {
+        Config::getInstance()->General['enable_users_admin'] = 0;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('has been disabled');
+
+        $this->api->addCapabilities($this->login, [TestCap2::ID], [1]);
+    }
+
     public function testAddCapabilitiesDoesNotAddSameCapabilityTwice()
     {
         $addAccess = [TestCap2::ID, View::ID, TestCap3::ID];
@@ -1570,6 +1581,16 @@ class APITest extends IntegrationTestCase
         $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
 
         $this->api->removeCapabilities('foobar', [TestCap2::ID], [1]);
+    }
+
+    public function testRemoveCapabilitiesFailsWhenUsersAdminIsDisabled()
+    {
+        Config::getInstance()->General['enable_users_admin'] = 0;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('has been disabled');
+
+        $this->api->removeCapabilities($this->login, [TestCap2::ID], [1]);
     }
 
     public function testRemoveCapabilities()


### PR DESCRIPTION
## Description

The `enable_users_admin` config option (default `1`) is meant to disable user management across an instance. When set to `0`, the user-mutating `UsersManager.API` methods (`addUser`, `inviteUser`, `updateUser`, `deleteUser`, `setUserAccess`, `setSuperUserAccess`) already refuse to run via `UsersManager::dieIfUsersAdminIsDisabled()`.

`addCapabilities()` and `removeCapabilities()` were not aligned with that behaviour and still allowed modifying a user's access while user management was disabled.

This change gates both capability methods the same way as the other access-mutation methods, so the toggle consistently disables all permission changes.

## Changes

- `addCapabilities()` and `removeCapabilities()` now call `UsersManager::dieIfUsersAdminIsDisabled()`.
- Added integration test coverage for both methods when `enable_users_admin = 0`.

## Review

- [ ] Functional review

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
