### PR TITLE
[DO NOT MERGE] Diagnostic: SparklinesRedesign on for all UI tests

### DIFF
--- a/tests/lib/screenshot-testing/support/test-environment.js
+++ b/tests/lib/screenshot-testing/support/test-environment.js
@@ -38,6 +38,16 @@ TestingEnvironment.prototype.reload = function () {
             this[key] = data[key];
         }
     }
+
+    // DIAGNOSTIC (do not merge): force-enable the SparklinesRedesign feature flag for every UI
+    // test suite, so CI reveals all screenshots affected by the sparklines redesign.
+    if (!this['configOverride']) {
+        this['configOverride'] = {};
+    }
+    if (!this['configOverride']['FeatureFlags']) {
+        this['configOverride']['FeatureFlags'] = {};
+    }
+    this['configOverride']['FeatureFlags']['SparklinesRedesign_feature'] = 'enabled';
 };
 
 /**


### PR DESCRIPTION
### Description

**Diagnostic only — this PR must never be merged.**

Force-enables the `SparklinesRedesign` feature flag for every UI test suite by injecting the `[FeatureFlags] SparklinesRedesign_feature = enabled` config override in `TestingEnvironment.reload()`. Every run path (the 6 sharded `UI-core` jobs and each per-plugin `UI-plugins` job) goes through `reload()`, and the injection survives the per-suite testing-environment reset, so the whole CI matrix runs with the redesign active.

Purpose: the failing UI jobs of this PR's CI run are the authoritative inventory of screenshot tests affected by the sparklines redesign. The expected screenshots will then be regenerated in small, independently green per-suite PRs (spec-level `overrideConfig` + regenerated screenshots), followed by a final PR that flips the product default and removes the scaffolding.

Notes for reading the results:
- `UIIntegrationTest_admin_diagnostics_configfile` is **expected noise**: the config override renders on the diagnostics config-file page. It is handled by shielding in the UIIntegration per-suite PR, not by regeneration.
- Any failing screenshot that does not contain a sparkline change needs investigation (flake or real bug) before being added to the inventory.

### Review

Not applicable — diagnostic draft, will be closed unmerged once the per-suite screenshot PRs land.

Checklist
[✔] I have understood, reviewed, and tested all AI outputs before use
[✔] All AI instructions respect security, IP, and privacy rules
