### PR TITLE
Add per-setting compliance enforcement read model, DEV-20349

### DIFF
--- a/core/Policy/CompliancePolicy.php
+++ b/core/Policy/CompliancePolicy.php
@@ -14,10 +14,13 @@ use Piwik\Plugin\Manager;
 use Piwik\Settings\FieldConfig;
 use Piwik\Settings\Interfaces\ConfigSettingInterface;
 use Piwik\Settings\Interfaces\MeasurableSettingInterface;
+use Piwik\Settings\Interfaces\PolicyComparisonInterface;
 use Piwik\Settings\Interfaces\SystemSettingInterface;
 use Piwik\Settings\Interfaces\Traits\Getters\ConfigGetterTrait;
 use Piwik\Settings\Interfaces\Traits\Setters\MeasurableSetterTrait;
 use Piwik\Settings\Interfaces\Traits\Setters\SystemSetterTrait;
+use Piwik\Settings\Measurable\MeasurableSetting;
+use Piwik\Settings\Plugin\SystemSetting;
 
 /**
  * @implements SystemSettingInterface<bool>
@@ -79,7 +82,7 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
     }
 
     /**
-     * @return array<array<string>> of [['title' => (string) 'TITLE', 'note' => (string) 'NOTE']]
+     * @return array<array<string>> of [['id' => (string) 'ID', 'title' => (string) 'TITLE', 'note' => (string) 'NOTE']]
      */
     abstract public static function getUnknownSettings(): array;
 
@@ -184,5 +187,95 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
     public static function isConfigControlled()
     {
         return !is_null(static::getConfigValue());
+    }
+
+    /**
+     * Name under which the per-setting enforcement state of the given
+     * policy-controlled setting is stored, at system and measurable scope.
+     *
+     * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
+     */
+    public static function getSettingEnforcementName(string $settingClass): string
+    {
+        $settingId = str_replace('.', '_', $settingClass::getPolicySettingId());
+        return preg_replace('/\s+/', '', static::getName()) . '_enforce__' . $settingId;
+    }
+
+    /**
+     * Returns whether this policy currently enforces the given policy-controlled
+     * setting for the given scope (instance-wide when $idSite is null).
+     *
+     * Resolution order:
+     *  1. config-level enforcement of the whole policy
+     *  2. explicit per-setting enforcement state; an enabled instance-wide state
+     *     applies to all sites, like {@link isActive()} does for the whole policy
+     *  3. the whole-policy enforcement flag, for scopes where no per-setting
+     *     state has been stored yet
+     *
+     * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
+     */
+    public static function isEnforcedForSetting(string $settingClass, ?int $idSite = null): bool
+    {
+        if (static::isConfigControlled()) {
+            return (bool) static::getConfigValue();
+        }
+
+        $systemValue = static::getSettingEnforcementSystemValue($settingClass);
+        if ($systemValue === true) {
+            return true;
+        }
+
+        if (!is_null($idSite)) {
+            $measurableValue = static::getSettingEnforcementMeasurableValue($settingClass, $idSite);
+            if (!is_null($measurableValue)) {
+                return $measurableValue;
+            }
+        }
+
+        if (!is_null($systemValue)) {
+            return false;
+        }
+
+        return static::isActive($idSite);
+    }
+
+    /**
+     * Instance-wide enforcement state of the given setting, or null when no state was ever stored.
+     *
+     * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
+     */
+    protected static function getSettingEnforcementSystemValue(string $settingClass): ?bool
+    {
+        // a null default value allows distinguishing "never stored" from an explicit value
+        $setting = new SystemSetting(
+            static::getSettingEnforcementName($settingClass),
+            null,
+            FieldConfig::TYPE_BOOL,
+            Piwik::getPluginNameOfMatomoClass(static::class)
+        );
+
+        $value = $setting->getValue();
+
+        return is_null($value) ? null : (bool) $value;
+    }
+
+    /**
+     * Per-site enforcement state of the given setting, or null when no state was ever stored.
+     *
+     * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
+     */
+    protected static function getSettingEnforcementMeasurableValue(string $settingClass, int $idSite): ?bool
+    {
+        $setting = new MeasurableSetting(
+            static::getSettingEnforcementName($settingClass),
+            null,
+            FieldConfig::TYPE_BOOL,
+            Piwik::getPluginNameOfMatomoClass(static::class),
+            $idSite
+        );
+
+        $value = $setting->getValue();
+
+        return is_null($value) ? null : (bool) $value;
     }
 }

--- a/core/Policy/PolicyEnforcementBypass.php
+++ b/core/Policy/PolicyEnforcementBypass.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Policy;
+
+/**
+ * Allows evaluating a policy-controlled setting as if no compliance policy was
+ * enforcing it, e.g. to determine whether the underlying Matomo setting would
+ * be compliant on its own.
+ *
+ * @internal
+ */
+class PolicyEnforcementBypass
+{
+    private static bool $active = false;
+
+    public static function isActive(): bool
+    {
+        return self::$active;
+    }
+
+    /**
+     * Runs the given callable with policy enforcement bypassed.
+     *
+     * @template TReturn
+     * @param callable(): TReturn $fn
+     * @return TReturn
+     */
+    public static function run(callable $fn)
+    {
+        $previous = self::$active;
+        self::$active = true;
+        try {
+            return $fn();
+        } finally {
+            self::$active = $previous;
+        }
+    }
+}

--- a/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
+++ b/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
@@ -11,6 +11,7 @@ namespace Piwik\Settings\Interfaces\Traits;
 
 use Piwik\Piwik;
 use Piwik\Policy\CompliancePolicy;
+use Piwik\Policy\PolicyEnforcementBypass;
 
 /**
  * @template T of mixed
@@ -28,7 +29,7 @@ trait PolicyComparisonTrait
 
         /** @var class-string<CompliancePolicy> $policy */
         foreach (array_keys($policyValues) as $policy) {
-            if (!$policy::isActive($idSite)) {
+            if (PolicyEnforcementBypass::isActive() || !$policy::isActive($idSite)) {
                 $policyValues[$policy] = null;
             }
         }

--- a/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
+++ b/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
@@ -13,10 +13,22 @@ class TestPolicy extends \Piwik\Policy\CompliancePolicy
     /** @var array<int,bool> */
     private static $perSite = [];
 
+    /** @var array<string,bool> */
+    private static $settingEnforcementSystem = [];
+
+    /** @var array<int,array<string,bool>> */
+    private static $settingEnforcementPerSite = [];
+
+    /** @var bool|null */
+    private static $configValue = null;
+
     public static function reset(): void
     {
         self::$system = false;
         self::$perSite = [];
+        self::$settingEnforcementSystem = [];
+        self::$settingEnforcementPerSite = [];
+        self::$configValue = null;
     }
 
     public static function getName(): string
@@ -64,6 +76,44 @@ class TestPolicy extends \Piwik\Policy\CompliancePolicy
         $manager = new MockManager();
         $manager->setActivatedPlugins([]);
         return $manager;
+    }
+
+    public static function getConfigValue(?int $idSite = null)
+    {
+        return self::$configValue;
+    }
+
+    public static function setConfigValue(?bool $value): void
+    {
+        self::$configValue = $value;
+    }
+
+    protected static function getSettingEnforcementSystemValue(string $settingClass): ?bool
+    {
+        return self::$settingEnforcementSystem[$settingClass] ?? null;
+    }
+
+    protected static function getSettingEnforcementMeasurableValue(string $settingClass, int $idSite): ?bool
+    {
+        return self::$settingEnforcementPerSite[$idSite][$settingClass] ?? null;
+    }
+
+    public static function setSettingEnforcementSystemValue(string $settingClass, ?bool $value): void
+    {
+        if (is_null($value)) {
+            unset(self::$settingEnforcementSystem[$settingClass]);
+        } else {
+            self::$settingEnforcementSystem[$settingClass] = $value;
+        }
+    }
+
+    public static function setSettingEnforcementMeasurableValue(string $settingClass, int $idSite, ?bool $value): void
+    {
+        if (is_null($value)) {
+            unset(self::$settingEnforcementPerSite[$idSite][$settingClass]);
+        } else {
+            self::$settingEnforcementPerSite[$idSite][$settingClass] = $value;
+        }
     }
 
     public static function setState($instanceLevel, $siteLevel)

--- a/tests/PHPUnit/Unit/Policy/CompliancePolicyTest.php
+++ b/tests/PHPUnit/Unit/Policy/CompliancePolicyTest.php
@@ -4,6 +4,7 @@ namespace Piwik\Tests\Unit\Policy;
 
 use PHPUnit\Framework\TestCase;
 use Piwik\Tests\Framework\Mock\Policy\TestPolicy;
+use Piwik\Tests\Framework\Mock\Settings\FakePolicySetting;
 
 class CompliancePolicyTest extends TestCase
 {
@@ -67,5 +68,92 @@ class CompliancePolicyTest extends TestCase
         yield [99, false, true, false, false, false];
         yield [99, false, false, true, false, false];
         yield [99, false, false, false, false, false];
+    }
+
+    public function testGetSettingEnforcementNameCombinesPolicyAndSettingId(): void
+    {
+        $this->assertSame(
+            'test_policy_v1_enforce__Fake_FakePolicySetting',
+            TestPolicy::getSettingEnforcementName(FakePolicySetting::class)
+        );
+    }
+
+    public function testIsEnforcedForSettingConfigValueShortCircuitsEverything(): void
+    {
+        // per-setting state says "off", config says "on"
+        TestPolicy::setSettingEnforcementSystemValue(FakePolicySetting::class, false);
+        TestPolicy::setConfigValue(true);
+
+        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
+        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
+
+        // per-setting and legacy state say "on", config says "off"
+        TestPolicy::setSettingEnforcementSystemValue(FakePolicySetting::class, true);
+        TestPolicy::setState(true, 99);
+        TestPolicy::setConfigValue(false);
+
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
+    }
+
+    public function testIsEnforcedForSettingSystemStateAppliesToAllSites(): void
+    {
+        TestPolicy::setSettingEnforcementSystemValue(FakePolicySetting::class, true);
+        TestPolicy::setSettingEnforcementMeasurableValue(FakePolicySetting::class, 99, false);
+
+        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
+        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
+    }
+
+    public function testIsEnforcedForSettingSiteStateWinsWhenSystemStateIsOff(): void
+    {
+        TestPolicy::setSettingEnforcementSystemValue(FakePolicySetting::class, false);
+        TestPolicy::setSettingEnforcementMeasurableValue(FakePolicySetting::class, 99, true);
+
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
+        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 100));
+    }
+
+    public function testIsEnforcedForSettingExplicitSystemOffSuppressesLegacyFlag(): void
+    {
+        TestPolicy::setState(true, 99);
+        TestPolicy::setSettingEnforcementSystemValue(FakePolicySetting::class, false);
+
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
+    }
+
+    public function testIsEnforcedForSettingExplicitSiteOffSuppressesLegacyFlag(): void
+    {
+        TestPolicy::setState(false, 99);
+        TestPolicy::setSettingEnforcementMeasurableValue(FakePolicySetting::class, 99, false);
+
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
+    }
+
+    /**
+     * @dataProvider possibleStatesForPolicyActive
+     */
+    public function testIsEnforcedForSettingFallsBackToLegacyPolicyFlag(
+        $idSite,
+        $newActiveState,
+        $currentInstanceState,
+        $currentSiteState,
+        $expectedInstanceState,
+        $expectedSiteState
+    ): void {
+        // without any per-setting state, enforcement must exactly mirror the legacy whole-policy flag
+        TestPolicy::setState($currentInstanceState, $currentSiteState ? 99 : false);
+        TestPolicy::setActiveStatus($idSite, $newActiveState);
+
+        $this->assertSame(
+            $expectedInstanceState,
+            TestPolicy::isEnforcedForSetting(FakePolicySetting::class)
+        );
+        $this->assertSame(
+            $expectedSiteState,
+            TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99)
+        );
     }
 }

--- a/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
+++ b/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
@@ -3,6 +3,7 @@
 namespace Piwik\Tests\Unit\Settings;
 
 use PHPUnit\Framework\TestCase;
+use Piwik\Policy\PolicyEnforcementBypass;
 use Piwik\Policy\PolicyManager;
 use Piwik\Tests\Framework\Mock\Policy\TestPolicy;
 use Piwik\Tests\Framework\Mock\Settings\TraitImpls\PolicyComparisonTraitImpl;
@@ -37,6 +38,37 @@ class PolicyComparisonTraitTest extends TestCase
         $this->assertTrue(
             PolicyComparisonTraitImpl::isControlledBySpecificPolicy(TestPolicy::class)
         );
+    }
+
+    public function testGetPolicyValuesNulledWhileEnforcementIsBypassed()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+
+        $values = PolicyEnforcementBypass::run(function () {
+            return PolicyComparisonTraitImpl::getPolicyRequiredValues();
+        });
+
+        $this->assertCount(1, $values);
+        $this->assertArrayHasKey(TestPolicy::class, $values);
+        $this->assertNull($values[TestPolicy::class]);
+
+        // the bypass must not leak outside of the callable
+        $valuesAfterBypass = PolicyComparisonTraitImpl::getPolicyRequiredValues();
+        $this->assertNotNull($valuesAfterBypass[TestPolicy::class]);
+    }
+
+    public function testBypassIsClearedWhenCallableThrows()
+    {
+        try {
+            PolicyEnforcementBypass::run(function (): void {
+                throw new \Exception('test');
+            });
+            $this->fail('expected the exception to bubble up');
+        } catch (\Exception $e) {
+            $this->assertSame('test', $e->getMessage());
+        }
+
+        $this->assertFalse(PolicyEnforcementBypass::isActive());
     }
 
     public function testGetPolicySettingIdDefaultsToPluginAndShortClassName()


### PR DESCRIPTION
Part of DEV-20349. Today the CNIL policy is a single flag, everything is enforced or nothing is. We want each setting to be enforceable on its own, so the policy needs to answer "is this specific setting enforced for this site?" rather than just "is the policy on?".

This PR adds the read side of that. `CompliancePolicy::isEnforcedForSetting()` resolves one setting's enforcement state in order: the config file wins (how config enforces everything), then an explicit per-setting value (one boolean per policy and setting in the existing `plugin_setting` / `site_setting` tables, no schema changes), then the old whole-policy flag as a fallback so instances that already enforce CNIL stay enforced until the migration later in the stack converts them.

It also adds `PolicyEnforcementBypass`, which evaluates a setting as if nothing was enforcing it. The dashboard uses this later to tell apart "compliant because the customer configured it themselves" from "compliant only because the switch is forcing it".

Nothing writes or consumes this state yet, that comes in the next PRs, so there's no behaviour change. Two thirds of the diff is the unit test matrix for the resolution order.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
