### PR TITLE
Detect Google-GeminiNotebook as Google-NotebookLM

### DIFF
--- a/plugins/BotTracking/BotDetector.php
+++ b/plugins/BotTracking/BotDetector.php
@@ -27,12 +27,22 @@ class BotDetector
      * @var array<string, string>
      */
     private $aiAssistantPatterns = [
-        'ChatGPT-User'         => self::BOT_TYPE_AI_CHATBOT,
-        'MistralAI-User'       => self::BOT_TYPE_AI_CHATBOT,
-        'Gemini-Deep-Research' => self::BOT_TYPE_AI_CHATBOT,
-        'Claude-User'          => self::BOT_TYPE_AI_CHATBOT,
-        'Perplexity-User'      => self::BOT_TYPE_AI_CHATBOT,
-        'Google-NotebookLM'    => self::BOT_TYPE_AI_CHATBOT,
+        'ChatGPT-User'          => self::BOT_TYPE_AI_CHATBOT,
+        'MistralAI-User'        => self::BOT_TYPE_AI_CHATBOT,
+        'Gemini-Deep-Research'  => self::BOT_TYPE_AI_CHATBOT,
+        'Claude-User'           => self::BOT_TYPE_AI_CHATBOT,
+        'Perplexity-User'       => self::BOT_TYPE_AI_CHATBOT,
+        'Google-GeminiNotebook' => self::BOT_TYPE_AI_CHATBOT,
+        'Google-NotebookLM'     => self::BOT_TYPE_AI_CHATBOT,
+    ];
+
+    /**
+     * Normalized bot names for renamed User-Agent patterns.
+     *
+     * @var array<string, string>
+     */
+    private $botNameAliases = [
+        'Google-GeminiNotebook' => 'Google-NotebookLM',
     ];
 
     public function __construct(string $userAgent)
@@ -55,7 +65,7 @@ class BotDetector
         foreach ($this->aiAssistantPatterns as $pattern => $botType) {
             if (stripos($userAgent, $pattern) !== false) {
                 return [
-                    'bot_name' => $pattern,
+                    'bot_name' => $this->botNameAliases[$pattern] ?? $pattern,
                     'bot_type' => $botType,
                 ];
             }

--- a/plugins/BotTracking/tests/Integration/TrackerTest.php
+++ b/plugins/BotTracking/tests/Integration/TrackerTest.php
@@ -77,6 +77,7 @@ class TrackerTest extends IntegrationTestCase
             ['Claude-User/3.0', 'Claude-User', BotDetector::BOT_TYPE_AI_CHATBOT],
             ['Perplexity-User/1.0', 'Perplexity-User', BotDetector::BOT_TYPE_AI_CHATBOT],
             ['Google-NotebookLM/1.0', 'Google-NotebookLM', BotDetector::BOT_TYPE_AI_CHATBOT],
+            ['Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36 (compatible; Google-GeminiNotebook; +https://developers.google.com/crawling/docs/crawlers-fetchers/google-gemininotebook)', 'Google-NotebookLM', BotDetector::BOT_TYPE_AI_CHATBOT],
         ];
     }
 

--- a/plugins/BotTracking/tests/Unit/BotDetectorTest.php
+++ b/plugins/BotTracking/tests/Unit/BotDetectorTest.php
@@ -66,6 +66,7 @@ class BotDetectorTest extends TestCase
             ['Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Claude-User/1.0; +Claude-User@anthropic.com)', 'Claude-User', BotDetector::BOT_TYPE_AI_CHATBOT],
             ['Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Perplexity-User/1.0; +https://perplexity.ai/perplexity-user)', 'Perplexity-User', BotDetector::BOT_TYPE_AI_CHATBOT],
             ['Google-NotebookLM', 'Google-NotebookLM', BotDetector::BOT_TYPE_AI_CHATBOT],
+            ['Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36 (compatible; Google-GeminiNotebook; +https://developers.google.com/crawling/docs/crawlers-fetchers/google-gemininotebook)', 'Google-NotebookLM', BotDetector::BOT_TYPE_AI_CHATBOT],
 
         ];
     }


### PR DESCRIPTION
ℹ️ Forward-port of #24913 from @eldk (merged to `5.x-dev`) to `6.x-dev`.

## Description

Google renamed the `Google-NotebookLM` User-Agent token to `Google-GeminiNotebook`. This change:

- detects both the current `Google-GeminiNotebook` token and the former `Google-NotebookLM` token;
- normalizes both to the existing `Google-NotebookLM` `bot_name`;
- preserves historical BotTracking statistics and the existing `CHATBOT_MAPPING` link to the `NotebookLM` referrer name;
- adds unit + integration coverage using Google's current desktop User-Agent.

```text
Google-NotebookLM     -> bot_name: Google-NotebookLM
Google-GeminiNotebook -> bot_name: Google-NotebookLM
```

Identical to the 5.x-dev change; the three files differed between branches by exactly this change.

Related Device Detector PR: matomo-org/device-detector#8336
Google documentation: https://developers.google.com/crawling/docs/crawlers-fetchers/google-user-triggered-fetchers#gemini-notebook

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules