### PR TITLE
Add stable identity and dashboard metadata to policy-controlled settings, DEV-20349

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ## Matomo 6.0.0
 
 ### Breaking Changes
+* The interface `Piwik\Settings\Interfaces\PolicyComparisonInterface` gained four methods used by the granular compliance dashboard: `getPolicySettingId()`, `isExternallyManagedByPolicyPage()`, `getWhatItDoes()` and `getImpact()`. Plugins that implement the interface directly must implement them. Plugins using `Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait` (as all known implementers do) inherit default implementations and are not affected.
 * The deprecated method `Piwik\Archive::getBlob()` has been removed. Use one of the `Piwik\Archive::getDataTable*()` methods instead.
 * The deprecated method `Piwik\Archive::clearStaticCache()` has been removed. It was a no-op kept only for backwards compatibility.
 * The deprecated method `Piwik\ArchiveProcessor\Parameters::setIsPartialArchive()` has been removed. Use `Piwik\ArchiveProcessor\Parameters::setArchiveOnlyReport()` instead.

--- a/core/Settings/Interfaces/PolicyComparisonInterface.php
+++ b/core/Settings/Interfaces/PolicyComparisonInterface.php
@@ -12,6 +12,11 @@ namespace Piwik\Settings\Interfaces;
 use Piwik\Policy\CompliancePolicy;
 
 /**
+ * Implement this interface via {@link \Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait},
+ * which provides default implementations for all dashboard-metadata methods.
+ * Methods may be added to this interface in major releases; the trait always
+ * ships matching defaults, so trait users are unaffected.
+ *
  * @template T of mixed
  */
 interface PolicyComparisonInterface
@@ -37,4 +42,34 @@ interface PolicyComparisonInterface
     public static function isControlledBySpecificPolicy(string $policy, ?int $idSite = null): bool;
 
     public static function getComplianceRequirementNote(?int $idSite = null): string;
+
+    /**
+     * Stable identifier of this policy-controlled setting, e.g. used to store
+     * and address its per-policy enforcement state.
+     *
+     * @since Matomo 6.0.0 — {@link PolicyComparisonTrait} provides a default.
+     */
+    public static function getPolicySettingId(): string;
+
+    /**
+     * Whether this setting cannot be enforced from the compliance dashboard and
+     * is instead managed outside of it (e.g. via a config file).
+     *
+     * @since Matomo 6.0.0 — {@link PolicyComparisonTrait} provides a default.
+     */
+    public static function isExternallyManagedByPolicyPage(): bool;
+
+    /**
+     * Short description of what enforcing this setting does.
+     *
+     * @since Matomo 6.0.0 — {@link PolicyComparisonTrait} provides a default.
+     */
+    public static function getWhatItDoes(): string;
+
+    /**
+     * Short description of the impact enforcing this setting has on reports and tracking.
+     *
+     * @since Matomo 6.0.0 — {@link PolicyComparisonTrait} provides a default.
+     */
+    public static function getImpact(): string;
 }

--- a/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
+++ b/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Settings\Interfaces\Traits;
 
+use Piwik\Piwik;
 use Piwik\Policy\CompliancePolicy;
 
 /**
@@ -79,6 +80,27 @@ trait PolicyComparisonTrait
     public static function isControlledBySpecificPolicy(string $policy, ?int $idSite = null): bool
     {
         return array_key_exists($policy, self::getPolicyRequiredValues($idSite));
+    }
+
+    public static function getPolicySettingId(): string
+    {
+        $shortClassName = substr(strrchr(static::class, '\\'), 1);
+        return Piwik::getPluginNameOfMatomoClass(static::class) . '.' . $shortClassName;
+    }
+
+    public static function isExternallyManagedByPolicyPage(): bool
+    {
+        return false;
+    }
+
+    public static function getWhatItDoes(): string
+    {
+        return '';
+    }
+
+    public static function getImpact(): string
+    {
+        return '';
     }
 
     /**

--- a/core/Tracker/Config/ThirdPartyCookies.php
+++ b/core/Tracker/Config/ThirdPartyCookies.php
@@ -72,6 +72,17 @@ class ThirdPartyCookies implements
         return Piwik::translate('General_ThirdPartyCookieSettingNote');
     }
 
+    public static function getPolicySettingId(): string
+    {
+        // Piwik::getPluginNameOfMatomoClass() would derive "Config" from the namespace
+        return 'Core.ThirdPartyCookies';
+    }
+
+    public static function isExternallyManagedByPolicyPage(): bool
+    {
+        return true;
+    }
+
     protected static function compareStrictness($value1, $value2): bool
     {
         if ($value1 === true && $value2 === true) {

--- a/tests/PHPUnit/Framework/Mock/Settings/FakePolicySetting.php
+++ b/tests/PHPUnit/Framework/Mock/Settings/FakePolicySetting.php
@@ -52,6 +52,26 @@ class FakePolicySetting implements PolicyComparisonInterface, SettingValueInterf
         return 'fake policy setting compliance note';
     }
 
+    public static function getPolicySettingId(): string
+    {
+        return 'Fake.FakePolicySetting';
+    }
+
+    public static function isExternallyManagedByPolicyPage(): bool
+    {
+        return false;
+    }
+
+    public static function getWhatItDoes(): string
+    {
+        return 'fake policy setting what it does';
+    }
+
+    public static function getImpact(): string
+    {
+        return 'fake policy setting impact';
+    }
+
     public static function getInstance(?int $idSite = null)
     {
         return new self(true);

--- a/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
+++ b/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
@@ -38,4 +38,19 @@ class PolicyComparisonTraitTest extends TestCase
             PolicyComparisonTraitImpl::isControlledBySpecificPolicy(TestPolicy::class)
         );
     }
+
+    public function testGetPolicySettingIdDefaultsToPluginAndShortClassName()
+    {
+        $this->assertSame(
+            'Framework.PolicyComparisonTraitImpl',
+            PolicyComparisonTraitImpl::getPolicySettingId()
+        );
+    }
+
+    public function testDefaultPolicyPageMetadata()
+    {
+        $this->assertFalse(PolicyComparisonTraitImpl::isExternallyManagedByPolicyPage());
+        $this->assertSame('', PolicyComparisonTraitImpl::getWhatItDoes());
+        $this->assertSame('', PolicyComparisonTraitImpl::getImpact());
+    }
 }


### PR DESCRIPTION
Part of DEV-20349. The CNIL compliance page is currently all or nothing, one enforce checkbox that switches every requirement on at once. This is changing to a switch per setting, because customers want to adopt the requirements one at a time, assess the impact of each, and leave the rest of their configuration alone.

For that to work every policy-controlled setting needs a stable identity and needs to explain itself on the new dashboard. This PR adds `getPolicySettingId()` (defaults to `<Plugin>.<ShortClassName>`, e.g. `PrivacyManager.IPAnonymisation`) so per-setting enforcement state can be stored and looked up, plus `isExternallyManagedByPolicyPage()`, `getWhatItDoes()` and `getImpact()` for the dashboard columns. Defaults live in `PolicyComparisonTrait` so existing core and premium settings need no changes. `ThirdPartyCookies` overrides its id (the namespace would derive "Config") and marks itself as managed outside the page, since it comes from the config file.

No behaviour change, this is groundwork. All known implementers use the trait (checked against AbTesting, HeatmapSessionRecording and AdvertisingConversionExport), and there's a changelog entry for anyone implementing the interface directly.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
