### PR TITLE
Add token_auth and token to default URL parameter exclusion list

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1028,7 +1028,7 @@ default_time_one_page_visit = 0
 
 ; Comma separated list of URL query string variable names that will be removed from your tracked URLs
 ; By default, Matomo will remove the most common parameters which are known to change often (eg. session ID parameters)
-url_query_parameter_to_exclude_from_url = "gclid,fbclid,msclkid,twclid,wbraid,gbraid,yclid,fb_xd_fragment,fb_comment_id,phpsessid,jsessionid,sessionid,aspsessionid,doing_wp_cron,sid,pk_vid,li_fat_id"
+url_query_parameter_to_exclude_from_url = "gclid,fbclid,msclkid,twclid,wbraid,gbraid,yclid,fb_xd_fragment,fb_comment_id,phpsessid,jsessionid,sessionid,aspsessionid,doing_wp_cron,sid,pk_vid,li_fat_id,token_auth,token"
 
 ; If set to 1, Matomo will use the default provider if no other provider is configured.
 ; In addition the default provider will be used as a fallback when the configure provider does not return any results.


### PR DESCRIPTION
# Summary

Adds `token_auth` and `token` to the shipped default exclusion list in `config/global.ini.php` under the `[Tracker]` section's `url_query_parameter_to_exclude_from_url` setting.

## Background

`token_auth` is a permanent authentication credential—more sensitive than any session identifier currently included in the default exclusion list (e.g., `phpsessid`, `jsessionid`, etc.).

When a tracked URL contains `token_auth` as a query parameter, the complete URL (including the credential) is stored in `matomo_log_action.name`. A user with view-level access can subsequently retrieve the token via the `Live.getLastVisitsDetails` API.

## Related

- Closes #24924
- HackerOne Report: **#3889819**

## Change

A one-line update appending the following parameters to the default exclusion list:

```ini
token_auth,token
```

This results in:

```ini
url_query_parameter_to_exclude_from_url = "...existing_parameters...,token_auth,token"
```

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules