### PR TITLE
Remove three more long-standing deprecations for Matomo 6 (round 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * The deprecated method `Piwik\ArchiveProcessor\Parameters::setIsPartialArchive()` has been removed. Use `Piwik\ArchiveProcessor\Parameters::setArchiveOnlyReport()` instead.
 * The deprecated method `Piwik\Db\Adapter::getDefaultPortForAdapter()` has been removed. Use `Piwik\Db\Schema::getDefaultPortForSchema()` instead.
 * The deprecated method `Piwik\Url::saveCORSHostnameInConfig()` has been removed. It was no longer in use.
+* The deprecated method `Piwik\Plugin\Report::getThirdLeveltableDimension()` has been removed. Use `Piwik\Plugin\Report::getNthLevelTableDimension(2)` instead.
 * The deprecated method `Piwik\Plugins\Overlay\API::getExcludedQueryParameters()` has been removed. Use the `SitesManager.getExcludedQueryParameters` API method instead.
 * The deprecated method `Piwik\Db::optimizeTables()` has been removed. Use `Piwik\Db\Schema::getInstance()->optimizeTables()` instead.
 * The deprecated method `Piwik\Db::isOptimizeInnoDBSupported()` has been removed. Use `Piwik\Db\Schema::getInstance()->isOptimizeInnoDBSupported()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * The deprecated method `Piwik\Db\Adapter::getDefaultPortForAdapter()` has been removed. Use `Piwik\Db\Schema::getDefaultPortForSchema()` instead.
 * The deprecated method `Piwik\Url::saveCORSHostnameInConfig()` has been removed. It was no longer in use.
 * The deprecated method `Piwik\Plugin\Report::getThirdLeveltableDimension()` has been removed. Use `Piwik\Plugin\Report::getNthLevelTableDimension(2)` instead.
-* The deprecated `API.getSettings` API method has been removed, along with the `[APISettings]` section in `config.ini.php` that it exposed. There is no replacement; integrations that fetched key/value pairs from that section over the REST API must migrate to another mechanism.
+* The deprecated `API.getSettings` API method has been removed, along with the default `[APISettings]` section shipped in `config/global.ini.php` that it exposed. There is no replacement; integrations that fetched key/value pairs from that section over the REST API must migrate to another mechanism. Any `[APISettings]` entries in a local `config.ini.php` simply become inert.
 * The deprecated static method `getDefaultPort()` has been removed from `Piwik\Db\AdapterInterface` and its implementations (`Piwik\Db\Adapter\Mysqli`, `Piwik\Db\Adapter\Pdo\Mysql`). Use `Piwik\Db\Schema::getDefaultPortForSchema()` instead.
 * The deprecated method `Piwik\Plugins\Overlay\API::getExcludedQueryParameters()` has been removed. Use the `SitesManager.getExcludedQueryParameters` API method instead.
 * The deprecated method `Piwik\Db::optimizeTables()` has been removed. Use `Piwik\Db\Schema::getInstance()->optimizeTables()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * The deprecated method `Piwik\Db\Adapter::getDefaultPortForAdapter()` has been removed. Use `Piwik\Db\Schema::getDefaultPortForSchema()` instead.
 * The deprecated method `Piwik\Url::saveCORSHostnameInConfig()` has been removed. It was no longer in use.
 * The deprecated method `Piwik\Plugin\Report::getThirdLeveltableDimension()` has been removed. Use `Piwik\Plugin\Report::getNthLevelTableDimension(2)` instead.
+* The deprecated `API.getSettings` API method has been removed, along with the `[APISettings]` section in `config.ini.php` that it exposed. There is no replacement; integrations that fetched key/value pairs from that section over the REST API must migrate to another mechanism.
 * The deprecated method `Piwik\Plugins\Overlay\API::getExcludedQueryParameters()` has been removed. Use the `SitesManager.getExcludedQueryParameters` API method instead.
 * The deprecated method `Piwik\Db::optimizeTables()` has been removed. Use `Piwik\Db\Schema::getInstance()->optimizeTables()` instead.
 * The deprecated method `Piwik\Db::isOptimizeInnoDBSupported()` has been removed. Use `Piwik\Db\Schema::getInstance()->isOptimizeInnoDBSupported()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * The deprecated method `Piwik\Url::saveCORSHostnameInConfig()` has been removed. It was no longer in use.
 * The deprecated method `Piwik\Plugin\Report::getThirdLeveltableDimension()` has been removed. Use `Piwik\Plugin\Report::getNthLevelTableDimension(2)` instead.
 * The deprecated `API.getSettings` API method has been removed, along with the `[APISettings]` section in `config.ini.php` that it exposed. There is no replacement; integrations that fetched key/value pairs from that section over the REST API must migrate to another mechanism.
+* The deprecated static method `getDefaultPort()` has been removed from `Piwik\Db\AdapterInterface` and its implementations (`Piwik\Db\Adapter\Mysqli`, `Piwik\Db\Adapter\Pdo\Mysql`). Use `Piwik\Db\Schema::getDefaultPortForSchema()` instead.
 * The deprecated method `Piwik\Plugins\Overlay\API::getExcludedQueryParameters()` has been removed. Use the `SitesManager.getExcludedQueryParameters` API method instead.
 * The deprecated method `Piwik\Db::optimizeTables()` has been removed. Use `Piwik\Db\Schema::getInstance()->optimizeTables()` instead.
 * The deprecated method `Piwik\Db::isOptimizeInnoDBSupported()` has been removed. Use `Piwik\Db\Schema::getInstance()->isOptimizeInnoDBSupported()` instead.

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1376,15 +1376,6 @@ time_dom_completion_cap_duration_ms = 0
 ; Cap for On load time: avg/high 10ms (recommended value: 1000)
 time_on_load_cap_duration_ms = 0
 
-[APISettings]
-; Any key/value pair can be added in this section, they will be available via the REST call
-; index.php?module=API&method=API.getSettings
-; Access to this API is unrestricted, so do not include any sensitive information here.
-; This can be used to expose values from Matomo, to control for example a Mobile app tracking
-
-SDK_batch_size = 10
-SDK_interval_value = 30
-
 [SitesManager]
 CommonPIIParams[] = account
 CommonPIIParams[] = accountnum

--- a/core/Db/Adapter/Mysqli.php
+++ b/core/Db/Adapter/Mysqli.php
@@ -62,17 +62,6 @@ class Mysqli extends Zend_Db_Adapter_Mysqli implements AdapterInterface
         $this->_config = array();
     }
 
-    /**
-     * Return default port.
-     *
-     * @deprecated Use Schema::getDefaultPortForSchema instead
-     * @return int
-     */
-    public static function getDefaultPort()
-    {
-        return 3306;
-    }
-
     protected function _connect() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($this->_connection) {

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -120,17 +120,6 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     }
 
     /**
-     * Return default port.
-     *
-     * @deprecated Use Schema::getDefaultPortForSchema instead
-     * @return int
-     */
-    public static function getDefaultPort()
-    {
-        return 3306;
-    }
-
-    /**
      * Checks the database server version against the required minimum for the
      * detected server type (MySQL or MariaDB).
      *

--- a/core/Db/AdapterInterface.php
+++ b/core/Db/AdapterInterface.php
@@ -19,14 +19,6 @@ interface AdapterInterface extends TransactionalDatabaseInterface
     public function resetConfig();
 
     /**
-     * Return default port.
-     * @deprecated Use Schema::getDefaultPortForSchema instead
-     *
-     * @return int
-     */
-    public static function getDefaultPort();
-
-    /**
      * Check database server version
      *
      * @throws Exception if database version is less than required version

--- a/core/Plugin/Report.php
+++ b/core/Plugin/Report.php
@@ -901,19 +901,6 @@ class Report
     }
 
     /**
-     * Returns the Dimension instance of the subtable report of this report's subtable report.
-     *
-     * @return Dimension|null The subtable report's dimension or null if there is no subtable report or
-     *                        no dimension for the subtable report.
-     * @deprecated since 5.3.0, use getNthLevelTableDimension(2) instead
-     * @api
-     */
-    public function getThirdLeveltableDimension()
-    {
-        return $this->getNthLevelTableDimension($level = 2);
-    }
-
-    /**
      * Returns the Dimension instance of the subtable report of this report's subtable report based on level.
      *
      * @param int $level The subTable level for which dimension is to be determined, zero-based

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -135,17 +135,6 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
-     * Returns the `[APISettings]` section from `config.ini.php`.
-     *
-     * @return array<string, mixed>
-     * @deprecated May be removed in one of the next major releases
-     */
-    public function getSettings()
-    {
-        return Config::getInstance()->APISettings;
-    }
-
-    /**
      * Returns all available measurable types.
      * Marked as internal so it won't appear on the API page.
      * @return list<array{id:string, name:string, description:string, longDescription:string, howToSetupUrl:string, settings:list<array<string, scalar>>}>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSettings.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSettings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<result>
-	<row>
-		<SDK_batch_size>10</SDK_batch_size>
-		<SDK_interval_value>30</SDK_interval_value>
-	</row>
-</result>

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b04cd57e4d270b9b64349578cdb444701e6064fdfa158852bdec34376c479cf
-size 5348001
+oid sha256:416ec26a2b991f67fe985e639e32876211e0f797ade3e8e95c129ec0b8c97d54
+size 5339723


### PR DESCRIPTION
## Summary

Round 2 of the Matomo 6 deprecation cleanup (follows #24880). Removes three more long-standing deprecated PHP symbols, each as its own commit with a "Matomo 6.0.0 > Breaking Changes" CHANGELOG entry.

| Removed | Replacement |
|---------|-------------|
| `Piwik\Plugin\Report::getThirdLeveltableDimension()` | `Report::getNthLevelTableDimension(2)` |
| `API.getSettings` + the default `[APISettings]` section in `config/global.ini.php` | none (documented; see below) |
| `getDefaultPort()` on `Piwik\Db\AdapterInterface` + `Adapter\Mysqli` + `Adapter\Pdo\Mysql` | `Piwik\Db\Schema::getDefaultPortForSchema()` |

### Notes

* `getThirdLeveltableDimension()` and the adapter `getDefaultPort()` had zero callers in core, bundled plugins, and the external plugin ecosystem. The adapter `getDefaultPort()` became caller-free once #24880 removed `getDefaultPortForAdapter()` (its last caller); the separate, non-deprecated Schema-side `getDefaultPort()` is untouched.
* `API.getSettings` exposed the `[APISettings]` config section (`SDK_batch_size`, `SDK_interval_value`) as an unauthenticated REST endpoint intended for mobile tracking SDKs. It is removed with no replacement; integrations relying on it must migrate. Any `[APISettings]` entries in a local `config.ini.php` simply become inert.
* Removing `API.getSettings` also deletes an orphaned core system-test expected file and required a coordinated submodule change (below).

### Coordinated submodule change

`AnonymousPiwikUsageMeasurement` used `API.getSettings` as a sample API call in its profiler integration test and system-report fixture. Companion submodule PR (based on the plugin's `prepare6x`): matomo-org/plugin-AnonymousPiwikUsageMeasurement#112 — drops the `API.getSettings` calls and regenerates the affected system-test expected files (tracked API-call actions 39 → 37; `API.getSettings` event rows removed). The submodule pointer is advanced in this PR.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
