### PR TITLE
Scope goal-name segment join to the matching site

### DIFF
--- a/core/Columns/Join.php
+++ b/core/Columns/Join.php
@@ -58,4 +58,17 @@ class Join
     {
         return $this->targetColumn;
     }
+
+    /**
+     * Columns that must additionally match between the joined-from table and the joined table
+     * to identify a row, given as column names present on both tables. Use this when the primary
+     * join column is not unique on its own and needs a composite key (for example the site id).
+     *
+     * @return string[]
+     * @since 5.13.0
+     */
+    public function getAdditionalKeyColumns()
+    {
+        return [];
+    }
 }

--- a/core/Columns/Join/GoalNameJoin.php
+++ b/core/Columns/Join/GoalNameJoin.php
@@ -21,4 +21,10 @@ class GoalNameJoin extends Columns\Join
     {
         parent::__construct('goal', 'idgoal', 'name');
     }
+
+    public function getAdditionalKeyColumns()
+    {
+        // a goal is identified by (idsite, idgoal), so the site must match too
+        return ['idsite'];
+    }
 }

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -435,11 +435,23 @@ class Segment
             // then we would join an extra table per segment when we ideally want to join each table only once. However, we still need
             // to see which table/column it joins to join it accurately each table extra if the same table is joined with different columns;
             $tableAlias = $join->getTable() . '_segment_' . str_replace('.', '', $sqlName ?: '');
+
+            $joinConditions = [$sqlName . ' = ' . $tableAlias . '.' . $join->getColumn()];
+
+            // additional key columns scope the join to the same row on both tables (eg the site id),
+            // so a value cannot match a row that only shares the primary join column
+            $sourceTable = strpos((string) $sqlName, '.') !== false ? strstr($sqlName, '.', true) : null;
+            if ($sourceTable !== null) {
+                foreach ($join->getAdditionalKeyColumns() as $keyColumn) {
+                    $joinConditions[] = $sourceTable . '.' . $keyColumn . ' = ' . $tableAlias . '.' . $keyColumn;
+                }
+            }
+
             $joinTable = [
                 'table' => $join->getTable(),
                 'tableAlias' => $tableAlias,
                 'field' => $tableAlias . '.' . $join->getTargetColumn(),
-                'joinOn' => $sqlName . ' = ' . $tableAlias . '.' . $join->getColumn(),
+                'joinOn' => implode(' AND ', $joinConditions),
             ];
 
             if ($dbDiscriminator) {

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -2764,4 +2764,79 @@ SQL;
             $dimensions[] = $thingCategoryDimension;
         });
     }
+
+    public function testJoinExposesNoAdditionalKeyColumnsByDefault()
+    {
+        $join = new \Piwik\Columns\Join('goal', 'idgoal', 'name');
+        $this->assertSame([], $join->getAdditionalKeyColumns());
+    }
+
+    public function testGoalNameJoinIsScopedBySite()
+    {
+        $join = new \Piwik\Columns\Join\GoalNameJoin();
+        $this->assertSame(['idsite'], $join->getAdditionalKeyColumns());
+    }
+
+    /**
+     * A goal is identified by the pair (idsite, idgoal), so the goal-name join must match on both
+     * columns and not on idgoal alone.
+     */
+    public function testVisitConvertedGoalNameSegmentScopesGoalJoinBySite()
+    {
+        $segment = new Segment('visitConvertedGoalName==name', $idSites = [1]);
+
+        $query = $segment->getSelectQuery('log_visit.*', 'log_visit', false);
+        $this->assertQueryDoesNotFail($query);
+
+        $sql = self::removeExtraWhiteSpaces($query['sql']);
+        $alias = 'goal_segment_log_conversionidgoal';
+
+        $this->assertStringContainsString('log_conversion.idgoal = ' . $alias . '.idgoal', $sql);
+        $this->assertStringContainsString('log_conversion.idsite = ' . $alias . '.idsite', $sql);
+    }
+
+    /**
+     * The join is built the same way regardless of which log table the query starts from, so the site
+     * scoping must also hold when the query is based on log_conversion directly.
+     */
+    public function testVisitConvertedGoalNameSegmentScopesGoalJoinBySiteWhenBasedOnConversion()
+    {
+        $segment = new Segment('visitConvertedGoalName==name', $idSites = [1]);
+
+        $query = $segment->getSelectQuery('log_conversion.*', 'log_conversion', false);
+        $this->assertQueryDoesNotFail($query);
+
+        $sql = self::removeExtraWhiteSpaces($query['sql']);
+
+        $this->assertStringContainsString('log_conversion.idsite = goal_segment_log_conversionidgoal.idsite', $sql);
+    }
+
+    /**
+     * The join is assembled before the match type is applied, so the site scoping must hold for every
+     * operator that can carry a goal name.
+     *
+     * @dataProvider getGoalNameSegmentOperators
+     */
+    public function testVisitConvertedGoalNameSegmentScopesGoalJoinBySiteForEveryOperator($operator)
+    {
+        $segment = new Segment('visitConvertedGoalName' . $operator . 'name', $idSites = [1]);
+
+        $query = $segment->getSelectQuery('log_visit.*', 'log_visit', false);
+        $this->assertQueryDoesNotFail($query);
+
+        $sql = self::removeExtraWhiteSpaces($query['sql']);
+        $this->assertStringContainsString('log_conversion.idsite = goal_segment_log_conversionidgoal.idsite', $sql);
+    }
+
+    public function getGoalNameSegmentOperators()
+    {
+        return [
+            'equals'       => ['=='],
+            'not equals'   => ['!='],
+            'contains'     => ['=@'],
+            'not contains' => ['!@'],
+            'starts with'  => ['=^'],
+            'ends with'    => ['=$'],
+        ];
+    }
 }


### PR DESCRIPTION
Scopes the goal-name segment (`visitConvertedGoalName`) join to the goal's site.

A goal is identified by the pair `(idsite, idgoal)`, but the join matched on `idgoal` alone. Join descriptors can now declare additional key columns, and the goal-name join adds the site id so a segment value only matches a goal belonging to the same site as the conversion. Includes regression tests.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
