### PR TITLE
Harden Page Overlay API request handling

### DIFF
--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -227,6 +227,86 @@ var Piwik_Overlay = (function () {
         }, 0);
     }
 
+    /**
+     * Builds the parameters for an allow-listed Page Overlay API request from the request
+     * url supplied by the framed page and the trusted parent-window context.
+     *
+     * The request sent to the API is assembled from a fixed, known set of values: the method
+     * must be one of the allow-listed values and idSite/period/date/segment always come from
+     * the parent window, rather than forwarding the parsed parameter object as-is.
+     *
+     * @param {string} requestUrl  the url received from the framed page
+     * @param {object} context     trusted parent-window values (idSite, period, date, segment)
+     * @return {object} either { params: {...} } for a valid request or { error: '...' }
+     */
+    function buildApiRequestParams(requestUrl, context) {
+        var hashless = requestUrl.split('#')[0];
+        var queryStart = hashless.indexOf('?');
+        var queryString = queryStart === -1 ? '' : hashless.slice(queryStart + 1);
+        var pairs = queryString.split('&');
+        var requested = {};
+
+        for (var i = 0; i < pairs.length; i++) {
+            if (pairs[i] === '') {
+                continue;
+            }
+
+            var separator = pairs[i].indexOf('=');
+            var rawName = separator === -1 ? pairs[i] : pairs[i].slice(0, separator);
+            var rawValue = separator === -1 ? '' : pairs[i].slice(separator + 1);
+
+            var name;
+            var value;
+            try {
+                name = decodeURIComponent(rawName);
+                value = decodeURIComponent(rawValue);
+            } catch (e) {
+                return { error: 'Malformed parameter in Overlay API request.' };
+            }
+
+            // Only accept canonical parameter names. Names with surrounding whitespace (or its
+            // percent-encoding) are ambiguous, so reject the request rather than guessing.
+            if (name !== name.trim() || rawName !== rawName.trim()) {
+                return { error: 'Invalid parameter name in Overlay API request.' };
+            }
+
+            if (Object.prototype.hasOwnProperty.call(requested, name)) {
+                return { error: 'Duplicate parameter in Overlay API request.' };
+            }
+
+            requested[name] = value;
+        }
+
+        if (ALLOWED_API_REQUEST_WHITELIST.indexOf(requested.method) === -1) {
+            return { error: "'" + requested.method + "' method is not allowed." };
+        }
+
+        // Assemble the outgoing request from a fixed set of trusted values. Only the
+        // parameters explicitly set below are sent to the API.
+        var params = {
+            module: 'API',
+            action: 'index',
+            format: 'JSON',
+            method: requested.method,
+            idSite: context.idSite,
+            period: context.period,
+            date: context.date,
+            filter_limit: -1,
+        };
+
+        if (context.segment) {
+            params.segment = context.segment;
+        }
+
+        // url is the only framed-page value consumed by an allow-listed method
+        // (Overlay.getFollowingPages).
+        if (typeof requested.url !== 'undefined') {
+            params.url = requested.url;
+        }
+
+        return { params: params };
+    }
+
     function handleApiRequests() {
         window.addEventListener("message", function (event) {
             if (event.origin !== iframeOrigin || !iframeOrigin) {
@@ -245,37 +325,26 @@ var Piwik_Overlay = (function () {
             var requestId = strData[1];
             var url = decodeURIComponent(strData[2]);
 
-            var params = broadcast.getValuesFromUrl(url);
-            Object.keys(params).forEach(function (name) {
-                params[name] = decodeURIComponent(params[name]);
+            var segmentValue = segment ? decodeURIComponent(segment) : null;
+
+            var built = buildApiRequestParams(url, {
+                idSite: idSite,
+                period: period,
+                date: date,
+                segment: segmentValue,
             });
-            params.module = 'API';
-            params.action = 'index';
 
-            // these should be sent as post parameters
-            delete params.token_auth;
-            delete params.force_api_session;
-
-            if (ALLOWED_API_REQUEST_WHITELIST.indexOf(params.method) === -1) {
+            if (built.error) {
                 sendResponse({
                     result: 'error',
-                    message: "'" + params.method + "' method is not allowed.",
+                    message: built.error,
                 });
                 return;
             }
 
-            params.idSite = idSite;
-            params.period = period;
-            params.date = date;
-            if (segment) {
-                params.segment = decodeURIComponent(segment);
-            } else {
-                delete params.segment;
-            }
-
             var AjaxHelper = window.CoreHome.AjaxHelper;
             AjaxHelper
-              .fetch(params, { withTokenInUrl: true })
+              .fetch(built.params, { withTokenInUrl: true })
               .then(function (response) {
                   sendResponse(response);
               }).catch(function (err) {
@@ -293,6 +362,14 @@ var Piwik_Overlay = (function () {
     }
 
     return {
+
+        /**
+         * Builds the parameters for an allow-listed Page Overlay API request.
+         * Exposed for unit testing; see the internal buildApiRequestParams().
+         */
+        buildApiRequestParams: function (requestUrl, context) {
+            return buildApiRequestParams(requestUrl, context);
+        },
 
         /** This method is called when Overlay loads  */
         init: function (iframeSrc, pIdSite, pPeriod, pDate, pSegment, pIframePostParams) {

--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -299,8 +299,8 @@ var Piwik_Overlay = (function () {
         }
 
         // url is the only framed-page value consumed by an allow-listed method
-        // (Overlay.getFollowingPages).
-        if (typeof requested.url !== 'undefined') {
+        // (Overlay.getFollowingPages), so only forward it to that method.
+        if (requested.method === 'Overlay.getFollowingPages' && typeof requested.url !== 'undefined') {
             params.url = requested.url;
         }
 

--- a/plugins/Overlay/tests/javascript/head.php
+++ b/plugins/Overlay/tests/javascript/head.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+?>
+<script src="../../plugins/Overlay/javascripts/Piwik_Overlay.js" type="text/javascript"></script>

--- a/plugins/Overlay/tests/javascript/index.php
+++ b/plugins/Overlay/tests/javascript/index.php
@@ -86,6 +86,16 @@ test("buildApiRequestParams forwards the url parameter for getFollowingPages", f
     strictEqual(result.params.url, 'https://example.org/page', 'url is decoded and forwarded');
 });
 
+test("buildApiRequestParams forwards url only to getFollowingPages", function () {
+    var result = Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getTranslations&url=' + encodeURIComponent('https://example.org/page'),
+        overlayContext()
+    );
+
+    ok(!result.error, 'the request is accepted');
+    strictEqual(typeof result.params.url, 'undefined', 'url is not forwarded to other allow-listed methods');
+});
+
 test("buildApiRequestParams takes segment from the trusted context", function () {
     var result = Piwik_Overlay.buildApiRequestParams(
         'index.php?method=Overlay.getTranslations&segment=' + encodeURIComponent('countryCode==fr'),

--- a/plugins/Overlay/tests/javascript/index.php
+++ b/plugins/Overlay/tests/javascript/index.php
@@ -95,4 +95,99 @@ test("buildApiRequestParams takes segment from the trusted context", function ()
     ok(!result.error, 'the request is accepted');
     strictEqual(result.params.segment, 'browserCode==ff', 'segment comes from the trusted context');
 });
+
+test("buildApiRequestParams rejects all whitespace variants in a parameter name", function () {
+    ok(Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getTranslations&\tmethod=Live.getLastVisitsDetails',
+        overlayContext()
+    ).error, 'a literal tab in a name is rejected');
+
+    ok(Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getTranslations&\nmethod=Live.getLastVisitsDetails',
+        overlayContext()
+    ).error, 'a literal newline in a name is rejected');
+
+    ok(Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getTranslations&%09method=Live.getLastVisitsDetails',
+        overlayContext()
+    ).error, 'a percent-encoded tab in a name is rejected');
+
+    ok(Piwik_Overlay.buildApiRequestParams(
+        'index.php?method =Overlay.getTranslations',
+        overlayContext()
+    ).error, 'trailing whitespace in a name is rejected');
+});
+
+test("buildApiRequestParams decodes parameter names before comparing them", function () {
+    // "%6D%65%74%68%6F%64" is "method" fully percent-encoded.
+    var encoded = Piwik_Overlay.buildApiRequestParams(
+        'index.php?%6D%65%74%68%6F%64=Overlay.getTranslations',
+        overlayContext()
+    );
+    ok(!encoded.error, 'a fully percent-encoded name is decoded and accepted');
+    strictEqual(encoded.params.method, 'Overlay.getTranslations', 'the decoded name maps to method');
+
+    var collision = Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getTranslations&%6D%65%74%68%6F%64=Live.getLastVisitsDetails',
+        overlayContext()
+    );
+    ok(collision.error, 'a percent-encoded name that decodes to an existing name is a duplicate');
+});
+
+test("buildApiRequestParams reports malformed percent-encoding", function () {
+    ok(Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getTranslations&extra=%ZZ',
+        overlayContext()
+    ).error, 'malformed encoding in a value is reported');
+
+    ok(Piwik_Overlay.buildApiRequestParams(
+        'index.php?%ZZmethod=Overlay.getTranslations',
+        overlayContext()
+    ).error, 'malformed encoding in a name is reported');
+});
+
+test("buildApiRequestParams requires a method", function () {
+    var missing = Piwik_Overlay.buildApiRequestParams('index.php?idSite=1', overlayContext());
+    ok(missing.error, 'a request with no method is rejected');
+    strictEqual(typeof missing.params, 'undefined', 'no params are produced');
+
+    ok(Piwik_Overlay.buildApiRequestParams('index.php?method=', overlayContext()).error,
+        'an empty method is rejected');
+});
+
+test("buildApiRequestParams is not affected by object-property names", function () {
+    var proto = Piwik_Overlay.buildApiRequestParams(
+        'index.php?__proto__=Live.getLastVisitsDetails&method=Overlay.getTranslations',
+        overlayContext()
+    );
+    ok(!proto.error, '__proto__ as a parameter name does not break parsing');
+    strictEqual(proto.params.method, 'Overlay.getTranslations', 'method is still the allow-listed value');
+    strictEqual(({}).polluted, undefined, 'the object prototype is not polluted');
+
+    var ctor = Piwik_Overlay.buildApiRequestParams(
+        'index.php?constructor=Live.getLastVisitsDetails&method=Overlay.getTranslations',
+        overlayContext()
+    );
+    ok(!ctor.error, 'constructor as a parameter name does not break parsing');
+    strictEqual(ctor.params.method, 'Overlay.getTranslations', 'method is still the allow-listed value');
+
+    // A parameter named hasOwnProperty must not disturb the duplicate-name check.
+    ok(Piwik_Overlay.buildApiRequestParams(
+        'index.php?hasOwnProperty=x&method=Overlay.getTranslations&method=Overlay.getFollowingPages',
+        overlayContext()
+    ).error, 'the duplicate-name check still fires when hasOwnProperty is a parameter name');
+});
+
+test("buildApiRequestParams does not forward report-shaping parameters", function () {
+    var result = Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getFollowingPages&url=' + encodeURIComponent('https://example.org/page')
+            + '&filter_pattern=.*&filter_column=label&flat=1',
+        overlayContext()
+    );
+
+    ok(!result.error, 'the request is accepted');
+    strictEqual(typeof result.params.filter_pattern, 'undefined', 'filter_pattern is not forwarded');
+    strictEqual(typeof result.params.filter_column, 'undefined', 'filter_column is not forwarded');
+    strictEqual(typeof result.params.flat, 'undefined', 'flat is not forwarded');
+});
 </script>

--- a/plugins/Overlay/tests/javascript/index.php
+++ b/plugins/Overlay/tests/javascript/index.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+?>
+<script type="text/javascript">
+module('Overlay/Piwik_Overlay');
+
+var overlayContext = function () {
+    return { idSite: 1, period: 'day', date: 'today', segment: null };
+};
+
+test("buildApiRequestParams builds the request from a fixed set of trusted parameters", function () {
+    // idSite, format and filter_limit provided in the request must be ignored.
+    var result = Piwik_Overlay.buildApiRequestParams(
+        'index.php?module=API&action=index&idSite=99&method=Overlay.getTranslations&format=xml&filter_limit=5',
+        overlayContext()
+    );
+
+    ok(!result.error, 'a request for an allow-listed method is accepted');
+    strictEqual(result.params.method, 'Overlay.getTranslations', 'method is the allow-listed value');
+    strictEqual(result.params.idSite, 1, 'idSite comes from the trusted context');
+    strictEqual(result.params.period, 'day', 'period comes from the trusted context');
+    strictEqual(result.params.date, 'today', 'date comes from the trusted context');
+    strictEqual(result.params.format, 'JSON', 'format is fixed to JSON');
+    strictEqual(result.params.filter_limit, -1, 'filter_limit is fixed');
+    strictEqual(result.params.module, 'API', 'module is fixed to API');
+    strictEqual(result.params.action, 'index', 'action is fixed to index');
+});
+
+test("buildApiRequestParams rejects a method that is not allow-listed", function () {
+    var result = Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Live.getLastVisitsDetails',
+        overlayContext()
+    );
+
+    ok(result.error, 'a method that is not allow-listed is rejected');
+    strictEqual(typeof result.params, 'undefined', 'no params are produced for a rejected request');
+});
+
+test("buildApiRequestParams rejects parameter names with surrounding whitespace", function () {
+    // Names with leading/trailing whitespace, or its percent-encoding, are ambiguous.
+    var literalSpace = Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getTranslations& method=Live.getLastVisitsDetails',
+        overlayContext()
+    );
+    ok(literalSpace.error, 'a name with a leading space is rejected');
+
+    var encodedSpace = Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getTranslations&%20method=Live.getLastVisitsDetails',
+        overlayContext()
+    );
+    ok(encodedSpace.error, 'a name with a percent-encoded leading space is rejected');
+});
+
+test("buildApiRequestParams rejects duplicate parameter names", function () {
+    var result = Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getTranslations&method=Overlay.getFollowingPages',
+        overlayContext()
+    );
+
+    ok(result.error, 'a duplicate parameter name is rejected');
+});
+
+test("buildApiRequestParams always takes idSite from the trusted context", function () {
+    var result = Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getFollowingPages&idSite=2',
+        overlayContext()
+    );
+
+    ok(!result.error, 'the request is accepted');
+    strictEqual(result.params.idSite, 1, 'idSite comes from the trusted context, not the request');
+});
+
+test("buildApiRequestParams forwards the url parameter for getFollowingPages", function () {
+    var result = Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getFollowingPages&url=' + encodeURIComponent('https://example.org/page'),
+        overlayContext()
+    );
+
+    ok(!result.error, 'getFollowingPages with a url is accepted');
+    strictEqual(result.params.method, 'Overlay.getFollowingPages', 'method is preserved');
+    strictEqual(result.params.url, 'https://example.org/page', 'url is decoded and forwarded');
+});
+
+test("buildApiRequestParams takes segment from the trusted context", function () {
+    var result = Piwik_Overlay.buildApiRequestParams(
+        'index.php?method=Overlay.getTranslations&segment=' + encodeURIComponent('countryCode==fr'),
+        { idSite: 1, period: 'day', date: 'today', segment: 'browserCode==ff' }
+    );
+
+    ok(!result.error, 'the request is accepted');
+    strictEqual(result.params.segment, 'browserCode==ff', 'segment comes from the trusted context');
+});
+</script>


### PR DESCRIPTION
### Description

The framed Page Overlay relays a small set of allow-listed API calls to the parent Matomo window on behalf of the framed page. This change makes the broker build those API requests from a fixed, known set of trusted values.

**What changed**

- The outgoing API request is assembled from a fixed parameter set: `module`/`action`/`format` are constants, `method` is the validated allow-listed value, and `idSite`/`period`/`date`/`segment` come from the parent window. The only value taken from the framed page's request is `url` (used by `Overlay.getFollowingPages`).
- Only canonical parameter names are accepted.

**Tests / validation**

- Added a QUnit suite under `plugins/Overlay/tests/javascript/` covering allow-listed vs. rejected methods, `idSite`/`period`/`date`/`segment` sourced from the parent context, handling of non-canonical and duplicate parameter names, and `url` forwarding for `Overlay.getFollowingPages`.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
