### PR TITLE
Improve help icons position on card hover (screenshots for #24892)

### DIFF
--- a/plugins/CoreHome/vue/src/EnrichedHeadline/EnrichedHeadline.less
+++ b/plugins/CoreHome/vue/src/EnrichedHeadline/EnrichedHeadline.less
@@ -33,6 +33,8 @@
 
     .iconsBar {
         line-height: 1 !important;
+        display: inline-flex;
+        align-items: center;
     }
 
     .ratingIcons {

--- a/tests/UI/expected-screenshots/UIIntegrationTest_actions_pages_tooltip_help.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_actions_pages_tooltip_help.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:32022523d90008b0b2749d902a8f0b1a24b95a9777e8a5feb172afe6a0b90fc5
-size 21369
+oid sha256:aa32a299dc1a413bd9820b125bb018b2efac710949c595061da5789d7c2ef3ae
+size 21389


### PR DESCRIPTION
CI vehicle branch for fork PR #24892 (`Armanio:patch-1`).

Its only purpose is to run the full "Matomo Tests" workflow on a matomo-org branch so the UI
screenshot artifacts are generated. The regenerated screenshots will then be committed back onto
`Armanio:patch-1` so #24892 can go green.

Contains the exact change from #24892 (single file: `EnrichedHeadline.less`, `.iconsBar` flex
alignment) with no other modifications.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules