### PR TITLE
Render sparkline description placeholder without raw output

### DIFF
--- a/plugins/CoreVisualizations/templates/macros.twig
+++ b/plugins/CoreVisualizations/templates/macros.twig
@@ -38,7 +38,8 @@
             {% for metric in group %}
                 <span class="sparkline-metrics" {% if allMetricsDocumentation[metric.column] is defined and allMetricsDocumentation[metric.column] %}title="{{ allMetricsDocumentation[metric.column] }}"{% endif %}>
                 {% if '%s' in metric.description -%}
-                    {{ metric.description|e('html')|replace({'%s': "<strong>"~metric.value|number(2)~"</strong>"})|raw }}
+                    {%- set descriptionParts = metric.description|split('%s', 2) -%}
+                    {{ descriptionParts[0] }}<strong>{{ metric.value|number(2) }}</strong>{{ descriptionParts[1] }}
                 {%- else %}
                     <strong>{{ metric.value|number(2) }}</strong> {{ metric.description }}
                 {%- endif %}{% if not loop.last %}, {% endif %}


### PR DESCRIPTION
## Summary

Follow-up to #24939. The sparkline macro's placeholder branch only needs to wrap the metric value in `<strong>`, but it did so by concatenating markup into the description, which required rendering the whole result through `|raw` and left the value itself unescaped — unlike the branch without a placeholder, where Twig escapes it.

The description is now split at the placeholder, so both description parts and the value are rendered as autoescaped text and `<strong>` is the only markup left in the branch. No `|raw` remains.

Rendered output is byte-identical to the current template for regular descriptions (verified for `%s bytes transferred`, `visits within %s pages`, `%s`, `ends with %s`), so no screenshot changes are expected. Only the first placeholder is substituted now instead of every occurrence; more than one was never supported, since the previous `translate` path passed a single value to `vsprintf`.

## Review

- [ ] Functional review done
- [ ] Potential edge cases considered
- [ ] Usable, i.e. no confusing behaviour

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules



Backport of #24949.
