### PR TITLE
Fix SegmentManagement page Sparkline size 

### DIFF
--- a/core/Twig.php
+++ b/core/Twig.php
@@ -290,8 +290,10 @@ class Twig
             'sparkline',
             /**
              * @param string $src
-             * @param int    $width  Displayed width in px (defaults to the standard sparkline size).
-             * @param int    $height Displayed height in px.
+             * @param int $width Display width in px, honored only when the SparklinesRedesign feature
+             *      flag is enabled (otherwise JS forces the legacy 100x25). Defaults to Sparkline::DEFAULT_WIDTH.
+             * @param int $height Display height in px, same flag-dependent behaviour. Defaults to
+             *      Sparkline::DEFAULT_HEIGHT.
              * @return string
              */
             function ($src, $width = Sparkline::DEFAULT_WIDTH, $height = Sparkline::DEFAULT_HEIGHT) use ($twigEnv) {

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -290,12 +290,12 @@ class Twig
             'sparkline',
             /**
              * @param string $src
+             * @param int    $width  Displayed width in px (defaults to the standard sparkline size).
+             * @param int    $height Displayed height in px.
              * @return string
              */
-            function ($src) use ($twigEnv) {
-                $width  = Sparkline::DEFAULT_WIDTH;
-                $height = Sparkline::DEFAULT_HEIGHT;
-                return sprintf(Twig::SPARKLINE_TEMPLATE, piwik_escape_filter($twigEnv, $src, 'html_attr'), $width, $height);
+            function ($src, $width = Sparkline::DEFAULT_WIDTH, $height = Sparkline::DEFAULT_HEIGHT) use ($twigEnv) {
+                return sprintf(Twig::SPARKLINE_TEMPLATE, piwik_escape_filter($twigEnv, $src, 'html_attr'), (int) $width, (int) $height);
             },
             ['is_safe' => ['html']]
         );

--- a/plugins/SegmentEditor/templates/manageSegments.twig
+++ b/plugins/SegmentEditor/templates/manageSegments.twig
@@ -82,7 +82,8 @@
                                 <td class="entityTable_Sparkline">
                                     {% if segment.sparklineUrl is defined %}
                                         <div class="sparkline" {% if sparklineTooltipKey -%} title="{{ sparklineTooltipKey|translate(segment.name) }}" {%- endif %}>
-                                            {{ sparkline(segment.sparklineUrl) }}
+                                            {# Keep the legacy 100x25 display size so the SparklinesRedesign flag does not enlarge this management-table sparkline #}
+                                            {{ sparkline(segment.sparklineUrl, 100, 25) }}
                                         </div>
                                     {% endif %}
                                 </td>

--- a/plugins/SegmentEditor/tests/Integration/ControllerTest.php
+++ b/plugins/SegmentEditor/tests/Integration/ControllerTest.php
@@ -156,6 +156,41 @@ class ControllerTest extends IntegrationTestCase
         $this->assertSame('-', $selectedActions);
     }
 
+    public function testManageSegmentsRendersSparklinesAtLegacyDisplaySize(): void
+    {
+        Rules::setBrowserTriggerArchiving(false);
+
+        $_GET = [
+            'idSite' => '1',
+            'period' => 'range',
+            'date' => '2010-03-06,2010-03-08',
+            'segment' => '',
+        ];
+        $_REQUEST = $_GET;
+
+        $html = (new Controller())->manageSegments();
+
+        $document = new \DOMDocument();
+        @$document->loadHTML($html);
+        $xpath = new \DOMXPath($document);
+
+        // The management table renders sparklines through the legacy sparkline() Twig helper. With the
+        // SparklinesRedesign flag on, refreshSparklines() honors the img width/height as the display
+        // size, so the helper must keep requesting the legacy 100x25 size here (see PR #24927).
+        $sparklineImages = $xpath->query('//td[contains(@class,"entityTable_Sparkline")]//img');
+        $this->assertNotFalse($sparklineImages);
+        $this->assertGreaterThan(0, $sparklineImages->length, 'Expected at least one management-table sparkline image');
+
+        foreach ($sparklineImages as $sparklineImage) {
+            $widthNode = $sparklineImage->attributes->getNamedItem('width');
+            $heightNode = $sparklineImage->attributes->getNamedItem('height');
+            $this->assertNotNull($widthNode);
+            $this->assertNotNull($heightNode);
+            $this->assertSame('100', $widthNode->nodeValue);
+            $this->assertSame('25', $heightNode->nodeValue);
+        }
+    }
+
     public function testGetSegmentDataReturnsMetricsForGivenSegment(): void
     {
         Rules::setBrowserTriggerArchiving(false);


### PR DESCRIPTION
### Description

When the `SparklinesRedesign` feature flag is enabled, the **Evolution Visits** sparklines on the Segments management page (Visitors → Segments) render at double size — 200×50 instead of the standard 100×25. Each sparkline overflows its fixed 100px-wide table cell and the rows become noticeably taller.

| Before (flag on) | After (this PR, flag on) |
|---|---|
| <img width="250" height="75" alt="Screenshot 2026-07-28 at 2 27 29 PM" src="https://github.com/user-attachments/assets/3d1cdd65-744e-4005-ab4e-4ce8c97c2b00" /> | <img width="250" height="75" alt="after-segmentmgt-page" src="https://github.com/user-attachments/assets/1cfcd2ce-1d5e-4fa2-b5ab-09ea5970898c" /> |
| Sparkline 200×50, overflows the cell, rows grow taller | Sparkline 100×25, fits the cell as before |


_(before/after screenshots attached)_

### Root cause

The manage-segments table renders each sparkline through the legacy Twig `sparkline()` helper, which emits `<img … width="200" height="50">` (the server render defaults). With the redesign flag on, `refreshSparklines()` in `plugins/CoreHome/javascripts/sparkline.js` starts honoring those `width`/`height` attributes as the **display** size — whereas the legacy path always forced the display down to 100×25. So this page's sparklines end up displayed at 200×50.

The redesigned sparkline **cards** are not involved: the Vue `Sparkline` component sets its `src` directly and never passes through `refreshSparklines()`. On 6.x, the manage-segments page is the only live page still rendering the legacy `sparkline()` macro while the flag is on.

### Fix

- Extend the `sparkline()` Twig helper (`core/Twig.php`) with optional display `width`/`height` arguments. Defaults are unchanged (`Sparkline::DEFAULT_WIDTH`/`DEFAULT_HEIGHT`), so every existing caller behaves exactly as before.
- On `plugins/SegmentEditor/templates/manageSegments.twig`, request `sparkline(segment.sparklineUrl, 100, 25)`.

With the flag on, the sparkline displays at 100×25 again while still requesting a 200×50 PNG (so it stays crisp on hi-DPI screens). With the flag off, nothing changes.

### Scope / impact

- Only the Segments management page is affected — all other `sparkline()` callers keep the default size.
- No behavior change when the flag is off.
- No UI screenshots added or changed: the `SegmentManagementPage` UI test on `6.x-dev` doesn't enable the flag, and the flag-off baseline is already 100×25.


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
