### PR TITLE
Deprecate component-oriented theme variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
   authenticate with its own `token_auth`, but may not change the session flag. A nested request whose
   parameters conflict with the outer request's authentication context aborts the whole bulk request.
 
+### Deprecations
+* The component-oriented theme variable `@theme-color-widget-background` (`ThemeStyles::$colorWidgetBackground`)
+  is deprecated and will be removed in Matomo 7; use `@theme-color-background-contrast` instead. It is the generic
+  elevated content surface and is already used well beyond widgets.
+* The component-oriented theme variables `@theme-color-menu-contrast-text`, `@theme-color-menu-contrast-textSelected`,
+  `@theme-color-menu-contrast-textActive`, `@theme-color-menu-contrast-background`,
+  `@theme-color-menu-contrast-backgroundHover`, `@theme-color-widget-border`, `@theme-color-widget-title-text`,
+  `@theme-color-widget-title-background` and `@theme-color-widget-exported-background-base` (and the corresponding
+  `ThemeStyles` properties, also readable via `themeStyles.getPropertyValue()`) are deprecated and will be removed
+  in Matomo 7. Matomo's theming is moving from component-oriented variable names to usage-oriented ones; because
+  these variables fill roles that no existing variable covers, usage-oriented replacements will be defined before
+  they are removed. They keep working until then.
+
 ## Matomo 5.12.0
 
 ### JavaScript Tracker

--- a/core/Plugin/ThemeStyles.php
+++ b/core/Plugin/ThemeStyles.php
@@ -41,13 +41,6 @@ class ThemeStyles
         'colorHeadlineAlternative' => 'theme-color-headline-alternative',
         'colorHeaderBackground' => 'theme-color-header-background',
         'colorHeaderText' => 'theme-color-header-text',
-        'colorMenuContrastText' => 'theme-color-menu-contrast-text',
-        'colorMenuContrastTextSelected' => 'theme-color-menu-contrast-textSelected',
-        'colorMenuContrastTextActive' => 'theme-color-menu-contrast-textActive',
-        'colorMenuContrastBackground' => 'theme-color-menu-contrast-background',
-        'colorWidgetExportedBackgroundBase' => 'theme-color-widget-exported-background-base',
-        'colorWidgetTitleText' => 'theme-color-widget-title-text',
-        'colorWidgetTitleBackground' => 'theme-color-widget-title-background',
         'colorBackgroundBase' => 'theme-color-background-base',
         'colorBackgroundTinyContrast' => 'theme-color-background-tinyContrast',
         'colorBackgroundLowContrast' => 'theme-color-background-lowContrast',
@@ -61,10 +54,22 @@ class ThemeStyles
         'shadowOverlay' => 'theme-shadow-overlay',
         'colorCode' => 'theme-color-code',
         'colorCodeBackground' => 'theme-color-code-background',
+        'filterOnIllustration' => 'theme-filter-on-illustration',
+
+        // Deprecated since Matomo 6.0.0, will be removed in Matomo 7. These names are
+        // component-oriented: they are named after the component they were first created for rather
+        // than the role they fill. Matomo's theming is moving to usage-oriented names. See the
+        // @deprecated tag on each property below for the replacement, where one already exists.
+        'colorMenuContrastText' => 'theme-color-menu-contrast-text',
+        'colorMenuContrastTextSelected' => 'theme-color-menu-contrast-textSelected',
+        'colorMenuContrastTextActive' => 'theme-color-menu-contrast-textActive',
+        'colorMenuContrastBackground' => 'theme-color-menu-contrast-background',
+        'colorMenuContrastBackgroundHover' => 'theme-color-menu-contrast-backgroundHover',
         'colorWidgetBackground' => 'theme-color-widget-background',
         'colorWidgetBorder' => 'theme-color-widget-border',
-        'filterOnIllustration' => 'theme-filter-on-illustration',
-        'colorMenuContrastBackgroundHover' => 'theme-color-menu-contrast-backgroundHover',
+        'colorWidgetTitleText' => 'theme-color-widget-title-text',
+        'colorWidgetTitleBackground' => 'theme-color-widget-title-background',
+        'colorWidgetExportedBackgroundBase' => 'theme-color-widget-exported-background-base',
     ];
 
     /**
@@ -188,41 +193,75 @@ class ThemeStyles
 
     /**
      * @var string|array<string>
+     * @deprecated since Matomo 6.0.0, will be removed in Matomo 7 (`@theme-color-menu-contrast-text`)
+     *             - component-oriented naming. Despite the name this no longer colours menu item
+     *             labels; it only remains for the menu dropdown caret. A usage-oriented replacement
+     *             will be defined before this is removed.
      */
     public $colorMenuContrastText;
 
     /**
      * @var string|array<string>
+     * @deprecated since Matomo 6.0.0, will be removed in Matomo 7
+     *             (`@theme-color-menu-contrast-textSelected`) - component-oriented naming. No core
+     *             stylesheet reads this variable, so setting it has no effect on Matomo's own UI.
      */
     public $colorMenuContrastTextSelected;
 
     /**
      * @var string|array<string>
+     * @deprecated since Matomo 6.0.0, will be removed in Matomo 7
+     *             (`@theme-color-menu-contrast-textActive`) - component-oriented naming. In practice
+     *             this is the app-wide hover/focus/active accent and is used well beyond menus. A
+     *             usage-oriented replacement will be defined before this is removed.
      */
     public $colorMenuContrastTextActive = ['#1976D2', '#fff'];
 
     /**
      * @var string|array<string>
+     * @deprecated since Matomo 6.0.0, will be removed in Matomo 7
+     *             (`@theme-color-menu-contrast-backgroundHover`) - component-oriented naming. In
+     *             practice this is the hover and focus background of a row on the navigation
+     *             surface. A usage-oriented replacement will be defined before this is removed.
      */
     public $colorMenuContrastBackgroundHover = ['#eff0f1', '#151819'];
 
     /**
      * @var string|array<string>
+     * @deprecated since Matomo 6.0.0, will be removed in Matomo 7
+     *             (`@theme-color-menu-contrast-background`) - component-oriented naming. In practice
+     *             this is the navigation surface, which themes intentionally tint differently from
+     *             card surfaces. A usage-oriented replacement will be defined before this is removed.
      */
     public $colorMenuContrastBackground;
 
     /**
      * @var string|array<string>
+     * @deprecated since Matomo 6.0.0, will be removed in Matomo 7
+     *             (`@theme-color-widget-exported-background-base`) - component-oriented naming, and
+     *             misleading: this is the page canvas for embedded and exported output, which
+     *             deliberately differs from the app canvas $colorBackgroundBase so that embedded
+     *             widgets blend into a host page. A usage-oriented replacement will be defined
+     *             before this is removed.
      */
     public $colorWidgetExportedBackgroundBase;
 
     /**
      * @var string|array<string>
+     * @deprecated since Matomo 6.0.0, will be removed in Matomo 7 (`@theme-color-widget-title-text`)
+     *             - component-oriented naming. In practice this is the text of the widget and report
+     *             header strip, which themes intentionally colour differently from $colorText. A
+     *             usage-oriented replacement will be defined before this is removed.
      */
     public $colorWidgetTitleText;
 
     /**
      * @var string|array<string>
+     * @deprecated since Matomo 6.0.0, will be removed in Matomo 7
+     *             (`@theme-color-widget-title-background`) - component-oriented naming. In practice
+     *             this is the widget and report header strip, which themes intentionally tint
+     *             differently from the card surface $colorBackgroundContrast. A usage-oriented
+     *             replacement will be defined before this is removed.
      */
     public $colorWidgetTitleBackground;
 
@@ -298,11 +337,19 @@ class ThemeStyles
 
     /**
      * @var string|array<string>
+     * @deprecated since Matomo 6.0.0, will be removed in Matomo 7 (`@theme-color-widget-background`)
+     *             - component-oriented naming. This is the generic elevated content surface and is
+     *             used well beyond widgets. Use $colorBackgroundContrast
+     *             (`@theme-color-background-contrast`) instead.
      */
     public $colorWidgetBackground;
 
     /**
      * @var string|array<string>
+     * @deprecated since Matomo 6.0.0, will be removed in Matomo 7 (`@theme-color-widget-border`)
+     *             - component-oriented naming. No core stylesheet reads this variable, so setting it
+     *             has no effect on Matomo's own UI. Note that core draws the widget border with
+     *             $colorBackgroundLowContrast, not with this variable.
      */
     public $colorWidgetBorder;
 


### PR DESCRIPTION
### Description

As part of the Matomo 6 theming direction, we are moving away from component-oriented theme color variables toward usage-oriented ones (colors named after their semantic role rather than the specific component they were introduced for).

This ticket marks the remaining component-oriented color variables as deprecated so consumers can migrate before they are removed in a future major version. The affected variables are the menu and widget color sets:

- @theme-color-menu* (and the corresponding colorMenu* definitions)
- @theme-color-widget* (and the corresponding colorWidget* definitions)

issue dev-20577

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)