### PR TITLE
Correct inaccurate Db return types and declare missing return types in core

### DIFF
--- a/core/API/Proxy.php
+++ b/core/API/Proxy.php
@@ -52,6 +52,9 @@ class Proxy
         $this->noDefaultValue = new NoDefaultValue();
     }
 
+    /**
+     * @return self
+     */
     public static function getInstance()
     {
         return StaticContainer::get(self::class);
@@ -423,6 +426,8 @@ class Proxy
 
     /**
      * Check if given method name is deprecated or not.
+     *
+     * @return bool
      */
     public function isDeprecatedMethod($class, $methodName)
     {

--- a/core/ArchiveProcessor/Record.php
+++ b/core/ArchiveProcessor/Record.php
@@ -98,6 +98,9 @@ class Record
      */
     private $legacyHierarchyToFlatReducerCallback = null;
 
+    /**
+     * @return self
+     */
     public static function make($type, $name)
     {
         $record = new Record();

--- a/core/CacheId.php
+++ b/core/CacheId.php
@@ -14,11 +14,17 @@ use Piwik\Plugin\Manager;
 
 class CacheId
 {
+    /**
+     * @return string
+     */
     public static function languageAware($cacheId)
     {
         return $cacheId . '-' . StaticContainer::get('Piwik\Translation\Translator')->getCurrentLanguage();
     }
 
+    /**
+     * @return string
+     */
     public static function pluginAware($cacheId)
     {
         $pluginManager = Manager::getInstance();

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -934,6 +934,9 @@ class LogAggregator
         return in_array($metricId, $metricsRequested);
     }
 
+    /**
+     * @return string
+     */
     public function getWhereStatement($tableName, $datetimeField, $extraWhere = false)
     {
         $where = "$tableName.$datetimeField >= ?

--- a/core/Db.php
+++ b/core/Db.php
@@ -136,9 +136,10 @@ class Db implements TransactionalDatabaseInterface
 
     /**
      * For tests only.
-     * @param $connection
+     * @param \Piwik\Db\AdapterInterface|null $connection
      * @ignore
      * @internal
+     * @return void
      */
     public static function setDatabaseObject($connection)
     {
@@ -152,6 +153,7 @@ class Db implements TransactionalDatabaseInterface
      *
      * @param array|null $dbConfig Connection parameters in an array. Defaults to the `[database]`
      *                             INI config section.
+     * @return void
      */
     public static function createDatabaseObject($dbConfig = null)
     {
@@ -171,6 +173,8 @@ class Db implements TransactionalDatabaseInterface
      *                             INI config section.
      *
      * @since Matomo 3.12
+     *
+     * @return void
      */
     public static function createReaderDatabaseObject($dbConfig = null)
     {
@@ -200,6 +204,7 @@ class Db implements TransactionalDatabaseInterface
      * Detect whether a database object is initialized / created or not.
      *
      * @internal
+     * @return bool
      */
     public static function hasDatabaseObject()
     {
@@ -210,6 +215,7 @@ class Db implements TransactionalDatabaseInterface
      * Detect whether a database object is initialized / created or not.
      *
      * @internal
+     * @return bool
      */
     public static function hasReaderDatabaseObject()
     {
@@ -220,6 +226,8 @@ class Db implements TransactionalDatabaseInterface
      * Disconnects and destroys the database connection.
      *
      * For tests.
+     *
+     * @return void
      */
     public static function destroyDatabaseObject()
     {
@@ -242,7 +250,7 @@ class Db implements TransactionalDatabaseInterface
      *
      * @param string $sql The SQL query.
      * @throws \Exception If there is an error in the SQL.
-     * @return integer|\Zend_Db_Statement
+     * @return int|\Zend_Db_Statement
      */
     public static function exec($sql)
     {
@@ -475,6 +483,8 @@ class Db implements TransactionalDatabaseInterface
 
     /**
      * Drops all tables
+     *
+     * @return void
      */
     public static function dropAllTables()
     {
@@ -680,6 +690,7 @@ class Db implements TransactionalDatabaseInterface
      * @param int $last The maximum ID to loop to.
      * @param int $step The maximum number of rows to scan in one query.
      * @param array $params Parameters to bind in the query, `array(param1 => value1, param2 => value2)`
+     * @return void
      */
     public static function segmentedQuery($sql, $first, $last, $step, $params = array())
     {
@@ -777,6 +788,9 @@ class Db implements TransactionalDatabaseInterface
         return self::$lockPrivilegeGranted;
     }
 
+    /**
+     * @return void
+     */
     private static function logExtraInfoIfDeadlock($ex)
     {
         if (
@@ -796,6 +810,9 @@ class Db implements TransactionalDatabaseInterface
         }
     }
 
+    /**
+     * @return void
+     */
     private static function logSql($functionName, $sql, $parameters = array())
     {
         self::checkBoundParametersIfInDevMode($sql, $parameters);
@@ -811,6 +828,9 @@ class Db implements TransactionalDatabaseInterface
         Log::debug("Db::%s() executing SQL: %s", $functionName, $sql);
     }
 
+    /**
+     * @return void
+     */
     private static function checkBoundParametersIfInDevMode($sql, $parameters)
     {
         if (!Development::isEnabled()) {
@@ -830,6 +850,7 @@ class Db implements TransactionalDatabaseInterface
 
     /**
      * @param bool $enable
+     * @return void
      */
     public static function enableQueryLog($enable)
     {
@@ -837,7 +858,7 @@ class Db implements TransactionalDatabaseInterface
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public static function isQueryLogEnabled()
     {

--- a/core/Db.php
+++ b/core/Db.php
@@ -244,13 +244,13 @@ class Db implements TransactionalDatabaseInterface
 
     /**
      * Executes an unprepared SQL query. Recommended for DDL statements like `CREATE`,
-     * `DROP` and `ALTER`. The return value is DBMS-specific. For MySQLI, it returns the
-     * number of rows affected. For PDO, it returns a
-     * [Zend_Db_Statement](https://framework.zend.com/manual/1.12/en/zend.db.statement.html) object.
+     * `DROP` and `ALTER`.
+     *
+     * Must not be used during tracker requests, as the tracker database does not provide a profiler.
      *
      * @param string $sql The SQL query.
      * @throws \Exception If there is an error in the SQL.
-     * @return int|\Zend_Db_Statement
+     * @return int The number of rows affected.
      */
     public static function exec($sql)
     {
@@ -344,8 +344,8 @@ class Db implements TransactionalDatabaseInterface
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
      * @throws \Exception If there is a problem with the SQL or bind parameters.
-     * @return array The fetched rows, each element is an associative array mapping column names
-     *               with column values.
+     * @return list<array<array-key, string|int|float|null>> The fetched rows, each an associative array of column => value.
+     *                                                       Numeric column names, eg, `SELECT 1`, yield integer keys.
      */
     public static function fetchAll($sql, $parameters = array())
     {
@@ -365,8 +365,9 @@ class Db implements TransactionalDatabaseInterface
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
      * @throws \Exception If there is a problem with the SQL or bind parameters.
-     * @return array The fetched row, each element is an associative array mapping column names
-     *               with column values.
+     * @return array<array-key, string|int|float|null>|false The fetched row as column => value, or false when the result
+     *                                                       set is empty. Numeric column names, eg, `SELECT 1`, yield
+     *                                                       integer keys.
      */
     public static function fetchRow($sql, $parameters = array())
     {
@@ -387,7 +388,7 @@ class Db implements TransactionalDatabaseInterface
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
      * @throws \Exception If there is a problem with the SQL or bind parameters.
-     * @return string
+     * @return string|int|float|null|false The first column of the first row, or `false` when the result set is empty.
      */
     public static function fetchOne($sql, $parameters = array())
     {
@@ -408,11 +409,8 @@ class Db implements TransactionalDatabaseInterface
      * @param string $sql The SQL query.
      * @param array $parameters Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`.
      * @throws \Exception If there is a problem with the SQL or bind parameters.
-     * @return array eg,
-     *               ```
-     *               array('col1value1' => array('col2' => '...', 'col3' => ...),
-     *                     'col1value2' => array('col2' => '...', 'col3' => ...))
-     *               ```
+     * @return array<array-key, array<array-key, string|int|float|null>> The rows indexed by the first selected column,
+     *                                                                  each row an associative array of column => value.
      */
     public static function fetchAssoc($sql, $parameters = array())
     {
@@ -502,7 +500,7 @@ class Db implements TransactionalDatabaseInterface
      *                                   be prefixed (see {@link Piwik\Common::prefixTable()}).
      * @param string|array $tablesToWrite The table or tables to obtain 'write' locks on. Table names must
      *                                    be prefixed (see {@link Piwik\Common::prefixTable()}).
-     * @return \Zend_Db_Statement
+     * @return int The number of rows affected, see {@link exec()}.
      */
     public static function lockTables($tablesToRead, $tablesToWrite = array())
     {
@@ -532,7 +530,7 @@ class Db implements TransactionalDatabaseInterface
      * **NOTE:** Piwik does not require the `LOCK TABLES` privilege to be available. Piwik
      * should still work if it has not been granted.
      *
-     * @return \Zend_Db_Statement
+     * @return int The number of rows affected, see {@link exec()}.
      */
     public static function unlockAllTables()
     {
@@ -575,7 +573,8 @@ class Db implements TransactionalDatabaseInterface
      * @param int $step The maximum number of rows to scan in one query.
      * @param array $params Parameters to bind in the query, eg, `array(param1 => value1, param2 => value2)`
      *
-     * @return string
+     * @return string|int|float|null|false The first value fetched that is not `false`, or `false` if no chunk
+     *                                     returned a value.
      */
     public static function segmentedFetchFirst($sql, $first, $last, $step, $params = array())
     {
@@ -613,7 +612,7 @@ class Db implements TransactionalDatabaseInterface
      * @param int $last The maximum ID to loop to.
      * @param int $step The maximum number of rows to scan in one query.
      * @param array $params Parameters to bind in the query, `array(param1 => value1, param2 => value2)`
-     * @return array An array of primitive values.
+     * @return list<string|int|float|null|false> One fetched value per chunk.
      */
     public static function segmentedFetchOne($sql, $first, $last, $step, $params = array())
     {
@@ -651,8 +650,8 @@ class Db implements TransactionalDatabaseInterface
      * @param int $last The maximum ID to loop to.
      * @param int $step The maximum number of rows to scan in one query.
      * @param array $params Parameters to bind in the query, array( param1 => value1, param2 => value2)
-     * @return array An array of rows that includes the result set of every smaller
-     *               query.
+     * @return list<array<array-key, string|int|float|null>> An array of rows that includes the result set of every
+     *                                                       smaller query.
      */
     public static function segmentedFetchAll($sql, $first, $last, $step, $params = array())
     {
@@ -762,7 +761,7 @@ class Db implements TransactionalDatabaseInterface
      *
      * Public so tests can simulate the situation where the lock tables privilege isn't granted.
      *
-     * @var bool
+     * @var bool|null
      * @ignore
      */
     public static $lockPrivilegeGranted = null;

--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -371,7 +371,6 @@ abstract class Controller
 
         $pluginName = $this->pluginName;
 
-        /** @var Proxy $apiProxy */
         $apiProxy = Proxy::getInstance();
 
         if (!$apiProxy->isExistingApiAction($pluginName, $apiAction)) {

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -374,6 +374,8 @@ class Segment
 
     /**
      * Returns `true` if the segment is empty, `false` if otherwise.
+     *
+     * @return bool
      */
     public function isEmpty()
     {

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -625,16 +625,21 @@ class Request
         }
     }
 
+    /**
+     * @return int
+     */
     public function getIdSite()
     {
         if (isset($this->idSiteCache)) {
             return $this->idSiteCache;
         }
 
-        $idSite = $this->getIdSiteUnverified();
+        $idSiteUnverified = $this->getIdSiteUnverified();
+        $idSite = (int) $idSiteUnverified;
 
         if ($idSite <= 0) {
-            throw new UnexpectedWebsiteFoundException('Invalid idSite: \'' . $idSite . '\'');
+            // report the value as provided, as casting it may have hidden what was actually wrong with it
+            throw new UnexpectedWebsiteFoundException('Invalid idSite: \'' . $idSiteUnverified . '\'');
         }
 
         // check site actually exists, should throw UnexpectedWebsiteFoundException directly
@@ -851,6 +856,9 @@ class Request
     }
 
 
+    /**
+     * @return string
+     */
     public function getIp()
     {
         return IPUtils::stringToBinaryIP($this->getIpString());

--- a/core/Tracker/RequestHandlerTrait.php
+++ b/core/Tracker/RequestHandlerTrait.php
@@ -54,7 +54,7 @@ trait RequestHandlerTrait
 
     protected function markArchivedReportsAsInvalidIfArchiveAlreadyFinished(Request $request): void
     {
-        $idSite = (int)$request->getIdSite();
+        $idSite = $request->getIdSite();
         $time   = $request->getCurrentTimestamp();
 
         $timezone = $this->getTimezoneForSite($idSite);

--- a/core/Tracker/RequestSet.php
+++ b/core/Tracker/RequestSet.php
@@ -132,7 +132,7 @@ class RequestSet
 
         $siteIds = array();
         foreach ($this->requests as $request) {
-            $siteIds[] = (int) $request->getIdSite();
+            $siteIds[] = $request->getIdSite();
         }
 
         return array_values(array_unique($siteIds));

--- a/core/Updates/2.1.1-b11.php
+++ b/core/Updates/2.1.1-b11.php
@@ -90,7 +90,7 @@ class Updates_2_1_1_b11 extends Updates
 
             // if there are missing idarchives, fill out new archive row values
             if (!empty($missingIdArchives)) {
-                $newIdArchiveStart = Db::fetchOne("SELECT MAX(idarchive) FROM `$table`") + 1;
+                $newIdArchiveStart = (int) Db::fetchOne("SELECT MAX(idarchive) FROM `$table`") + 1;
                 foreach ($missingIdArchives as $withMetricsIdArchive => &$rowToInsert) {
                     $idArchiveMappings[$withMetricsIdArchive] = $newIdArchiveStart;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -745,12 +745,6 @@ parameters:
 			path: core/Db.php
 
 		-
-			message: '#^Call to function is_null\(\) with bool will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: core/Db.php
-
-		-
 			message: '#^Cannot access property \$server_version on object\|resource\.$#'
 			identifier: property.nonObject
 			count: 1
@@ -1919,12 +1913,6 @@ parameters:
 			identifier: catch.neverThrown
 			count: 1
 			path: core/Updates/2.0.4-b5.php
-
-		-
-			message: '#^Binary operation "\+" between string and 1 results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: core/Updates/2.1.1-b11.php
 
 		-
 			message: '#^Call to an undefined method Piwik\\Db\|Piwik\\Db\\AdapterInterface\|Piwik\\Tracker\\Db\:\:fetchCol\(\)\.$#'
@@ -3727,12 +3715,6 @@ parameters:
 			path: plugins/PrivacyManager/DoNotTrackHeaderChecker.php
 
 		-
-			message: '#^Parameter \#2 \$first of static method Piwik\\Db\:\:segmentedFetchFirst\(\) expects int, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: plugins/PrivacyManager/LogDataPurger.php
-
-		-
 			message: '#^Call to function is_array\(\) with non\-falsy\-string will always evaluate to false\.$#'
 			identifier: function.impossibleType
 			count: 1
@@ -3772,18 +3754,6 @@ parameters:
 			message: '#^Parameter \#2 \$reportDateMonth of static method Piwik\\Plugins\\PrivacyManager\\ReportsPurger\:\:shouldReportBePurged\(\) expects int, string given\.$#'
 			identifier: argument.type
 			count: 1
-			path: plugins/PrivacyManager/ReportsPurger.php
-
-		-
-			message: '#^Parameter \#3 \$last of static method Piwik\\Db\:\:segmentedFetchAll\(\) expects int, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: plugins/PrivacyManager/ReportsPurger.php
-
-		-
-			message: '#^Parameter \#3 \$last of static method Piwik\\Db\:\:segmentedFetchOne\(\) expects int, string given\.$#'
-			identifier: argument.type
-			count: 2
 			path: plugins/PrivacyManager/ReportsPurger.php
 
 		-

--- a/plugins/PrivacyManager/LogDataPurger.php
+++ b/plugins/PrivacyManager/LogDataPurger.php
@@ -141,17 +141,16 @@ class LogDataPurger
     }
 
     /**
-     * get highest idVisit to delete rows from
-     * @return string|false
+     * get highest idVisit to delete rows from, or 0 when there is nothing to purge
      */
-    private function getDeleteIdVisitOffset($deleteLogsOlderThan)
+    private function getDeleteIdVisitOffset($deleteLogsOlderThan): int
     {
         $logVisit = Common::prefixTable("log_visit");
 
         // get max idvisit
-        $maxIdVisit = Db::fetchOne("SELECT MAX(idvisit) FROM `$logVisit`");
+        $maxIdVisit = (int) Db::fetchOne("SELECT MAX(idvisit) FROM `$logVisit`");
         if (empty($maxIdVisit)) {
-            return false;
+            return 0;
         }
 
         // select highest idvisit to delete from
@@ -164,7 +163,7 @@ class LogDataPurger
 		      ORDER BY idvisit DESC
 		         LIMIT 1";
 
-        return Db::segmentedFetchFirst($sql, $maxIdVisit, 0, -self::$selectSegmentSize);
+        return (int) Db::segmentedFetchFirst($sql, $maxIdVisit, 0, -self::$selectSegmentSize);
     }
 
     private function getLogTableDeleteCount($table, $maxIdVisit)

--- a/plugins/PrivacyManager/ReportsPurger.php
+++ b/plugins/PrivacyManager/ReportsPurger.php
@@ -262,7 +262,7 @@ class ReportsPurger
 
     private function getNumericTableDeleteCount($table)
     {
-        $maxIdArchive = Db::fetchOne("SELECT MAX(idarchive) FROM `$table`");
+        $maxIdArchive = (int) Db::fetchOne("SELECT MAX(idarchive) FROM `$table`");
 
         $sql = "SELECT COUNT(*) FROM `$table`
                  WHERE name NOT IN ('" . implode("','", $this->metricsToKeep) . "')
@@ -276,7 +276,7 @@ class ReportsPurger
 
     private function getBlobTableDeleteCount($oldNumericTables, $table)
     {
-        $maxIdArchive = Db::fetchOne("SELECT MAX(idarchive) FROM `$table`");
+        $maxIdArchive = (int) Db::fetchOne("SELECT MAX(idarchive) FROM `$table`");
 
         $blobTableWhere = $this->getBlobTableWhereExpr($oldNumericTables, $table);
         if (empty($blobTableWhere)) {
@@ -329,7 +329,7 @@ class ReportsPurger
         foreach ($numericTables as $table) {
             $tableDate = ArchiveTableCreator::getDateFromTableName($table);
 
-            $maxIdArchive = Db::fetchOne("SELECT MAX(idarchive) FROM `$table`");
+            $maxIdArchive = (int) Db::fetchOne("SELECT MAX(idarchive) FROM `$table`");
 
             $sql = "SELECT idarchive FROM `$table`
                      WHERE name != 'done'

--- a/plugins/Referrers/Columns/Base.php
+++ b/plugins/Referrers/Columns/Base.php
@@ -744,7 +744,7 @@ abstract class Base extends VisitDimension
 
         if (
             $type === Common::REFERRER_TYPE_CAMPAIGN
-            && CampaignParameterValuesMasked::isEnabled((int) $request->getIdSite())
+            && CampaignParameterValuesMasked::isEnabled($request->getIdSite())
         ) {
             $name = CampaignParameterValuesMasked::getPlaceholderValue();
             $keyword = CampaignParameterValuesMasked::getPlaceholderValue();

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -123,6 +123,9 @@ class Model
         return $return;
     }
 
+    /**
+     * @return array<array-key, string>
+     */
     public function getUsersAccessFromSite($idSite)
     {
         $db = $this->getDb();

--- a/tests/PHPUnit/Framework/XssTesting.php
+++ b/tests/PHPUnit/Framework/XssTesting.php
@@ -21,6 +21,9 @@ class XssTesting
 {
     public const OPTION_NAME = 'Tests.xssEntries';
 
+    /**
+     * @return string
+     */
     public function forTwig($type, $sanitize = false)
     {
         $n = $this->addXssEntry($type, 'twig');
@@ -42,6 +45,9 @@ class XssTesting
         return $this->forVueJs($type, $sanitize);
     }
 
+    /**
+     * @return string
+     */
     public function forVueJs($type, $sanitize = false)
     {
         $n = $this->addXssEntry($type, 'vuejs');


### PR DESCRIPTION
Corrects the `core/Db.php` fetch and lock annotations, which describe a different return type than the adapters actually produce, and declares return types on core methods that currently have none. No behaviour changes; every fix makes a type contract match what the code already does.

The missing return types are `missingType.return` findings that only fire above core's configured level 5, so they leave core's own count unchanged. They are included because plugins running PHPStan at `level: max` analyse core's signatures as their upstream contract: an absent return type makes the call site `mixed` and cascades into `argument.type`, `return.type` and `missingType` findings in otherwise well-typed plugin code, which can then only be silenced with casts, `@var` annotations or baseline entries. Declaring the types here removes that work from every plugin preparing for 6.x.

Scope was deliberately limited to cases where the correct type is unambiguous from the code.

### Inaccurate `@return` — `core/Db.php`

- `fetchAll()`, `fetchRow()`, `fetchOne()`, `fetchAssoc()` and the `segmentedFetchAll()`, `segmentedFetchOne()`, `segmentedFetchFirst()` variants were annotated with plain `array`/`string`, omitting the `false` an empty result set yields and the integer keys that numeric column names (eg, `SELECT 1`) produce.
- `exec()` claimed `int|\Zend_Db_Statement` and "the return value is DBMS-specific". Both adapters return the number of affected rows — mysqli directly, PDO by throwing rather than returning `false` — so it is `int`. Also documented that it must not be used during tracker requests, since it calls `getProfiler()`, which `Tracker\Db` does not implement.
- `lockTables()` and `unlockAllTables()` claimed `\Zend_Db_Statement`; they return whatever `exec()` returns.
- `setDatabaseObject()` had a bare `@param $connection`, now `AdapterInterface|null`.
- `$lockPrivilegeGranted` was `@var bool` while initialised to `null`, which is what made the `is_null()` guard in `hasLockPrivilege()` look impossible. Now `bool|null`.

### `MAX()` results used as ints

Consequences of `fetchOne()` now being honestly typed: the `SELECT MAX(...)` values used as segmented-fetch bounds and as an arithmetic operand are cast at the source, in `PrivacyManager\ReportsPurger` (3 call sites), `PrivacyManager\LogDataPurger::getDeleteIdVisitOffset()` and `core/Updates/2.1.1-b11.php`.

`getDeleteIdVisitOffset()` also gained a native `int` return type and returns `0` instead of `false` for "nothing to purge"; both are falsy and its single caller only tests emptiness.

### Missing return types

Declared following each file's existing style — PHPDoc where the surrounding code uses PHPDoc, native where it uses native types:

- `API\Proxy::getInstance()` → `self`, `Proxy::isDeprecatedMethod()` → `bool`
- `ArchiveProcessor\Record::make()` → `self`
- `CacheId::languageAware()`, `CacheId::pluginAware()` → `string`
- `DataAccess\LogAggregator::getWhereStatement()` → `string`
- `Segment::isEmpty()` → `bool`
- `Tracker\Request::getIp()` → `string`, `Tracker\Request::getIdSite()` → `int`
- `UsersManager\Model::getUsersAccessFromSite()` → `array<array-key, string>`
- `XssTesting::forTwig()`, `XssTesting::forVueJs()` → `string`
- the remaining untyped `void` helpers in `core/Db.php`

These are the methods plugin code calls most often, not an attempt to make the touched files clean at `level: max`; the findings left there are missing *parameter* types and returns that depend on untyped properties, which is a larger separate change.

Three workarounds inside core that existed only because of the missing types are removed, as an illustration of what plugins can drop too: the `/** @var Proxy $apiProxy */` annotation in `Plugin\Controller`, and the `(int)` casts around `$request->getIdSite()` in `Tracker\RequestHandlerTrait`, `Tracker\RequestSet` and `Referrers\Columns\Base`.

`Request::getIdSite()` is the one method where the annotation alone was not enough. The value arrives from the request as an `int`, but the `Tracker.Request.getIdSite` event lets subscribers replace it with anything, so it is cast before the `<= 0` guard. The exception message deliberately reports the *uncast* value, since casting can hide what was actually wrong with the input.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
