### PR TITLE
Make the pinned UI-test browser take effect where it silently did not

### DIFF
--- a/.ddev/commands/host/matomo_init_tests
+++ b/.ddev/commands/host/matomo_init_tests
@@ -22,6 +22,11 @@ ddev matomo:console tests:setup-fixture OmniFixture
 echo "Install the JavaScript dependencies for the UI tests ..."
 ddev exec 'cd tests/lib/screenshot-testing && npm install'
 
+# npm only runs Puppeteer's postinstall (which downloads the browser) when it actually reinstalls
+# Puppeteer, so an existing node_modules would otherwise keep the pinned browser missing.
+echo "Download the pinned browser for the UI tests ..."
+ddev exec 'cd tests/lib/screenshot-testing && npm run install-browser'
+
 echo "TODO: Locally install the git-lfs extension to be able to download and commit UI screenshots."
 echo "@see https://github.com/git-lfs/git-lfs#installing"
 echo "@see https://git-lfs.com/"

--- a/.ddev/initial-config/config.js
+++ b/.ddev/initial-config/config.js
@@ -5,6 +5,9 @@ exports.phpServer = {
     REMOTE_ADDR: '127.0.0.1'
 };
 
-// browserConfig (including the Chrome/Chromium executable path) is provided by tests/UI/config.dist.js,
-// which resolves the Chromium the ddev web image installs. Local screenshots may still differ
-// slightly from the CI-generated expected screenshots.
+// browserConfig (including the Chrome executable path) is provided by tests/UI/config.dist.js,
+// which resolves the Chrome for Testing version pinned in
+// tests/lib/screenshot-testing/.puppeteerrc.cjs -- the same browser CI uses, so local screenshots
+// should match the expected ones. If it warns about falling back to the ddev web image's Chromium
+// instead, the pinned browser has not been downloaded yet: run
+// `ddev exec 'cd tests/lib/screenshot-testing && npm run install-browser'`.

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-[*.{js,jsx,ts,tsx,vue}]
+[*.{js,cjs,mjs,jsx,ts,tsx,vue}]
 indent_style = space
 indent_size = 2
 end_of_line = lf

--- a/tests/README.screenshots.md
+++ b/tests/README.screenshots.md
@@ -4,3 +4,15 @@ Matomo contains UI tests that compare captured screenshots of URLs and UI contro
 If a captured screenshot does not match its expected screenshot, the build will fail. 
 
 For a developer documentation, refer to the following guide: https://developer.matomo.org/guides/tests-ui
+
+## Browser
+
+Screenshots are rendered by a fixed Chrome for Testing version, pinned in
+`lib/screenshot-testing/.puppeteerrc.cjs`, so that rendering does not change with the Chrome release
+the machine happens to have. Download it with `npm run install-browser` in `tests/lib/screenshot-testing`
+(`ddev matomo:init:tests` does this for you). Without it, the tests warn and fall back to a system
+Chrome, whose screenshots will not match the expected ones.
+
+Bumping the pinned version changes rendering, so **all** expected screenshots -- core and plugins --
+have to be re-generated in the same change. Native linux/arm64 has no Chrome for Testing build and
+always uses a system browser, so expected screenshots cannot be generated there.

--- a/tests/UI/config.dist.js
+++ b/tests/UI/config.dist.js
@@ -89,7 +89,9 @@ function resolveBrowserExecutablePath() {
         pinnedConfig = require(path.join(harnessDir, '.puppeteerrc.cjs'));
         // Compute the pinned browser's path from the harness config directly: Puppeteer's own
         // executablePath() reads .puppeteerrc.cjs relative to process.cwd(), so it misses the pin
-        // when not run from the harness directory (e.g. the JS test runner).
+        // when not run from the harness directory (e.g. the JS test runner). @puppeteer/browsers is
+        // deliberately resolved through Puppeteer's own tree rather than declared as a dependency
+        // here, so it always matches the exact version the installed Puppeteer pins.
         const puppeteerDir = path.dirname(
             require.resolve('puppeteer/package.json', { paths: [harnessDir] })
         );

--- a/tests/UI/config.dist.js
+++ b/tests/UI/config.dist.js
@@ -98,10 +98,12 @@ function resolveBrowserExecutablePath() {
         const { computeExecutablePath } = require(
             require.resolve('@puppeteer/browsers', { paths: [puppeteerDir] })
         );
+        // Apply the same environment overrides Puppeteer applies when it downloads the browser,
+        // otherwise the browser gets downloaded to one location and looked for in another.
         const pinnedBrowser = computeExecutablePath({
             browser: 'chrome',
-            buildId: pinnedConfig.chrome.version,
-            cacheDir: pinnedConfig.cacheDirectory,
+            buildId: process.env.PUPPETEER_CHROME_VERSION || pinnedConfig.chrome.version,
+            cacheDir: process.env.PUPPETEER_CACHE_DIR || pinnedConfig.cacheDirectory,
         });
         if (fs.existsSync(pinnedBrowser)) {
             return pinnedBrowser;

--- a/tests/UI/config.dist.js
+++ b/tests/UI/config.dist.js
@@ -68,12 +68,22 @@ exports.processedScreenshotsDir = "./processed-ui-screenshots";
  */
 exports.screenshotDiffDir = "./screenshot-diffs";
 
+function warnAboutFallbackBrowser(reason, systemBrowser) {
+    const fallback = systemBrowser
+        ? 'the system browser at ' + systemBrowser
+        : "Puppeteer's own browser resolution";
+
+    console.warn('WARNING: ' + reason + '. Falling back to ' + fallback + ' -- any UI screenshots '
+        + 'generated with it will NOT match the CI-generated expected ones.');
+}
+
 /**
  * Resolve the browser executable Puppeteer should launch. Prefer an explicit
  * PUPPETEER_EXECUTABLE_PATH, then the Chrome for Testing version pinned in
- * tests/lib/screenshot-testing/.puppeteerrc.cjs (downloaded by `npm ci` there). A system
- * Chrome/Chromium is a last resort (e.g. native linux/arm64, which has no Chrome for Testing
- * build): it renders differently, so UI screenshots generated with it will NOT match CI.
+ * tests/lib/screenshot-testing/.puppeteerrc.cjs (see `npm run install-browser` there). A system
+ * Chrome/Chromium is a last resort: it renders differently, so UI screenshots generated with it
+ * will NOT match CI. That is expected on platforms without a Chrome for Testing build (native
+ * linux/arm64) and a setup problem everywhere else, which fails hard on CI.
  */
 function resolveBrowserExecutablePath() {
     if (process.env.PUPPETEER_EXECUTABLE_PATH) {
@@ -85,31 +95,46 @@ function resolveBrowserExecutablePath() {
     const harnessDir = path.join(__dirname, '..', 'lib', 'screenshot-testing');
 
     let pinnedConfig;
+    let pinnedError;
     try {
         pinnedConfig = require(path.join(harnessDir, '.puppeteerrc.cjs'));
-        // Compute the pinned browser's path from the harness config directly: Puppeteer's own
-        // executablePath() reads .puppeteerrc.cjs relative to process.cwd(), so it misses the pin
-        // when not run from the harness directory (e.g. the JS test runner). @puppeteer/browsers is
-        // deliberately resolved through Puppeteer's own tree rather than declared as a dependency
-        // here, so it always matches the exact version the installed Puppeteer pins.
-        const puppeteerDir = path.dirname(
-            require.resolve('puppeteer/package.json', { paths: [harnessDir] })
-        );
-        const { computeExecutablePath } = require(
-            require.resolve('@puppeteer/browsers', { paths: [puppeteerDir] })
-        );
-        // Apply the same environment overrides Puppeteer applies when it downloads the browser,
-        // otherwise the browser gets downloaded to one location and looked for in another.
-        const pinnedBrowser = computeExecutablePath({
-            browser: 'chrome',
-            buildId: process.env.PUPPETEER_CHROME_VERSION || pinnedConfig.chrome.version,
-            cacheDir: process.env.PUPPETEER_CACHE_DIR || pinnedConfig.cacheDirectory,
-        });
-        if (fs.existsSync(pinnedBrowser)) {
-            return pinnedBrowser;
-        }
     } catch (e) {
-        // fall through to the system browsers below
+        pinnedError = e;
+    }
+
+    // Platforms the pin skips have no Chrome for Testing build to launch. Do not even look for one
+    // there: @puppeteer/browsers maps linux/arm64 onto the linux64 download, so a browser found in
+    // the cache would be an x64 binary that cannot run. An unreadable config is a setup problem
+    // rather than an unsupported platform, so it must not take this branch.
+    const platformSkipsPinnedBuild = !!pinnedConfig && !!pinnedConfig.chrome
+        && !!pinnedConfig.chrome.skipDownload;
+
+    if (pinnedConfig && !platformSkipsPinnedBuild) {
+        try {
+            // Compute the pinned browser's path from the harness config directly: Puppeteer's own
+            // executablePath() reads .puppeteerrc.cjs relative to process.cwd(), so it misses the
+            // pin when not run from the harness directory (e.g. the JS test runner).
+            // @puppeteer/browsers is deliberately resolved through Puppeteer's own tree rather than
+            // declared as a dependency here, so it always matches the version Puppeteer pins.
+            const puppeteerDir = path.dirname(
+                require.resolve('puppeteer/package.json', { paths: [harnessDir] })
+            );
+            const { computeExecutablePath } = require(
+                require.resolve('@puppeteer/browsers', { paths: [puppeteerDir] })
+            );
+            // Apply the same environment overrides Puppeteer applies when it downloads the browser,
+            // otherwise the browser gets downloaded to one location and looked for in another.
+            const pinnedBrowser = computeExecutablePath({
+                browser: 'chrome',
+                buildId: process.env.PUPPETEER_CHROME_VERSION || pinnedConfig.chrome.version,
+                cacheDir: process.env.PUPPETEER_CACHE_DIR || pinnedConfig.cacheDirectory,
+            });
+            if (fs.existsSync(pinnedBrowser)) {
+                return pinnedBrowser;
+            }
+        } catch (e) {
+            pinnedError = e;
+        }
     }
 
     const candidates = [
@@ -121,15 +146,24 @@ function resolveBrowserExecutablePath() {
 
     const systemBrowser = candidates.find((candidate) => fs.existsSync(candidate));
 
-    if (systemBrowser) {
-        const reason = (pinnedConfig && pinnedConfig.chrome.skipDownload)
-            ? 'no Chrome for Testing build exists for this platform'
-            : 'the pinned Chrome for Testing browser was not found (run "npm ci" in '
-                + 'tests/lib/screenshot-testing to download it)';
-        console.warn('WARNING: ' + reason + '. Falling back to the system browser at '
-            + systemBrowser + ' -- any UI screenshots generated with this browser will NOT match '
-            + 'the CI-generated expected ones.');
+    if (platformSkipsPinnedBuild) {
+        warnAboutFallbackBrowser('no Chrome for Testing build exists for this platform',
+            systemBrowser);
+
+        return systemBrowser;
     }
+
+    // Anywhere else a missing pin is a setup problem. Warn locally so a developer can still work,
+    // but fail on CI: comparing screenshots rendered by an unpinned browser is worse than no run.
+    const reason = 'the pinned Chrome for Testing browser was not found'
+        + (pinnedError ? ' (' + pinnedError.message + ')' : '')
+        + '. Run "npm run install-browser" in tests/lib/screenshot-testing to download it';
+
+    if (process.env.CI) {
+        throw new Error(reason);
+    }
+
+    warnAboutFallbackBrowser(reason, systemBrowser);
 
     return systemBrowser;
 }

--- a/tests/lib/screenshot-testing/package-lock.json
+++ b/tests/lib/screenshot-testing/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "GPL-3.0+",
       "dependencies": {
-        "@puppeteer/browsers": "2.13.2",
         "@testomatio/reporter": "^1.6.17",
         "chai": "^4.5.0",
         "chai-files": "^1.4.0",

--- a/tests/lib/screenshot-testing/package.json
+++ b/tests/lib/screenshot-testing/package.json
@@ -13,7 +13,6 @@
     "fs-extra": "^11.3.5",
     "mocha": "^11.7.6",
     "puppeteer": "^24.0.0",
-    "@puppeteer/browsers": "2.13.2",
     "qs": "^6.14.0",
     "@testomatio/reporter": "^1.6.17",
     "mocha-multi-reporters": "^1.5.1"

--- a/tests/lib/screenshot-testing/package.json
+++ b/tests/lib/screenshot-testing/package.json
@@ -7,6 +7,9 @@
   "engines": {
     "node": ">=24.0.0 <25.0.0"
   },
+  "scripts": {
+    "install-browser": "puppeteer browsers install chrome"
+  },
   "dependencies": {
     "chai": "^4.5.0",
     "chai-files": "^1.4.0",


### PR DESCRIPTION
### Description

Follow-up polish for #24954, which is already merged.

An adversarial review of #24954 confirmed the pin itself works — CI genuinely launches Chrome for Testing `150.0.7871.124` now (the runner's own `google-chrome-stable` was apt-upgraded to `151.0.7922.71` in that run, and the fallback warning is absent from every UI job log). The issues found were all around the pin rather than in it: the places where it silently does *not* take effect.

**The pin was reachable only through Puppeteer's `postinstall`, which npm skips when Puppeteer is already installed.** `ddev matomo:init:tests` runs `npm install`, so every existing local checkout kept rendering with the DDEV image's Chromium — the exact mismatch the pin removes. Reproduced in DDEV: `npm install` leaves no `.chrome-cache/` at all. There is now an explicit `npm run install-browser` script, wired into `matomo:init:tests`, which also keeps working under `--ignore-scripts` and under npm 12's blocked-by-default install scripts.

**A missing pin degraded quietly.** It only printed a warning, and printed nothing at all when no system browser existed — Puppeteer then resolved its own browser through its cwd-relative config lookup, i.e. the very miss that `0cf6c840d3` fixed. A wrong-browser run could therefore compare screenshots and report green. It now warns locally (so a developer can keep working) but throws when `CI` is set, and reports the underlying cause instead of discarding it.

**The hand-rolled path computation skipped Puppeteer's own environment overrides.** With `PUPPETEER_CACHE_DIR` set, `npm ci` stored the browser in one place while the UI tests looked for it in another and fell back to the system browser — reproduced in DDEV, fixed by applying `PUPPETEER_CACHE_DIR` / `PUPPETEER_CHROME_VERSION` the same way Puppeteer does when downloading.

**The pinned path is no longer trusted on platforms the pin skips.** `@puppeteer/browsers` maps linux/arm64 onto the *linux64* download (no arm64 Chrome for Testing build exists — verified 404), so a browser found in the cache there would be an unrunnable x64 binary.

Also: `@puppeteer/browsers` no longer appears in `package.json`. The code deliberately resolves it from the installed Puppeteer's own tree to stay in lockstep with the exact version Puppeteer pins, so a second declaration could only compete with that — Dependabot would bump it independently. `package-lock.json` returns to its pre-#24954 state. Documentation follows: the regenerate-all-screenshots rule and the arm64 caveat move out of a code comment into `tests/README.screenshots.md`, and the DDEV UI-test config no longer tells developers their screenshots will differ from CI's.

Two review findings were deliberately **not** acted on:

- **`allowScripts` stays name-only (`"puppeteer": true`) rather than version-pinned.** npm 12 writes pinned entries by default so a bumped version gets re-reviewed, but CI installs the harness through `matomo-org/github-action-tests`, which has no step that would call `npm run install-browser` — under npm 12 the postinstall is what keeps CI on the pin, and a pinned entry would drop the browser on every Dependabot Puppeteer bump.
- **The browser cache stays inside the harness directory.** Surviving DDEV container rebuilds is worth more than keeping 382 MB out of the mutagen-synced project dir; worth revisiting only if someone actually hits sync slowness.

### Verification

Run in DDEV (node 24.13.0, npm 11.6.2). Every branch of the resolver was exercised:

| Scenario | Result |
| --- | --- |
| Pinned browser present | resolves `.chrome-cache/chrome/linux-150.0.7871.124/.../chrome`, launches |
| `PUPPETEER_EXECUTABLE_PATH` set | override wins |
| Pin missing, local | warns, falls back to system browser |
| Pin missing, `CI=true` | throws, naming the root cause |
| Pin missing, `PUPPETEER_CACHE_DIR` set | resolves the browser at the overridden cache dir |
| Unsupported platform (`skipDownload`) | warns, never throws, ignores any cached binary |
| Unreadable `.puppeteerrc.cjs` | treated as a setup problem, not an unsupported platform |

Also verified: `npm install` alone leaves no browser, while `npm run install-browser` produces `linux-150.0.7871.124`; the resolver is still cwd-independent (checked from `tests/javascript`); `package-lock.json` is byte-identical to its pre-#24954 state; and no added line exceeds the 100-character `.editorconfig` limit.

Not verified locally: a real screenshot comparison. `tests:run-ui Theme` fails in this environment with `net::ERR_BLOCKED_BY_CLIENT` on the `tests/PHPUnit/proxy/` URL — but identically without these changes, so it pre-dates them. Neither branch printed the fallback warning, so both used the pinned browser. CI on this PR is the real check, and it also exercises the new hard-fail path.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
