### PR TITLE
Exclude token_auth and token from tracked URLs by default

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1028,7 +1028,7 @@ default_time_one_page_visit = 0
 
 ; Comma separated list of URL query string variable names that will be removed from your tracked URLs
 ; By default, Matomo will remove the most common parameters which are known to change often (eg. session ID parameters)
-url_query_parameter_to_exclude_from_url = "gclid,fbclid,msclkid,twclid,wbraid,gbraid,yclid,fb_xd_fragment,fb_comment_id,phpsessid,jsessionid,sessionid,aspsessionid,doing_wp_cron,sid,pk_vid,li_fat_id"
+url_query_parameter_to_exclude_from_url = "gclid,fbclid,msclkid,twclid,wbraid,gbraid,yclid,fb_xd_fragment,fb_comment_id,phpsessid,jsessionid,sessionid,aspsessionid,doing_wp_cron,sid,pk_vid,li_fat_id,token_auth,token"
 
 ; If set to 1, Matomo will use the default provider if no other provider is configured.
 ; In addition the default provider will be used as a fallback when the configure provider does not return any results.

--- a/tests/PHPUnit/Integration/Tracker/ActionTest.php
+++ b/tests/PHPUnit/Integration/Tracker/ActionTest.php
@@ -231,6 +231,45 @@ class ActionTest extends IntegrationTestCase
         $this->assertEquals($filteredUrl, PageUrl::excludeQueryParametersFromUrl($url, $idSite));
     }
 
+    public function getTestSensitiveTokenUrls()
+    {
+        return [
+            ['https://www.example.com?token_auth=abc123', 'https://www.example.com'],
+            ['https://www.example.com?token=abc123', 'https://www.example.com'],
+            // preserves unrelated params, strips only the credential
+            ['https://www.example.com/path?token_auth=abc123&random=1', 'https://www.example.com/path?random=1'],
+            // matching is case-insensitive (PageUrl lowercases the excluded parameter names)
+            ['https://www.example.com?Token_Auth=abc123', 'https://www.example.com'],
+        ];
+    }
+
+    /**
+     * Sensitive auth tokens must be stripped from tracked URLs by the shipped default exclusion list
+     *
+     * @dataProvider getTestSensitiveTokenUrls
+     */
+    public function testExcludeQueryParametersSensitiveTokens($url, $filteredUrl)
+    {
+        $this->setUpRootAccess();
+        $idSite = API::getInstance()->addSite(
+            "site1",
+            array('http://example.org'),
+            $ecommerce = 0,
+            $siteSearch = 1,
+            $searchKeywordParameters = null,
+            $searchCategoryParameters = null,
+            $excludedIps = '',
+            $excludedQueryParameters = '',
+            $timezone = null,
+            $currency = null,
+            $group = null,
+            $startDate = null,
+            $excludedUserAgents = null,
+            $keepURLFragments = 1
+        );
+        $this->assertEquals($filteredUrl, PageUrl::excludeQueryParametersFromUrl($url, $idSite));
+    }
+
     public function getTestUrlsHashtag()
     {
         $urls = array(

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f481dac18e95a0f4d7dc22b9decc33c76b676ca06c1d5346057a9169c8ea209
-size 4703406
+oid sha256:4c48684337c682d13428227b3b7c4b718e850dcbf9cfa4f7cbd6e1dfb72c56f8
+size 4703923


### PR DESCRIPTION
### Description
DEV-20572

Excluded `token_auth` and `token`by default

refs https://github.com/matomo-org/matomo/issues/24924

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
