### PR TITLE
Differentiate EOL between MariaDB Community and Enterprise Server

### DIFF
--- a/core/Db/Schema/Mariadb.php
+++ b/core/Db/Schema/Mariadb.php
@@ -61,14 +61,15 @@ class Mariadb extends Mysql
     public function hasReachedEOL(): bool
     {
         $currentVersion = $this->getVersion();
+        $isEnterprise = false !== strpos($currentVersion, 'enterprise');
 
         // End of security update for certain MariaDb versions as of https://mariadb.org/about/#maintenance-policy
 
-        // Support for 10.6 LTS ends on 6th July 2026
+        // Community Support for 10.6 LTS ends on 6th July 2026, Enterprise on 23rd August 2029
         if (
             version_compare($currentVersion, '10.6', '>=') &&
             version_compare($currentVersion, '10.7', '<') &&
-            Date::today()->isEarlier(Date::factory('2026-07-07'))
+            Date::today()->isEarlier(Date::factory($isEnterprise ? '2029-08-24' : '2026-07-07'))
         ) {
             return false;
         }
@@ -82,11 +83,11 @@ class Mariadb extends Mysql
             return false;
         }
 
-        // Support for 11.4 LTS ends on 29th May 2029
+        // Community Support for 11.4 LTS ends on 29th May 2029, Enterprise on 16th January 2033
         if (
             version_compare($currentVersion, '11.4', '>=') &&
             version_compare($currentVersion, '11.5', '<') &&
-            Date::today()->isEarlier(Date::factory('2029-05-30'))
+            Date::today()->isEarlier(Date::factory($isEnterprise ? '2033-01-17' : '2029-05-30'))
         ) {
             return false;
         }


### PR DESCRIPTION
### Description

Fixes https://github.com/matomo-org/matomo/issues/24881

The EOL dates for MariaDB Server Enterprise were taken from the latest available [Engineering Policy](https://mariadb.com/engineering-policies/) to date:
https://mariadb.com/wp-content/uploads/2026/07/mariadb-engineering-policies-v4-33_policy_1222.pdf#section.2

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [x] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [x] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [x] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [x] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [x] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [x] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [x] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
