### PR TITLE
Encode comparison series suffix when building comparison labels (backport of #24964)

### DIFF
--- a/core/API/DataTableManipulator/LabelFilter.php
+++ b/core/API/DataTableManipulator/LabelFilter.php
@@ -204,8 +204,11 @@ class LabelFilter extends DataTableManipulator
 
                             $row = $comparisons->getRowFromId($labelSeriesIndex);
 
+                            // the suffix is appended after labels are sanitized, so encode it to match
+                            $comparisonSuffix = Common::sanitizeInputValue((string) $row->getMetadata('compareSeriesPretty'));
+
                             // add label and make sure it is the first column
-                            $columns = array_merge(['label' => $originalLabel . ' ' . $row->getMetadata('compareSeriesPretty')], $row->getColumns());
+                            $columns = array_merge(['label' => $originalLabel . ' ' . $comparisonSuffix], $row->getColumns());
                             $row->setColumns($columns);
                         }
                     }


### PR DESCRIPTION
Encodes the comparison series suffix the same way as the surrounding label when it is appended while building comparison labels, so the label column stays consistently encoded. No-op for labels without HTML-special characters.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

Backport of #24964.
