### PR TITLE
Allow pending invitees to recover account access

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -694,7 +694,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             throw new RedirectException(Piwik::translate('Login_InvalidOrExpiredTokenV2'), SettingsPiwik::getPiwikUrl(), 3);
         }
 
-        if (!empty($user['invite_expired_at']) && Date::factory($user['invite_expired_at'])->isEarlier(Date::now())) {
+        if (empty($user['invite_expired_at']) || Date::factory($user['invite_expired_at'])->isEarlier(Date::now())) {
             throw new RedirectException(Piwik::translate('Login_InvalidOrExpiredTokenV2'), SettingsPiwik::getPiwikUrl(), 3);
         }
 

--- a/plugins/Login/Emails/PasswordResetEmail.php
+++ b/plugins/Login/Emails/PasswordResetEmail.php
@@ -36,14 +36,25 @@ class PasswordResetEmail extends Mail
      */
     protected $resetUrl;
 
-    public function __construct(string $login, string $ip, string $resetUrl, string $cancelUrl)
-    {
+    /**
+     * @var string|null
+     */
+    protected $linkValidity;
+
+    public function __construct(
+        string $login,
+        string $ip,
+        string $resetUrl,
+        string $cancelUrl,
+        ?string $linkValidity = null
+    ) {
         parent::__construct();
 
         $this->login = $login;
         $this->ip = $ip;
         $this->resetUrl = $resetUrl;
         $this->cancelUrl = $cancelUrl;
+        $this->linkValidity = $linkValidity;
 
         $this->setUpEmail();
     }
@@ -88,5 +99,6 @@ class PasswordResetEmail extends Mail
         $view->ip = $this->ip;
         $view->resetUrl = $this->resetUrl;
         $view->cancelUrl = $this->cancelUrl;
+        $view->linkValidity = $this->linkValidity;
     }
 }

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -42,7 +42,9 @@ use Piwik\Url;
  * 3. PasswordResetter will generate a reset token and email the user a link
  *    to confirm that they requested a password reset. (This way an attacker
  *    cannot reset a user's password if they do not have control of the user's
- *    email address.)
+ *    email address.) For a pending invitee, it will instead refresh the
+ *    invitation link token and email an activation link that keeps the
+ *    invitation's original expiry.
  * 4. The user opens the email and clicks on the link. The link leads to
  *    a controller action that finishes the password reset process.
  * 5. When the link is clicked, PasswordResetter will update the user's password
@@ -201,7 +203,9 @@ class PasswordResetter
      * information as an {@link Option} and send an email with the reset confirmation
      * link to the user whose password is being reset.
      *
-     * The email confirmation link will contain the generated reset token.
+     * For an active user, the email confirmation link contains the generated
+     * reset token. For a pending invitee, the email contains an activation link
+     * that preserves the original invitation expiry.
      *
      * @param string $loginOrEmail The user's login or email address.
      * @param string $newPassword The un-hashed/unencrypted password.
@@ -233,7 +237,10 @@ class PasswordResetter
 
         // ... send email with confirmation link
         try {
-            $this->sendEmailConfirmationLink($user, $keySuffix);
+            if (!$this->sendEmailConfirmationLink($user, $keySuffix)) {
+                $this->removePasswordResetInfo($login);
+                return;
+            }
         } catch (Exception $ex) {
             // remove password reset info
             $this->removePasswordResetInfo($login);
@@ -480,14 +487,14 @@ class PasswordResetter
     /**
      * @return array<string, mixed>|null
      */
-    private function getUserInformationForPasswordResetInitiation(string $loginOrMail): ?array
+    protected function getUserInformationForPasswordResetInitiation(string $loginOrMail): ?array
     {
         $user = $this->getUserInformation($loginOrMail);
         if ($user !== null) {
             return $user;
         }
 
-        $pendingUser = UserLoginHelper::findUserByLoginOrEmail($loginOrMail);
+        $pendingUser = $this->getPendingUserInformation($loginOrMail);
         if (empty($pendingUser['invite_token']) || empty($pendingUser['invite_expired_at'])) {
             return null;
         }
@@ -503,6 +510,19 @@ class PasswordResetter
         }
 
         return $pendingUser;
+    }
+
+    /**
+     * Returns pending user information based on a login or email.
+     *
+     * Derived classes can override this method to provide custom pending user
+     * querying logic.
+     *
+     * @return array<string, mixed>|null
+     */
+    protected function getPendingUserInformation(string $loginOrMail): ?array
+    {
+        return UserLoginHelper::findUserByLoginOrEmail($loginOrMail);
     }
 
     /**
@@ -553,8 +573,9 @@ class PasswordResetter
      *
      * @param array $user User info for the requested password reset.
      * @param string $keySuffix The suffix used in generating a token.
+     * @return bool Whether an email send was attempted.
      */
-    private function sendEmailConfirmationLink($user, $keySuffix)
+    private function sendEmailConfirmationLink($user, $keySuffix): bool
     {
         $login = $user['login'];
         $email = $user['email'];
@@ -563,6 +584,10 @@ class PasswordResetter
 
         if (!empty($user['invite_token'])) {
             $inviteToken = StaticContainer::get(UserRepository::class)->refreshInviteLinkToken($login);
+            if ($inviteToken === null) {
+                return false;
+            }
+
             $urlConfirm = Url::getCurrentUrlWithoutQueryString()
                 . '?module=' . urlencode(Piwik::getLoginPluginName())
                 . '&action=acceptInvitation'
@@ -601,6 +626,8 @@ class PasswordResetter
         }
 
         @$mail->send();
+
+        return true;
     }
 
     /**

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -14,13 +14,16 @@ use Piwik\Access;
 use Piwik\Auth\Password;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
+use Piwik\Date;
 use Piwik\IP;
+use Piwik\Metrics\Formatter;
 use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugins\Login\Emails\PasswordResetEmail;
 use Piwik\Plugins\Login\Emails\PasswordResetCancelEmail;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\UsersManager\Model;
+use Piwik\Plugins\UsersManager\Repository\UserRepository;
 use Piwik\Plugins\UsersManager\UserLoginHelper;
 use Piwik\Plugins\UsersManager\UsersManager;
 use Piwik\Plugins\UsersManager\UserUpdater;
@@ -217,7 +220,7 @@ class PasswordResetter
         }
 
         // get the user's login
-        $user = $this->getUserInformation($loginOrEmail);
+        $user = $this->getUserInformationForPasswordResetInitiation($loginOrEmail);
         if ($user === null) {
             // throw a custom exception type so it can be handled/suppressed
             throw new PasswordResetUserIsInvalidException(Piwik::translate('Login_InvalidUsernameEmail'));
@@ -475,6 +478,34 @@ class PasswordResetter
     }
 
     /**
+     * @return array<string, mixed>|null
+     */
+    private function getUserInformationForPasswordResetInitiation(string $loginOrMail): ?array
+    {
+        $user = $this->getUserInformation($loginOrMail);
+        if ($user !== null) {
+            return $user;
+        }
+
+        $pendingUser = UserLoginHelper::findUserByLoginOrEmail($loginOrMail);
+        if (empty($pendingUser['invite_token']) || empty($pendingUser['invite_expired_at'])) {
+            return null;
+        }
+
+        try {
+            $inviteExpiresAt = Date::factory($pendingUser['invite_expired_at']);
+        } catch (Exception $e) {
+            return null;
+        }
+
+        if ($inviteExpiresAt->isEarlier(Date::now())) {
+            return null;
+        }
+
+        return $pendingUser;
+    }
+
+    /**
      * Checks the password hash that was retrieved from the Option table. Used as a sanity check
      * when finishing the reset password process. If a password is obviously malformed, changing
      * a user's password to it will keep the user from being able to login again.
@@ -527,18 +558,31 @@ class PasswordResetter
     {
         $login = $user['login'];
         $email = $user['email'];
-
-        // construct a password reset token from user information
-        $resetToken = $this->generatePasswordResetToken($user, $keySuffix);
-
         $ip = IP::getIpFromHeader();
-        $urlBase = Url::getCurrentUrlWithoutQueryString()
-            . "?module={$this->confirmPasswordModule}"
-            . "&login=" . urlencode($login)
-            . "&resetToken=" . urlencode($resetToken);
+        $linkValidity = null;
 
-        $urlCancel = $urlBase . "&action={$this->cancelResetPasswordAction}";
-        $urlConfirm = $urlBase . "&action={$this->confirmPasswordAction}";
+        if (!empty($user['invite_token'])) {
+            $inviteToken = StaticContainer::get(UserRepository::class)->refreshInviteLinkToken($login);
+            $urlConfirm = Url::getCurrentUrlWithoutQueryString()
+                . '?module=' . urlencode(Piwik::getLoginPluginName())
+                . '&action=acceptInvitation'
+                . '&token=' . urlencode($inviteToken);
+            $urlCancel = '';
+
+            $expiryInSeconds = Date::factory($user['invite_expired_at'])->getTimestamp()
+                - Date::now()->getTimestamp();
+            $linkValidity = (new Formatter())->getPrettyTimeFromSeconds($expiryInSeconds, true);
+        } else {
+            // construct a password reset token from user information
+            $resetToken = $this->generatePasswordResetToken($user, $keySuffix);
+            $urlBase = Url::getCurrentUrlWithoutQueryString()
+                . "?module={$this->confirmPasswordModule}"
+                . "&login=" . urlencode($login)
+                . "&resetToken=" . urlencode($resetToken);
+
+            $urlCancel = $urlBase . "&action={$this->cancelResetPasswordAction}";
+            $urlConfirm = $urlBase . "&action={$this->confirmPasswordAction}";
+        }
 
         // send email with new password
         $mail = StaticContainer::getContainer()->make(PasswordResetEmail::class, [
@@ -546,6 +590,7 @@ class PasswordResetter
             'ip' => $ip,
             'resetUrl' => $urlConfirm,
             'cancelUrl' => $urlCancel,
+            'linkValidity' => $linkValidity,
         ]);
         $mail->addTo($email, $login);
 

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -583,7 +583,11 @@ class PasswordResetter
         $linkValidity = null;
 
         if (!empty($user['invite_token'])) {
-            $inviteToken = StaticContainer::get(UserRepository::class)->refreshInviteLinkToken($login);
+            $inviteToken = StaticContainer::get(UserRepository::class)->refreshInviteToken(
+                $login,
+                $user['invite_token'],
+                $email
+            );
             if ($inviteToken === null) {
                 return false;
             }

--- a/plugins/Login/lang/en.json
+++ b/plugins/Login/lang/en.json
@@ -77,6 +77,7 @@
         "PasswordResetEmailAppTokens": "Changing your password does not automatically revoke your app-specific tokens. If you suspect unauthorised access, please delete your existing tokens and generate new ones in the token management section.",
         "PasswordResetEmailLinkCancel": "This wasn't me",
         "PasswordResetEmailLinkReset": "Reset your password",
+        "PasswordResetEmailLinkValidity": "This link will expire in %1$s for security reasons.",
         "PasswordResetEmailSubject": "Reset your Matomo account password",
         "PasswordsDoNotMatch": "Mismatching passwords.",
         "PleaseNote": "Please note",

--- a/plugins/Login/templates/_passwordResetHtmlEmail.twig
+++ b/plugins/Login/templates/_passwordResetHtmlEmail.twig
@@ -1,7 +1,12 @@
 <p>{{ 'General_HelloUser'|translate(login) }}</p>
 <p>{{ 'Login_PasswordResetEmail1'|translate(ip) }}</p>
 <p><a href="{{ resetUrl }}">{{ 'Login_PasswordResetEmailLinkReset'|translate }}</a></p>
+{% if linkValidity %}
+<p>{{ 'Login_PasswordResetEmailLinkValidity'|translate(linkValidity) }}</p>
+{% else %}
 <p>{{ 'Login_PasswordResetEmail2'|translate }}</p>
+{% endif %}
+{% if cancelUrl %}
 <p>{{ 'Login_PasswordResetEmail3'|translate }}</p>
 <p><a href="{{ cancelUrl }}">{{ 'Login_PasswordResetEmailLinkCancel'|translate }}</a></p>
 <p>{{ 'Login_PasswordResetEmail4'|translate }}</p>
@@ -9,3 +14,4 @@
 <p>{{ 'Login_PasswordResetEmailAppTokens'|translate }}</p>
 <p><strong>{{ 'Login_SecurityTip'|translate }}:</strong></p>
 <p>{{ 'Login_PasswordResetEmail5'|translate }}</p>
+{% endif %}

--- a/plugins/Login/templates/_passwordResetTextEmail.twig
+++ b/plugins/Login/templates/_passwordResetTextEmail.twig
@@ -5,8 +5,13 @@
 
 {{ resetUrl }}
 
+{% if linkValidity %}
+{{ 'Login_PasswordResetEmailLinkValidity'|translate(linkValidity) }}
+{% else %}
 {{ 'Login_PasswordResetEmail2'|translate }}
+{% endif %}
 
+{% if cancelUrl %}
 {{ 'Login_PasswordResetEmail3'|translate }}
 
 {{ cancelUrl }}
@@ -20,4 +25,5 @@
 {{ 'Login_SecurityTip'|translate }}:
 
 {{ 'Login_PasswordResetEmail5'|translate }}
+{% endif %}
 {% endautoescape %}

--- a/plugins/Login/tests/Integration/ControllerTest.php
+++ b/plugins/Login/tests/Integration/ControllerTest.php
@@ -13,6 +13,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Auth;
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Exception\RedirectException;
 use Piwik\Plugins\Login\Controller;
 use Piwik\Plugins\Login\PasswordResetter;
 use Piwik\Nonce;
@@ -146,6 +147,18 @@ class ControllerTest extends IntegrationTestCase
         $this->assertTrue((new Model())->isPendingUser('test'));
         // and the set password form is rendered again instead
         $this->assertStringContainsString('invitation_form', $response);
+    }
+
+    public function testAcceptInvitationRejectsInvitationWithoutExpiry()
+    {
+        [, $token] = $this->generateTestUser();
+
+        (new Model())->updateUserFields('test', ['invite_expired_at' => null]);
+        $_POST['token'] = $token;
+
+        $this->expectException(RedirectException::class);
+
+        $this->controller->acceptInvitation();
     }
 
     public function testAuthenticateAndRedirectRebuildsFormRedirectUrl()

--- a/plugins/Login/tests/Integration/PasswordResetterTest.php
+++ b/plugins/Login/tests/Integration/PasswordResetterTest.php
@@ -22,6 +22,7 @@ use Piwik\Plugin\Manager;
 use Piwik\Plugins\Login\PasswordResetter;
 use Piwik\Plugins\Login\PasswordResetUserIsInvalidException;
 use Piwik\Plugins\UsersManager\Model;
+use Piwik\Plugins\UsersManager\Repository\UserRepository;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -271,6 +272,108 @@ class PasswordResetterTest extends IntegrationTestCase
 
             throw $e;
         }
+    }
+
+    public function testPendingUserLookupCanBeOverridden()
+    {
+        Request::processRequest(
+            'UsersManager.inviteUser',
+            [
+                'userLogin' => 'customPendingLookup',
+                'email' => 'custom.pending.lookup@user.io',
+                'initialIdSite' => 1,
+                'expiryInDays' => 7,
+            ]
+        );
+
+        $passwordResetter = new class extends PasswordResetter {
+            protected function getPendingUserInformation(string $loginOrMail): ?array
+            {
+                return null;
+            }
+        };
+
+        $this->expectException(PasswordResetUserIsInvalidException::class);
+
+        $passwordResetter->initiatePasswordResetProcess(
+            'custom.pending.lookup@user.io',
+            self::NEWPASSWORD
+        );
+    }
+
+    /**
+     * @dataProvider provideInvitationInvalidationDuringPasswordReset
+     */
+    public function testPasswordResetDoesNotSendInvitationLinkIfInvitationBecomesInvalidDuringRequest(
+        string $login,
+        string $email,
+        bool $acceptsInvitation
+    ) {
+        Request::processRequest(
+            'UsersManager.inviteUser',
+            [
+                'userLogin' => $login,
+                'email' => $email,
+                'initialIdSite' => 1,
+                'expiryInDays' => 7,
+            ]
+        );
+
+        $model = new Model();
+        $repository = StaticContainer::get(UserRepository::class);
+        $racingRepository = $this->createMock(UserRepository::class);
+        $racingRepository
+            ->method('refreshInviteLinkToken')
+            ->willReturnCallback(function (string $userLogin) use ($acceptsInvitation, $model, $repository) {
+                $fields = $acceptsInvitation
+                    ? [
+                        'invite_token' => null,
+                        'invite_link_token' => null,
+                        'invite_expired_at' => null,
+                    ]
+                    : [
+                        'invite_expired_at' => Date::now()->subDay(1)->getDatetime(),
+                    ];
+                $model->updateUserFields($userLogin, $fields);
+
+                return $repository->refreshInviteLinkToken($userLogin);
+            });
+
+        StaticContainer::getContainer()->set(UserRepository::class, $racingRepository);
+
+        try {
+            $this->passwordResetter->initiatePasswordResetProcess(
+                $email,
+                self::NEWPASSWORD
+            );
+        } finally {
+            StaticContainer::getContainer()->set(UserRepository::class, $repository);
+        }
+
+        $userAfterReset = $model->getUser($login);
+
+        self::assertNull($userAfterReset['invite_link_token']);
+        self::assertNull($this->passwordResetEmailBody);
+        self::assertSame([], $this->eventInitiatedInfo);
+        self::assertFalse(Option::get(
+            PasswordResetter::getPasswordResetInfoOptionName($login)
+        ));
+    }
+
+    public function provideInvitationInvalidationDuringPasswordReset(): array
+    {
+        return [
+            'accepted invitation' => [
+                'acceptedDuringReset',
+                'accepted.during.reset@user.io',
+                true,
+            ],
+            'expired invitation' => [
+                'expiredDuringReset',
+                'expired.during.reset@user.io',
+                false,
+            ],
+        ];
     }
 
     public function testPasswordResetShouldNotWorkForInvalidUserAndThrowException()

--- a/plugins/Login/tests/Integration/PasswordResetterTest.php
+++ b/plugins/Login/tests/Integration/PasswordResetterTest.php
@@ -14,6 +14,7 @@ use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\Auth;
 use Piwik\Container\StaticContainer;
+use Piwik\Date;
 use Piwik\DI;
 use Piwik\Option;
 use Piwik\Piwik;
@@ -35,6 +36,16 @@ class PasswordResetterTest extends IntegrationTestCase
      * @var string
      */
     private $capturedToken;
+
+    /**
+     * @var string|null
+     */
+    private $capturedActivationToken;
+
+    /**
+     * @var string|null
+     */
+    private $passwordResetEmailBody;
 
     /**
      * @var PasswordResetter
@@ -67,6 +78,8 @@ class PasswordResetterTest extends IntegrationTestCase
         Fixture::createWebsite('2010-01-01 05:00:00');
         $this->passwordResetter = new PasswordResetter();
         $this->capturedToken = null;
+        $this->capturedActivationToken = null;
+        $this->passwordResetEmailBody = null;
         $this->receivedCancelEmail = false;
         $this->eventCancelledInfo = [];
         $this->eventConfirmedInfo = [];
@@ -197,11 +210,8 @@ class PasswordResetterTest extends IntegrationTestCase
         $this->passwordResetter->checkValidConfirmPasswordToken('superUserLogin', $oldCapturedToken);
     }
 
-    public function testPasswordResetShouldNotWorkForPendingUser()
+    public function testPasswordResetForPendingUserSendsActivationLinkWithoutExtendingExpiry()
     {
-        $this->expectException(PasswordResetUserIsInvalidException::class);
-        $this->expectExceptionMessage('Invalid username or e-mail address.');
-
         Request::processRequest(
             'UsersManager.inviteUser',
             [
@@ -214,12 +224,50 @@ class PasswordResetterTest extends IntegrationTestCase
 
         $model = new Model();
         self::assertTrue($model->isPendingUser('pendingUser'));
+        $userBeforeReset = $model->getUser('pendingUser');
+
+        $this->passwordResetter->initiatePasswordResetProcess('pending@user.io', self::NEWPASSWORD);
+
+        $userAfterReset = $model->getUser('pendingUser');
+
+        self::assertSame($userBeforeReset['invite_expired_at'], $userAfterReset['invite_expired_at']);
+        self::assertSame($userBeforeReset['invite_token'], $userAfterReset['invite_token']);
+        self::assertNotEmpty($this->capturedActivationToken);
+        self::assertSame(
+            $model->hashTokenAuth($this->capturedActivationToken),
+            $userAfterReset['invite_link_token']
+        );
+        self::assertStringContainsString('action=3DacceptInvitation', $this->passwordResetEmailBody);
+        self::assertStringContainsString('This link will expire in ', $this->passwordResetEmailBody);
+        self::assertStringNotContainsString('expire in 24 hours', $this->passwordResetEmailBody);
+        self::assertSame(['pendingUser'], $this->eventInitiatedInfo);
+    }
+
+    public function testPasswordResetShouldNotWorkForPendingUserWithExpiredInvitation()
+    {
+        $this->expectException(PasswordResetUserIsInvalidException::class);
+        $this->expectExceptionMessage('Invalid username or e-mail address.');
+
+        Request::processRequest(
+            'UsersManager.inviteUser',
+            [
+                'userLogin' => 'expiredPendingUser',
+                'email' => 'expired.pending@user.io',
+                'initialIdSite' => 1,
+                'expiryInDays' => 7,
+            ]
+        );
+
+        $model = new Model();
+        $model->updateUserFields('expiredPendingUser', [
+            'invite_expired_at' => Date::now()->subDay(1)->getDatetime(),
+        ]);
 
         try {
-            $this->passwordResetter->initiatePasswordResetProcess('pendingUser', self::NEWPASSWORD);
+            $this->passwordResetter->initiatePasswordResetProcess('expired.pending@user.io', self::NEWPASSWORD);
         } catch (\Exception $e) {
-            // event should not have been dispatched
-            $this->assertSame([], $this->eventInitiatedInfo);
+            self::assertNull($this->passwordResetEmailBody);
+            self::assertSame([], $this->eventInitiatedInfo);
 
             throw $e;
         }
@@ -317,14 +365,23 @@ class PasswordResetterTest extends IntegrationTestCase
                     if ($subjectReset === $mail->Subject) {
                         $body = $mail->createBody();
                         $body = preg_replace("/=[\r\n]+/", '', $body);
+                        $this->passwordResetEmailBody = $body;
 
                         preg_match('/resetToken=[\s]*3D([a-zA-Z0-9=\s]+)/', $body, $matches);
 
-                        $this->assertNotEmpty($matches[1]);
+                        if (!empty($matches[1])) {
+                            $capturedToken = $matches[1];
+                            $capturedToken = preg_replace('/=\s*/', '', $capturedToken);
+                            $this->capturedToken = $capturedToken;
+                        }
 
-                        $capturedToken = $matches[1];
-                        $capturedToken = preg_replace('/=\s*/', '', $capturedToken);
-                        $this->capturedToken = $capturedToken;
+                        preg_match('/action=3DacceptInvitation&amp;token=3D([a-zA-Z0-9=\s]+)"/', $body, $matches);
+
+                        if (!empty($matches[1])) {
+                            $capturedToken = $matches[1];
+                            $capturedToken = preg_replace('/=\s*/', '', $capturedToken);
+                            $this->capturedActivationToken = $capturedToken;
+                        }
                     }
 
                     if ($subjectCancel === $mail->Subject) {

--- a/plugins/Login/tests/Integration/PasswordResetterTest.php
+++ b/plugins/Login/tests/Integration/PasswordResetterTest.php
@@ -21,6 +21,7 @@ use Piwik\Piwik;
 use Piwik\Plugin\Manager;
 use Piwik\Plugins\Login\PasswordResetter;
 use Piwik\Plugins\Login\PasswordResetUserIsInvalidException;
+use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\Plugins\UsersManager\Repository\UserRepository;
 use Piwik\Tests\Framework\Fixture;
@@ -232,16 +233,49 @@ class PasswordResetterTest extends IntegrationTestCase
         $userAfterReset = $model->getUser('pendingUser');
 
         self::assertSame($userBeforeReset['invite_expired_at'], $userAfterReset['invite_expired_at']);
-        self::assertSame($userBeforeReset['invite_token'], $userAfterReset['invite_token']);
+        self::assertNotSame($userBeforeReset['invite_token'], $userAfterReset['invite_token']);
         self::assertNotEmpty($this->capturedActivationToken);
         self::assertSame(
             $model->hashTokenAuth($this->capturedActivationToken),
-            $userAfterReset['invite_link_token']
+            $userAfterReset['invite_token']
         );
+        self::assertNull($userAfterReset['invite_link_token']);
         self::assertStringContainsString('action=3DacceptInvitation', $this->passwordResetEmailBody);
         self::assertStringContainsString('This link will expire in ', $this->passwordResetEmailBody);
         self::assertStringNotContainsString('expire in 24 hours', $this->passwordResetEmailBody);
         self::assertSame(['pendingUser'], $this->eventInitiatedInfo);
+    }
+
+    public function testChangingPendingUserEmailInvalidatesRecoveryActivationLink()
+    {
+        Request::processRequest(
+            'UsersManager.inviteUser',
+            [
+                'userLogin' => 'reassignedPendingUser',
+                'email' => 'previous.pending@user.io',
+                'initialIdSite' => 1,
+                'expiryInDays' => 7,
+            ]
+        );
+
+        $model = new Model();
+
+        $this->passwordResetter->initiatePasswordResetProcess(
+            'previous.pending@user.io',
+            self::NEWPASSWORD
+        );
+
+        self::assertNotEmpty($this->capturedActivationToken);
+        self::assertNotEmpty($model->getUserByInviteToken($this->capturedActivationToken));
+
+        UsersManagerAPI::$UPDATE_USER_REQUIRE_PASSWORD_CONFIRMATION = false;
+        UsersManagerAPI::getInstance()->updateUser(
+            'reassignedPendingUser',
+            false,
+            'new.pending@user.io'
+        );
+
+        self::assertEmpty($model->getUserByInviteToken($this->capturedActivationToken));
     }
 
     public function testPasswordResetShouldNotWorkForPendingUserWithExpiredInvitation()
@@ -323,8 +357,16 @@ class PasswordResetterTest extends IntegrationTestCase
         $repository = StaticContainer::get(UserRepository::class);
         $racingRepository = $this->createMock(UserRepository::class);
         $racingRepository
-            ->method('refreshInviteLinkToken')
-            ->willReturnCallback(function (string $userLogin) use ($acceptsInvitation, $model, $repository) {
+            ->method('refreshInviteToken')
+            ->willReturnCallback(function (
+                string $userLogin,
+                string $expectedInviteToken,
+                string $expectedEmail
+            ) use (
+                $acceptsInvitation,
+                $model,
+                $repository
+            ) {
                 $fields = $acceptsInvitation
                     ? [
                         'invite_token' => null,
@@ -336,7 +378,11 @@ class PasswordResetterTest extends IntegrationTestCase
                     ];
                 $model->updateUserFields($userLogin, $fields);
 
-                return $repository->refreshInviteLinkToken($userLogin);
+                return $repository->refreshInviteToken(
+                    $userLogin,
+                    $expectedInviteToken,
+                    $expectedEmail
+                );
             });
 
         StaticContainer::getContainer()->set(UserRepository::class, $racingRepository);
@@ -374,6 +420,67 @@ class PasswordResetterTest extends IntegrationTestCase
                 false,
             ],
         ];
+    }
+
+    public function testPasswordResetDoesNotSendActivationLinkIfPendingUserEmailChangesDuringRequest()
+    {
+        Request::processRequest(
+            'UsersManager.inviteUser',
+            [
+                'userLogin' => 'emailChangedDuringReset',
+                'email' => 'old.pending@user.io',
+                'initialIdSite' => 1,
+                'expiryInDays' => 7,
+            ]
+        );
+
+        $model = new Model();
+        $userBeforeReset = $model->getUser('emailChangedDuringReset');
+        $repository = StaticContainer::get(UserRepository::class);
+        $racingRepository = $this->createMock(UserRepository::class);
+        $racingRepository
+            ->method('refreshInviteToken')
+            ->willReturnCallback(function (
+                string $userLogin,
+                string $expectedInviteToken,
+                string $expectedEmail
+            ) use ($repository) {
+                UsersManagerAPI::$UPDATE_USER_REQUIRE_PASSWORD_CONFIRMATION = false;
+                UsersManagerAPI::getInstance()->updateUser(
+                    $userLogin,
+                    false,
+                    'new.pending@user.io'
+                );
+
+                return $repository->refreshInviteToken(
+                    $userLogin,
+                    $expectedInviteToken,
+                    $expectedEmail
+                );
+            });
+
+        StaticContainer::getContainer()->set(UserRepository::class, $racingRepository);
+
+        try {
+            $this->passwordResetter->initiatePasswordResetProcess(
+                'old.pending@user.io',
+                self::NEWPASSWORD
+            );
+        } finally {
+            StaticContainer::getContainer()->set(UserRepository::class, $repository);
+        }
+
+        $userAfterReset = $model->getUser('emailChangedDuringReset');
+
+        self::assertSame('new.pending@user.io', $userAfterReset['email']);
+        self::assertNotSame($userBeforeReset['invite_token'], $userAfterReset['invite_token']);
+        self::assertNull($userAfterReset['invite_link_token']);
+        self::assertNull($this->capturedActivationToken);
+        self::assertNull($this->passwordResetEmailBody);
+        self::assertSame([], $this->eventInitiatedInfo);
+        self::assertFalse(Option::get(
+            PasswordResetter::getPasswordResetInfoOptionName('emailChangedDuringReset')
+        ));
     }
 
     public function testPasswordResetShouldNotWorkForInvalidUserAndThrowException()

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -688,6 +688,7 @@ class Model
     {
         $this->updateUserFields($userLogin, [
           'invite_token'      => $this->hashTokenAuth($token),
+          'invite_link_token' => null,
           'invite_expired_at' => Date::now()->addDay($expiryInDays)->getDatetime(),
         ]);
     }
@@ -700,13 +701,19 @@ class Model
         ]);
     }
 
-    public function updateInviteLinkTokenForPendingUser(string $userLogin, string $token): bool
-    {
+    public function replaceInviteTokenForPendingUser(
+        string $userLogin,
+        string $token,
+        string $expectedInviteToken,
+        string $expectedEmail
+    ): bool {
         $sql = sprintf(
             'UPDATE `%s`
-             SET `invite_link_token` = ?
+             SET `invite_token` = ?,
+                 `invite_link_token` = NULL
              WHERE `login` = ?
-               AND `invite_token` IS NOT NULL
+               AND `invite_token` = ?
+               AND `email` = ?
                AND `invite_expired_at` IS NOT NULL
                AND `invite_expired_at` >= ?',
             $this->userTable
@@ -714,6 +721,8 @@ class Model
         $query = $this->getDb()->query($sql, [
             $this->hashTokenAuth($token),
             $userLogin,
+            $expectedInviteToken,
+            $expectedEmail,
             Date::now()->getDatetime(),
         ]);
 

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -700,6 +700,26 @@ class Model
         ]);
     }
 
+    public function updateInviteLinkTokenForPendingUser(string $userLogin, string $token): bool
+    {
+        $sql = sprintf(
+            'UPDATE `%s`
+             SET `invite_link_token` = ?
+             WHERE `login` = ?
+               AND `invite_token` IS NOT NULL
+               AND `invite_expired_at` IS NOT NULL
+               AND `invite_expired_at` >= ?',
+            $this->userTable
+        );
+        $query = $this->getDb()->query($sql, [
+            $this->hashTokenAuth($token),
+            $userLogin,
+            Date::now()->getDatetime(),
+        ]);
+
+        return $query->rowCount() === 1;
+    }
+
     public function setSuperUserAccess($userLogin, $hasSuperUserAccess)
     {
         $this->updateUserFields($userLogin, array(

--- a/plugins/UsersManager/Repository/UserRepository.php
+++ b/plugins/UsersManager/Repository/UserRepository.php
@@ -113,14 +113,17 @@ class UserRepository
     }
 
     /**
-     * Generates a new invitation link token without changing the invitation expiry.
+     * Generates a new invitation link token for an unexpired pending user without
+     * changing the invitation expiry.
      */
-    public function refreshInviteLinkToken(string $userLogin): string
+    public function refreshInviteLinkToken(string $userLogin): ?string
     {
         $generatedToken = $this->model->generateRandomInviteToken();
-        $this->model->updateUserFields($userLogin, [
-            'invite_link_token' => $this->model->hashTokenAuth($generatedToken),
-        ]);
+
+        if (!$this->model->updateInviteLinkTokenForPendingUser($userLogin, $generatedToken)) {
+            return null;
+        }
+
         return $generatedToken;
     }
 

--- a/plugins/UsersManager/Repository/UserRepository.php
+++ b/plugins/UsersManager/Repository/UserRepository.php
@@ -112,6 +112,18 @@ class UserRepository
         $this->sendInvitationEmail($user, $generatedToken, $expiryInDays);
     }
 
+    /**
+     * Generates a new invitation link token without changing the invitation expiry.
+     */
+    public function refreshInviteLinkToken(string $userLogin): string
+    {
+        $generatedToken = $this->model->generateRandomInviteToken();
+        $this->model->updateUserFields($userLogin, [
+            'invite_link_token' => $this->model->hashTokenAuth($generatedToken),
+        ]);
+        return $generatedToken;
+    }
+
     public function generateInviteToken(string $userLogin, int $expiryInDays): string
     {
         $generatedToken = $this->model->generateRandomInviteToken();

--- a/plugins/UsersManager/Repository/UserRepository.php
+++ b/plugins/UsersManager/Repository/UserRepository.php
@@ -113,14 +113,24 @@ class UserRepository
     }
 
     /**
-     * Generates a new invitation link token for an unexpired pending user without
-     * changing the invitation expiry.
+     * Replaces the activation token for an unchanged, unexpired pending user
+     * without changing the invitation expiry.
      */
-    public function refreshInviteLinkToken(string $userLogin): ?string
-    {
+    public function refreshInviteToken(
+        string $userLogin,
+        string $expectedInviteToken,
+        string $expectedEmail
+    ): ?string {
         $generatedToken = $this->model->generateRandomInviteToken();
 
-        if (!$this->model->updateInviteLinkTokenForPendingUser($userLogin, $generatedToken)) {
+        if (
+            !$this->model->replaceInviteTokenForPendingUser(
+                $userLogin,
+                $generatedToken,
+                $expectedInviteToken,
+                $expectedEmail
+            )
+        ) {
             return null;
         }
 


### PR DESCRIPTION
### Description

Pending invitees currently reach the password recovery form because they have not set a password yet, but the flow treats them as invalid and sends no email.

This change lets an invitee with an unexpired pending invitation receive a fresh activation link from the recovery flow. The link points to `acceptInvitation`, preserves the existing `invite_expired_at` value, and shows the remaining validity in the email. Expired or malformed invitations still fail closed, while active users keep the existing password reset and cancellation flow.

Recovery now atomically replaces the pending user's existing invitation token instead of creating a second valid activation credential. The update succeeds only when the login, previous token, email, and unexpired pending state still match. If acceptance, expiry, or an email reassignment wins the race, no stale link is sent and the temporary reset state is removed.

Re-inviting a pending user or changing the invitation email also clears any previously generated recovery link, so the previous mailbox owner cannot complete an outdated invitation.

The existing recovery request limit remains in place.

Fixes #20297

### Validation

- Failing-first regressions for preserving the original token and for an old recovery link surviving pending-email reassignment.
- Focused recovery, reassignment, acceptance/expiry race, and email-change race coverage: 5 tests, 28 assertions passed.
- Full `PasswordResetterTest`: 17 tests, 77 assertions passed.
- Full Login `ControllerTest`: 7 tests, 9 assertions passed.
- Existing UsersManager email-change/re-invite integration test: 1 test, 4 assertions passed.
- Full `UserInviteTest`, including local HTTP acceptance and decline routes: 2 tests, 9 assertions passed.
- PHPCS passed for all changed PHP files.
- Targeted PHPStan passed with no errors.
- PHP syntax and `git diff --check` passed.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
