### PR TITLE
Remove five lowest-risk long-standing deprecations for Matomo 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ### Breaking Changes
 * The deprecated method `Piwik\Archive::getBlob()` has been removed. Use one of the `Piwik\Archive::getDataTable*()` methods instead.
 * The deprecated method `Piwik\Archive::clearStaticCache()` has been removed. It was a no-op kept only for backwards compatibility.
+* The deprecated method `Piwik\ArchiveProcessor\Parameters::setIsPartialArchive()` has been removed. Use `Piwik\ArchiveProcessor\Parameters::setArchiveOnlyReport()` instead.
 * The deprecated method `Piwik\Plugins\Overlay\API::getExcludedQueryParameters()` has been removed. Use the `SitesManager.getExcludedQueryParameters` API method instead.
 * The deprecated method `Piwik\Db::optimizeTables()` has been removed. Use `Piwik\Db\Schema::getInstance()->optimizeTables()` instead.
 * The deprecated method `Piwik\Db::isOptimizeInnoDBSupported()` has been removed. Use `Piwik\Db\Schema::getInstance()->isOptimizeInnoDBSupported()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 
 ### Breaking Changes
 * The deprecated method `Piwik\Archive::getBlob()` has been removed. Use one of the `Piwik\Archive::getDataTable*()` methods instead.
+* The deprecated method `Piwik\Archive::clearStaticCache()` has been removed. It was a no-op kept only for backwards compatibility.
 * The deprecated method `Piwik\Plugins\Overlay\API::getExcludedQueryParameters()` has been removed. Use the `SitesManager.getExcludedQueryParameters` API method instead.
 * The deprecated method `Piwik\Db::optimizeTables()` has been removed. Use `Piwik\Db\Schema::getInstance()->optimizeTables()` instead.
 * The deprecated method `Piwik\Db::isOptimizeInnoDBSupported()` has been removed. Use `Piwik\Db\Schema::getInstance()->isOptimizeInnoDBSupported()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * The deprecated method `Piwik\Archive::getBlob()` has been removed. Use one of the `Piwik\Archive::getDataTable*()` methods instead.
 * The deprecated method `Piwik\Archive::clearStaticCache()` has been removed. It was a no-op kept only for backwards compatibility.
 * The deprecated method `Piwik\ArchiveProcessor\Parameters::setIsPartialArchive()` has been removed. Use `Piwik\ArchiveProcessor\Parameters::setArchiveOnlyReport()` instead.
+* The deprecated method `Piwik\Db\Adapter::getDefaultPortForAdapter()` has been removed. Use `Piwik\Db\Schema::getDefaultPortForSchema()` instead.
 * The deprecated method `Piwik\Plugins\Overlay\API::getExcludedQueryParameters()` has been removed. Use the `SitesManager.getExcludedQueryParameters` API method instead.
 * The deprecated method `Piwik\Db::optimizeTables()` has been removed. Use `Piwik\Db\Schema::getInstance()->optimizeTables()` instead.
 * The deprecated method `Piwik\Db::isOptimizeInnoDBSupported()` has been removed. Use `Piwik\Db\Schema::getInstance()->isOptimizeInnoDBSupported()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * The deprecated method `Piwik\Archive::clearStaticCache()` has been removed. It was a no-op kept only for backwards compatibility.
 * The deprecated method `Piwik\ArchiveProcessor\Parameters::setIsPartialArchive()` has been removed. Use `Piwik\ArchiveProcessor\Parameters::setArchiveOnlyReport()` instead.
 * The deprecated method `Piwik\Db\Adapter::getDefaultPortForAdapter()` has been removed. Use `Piwik\Db\Schema::getDefaultPortForSchema()` instead.
+* The deprecated method `Piwik\Url::saveCORSHostnameInConfig()` has been removed. It was no longer in use.
 * The deprecated method `Piwik\Plugins\Overlay\API::getExcludedQueryParameters()` has been removed. Use the `SitesManager.getExcludedQueryParameters` API method instead.
 * The deprecated method `Piwik\Db::optimizeTables()` has been removed. Use `Piwik\Db\Schema::getInstance()->optimizeTables()` instead.
 * The deprecated method `Piwik\Db::isOptimizeInnoDBSupported()` has been removed. Use `Piwik\Db\Schema::getInstance()->isOptimizeInnoDBSupported()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ## Matomo 6.0.0
 
 ### Breaking Changes
+* The deprecated method `Piwik\Archive::getBlob()` has been removed. Use one of the `Piwik\Archive::getDataTable*()` methods instead.
 * The deprecated method `Piwik\Plugins\Overlay\API::getExcludedQueryParameters()` has been removed. Use the `SitesManager.getExcludedQueryParameters` API method instead.
 * The deprecated method `Piwik\Db::optimizeTables()` has been removed. Use `Piwik\Db\Schema::getInstance()->optimizeTables()` instead.
 * The deprecated method `Piwik\Db::isOptimizeInnoDBSupported()` has been removed. Use `Piwik\Db\Schema::getInstance()->isOptimizeInnoDBSupported()` instead.

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -325,23 +325,6 @@ class Archive implements ArchiveQuery
     }
 
     /**
-     * Queries and returns blob records without turning them into DataTables.
-     *
-     * Unlike other methods, this returns a DataCollection instance directly. Use it to directly access
-     * and process blob data.
-     *
-     * @param string|string[] $names One or more archive names, eg, `'nb_visits'`, `'Referrers_distinctKeywords'`, etc.
-     * @param int|string|null $idSubtable
-     * @return DataCollection the queried data.
-     *
-     * @deprecated remove with Matomo 6
-     */
-    public function getBlob($names, $idSubtable = null)
-    {
-        return $this->get($names, 'blob', $idSubtable);
-    }
-
-    /**
      * Queries blob data for a single record. Uses a cursor instead of fetching all the data at once,
      * and makes sure the result set's order allows aggregating the data one row at a time.
      *

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -1050,15 +1050,6 @@ class Archive implements ArchiveQuery
     }
 
     /**
-     * Only kept for BC
-     * @return void
-     * @deprecated Remove with Matomo 6
-     */
-    public static function clearStaticCache()
-    {
-    }
-
-    /**
      * @return void
      */
     public function forceFetchingWithoutLaunchingArchiving()

--- a/core/ArchiveProcessor/Parameters.php
+++ b/core/ArchiveProcessor/Parameters.php
@@ -51,11 +51,6 @@ class Parameters
     private $archiveOnlyReport = null;
 
     /**
-     * @var bool
-     */
-    private $isArchiveOnlyReportHandled = false;
-
-    /**
      * @var string[]|null
      */
     private $foundRequestedReports;
@@ -288,24 +283,7 @@ class Parameters
             return false;
         }
 
-        if (!empty($this->getArchiveOnlyReport())) {
-            return true;
-        }
-
-        return $this->isArchiveOnlyReportHandled;
-    }
-
-    /**
-     * If a plugin's archiver handles the setArchiveOnlyReport() setting, it should call this method
-     * so it is known that the archive only contains the requested report. This should be called
-     * in an Archiver's __construct method.
-     *
-     * @param bool $isArchiveOnlyReportHandled
-     * @deprecated use `setArchiveOnlyReport` instead
-     */
-    public function setIsPartialArchive($isArchiveOnlyReportHandled)
-    {
-        $this->isArchiveOnlyReportHandled = $isArchiveOnlyReportHandled;
+        return !empty($this->getArchiveOnlyReport());
     }
 
     public function getArchiveOnlyReportAsArray()

--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -89,19 +89,6 @@ class Adapter
     }
 
     /**
-     * Get default port for named adapter
-     *
-     * @deprecated use Schema::getDefaultPortForSchema instead
-     * @param string $adapterName
-     * @return int
-     */
-    public static function getDefaultPortForAdapter($adapterName)
-    {
-        $className = self::getAdapterClassName($adapterName);
-        return call_user_func(array($className, 'getDefaultPort'));
-    }
-
-    /**
      * Get list of adapters
      *
      * @return array

--- a/core/Url.php
+++ b/core/Url.php
@@ -304,16 +304,6 @@ class Url
 
     /**
      * @param string|string[] $host
-     * @return bool
-     * @deprecated no longer in use, will be removed with Matomo 6
-     */
-    public static function saveCORSHostnameInConfig($host)
-    {
-        return self::saveHostsnameInConfig($host, 'General', 'cors_domains');
-    }
-
-    /**
-     * @param string|string[] $host
      * @param string $domain
      * @param string $key
      * @return bool


### PR DESCRIPTION
## Summary

Removes five long-standing, lowest-risk deprecated symbols as part of the Matomo 6 deprecation cleanup. Each was flagged for removal with Matomo 6 (or earlier) and has **zero remaining callers** in core, bundled plugins, and the external plugin ecosystem (verified against local `../plugin-*` (34) and `../marketplace-plugins/*` (154) checkouts).

Each removal is its own commit with a matching CHANGELOG "Breaking Changes" entry.

| Removed | Replacement |
|---------|-------------|
| `Piwik\Archive::getBlob()` | `Piwik\Archive::getDataTable*()` |
| `Piwik\Archive::clearStaticCache()` | — (was a no-op) |
| `Piwik\ArchiveProcessor\Parameters::setIsPartialArchive()` | `Parameters::setArchiveOnlyReport()` |
| `Piwik\Db\Adapter::getDefaultPortForAdapter()` | `Piwik\Db\Schema::getDefaultPortForSchema()` |
| `Piwik\Url::saveCORSHostnameInConfig()` | — (no longer in use) |

### Notes

* `getBlob()` was announced deprecated as far back as Piwik 2.13.0.
* Removing `setIsPartialArchive()` also drops the now-dead private `isArchiveOnlyReportHandled` property and the corresponding branch of `isPartialArchive()`, since that setter was its only writer.
* The private `saveHostsnameInConfig()` helper used by `saveCORSHostnameInConfig()` is retained — it is still shared by `saveTrustedHostnameInConfig()`.

### Deliberately excluded (not lowest-risk after re-verification)

* `Piwik\Concurrency\Lock::reexpireLock()` — still called by `GoogleAnalyticsImporter`.
* `Piwik\Concurrency\Lock::expireLock()` — still relied on by `QueuedTracking` (`Queue\Lock extends Piwik\Concurrency\Lock`).
* Settings `get*SettingShortName()` (x5) — invoked dynamically by `PolicyManager`; requires making `get*Name` public and rewiring `PolicyManager` first.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
