### PR TITLE
Declare the complete MatomoUrl type in the CoreHome spec stub

### DIFF
--- a/plugins/CoreVue/types/plugin-modules.d.ts
+++ b/plugins/CoreVue/types/plugin-modules.d.ts
@@ -3,6 +3,11 @@
 // generated tree is only present during a full prod build, so ts-jest needs
 // these ambient declarations to type-check spec files that pull in production
 // source which uses the externals.
+//
+// When adding a symbol here, mirror its COMPLETE public type from source, not a
+// narrow subset: this ambient module also merges into other plugins' spec
+// type-checks, so a narrow entry both drops members and collides with plugins
+// that augment `CoreHome` with the fuller type.
 
 declare module 'CoreHome' {
   export const ComparisonsStoreInstance: {
@@ -10,7 +15,29 @@ declare module 'CoreHome' {
     isComparisonEnabled(): boolean | null;
   };
   export function translate(translationStringId: string, values?: unknown[]): string;
+
+  // MatomoUrl's parsed/urlParsed/hashParsed are Vue computed refs over the decoded query.
+  type ParsedQueryRef = import('vue').ComputedRef<
+    import('vue').DeepReadonly<Record<string, unknown>>
+  >;
+
   export const MatomoUrl: {
-    parse(search: string): Record<string, string>;
+    readonly url: import('vue').Ref<URL | null>;
+    readonly urlQuery: import('vue').ComputedRef<string>;
+    readonly hashQuery: import('vue').ComputedRef<string>;
+    readonly urlParsed: ParsedQueryRef;
+    readonly hashParsed: ParsedQueryRef;
+    readonly parsed: ParsedQueryRef;
+    updateHashToUrl(urlWithoutLeadingHash: string): void;
+    updateHash(params: QueryParameters | string): void;
+    updateUrl(params: QueryParameters | string, hashParams?: QueryParameters | string): void;
+    updateLocation(params: QueryParameters | string): void;
+    getSearchParam(paramName: string): string;
+    parse(query: string): QueryParameters;
+    stringify(search: QueryParameters): string;
+    getMenuPathSuffix(): { category: string; subcategory: string };
+    getDateAndPeriodFromUrl(): { date: string; period: string };
+    updatePageTitle(): void;
+    updatePeriodParamsFromUrl(): void;
   };
 }


### PR DESCRIPTION
### Description

This issue was reported by Brent and it was causing him errors on a plugin he is working on that has the test shim for MatomoUrl. He could not use my MatomoUrl stub as it is lacking `parsed` function.

### Root cause
`plugins/CoreVue/types/plugin-modules.d.ts` is the ambient stub that lets ts-jest type-check spec files which pull in production source importing from the `CoreHome` webpack external (the generated `@types/CoreHome` tree only exists during a full prod build, so specs need this stand-in).

Its `MatomoUrl` entry previously declared a single, and inaccurate, member:

```ts
export const MatomoUrl: {
  parse(search: string): Record<string, string>;
};
```

The real MatomoUrl (plugins/CoreHome/vue/src/MatomoUrl/MatomoUrl.ts) exposes a much larger surface, and parse() actually returns QueryParameters, not Record<string, string>. A narrow/incorrect stub has two problems as more plugins' specs consume MatomoUrl: it drops members, so any .ts pulled into a spec that uses updateHash, stringify, parsed, etc. fails type-checking with a spurious "no exported member", and it collides with the fuller type other plugins expect, because this ambient module merges into every plugin's spec type-check.

This PR replaces the stub with a complete, faithful mirror of MatomoUrl's public surface (private getFinalHashParams intentionally omitted) and adds a header comment documenting the "mirror the COMPLETE source type" rule for future maintainers.

### Scope / impact
 - Types-only, test-support change. No production runtime, bundle, or vue:build output is affected — this file is consumed only by ts-jest.
 - 5.x-dev only. The Vite migration on 6.x removed this ambient stub (and tsconfig.spec.json) entirely, so there is nothing to forward-port.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
