### PR TITLE
Declare native types on private properties that only had a @var annotation

### DIFF
--- a/core/API/DataTableManipulator/LabelFilter.php
+++ b/core/API/DataTableManipulator/LabelFilter.php
@@ -32,10 +32,7 @@ class LabelFilter extends DataTableManipulator
     private $isComparing;
     private $labelSeries;
 
-    /**
-     * @var string
-     */
-    private $labelColumn;
+    private string $labelColumn;
 
     public function __construct($apiModule = false, $apiMethod = false, $request = array(), string $labelColumn = 'label')
     {

--- a/core/API/DataTablePostProcessor.php
+++ b/core/API/DataTablePostProcessor.php
@@ -56,10 +56,7 @@ class DataTablePostProcessor
      */
     private $apiMethod;
 
-    /**
-     * @var Inconsistencies
-     */
-    private $apiInconsistencies;
+    private Inconsistencies $apiInconsistencies;
 
     /**
      * @var Formatter

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -87,10 +87,8 @@ class Request
 {
     /**
      * The count of nested API request invocations. Used to determine if the currently executing request is the root or not.
-     *
-     * @var int
      */
-    private static $nestedApiInvocationCount = 0;
+    private static int $nestedApiInvocationCount = 0;
 
     private $request = null;
 

--- a/core/Access.php
+++ b/core/Access.php
@@ -77,12 +77,9 @@ class Access
      *
      * @var Auth
      */
-    private $auth = null;
+    private ?Auth $auth = null;
 
-    /**
-     * @var bool
-     */
-    private $sessionExpired = false;
+    private bool $sessionExpired = false;
 
     /**
      * Gets the singleton instance. Creates it if necessary.

--- a/core/Access.php
+++ b/core/Access.php
@@ -75,7 +75,7 @@ class Access
     /**
      * Authentication object (see Auth)
      *
-     * @var Auth
+     * @var Auth|null
      */
     private ?Auth $auth = null;
 

--- a/core/Application/Environment.php
+++ b/core/Application/Environment.php
@@ -51,10 +51,7 @@ class Environment
      */
     private $environment;
 
-    /**
-     * @var array
-     */
-    private $definitions;
+    private array $definitions;
 
     /**
      * @var Container

--- a/core/Application/Kernel/PluginList.php
+++ b/core/Application/Kernel/PluginList.php
@@ -23,16 +23,12 @@ use Piwik\Plugin\MetadataLoader;
  */
 class PluginList
 {
-    /**
-     * @var GlobalSettingsProvider
-     */
-    private $settings;
+    private GlobalSettingsProvider $settings;
 
     /**
      * Plugins bundled with core package, disabled by default
-     * @var array
      */
-    private $corePluginsDisabledByDefault = array(
+    private array $corePluginsDisabledByDefault = array(
         'ArchivingMetrics',
         'DBStats',
         'ExamplePlugin',

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -182,10 +182,7 @@ class Archive implements ArchiveQuery
      */
     private $forceIndexedByDate;
 
-    /**
-     * @var Parameters
-     */
-    private $params;
+    private Parameters $params;
 
     /**
      * If true, this Archive instance will not launch the archiving process, even if the current request

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -63,20 +63,11 @@ class ArchiveInvalidator
 
     private $rememberArchivedReportIdStart = 'report_to_invalidate_';
 
-    /**
-     * @var Model
-     */
-    private $model;
+    private Model $model;
 
-    /**
-     * @var SegmentArchiving|null
-     */
-    private $segmentArchiving;
+    private ?SegmentArchiving $segmentArchiving;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     /**
      * @var int[]

--- a/core/Archive/DataTableFactory.php
+++ b/core/Archive/DataTableFactory.php
@@ -39,10 +39,8 @@ class DataTableFactory
      * Whether to expand the DataTables that're created or not. Expanding a DataTable
      * means creating DataTables using subtable blobs and correctly setting the subtable
      * IDs of all DataTables.
-     *
-     * @var bool
      */
-    private $expandDataTable = false;
+    private bool $expandDataTable = false;
 
     /**
      * Whether to add the subtable ID used in the database to the in-memory DataTables
@@ -70,10 +68,7 @@ class DataTableFactory
      */
     private $periods;
 
-    /**
-     * @var Segment
-     */
-    private $segment;
+    private Segment $segment;
 
     /**
      * The ID of the subtable to create a DataTable for. Only relevant for blob data.

--- a/core/Archive/Parameters.php
+++ b/core/Archive/Parameters.php
@@ -30,10 +30,8 @@ class Parameters
 
     /**
      * Segment applied to the visits set.
-     *
-     * @var Segment
      */
-    private $segment;
+    private Segment $segment;
 
     public function getSegment()
     {

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -85,9 +85,9 @@ class ArchiveProcessor
      */
     public static $isRootArchivingRequest = true;
 
-    private \Piwik\DataAccess\ArchiveWriter $archiveWriter;
+    private ArchiveWriter $archiveWriter;
 
-    private \Piwik\DataAccess\LogAggregator $logAggregator;
+    private LogAggregator $logAggregator;
 
     /**
      * @var \Piwik\Archive\ArchiveQuery|null

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -85,25 +85,16 @@ class ArchiveProcessor
      */
     public static $isRootArchivingRequest = true;
 
-    /**
-     * @var \Piwik\DataAccess\ArchiveWriter
-     */
-    private $archiveWriter;
+    private \Piwik\DataAccess\ArchiveWriter $archiveWriter;
 
-    /**
-     * @var \Piwik\DataAccess\LogAggregator
-     */
-    private $logAggregator;
+    private \Piwik\DataAccess\LogAggregator $logAggregator;
 
     /**
      * @var \Piwik\Archive\ArchiveQuery|null
      */
     public $archive = null;
 
-    /**
-     * @var Parameters
-     */
-    private $params;
+    private Parameters $params;
 
     /**
      * @var int|false

--- a/core/ArchiveProcessor/ArchivingStatus.php
+++ b/core/ArchiveProcessor/ArchivingStatus.php
@@ -18,10 +18,7 @@ class ArchivingStatus
     public const LOCK_KEY_PREFIX = 'Archiving';
     public const DEFAULT_ARCHIVING_TTL = 7200; // 2 hours
 
-    /**
-     * @var LockBackend
-     */
-    private $lockBackend;
+    private LockBackend $lockBackend;
 
     /**
      * @var int
@@ -31,7 +28,7 @@ class ArchivingStatus
     /**
      * @var Lock[]
      */
-    private $lockStack = [];
+    private array $lockStack = [];
 
     public function __construct(LockBackend $lockBackend, $archivingTTLSecs = self::DEFAULT_ARCHIVING_TTL)
     {

--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -41,7 +41,7 @@ class Loader
      *
      * @var boolean
      */
-    private $didReuseArchive = false;
+    private bool $didReuseArchive = false;
 
     /**
      * @var Parameters
@@ -63,15 +63,9 @@ class Loader
      */
     private $logger;
 
-    /**
-     * @var RawLogDao
-     */
-    private $rawLogDao;
+    private RawLogDao $rawLogDao;
 
-    /**
-     * @var Model
-     */
-    private $dataAccessModel;
+    private Model $dataAccessModel;
 
     /**
      * @var bool

--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -38,8 +38,6 @@ class Loader
 
     /**
      * Tracks whether the current prepareArchive run reused an existing archive instead of processing.
-     *
-     * @var boolean
      */
     private bool $didReuseArchive = false;
 

--- a/core/ArchiveProcessor/Parameters.php
+++ b/core/ArchiveProcessor/Parameters.php
@@ -26,17 +26,17 @@ class Parameters
     /**
      * @var Site
      */
-    private $site = null;
+    private ?Site $site = null;
 
     /**
      * @var Period
      */
-    private $period = null;
+    private ?Period $period = null;
 
     /**
      * @var Segment
      */
-    private $segment = null;
+    private ?Segment $segment = null;
 
     /**
      * @var string|bool Plugin name which triggered this archive processor, or false if none
@@ -53,7 +53,7 @@ class Parameters
     /**
      * @var string[]|null
      */
-    private $foundRequestedReports;
+    private ?array $foundRequestedReports = null;
 
     /**
      * @ignore

--- a/core/ArchiveProcessor/Parameters.php
+++ b/core/ArchiveProcessor/Parameters.php
@@ -23,20 +23,11 @@ use Piwik\Site;
  */
 class Parameters
 {
-    /**
-     * @var Site
-     */
-    private ?Site $site = null;
+    private Site $site;
 
-    /**
-     * @var Period
-     */
-    private ?Period $period = null;
+    private Period $period;
 
-    /**
-     * @var Segment
-     */
-    private ?Segment $segment = null;
+    private Segment $segment;
 
     /**
      * @var string|bool Plugin name which triggered this archive processor, or false if none

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -43,10 +43,7 @@ class PluginsArchiver
      */
     protected $params;
 
-    /**
-     * @var LogAggregator
-     */
-    private $logAggregator;
+    private LogAggregator $logAggregator;
 
     /**
      * Public only for tests. Won't be necessary after DI changes are complete.

--- a/core/ArchiveProcessor/Record.php
+++ b/core/ArchiveProcessor/Record.php
@@ -28,50 +28,26 @@ class Record
      */
     private $name;
 
-    /**
-     * @var string|null
-     */
-    private $plugin = null;
+    private ?string $plugin = null;
 
     /**
      * @var string|int
      */
     private $columnToSortByBeforeTruncation;
 
-    /**
-     * @var int|null
-     */
-    private $maxRowsInTable;
+    private ?int $maxRowsInTable = null;
 
-    /**
-     * @var int|null
-     */
-    private $maxRowsInSubtable;
+    private ?int $maxRowsInSubtable = null;
 
-    /**
-     * @var string|null
-     */
-    private $countOfRecordName = null;
+    private ?string $countOfRecordName = null;
 
-    /**
-     * @var bool
-     */
-    private $countOfRecordNameIsRecursive = false;
+    private bool $countOfRecordNameIsRecursive = false;
 
-    /**
-     * @var bool
-     */
-    private $countOfRecordNameIsForLeafs = false;
+    private bool $countOfRecordNameIsForLeafs = false;
 
-    /**
-     * @var array|null
-     */
-    private $columnToRenameAfterAggregation = null;
+    private ?array $columnToRenameAfterAggregation = null;
 
-    /**
-     * @var array|null
-     */
-    private $blobColumnAggregationOps = null;
+    private ?array $blobColumnAggregationOps = null;
 
     /**
      * @var callable|null
@@ -83,10 +59,7 @@ class Record
      */
     private $aggregatedRecordTransform = null;
 
-    /**
-     * @var string|null
-     */
-    private $builtFromFlatRecord = null;
+    private ?string $builtFromFlatRecord = null;
 
     /**
      * @var callable|null

--- a/core/AssetManager/UIAssetCatalog.php
+++ b/core/AssetManager/UIAssetCatalog.php
@@ -14,7 +14,7 @@ class UIAssetCatalog
     /**
      * @var UIAsset[]
      */
-    private $uiAssets = array();
+    private array $uiAssets = array();
 
     /**
      * @var UIAssetCatalogSorter
@@ -24,7 +24,7 @@ class UIAssetCatalog
     /**
      * @var string[]  Absolute file locations
      */
-    private $existingAssetLocations = array();
+    private array $existingAssetLocations = array();
 
     /**
      * @param UIAssetCatalogSorter $catalogSorter

--- a/core/AssetManager/UIAssetMerger/StylesheetUIAssetMerger.php
+++ b/core/AssetManager/UIAssetMerger/StylesheetUIAssetMerger.php
@@ -29,7 +29,7 @@ class StylesheetUIAssetMerger extends UIAssetMerger
     /**
      * @var UIAsset[]
      */
-    private $cssAssetsToReplace = array();
+    private array $cssAssetsToReplace = array();
 
     public function __construct($mergedAsset, $assetFetcher, $cacheBuster)
     {

--- a/core/Auth/PasswordStrength.php
+++ b/core/Auth/PasswordStrength.php
@@ -19,8 +19,7 @@ use Piwik\Piwik;
  */
 class PasswordStrength
 {
-    /** @var bool */
-    private $enabled;
+    private bool $enabled;
 
     public function __construct(bool $featureEnabled)
     {

--- a/core/Category/CategoryList.php
+++ b/core/Category/CategoryList.php
@@ -21,7 +21,7 @@ class CategoryList
     /**
      * @var Category[] indexed by categoryId
      */
-    private $categories = array();
+    private array $categories = array();
 
     public function addCategory(Category $category)
     {

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -49,7 +49,7 @@ class CliMulti
     /**
      * @var Process[]|ProcessSymfony[]
      */
-    private $processes = [];
+    private array $processes = [];
 
     /**
      * If set it will issue at most concurrentProcessesLimit requests
@@ -60,7 +60,7 @@ class CliMulti
     /**
      * @var OutputInterface[]
      */
-    private $outputs = [];
+    private array $outputs = [];
 
     private $acceptInvalidSSLCertificate = false;
 
@@ -95,10 +95,7 @@ class CliMulti
      */
     private $logger;
 
-    /**
-     * @var int|null
-     */
-    private $signal = null;
+    private ?int $signal = null;
 
     public function __construct(?LoggerInterface $logger = null)
     {

--- a/core/CliMulti/ProcessSymfony.php
+++ b/core/CliMulti/ProcessSymfony.php
@@ -16,10 +16,7 @@ use Piwik\Process;
  */
 class ProcessSymfony extends Process
 {
-    /**
-     * @var string|null
-     */
-    private $commandId;
+    private ?string $commandId = null;
 
     public function getCommandId(): ?string
     {

--- a/core/Columns/ComputedMetricFactory.php
+++ b/core/Columns/ComputedMetricFactory.php
@@ -19,10 +19,7 @@ use Piwik\Plugin\ComputedMetric;
  */
 class ComputedMetricFactory
 {
-    /**
-     * @var MetricsList
-     */
-    private ?MetricsList $metricsList = null;
+    private MetricsList $metricsList;
 
     /**
      * Generates a new report metric factory.

--- a/core/Columns/ComputedMetricFactory.php
+++ b/core/Columns/ComputedMetricFactory.php
@@ -22,7 +22,7 @@ class ComputedMetricFactory
     /**
      * @var MetricsList
      */
-    private $metricsList = null;
+    private ?MetricsList $metricsList = null;
 
     /**
      * Generates a new report metric factory.

--- a/core/Columns/DimensionMetricFactory.php
+++ b/core/Columns/DimensionMetricFactory.php
@@ -20,10 +20,7 @@ use Piwik\Plugin\ComputedMetric;
  */
 class DimensionMetricFactory
 {
-    /**
-     * @var Dimension
-     */
-    private ?Dimension $dimension = null;
+    private Dimension $dimension;
 
     /**
      * Generates a new dimension metric factory.

--- a/core/Columns/DimensionMetricFactory.php
+++ b/core/Columns/DimensionMetricFactory.php
@@ -23,7 +23,7 @@ class DimensionMetricFactory
     /**
      * @var Dimension
      */
-    private $dimension = null;
+    private ?Dimension $dimension = null;
 
     /**
      * Generates a new dimension metric factory.

--- a/core/Columns/DimensionSegmentFactory.php
+++ b/core/Columns/DimensionSegmentFactory.php
@@ -22,7 +22,7 @@ class DimensionSegmentFactory
     /**
      * @var Dimension
      */
-    private $dimension = null;
+    private ?Dimension $dimension = null;
 
     /**
      * Generates a new dimension segment factory.

--- a/core/Columns/DimensionSegmentFactory.php
+++ b/core/Columns/DimensionSegmentFactory.php
@@ -19,10 +19,7 @@ use Piwik\Plugin\Segment;
  */
 class DimensionSegmentFactory
 {
-    /**
-     * @var Dimension
-     */
-    private ?Dimension $dimension = null;
+    private Dimension $dimension;
 
     /**
      * Generates a new dimension segment factory.

--- a/core/Columns/MetricsList.php
+++ b/core/Columns/MetricsList.php
@@ -33,7 +33,7 @@ class MetricsList
      *
      * @var Metric[]
      */
-    private $metrics = array();
+    private array $metrics = array();
 
     private $metricsByNameCache = array();
 

--- a/core/Concurrency/Lock.php
+++ b/core/Concurrency/Lock.php
@@ -17,10 +17,7 @@ class Lock
     public const MAX_KEY_LEN = 70;
     public const DEFAULT_TTL = 60;
 
-    /**
-     * @var LockBackend
-     */
-    private $backend;
+    private LockBackend $backend;
 
     private $namespace;
 

--- a/core/Container/ContainerFactory.php
+++ b/core/Container/ContainerFactory.php
@@ -19,27 +19,21 @@ use Piwik\Plugin\Manager;
  */
 class ContainerFactory
 {
-    /**
-     * @var PluginList
-     */
-    private $pluginList;
+    private PluginList $pluginList;
 
-    /**
-     * @var GlobalSettingsProvider
-     */
-    private $settings;
+    private GlobalSettingsProvider $settings;
 
     /**
      * Optional environment configs to load.
      *
      * @var string[]
      */
-    private $environments;
+    private array $environments;
 
     /**
      * @var array[]
      */
-    private $definitions;
+    private array $definitions;
 
     /**
      * @param string[] $environments Optional environment configs to load.

--- a/core/Container/IniConfigDefinitionSource.php
+++ b/core/Container/IniConfigDefinitionSource.php
@@ -23,10 +23,7 @@ use Piwik\Application\Kernel\GlobalSettingsProvider;
  */
 class IniConfigDefinitionSource implements DefinitionSource
 {
-    /**
-     * @var GlobalSettingsProvider
-     */
-    private $config;
+    private GlobalSettingsProvider $config;
 
     /**
      * @var string

--- a/core/Container/StaticContainer.php
+++ b/core/Container/StaticContainer.php
@@ -26,14 +26,14 @@ class StaticContainer
     /**
      * @var Container[]
      */
-    private static $containerStack = array();
+    private static array $containerStack = array();
 
     /**
      * Definitions to register in the container.
      *
      * @var array[]
      */
-    private static $definitions = array();
+    private static array $definitions = array();
 
     /**
      * @return Container

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -223,20 +223,14 @@ class CronArchive
      */
     private $periodIdsToLabels;
 
-    /**
-     * @var ArchiveFilter
-     */
-    private $archiveFilter;
+    private ArchiveFilter $archiveFilter;
 
     /**
      * @var bool|mixed
      */
     private $supportsAsync;
 
-    /**
-     * @var null|int
-     */
-    private $signal = null;
+    private ?int $signal = null;
 
     /**
      * @var CliMulti|null

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -26,10 +26,7 @@ use Piwik\Log\LoggerInterface;
 
 class QueueConsumer
 {
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     /**
      * @var FixedSiteIds|SharedSiteIds
@@ -46,30 +43,18 @@ class QueueConsumer
      */
     private $pid;
 
-    /**
-     * @var Model
-     */
-    private $model;
+    private Model $model;
 
     /**
      * @var ArchiveFilter
      */
     private $archiveFilter;
 
-    /**
-     * @var SegmentArchiving
-     */
-    private $segmentArchiving;
+    private SegmentArchiving $segmentArchiving;
 
-    /**
-     * @var CronArchive
-     */
-    private $cronArchive;
+    private CronArchive $cronArchive;
 
-    /**
-     * @var array
-     */
-    private $invalidationsToExclude;
+    private array $invalidationsToExclude;
 
     /**
      * @var string[]

--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -110,10 +110,7 @@ class ArchiveWriter
      */
     private $period;
 
-    /**
-     * @var ArchiveProcessor\Parameters
-     */
-    private $parameters;
+    private ArchiveProcessor\Parameters $parameters;
 
     /**
      * @var string

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -158,15 +158,9 @@ class LogAggregator
      */
     private $logger;
 
-    /**
-     * @var bool
-     */
-    private $allowUsageSegmentCache = false;
+    private bool $allowUsageSegmentCache = false;
 
-    /**
-     * @var Parameters
-     */
-    private $params;
+    private Parameters $params;
 
     public function __construct(Parameters $params, ?LoggerInterface $logger = null)
     {

--- a/core/DataAccess/LogQueryBuilder.php
+++ b/core/DataAccess/LogQueryBuilder.php
@@ -19,10 +19,7 @@ class LogQueryBuilder
 {
     public const FORCE_INNER_GROUP_BY_NO_SUBSELECT = '__##nosubquery##__';
 
-    /**
-     * @var LogTablesProvider
-     */
-    private $logTableProvider;
+    private LogTablesProvider $logTableProvider;
 
     /**
      * Forces to use a subselect when generating the query. Set value to the FORCE_INNER_GROUP_BY_NO_SUBSELECT constant to force not using a subselect.

--- a/core/DataAccess/LogQueryBuilder/JoinGenerator.php
+++ b/core/DataAccess/LogQueryBuilder/JoinGenerator.php
@@ -21,20 +21,11 @@ class JoinGenerator
      */
     protected $tables;
 
-    /**
-     * @var bool
-     */
-    private $joinWithSubSelect = false;
+    private bool $joinWithSubSelect = false;
 
-    /**
-     * @var string
-     */
-    private $joinString = '';
+    private string $joinString = '';
 
-    /**
-     * @var array
-     */
-    private $nonVisitJoins = array();
+    private array $nonVisitJoins = array();
 
     public function __construct(JoinTables $tables)
     {

--- a/core/DataAccess/LogQueryBuilder/JoinTables.php
+++ b/core/DataAccess/LogQueryBuilder/JoinTables.php
@@ -15,10 +15,7 @@ use Piwik\Plugin\LogTablesProvider;
 
 class JoinTables extends \ArrayObject
 {
-    /**
-     * @var LogTablesProvider
-     */
-    private $logTableProvider;
+    private LogTablesProvider $logTableProvider;
 
     // NOTE: joins can be specified explicitly as arrays w/ 'joinOn' keys or implicitly as table names. when
     // table names are used, the joins dependencies are assumed based on how we want to order those joins.

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1518,15 +1518,14 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
     }
 
     /** @var string[] */
-    private static $previousRowClasses = [
+    private static array $previousRowClasses = [
         'O:39:"Piwik\DataTable\Row\DataTableSummaryRow"',
         'O:19:"Piwik\DataTable\Row"',
         'O:36:"Piwik_DataTable_Row_DataTableSummary"',
         'O:19:"Piwik_DataTable_Row"',
     ];
 
-    /** @var string */
-    private static $rowClassToUseForUnserialize = 'O:29:"Piwik_DataTable_SerializedRow"';
+    private static string $rowClassToUseForUnserialize = 'O:29:"Piwik_DataTable_SerializedRow"';
 
     /**
      * It is faster to unserialize existing serialized Row instances to "Piwik_DataTable_SerializedRow" and access the

--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -61,7 +61,7 @@ class Csv extends Renderer
     /**
      * @var string[]
      */
-    private $unsupportedColumns = [];
+    private array $unsupportedColumns = [];
 
     /**
      * Computes the dataTable output and returns the string/binary

--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -31,10 +31,8 @@ class Row extends \ArrayObject
 
     /**
      * List of columns that cannot be summed. An associative array for speed.
-     *
-     * @var array
      */
-    private static $unsummableColumns = array(
+    private static array $unsummableColumns = array(
         'label' => true,
         'full_url' => true, // column used w/ old Piwik versions,
         DataTable::ARCHIVED_DATE_METADATA_NAME => true, // date column used in metadata for proportional tooltips

--- a/core/Db/TransactionLevel.php
+++ b/core/Db/TransactionLevel.php
@@ -18,10 +18,7 @@ class TransactionLevel
 
     private $statusBackup;
 
-    /**
-     * @var TransactionalDatabaseInterface $transactionalDatabase
-     */
-    private $transactionalDatabase;
+    private TransactionalDatabaseInterface $transactionalDatabase;
 
     public function __construct(TransactionalDatabaseInterface $transactionalDatabase)
     {

--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -50,7 +50,7 @@ class EventDispatcher
     /**
      * Plugin\Manager instance used to get list of loaded plugins.
      */
-    private \Piwik\Plugin\Manager $pluginManager;
+    private Plugin\Manager $pluginManager;
 
     private $pluginHooks = array();
 

--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -33,10 +33,8 @@ class EventDispatcher
     /**
      * Array of observers (callbacks attached to events) that are not methods
      * of plugin classes.
-     *
-     * @var array
      */
-    private $extraObservers = array();
+    private array $extraObservers = array();
 
     /**
      * Array storing information for all pending events. Each item in the array
@@ -46,17 +44,13 @@ class EventDispatcher
      *     'Event.Name',                  // the event name
      *     array('event', 'parameters')   // the parameters to pass to event observers
      * )
-     *
-     * @var array
      */
-    private $pendingEvents = array();
+    private array $pendingEvents = array();
 
     /**
      * Plugin\Manager instance used to get list of loaded plugins.
-     *
-     * @var \Piwik\Plugin\Manager
      */
-    private $pluginManager;
+    private \Piwik\Plugin\Manager $pluginManager;
 
     private $pluginHooks = array();
 

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -84,10 +84,7 @@ class FrontController extends Singleton
      */
     public static $enableDispatch = true;
 
-    /**
-     * @var bool
-     */
-    private $initialized = false;
+    private bool $initialized = false;
 
     /**
      * @param $lastError

--- a/core/Http/ControllerResolver.php
+++ b/core/Http/ControllerResolver.php
@@ -21,15 +21,9 @@ use Piwik\Plugin\WidgetsProvider;
  */
 class ControllerResolver
 {
-    /**
-     * @var FactoryInterface
-     */
-    private $abstractFactory;
+    private FactoryInterface $abstractFactory;
 
-    /**
-     * @var WidgetsProvider
-     */
-    private $widgets;
+    private WidgetsProvider $widgets;
 
     public function __construct(FactoryInterface $abstractFactory, WidgetsProvider $widgets)
     {

--- a/core/Log.php
+++ b/core/Log.php
@@ -88,10 +88,7 @@ class Log extends Singleton
      */
     private static $instance;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     public static function getInstance()
     {

--- a/core/LogDeleter.php
+++ b/core/LogDeleter.php
@@ -21,15 +21,9 @@ use Piwik\Plugins\SitesManager\Model;
  */
 class LogDeleter
 {
-    /**
-     * @var RawLogDao
-     */
-    private $rawLogDao;
+    private RawLogDao $rawLogDao;
 
-    /**
-     * @var LogTablesProvider
-     */
-    private $logTablesProvider;
+    private LogTablesProvider $logTablesProvider;
 
     public function __construct(RawLogDao $rawLogDao, LogTablesProvider $logTablesProvider)
     {

--- a/core/Metrics/Sorter.php
+++ b/core/Metrics/Sorter.php
@@ -16,10 +16,7 @@ use Piwik\Plugin\Metric;
 
 class Sorter
 {
-    /**
-     * @var Sorter\Config
-     */
-    private $config;
+    private Sorter\Config $config;
 
     public function __construct(Sorter\Config $config)
     {

--- a/core/Option.php
+++ b/core/Option.php
@@ -118,15 +118,9 @@ class Option
         $option->all = array();
     }
 
-    /**
-     * @var array
-     */
-    private $all = array();
+    private array $all = array();
 
-    /**
-     * @var bool
-     */
-    private $loaded = false;
+    private bool $loaded = false;
 
     /**
      * Singleton instance

--- a/core/Plugin/Archiver.php
+++ b/core/Plugin/Archiver.php
@@ -62,9 +62,9 @@ class Archiver
 {
     public static $ARCHIVE_DEPENDENT = true;
 
-    private \Piwik\ArchiveProcessor $processor;
+    private ArchiveProcessor $processor;
 
-    private bool $enabled;
+    private bool $enabled = true;
 
     /**
      * @var mixed

--- a/core/Plugin/Archiver.php
+++ b/core/Plugin/Archiver.php
@@ -62,15 +62,9 @@ class Archiver
 {
     public static $ARCHIVE_DEPENDENT = true;
 
-    /**
-     * @var \Piwik\ArchiveProcessor
-     */
-    private $processor;
+    private \Piwik\ArchiveProcessor $processor;
 
-    /**
-     * @var bool
-     */
-    private $enabled;
+    private bool $enabled;
 
     /**
      * @var mixed
@@ -79,10 +73,8 @@ class Archiver
 
     /**
      * Used if a plugin has RecordBuilders but no Archiver subclass.
-     *
-     * @var string|null
      */
-    private $pluginName = null;
+    private ?string $pluginName = null;
 
     /**
      * @param ArchiveProcessor $processor The ArchiveProcessor instance to use when persisting archive

--- a/core/Plugin/ConsoleCommand.php
+++ b/core/Plugin/ConsoleCommand.php
@@ -35,20 +35,11 @@ use Throwable;
  */
 class ConsoleCommand extends SymfonyCommand implements SignalableCommandInterface
 {
-    /**
-     * @var ProgressBar|null
-     */
-    private $progress = null;
+    private ?ProgressBar $progress = null;
 
-    /**
-     * @var OutputInterface|null
-     */
-    private $output = null;
+    private ?OutputInterface $output = null;
 
-    /**
-     * @var InputInterface|null
-     */
-    private $input = null;
+    private ?InputInterface $input = null;
 
     /**
      * Sends the given message(s) as success message(s) to the output interface (surrounded by empty lines)

--- a/core/Plugin/Dimension/DimensionMetadataProvider.php
+++ b/core/Plugin/Dimension/DimensionMetadataProvider.php
@@ -20,10 +20,8 @@ class DimensionMetadataProvider
      * Overrids for the result of the getActionReferenceColumnsByTable() method. Exists so Piwik
      * instances can be monkey patched, in case there are idaction columns that this class does not
      * naturally discover.
-     *
-     * @var array
      */
-    private $actionReferenceColumnsOverride;
+    private array $actionReferenceColumnsOverride;
 
     public function __construct(array $actionReferenceColumnsOverride = array())
     {

--- a/core/Plugin/LogTablesProvider.php
+++ b/core/Plugin/LogTablesProvider.php
@@ -16,10 +16,7 @@ use Piwik\Tracker\LogTable;
 
 class LogTablesProvider
 {
-    /**
-     * @var Manager
-     */
-    private $pluginManager;
+    private Manager $pluginManager;
 
     /**
      * @var LogTable[]|null

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -123,10 +123,7 @@ class Manager
      */
     private $trackerPluginsNotToLoad = [];
 
-    /**
-     * @var PluginList
-     */
-    private $pluginList;
+    private PluginList $pluginList;
 
     public function __construct(PluginList $pluginList)
     {

--- a/core/Plugin/ReleaseChannels.php
+++ b/core/Plugin/ReleaseChannels.php
@@ -18,10 +18,7 @@ use Piwik\UpdateCheck\ReleaseChannel;
  */
 class ReleaseChannels
 {
-    /**
-     * @var Manager
-     */
-    private $pluginManager;
+    private Manager $pluginManager;
 
     public function __construct(Manager $pluginManager)
     {

--- a/core/Plugin/SettingsProvider.php
+++ b/core/Plugin/SettingsProvider.php
@@ -28,10 +28,7 @@ use Piwik\Settings\Plugin\SystemSettings;
  */
 class SettingsProvider
 {
-    /**
-     * @var Plugin\Manager
-     */
-    private $pluginManager;
+    private Plugin\Manager $pluginManager;
 
     public function __construct(Plugin\Manager $pluginManager)
     {

--- a/core/Plugin/Tasks.php
+++ b/core/Plugin/Tasks.php
@@ -24,7 +24,7 @@ class Tasks
     /**
      * @var Task[]
      */
-    private $tasks = array();
+    private array $tasks = array();
 
     public const LOWEST_PRIORITY  = Task::LOWEST_PRIORITY;
     public const LOW_PRIORITY     = Task::LOW_PRIORITY;

--- a/core/Plugin/WidgetsProvider.php
+++ b/core/Plugin/WidgetsProvider.php
@@ -21,10 +21,7 @@ use Piwik\Widget\WidgetContainerConfig;
  */
 class WidgetsProvider
 {
-    /**
-     * @var Plugin\Manager
-     */
-    private $pluginManager;
+    private Plugin\Manager $pluginManager;
 
     public function __construct(Plugin\Manager $pluginManager)
     {

--- a/core/ProfessionalServices/Advertising.php
+++ b/core/ProfessionalServices/Advertising.php
@@ -24,15 +24,9 @@ class Advertising
 {
     public const CAMPAIGN_NAME_PROFESSIONAL_SERVICES = 'App_ProfessionalServices';
 
-    /**
-     * @var Plugin\Manager
-     */
-    private $pluginManager;
+    private Plugin\Manager $pluginManager;
 
-    /**
-     * @var Config
-     */
-    private $config;
+    private Config $config;
 
     public function __construct(Plugin\Manager $pluginManager, Config $config)
     {

--- a/core/Profiler.php
+++ b/core/Profiler.php
@@ -27,10 +27,8 @@ class Profiler
 {
     /**
      * Whether xhprof has been setup or not.
-     *
-     * @var bool
      */
-    private static $isXhprofSetup = false;
+    private static bool $isXhprofSetup = false;
 
     /**
      * Returns memory usage

--- a/core/RankingQuery.php
+++ b/core/RankingQuery.php
@@ -49,16 +49,14 @@ class RankingQuery
     /**
      * Contains the labels of the inner query.
      * Format: "label" => true (to make sure labels don't appear twice)
-     * @var array
      */
-    private $labelColumns = array();
+    private array $labelColumns = array();
 
     /**
      * The columns of the inner query that are not labels
      * Format: "label" => "aggregation function" or false for no aggregation
-     * @var array
      */
-    private $additionalColumns = array();
+    private array $additionalColumns = array();
 
     /**
      * The limit for each group

--- a/core/Report/ReportWidgetFactory.php
+++ b/core/Report/ReportWidgetFactory.php
@@ -25,7 +25,7 @@ class ReportWidgetFactory
     /**
      * @var Report
      */
-    private $report = null;
+    private ?Report $report = null;
 
     /**
      * Generates a new report widget factory.

--- a/core/Report/ReportWidgetFactory.php
+++ b/core/Report/ReportWidgetFactory.php
@@ -22,10 +22,7 @@ use Piwik\Widget\WidgetContainerConfig;
  */
 class ReportWidgetFactory
 {
-    /**
-     * @var Report
-     */
-    private ?Report $report = null;
+    private Report $report;
 
     /**
      * Generates a new report widget factory.

--- a/core/Scheduler/Scheduler.php
+++ b/core/Scheduler/Scheduler.php
@@ -51,30 +51,19 @@ class Scheduler
 {
     /**
      * Is the scheduler running any task.
-     * @var bool
      */
-    private $isRunningTask = false;
+    private bool $isRunningTask = false;
 
     /**
      * Should the last run task be scheduled for a retry
-     * @var bool
      */
-    private $scheduleRetry = false;
+    private bool $scheduleRetry = false;
 
-    /**
-     * @var Timetable
-     */
-    private $timetable;
+    private Timetable $timetable;
 
-    /**
-     * @var TaskLoader
-     */
-    private $loader;
+    private TaskLoader $loader;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     /**
      * @var Lock

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -99,10 +99,7 @@ class Segment
      */
     private $isSegmentEncoded;
 
-    /**
-     * @var Exception|null
-     */
-    private $missingDatesException = null;
+    private ?Exception $missingDatesException = null;
 
     /**
      * Truncate the Segments to 8k

--- a/core/Segment/SegmentsList.php
+++ b/core/Segment/SegmentsList.php
@@ -32,7 +32,7 @@ class SegmentsList
      *
      * @var Segment[]
      */
-    private $segments = array();
+    private array $segments = array();
 
     private $segmentsByNameCache = array();
 

--- a/core/Session/SessionAuth.php
+++ b/core/Session/SessionAuth.php
@@ -46,10 +46,7 @@ class SessionAuth implements Auth
 
     private $tokenAuth;
 
-    /**
-     * @var bool
-     */
-    private $sessionExpired = false;
+    private bool $sessionExpired = false;
 
     public function __construct(?UsersModel $userModel = null, $shouldDestroySession = true)
     {

--- a/core/Settings/Settings.php
+++ b/core/Settings/Settings.php
@@ -21,7 +21,7 @@ abstract class Settings
      *
      * @var Setting[]
      */
-    private $settings = array();
+    private array $settings = array();
 
     protected $pluginName;
 

--- a/core/Settings/Storage/Backend/Cache.php
+++ b/core/Settings/Storage/Backend/Cache.php
@@ -19,10 +19,7 @@ use Piwik\Cache as PiwikCache;
  */
 class Cache implements BackendInterface
 {
-    /**
-     * @var BackendInterface
-     */
-    private $backend;
+    private BackendInterface $backend;
 
     public function __construct(BackendInterface $backend)
     {

--- a/core/Settings/Storage/Backend/SitesTable.php
+++ b/core/Settings/Storage/Backend/SitesTable.php
@@ -26,7 +26,7 @@ class SitesTable implements BackendInterface
     /**
      * @var string[]
      */
-    private $commaSeparatedArrayFields = array(
+    private array $commaSeparatedArrayFields = array(
         'sitesearch_keyword_parameters',
         'sitesearch_category_parameters',
         'excluded_user_agents',
@@ -39,7 +39,7 @@ class SitesTable implements BackendInterface
      * these fields are standard fields of a site and cannot be adjusted via a setting
      * @var string[]
      */
-    private $allowedNames = array(
+    private array $allowedNames = array(
         'ecommerce', 'sitesearch', 'sitesearch_keyword_parameters',
         'sitesearch_category_parameters', 'exclude_unknown_urls',
         'excluded_ips', 'excluded_parameters', 'excluded_referrers',

--- a/core/Settings/Storage/Storage.php
+++ b/core/Settings/Storage/Storage.php
@@ -28,16 +28,12 @@ class Storage
     // for lazy loading of setting values
     private $settingValuesLoaded = false;
 
-    /**
-     * @var Backend\BackendInterface
-     */
-    private $backend;
+    private Backend\BackendInterface $backend;
 
     /**
      * Defines whether a value has changed since the settings were loaded or not.
-     * @var bool
      */
-    private $isDirty = false;
+    private bool $isDirty = false;
 
     public function __construct(Backend\BackendInterface $backend)
     {

--- a/core/Tracker/Cache.php
+++ b/core/Tracker/Cache.php
@@ -33,9 +33,8 @@ class Cache
 
     /**
      * {@see self::withDelegatedCacheClears()}
-     * @var array
      */
-    private static $delegatedClears = [];
+    private static array $delegatedClears = [];
 
     private static $cacheIdGeneral = 'general';
 

--- a/core/Tracker/Config/ThirdPartyCookies.php
+++ b/core/Tracker/Config/ThirdPartyCookies.php
@@ -30,10 +30,7 @@ class ThirdPartyCookies implements
      */
     use PolicyComparisonTrait;
 
-    /**
-     * @var bool|null
-     */
-    private $value;
+    private ?bool $value;
 
     private function __construct(?bool $value)
     {

--- a/core/Tracker/RequestSet.php
+++ b/core/Tracker/RequestSet.php
@@ -20,7 +20,7 @@ class RequestSet
      *
      * @var Request[]
      */
-    private $requests = null;
+    private ?array $requests = null;
 
     /**
      * The token auth supplied with a bulk visits POST.

--- a/core/Tracker/RequestSet.php
+++ b/core/Tracker/RequestSet.php
@@ -18,7 +18,7 @@ class RequestSet
     /**
      * The set of visits to track.
      *
-     * @var Request[]
+     * @var Request[]|null
      */
     private ?array $requests = null;
 

--- a/core/Tracker/TrackerCodeGenerator.php
+++ b/core/Tracker/TrackerCodeGenerator.php
@@ -25,9 +25,8 @@ class TrackerCodeGenerator
 {
     /**
      * whether matomo.js|php should be forced over piwik.js|php
-     * @var bool
      */
-    private $shouldForceMatomoEndpoint = false;
+    private bool $shouldForceMatomoEndpoint = false;
 
     public function forceMatomoEndpoint()
     {

--- a/core/Tracker/Visit/VisitProperties.php
+++ b/core/Tracker/Visit/VisitProperties.php
@@ -18,17 +18,13 @@ class VisitProperties
      * Information about the current visit. This array holds the column values that will be inserted or updated
      * in the `log_visit` table, or the values for the last known visit of the current visitor. These properties
      * can be modified during request processing.
-     *
-     * @var array
      */
-    private $visitInfo = [];
+    private array $visitInfo = [];
 
     /**
      * Holds the initial visit properties information about the current visit, this data is not changed during request processing.
-     *
-     * @var array
      */
-    private $visitInfoImmutableProperties = [];
+    private array $visitInfoImmutableProperties = [];
 
 
     public function __construct(array $visitInfo = [])

--- a/core/Tracker/VisitExcluded.php
+++ b/core/Tracker/VisitExcluded.php
@@ -25,10 +25,7 @@ use Piwik\Config;
  */
 class VisitExcluded
 {
-    /**
-     * @var ReferrerSpamFilter
-     */
-    private $spamFilter;
+    private ReferrerSpamFilter $spamFilter;
 
     private $siteCache = array();
 

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -54,15 +54,9 @@ class VisitorRecognizer
      */
     private $lookBackNSecondsCustom;
 
-    /**
-     * @var Model
-     */
-    private $model;
+    private Model $model;
 
-    /**
-     * @var EventDispatcher
-     */
-    private $eventDispatcher;
+    private EventDispatcher $eventDispatcher;
 
     /**
      * @var array|false

--- a/core/Translation/Loader/DevelopmentLoader.php
+++ b/core/Translation/Loader/DevelopmentLoader.php
@@ -71,15 +71,9 @@ class DevelopmentLoader implements LoaderInterface
         "Z" => 'Ẑ',
     ];
 
-    /**
-     * @var LoaderInterface
-     */
-    private $loader;
+    private LoaderInterface $loader;
 
-    /**
-     * @var string
-     */
-    private $fallbackLanguage = 'en';
+    private string $fallbackLanguage = 'en';
 
     /**
      * @param LoaderInterface $loader Decorate another loader to add the pseudo-language.

--- a/core/Translation/Loader/LoaderCache.php
+++ b/core/Translation/Loader/LoaderCache.php
@@ -16,15 +16,9 @@ use Matomo\Cache\Lazy;
  */
 class LoaderCache implements LoaderInterface
 {
-    /**
-     * @var LoaderInterface
-     */
-    private $loader;
+    private LoaderInterface $loader;
 
-    /**
-     * @var Lazy
-     */
-    private $cache;
+    private Lazy $cache;
 
     public function __construct(LoaderInterface $loader, Lazy $cache)
     {

--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -24,20 +24,15 @@ class Translator
 {
     /**
      * Contains the translated messages, indexed by the language name.
-     *
-     * @var array
      */
-    private $translations = [];
+    private array $translations = [];
 
     /**
      * @var string
      */
     private $currentLanguage;
 
-    /**
-     * @var string
-     */
-    private $fallback = 'en';
+    private string $fallback = 'en';
 
     /**
      * Directories containing the translations to load.
@@ -46,10 +41,7 @@ class Translator
      */
     private $directories = [];
 
-    /**
-     * @var LoaderInterface
-     */
-    private $loader;
+    private LoaderInterface $loader;
 
     private const LIST_TYPE_AND = 'And';
     private const LIST_TYPE_OR = 'Or';

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -97,15 +97,9 @@ class Twig
     public const SPARKLINE_TEMPLATE = '<img loading="lazy" alt="" data-src="%s" width="%d" height="%d" />
     <script type="text/javascript">$(function() { piwik.initSparklines(); });</script>';
 
-    /**
-     * @var Environment
-     */
-    private $twig;
+    private Environment $twig;
 
-    /**
-     * @var Formatter
-     */
-    private $formatter;
+    private Formatter $formatter;
 
     public function __construct()
     {

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -38,7 +38,7 @@ class Updater
     /**
      * @var UpdateObserver[]
      */
-    private $updateObservers = array();
+    private array $updateObservers = array();
 
     /**
      * @var Columns\Updater

--- a/core/Updater/Migration/Plugin/Activate.php
+++ b/core/Updater/Migration/Plugin/Activate.php
@@ -23,10 +23,7 @@ class Activate extends Migration
      */
     private $pluginName;
 
-    /**
-     * @var Plugin\Manager
-     */
-    private $pluginManager;
+    private Plugin\Manager $pluginManager;
 
     public function __construct(Plugin\Manager $pluginManager, $pluginName)
     {

--- a/core/Updater/Migration/Plugin/Deactivate.php
+++ b/core/Updater/Migration/Plugin/Deactivate.php
@@ -23,10 +23,7 @@ class Deactivate extends Migration
      */
     private $pluginName;
 
-    /**
-     * @var Plugin\Manager
-     */
-    private $pluginManager;
+    private Plugin\Manager $pluginManager;
 
     public function __construct(Plugin\Manager $pluginManager, $pluginName)
     {

--- a/core/Updater/Migration/Plugin/Uninstall.php
+++ b/core/Updater/Migration/Plugin/Uninstall.php
@@ -23,10 +23,7 @@ class Uninstall extends Migration
      */
     private $pluginName;
 
-    /**
-     * @var Plugin\Manager
-     */
-    private $pluginManager;
+    private Plugin\Manager $pluginManager;
 
     public function __construct(Plugin\Manager $pluginManager, $pluginName)
     {

--- a/core/Updates/0.2.10.php
+++ b/core/Updates/0.2.10.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_2_10 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.2.12.php
+++ b/core/Updates/0.2.12.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_2_12 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.2.13.php
+++ b/core/Updates/0.2.13.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_2_13 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.2.24.php
+++ b/core/Updates/0.2.24.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_2_24 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.2.27.php
+++ b/core/Updates/0.2.27.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_2_27 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.2.32.php
+++ b/core/Updates/0.2.32.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_2_32 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.2.33.php
+++ b/core/Updates/0.2.33.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_2_33 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.2.35.php
+++ b/core/Updates/0.2.35.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_2_35 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.2.37.php
+++ b/core/Updates/0.2.37.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_2_37 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.4.1.php
+++ b/core/Updates/0.4.1.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_4_1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.4.2.php
+++ b/core/Updates/0.4.2.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_4_2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.4.php
+++ b/core/Updates/0.4.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_4 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.5.4.php
+++ b/core/Updates/0.5.4.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_5_4 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.5.5.php
+++ b/core/Updates/0.5.5.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_5_5 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.5.php
+++ b/core/Updates/0.5.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_5 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.6-rc1.php
+++ b/core/Updates/0.6-rc1.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration;
 
 class Updates_0_6_rc1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.6.3.php
+++ b/core/Updates/0.6.3.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_6_3 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.7.php
+++ b/core/Updates/0.7.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_7 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/0.9.1.php
+++ b/core/Updates/0.9.1.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_0_9_1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.10.2-b1.php
+++ b/core/Updates/1.10.2-b1.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_10_2_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.10.2-b2.php
+++ b/core/Updates/1.10.2-b2.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_10_2_b2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.12-b1.php
+++ b/core/Updates/1.12-b1.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_12_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.12-b16.php
+++ b/core/Updates/1.12-b16.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_12_b16 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.2-rc1.php
+++ b/core/Updates/1.2-rc1.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_2_rc1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.2.3.php
+++ b/core/Updates/1.2.3.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_2_3 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.2.5-rc1.php
+++ b/core/Updates/1.2.5-rc1.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_2_5_rc1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.2.5-rc7.php
+++ b/core/Updates/1.2.5-rc7.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_2_5_rc7 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.4-rc1.php
+++ b/core/Updates/1.4-rc1.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_4_rc1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.4-rc2.php
+++ b/core/Updates/1.4-rc2.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_4_rc2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.5-b1.php
+++ b/core/Updates/1.5-b1.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_5_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.5-b2.php
+++ b/core/Updates/1.5-b2.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_5_b2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.5-b3.php
+++ b/core/Updates/1.5-b3.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_5_b3 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.5-b4.php
+++ b/core/Updates/1.5-b4.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_5_b4 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.5-b5.php
+++ b/core/Updates/1.5-b5.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_5_b5 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.6-b1.php
+++ b/core/Updates/1.6-b1.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_6_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.7-b1.php
+++ b/core/Updates/1.7-b1.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_7_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.7.2-rc5.php
+++ b/core/Updates/1.7.2-rc5.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_7_2_rc5 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.7.2-rc7.php
+++ b/core/Updates/1.7.2-rc7.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_7_2_rc7 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.8.3-b1.php
+++ b/core/Updates/1.8.3-b1.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_8_3_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.8.4-b1.php
+++ b/core/Updates/1.8.4-b1.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_8_4_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.9-b16.php
+++ b/core/Updates/1.9-b16.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_9_b16 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.9-b19.php
+++ b/core/Updates/1.9-b19.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_9_b19 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.9-b9.php
+++ b/core/Updates/1.9-b9.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_9_b9 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.9.1-b2.php
+++ b/core/Updates/1.9.1-b2.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_9_1_b2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/1.9.3-b8.php
+++ b/core/Updates/1.9.3-b8.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_9_3_b8 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.0-a12.php
+++ b/core/Updates/2.0-a12.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_0_a12 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.0-a13.php
+++ b/core/Updates/2.0-a13.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_0_a13 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.0-a7.php
+++ b/core/Updates/2.0-a7.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_0_a7 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.0-b3.php
+++ b/core/Updates/2.0-b3.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_0_b3 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.0-b9.php
+++ b/core/Updates/2.0-b9.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_0_b9 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.0.4-b5.php
+++ b/core/Updates/2.0.4-b5.php
@@ -22,10 +22,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_0_4_b5 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.1.1-b11.php
+++ b/core/Updates/2.1.1-b11.php
@@ -22,10 +22,7 @@ use Piwik\Updates;
 
 class Updates_2_1_1_b11 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.10.0-b10.php
+++ b/core/Updates/2.10.0-b10.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_10_0_b10 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.10.0-b5.php
+++ b/core/Updates/2.10.0-b5.php
@@ -43,10 +43,7 @@ class Updates_2_10_0_b5 extends Updates
 {
     public static $archiveBlobTables;
 
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.10.0-b7.php
+++ b/core/Updates/2.10.0-b7.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_10_0_b7 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.11.0-b2.php
+++ b/core/Updates/2.11.0-b2.php
@@ -22,10 +22,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_2_11_0_b2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.11.0-b4.php
+++ b/core/Updates/2.11.0-b4.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_11_0_b4 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.11.0-b5.php
+++ b/core/Updates/2.11.0-b5.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_11_0_b5 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.13.0-b3.php
+++ b/core/Updates/2.13.0-b3.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_13_0_b3 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.13.1.php
+++ b/core/Updates/2.13.1.php
@@ -19,10 +19,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_2_13_1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.14.0-b2.php
+++ b/core/Updates/2.14.0-b2.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_14_0_b2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.14.2.php
+++ b/core/Updates/2.14.2.php
@@ -24,10 +24,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_2_14_2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.15.0-b3.php
+++ b/core/Updates/2.15.0-b3.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_15_0_b3 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.15.0.php
+++ b/core/Updates/2.15.0.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_15_0 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.4.0-b8.php
+++ b/core/Updates/2.4.0-b8.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_4_0_b8 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.7.0-b2.php
+++ b/core/Updates/2.7.0-b2.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_7_0_b2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.9.0-b1.php
+++ b/core/Updates/2.9.0-b1.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_9_0_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/2.9.0-b7.php
+++ b/core/Updates/2.9.0-b7.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_9_0_b7 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     private $sequenceTable = 'sequence';
 

--- a/core/Updates/3.0.0-b1.php
+++ b/core/Updates/3.0.0-b1.php
@@ -25,10 +25,7 @@ use Piwik\Plugins\Dashboard;
  */
 class Updates_3_0_0_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     private $pluginSettingsTable = 'plugin_setting';
     private $siteSettingsTable = 'site_setting';

--- a/core/Updates/3.0.0-b4.php
+++ b/core/Updates/3.0.0-b4.php
@@ -19,15 +19,9 @@ use Piwik\Updates;
 
 class Updates_3_0_0_b4 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
-    /**
-     * @var string
-     */
-    private $userTable = 'user';
+    private string $userTable = 'user';
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.10.0-b2.php
+++ b/core/Updates/3.10.0-b2.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_3_10_0_b2 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.10.0-rc5.php
+++ b/core/Updates/3.10.0-rc5.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_3_10_0_rc5 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.11.0-b1.php
+++ b/core/Updates/3.11.0-b1.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_3_11_0_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.12.0-b1.php
+++ b/core/Updates/3.12.0-b1.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_3_12_0_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.12.0-b7.php
+++ b/core/Updates/3.12.0-b7.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_3_12_0_b7 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.13.1-b2.php
+++ b/core/Updates/3.13.1-b2.php
@@ -23,10 +23,7 @@ class Updates_3_13_1_b2 extends PiwikUpdates
 {
     public const GEO_LITE_COUNTRY_URL = 'https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz';
 
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.5.0-b2.php
+++ b/core/Updates/3.5.0-b2.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_3_5_0_b2 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.5.0-b4.php
+++ b/core/Updates/3.5.0-b4.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_3_5_0_b4 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.6.0-b2.php
+++ b/core/Updates/3.6.0-b2.php
@@ -21,10 +21,7 @@ use Piwik\DbHelper;
  */
 class Updates_3_6_0_b2 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     private $pluginSettingsTable = 'plugin_setting';
     private $siteSettingsTable = 'site_setting';

--- a/core/Updates/3.6.0-b3.php
+++ b/core/Updates/3.6.0-b3.php
@@ -18,10 +18,7 @@ use Piwik\Updates;
  */
 class Updates_3_6_0_b3 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.6.0-b4.php
+++ b/core/Updates/3.6.0-b4.php
@@ -20,10 +20,7 @@ use Piwik\Updater;
  */
 class Updates_3_6_0_b4 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.6.1-b2.php
+++ b/core/Updates/3.6.1-b2.php
@@ -18,10 +18,7 @@ use Piwik\Updater;
  */
 class Updates_3_6_1_b2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.6.1-b3.php
+++ b/core/Updates/3.6.1-b3.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_3_6_1_b3 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.7.0-b1.php
+++ b/core/Updates/3.7.0-b1.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_3_7_0_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.8.0-b3.php
+++ b/core/Updates/3.8.0-b3.php
@@ -19,10 +19,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_3_8_0_b3 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/3.8.0-b4.php
+++ b/core/Updates/3.8.0-b4.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_3_8_0_b4 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.0.0-b1.php
+++ b/core/Updates/4.0.0-b1.php
@@ -39,10 +39,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_0_0_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.0.0-b3.php
+++ b/core/Updates/4.0.0-b3.php
@@ -19,10 +19,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_0_0_b3 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.0.0-rc3.php
+++ b/core/Updates/4.0.0-rc3.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_0_0_rc3 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.0.0-rc4.php
+++ b/core/Updates/4.0.0-rc4.php
@@ -23,10 +23,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_0_0_rc4 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.0.1-b1.php
+++ b/core/Updates/4.0.1-b1.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_4_0_1_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.0.4-b1.php
+++ b/core/Updates/4.0.4-b1.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_4_0_4_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.1.2-b1.php
+++ b/core/Updates/4.1.2-b1.php
@@ -21,10 +21,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_4_1_2_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.1.2-b2.php
+++ b/core/Updates/4.1.2-b2.php
@@ -16,10 +16,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_4_1_2_b2 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.10.0-b1.php
+++ b/core/Updates/4.10.0-b1.php
@@ -21,10 +21,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_10_0_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.11.0-b1.php
+++ b/core/Updates/4.11.0-b1.php
@@ -19,10 +19,7 @@ use Piwik\Updates as PiwikUpdates;
  */
 class Updates_4_11_0_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.11.0-rc2.php
+++ b/core/Updates/4.11.0-rc2.php
@@ -26,10 +26,7 @@ use Piwik\Updates as PiwikUpdates;
  */
 class Updates_4_11_0_rc2 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     private $pendingUsers;
 

--- a/core/Updates/4.12.0-b1.php
+++ b/core/Updates/4.12.0-b1.php
@@ -19,10 +19,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_12_0_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.12.0-b2.php
+++ b/core/Updates/4.12.0-b2.php
@@ -19,10 +19,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_12_0_b2 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.12.0-b3.php
+++ b/core/Updates/4.12.0-b3.php
@@ -21,10 +21,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_12_0_b3 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.12.0-b4.php
+++ b/core/Updates/4.12.0-b4.php
@@ -19,10 +19,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_12_0_b4 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.3.0-b3.php
+++ b/core/Updates/4.3.0-b3.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_3_0_b3 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.3.0-b4.php
+++ b/core/Updates/4.3.0-b4.php
@@ -20,10 +20,7 @@ use Piwik\Common;
  */
 class Updates_4_3_0_b4 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.3.0-rc2.php
+++ b/core/Updates/4.3.0-rc2.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_3_0_rc2 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.4.0-b1.php
+++ b/core/Updates/4.4.0-b1.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_4_0_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.5.0-b1.php
+++ b/core/Updates/4.5.0-b1.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_4_5_0_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.6.0-b1.php
+++ b/core/Updates/4.6.0-b1.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_4_6_0_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.6.0-b4.php
+++ b/core/Updates/4.6.0-b4.php
@@ -27,10 +27,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_6_0_b4 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.7.0-b2.php
+++ b/core/Updates/4.7.0-b2.php
@@ -19,10 +19,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_7_0_b2 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/4.7.1-b1.php
+++ b/core/Updates/4.7.1-b1.php
@@ -19,10 +19,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_4_7_1_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.0.0-b1.php
+++ b/core/Updates/5.0.0-b1.php
@@ -26,10 +26,7 @@ use Piwik\Plugins\Goals\Commands\CalculateConversionPages;
  */
 class Updates_5_0_0_b1 extends PiwikUpdates
 {
-    /**
-     * @var Factory
-     */
-    private $migration;
+    private Factory $migration;
     private $tableName;
     private $indexName;
     private $newIndexName;

--- a/core/Updates/5.0.0-rc2.php
+++ b/core/Updates/5.0.0-rc2.php
@@ -20,10 +20,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_5_0_0_rc2 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.0.0-rc5.php
+++ b/core/Updates/5.0.0-rc5.php
@@ -19,10 +19,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_5_0_0_rc5 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.11.0-b1.php
+++ b/core/Updates/5.11.0-b1.php
@@ -17,10 +17,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_5_11_0_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.2.0-b2.php
+++ b/core/Updates/5.2.0-b2.php
@@ -20,10 +20,7 @@ use Piwik\Updates;
 
 class Updates_5_2_0_b2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.2.0-b6.php
+++ b/core/Updates/5.2.0-b6.php
@@ -19,10 +19,7 @@ use Piwik\Updates;
 
 class Updates_5_2_0_b6 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.3.0-b1.php
+++ b/core/Updates/5.3.0-b1.php
@@ -15,10 +15,7 @@ use Piwik\Updates;
 
 class Updates_5_3_0_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.3.0-rc1.php
+++ b/core/Updates/5.3.0-rc1.php
@@ -17,10 +17,7 @@ use Piwik\Updates;
 
 class Updates_5_3_0_rc1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.4.0-b1.php
+++ b/core/Updates/5.4.0-b1.php
@@ -15,10 +15,7 @@ use Piwik\Updates;
 
 class Updates_5_4_0_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.4.0-b3.php
+++ b/core/Updates/5.4.0-b3.php
@@ -15,10 +15,7 @@ use Piwik\Updates;
 
 class Updates_5_4_0_b3 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.4.0-b4.php
+++ b/core/Updates/5.4.0-b4.php
@@ -20,10 +20,7 @@ use Piwik\Updates as PiwikUpdates;
  */
 class Updates_5_4_0_b4 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     /**
      * @var string

--- a/core/Updates/5.7.0-b1.php
+++ b/core/Updates/5.7.0-b1.php
@@ -15,10 +15,7 @@ use Piwik\Updates;
 
 class Updates_5_7_0_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.7.0-b2.php
+++ b/core/Updates/5.7.0-b2.php
@@ -19,10 +19,7 @@ use Piwik\Updater\Migration;
  */
 class Updates_5_7_0_b2 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.7.0-b3.php
+++ b/core/Updates/5.7.0-b3.php
@@ -16,10 +16,7 @@ use Piwik\Updater;
 
 class Updates_5_7_0_b3 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.8.0-b1.php
+++ b/core/Updates/5.8.0-b1.php
@@ -24,10 +24,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_5_8_0_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.8.0-b2.php
+++ b/core/Updates/5.8.0-b2.php
@@ -15,10 +15,7 @@ use Piwik\Updates;
 
 class Updates_5_8_0_b2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/5.9.0-b2.php
+++ b/core/Updates/5.9.0-b2.php
@@ -16,10 +16,7 @@ use Piwik\Updates;
 
 class Updates_5_9_0_b2 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/Updates/6.0.0-b1.php
+++ b/core/Updates/6.0.0-b1.php
@@ -20,10 +20,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_6_0_0_b1 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/core/UrlHelper.php
+++ b/core/UrlHelper.php
@@ -21,7 +21,7 @@ class UrlHelper
     /**
      * @var string[]
      */
-    private static $validLinkProtocols = [
+    private static array $validLinkProtocols = [
         'http',
         'https',
         'tel',

--- a/core/View/SecurityPolicy.php
+++ b/core/View/SecurityPolicy.php
@@ -27,10 +27,8 @@ class SecurityPolicy
     /**
      * The policies that will generate the CSP header.
      * These are keyed by the directive.
-     *
-     * @var array
      */
-    private $policies = array();
+    private array $policies = array();
 
     private $cspEnabled;
     private $reportOnly;

--- a/core/View/UIControl.php
+++ b/core/View/UIControl.php
@@ -69,10 +69,8 @@ class UIControl extends \Piwik\View
 
     /**
      * The inner view that renders the actual control content.
-     *
-     * @var View
      */
-    private ?View $innerView = null;
+    private View $innerView;
 
     public function __construct()
     {

--- a/core/View/UIControl.php
+++ b/core/View/UIControl.php
@@ -72,7 +72,7 @@ class UIControl extends \Piwik\View
      *
      * @var View
      */
-    private $innerView = null;
+    private ?View $innerView = null;
 
     public function __construct()
     {

--- a/core/Widget/WidgetsList.php
+++ b/core/Widget/WidgetsList.php
@@ -30,7 +30,7 @@ class WidgetsList
      *
      * @var WidgetConfig[]
      */
-    private $widgets = array();
+    private array $widgets = array();
 
     /**
      * @var WidgetContainerConfig[]

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -139,12 +139,6 @@ parameters:
 			path: core/API/ResponseBuilder.php
 
 		-
-			message: '#^Property Piwik\\Access\:\:\$auth \(Piwik\\Auth\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
-			count: 1
-			path: core/Access.php
-
-		-
 			message: '#^Method Piwik\\Archive\\ArchiveInvalidator\:\:getSegmentArchiving\(\) is unused\.$#'
 			identifier: method.unused
 			count: 1
@@ -1759,18 +1753,6 @@ parameters:
 			path: core/Tracker/Request.php
 
 		-
-			message: '#^Call to function is_array\(\) with array\<Piwik\\Tracker\\Request\> will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: core/Tracker/RequestSet.php
-
-		-
-			message: '#^Call to function is_null\(\) with array\<Piwik\\Tracker\\Request\> will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: core/Tracker/RequestSet.php
-
-		-
 			message: '#^Call to function is_null\(\) with string will always evaluate to false\.$#'
 			identifier: function.impossibleType
 			count: 1
@@ -1785,7 +1767,7 @@ parameters:
 		-
 			message: '#^Unreachable statement \- code above always terminates\.$#'
 			identifier: deadCode.unreachable
-			count: 2
+			count: 1
 			path: core/Tracker/RequestSet.php
 
 		-

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -46,12 +46,9 @@ parameters:
         -
             identifier: class.extendsFinalByPhpDoc
             path: plugins/Monolog/Formatter/ConsoleFormatter.php
-        # These messages embed an absolute path that differs between environments (local/ddev vs CI),
-        # so they cannot live in the baseline; ignore them by identifier + relative path instead.
+        # This message embeds an absolute path that differs between environments (local/ddev vs CI),
+        # so it cannot live in the baseline; ignore it by identifier + relative path instead.
         # The required files are generated at build/install time and are absent from a plain checkout.
-        -
-            identifier: requireOnce.fileNotFound
-            path: core/FileIntegrity.php
         -
             identifier: requireOnce.fileNotFound
             path: core/bootstrap.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -46,14 +46,18 @@ parameters:
         -
             identifier: class.extendsFinalByPhpDoc
             path: plugins/Monolog/Formatter/ConsoleFormatter.php
-        # This message embeds an absolute path that differs between environments (local/ddev vs CI),
-        # so it cannot live in the baseline; ignore it by identifier + relative path instead.
-        # The required files are generated at build/install time and are absent from a plain checkout.
-        -
-            identifier: requireOnce.fileNotFound
-            path: core/bootstrap.php
     universalObjectCratesClasses:
         - Piwik\Config
         - Piwik\View
         - Piwik\ViewDataTable\Config
         - Piwik\Session\SessionNamespace
+    # These constants point at the installation directory, so any require() built from them
+    # resolves differently per environment (local/ddev vs CI) and per analysis mode: parallel
+    # workers do not see the bootstrapped values, the single-process analyser does. Treating
+    # them as dynamic keeps requireOnce.fileNotFound from appearing and disappearing, which
+    # an ignore entry cannot follow.
+    dynamicConstantNames:
+        PIWIK_INCLUDE_PATH: string
+        PIWIK_VENDOR_PATH: string
+        PIWIK_DOCUMENT_ROOT: string
+        PIWIK_USER_PATH: string

--- a/plugins/AIAgents/Columns/Metrics/AIAgentMetric.php
+++ b/plugins/AIAgents/Columns/Metrics/AIAgentMetric.php
@@ -34,15 +34,9 @@ class AIAgentMetric extends ProcessedMetric
         'nb_actions_per_visit_human'    => 'AIAgents_ColumnHumanAvgActionsPerVisit',
     ];
 
-    /**
-     * @var ProcessedMetric
-     */
-    private $wrapped;
+    private ProcessedMetric $wrapped;
 
-    /**
-     * @var string
-     */
-    private $suffix;
+    private string $suffix;
 
     public function __construct(ProcessedMetric $wrapped, string $suffix)
     {

--- a/plugins/AIAgents/Controller.php
+++ b/plugins/AIAgents/Controller.php
@@ -17,10 +17,7 @@ use Piwik\Translation\Translator;
 
 class Controller extends PluginController
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -60,15 +60,9 @@ require_once PIWIK_INCLUDE_PATH . '/core/Config.php';
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var SettingsProvider
-     */
-    private $settingsProvider;
+    private SettingsProvider $settingsProvider;
 
-    /**
-     * @var ProcessedReport
-     */
-    private $processedReport;
+    private ProcessedReport $processedReport;
 
     /**
      * For Testing purpose only

--- a/plugins/API/DataTable/MergeDataTables.php
+++ b/plugins/API/DataTable/MergeDataTables.php
@@ -14,10 +14,7 @@ use Piwik\DataTable;
 
 class MergeDataTables
 {
-    /**
-     * @var bool
-     */
-    private $copyExtraProcessedMetrics;
+    private bool $copyExtraProcessedMetrics;
 
     public function __construct(bool $copyExtraProcessedMetrics = false)
     {

--- a/plugins/API/Filter/DataComparisonFilter.php
+++ b/plugins/API/Filter/DataComparisonFilter.php
@@ -65,10 +65,7 @@ use Piwik\Site;
  */
 class DataComparisonFilter
 {
-    /**
-     * @var \Piwik\Request
-     */
-    private $request;
+    private \Piwik\Request $request;
 
     /**
      * @var int
@@ -115,10 +112,7 @@ class DataComparisonFilter
      */
     private $isRequestMultiplePeriod;
 
-    /**
-     * @var ComparisonRowGenerator
-     */
-    private $comparisonRowGenerator;
+    private ComparisonRowGenerator $comparisonRowGenerator;
 
     /**
      * @var array

--- a/plugins/API/Glossary.php
+++ b/plugins/API/Glossary.php
@@ -13,10 +13,7 @@ use Piwik\Metrics;
 
 class Glossary
 {
-    /**
-     * @var API
-     */
-    private $api;
+    private API $api;
 
     public function __construct(API $api)
     {

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -47,10 +47,7 @@ use Piwik\Timer;
  */
 class ProcessedReport
 {
-    /**
-     * @var ReportsProvider
-     */
-    private $reportsProvider;
+    private ReportsProvider $reportsProvider;
 
     private const PERFORMANCE_METRICS_TO_FORMAT = [
         'avg_time_network',

--- a/plugins/API/RowEvolution.php
+++ b/plugins/API/RowEvolution.php
@@ -39,7 +39,7 @@ class RowEvolution
     /**
      * @var string[]
      */
-    private static $actionsUrlReports = [
+    private static array $actionsUrlReports = [
         'getPageUrls',
         'getPageUrlsFollowingSiteSearch',
         'getEntryPageUrls',

--- a/plugins/API/SegmentMetadata.php
+++ b/plugins/API/SegmentMetadata.php
@@ -18,9 +18,8 @@ class SegmentMetadata
 {
     /**
      * Map of category name to order
-     * @var array
      */
-    private $categoryOrder = array();
+    private array $categoryOrder = array();
 
     public function getSegmentsMetadata($idSites, $_hideImplementationData, $isRegisteredUser, $_showAllSegments = false)
     {

--- a/plugins/ArchivingMetrics/Timer.php
+++ b/plugins/ArchivingMetrics/Timer.php
@@ -20,20 +20,11 @@ use Piwik\Plugins\ArchivingMetrics\Writer\WriterInterface;
 
 final class Timer
 {
-    /**
-     * @var bool
-     */
-    private $isArchivePhpTriggered;
+    private bool $isArchivePhpTriggered;
 
-    /**
-     * @var ClockInterface
-     */
-    private $clock;
+    private ClockInterface $clock;
 
-    /**
-     * @var WriterInterface
-     */
-    private $writer;
+    private WriterInterface $writer;
 
     /**
      * @var array<string, array<string, mixed>>

--- a/plugins/BotTracking/Tracker/BotRequestProcessor.php
+++ b/plugins/BotTracking/Tracker/BotRequestProcessor.php
@@ -25,15 +25,9 @@ use Piwik\Tracker\TableLogAction;
  */
 class BotRequestProcessor extends \Piwik\Tracker\BotRequestProcessor
 {
-    /**
-     * @var BotRequestsDao
-     */
-    private $dao;
+    private BotRequestsDao $dao;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(BotRequestsDao $dao, LoggerInterface $logger)
     {

--- a/plugins/BulkTracking/Tracker/Response.php
+++ b/plugins/BulkTracking/Tracker/Response.php
@@ -25,10 +25,7 @@ class Response extends Tracker\Response
      */
     private $isAuthenticated = false;
 
-    /**
-     * @var bool
-     */
-    private $shouldSendResponse = true;
+    private bool $shouldSendResponse = true;
 
     /**
      * Echos an error message & other information, then exits.

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -43,25 +43,13 @@ use Piwik\Plugins\UsersManager\Model as UsersModel;
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var Scheduler
-     */
-    private $scheduler;
+    private Scheduler $scheduler;
 
-    /**
-     * @var ArchiveInvalidator
-     */
-    private $invalidator;
+    private ArchiveInvalidator $invalidator;
 
-    /**
-     * @var Failures
-     */
-    private $trackingFailures;
+    private Failures $trackingFailures;
 
-    /**
-     * @var OptOutManager
-     */
-    private $optOutManager;
+    private OptOutManager $optOutManager;
 
     public function __construct(
         Scheduler $scheduler,

--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -41,16 +41,11 @@ use Piwik\Plugins\UsersManager\UserPreferences;
 
 class Controller extends ControllerAdmin
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
-    /** @var OptOutManager */
-    private $optOutManager;
+    private OptOutManager $optOutManager;
 
-    /** @var PasswordVerifier */
-    private $passwordVerify;
+    private PasswordVerifier $passwordVerify;
 
     public function __construct(Translator $translator, OptOutManager $optOutManager, PasswordVerifier $passwordVerify)
     {

--- a/plugins/CoreAdminHome/Model/DuplicateActionRemover.php
+++ b/plugins/CoreAdminHome/Model/DuplicateActionRemover.php
@@ -50,7 +50,7 @@ class DuplicateActionRemover
      *
      * @var string[]
      */
-    private $idactionColumns = null;
+    private ?array $idactionColumns = null;
 
     public function __construct(?TableMetadata $tableMetadataAccess = null, ?LoggerInterface $logger = null)
     {

--- a/plugins/CoreAdminHome/Model/DuplicateActionRemover.php
+++ b/plugins/CoreAdminHome/Model/DuplicateActionRemover.php
@@ -48,7 +48,7 @@ class DuplicateActionRemover
      * List of idaction columns in each table in $tablesWithIdActionColumns. idaction
      * columns are table columns with the string `"idaction"` in them.
      *
-     * @var string[]
+     * @var string[]|null
      */
     private ?array $idactionColumns = null;
 

--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -47,20 +47,16 @@ class OptOutManager
     /** @var DoNotTrackHeaderChecker */
     private $doNotTrackHeaderChecker;
 
-    /** @var array */
-    private $javascripts;
+    private array $javascripts;
 
-    /** @var array */
-    private $stylesheets;
+    private array $stylesheets;
 
     /** @var string */
     private $title;
 
-    /** @var View|null */
-    private $view;
+    private ?View $view = null;
 
-    /** @var array */
-    private $queryParameters = array();
+    private array $queryParameters = array();
 
     public function __construct(?DoNotTrackHeaderChecker $doNotTrackHeaderChecker = null)
     {

--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -40,20 +40,11 @@ use Piwik\SettingsPiwik;
 class Tasks extends \Piwik\Plugin\Tasks
 {
     public const TRACKING_CODE_CHECK_FLAG = 'trackingCodeExistsCheck';
-    /**
-     * @var ArchivePurger
-     */
-    private $archivePurger;
+    private ArchivePurger $archivePurger;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
-    /**
-     * @var Failures
-     */
-    private $trackingFailures;
+    private Failures $trackingFailures;
 
     public function __construct(ArchivePurger $archivePurger, LoggerInterface $logger, Failures $failures)
     {

--- a/plugins/CoreHome/Columns/Metrics/EvolutionMetric.php
+++ b/plugins/CoreHome/Columns/Metrics/EvolutionMetric.php
@@ -70,7 +70,7 @@ class EvolutionMetric extends ProcessedMetric
      *
      * @var string[]
      */
-    private $labelPath = [];
+    private array $labelPath = [];
 
     /**
      * @param string|Metric $wrapped The metric used to calculate the evolution.

--- a/plugins/CoreHome/Controller.php
+++ b/plugins/CoreHome/Controller.php
@@ -40,15 +40,9 @@ use Piwik\Widget\WidgetConfig;
 
 class Controller extends \Piwik\Plugin\Controller
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
-    /**
-     * @var FeatureFlagManager
-     */
-    private $featureFlagManager;
+    private FeatureFlagManager $featureFlagManager;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -54,20 +54,11 @@ class VisitRequestProcessor extends RequestProcessor
 {
     // TODO: much of the logic in this class should be moved to new service class
 
-    /**
-     * @var EventDispatcher
-     */
-    private $eventDispatcher;
+    private EventDispatcher $eventDispatcher;
 
-    /**
-     * @var VisitorRecognizer
-     */
-    private $visitorRecognizer;
+    private VisitorRecognizer $visitorRecognizer;
 
-    /**
-     * @var Settings
-     */
-    private $userSettings;
+    private Settings $userSettings;
 
     /**
      * @var int

--- a/plugins/CoreHome/Widgets/GetDonateForm.php
+++ b/plugins/CoreHome/Widgets/GetDonateForm.php
@@ -17,10 +17,7 @@ use Piwik\Translation\Translator;
 
 class GetDonateForm extends Widget
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/CoreHome/Widgets/GetPromoVideo.php
+++ b/plugins/CoreHome/Widgets/GetPromoVideo.php
@@ -17,10 +17,7 @@ use Piwik\View;
 
 class GetPromoVideo extends Widget
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/CoreHome/Widgets/GetSystemSummary.php
+++ b/plugins/CoreHome/Widgets/GetSystemSummary.php
@@ -22,15 +22,9 @@ class GetSystemSummary extends Widget
 {
     public const TEST_MYSQL_VERSION = 'mysql-version-redacted';
     public const TEST_PHP_VERSION = 'php-version-redacted';
-    /**
-     * @var StoredSegmentService
-     */
-    private $storedSegmentService;
+    private StoredSegmentService $storedSegmentService;
 
-    /**
-     * @var Plugin\Manager
-     */
-    private $pluginManager;
+    private Plugin\Manager $pluginManager;
 
     public function __construct(StoredSegmentService $storedSegmentService, Plugin\Manager $pluginManager)
     {

--- a/plugins/CorePluginsAdmin/API.php
+++ b/plugins/CorePluginsAdmin/API.php
@@ -25,15 +25,9 @@ use Piwik\Plugins\Marketplace\Marketplace;
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var SettingsMetadata
-     */
-    private $settingsMetadata;
+    private SettingsMetadata $settingsMetadata;
 
-    /**
-     * @var SettingsProvider
-     */
-    private $settingsProvider;
+    private SettingsProvider $settingsProvider;
 
     public function __construct(SettingsProvider $settingsProvider, SettingsMetadata $settingsMetadata)
     {

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -40,20 +40,11 @@ class Controller extends Plugin\ControllerAdmin
     public const DEACTIVATE_NONCE = 'CorePluginsAdmin.deactivatePlugin';
     public const UNINSTALL_NONCE = 'CorePluginsAdmin.uninstallPlugin';
 
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
-    /**
-     * @var Plugin\SettingsProvider
-     */
-    private $settingsProvider;
+    private Plugin\SettingsProvider $settingsProvider;
 
-    /**
-     * @var PluginInstaller
-     */
-    private $pluginInstaller;
+    private PluginInstaller $pluginInstaller;
     /**
      * @var Plugin\Manager
      */
@@ -64,10 +55,7 @@ class Controller extends Plugin\ControllerAdmin
      */
     private $marketplacePlugins;
 
-    /**
-     * @var PasswordVerifier
-     */
-    private $passwordVerify;
+    private PasswordVerifier $passwordVerify;
 
     /**
      * Controller constructor.

--- a/plugins/CoreUpdater/Commands/Update/CliUpdateObserver.php
+++ b/plugins/CoreUpdater/Commands/Update/CliUpdateObserver.php
@@ -21,20 +21,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class CliUpdateObserver extends UpdateObserver
 {
-    /**
-     * @var OutputInterface
-     */
-    private $output;
+    private OutputInterface $output;
 
     /**
      * @var int
      */
     private $totalMigrationQueryCount;
 
-    /**
-     * @var int
-     */
-    private $currentMigrationQueryExecutionCount = 0;
+    private int $currentMigrationQueryExecutionCount = 0;
 
     public function __construct(OutputInterface $output, $totalMigrationQueryCount)
     {

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -42,10 +42,7 @@ class Controller extends \Piwik\Plugin\Controller
     private $errorMessages = array();
     private $deactivatedPlugins = array();
 
-    /**
-     * @var Updater
-     */
-    private $updater;
+    private Updater $updater;
 
     /**
      * @var Plugins

--- a/plugins/CoreUpdater/Diagnostic/HttpsUpdateCheck.php
+++ b/plugins/CoreUpdater/Diagnostic/HttpsUpdateCheck.php
@@ -21,10 +21,7 @@ use Piwik\Url;
  */
 class HttpsUpdateCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/CoreUpdater/SystemSettings.php
+++ b/plugins/CoreUpdater/SystemSettings.php
@@ -39,10 +39,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     /** @var Setting|null */
     public $updateToUtf8mb4 = null;
 
-    /**
-     * @var ReleaseChannels
-     */
-    private $releaseChannels;
+    private ReleaseChannels $releaseChannels;
 
     public function __construct(ReleaseChannels $releaseChannels)
     {

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -34,15 +34,9 @@ class Updater
     public const PATH_TO_EXTRACT_LATEST_VERSION = '/latest/';
     public const DOWNLOAD_TIMEOUT = 720;
 
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
-    /**
-     * @var ReleaseChannels
-     */
-    private $releaseChannels;
+    private ReleaseChannels $releaseChannels;
 
     /**
      * @var string

--- a/plugins/CoreUpdater/UpdaterException.php
+++ b/plugins/CoreUpdater/UpdaterException.php
@@ -19,7 +19,7 @@ class UpdaterException extends Exception
     /**
      * @var string[]
      */
-    private $updateLogMessages;
+    private array $updateLogMessages;
 
     public function __construct(Exception $exception, array $updateLogMessages)
     {

--- a/plugins/CoreVisualizations/Visualizations/EvolutionPeriodSelector.php
+++ b/plugins/CoreVisualizations/Visualizations/EvolutionPeriodSelector.php
@@ -16,10 +16,7 @@ use Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines\Config;
 
 class EvolutionPeriodSelector
 {
-    /**
-     * @var Config
-     */
-    private $config;
+    private Config $config;
 
     public function __construct(Config $config)
     {

--- a/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
@@ -32,15 +32,13 @@ class Config extends \Piwik\ViewDataTable\Config
 
     /**
      * Holds the actual sparkline entries based on fetched data that will be used in the template.
-     * @var array
      */
-    private $sparklines = array();
+    private array $sparklines = array();
 
     /**
      * If false, will not link them with any evolution graph
-     * @var bool
      */
-    private $evolutionGraphLinkable = true;
+    private bool $evolutionGraphLinkable = true;
 
     /**
      * Adds possibility to set html attributes on the sparklines title / headline.

--- a/plugins/CustomDimensions/CustomDimensions.php
+++ b/plugins/CustomDimensions/CustomDimensions.php
@@ -25,10 +25,7 @@ class CustomDimensions extends Plugin
     public const SCOPE_VISIT = 'visit';
     public const SCOPE_CONVERSION = 'conversion';
 
-    /**
-     * @var Configuration
-     */
-    private $configuration;
+    private Configuration $configuration;
 
     public function __construct()
     {

--- a/plugins/CustomDimensions/RecordBuilders/CustomDimension.php
+++ b/plugins/CustomDimensions/RecordBuilders/CustomDimension.php
@@ -28,10 +28,7 @@ use Piwik\Tracker;
 
 class CustomDimension extends RecordBuilder
 {
-    /**
-     * @var array
-     */
-    private $dimensionInfo;
+    private array $dimensionInfo;
 
     /**
      * @var int

--- a/plugins/CustomDimensions/Updates/0.1.2.php
+++ b/plugins/CustomDimensions/Updates/0.1.2.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_0_1_2 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/plugins/CustomDimensions/Updates/3.1.7.php
+++ b/plugins/CustomDimensions/Updates/3.1.7.php
@@ -18,10 +18,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_3_1_7 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/plugins/CustomJsTracker/Diagnostic/TrackerJsCheck.php
+++ b/plugins/CustomJsTracker/Diagnostic/TrackerJsCheck.php
@@ -24,10 +24,7 @@ use Piwik\Translation\Translator;
  */
 class TrackerJsCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/CustomJsTracker/TrackingCode/PiwikJsManipulator.php
+++ b/plugins/CustomJsTracker/TrackingCode/PiwikJsManipulator.php
@@ -19,8 +19,7 @@ class PiwikJsManipulator
      */
     private $content;
 
-    /** @var PluginTrackerFiles */
-    private $pluginTrackerFiles;
+    private PluginTrackerFiles $pluginTrackerFiles;
 
     public function __construct($content, PluginTrackerFiles $pluginTrackerFiles)
     {

--- a/plugins/DBStats/API.php
+++ b/plugins/DBStats/API.php
@@ -20,10 +20,7 @@ use Piwik\Piwik;
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var MySQLMetadataProvider
-     */
-    private $metadataProvider;
+    private MySQLMetadataProvider $metadataProvider;
 
     public function __construct(MySQLMetadataProvider $metadataProvider)
     {

--- a/plugins/Dashboard/API.php
+++ b/plugins/Dashboard/API.php
@@ -23,15 +23,9 @@ use Piwik\Piwik;
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var Dashboard
-     */
-    private $dashboard;
+    private Dashboard $dashboard;
 
-    /**
-     * @var Model
-     */
-    private $model;
+    private Model $model;
 
     public function __construct(Dashboard $dashboard, Model $model)
     {

--- a/plugins/DevicesDetection/RecordBuilders/Base.php
+++ b/plugins/DevicesDetection/RecordBuilders/Base.php
@@ -18,20 +18,11 @@ use Piwik\Metrics;
 
 abstract class Base extends RecordBuilder
 {
-    /**
-     * @var string
-     */
-    private $recordName;
+    private string $recordName;
 
-    /**
-     * @var string
-     */
-    private $labelSql;
+    private string $labelSql;
 
-    /**
-     * @var bool
-     */
-    private $enrichWithConversionMetrics;
+    private bool $enrichWithConversionMetrics;
 
     public function __construct(string $recordName, string $labelSql, bool $enrichWithConversionMetrics = false)
     {

--- a/plugins/DevicesDetection/Settings/OnlyMajorVersions.php
+++ b/plugins/DevicesDetection/Settings/OnlyMajorVersions.php
@@ -19,8 +19,7 @@ class OnlyMajorVersions implements
     /** @use PolicyComparisonTrait<bool> */
     use PolicyComparisonTrait;
 
-    /** @var bool */
-    private $value;
+    private bool $value;
 
     protected function __construct(bool $value)
     {

--- a/plugins/DevicesDetection/Updates/1.14.php
+++ b/plugins/DevicesDetection/Updates/1.14.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_14 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/plugins/Diagnostics/ConfigReader.php
+++ b/plugins/Diagnostics/ConfigReader.php
@@ -19,15 +19,9 @@ use Piwik\Settings as PiwikSettings;
  */
 class ConfigReader
 {
-    /**
-     * @var GlobalSettingsProvider
-     */
-    private $settings;
+    private GlobalSettingsProvider $settings;
 
-    /**
-     * @var IniReader
-     */
-    private $iniReader;
+    private IniReader $iniReader;
 
     public function __construct(GlobalSettingsProvider $settings, IniReader $iniReader)
     {

--- a/plugins/Diagnostics/Controller.php
+++ b/plugins/Diagnostics/Controller.php
@@ -15,10 +15,7 @@ use Piwik\Plugin\SettingsProvider;
 
 class Controller extends \Piwik\Plugin\ControllerAdmin
 {
-    /**
-     * @var ConfigReader
-     */
-    private $configReader;
+    private ConfigReader $configReader;
 
     public function __construct(ConfigReader $configReader)
     {

--- a/plugins/Diagnostics/Diagnostic/ArchiveInvalidationsInformational.php
+++ b/plugins/Diagnostics/Diagnostic/ArchiveInvalidationsInformational.php
@@ -20,10 +20,7 @@ use Piwik\Translation\Translator;
  */
 class ArchiveInvalidationsInformational implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/ConfigInformational.php
+++ b/plugins/Diagnostics/Diagnostic/ConfigInformational.php
@@ -21,10 +21,7 @@ use Piwik\Translation\Translator;
  */
 class ConfigInformational implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/CronArchivingCheck.php
+++ b/plugins/Diagnostics/Diagnostic/CronArchivingCheck.php
@@ -23,10 +23,7 @@ use Piwik\Url;
  */
 class CronArchivingCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/CronArchivingLastRunCheck.php
+++ b/plugins/Diagnostics/Diagnostic/CronArchivingLastRunCheck.php
@@ -27,10 +27,7 @@ class CronArchivingLastRunCheck implements Diagnostic
 {
     public const SECONDS_IN_DAY = 86400;
 
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
@@ -22,10 +22,7 @@ use Piwik\Url;
  */
 class DatabaseAbilitiesCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/DatabaseInformational.php
+++ b/plugins/Diagnostics/Diagnostic/DatabaseInformational.php
@@ -21,10 +21,7 @@ use Piwik\Translation\Translator;
  */
 class DatabaseInformational implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/DbAdapterCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DbAdapterCheck.php
@@ -18,10 +18,7 @@ use Piwik\Translation\Translator;
  */
 class DbAdapterCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/DbMaxPacket.php
+++ b/plugins/Diagnostics/Diagnostic/DbMaxPacket.php
@@ -14,10 +14,7 @@ use Piwik\Url;
  */
 class DbMaxPacket implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public const MIN_VALUE_MAX_PACKET_MB = 64;
 

--- a/plugins/Diagnostics/Diagnostic/DbOverSSLCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DbOverSSLCheck.php
@@ -12,10 +12,7 @@ use Piwik\Url;
  */
 class DbOverSSLCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/DbReaderCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DbReaderCheck.php
@@ -19,10 +19,7 @@ use Piwik\Translation\Translator;
  */
 class DbReaderCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/DiagnosticResult.php
+++ b/plugins/Diagnostics/Diagnostic/DiagnosticResult.php
@@ -36,7 +36,7 @@ class DiagnosticResult implements \JsonSerializable
     /**
      * @var DiagnosticResultItem[]
      */
-    private $items = array();
+    private array $items = array();
 
     public function __construct($label)
     {

--- a/plugins/Diagnostics/Diagnostic/FileIntegrityCheck.php
+++ b/plugins/Diagnostics/Diagnostic/FileIntegrityCheck.php
@@ -18,10 +18,7 @@ use Piwik\Translation\Translator;
  */
 class FileIntegrityCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/ForceSSLCheck.php
+++ b/plugins/Diagnostics/Diagnostic/ForceSSLCheck.php
@@ -21,10 +21,7 @@ use Piwik\View;
  */
 class ForceSSLCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/GdExtensionCheck.php
+++ b/plugins/Diagnostics/Diagnostic/GdExtensionCheck.php
@@ -17,10 +17,7 @@ use Piwik\Translation\Translator;
  */
 class GdExtensionCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/HttpClientCheck.php
+++ b/plugins/Diagnostics/Diagnostic/HttpClientCheck.php
@@ -18,10 +18,7 @@ use Piwik\Translation\Translator;
  */
 class HttpClientCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/MatomoInformational.php
+++ b/plugins/Diagnostics/Diagnostic/MatomoInformational.php
@@ -21,10 +21,7 @@ use Piwik\Version;
  */
 class MatomoInformational implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/MemoryLimitCheck.php
+++ b/plugins/Diagnostics/Diagnostic/MemoryLimitCheck.php
@@ -17,10 +17,7 @@ use Piwik\Translation\Translator;
  */
 class MemoryLimitCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     /**
      * @var int

--- a/plugins/Diagnostics/Diagnostic/NfsDiskCheck.php
+++ b/plugins/Diagnostics/Diagnostic/NfsDiskCheck.php
@@ -21,10 +21,7 @@ use Piwik\Translation\Translator;
  */
 class NfsDiskCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/PHPBinaryCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PHPBinaryCheck.php
@@ -16,10 +16,7 @@ use Piwik\Translation\Translator;
  */
 class PHPBinaryCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/PageSpeedCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PageSpeedCheck.php
@@ -20,15 +20,9 @@ use Piwik\Log\LoggerInterface;
  */
 class PageSpeedCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(Translator $translator, LoggerInterface $logger)
     {

--- a/plugins/Diagnostics/Diagnostic/PhpExtensionsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpExtensionsCheck.php
@@ -16,10 +16,7 @@ use Piwik\Translation\Translator;
  */
 class PhpExtensionsCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/PhpFunctionsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpFunctionsCheck.php
@@ -16,10 +16,7 @@ use Piwik\Translation\Translator;
  */
 class PhpFunctionsCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/PhpInformational.php
+++ b/plugins/Diagnostics/Diagnostic/PhpInformational.php
@@ -20,10 +20,7 @@ use Piwik\Translation\Translator;
  */
 class PhpInformational implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/PhpSettingsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpSettingsCheck.php
@@ -16,10 +16,7 @@ use Piwik\Translation\Translator;
  */
 class PhpSettingsCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/PhpVersionCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpVersionCheck.php
@@ -16,10 +16,7 @@ use Piwik\Translation\Translator;
  */
 class PhpVersionCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/RecommendedExtensionsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/RecommendedExtensionsCheck.php
@@ -16,10 +16,7 @@ use Piwik\Translation\Translator;
  */
 class RecommendedExtensionsCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/RecommendedFunctionsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/RecommendedFunctionsCheck.php
@@ -17,10 +17,7 @@ use Piwik\Url;
  */
 class RecommendedFunctionsCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/ReportInformational.php
+++ b/plugins/Diagnostics/Diagnostic/ReportInformational.php
@@ -24,10 +24,7 @@ use Piwik\Translation\Translator;
  */
 class ReportInformational implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     private $idSiteCache;
 

--- a/plugins/Diagnostics/Diagnostic/ServerInformational.php
+++ b/plugins/Diagnostics/Diagnostic/ServerInformational.php
@@ -18,10 +18,7 @@ use Piwik\SettingsPiwik;
  */
 class ServerInformational implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/TimezoneCheck.php
+++ b/plugins/Diagnostics/Diagnostic/TimezoneCheck.php
@@ -18,10 +18,7 @@ use Piwik\Url;
  */
 class TimezoneCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/TrackerCheck.php
+++ b/plugins/Diagnostics/Diagnostic/TrackerCheck.php
@@ -17,10 +17,7 @@ use Piwik\Translation\Translator;
  */
 class TrackerCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/UserInformational.php
+++ b/plugins/Diagnostics/Diagnostic/UserInformational.php
@@ -17,10 +17,7 @@ use Piwik\Translation\Translator;
  */
 class UserInformational implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Diagnostics/Diagnostic/WriteAccessCheck.php
+++ b/plugins/Diagnostics/Diagnostic/WriteAccessCheck.php
@@ -19,10 +19,7 @@ use Piwik\Translation\Translator;
  */
 class WriteAccessCheck implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     /**
      * Path to the temp directory.

--- a/plugins/Diagnostics/DiagnosticReport.php
+++ b/plugins/Diagnostics/DiagnosticReport.php
@@ -19,27 +19,21 @@ class DiagnosticReport
     /**
      * @var DiagnosticResult[]
      */
-    private $mandatoryDiagnosticResults;
+    private array $mandatoryDiagnosticResults;
 
     /**
      * @var DiagnosticResult[]
      */
-    private $optionalDiagnosticResults;
+    private array $optionalDiagnosticResults;
 
     /**
      * @var DiagnosticResult[]
      */
-    private $informationalResults;
+    private array $informationalResults;
 
-    /**
-     * @var int
-     */
-    private $errorCount = 0;
+    private int $errorCount = 0;
 
-    /**
-     * @var int
-     */
-    private $warningCount = 0;
+    private int $warningCount = 0;
 
     /**
      * @param DiagnosticResult[] $mandatoryDiagnosticResults

--- a/plugins/Ecommerce/Settings/OrderIdAnonymization.php
+++ b/plugins/Ecommerce/Settings/OrderIdAnonymization.php
@@ -27,8 +27,7 @@ class OrderIdAnonymization implements
     /** @use CustomGetterTrait<bool> */
     use CustomGetterTrait;
 
-    /** @var bool */
-    private $value;
+    private bool $value;
 
     private function __construct(bool $value)
     {

--- a/plugins/ExamplePlugin/Updates/0.0.2.php
+++ b/plugins/ExamplePlugin/Updates/0.0.2.php
@@ -19,10 +19,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_0_0_2 extends PiwikUpdates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/plugins/FeatureFlags/FeatureFlagManager.php
+++ b/plugins/FeatureFlags/FeatureFlagManager.php
@@ -17,12 +17,9 @@ class FeatureFlagManager
     /**
      * @var FeatureFlagStorageInterface[]
      */
-    private $storages;
+    private array $storages;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(array $storages, LoggerInterface $logger)
     {

--- a/plugins/FeatureFlags/Storage/ConfigFeatureFlagStorage.php
+++ b/plugins/FeatureFlags/Storage/ConfigFeatureFlagStorage.php
@@ -20,10 +20,7 @@ class ConfigFeatureFlagStorage implements FeatureFlagStorageInterface
     private const CONFIG_FEATURE_ENABLED_VALUE = 'enabled';
     private const CONFIG_FEATURE_DISABLED_VALUE = 'disabled';
 
-    /**
-     * @var Config
-     */
-    private $config;
+    private Config $config;
 
     /**
      * @internal

--- a/plugins/Goals/Controller.php
+++ b/plugins/Goals/Controller.php
@@ -44,10 +44,7 @@ class Controller extends \Piwik\Plugin\Controller
         'items'             => 'General_PurchasedProducts',
     );
 
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
     private $goals;
 
     private function formatConversionRate($conversionRate, $columnName = 'conversion_rate')

--- a/plugins/Goals/Updates/3.0.0-b1.php
+++ b/plugins/Goals/Updates/3.0.0-b1.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_3_0_0_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/plugins/ImageGraph/API.php
+++ b/plugins/ImageGraph/API.php
@@ -84,7 +84,7 @@ class API extends \Piwik\Plugin\API
     /**
      * @var array[]
      */
-    private static $DEFAULT_GRAPH_TYPE_OVERRIDE = array(
+    private static array $DEFAULT_GRAPH_TYPE_OVERRIDE = array(
         'Referrers_getReferrerType' => array(
             false // override if !$isMultiplePeriod
             => StaticGraph::GRAPH_TYPE_HORIZONTAL_BAR,

--- a/plugins/Insights/API.php
+++ b/plugins/Insights/API.php
@@ -35,10 +35,7 @@ class API extends \Piwik\Plugin\API
      */
     public const FILTER_BY_DISAPPEARED = 'disappeared';
 
-    /**
-     * @var Model
-     */
-    private $model;
+    private Model $model;
 
     public function __construct(Model $model)
     {

--- a/plugins/Insights/Model.php
+++ b/plugins/Insights/Model.php
@@ -20,10 +20,7 @@ use Piwik\Plugins\VisitsSummary\API as VisitsSummaryAPI;
  */
 class Model
 {
-    /**
-     * @var ProcessedReport
-     */
-    private $processedReport;
+    private ProcessedReport $processedReport;
 
     public function __construct(ProcessedReport $processedReport)
     {

--- a/plugins/Installation/Widgets/GetSystemCheck.php
+++ b/plugins/Installation/Widgets/GetSystemCheck.php
@@ -19,10 +19,7 @@ use Piwik\Widget\WidgetConfig;
 
 class GetSystemCheck extends Widget
 {
-    /**
-     * @var DiagnosticService
-     */
-    private $diagnosticService;
+    private DiagnosticService $diagnosticService;
 
     public function __construct(DiagnosticService $diagnosticService)
     {

--- a/plugins/LanguagesManager/Updates/2.15.1-b1.php
+++ b/plugins/LanguagesManager/Updates/2.15.1-b1.php
@@ -15,10 +15,7 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_15_1_b1 extends Updates
 {
-    /**
-     * @var MigrationFactory
-     */
-    private $migration;
+    private MigrationFactory $migration;
 
     public function __construct(MigrationFactory $factory)
     {

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -48,10 +48,7 @@ require_once PIWIK_INCLUDE_PATH . '/plugins/UserCountry/functions.php';
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(LoggerInterface $logger)
     {

--- a/plugins/Live/ProfileSummaryProvider.php
+++ b/plugins/Live/ProfileSummaryProvider.php
@@ -17,10 +17,7 @@ use Piwik\Plugins\Live\ProfileSummary\ProfileSummaryAbstract;
 
 class ProfileSummaryProvider
 {
-    /**
-     * @var Plugin\Manager
-     */
-    private $pluginManager;
+    private Plugin\Manager $pluginManager;
 
     public function __construct(Plugin\Manager $pluginManager)
     {

--- a/plugins/Live/Settings/VisitorLogDisabled.php
+++ b/plugins/Live/Settings/VisitorLogDisabled.php
@@ -36,10 +36,7 @@ class VisitorLogDisabled implements MeasurableSettingInterface, PolicyComparison
      */
     use SystemGetterTrait;
 
-    /**
-     * @var bool
-     */
-    private $value;
+    private bool $value;
 
     private function __construct(bool $value)
     {

--- a/plugins/Login/API.php
+++ b/plugins/Login/API.php
@@ -19,10 +19,7 @@ use Piwik\Plugins\Login\Security\BruteForceDetection;
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var BruteForceDetection
-     */
-    private $bruteForceDetection;
+    private BruteForceDetection $bruteForceDetection;
 
     public function __construct(BruteForceDetection $bruteForceDetection)
     {

--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -24,15 +24,9 @@ class Auth implements \Piwik\Auth
     protected $token_auth;
     protected $hashedPassword;
 
-    /**
-     * @var Model
-     */
-    private $userModel;
+    private Model $userModel;
 
-    /**
-     * @var Password
-     */
-    private $passwordHelper;
+    private Password $passwordHelper;
 
     public function __construct()
     {

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -27,20 +27,11 @@ use Piwik\SettingsServer;
 
 class Login extends \Piwik\Plugin
 {
-    /**
-     * @var bool
-     */
-    private $hasAddedFailedAttempt = false;
+    private bool $hasAddedFailedAttempt = false;
 
-    /**
-     * @var bool
-     */
-    private $hasPerformedBruteForceCheck = false;
+    private bool $hasPerformedBruteForceCheck = false;
 
-    /**
-     * @var bool
-     */
-    private $hasPerformedBruteForceCheckForUserPwdLogin = false;
+    private bool $hasPerformedBruteForceCheckForUserPwdLogin = false;
 
     /**
      * @see \Piwik\Plugin::registerEvents

--- a/plugins/Login/PasswordVerifier.php
+++ b/plugins/Login/PasswordVerifier.php
@@ -20,15 +20,9 @@ class PasswordVerifier
     public const VERIFY_VALID_FOR_MINUTES = 30;
     public const VERIFY_REVALIDATE_X_MINUTES_LEFT = 15;
 
-    /**
-     * @var Date|null
-     */
-    private $now;
+    private ?Date $now = null;
 
-    /**
-     * @var bool
-     */
-    private $enableRedirect = true;
+    private bool $enableRedirect = true;
 
     /**
      * @return void

--- a/plugins/Login/Security/BruteForceDetection.php
+++ b/plugins/Login/Security/BruteForceDetection.php
@@ -30,20 +30,11 @@ class BruteForceDetection
     private $table = self::TABLE_NAME;
     private $tablePrefixed = '';
 
-    /**
-     * @var SystemSettings
-     */
-    private $settings;
+    private SystemSettings $settings;
 
-    /**
-     * @var Updater
-     */
-    private $updater;
+    private Updater $updater;
 
-    /**
-     * @var Model
-     */
-    private $model;
+    private Model $model;
 
     public function __construct(SystemSettings $systemSettings, Model $model)
     {

--- a/plugins/Login/Security/LoginFromDifferentCountryDetection.php
+++ b/plugins/Login/Security/LoginFromDifferentCountryDetection.php
@@ -19,15 +19,9 @@ use Piwik\Plugins\UsersManager\Model as UsersModel;
 
 class LoginFromDifferentCountryDetection
 {
-    /**
-     * @var Model
-     */
-    private $model;
+    private Model $model;
 
-    /**
-     * @var UsersModel
-     */
-    private $usersModel;
+    private UsersModel $usersModel;
 
     public function __construct(Model $model, UsersModel $usersModel)
     {

--- a/plugins/Login/Tasks.php
+++ b/plugins/Login/Tasks.php
@@ -13,10 +13,7 @@ use Piwik\Plugins\Login\Security\BruteForceDetection;
 
 class Tasks extends \Piwik\Plugin\Tasks
 {
-    /**
-     * @var BruteForceDetection
-     */
-    private $bruteForceDetection;
+    private BruteForceDetection $bruteForceDetection;
 
     public function __construct(BruteForceDetection $bruteForceDetection)
     {

--- a/plugins/Marketplace/API.php
+++ b/plugins/Marketplace/API.php
@@ -29,35 +29,17 @@ use Piwik\Validators\NotEmpty;
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var Client
-     */
-    private $marketplaceClient;
+    private Client $marketplaceClient;
 
-    /**
-     * @var Service
-     */
-    private $marketplaceService;
+    private Service $marketplaceService;
 
-    /**
-     * @var InvalidLicenses
-     */
-    private $expired;
+    private InvalidLicenses $expired;
 
-    /**
-     * @var PluginManager
-     */
-    private $pluginManager;
+    private PluginManager $pluginManager;
 
-    /**
-     * @var Environment
-     */
-    private $environment;
+    private Environment $environment;
 
-    /**
-     * @var PluginTrialService
-     */
-    private $pluginTrialService;
+    private PluginTrialService $pluginTrialService;
 
     public function __construct(
         Service $service,

--- a/plugins/Marketplace/Api/Client.php
+++ b/plugins/Marketplace/Api/Client.php
@@ -26,25 +26,16 @@ class Client
     public const CACHE_TIMEOUT_IN_SECONDS = 3600;
     public const HTTP_REQUEST_TIMEOUT = 60;
 
-    /**
-     * @var Service
-     */
-    private $service;
+    private Service $service;
 
-    /**
-     * @var Lazy
-     */
-    private $cache;
+    private Lazy $cache;
 
     /**
      * @var Plugin\Manager
      */
     private $pluginManager;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     /**
      * @var Environment

--- a/plugins/Marketplace/Api/Service.php
+++ b/plugins/Marketplace/Api/Service.php
@@ -28,9 +28,8 @@ class Service
 
     /**
      * API version to use on the Marketplace
-     * @var string
      */
-    private $version = '2.0';
+    private string $version = '2.0';
 
     public function __construct($domain)
     {

--- a/plugins/Marketplace/Consumer.php
+++ b/plugins/Marketplace/Consumer.php
@@ -14,10 +14,7 @@ namespace Piwik\Plugins\Marketplace;
  */
 class Consumer
 {
-    /**
-     * @var Api\Client
-     */
-    private $marketplaceClient;
+    private Api\Client $marketplaceClient;
 
     private $consumer = false;
     private $isValid = null;
@@ -25,7 +22,7 @@ class Consumer
     /**
      * @var array
      */
-    private $pluginLicenseStatus = null;
+    private ?array $pluginLicenseStatus = null;
 
     public function __construct(Api\Client $marketplaceClient)
     {

--- a/plugins/Marketplace/Consumer.php
+++ b/plugins/Marketplace/Consumer.php
@@ -19,9 +19,6 @@ class Consumer
     private $consumer = false;
     private $isValid = null;
 
-    /**
-     * @var array
-     */
     private ?array $pluginLicenseStatus = null;
 
     public function __construct(Api\Client $marketplaceClient)

--- a/plugins/Marketplace/Controller.php
+++ b/plugins/Marketplace/Controller.php
@@ -42,44 +42,23 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
     public const INSTALL_NONCE = 'Marketplace.installPlugin';
     public const DOWNLOAD_NONCE_PREFIX = 'Marketplace.downloadPlugin.';
 
-    /**
-     * @var LicenseKey
-     */
-    private $licenseKey;
-    /**
-     * @var Plugins
-     */
-    private $plugins;
+    private LicenseKey $licenseKey;
+    private Plugins $plugins;
 
-    /**
-     * @var Api\Client
-     */
-    private $marketplaceApi;
+    private Api\Client $marketplaceApi;
 
-    /**
-     * @var Consumer
-     */
-    private $consumer;
+    private Consumer $consumer;
 
-    /**
-     * @var PluginInstaller
-     */
-    private $pluginInstaller;
+    private PluginInstaller $pluginInstaller;
 
     /**
      * @var Plugin\Manager
      */
     private $pluginManager;
 
-    /**
-     * @var Environment
-     */
-    private $environment;
+    private Environment $environment;
 
-    /**
-     * @var PasswordVerifier
-     */
-    private $passwordVerify;
+    private PasswordVerifier $passwordVerify;
 
     /**
      * @var array<int, array<string, mixed>>|null

--- a/plugins/Marketplace/Emails/RequestTrialNotificationEmail.php
+++ b/plugins/Marketplace/Emails/RequestTrialNotificationEmail.php
@@ -18,24 +18,12 @@ use Piwik\View;
 
 class RequestTrialNotificationEmail extends Mail
 {
-    /**
-     * @var string
-     */
-    private $emailAddress;
+    private string $emailAddress;
 
-    /**
-     * @var string
-     */
-    private $login;
+    private string $login;
 
-    /**
-     * @var string
-     */
-    private $pluginName;
-    /**
-     * @var string
-     */
-    private $pluginDisplayName;
+    private string $pluginName;
+    private string $pluginDisplayName;
 
     public function __construct(string $login, string $emailAddress, string $pluginName, string $pluginDisplayName)
     {

--- a/plugins/Marketplace/PluginTrial/Notification.php
+++ b/plugins/Marketplace/PluginTrial/Notification.php
@@ -17,15 +17,9 @@ use Piwik\Url;
 
 class Notification
 {
-    /**
-     * @var string
-     */
-    private $pluginName;
+    private string $pluginName;
 
-    /**
-     * @var Storage
-     */
-    private $storage;
+    private Storage $storage;
 
     public function __construct(string $pluginName, Storage $storage)
     {

--- a/plugins/Marketplace/PluginTrial/Request.php
+++ b/plugins/Marketplace/PluginTrial/Request.php
@@ -17,15 +17,9 @@ use Piwik\Plugins\Marketplace\Emails\RequestTrialNotificationEmail;
 
 class Request
 {
-    /**
-     * @var string
-     */
-    private $pluginName;
+    private string $pluginName;
 
-    /**
-     * @var Storage
-     */
-    private $storage;
+    private Storage $storage;
 
     public function __construct(string $pluginName, Storage $storage)
     {

--- a/plugins/Marketplace/Plugins.php
+++ b/plugins/Marketplace/Plugins.php
@@ -20,20 +20,11 @@ use Piwik\Plugins\Marketplace\Input\Sort;
 
 class Plugins
 {
-    /**
-     * @var Api\Client
-     */
-    private $marketplaceClient;
+    private Api\Client $marketplaceClient;
 
-    /**
-     * @var Consumer
-     */
-    private $consumer;
+    private Consumer $consumer;
 
-    /**
-     * @var Advertising
-     */
-    private $advertising;
+    private Advertising $advertising;
 
     /**
      * @var Plugin\Manager

--- a/plugins/Marketplace/Plugins/InvalidLicenses.php
+++ b/plugins/Marketplace/Plugins/InvalidLicenses.php
@@ -20,25 +20,16 @@ use Piwik\Url;
 
 class InvalidLicenses
 {
-    /**
-     * @var Client
-     */
-    private $client;
+    private Client $client;
 
     /**
      * @var Plugin\Manager
      */
     private $pluginManager;
 
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
-    /**
-     * @var Eager
-     */
-    private $cache;
+    private Eager $cache;
 
     /**
      * @var array

--- a/plugins/Marketplace/Tasks.php
+++ b/plugins/Marketplace/Tasks.php
@@ -11,15 +11,9 @@ namespace Piwik\Plugins\Marketplace;
 
 class Tasks extends \Piwik\Plugin\Tasks
 {
-    /**
-     * @var UpdateCommunication
-     */
-    private $updateCommunication;
+    private UpdateCommunication $updateCommunication;
 
-    /**
-     * @var Api\Client
-     */
-    private $api;
+    private Api\Client $api;
 
     public function __construct(UpdateCommunication $updateCommunication, Api\Client $api)
     {

--- a/plugins/Marketplace/UpdateCommunication.php
+++ b/plugins/Marketplace/UpdateCommunication.php
@@ -24,10 +24,7 @@ use Piwik\View;
  */
 class UpdateCommunication
 {
-    /**
-     * @var SystemSettings
-     */
-    private $updaterSettings;
+    private SystemSettings $updaterSettings;
 
     public function __construct(SystemSettings $settings)
     {

--- a/plugins/Marketplace/Widgets/GetNewPlugins.php
+++ b/plugins/Marketplace/Widgets/GetNewPlugins.php
@@ -19,10 +19,7 @@ use Piwik\Widget\WidgetConfig;
 
 class GetNewPlugins extends Widget
 {
-    /**
-     * @var Client
-     */
-    private $marketplaceApiClient;
+    private Client $marketplaceApiClient;
 
     public function __construct(Client $marketplaceApiClient)
     {

--- a/plugins/Marketplace/Widgets/GetPremiumFeatures.php
+++ b/plugins/Marketplace/Widgets/GetPremiumFeatures.php
@@ -18,10 +18,7 @@ use Piwik\Widget\WidgetConfig;
 
 class GetPremiumFeatures extends Widget
 {
-    /**
-     * @var Client
-     */
-    private $marketplaceApiClient;
+    private Client $marketplaceApiClient;
 
     public function __construct(Client $marketplaceApiClient)
     {

--- a/plugins/MobileMessaging/Controller.php
+++ b/plugins/MobileMessaging/Controller.php
@@ -24,15 +24,9 @@ require_once PIWIK_INCLUDE_PATH . '/plugins/UserCountry/functions.php';
 
 class Controller extends ControllerAdmin
 {
-    /**
-     * @var RegionDataProvider
-     */
-    private $regionDataProvider;
+    private RegionDataProvider $regionDataProvider;
 
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(RegionDataProvider $regionDataProvider, Translator $translator)
     {

--- a/plugins/MobileMessaging/Diagnostic/MobileMessagingInformational.php
+++ b/plugins/MobileMessaging/Diagnostic/MobileMessagingInformational.php
@@ -20,10 +20,7 @@ use Piwik\Translation\Translator;
  */
 class MobileMessagingInformational implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/Monolog/Handler/FailureLogMessageDetector.php
+++ b/plugins/Monolog/Handler/FailureLogMessageDetector.php
@@ -21,7 +21,7 @@ class FailureLogMessageDetector extends AbstractHandler
     /**
      * @var boolean
      */
-    private $hasEncounteredImportantLog = false;
+    private bool $hasEncounteredImportantLog = false;
 
     public function __construct($level = Logger::WARNING)
     {

--- a/plugins/MultiSites/Controller.php
+++ b/plugins/MultiSites/Controller.php
@@ -23,8 +23,7 @@ use Piwik\View;
 
 class Controller extends \Piwik\Plugin\Controller
 {
-    /** @var Translator */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/MultiSites/DataTable/Filter/NestedSitesLimiter.php
+++ b/plugins/MultiSites/DataTable/Filter/NestedSitesLimiter.php
@@ -49,12 +49,10 @@ use Piwik\DataTable;
  */
 class NestedSitesLimiter extends BaseFilter
 {
-    /** @var int */
-    private $offset = 0;
-    /** @var int */
-    private $limit  = 0;
+    private int $offset = 0;
+    private int $limit  = 0;
     /** @var Row[] */
-    private $rows   = [];
+    private array $rows   = [];
 
     /**
      * @param DataTable $table The table to eventually filter.

--- a/plugins/Overlay/Controller.php
+++ b/plugins/Overlay/Controller.php
@@ -27,10 +27,7 @@ use Piwik\Plugins\SitesManager;
 
 class Controller extends \Piwik\Plugin\Controller
 {
-    /**
-     * @var SegmentFormatter
-     */
-    private $segmentFormatter;
+    private SegmentFormatter $segmentFormatter;
 
     public function __construct(SegmentFormatter $segmentFormatter)
     {

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -39,20 +39,11 @@ use Piwik\Validators\BaseValidator;
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var DataSubjects
-     */
-    private $gdpr;
+    private DataSubjects $gdpr;
 
-    /**
-     * @var LogDataAnonymizations
-     */
-    private $logDataAnonymizations;
+    private LogDataAnonymizations $logDataAnonymizations;
 
-    /**
-     * @var LogDataAnonymizer
-     */
-    private $logDataAnonymizer;
+    private LogDataAnonymizer $logDataAnonymizer;
 
     public function __construct(
         DataSubjects $gdpr,

--- a/plugins/PrivacyManager/Config.php
+++ b/plugins/PrivacyManager/Config.php
@@ -40,10 +40,8 @@ class Config
 {
     /**
      * If provided, tells the config to only apply to a specific site ID.
-     *
-     * @var int|null
      */
-    private $idSite;
+    private ?int $idSite = null;
 
     public function __construct(?int $idSite = null)
     {

--- a/plugins/PrivacyManager/Controller.php
+++ b/plugins/PrivacyManager/Controller.php
@@ -32,8 +32,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
     public const ACTIVATE_DNT_NONCE = 'PrivacyManager.activateDnt';
     public const DEACTIVATE_DNT_NONCE = 'PrivacyManager.deactivateDnt';
 
-    /** @var SiteContentDetector */
-    private $siteContentDetector;
+    private SiteContentDetector $siteContentDetector;
 
     public function __construct(SiteContentDetector $siteContentDetector)
     {

--- a/plugins/PrivacyManager/Diagnostic/PrivacyInformational.php
+++ b/plugins/PrivacyManager/Diagnostic/PrivacyInformational.php
@@ -20,10 +20,7 @@ use Piwik\Translation\Translator;
  */
 class PrivacyInformational implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/PrivacyManager/LogDataPurger.php
+++ b/plugins/PrivacyManager/LogDataPurger.php
@@ -31,17 +31,13 @@ class LogDataPurger
 
     /**
      * LogDeleter service used to delete visits.
-     *
-     * @var LogDeleter
      */
-    private $logDeleter;
+    private LogDeleter $logDeleter;
 
     /**
      * DAO class that is used to delete unused actions.
-     *
-     * @var RawLogDao
      */
-    private $rawLogDao;
+    private RawLogDao $rawLogDao;
 
     public function __construct(LogDeleter $logDeleter, RawLogDao $rawLogDao)
     {

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -26,10 +26,7 @@ use Piwik\Log\LoggerInterface;
 
 class DataSubjects
 {
-    /**
-     * @var LogTablesProvider
-     */
-    private $logTablesProvider;
+    private LogTablesProvider $logTablesProvider;
 
     public function __construct(LogTablesProvider $logTablesProvider)
     {

--- a/plugins/PrivacyManager/Model/LogDataAnonymizations.php
+++ b/plugins/PrivacyManager/Model/LogDataAnonymizations.php
@@ -26,10 +26,7 @@ class LogDataAnonymizations
      */
     private $onOutputCallback;
 
-    /**
-     * @var LogDataAnonymizer
-     */
-    private $logDataAnonymizer;
+    private LogDataAnonymizer $logDataAnonymizer;
 
     private $tablePrefixed;
 

--- a/plugins/PrivacyManager/Settings/CampaignParameterValuesMasked.php
+++ b/plugins/PrivacyManager/Settings/CampaignParameterValuesMasked.php
@@ -31,8 +31,7 @@ class CampaignParameterValuesMasked implements
 
     public const DISCARDED_CAMPAIGN_PLACEHOLDER = '__discarded_by_policy__';
 
-    /** @var bool */
-    private $value;
+    private bool $value;
 
     protected function __construct(bool $value)
     {

--- a/plugins/PrivacyManager/Settings/CompliancePolicyEnforcedSetting.php
+++ b/plugins/PrivacyManager/Settings/CompliancePolicyEnforcedSetting.php
@@ -19,8 +19,7 @@ abstract class CompliancePolicyEnforcedSetting implements
     /** @use PolicyComparisonTrait<bool> */
     use PolicyComparisonTrait;
 
-    /** @var bool */
-    private $value;
+    private bool $value;
 
     abstract public static function getTitle(): string;
 

--- a/plugins/PrivacyManager/Settings/IPAnonymisation.php
+++ b/plugins/PrivacyManager/Settings/IPAnonymisation.php
@@ -35,10 +35,7 @@ class IPAnonymisation implements CustomSettingInterface, PolicyComparisonInterfa
      */
     use CustomGetterTrait;
 
-    /**
-     * @var int|null
-     */
-    private $value;
+    private ?int $value;
 
     private function __construct(?int $value)
     {

--- a/plugins/PrivacyManager/Settings/IpAddressMaskLength.php
+++ b/plugins/PrivacyManager/Settings/IpAddressMaskLength.php
@@ -35,10 +35,7 @@ class IpAddressMaskLength implements CustomSettingInterface, PolicyComparisonInt
      */
     use CustomGetterTrait;
 
-    /**
-     * @var int|null
-     */
-    private $value;
+    private ?int $value;
 
     private function __construct(?int $value)
     {

--- a/plugins/PrivacyManager/Settings/ReferrerAnonymisation.php
+++ b/plugins/PrivacyManager/Settings/ReferrerAnonymisation.php
@@ -36,10 +36,7 @@ class ReferrerAnonymisation implements CustomSettingInterface, PolicyComparisonI
      */
     use CustomGetterTrait;
 
-    /**
-     * @var string|null
-     */
-    private $value;
+    private ?string $value;
 
     private function __construct(?string $value)
     {

--- a/plugins/PrivacyManager/Settings/ReportRetention.php
+++ b/plugins/PrivacyManager/Settings/ReportRetention.php
@@ -35,10 +35,7 @@ class ReportRetention implements
 
     use OptionGetterTrait;
 
-    /**
-     * @var int|null
-     */
-    private $value;
+    private ?int $value;
 
     private function __construct(?int $value)
     {

--- a/plugins/PrivacyManager/Tasks.php
+++ b/plugins/PrivacyManager/Tasks.php
@@ -15,20 +15,11 @@ use Piwik\Plugins\SitesManager\API as SitesManagerAPI;
 
 class Tasks extends \Piwik\Plugin\Tasks
 {
-    /**
-     * @var LogDataAnonymizations
-     */
-    private $logDataAnonymizations;
+    private LogDataAnonymizations $logDataAnonymizations;
 
-    /**
-     * @var DataSubjects
-     */
-    private $dataSubjects;
+    private DataSubjects $dataSubjects;
 
-    /**
-     * @var SitesManagerAPI
-     */
-    private $sitesManagerAPI;
+    private SitesManagerAPI $sitesManagerAPI;
 
     public function __construct(LogDataAnonymizations $logDataAnonymizations, DataSubjects $dataSubjects, SitesManagerAPI $sitesManagerAPI)
     {

--- a/plugins/ProfessionalServices/API.php
+++ b/plugins/ProfessionalServices/API.php
@@ -20,10 +20,7 @@ use Piwik\Request;
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var PromoWidgetDismissal
-     */
-    private $promoWidgetDismissal;
+    private PromoWidgetDismissal $promoWidgetDismissal;
 
     public function __construct(PromoWidgetDismissal $promoWidgetDismissal)
     {

--- a/plugins/ProfessionalServices/PromoWidgetApplicable.php
+++ b/plugins/ProfessionalServices/PromoWidgetApplicable.php
@@ -15,20 +15,11 @@ use Piwik\ProfessionalServices\Advertising;
 
 class PromoWidgetApplicable
 {
-    /**
-     * @var Manager
-     */
-    private $manager;
+    private Manager $manager;
 
-    /**
-     * @var Config
-     */
-    private $config;
+    private Config $config;
 
-    /**
-     * @var PromoWidgetDismissal
-     */
-    private $promoWidgetDismissal;
+    private PromoWidgetDismissal $promoWidgetDismissal;
 
     public function __construct(Manager $manager, Config $config, PromoWidgetDismissal $promoWidgetDismissal)
     {

--- a/plugins/ProfessionalServices/PromoWidgetDismissal.php
+++ b/plugins/ProfessionalServices/PromoWidgetDismissal.php
@@ -16,8 +16,7 @@ class PromoWidgetDismissal
 {
     private const STORE_KEY_DISMISSED_WIDGETS = 'dismissedWidgets';
 
-    /** @var UserScopedSettingsAccessManager */
-    private $accessManager;
+    private UserScopedSettingsAccessManager $accessManager;
 
     public function __construct(UserScopedSettingsAccessManager $accessManager)
     {

--- a/plugins/ProfessionalServices/Widgets/PromoServices.php
+++ b/plugins/ProfessionalServices/Widgets/PromoServices.php
@@ -17,15 +17,9 @@ use Piwik\Widget\WidgetConfig;
 
 class PromoServices extends \Piwik\Widget\Widget
 {
-    /**
-     * @var Advertising
-     */
-    private $advertising;
+    private Advertising $advertising;
 
-    /**
-     * @var Promo
-     */
-    private $promo;
+    private Promo $promo;
 
     public function __construct(Advertising $advertising, Promo $promo)
     {

--- a/plugins/Referrers/Columns/Metrics/VisitorsFromReferrerPercent.php
+++ b/plugins/Referrers/Columns/Metrics/VisitorsFromReferrerPercent.php
@@ -17,15 +17,9 @@ use Piwik\Plugin\ProcessedMetric;
 
 class VisitorsFromReferrerPercent extends ProcessedMetric
 {
-    /**
-     * @var string
-     */
-    private $name;
+    private string $name;
 
-    /**
-     * @var string
-     */
-    private $referrerSourceColumn;
+    private string $referrerSourceColumn;
 
     /**
      * @var numeric

--- a/plugins/Referrers/Controller.php
+++ b/plugins/Referrers/Controller.php
@@ -19,10 +19,7 @@ use Piwik\Translation\Translator;
 
 class Controller extends \Piwik\Plugin\Controller
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -94,10 +94,7 @@ class API extends \Piwik\Plugin\API
     public const OUTPUT_INLINE = 3;
     public const OUTPUT_RETURN = 4;
 
-    /**
-     * @var bool
-     */
-    private $enableSaveReportOnDisk = false;
+    private bool $enableSaveReportOnDisk = false;
 
     /**
      * static cache storing reports
@@ -106,10 +103,7 @@ class API extends \Piwik\Plugin\API
      */
     public static $cache = [];
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(LoggerInterface $logger)
     {

--- a/plugins/ScheduledReports/GeneratedReport.php
+++ b/plugins/ScheduledReports/GeneratedReport.php
@@ -14,10 +14,7 @@ use Piwik\Piwik;
 
 class GeneratedReport
 {
-    /**
-     * @var array
-     */
-    private $reportDetails;
+    private array $reportDetails;
 
     /**
      * @var string
@@ -34,10 +31,7 @@ class GeneratedReport
      */
     private $contents;
 
-    /**
-     * @var array
-     */
-    private $additionalFiles;
+    private array $additionalFiles;
 
     public function __construct(array $reportDetails, $reportTitle, $prettyDate, $contents, array $additionalFiles)
     {

--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -48,15 +48,9 @@ use Piwik\Url;
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var Model
-     */
-    private $model;
+    private Model $model;
 
-    /**
-     * @var SegmentArchiving
-     */
-    private $segmentArchiving;
+    private SegmentArchiving $segmentArchiving;
 
     /**
      * @var string

--- a/plugins/SegmentEditor/SegmentFormatter.php
+++ b/plugins/SegmentEditor/SegmentFormatter.php
@@ -16,10 +16,7 @@ use Piwik\Segment\SegmentExpression;
 
 class SegmentFormatter
 {
-    /**
-     * @var Segment\SegmentsList
-     */
-    private $segmentList;
+    private Segment\SegmentsList $segmentList;
 
     private $matchesMetric = array(
         SegmentExpression::MATCH_EQUAL => 'General_OperationEquals',

--- a/plugins/SegmentEditor/SegmentQueryDecorator.php
+++ b/plugins/SegmentEditor/SegmentQueryDecorator.php
@@ -23,10 +23,7 @@ use Piwik\SettingsServer;
  */
 class SegmentQueryDecorator extends LogQueryBuilder
 {
-    /**
-     * @var StoredSegmentService
-     */
-    private $storedSegmentService;
+    private StoredSegmentService $storedSegmentService;
 
     public function __construct(StoredSegmentService $storedSegmentService, LogTablesProvider $logTablesProvider)
     {

--- a/plugins/SegmentEditor/Services/StoredSegmentService.php
+++ b/plugins/SegmentEditor/Services/StoredSegmentService.php
@@ -17,15 +17,9 @@ use Matomo\Cache\Transient as TransientCache;
  */
 class StoredSegmentService
 {
-    /**
-     * @var Model
-     */
-    private $model;
+    private Model $model;
 
-    /**
-     * @var TransientCache
-     */
-    private $transientCache;
+    private TransientCache $transientCache;
 
     public function __construct(Model $model, TransientCache $transientCache)
     {

--- a/plugins/SegmentEditor/UnprocessedSegmentException.php
+++ b/plugins/SegmentEditor/UnprocessedSegmentException.php
@@ -14,15 +14,9 @@ use Piwik\Segment;
 
 class UnprocessedSegmentException extends \Exception
 {
-    /**
-     * @var Segment
-     */
-    private $segment;
+    private Segment $segment;
 
-    /**
-     * @var array|null
-     */
-    private $storedSegment;
+    private ?array $storedSegment;
 
     /**
      * @var bool

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -100,29 +100,18 @@ class API extends \Piwik\Plugin\API
     public const OPTION_KEEP_URL_FRAGMENTS_GLOBAL = 'SitesManager_KeepURLFragmentsGlobal';
     public const OPTION_EXCLUDE_TYPE_QUERY_PARAMS_GLOBAL = 'SitesManager_ExcludeTypeQueryParamsGlobal';
 
-    /**
-     * @var SettingsProvider
-     */
-    private $settingsProvider;
+    private SettingsProvider $settingsProvider;
 
-    /**
-     * @var SettingsMetadata
-     */
-    private $settingsMetadata;
+    private SettingsMetadata $settingsMetadata;
 
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     /** @var array<string, string> */
     private $timezoneNameCache = [];
 
-    /** @var SiteContentDetector */
-    private $siteContentDetector;
+    private SiteContentDetector $siteContentDetector;
 
-    /** @var TypeManager */
-    private $typeManager;
+    private TypeManager $typeManager;
 
     public function __construct(
         SettingsProvider $provider,

--- a/plugins/SitesManager/Controller.php
+++ b/plugins/SitesManager/Controller.php
@@ -27,8 +27,7 @@ use Piwik\View;
 
 class Controller extends \Piwik\Plugin\ControllerAdmin
 {
-    /** @var SiteContentDetector */
-    private $siteContentDetector;
+    private SiteContentDetector $siteContentDetector;
 
     public function __construct(SiteContentDetector $siteContentDetector)
     {

--- a/plugins/SitesManager/Settings/FilterPIIParameters.php
+++ b/plugins/SitesManager/Settings/FilterPIIParameters.php
@@ -26,8 +26,7 @@ class FilterPIIParameters implements
     /** @use PolicyComparisonTrait<string> */
     use PolicyComparisonTrait;
 
-    /** @var string $value */
-    private $value;
+    private string $value;
 
     protected function __construct(string $value)
     {

--- a/plugins/SitesManager/Tracker/SitesManagerRequestProcessor.php
+++ b/plugins/SitesManager/Tracker/SitesManagerRequestProcessor.php
@@ -21,10 +21,7 @@ use Piwik\Plugins\SitesManager\Model as SitesManagerModel;
  */
 class SitesManagerRequestProcessor extends RequestProcessor
 {
-    /**
-     * @var SitesManagerModel
-     */
-    private $sitesManagerModel;
+    private SitesManagerModel $sitesManagerModel;
 
     public function __construct(SitesManagerModel $sitesManagerModel)
     {

--- a/plugins/Tour/API.php
+++ b/plugins/Tour/API.php
@@ -20,15 +20,9 @@ use Piwik\Plugins\Tour\Engagement\Challenges;
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var Challenges
-     */
-    private $challenges;
+    private Challenges $challenges;
 
-    /**
-     * @var Levels
-     */
-    private $levels;
+    private Levels $levels;
 
     public function __construct(Challenges $challenges, Levels $levels)
     {

--- a/plugins/Tour/Engagement/ChallengeAddedSegment.php
+++ b/plugins/Tour/Engagement/ChallengeAddedSegment.php
@@ -15,10 +15,7 @@ use Piwik\Url;
 
 class ChallengeAddedSegment extends Challenge
 {
-    /**
-     * @var DataFinder
-     */
-    private $finder;
+    private DataFinder $finder;
 
     /**
      * @var null|bool

--- a/plugins/Tour/Engagement/ChallengeAddedWebsite.php
+++ b/plugins/Tour/Engagement/ChallengeAddedWebsite.php
@@ -15,10 +15,7 @@ use Piwik\Url;
 
 class ChallengeAddedWebsite extends Challenge
 {
-    /**
-     * @var DataFinder
-     */
-    private $finder;
+    private DataFinder $finder;
 
     /**
      * @var null|bool

--- a/plugins/Tour/Engagement/ChallengeCustomLogo.php
+++ b/plugins/Tour/Engagement/ChallengeCustomLogo.php
@@ -16,10 +16,7 @@ use Piwik\Url;
 
 class ChallengeCustomLogo extends Challenge
 {
-    /**
-     * @var DataFinder
-     */
-    private $finder;
+    private DataFinder $finder;
 
     /**
      * @var null|bool

--- a/plugins/Tour/Engagement/ChallengeCustomiseDashboard.php
+++ b/plugins/Tour/Engagement/ChallengeCustomiseDashboard.php
@@ -15,10 +15,7 @@ use Piwik\Url;
 
 class ChallengeCustomiseDashboard extends Challenge
 {
-    /**
-     * @var DataFinder
-     */
-    private $finder;
+    private DataFinder $finder;
 
     /**
      * @var null|bool

--- a/plugins/Tour/Engagement/ChallengeScheduledReport.php
+++ b/plugins/Tour/Engagement/ChallengeScheduledReport.php
@@ -15,10 +15,7 @@ use Piwik\Url;
 
 class ChallengeScheduledReport extends Challenge
 {
-    /**
-     * @var DataFinder
-     */
-    private $finder;
+    private DataFinder $finder;
 
     /**
      * @var null|bool

--- a/plugins/Tour/Engagement/ChallengeSetupConsentManager.php
+++ b/plugins/Tour/Engagement/ChallengeSetupConsentManager.php
@@ -16,8 +16,7 @@ use Piwik\SiteContentDetector;
 
 class ChallengeSetupConsentManager extends Challenge
 {
-    /** @var SiteContentDetector */
-    private $siteContentDetector;
+    private SiteContentDetector $siteContentDetector;
 
     /**
      * @var ConsentManagerDetectionAbstract|null

--- a/plugins/Tour/Engagement/ChallengeTrackingCode.php
+++ b/plugins/Tour/Engagement/ChallengeTrackingCode.php
@@ -15,10 +15,7 @@ use Piwik\Url;
 
 class ChallengeTrackingCode extends Challenge
 {
-    /**
-     * @var DataFinder
-     */
-    private $finder;
+    private DataFinder $finder;
 
     /**
      * @var null|bool

--- a/plugins/Tour/Engagement/Challenges.php
+++ b/plugins/Tour/Engagement/Challenges.php
@@ -20,10 +20,7 @@ use Piwik\Plugins\UsersManager\UsersManager;
 
 class Challenges
 {
-    /**
-     * @var DataFinder
-     */
-    private $finder;
+    private DataFinder $finder;
 
     public function __construct(DataFinder $dataFinder)
     {

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -602,15 +602,9 @@ class API extends \Piwik\Plugin\API
         return 'url';
     }
 
-    /**
-     * @var int
-     */
-    private $limitBeforeGrouping = 5;
+    private int $limitBeforeGrouping = 5;
 
-    /**
-     * @var int
-     */
-    private $totalTransitionsToFollowingPages = 0;
+    private int $totalTransitionsToFollowingPages = 0;
 
     /**
      * Get the sum of all transitions to following actions (pages, outlinks, downloads).

--- a/plugins/TwoFactorAuth/API.php
+++ b/plugins/TwoFactorAuth/API.php
@@ -18,10 +18,7 @@ use Piwik\Piwik;
  */
 class API extends \Piwik\Plugin\API
 {
-    /**
-     * @var TwoFactorAuthentication
-     */
-    private $twoFa;
+    private TwoFactorAuthentication $twoFa;
 
     public function __construct(TwoFactorAuthentication $twoFa)
     {

--- a/plugins/TwoFactorAuth/Controller.php
+++ b/plugins/TwoFactorAuth/Controller.php
@@ -35,30 +35,15 @@ class Controller extends \Piwik\Plugin\Controller
     public const REGENERATE_CODES_2FA_NONCE = 'TwoFactorAuth.regenerateCodes';
     public const VERIFY_PASSWORD_NONCE = 'TwoFactorAuth.verifyPassword';
 
-    /**
-     * @var SystemSettings
-     */
-    private $settings;
+    private SystemSettings $settings;
 
-    /**
-     * @var RecoveryCodeDao
-     */
-    private $recoveryCodeDao;
+    private RecoveryCodeDao $recoveryCodeDao;
 
-    /**
-     * @var PasswordVerifier
-     */
-    private $passwordVerify;
+    private PasswordVerifier $passwordVerify;
 
-    /**
-     * @var TwoFactorAuthentication
-     */
-    private $twoFa;
+    private TwoFactorAuthentication $twoFa;
 
-    /**
-     * @var Validator
-     */
-    private $validator;
+    private Validator $validator;
 
     public function __construct(SystemSettings $systemSettings, RecoveryCodeDao $recoveryCodeDao, PasswordVerifier $passwordVerify, TwoFactorAuthentication $twoFa, Validator $validator)
     {

--- a/plugins/TwoFactorAuth/Dao/RecoveryCodeDao.php
+++ b/plugins/TwoFactorAuth/Dao/RecoveryCodeDao.php
@@ -17,10 +17,7 @@ class RecoveryCodeDao
     protected $table = 'twofactor_recovery_code';
     protected $tablePrefixed = '';
 
-    /**
-     * @var RecoveryCodeRandomGenerator $generator
-     */
-    private $generator;
+    private RecoveryCodeRandomGenerator $generator;
 
     public function __construct(RecoveryCodeRandomGenerator $generator)
     {

--- a/plugins/TwoFactorAuth/Tasks.php
+++ b/plugins/TwoFactorAuth/Tasks.php
@@ -11,10 +11,7 @@ namespace Piwik\Plugins\TwoFactorAuth;
 
 class Tasks extends \Piwik\Plugin\Tasks
 {
-    /**
-     * @var TwoFactorAuthentication
-     */
-    private $twoFa;
+    private TwoFactorAuthentication $twoFa;
 
     public function __construct(TwoFactorAuthentication $twoFa)
     {

--- a/plugins/TwoFactorAuth/TwoFactorAuthentication.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuthentication.php
@@ -34,20 +34,11 @@ class TwoFactorAuthentication
      */
     public const BLOCK_TWOFA_CODE_MINUTES = 10;
 
-    /**
-     * @var SystemSettings
-     */
-    private $settings;
+    private SystemSettings $settings;
 
-    /**
-     * @var RecoveryCodeDao
-     */
-    private $recoveryCodeDao;
+    private RecoveryCodeDao $recoveryCodeDao;
 
-    /**
-     * @var TwoFaSecretRandomGenerator
-     */
-    private $secretGenerator;
+    private TwoFaSecretRandomGenerator $secretGenerator;
 
     public function __construct(SystemSettings $systemSettings, RecoveryCodeDao $recoveryCodeDao, TwoFaSecretRandomGenerator $twoFaSecretRandomGenerator)
     {

--- a/plugins/TwoFactorAuth/Validator.php
+++ b/plugins/TwoFactorAuth/Validator.php
@@ -18,10 +18,7 @@ use Piwik\SettingsPiwik;
 
 class Validator
 {
-    /**
-     * @var TwoFactorAuthentication
-     */
-    private $twoFa;
+    private TwoFactorAuthentication $twoFa;
 
     public function __construct(TwoFactorAuthentication $twoFactorAuthentication)
     {

--- a/plugins/UserCountry/Commands/AttributeHistoricalDataWithLocations.php
+++ b/plugins/UserCountry/Commands/AttributeHistoricalDataWithLocations.php
@@ -35,10 +35,7 @@ class AttributeHistoricalDataWithLocations extends ConsoleCommand
      */
     protected $visitorGeolocator;
 
-    /**
-     * @var int
-     */
-    private $processed = 0;
+    private int $processed = 0;
 
     /**
      * @var int

--- a/plugins/UserCountry/Diagnostic/GeolocationDiagnostic.php
+++ b/plugins/UserCountry/Diagnostic/GeolocationDiagnostic.php
@@ -21,10 +21,7 @@ use Piwik\Translation\Translator;
  */
 class GeolocationDiagnostic implements Diagnostic
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/UserCountryMap/Controller.php
+++ b/plugins/UserCountryMap/Controller.php
@@ -26,10 +26,7 @@ class Controller extends \Piwik\Plugin\Controller
     // By default plot up to the last 3 days of visitors on the map, for low traffic sites
     public const REAL_TIME_WINDOW = 'last3';
 
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/UserId/Settings/UserIdDisabled.php
+++ b/plugins/UserId/Settings/UserIdDisabled.php
@@ -28,8 +28,7 @@ class UserIdDisabled implements
     /** @use MeasurableGetterTrait<bool> */
     use MeasurableGetterTrait;
 
-    /** @var bool */
-    private $value;
+    private bool $value;
 
     protected function __construct(bool $value)
     {

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -72,20 +72,11 @@ class API extends \Piwik\Plugin\API
      */
     public static $SET_SUPERUSER_ACCESS_REQUIRE_PASSWORD_CONFIRMATION = true;
 
-    /**
-     * @var Model
-     */
-    private $model;
+    private Model $model;
 
-    /**
-     * @var Password
-     */
-    private $password;
+    private Password $password;
 
-    /**
-     * @var UserAccessFilter
-     */
-    private $userFilter;
+    private UserAccessFilter $userFilter;
 
     /**
      * @var Access
@@ -112,10 +103,7 @@ class API extends \Piwik\Plugin\API
      */
     private $allowedEmailDomain;
 
-    /**
-     * @var UserRepository
-     */
-    private $userRepository;
+    private UserRepository $userRepository;
 
     public const PREFERENCE_THEME_MODE = 'themeMode';
     public const PREFERENCE_DEFAULT_THEME_MODE = ThemeStyles::LIGHT_MODE;

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -47,30 +47,18 @@ class Controller extends ControllerAdmin
     public const NONCE_DELETE_AUTH_TOKEN = 'deleteAuthTokenNonce';
     public const NONCE_SET_IGNORE_COOKIE = 'setIgnoreCookieNonce';
 
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
-    /**
-     * @var PasswordVerifier
-     */
-    private $passwordVerify;
+    private PasswordVerifier $passwordVerify;
 
     /**
      * @var Plugin\Manager
      */
     private $pluginManager;
 
-    /**
-     * @var Model
-     */
-    private $userModel;
+    private Model $userModel;
 
-    /**
-     * @var PasswordStrength
-     */
-    private $passwordStrength;
+    private PasswordStrength $passwordStrength;
 
     public function __construct(
         Translator $translator,

--- a/plugins/UsersManager/Emails/AuthTokenExpirationWarningNotificationEmail.php
+++ b/plugins/UsersManager/Emails/AuthTokenExpirationWarningNotificationEmail.php
@@ -19,16 +19,11 @@ use Piwik\View;
 
 class AuthTokenExpirationWarningNotificationEmail extends Mail
 {
-    /**
-     * @var AuthTokenExpirationWarningEmailNotification
-     */
-    private $notification;
+    private AuthTokenExpirationWarningEmailNotification $notification;
 
-    /** @var string */
-    private $recipient;
+    private string $recipient;
 
-    /** @var array */
-    private $emailData;
+    private array $emailData;
 
     public function __construct(
         AuthTokenExpirationWarningEmailNotification $notification,

--- a/plugins/UsersManager/Emails/AuthTokenRotationNotificationEmail.php
+++ b/plugins/UsersManager/Emails/AuthTokenRotationNotificationEmail.php
@@ -19,16 +19,11 @@ use Piwik\View;
 
 class AuthTokenRotationNotificationEmail extends Mail
 {
-    /**
-     * @var TokenNotification
-     */
-    private $notification;
+    private TokenNotification $notification;
 
-    /** @var string */
-    private $recipient;
+    private string $recipient;
 
-    /** @var array */
-    private $emailData;
+    private array $emailData;
 
     public function __construct(TokenNotification $notification, string $recipient, array $emailData)
     {

--- a/plugins/UsersManager/Emails/InactiveUsersNotificationEmail.php
+++ b/plugins/UsersManager/Emails/InactiveUsersNotificationEmail.php
@@ -20,19 +20,13 @@ use Piwik\View;
 
 class InactiveUsersNotificationEmail extends Mail
 {
-    /**
-     * @var UserNotification
-     */
-    private $notification;
+    private UserNotification $notification;
 
-    /** @var string */
-    private $recipient;
+    private string $recipient;
 
-    /** @var array */
-    private $emailData;
+    private array $emailData;
 
-    /** @var Model */
-    private $userModel;
+    private Model $userModel;
 
     public function __construct(UserNotification $notification, string $recipient, array $emailData)
     {

--- a/plugins/UsersManager/Tasks.php
+++ b/plugins/UsersManager/Tasks.php
@@ -16,15 +16,9 @@ use Piwik\Plugins\UsersManager\UserNotifications\UserNotifierTask;
 
 class Tasks extends \Piwik\Plugin\Tasks
 {
-    /**
-     * @var Model
-     */
-    private $usersModel;
+    private Model $usersModel;
 
-    /**
-     * @var API
-     */
-    private $usersManagerApi;
+    private API $usersManagerApi;
 
     public function __construct(Model $usersModel, API $usersManagerApi)
     {

--- a/plugins/UsersManager/TokenNotifications/TokenEmailNotification.php
+++ b/plugins/UsersManager/TokenNotifications/TokenEmailNotification.php
@@ -23,10 +23,8 @@ abstract class TokenEmailNotification extends TokenNotification
 
     /**
      * Data in the format of ['email@example.com' => ['item1' => 'value1'], ...] that will be passed to the email class
-     *
-     * @var array
      */
-    private $emailData;
+    private array $emailData;
 
     /**
      * @param array{login: string, tokenId: string, tokenName: string, tokenDate: string} $tokens

--- a/plugins/UsersManager/UserAccessFilter.php
+++ b/plugins/UsersManager/UserAccessFilter.php
@@ -26,15 +26,9 @@ use Piwik\Access;
  */
 class UserAccessFilter
 {
-    /**
-     * @var Model
-     */
-    private $model;
+    private Model $model;
 
-    /**
-     * @var Access
-     */
-    private $access;
+    private Access $access;
 
     /**
      * Holds a list of all idSites the current user has admin access to. Only used for caching.

--- a/plugins/UsersManager/UserNotifications/UserEmailNotification.php
+++ b/plugins/UsersManager/UserNotifications/UserEmailNotification.php
@@ -22,10 +22,8 @@ abstract class UserEmailNotification extends UserNotification
 
     /**
      * Data in the format of ['email@example.com' => ['item1' => 'value1'], ...] that will be passed to the email class
-     *
-     * @var array
      */
-    private $emailData;
+    private array $emailData;
 
     /**
      * @param array $users A list of users this notification is about

--- a/plugins/UsersManager/UserNotifications/UserNotification.php
+++ b/plugins/UsersManager/UserNotifications/UserNotification.php
@@ -13,10 +13,8 @@ abstract class UserNotification implements UserNotificationInterface
 {
     /**
      * Data to hold for users, keyed by their username.
-     *
-     * @var array
      */
-    private $users;
+    private array $users;
 
     public function __construct(
         array $users

--- a/plugins/UsersManager/Validators/AllowedEmailDomain.php
+++ b/plugins/UsersManager/Validators/AllowedEmailDomain.php
@@ -17,10 +17,7 @@ use Piwik\Validators\Exception;
 
 class AllowedEmailDomain extends BaseValidator
 {
-    /**
-     * @var SystemSettings
-     */
-    private $settings;
+    private SystemSettings $settings;
 
     public function __construct(SystemSettings $settings)
     {

--- a/plugins/VisitFrequency/Columns/Metrics/ReturningMetric.php
+++ b/plugins/VisitFrequency/Columns/Metrics/ReturningMetric.php
@@ -34,10 +34,7 @@ class ReturningMetric extends ProcessedMetric
         'nb_users_new' => 'VisitFrequency_ColumnNewUsers',
     );
 
-    /**
-     * @var ProcessedMetric
-     */
-    private $wrapped;
+    private ProcessedMetric $wrapped;
 
     private $suffix;
 

--- a/plugins/VisitFrequency/Controller.php
+++ b/plugins/VisitFrequency/Controller.php
@@ -18,10 +18,7 @@ use Piwik\Translation\Translator;
 
 class Controller extends \Piwik\Plugin\Controller
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/VisitsSummary/Controller.php
+++ b/plugins/VisitsSummary/Controller.php
@@ -22,10 +22,7 @@ use Piwik\Url;
 
 class Controller extends \Piwik\Plugin\Controller
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
+    private Translator $translator;
 
     public function __construct(Translator $translator)
     {

--- a/plugins/WebsiteMeasurable/MeasurableSettings.php
+++ b/plugins/WebsiteMeasurable/MeasurableSettings.php
@@ -71,20 +71,11 @@ class MeasurableSettings extends \Piwik\Settings\Measurable\MeasurableSettings
     /** @var Setting */
     public $ecommerce;
 
-    /**
-     * @var SitesManager\API
-     */
-    private $sitesManagerApi;
+    private SitesManager\API $sitesManagerApi;
 
-    /**
-     * @var TypeManager
-     */
-    private $typeManager;
+    private TypeManager $typeManager;
 
-    /**
-     * @var bool
-     */
-    private $unsetSiteSearchKeywords = false;
+    private bool $unsetSiteSearchKeywords = false;
 
     public function __construct(
         SitesManager\API $api,


### PR DESCRIPTION
Declares native PHP 8.1 types on 579 **private** properties in `core/` and the bundled plugins that until now carried their type only in a `@var` annotation. The type is then enforced by PHP instead of being a hint that can silently drift from the code, and PHPStan reads it from the signature rather than from a comment. No behaviour changes are intended.

Class *constants* are deliberately not part of this: typed constants require PHP 8.3, and the floor here is 8.1. Protected and public properties are also untouched, since a subclass that redeclares one has to repeat the type exactly and plugin subclasses are outside this repository.

### Why the annotations could not simply be trusted

Matomo's `@var` annotations are wrong often enough that converting them mechanically breaks things. Two examples that produced real runtime `TypeError`s in an earlier iteration of this change:

- `Option::$instance` is annotated `\Piwik\Option`, but `setSingletonInstance()` is a test seam taking `@param mixed`, and the test suite passes mocks built from `stdClass`. Typing the property broke ~50 tests.
- `ArchiveProcessor\Parameters::$archiveOnlyReport` is annotated `string`, while `setArchiveOnlyReport()` documents `string|string[]` and assigns straight through.

So a property was only converted when its type is provable from the code rather than from the comment:

- **every** write to it, anywhere in the class, assigns a value of provable type — a natively typed parameter, a literal, a `new X`, or a call to a method with a declared return type; and
- it either has a declared default or is unconditionally assigned by the constructor, so it can never be read while uninitialised. A typed property without a default is *uninitialised* and throws on read, where an untyped one returned `null`.

Checking only the constructor is not sufficient, which is what the two cases above demonstrate.

Skipped for the same reason: classes with `__sleep`/`__wakeup`/`__serialize`/`__unserialize`/`__set_state` (unserialising a payload written by an older version leaves a typed property without a default uninitialised), classes with magic access, classes that write properties dynamically, and properties that are `unset()` anywhere.

That leaves roughly 500 private properties untyped, so plenty of classes still have a mix of typed and untyped properties. This is the conservative gate doing its job rather than an unfinished pass; the dominant remaining pattern is a property fed from an untyped setter or constructor parameter, where the annotation is the only evidence for the type.

To make the remainder actionable rather than something the next pass has to re-derive: those properties need **the parameter typed first**. Once the setter or constructor declares a type, the property's type is provable and the same conversion applies. Doing it in that order is what keeps the guarantee, and it is why they are not simply swept in here.

### Redundant annotations

Where the native type says exactly what the annotation said, the `@var` line is dropped, and with it the docblock if that is all it contained. Where the annotation is more specific it stays, so element types are not lost:

```php
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;

     /**
      * @var Request[]
      */
-    private $requests = null;
+    private ?array $requests = null;
```

Properties that had no default keep their previous value as an explicit `= null`, which is what an untyped property already held.

### Annotations that contradicted the code

Two properties are annotated non-nullable while being initialised to `null`, which had made PHPStan treat their null guards as unreachable. The accurate types make those guards meaningful again, so four baseline entries are retired: `Access::$auth` (now `?Auth`) and `RequestSet::$requests` (now `?array`). The `deadCode.unreachable` count for `RequestSet` drops from 2 to 1 rather than being removed, since only one of the two statements becomes reachable.

A further 15 properties turned out to have annotations *proven* wrong by a nullable constructor parameter — `Access::$roleProvider`, `Console::$environment`, `CronArchive\Performance\Logger::$logger`, `QueueConsumer::$archiveFilter`, `Translator::$directories`, `EvolutionMetric::$pastData` and `$currentData`, `VisitorGeolocator::$provider` and others. Those are left alone here; correcting an annotation is a different change from declaring a type, and they are better done as a follow-up where each can be looked at.

`readonly` is deliberately not applied to the constructor-only properties, even though most would qualify: `CoreAdminHome\tests\Integration\ControllerTest` and `tests\Integration\API\RequestTest` overwrite private properties by reflection after construction, which `readonly` forbids.

`ViewDataTable\Factory::$defaultViewTypes` is dead private state — never read, never written — which only becomes visible once it is typed. Also left for a follow-up, since deleting it is not a type declaration.

### Testing

- PHPCS clean.
- PHPStan reports 0 errors.
- One PHPStan fix here is unrelated to the property types and was inherited from the base branch: `6.x-dev` currently fails PHPStan on its own, because the `ignoreErrors` entry for `requireOnce.fileNotFound` in `core/FileIntegrity.php` no longer matches anything and `reportUnmatchedIgnoredErrors` turns that into an error. A clean checkout of `6.x-dev` reports it, and it first appears in #24451; it went unnoticed because `phpstan.yml` only runs `on: pull_request`, so PHPStan never runs against `6.x-dev` itself. The obsolete entry is removed so this branch can be verified at all — the sibling entry for `core/bootstrap.php` still matches and stays.
- The unit suite is byte-identical to `6.x-dev`: 10877 tests, 16737 assertions, the same 4 pre-existing failures and 6 warnings, 0 errors.
- Across the 12144 integration tests there are zero occurrences of the only runtime signatures this change can introduce — `Cannot assign … to property`, `must not be accessed before initialization` and `Cannot auto-initialize an array inside property`.

One behaviour worth recording, since it decided a gate: a `null`-valued `?array` property *does* still auto-vivify on `$this->prop[] = …` in 8.1, so `$this->requests[] = …` on the now-`?array` property is safe. Only a type that cannot hold an array raises `Cannot auto-initialize an array inside property`, which was verified directly on 8.1 rather than assumed.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
