### PR TITLE
Send API exception HTTP response codes only for actual API requests

### DIFF
--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -143,7 +143,11 @@ class ResponseBuilder
             $this->sendHeader
             && $e instanceof HttpCodeException
             && $e->getCode() > 0
+            && Request::isRootRequestApiRequest()
         ) {
+            // Only the response of an actual API HTTP request may carry the exception's HTTP code.
+            // API calls issued while rendering a regular page (e.g. a widget fetching additional
+            // data) would otherwise overwrite the status code of an outer response that succeeds.
             http_response_code($e->getCode());
         }
 


### PR DESCRIPTION
### Description

Fixes #25001

A dashboard widget could render successfully yet be delivered with an HTTP 4xx status code, making the dashboard show it as failed to load. This happens when an API call issued in-process while rendering the page — for example the evolution graphs' forecast precomputation added in #24938 — throws an `HttpCodeException`: `ResponseBuilder::getResponseException()` set the exception's HTTP code on the outer response, even though the `original`-format renderer rethrows the exception to a caller that may handle it and finish rendering normally. First reported for the Cohorts plugin's evolution graph widgets, whose required API parameters are injected server-side and are therefore missing from the forecast's inner requests.

The fix guards the `http_response_code()` call with `Request::isRootRequestApiRequest()` — the same condition `Plugins\API\Renderer\Original::sendHeader()` already uses to keep the API content-type header out of non-API responses — so only responses to actual `module=API` HTTP requests carry API exception status codes.

Note on test coverage: this path is not reachable under PHPUnit, because `decorateExceptionWithDebugTrace()` rewraps every exception as a plain `Exception` whenever `PIWIK_PATH_TEST_TO_ROOT` is defined, so the `instanceof HttpCodeException` guard can never pass in a test run (the behaviour introduced in #14023 has no direct coverage for the same reason). The fix was verified by tracing the reported failure end-to-end against a production instance.

This needs a backport to 5.x-dev before 5.13.0 stable, since #24938 is what makes this path hot there.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
