### PR TITLE
Encode container-widget id as a clean attribute so per-container graph settings persist on reload

### DIFF
--- a/plugins/CoreHome/templates/widgetContainer.twig
+++ b/plugins/CoreHome/templates/widgetContainer.twig
@@ -1,20 +1,7 @@
 <div>
     <div
         vue-entry="CoreHome.Widget"
-        containerid="{{ containerId|json_encode }}"
+        containerid="{{ containerId|e('html_attr') }}"
         widgetized="{% if isWidgetized %}true{% else %}false{% endif %}"
     ></div>
-
-    <script type="text/javascript">
-        $(function () {
-
-            var piwikWidget = $('[vue-entry="CoreHome.Widget"][containerid={{ containerId|e('js') }}]');
-            var isExportedAsWidget = $('body > .widget').length;
-
-            if (!isExportedAsWidget) {
-                piwikHelper.compileVueEntryComponents(piwikWidget);
-            }
-
-        });
-    </script>
 </div>


### PR DESCRIPTION
### Description

**Summary**

Container-widget graph settings (for example the metrics selected on the "Visits Overview (with graph)" dashboard widget, container id `VisitOverviewWithGraph`) were not persisted across a dashboard reload. Changing the plotted metrics appeared to work, but after reloading the widget reset to its defaults.

**Root cause**

`plugins/CoreHome/templates/widgetContainer.twig` rendered the container id into the DOM attribute with `json_encode`, which wraps the value in double quotes, so the attribute became `containerid="&quot;VisitOverviewWithGraph&quot;"`. The save path in `plugins/CoreHome/javascripts/dataTable.js` reads that attribute raw via jQuery `.attr('containerid')`, so it stored the ViewDataTable option under a quoted key:

```
viewDataTableParameters_admin_VisitsSummary.getEvolutionGraph_"VisitOverviewWithGraph"
```

The read/render path resolves the container id cleanly (`Common::getRequestVar('containerId')` → `VisitOverviewWithGraph`) and therefore looked up the option under the unquoted key, never found the saved value, and fell back to the defaults. The `[containerid={{ containerId|e('js') }}]` jQuery selector on line 11 of the same template also expects the clean, unquoted value, so it did not match the quoted attribute either.

**Changes**

- Emit the attribute with `e('html_attr')` instead of `json_encode`, so the value is the clean `VisitOverviewWithGraph`. The save (`.attr`) and read (request var) paths now agree on the same option key, and the line-11 `[containerid=...]` selector matches.

This is a follow-up to the earlier change that persists ViewDataTable settings per container: that change was necessary but had no visible effect because of this attribute-quoting mismatch. With this one-line fix the persistence works end to end.

**Tests / validation**

Verified in a local dev environment with a headless browser: logged in, opened the dashboard, added metrics (Unique visitors, Users) to the "Visits Overview (with graph)" widget, reloaded, and confirmed the added metrics were still selected and plotted. Confirmed the stored option row is now keyed on the clean `..._VisitOverviewWithGraph` (no quotes), and that the widget container and its child evolution graph still render without regression.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)



Backport of #24873.
