### PR TITLE
Fix broken json response

### DIFF
--- a/plugins/SitesManager/Controller.php
+++ b/plugins/SitesManager/Controller.php
@@ -305,19 +305,19 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         }
 
         Json::sendHeaderJSON();
-        echo json_encode([
+        return json_encode([
             'trackingMethods' => $trackingMethods,
             'recommendedMethod' => $recommendedMethod,
             // The standalone page gets this as a template variable; the SPA gate has to fetch it.
             'ctaContent' => $this->renderSiteWithoutDataCta(),
         ]);
-        exit;
     }
 
     private function renderSiteWithoutDataCta(): string
     {
         $view = new View('@SitesManager/_siteWithoutDataCta');
         $view->inviteUserLink = $this->getInviteUserLink();
+        $view->sendHeadersWhenRendering = false;
         return $view->render();
     }
 


### PR DESCRIPTION
### Description

`getTrackingMethodsForSite` incorrectly returned a html response, due to `renderSiteWithoutDataCta` overwriting the JSON header.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)



Backport of #24867.
