### PR TITLE
Use the web image's Debian codename for the ddev contrib apt source

### DIFF
--- a/.ddev/web-build/pre.Dockerfile.aptSourcesContrib
+++ b/.ddev/web-build/pre.Dockerfile.aptSourcesContrib
@@ -1,3 +1,5 @@
 # UI tests require ttf-mscorefonts-installer from contrib
-RUN echo "deb http://deb.debian.org/debian bookworm contrib non-free non-free-firmware" > /etc/apt/sources.list.d/contrib.list
+# Read the codename from the image instead of hardcoding it, so the contrib source
+# stays on the same Debian release the web image is built from
+RUN . /etc/os-release && echo "deb http://deb.debian.org/debian $VERSION_CODENAME contrib non-free non-free-firmware" > /etc/apt/sources.list.d/contrib.list
 RUN apt-get -qq update || true


### PR DESCRIPTION
### Description

Fresh `ddev start` builds of the Matomo web image currently fail while installing `ttf-mscorefonts-installer`: `.ddev/web-build/pre.Dockerfile.aptSourcesContrib` hardcodes the `bookworm` contrib apt source, but DDEV's current web image is based on Debian 13 (trixie), so the package installs from the wrong release and its setup fails, aborting the image build. Existing environments are unaffected until their web image is rebuilt from scratch.

This reads the codename from the image's `/etc/os-release` instead, so the contrib source always matches the Debian release the web image is built from. Verified on a fresh DDEV v1.25.3 build: the hardcoded suite reproducibly fails, the codename-based source builds successfully.

The same file exists on 5.x-dev, where a fresh image build fails identically, so this is worth backporting.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
