### PR TITLE
Pin UI screenshot tests to Chrome for Testing 150.0.7871.124

### DIFF
--- a/tests/UI/config.dist.js
+++ b/tests/UI/config.dist.js
@@ -69,11 +69,13 @@ exports.processedScreenshotsDir = "./processed-ui-screenshots";
 exports.screenshotDiffDir = "./screenshot-diffs";
 
 /**
- * Resolve the browser executable Puppeteer should launch. Puppeteer 24 otherwise looks for the
- * specific Chrome build it pins (in ~/.cache/puppeteer), which is not provisioned in CI -- the test
- * runner installs a system google-chrome-stable instead. Prefer an explicit
- * PUPPETEER_EXECUTABLE_PATH, then a system Chrome/Chromium, and finally fall back to Puppeteer's own
- * downloaded browser (used on fresh local setups that have neither installed).
+ * Resolve the browser executable Puppeteer should launch. Prefer an explicit
+ * PUPPETEER_EXECUTABLE_PATH, then the exact Chrome for Testing build pinned in
+ * tests/lib/screenshot-testing/.puppeteerrc.cjs (downloaded by `npm ci` there). CI and local runs
+ * both use that pinned binary, which is what keeps locally generated screenshots comparable to the
+ * CI-generated expected ones. A system Chrome/Chromium is only a last resort (e.g. on linux/arm64,
+ * where no Chrome for Testing build exists): it renders differently, so screenshots generated with
+ * it will NOT match CI.
  */
 function resolveBrowserExecutablePath() {
     if (process.env.PUPPETEER_EXECUTABLE_PATH) {
@@ -81,6 +83,20 @@ function resolveBrowserExecutablePath() {
     }
 
     const fs = require('fs');
+    const path = require('path');
+
+    try {
+        const puppeteer = require(require.resolve('puppeteer', {
+            paths: [path.join(__dirname, '..', 'lib', 'screenshot-testing')],
+        }));
+        const pinnedBrowser = puppeteer.executablePath();
+        if (pinnedBrowser && fs.existsSync(pinnedBrowser)) {
+            return pinnedBrowser;
+        }
+    } catch (e) {
+        // fall through to the system browsers below
+    }
+
     const candidates = [
         '/usr/bin/google-chrome-stable',
         '/usr/bin/google-chrome',
@@ -88,7 +104,15 @@ function resolveBrowserExecutablePath() {
         '/usr/bin/chromium-browser',
     ];
 
-    return candidates.find((candidate) => fs.existsSync(candidate));
+    const systemBrowser = candidates.find((candidate) => fs.existsSync(candidate));
+
+    if (systemBrowser) {
+        console.warn('WARNING: the pinned Chrome for Testing browser was not found (run "npm ci" in '
+            + 'tests/lib/screenshot-testing to download it). Falling back to the system browser at '
+            + systemBrowser + ' -- generated screenshots will NOT match the CI-generated expected ones.');
+    }
+
+    return systemBrowser;
 }
 
 /**

--- a/tests/UI/config.dist.js
+++ b/tests/UI/config.dist.js
@@ -70,12 +70,10 @@ exports.screenshotDiffDir = "./screenshot-diffs";
 
 /**
  * Resolve the browser executable Puppeteer should launch. Prefer an explicit
- * PUPPETEER_EXECUTABLE_PATH, then the exact Chrome for Testing build pinned in
- * tests/lib/screenshot-testing/.puppeteerrc.cjs (downloaded by `npm ci` there). CI and local runs
- * both use that pinned binary, which is what keeps locally generated screenshots comparable to the
- * CI-generated expected ones. A system Chrome/Chromium is only a last resort (e.g. on linux/arm64,
- * where no Chrome for Testing build exists): it renders differently, so screenshots generated with
- * it will NOT match CI.
+ * PUPPETEER_EXECUTABLE_PATH, then the Chrome for Testing version pinned in
+ * tests/lib/screenshot-testing/.puppeteerrc.cjs (downloaded by `npm ci` there). A system
+ * Chrome/Chromium is a last resort (e.g. native linux/arm64, which has no Chrome for Testing
+ * build): it renders differently, so UI screenshots generated with it will NOT match CI.
  */
 function resolveBrowserExecutablePath() {
     if (process.env.PUPPETEER_EXECUTABLE_PATH) {
@@ -84,13 +82,26 @@ function resolveBrowserExecutablePath() {
 
     const fs = require('fs');
     const path = require('path');
+    const harnessDir = path.join(__dirname, '..', 'lib', 'screenshot-testing');
 
+    let pinnedConfig;
     try {
-        const puppeteer = require(require.resolve('puppeteer', {
-            paths: [path.join(__dirname, '..', 'lib', 'screenshot-testing')],
-        }));
-        const pinnedBrowser = puppeteer.executablePath();
-        if (pinnedBrowser && fs.existsSync(pinnedBrowser)) {
+        pinnedConfig = require(path.join(harnessDir, '.puppeteerrc.cjs'));
+        // Compute the pinned browser's path from the harness config directly: Puppeteer's own
+        // executablePath() reads .puppeteerrc.cjs relative to process.cwd(), so it misses the pin
+        // when not run from the harness directory (e.g. the JS test runner).
+        const puppeteerDir = path.dirname(
+            require.resolve('puppeteer/package.json', { paths: [harnessDir] })
+        );
+        const { computeExecutablePath } = require(
+            require.resolve('@puppeteer/browsers', { paths: [puppeteerDir] })
+        );
+        const pinnedBrowser = computeExecutablePath({
+            browser: 'chrome',
+            buildId: pinnedConfig.chrome.version,
+            cacheDir: pinnedConfig.cacheDirectory,
+        });
+        if (fs.existsSync(pinnedBrowser)) {
             return pinnedBrowser;
         }
     } catch (e) {
@@ -107,9 +118,13 @@ function resolveBrowserExecutablePath() {
     const systemBrowser = candidates.find((candidate) => fs.existsSync(candidate));
 
     if (systemBrowser) {
-        console.warn('WARNING: the pinned Chrome for Testing browser was not found (run "npm ci" in '
-            + 'tests/lib/screenshot-testing to download it). Falling back to the system browser at '
-            + systemBrowser + ' -- generated screenshots will NOT match the CI-generated expected ones.');
+        const reason = (pinnedConfig && pinnedConfig.chrome.skipDownload)
+            ? 'no Chrome for Testing build exists for this platform'
+            : 'the pinned Chrome for Testing browser was not found (run "npm ci" in '
+                + 'tests/lib/screenshot-testing to download it)';
+        console.warn('WARNING: ' + reason + '. Falling back to the system browser at '
+            + systemBrowser + ' -- any UI screenshots generated with this browser will NOT match '
+            + 'the CI-generated expected ones.');
     }
 
     return systemBrowser;

--- a/tests/javascript/testrunnerNode.js
+++ b/tests/javascript/testrunnerNode.js
@@ -9,8 +9,7 @@
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0; // ignore ssl errors
 
 const puppeteer = require('puppeteer');
-// Reuse the UI tests' browser config so this runner resolves the same system Chrome/Chromium
-// (Puppeteer 24 otherwise looks for a pinned Chrome build that is not provisioned in CI).
+// Reuse the UI tests' browser config so this runner follows the same browser-selection policy.
 const { browserConfig } = require('../UI/config.dist');
 const baseUrl = process.argv[2] || 'http://localhost/tests/javascript/';
 

--- a/tests/lib/screenshot-testing/.gitignore
+++ b/tests/lib/screenshot-testing/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /*-debug.log
 /local-extras.js
+/.chrome-cache/

--- a/tests/lib/screenshot-testing/.puppeteerrc.cjs
+++ b/tests/lib/screenshot-testing/.puppeteerrc.cjs
@@ -1,0 +1,23 @@
+const { join } = require('path');
+const os = require('os');
+
+/**
+ * Pins the exact Chrome for Testing build Puppeteer downloads (on `npm ci`) and launches for UI
+ * screenshot tests, so CI and local runs render with the byte-identical browser binary.
+ *
+ * Bumping this version is a deliberate event: it changes rendering, so ALL expected screenshots
+ * (core and plugins) must be re-generated against the new browser.
+ */
+module.exports = {
+  // Keep the browser inside the harness directory (like Puppeteer 8's node_modules/.local-chromium)
+  // so it survives DDEV container rebuilds and lives in the same place on CI checkouts.
+  cacheDirectory: join(__dirname, '.chrome-cache'),
+  chrome: {
+    version: '150.0.7871.124',
+    // Chrome for Testing publishes no linux/arm64 build; skip the download there so `npm ci`
+    // succeeds (tests/UI/config.dist.js then falls back to a system browser with a warning).
+    skipDownload: os.arch() !== 'x64' && process.platform === 'linux',
+  },
+  // Unused: tests run the default "new" headless mode of the full Chrome binary.
+  'chrome-headless-shell': { skipDownload: true },
+};

--- a/tests/lib/screenshot-testing/.puppeteerrc.cjs
+++ b/tests/lib/screenshot-testing/.puppeteerrc.cjs
@@ -1,22 +1,22 @@
 const { join } = require('path');
-const os = require('os');
 
 /**
- * Pins the exact Chrome for Testing build Puppeteer downloads (on `npm ci`) and launches for UI
- * screenshot tests, so CI and local runs render with the byte-identical browser binary.
+ * Pins the Chrome for Testing version Puppeteer downloads (on `npm ci`) and launches for UI
+ * screenshot tests. CI and local linux/x64 runs (incl. DDEV as amd64 under Rosetta) use the same
+ * binary; native linux/arm64 has no Chrome for Testing build and falls back to a system browser
+ * (see tests/UI/config.dist.js).
  *
  * Bumping this version is a deliberate event: it changes rendering, so ALL expected screenshots
  * (core and plugins) must be re-generated against the new browser.
  */
 module.exports = {
-  // Keep the browser inside the harness directory (like Puppeteer 8's node_modules/.local-chromium)
-  // so it survives DDEV container rebuilds and lives in the same place on CI checkouts.
+  // Keep the browser inside the harness dir so it survives DDEV container rebuilds
+  // (as Puppeteer 8's node_modules/.local-chromium did).
   cacheDirectory: join(__dirname, '.chrome-cache'),
   chrome: {
     version: '150.0.7871.124',
-    // Chrome for Testing publishes no linux/arm64 build; skip the download there so `npm ci`
-    // succeeds (tests/UI/config.dist.js then falls back to a system browser with a warning).
-    skipDownload: os.arch() !== 'x64' && process.platform === 'linux',
+    // No linux/arm64 build exists; skip the download there so `npm ci` succeeds.
+    skipDownload: process.arch !== 'x64' && process.platform === 'linux',
   },
   // Unused: tests run the default "new" headless mode of the full Chrome binary.
   'chrome-headless-shell': { skipDownload: true },

--- a/tests/lib/screenshot-testing/package-lock.json
+++ b/tests/lib/screenshot-testing/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0+",
       "dependencies": {
+        "@puppeteer/browsers": "2.13.2",
         "@testomatio/reporter": "^1.6.17",
         "chai": "^4.5.0",
         "chai-files": "^1.4.0",

--- a/tests/lib/screenshot-testing/package.json
+++ b/tests/lib/screenshot-testing/package.json
@@ -13,11 +13,15 @@
     "fs-extra": "^11.3.5",
     "mocha": "^11.7.6",
     "puppeteer": "^24.0.0",
+    "@puppeteer/browsers": "2.13.2",
     "qs": "^6.14.0",
     "@testomatio/reporter": "^1.6.17",
     "mocha-multi-reporters": "^1.5.1"
   },
   "overrides": {
     "axios": "^1.12.2"
+  },
+  "allowScripts": {
+    "puppeteer": true
   }
 }


### PR DESCRIPTION
### Description

Since the Puppeteer 24 modernization (#24677), the screenshot harness prefers a *system* browser. That made UI test rendering unpredictable on both sides:

- **CI** launches `google-chrome-stable`, which the test action apt-upgrades on every run — a floating version (149 → 150 → 151 flips already observed). Every Chrome stable release silently invalidates the expected screenshots of every open branch at once.
- **Local DDEV** launches Debian's Chromium — a different vendor build and a different major than CI — so locally generated screenshots stopped matching the CI-generated expected ones (full-page screenshots even differ in *dimensions*, since font metrics change the page height).

On 5.x this never happened because neither side set `executablePath`: both ran the exact Chromium build pinned inside Puppeteer 8. This PR restores that guarantee with the modern mechanism:

- **`tests/lib/screenshot-testing/.puppeteerrc.cjs`** pins Chrome for Testing `150.0.7871.124`. `npm ci` downloads it (CI already runs that; locally it lands in the in-repo `.chrome-cache/` so it survives DDEV container rebuilds — same pattern as Puppeteer 8's `node_modules/.local-chromium`).
- **`tests/UI/config.dist.js`** now prefers the pinned browser; an explicit `PUPPETEER_EXECUTABLE_PATH` still wins, and a system browser remains a last resort (e.g. linux/arm64, where no Chrome for Testing build exists) with a loud warning that its screenshots will not match CI.
- **`.gitignore`**: ignore the browser cache directory.

No changes to github-action-tests are needed — its `npm ci` picks up the pin automatically, and its `apt-get --only-upgrade google-chrome-stable` step simply becomes unused on 6.x (still needed for 5.x).

**Version choice:** `150.0.7871.124` is the latest patch of the 150.0.7871 build in the Chrome-for-Testing known-good list, i.e. the same build line the current expected screenshots were rendered with — so re-baselining churn is minimal. (Puppeteer 24.43.1's stock pin would be Chrome 148, forcing a full re-baseline of everything.) Bumping this pin in the future is a deliberate event that requires re-generating all expected screenshots (core + plugins).

### Verification

- Local run with the pinned browser (Login suite): 20 of 21 screenshots match the CI-generated expected files pixel-perfectly; the one failure is the known local font-inventory difference on the Morpheus error page (a follow-up will align the DDEV fonts with CI).
- Expected screenshots synced from CI runs after 2026-07-29 were rendered by Chrome 151 and may need a one-time re-sync against this pin; after that, Chrome stable releases can no longer move CI's rendering.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
