### PR TITLE
Substitute sparkline value into description placeholder without misusing translate

### DIFF
--- a/plugins/CoreVisualizations/templates/macros.twig
+++ b/plugins/CoreVisualizations/templates/macros.twig
@@ -38,7 +38,7 @@
             {% for metric in group %}
                 <span class="sparkline-metrics" {% if allMetricsDocumentation[metric.column] is defined and allMetricsDocumentation[metric.column] %}title="{{ allMetricsDocumentation[metric.column] }}"{% endif %}>
                 {% if '%s' in metric.description -%}
-                    {{ metric.description|translate("<strong>"~metric.value|number(2)~"</strong>")|raw }}
+                    {{ metric.description|e('html')|replace({'%s': "<strong>"~metric.value|number(2)~"</strong>"})|raw }}
                 {%- else %}
                     <strong>{{ metric.value|number(2) }}</strong> {{ metric.description }}
                 {%- endif %}{% if not loop.last %}, {% endif %}


### PR DESCRIPTION
## Summary

A sparkline metric description is already translated and only carries an optional `%s` placeholder marking where the value should appear. The macro passed the description through the `translate` filter purely to inject the value into that placeholder, which treats the whole description as a printf-style format string. This replaces it with an explicit placeholder replacement so the description is handled as plain text.

## Review

- [ ] Functional review done
- [ ] Potential edge cases considered
- [ ] Usable, i.e. no confusing behaviour

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
