### PR TITLE
Add internal API to read granular compliance policy settings, DEV-20349

### DIFF
--- a/core/Policy/CnilPolicy.php
+++ b/core/Policy/CnilPolicy.php
@@ -57,6 +57,7 @@ class CnilPolicy extends CompliancePolicy
     {
         return [
             [
+                'id' => 'optOut',
                 'title' => Piwik::translate('General_ComplianceCNILUnknownSettingOptOutTitle'),
                 'note' =>
                     Piwik::translate('General_ComplianceCNILUnknownSettingOptOutNotes', [

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -17,7 +17,10 @@ use Piwik\Piwik;
 use Piwik\Config as PiwikConfig;
 use Piwik\Plugin\Manager;
 use Piwik\Plugins\CustomJsTracker\File;
+use Piwik\Plugins\FeatureFlags\FeatureFlagManager;
 use Piwik\Plugins\Live\Live;
+use Piwik\Plugins\PrivacyManager\Compliance\ComplianceSettingsProvider;
+use Piwik\Plugins\PrivacyManager\FeatureFlags\GranularPrivacyCompliance;
 use Piwik\Plugins\PrivacyManager\Model\DataSubjects;
 use Piwik\Plugins\PrivacyManager\Dao\LogDataAnonymizer;
 use Piwik\Plugins\PrivacyManager\Model\LogDataAnonymizations;
@@ -45,14 +48,22 @@ class API extends \Piwik\Plugin\API
 
     private LogDataAnonymizer $logDataAnonymizer;
 
+    private ComplianceSettingsProvider $complianceSettingsProvider;
+
+    private FeatureFlagManager $featureFlagManager;
+
     public function __construct(
         DataSubjects $gdpr,
         LogDataAnonymizations $logDataAnonymizations,
-        LogDataAnonymizer $logDataAnonymizer
+        LogDataAnonymizer $logDataAnonymizer,
+        ComplianceSettingsProvider $complianceSettingsProvider,
+        FeatureFlagManager $featureFlagManager
     ) {
         $this->gdpr = $gdpr;
         $this->logDataAnonymizations = $logDataAnonymizations;
         $this->logDataAnonymizer = $logDataAnonymizer;
+        $this->complianceSettingsProvider = $complianceSettingsProvider;
+        $this->featureFlagManager = $featureFlagManager;
     }
 
     /**
@@ -682,6 +693,49 @@ class API extends \Piwik\Plugin\API
             ];
         }
         return $payload;
+    }
+
+    /**
+     * Returns the granular per-setting enforcement configuration and compliance status of a compliance policy.
+     *
+     * Each returned setting contains its stable identifier, translated texts, current compliance
+     * status (`compliant` when the underlying Matomo setting satisfies the requirement on its own,
+     * `enforced` when the requirement is only met through policy enforcement, `non_compliant`
+     * otherwise) and, for toggleable settings, its current enforcement state.
+     *
+     * @param int|string $idSite Site ID to inspect, or `all` for the instance-wide view.
+     * @param string $compliancePolicy Compliance policy id to inspect, e.g. `cnil_v1`.
+     * @return array<string, mixed> Policy details, config control flag, derived whole-policy
+     *                              enforcement state and the list of settings.
+     * @internal
+     *
+     */
+    public function getCompliancePolicySettings($idSite, string $compliancePolicy): array
+    {
+        Piwik::checkUserHasSuperUserAccess();
+
+        $this->checkGranularComplianceFeatureIsEnabled();
+
+        $policy = PolicyManager::getPolicyByName($compliancePolicy);
+
+        if (is_null($policy)) {
+            throw new Exception('Invalid compliance policy');
+        }
+
+        if ($idSite === 'all') {
+            $idSite = null;
+        } else {
+            $idSite = intval($idSite);
+        }
+
+        return $this->complianceSettingsProvider->getPolicySettings($policy, $idSite);
+    }
+
+    private function checkGranularComplianceFeatureIsEnabled(): void
+    {
+        if (!$this->featureFlagManager->isFeatureActive(GranularPrivacyCompliance::class)) {
+            throw new Exception('Granular compliance configuration is not enabled');
+        }
     }
 
     /**

--- a/plugins/PrivacyManager/Compliance/ComplianceSettingsProvider.php
+++ b/plugins/PrivacyManager/Compliance/ComplianceSettingsProvider.php
@@ -52,7 +52,7 @@ class ComplianceSettingsProvider
                 'name' => $settingClass::getTitle(),
                 'whatItDoes' => $settingClass::getWhatItDoes(),
                 'impact' => $settingClass::getImpact(),
-                'status' => $this->computeStatus($policyClass, $settingClass, $idSite),
+                'status' => $this->computeStatus($policyClass, $settingClass, $idSite, $enforced),
                 'enforced' => $enforced,
                 'toggleable' => true,
                 'section' => self::SECTION_SETTINGS,
@@ -127,27 +127,21 @@ class ComplianceSettingsProvider
     }
 
     /**
-     * A setting is "compliant" when the underlying Matomo configuration satisfies
-     * the policy requirement on its own, and "enforced" when the requirement is
-     * only met because the policy enforcement overrides the underlying value.
+     * A setting whose requirement is met reports "enforced" whenever its enforcement
+     * toggle is on — even when the underlying configuration would satisfy the
+     * requirement on its own — and "compliant" otherwise. A setting whose requirement
+     * isn't met reports "non_compliant" regardless of the toggle (e.g. the IP address
+     * mask length while IP anonymisation itself is disabled).
      *
      * @param class-string<CompliancePolicy> $policyClass
      * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
      */
-    private function computeStatus(string $policyClass, string $settingClass, ?int $idSite): string
+    private function computeStatus(string $policyClass, string $settingClass, ?int $idSite, bool $enforced): string
     {
-        $compliantOnItsOwn = PolicyEnforcementBypass::run(
-            function () use ($settingClass, $policyClass, $idSite): bool {
-                return $settingClass::isCompliant($policyClass, $idSite);
-            }
-        );
-
-        if ($compliantOnItsOwn) {
-            return self::STATUS_COMPLIANT;
+        if (!$settingClass::isCompliant($policyClass, $idSite)) {
+            return self::STATUS_NON_COMPLIANT;
         }
 
-        return $settingClass::isCompliant($policyClass, $idSite)
-            ? self::STATUS_ENFORCED
-            : self::STATUS_NON_COMPLIANT;
+        return $enforced ? self::STATUS_ENFORCED : self::STATUS_COMPLIANT;
     }
 }

--- a/plugins/PrivacyManager/Compliance/ComplianceSettingsProvider.php
+++ b/plugins/PrivacyManager/Compliance/ComplianceSettingsProvider.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\PrivacyManager\Compliance;
+
+use Piwik\Policy\CompliancePolicy;
+use Piwik\Policy\PolicyEnforcementBypass;
+use Piwik\Policy\PolicyManager;
+use Piwik\Settings\Interfaces\PolicyComparisonInterface;
+
+/**
+ * Builds the granular per-setting compliance payload for a policy.
+ */
+class ComplianceSettingsProvider
+{
+    public const STATUS_COMPLIANT = 'compliant';
+    public const STATUS_ENFORCED = 'enforced';
+    public const STATUS_NON_COMPLIANT = 'non_compliant';
+    public const STATUS_ON_BY_DEFAULT = 'on_by_default';
+    public const STATUS_MANUAL = 'manual';
+
+    public const SECTION_SETTINGS = 'settings';
+    public const SECTION_EXTERNAL = 'external';
+
+    /**
+     * @param class-string<CompliancePolicy> $policyClass
+     * @return array<string, mixed>
+     */
+    public function getPolicySettings(string $policyClass, ?int $idSite): array
+    {
+        $settings = [];
+        $toggleableCount = 0;
+        $allToggleablesEnforced = true;
+
+        foreach (PolicyManager::getAllControlledSettings($policyClass, $idSite) as $settingClass) {
+            if ($settingClass::isExternallyManagedByPolicyPage()) {
+                continue;
+            }
+
+            $toggleableCount++;
+            $enforced = $settingClass::isEnforced($idSite);
+            $allToggleablesEnforced = $allToggleablesEnforced && $enforced;
+
+            $settings[] = [
+                'id' => $settingClass::getPolicySettingId(),
+                'name' => $settingClass::getTitle(),
+                'whatItDoes' => $settingClass::getWhatItDoes(),
+                'impact' => $settingClass::getImpact(),
+                'status' => $this->computeStatus($policyClass, $settingClass, $idSite),
+                'enforced' => $enforced,
+                'toggleable' => true,
+                'section' => self::SECTION_SETTINGS,
+            ];
+        }
+
+        foreach ($this->getExternallyManagedSettings($policyClass, $idSite) as $externalSetting) {
+            $settings[] = $externalSetting;
+        }
+
+        $details = $policyClass::getDetails();
+
+        return [
+            'policy' => $details['id'],
+            'title' => $details['title'],
+            'description' => $details['description'],
+            'configControlled' => PolicyManager::isPolicyConfigControlled($policyClass),
+            'policyEnforced' => $toggleableCount > 0 && $allToggleablesEnforced,
+            'settings' => $settings,
+        ];
+    }
+
+    /**
+     * @param class-string<CompliancePolicy> $policyClass
+     * @return array<int, array<string, mixed>>
+     */
+    private function getExternallyManagedSettings(string $policyClass, ?int $idSite): array
+    {
+        $settings = [];
+
+        foreach (PolicyManager::getAllControlledSettings($policyClass, $idSite) as $settingClass) {
+            if (!$settingClass::isExternallyManagedByPolicyPage()) {
+                continue;
+            }
+
+            // reflect the raw configuration: these settings are managed outside the
+            // dashboard, so an active policy must not mask a non-compliant config
+            $compliantOnItsOwn = PolicyEnforcementBypass::run(
+                function () use ($settingClass, $policyClass, $idSite): bool {
+                    return $settingClass::isCompliant($policyClass, $idSite);
+                }
+            );
+
+            $settings[] = [
+                'id' => $settingClass::getPolicySettingId(),
+                'name' => $settingClass::getTitle(),
+                'whatItDoes' => $settingClass::getWhatItDoes(),
+                'impact' => $settingClass::getImpact(),
+                'status' => $compliantOnItsOwn
+                    ? self::STATUS_ON_BY_DEFAULT
+                    : self::STATUS_NON_COMPLIANT,
+                'enforced' => null,
+                'toggleable' => false,
+                'section' => self::SECTION_EXTERNAL,
+            ];
+        }
+
+        foreach (PolicyManager::getAllUnknownSettings($policyClass) as $index => $unknownSetting) {
+            $settings[] = [
+                'id' => $policyClass::getName() . '.' . ($unknownSetting['id'] ?? 'unknown' . $index),
+                'name' => $unknownSetting['title'],
+                'whatItDoes' => $unknownSetting['note'],
+                'impact' => '',
+                'status' => self::STATUS_MANUAL,
+                'enforced' => null,
+                'toggleable' => false,
+                'section' => self::SECTION_EXTERNAL,
+            ];
+        }
+
+        return $settings;
+    }
+
+    /**
+     * A setting is "compliant" when the underlying Matomo configuration satisfies
+     * the policy requirement on its own, and "enforced" when the requirement is
+     * only met because the policy enforcement overrides the underlying value.
+     *
+     * @param class-string<CompliancePolicy> $policyClass
+     * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
+     */
+    private function computeStatus(string $policyClass, string $settingClass, ?int $idSite): string
+    {
+        $compliantOnItsOwn = PolicyEnforcementBypass::run(
+            function () use ($settingClass, $policyClass, $idSite): bool {
+                return $settingClass::isCompliant($policyClass, $idSite);
+            }
+        );
+
+        if ($compliantOnItsOwn) {
+            return self::STATUS_COMPLIANT;
+        }
+
+        return $settingClass::isCompliant($policyClass, $idSite)
+            ? self::STATUS_ENFORCED
+            : self::STATUS_NON_COMPLIANT;
+    }
+}

--- a/plugins/PrivacyManager/FeatureFlags/GranularPrivacyCompliance.php
+++ b/plugins/PrivacyManager/FeatureFlags/GranularPrivacyCompliance.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\PrivacyManager\FeatureFlags;
+
+use Piwik\Plugins\FeatureFlags\FeatureFlagInterface;
+
+class GranularPrivacyCompliance implements FeatureFlagInterface
+{
+    public function getName(): string
+    {
+        return 'GranularPrivacyCompliance';
+    }
+}

--- a/plugins/PrivacyManager/tests/Integration/ApiTest.php
+++ b/plugins/PrivacyManager/tests/Integration/ApiTest.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\PrivacyManager\tests\Integration;
 
 use Exception;
 use Piwik\Access;
+use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\NoAccessException;
 use Piwik\Policy\CnilPolicy;
@@ -150,6 +151,151 @@ class ApiTest extends IntegrationTestCase
 
         $this->assertSame($maskLength, IpAddressMaskLength::getCustomValue());
         $this->assertFalse(IpAddressMaskLength::isCompliant(CnilPolicy::class, $this->siteId));
+    }
+
+    public function testGetCompliancePolicySettingsThrowsWhenFeatureIsNotEnabled(): void
+    {
+        $this->expectExceptionMessage('Granular compliance configuration is not enabled');
+
+        $this->api->getCompliancePolicySettings($this->siteId, 'cnil_v1');
+    }
+
+    public function testGetCompliancePolicySettingsThrowsForInvalidPolicy(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        $this->expectExceptionMessage('Invalid compliance policy');
+
+        $this->api->getCompliancePolicySettings($this->siteId, 'egg');
+    }
+
+    public function testGetCompliancePolicySettingsThrowsWithoutSuperUserAccess(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        $fakeAccess = StaticContainer::getContainer()->get(Access::class);
+        $fakeAccess->setSuperUserAccess(false);
+
+        $this->expectException(NoAccessException::class);
+
+        $this->api->getCompliancePolicySettings($this->siteId, 'cnil_v1');
+    }
+
+    public function testGetCompliancePolicySettingsReturnsAllSettingsWithDefaultState(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        // IP anonymisation is enabled by default, disable it to get a deterministic non-compliant setting
+        $this->api->setAnonymizeIpSettings(false, 2, true);
+
+        $payload = $this->api->getCompliancePolicySettings($this->siteId, 'cnil_v1');
+
+        $this->assertSame('cnil_v1', $payload['policy']);
+        $this->assertNotEmpty($payload['title']);
+        $this->assertNotEmpty($payload['description']);
+        $this->assertFalse($payload['configControlled']);
+        $this->assertFalse($payload['policyEnforced']);
+
+        $settings = $this->getSettingsById($payload);
+
+        foreach ($payload['settings'] as $setting) {
+            $this->assertSame(
+                ['id', 'name', 'whatItDoes', 'impact', 'status', 'enforced', 'toggleable', 'section'],
+                array_keys($setting)
+            );
+        }
+
+        $ipAnonymisation = $settings['PrivacyManager.IPAnonymisation'];
+        $this->assertSame('non_compliant', $ipAnonymisation['status']);
+        $this->assertFalse($ipAnonymisation['enforced']);
+        $this->assertTrue($ipAnonymisation['toggleable']);
+        $this->assertSame('settings', $ipAnonymisation['section']);
+
+        $thirdPartyCookies = $settings['Core.ThirdPartyCookies'];
+        $this->assertSame('on_by_default', $thirdPartyCookies['status']);
+        $this->assertNull($thirdPartyCookies['enforced']);
+        $this->assertFalse($thirdPartyCookies['toggleable']);
+        $this->assertSame('external', $thirdPartyCookies['section']);
+
+        $optOut = $settings['cnil_v1.optOut'];
+        $this->assertSame('manual', $optOut['status']);
+        $this->assertNull($optOut['enforced']);
+        $this->assertFalse($optOut['toggleable']);
+        $this->assertSame('external', $optOut['section']);
+    }
+
+    public function testGetCompliancePolicySettingsReflectsLegacyEnforcedPolicy(): void
+    {
+        // disable the underlying setting so the requirement can only be met through enforcement
+        $this->api->setAnonymizeIpSettings(false, 2, true);
+        $this->api->setComplianceStatus((string) $this->siteId, 'cnil_v1', true);
+
+        $this->enableGranularComplianceFeature();
+
+        $payload = $this->api->getCompliancePolicySettings($this->siteId, 'cnil_v1');
+        $this->assertTrue($payload['policyEnforced']);
+
+        $settings = $this->getSettingsById($payload);
+
+        // the underlying setting is not configured, the requirement is only met through enforcement
+        $this->assertSame('enforced', $settings['PrivacyManager.IPAnonymisation']['status']);
+        $this->assertTrue($settings['PrivacyManager.IPAnonymisation']['enforced']);
+        $this->assertSame('enforced', $settings['PrivacyManager.DataRoundingEnabled']['status']);
+
+        // the policy was only enforced for one site, the instance-wide view stays unenforced
+        $allSitesPayload = $this->api->getCompliancePolicySettings('all', 'cnil_v1');
+        $this->assertFalse($allSitesPayload['policyEnforced']);
+        $this->assertFalse($this->getSettingsById($allSitesPayload)['PrivacyManager.IPAnonymisation']['enforced']);
+    }
+
+    public function testGetCompliancePolicySettingsStatusIsCompliantWhenUnderlyingSettingSatisfiesRequirement(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        $this->api->setAnonymizeIpSettings(true, 2, true);
+
+        $payload = $this->api->getCompliancePolicySettings($this->siteId, 'cnil_v1');
+        $settings = $this->getSettingsById($payload);
+
+        $this->assertSame('compliant', $settings['PrivacyManager.IPAnonymisation']['status']);
+        $this->assertFalse($settings['PrivacyManager.IPAnonymisation']['enforced']);
+        $this->assertSame('compliant', $settings['PrivacyManager.IpAddressMaskLength']['status']);
+    }
+
+    public function testGetCompliancePolicySettingsExternalStatusReflectsRawConfigDespiteEnforcement(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        // raw non-compliant config for an externally managed setting + enforced policy
+        Config::getInstance()->Tracker = array_merge(
+            Config::getInstance()->Tracker ?: [],
+            ['use_third_party_id_cookie' => 1]
+        );
+        $this->api->setComplianceStatus((string) $this->siteId, 'cnil_v1', true);
+
+        $payload = $this->api->getCompliancePolicySettings($this->siteId, 'cnil_v1');
+        $thirdPartyCookies = $this->getSettingsById($payload)['Core.ThirdPartyCookies'];
+
+        // the policy override must not mask the raw non-compliant config
+        $this->assertSame('non_compliant', $thirdPartyCookies['status']);
+    }
+
+    private function enableGranularComplianceFeature(): void
+    {
+        Config::getInstance()->FeatureFlags = ['GranularPrivacyCompliance_feature' => 'enabled'];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return array<string, array<string, mixed>>
+     */
+    private function getSettingsById(array $payload): array
+    {
+        $settings = [];
+        foreach ($payload['settings'] as $setting) {
+            $settings[$setting['id']] = $setting;
+        }
+        return $settings;
     }
 
     public function provideContainerConfig()

--- a/plugins/PrivacyManager/tests/System/APITest.php
+++ b/plugins/PrivacyManager/tests/System/APITest.php
@@ -274,6 +274,76 @@ class APITest extends SystemTestCase
         Config::getInstance()->{$configSection} = null;
     }
 
+    public function testGetCompliancePolicySettingsReturnsErrorWhenFeatureNotEnabled(): void
+    {
+        $this->runApiTests('PrivacyManager.getCompliancePolicySettings', [
+            'testSuffix' => 'granularFeatureDisabled',
+            'otherRequestParameters' => [
+                'idSite' => '1',
+                'compliancePolicy' => 'cnil_v1',
+            ],
+        ]);
+    }
+
+    public function testGetCompliancePolicySettingsReturnsAllSettings(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        try {
+            $this->runApiTests('PrivacyManager.getCompliancePolicySettings', [
+                'otherRequestParameters' => [
+                    'idSite' => '1',
+                    'compliancePolicy' => 'cnil_v1',
+                ],
+            ]);
+        } finally {
+            Config::getInstance()->FeatureFlags = null;
+        }
+    }
+
+    public function testGetCompliancePolicySettingsWhenPolicyEnforcedForSite(): void
+    {
+        $this->enableGranularComplianceFeature();
+        CnilPolicy::setActiveStatus(1, true);
+
+        try {
+            $this->runApiTests('PrivacyManager.getCompliancePolicySettings', [
+                'testSuffix' => 'granularPolicyEnforced',
+                'otherRequestParameters' => [
+                    'idSite' => '1',
+                    'compliancePolicy' => 'cnil_v1',
+                ],
+            ]);
+        } finally {
+            CnilPolicy::setActiveStatus(1, false);
+            Config::getInstance()->FeatureFlags = null;
+        }
+    }
+
+    public function testGetCompliancePolicySettingsConfigControlled(): void
+    {
+        $this->enableGranularComplianceFeature();
+        Config::getInstance()->CnilPolicy['cnil_v1_policy_enabled'] = 1;
+
+        try {
+            $this->runApiTests('PrivacyManager.getCompliancePolicySettings', [
+                'testSuffix' => 'granularConfigControlled',
+                'otherRequestParameters' => [
+                    'idSite' => '1',
+                    'compliancePolicy' => 'cnil_v1',
+                ],
+            ]);
+        } finally {
+            Config::getInstance()->CnilPolicy = null;
+            Config::getInstance()->FeatureFlags = null;
+        }
+    }
+
+    private function enableGranularComplianceFeature(): void
+    {
+        Config::getInstance()->FeatureFlags = ['GranularPrivacyCompliance_feature' => 'enabled'];
+    }
+
     public static function getOutputPrefix()
     {
         return '';

--- a/plugins/PrivacyManager/tests/System/expected/test___PrivacyManager.getCompliancePolicySettings.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test___PrivacyManager.getCompliancePolicySettings.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<policy>cnil_v1</policy>
+	<title>CNIL Website Analytics Compliance</title>
+	<description>This table shows how specific Matomo configuration settings align with &lt;a href=&quot;https://matomo.org/faq/how-to/how-do-i-configure-matomo-without-tracking-consent-for-french-visitors-cnil-exemption/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;CNIL guidance&lt;/a&gt; on consent-exempt audience measurement. It is provided for &lt;b&gt;informational purposes only&lt;/b&gt; and does not constitute legal advice or guarantee full compliance. To rely on CNIL's consent exemption, &lt;b&gt;all&lt;/b&gt; required configurations must be correctly implemented.&lt;br/&gt;&lt;br/&gt;&lt;ul class='browser-default'&gt;&lt;li&gt;If a setting is marked &lt;b&gt;non-compliant&lt;/b&gt;, the exemption conditions are not satisfied and valid user consent must be obtained.&lt;/li&gt;&lt;li&gt;If a setting is marked &lt;b&gt;unknown&lt;/b&gt;, Matomo cannot determine whether the requirement has been met; these items must be verified manually by you, the publisher/controller.&lt;/li&gt;&lt;/ul&gt;&lt;br/&gt;To assess your overall compliance make sure you consult your legal advisors for a definitive compliance assessment.&lt;br/&gt;Click &lt;a href=&quot;https://matomo.org/faq/how-to/how-do-i-configure-matomo-without-tracking-consent-for-french-visitors-cnil-exemption/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;here&lt;/a&gt; to access the Matomo Self-Assessment, learn more about the CNIL criteria for consent-exempt analytics and understand how to configure Matomo for CNIL exemption.&lt;br/&gt;&lt;b&gt;Compliance cannot be guaranteed with the use of third-party plugins.&lt;/b&gt;</description>
+	<configControlled>0</configControlled>
+	<policyEnforced>0</policyEnforced>
+	<settings>
+		<row>
+			<id>DevicesDetection.DeviceModelDetectionDisabled</id>
+			<name>Device model detection disabled</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>DevicesDetection.OnlyMajorVersions</id>
+			<name>Only Major versions</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Ecommerce.EcommerceRestricted</id>
+			<name>Ecommerce Restricted</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Ecommerce.OrderIdAnonymization</id>
+			<name>Ecommerce - Order ID anonymisation</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>SitesManager.FilterPIIParameters</id>
+			<name>PII data filtered</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Live.VisitorLogDisabled</id>
+			<name>Turn off Visits log and Visitor profiles</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.CampaignParameterValuesMasked</id>
+			<name>Campaign parameter values masked</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.DataRoundingEnabled</id>
+			<name>Segmented data rounding enabled</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.IPAnonymisation</id>
+			<name>IP Anonymisation Enabled</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.IpAddressMaskLength</id>
+			<name>IP Address Mask Length</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.ReferrerAnonymisation</id>
+			<name>Referrer Anonymisation</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.ReportRetention</id>
+			<name>Data retention period</name>
+			<whatItDoes />
+			<impact />
+			<status>compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>SegmentEditor.LimitSegments</id>
+			<name>Limit available segments</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Resolution.ScreenResolutionDetectionDisabled</id>
+			<name>Screen resolution detection disabled</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>UserId.UserIdDisabled</id>
+			<name>User ID disabled</name>
+			<whatItDoes />
+			<impact />
+			<status>non_compliant</status>
+			<enforced>0</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Core.ThirdPartyCookies</id>
+			<name>Third-party cookies</name>
+			<whatItDoes />
+			<impact />
+			<status>on_by_default</status>
+			<enforced />
+			<toggleable>0</toggleable>
+			<section>external</section>
+		</row>
+		<row>
+			<id>cnil_v1.optOut</id>
+			<name>Opt out</name>
+			<whatItDoes>Opt out must be manually set up and configured. &lt;a href=&quot;https://matomo.org/faq/general/faq_20000/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Learn more&lt;/a&gt;</whatItDoes>
+			<impact />
+			<status>manual</status>
+			<enforced />
+			<toggleable>0</toggleable>
+			<section>external</section>
+		</row>
+	</settings>
+</result>

--- a/plugins/PrivacyManager/tests/System/expected/test_granularConfigControlled__PrivacyManager.getCompliancePolicySettings.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_granularConfigControlled__PrivacyManager.getCompliancePolicySettings.xml
@@ -121,7 +121,7 @@
 			<name>Data retention period</name>
 			<whatItDoes />
 			<impact />
-			<status>compliant</status>
+			<status>enforced</status>
 			<enforced>1</enforced>
 			<toggleable>1</toggleable>
 			<section>settings</section>

--- a/plugins/PrivacyManager/tests/System/expected/test_granularConfigControlled__PrivacyManager.getCompliancePolicySettings.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_granularConfigControlled__PrivacyManager.getCompliancePolicySettings.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<policy>cnil_v1</policy>
+	<title>CNIL Website Analytics Compliance</title>
+	<description>This table shows how specific Matomo configuration settings align with &lt;a href=&quot;https://matomo.org/faq/how-to/how-do-i-configure-matomo-without-tracking-consent-for-french-visitors-cnil-exemption/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;CNIL guidance&lt;/a&gt; on consent-exempt audience measurement. It is provided for &lt;b&gt;informational purposes only&lt;/b&gt; and does not constitute legal advice or guarantee full compliance. To rely on CNIL's consent exemption, &lt;b&gt;all&lt;/b&gt; required configurations must be correctly implemented.&lt;br/&gt;&lt;br/&gt;&lt;ul class='browser-default'&gt;&lt;li&gt;If a setting is marked &lt;b&gt;non-compliant&lt;/b&gt;, the exemption conditions are not satisfied and valid user consent must be obtained.&lt;/li&gt;&lt;li&gt;If a setting is marked &lt;b&gt;unknown&lt;/b&gt;, Matomo cannot determine whether the requirement has been met; these items must be verified manually by you, the publisher/controller.&lt;/li&gt;&lt;/ul&gt;&lt;br/&gt;To assess your overall compliance make sure you consult your legal advisors for a definitive compliance assessment.&lt;br/&gt;Click &lt;a href=&quot;https://matomo.org/faq/how-to/how-do-i-configure-matomo-without-tracking-consent-for-french-visitors-cnil-exemption/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;here&lt;/a&gt; to access the Matomo Self-Assessment, learn more about the CNIL criteria for consent-exempt analytics and understand how to configure Matomo for CNIL exemption.&lt;br/&gt;&lt;b&gt;Compliance cannot be guaranteed with the use of third-party plugins.&lt;/b&gt;</description>
+	<configControlled>1</configControlled>
+	<policyEnforced>1</policyEnforced>
+	<settings>
+		<row>
+			<id>DevicesDetection.DeviceModelDetectionDisabled</id>
+			<name>Device model detection disabled</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>DevicesDetection.OnlyMajorVersions</id>
+			<name>Only Major versions</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Ecommerce.EcommerceRestricted</id>
+			<name>Ecommerce Restricted</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Ecommerce.OrderIdAnonymization</id>
+			<name>Ecommerce - Order ID anonymisation</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>SitesManager.FilterPIIParameters</id>
+			<name>PII data filtered</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Live.VisitorLogDisabled</id>
+			<name>Turn off Visits log and Visitor profiles</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.CampaignParameterValuesMasked</id>
+			<name>Campaign parameter values masked</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.DataRoundingEnabled</id>
+			<name>Segmented data rounding enabled</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.IPAnonymisation</id>
+			<name>IP Anonymisation Enabled</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.IpAddressMaskLength</id>
+			<name>IP Address Mask Length</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.ReferrerAnonymisation</id>
+			<name>Referrer Anonymisation</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.ReportRetention</id>
+			<name>Data retention period</name>
+			<whatItDoes />
+			<impact />
+			<status>compliant</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>SegmentEditor.LimitSegments</id>
+			<name>Limit available segments</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Resolution.ScreenResolutionDetectionDisabled</id>
+			<name>Screen resolution detection disabled</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>UserId.UserIdDisabled</id>
+			<name>User ID disabled</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Core.ThirdPartyCookies</id>
+			<name>Third-party cookies</name>
+			<whatItDoes />
+			<impact />
+			<status>on_by_default</status>
+			<enforced />
+			<toggleable>0</toggleable>
+			<section>external</section>
+		</row>
+		<row>
+			<id>cnil_v1.optOut</id>
+			<name>Opt out</name>
+			<whatItDoes>Opt out must be manually set up and configured. &lt;a href=&quot;https://matomo.org/faq/general/faq_20000/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Learn more&lt;/a&gt;</whatItDoes>
+			<impact />
+			<status>manual</status>
+			<enforced />
+			<toggleable>0</toggleable>
+			<section>external</section>
+		</row>
+	</settings>
+</result>

--- a/plugins/PrivacyManager/tests/System/expected/test_granularFeatureDisabled__PrivacyManager.getCompliancePolicySettings.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_granularFeatureDisabled__PrivacyManager.getCompliancePolicySettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<error message="Granular compliance configuration is not enabled
+ 
+ --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
+</result>

--- a/plugins/PrivacyManager/tests/System/expected/test_granularPolicyEnforced__PrivacyManager.getCompliancePolicySettings.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_granularPolicyEnforced__PrivacyManager.getCompliancePolicySettings.xml
@@ -121,7 +121,7 @@
 			<name>Data retention period</name>
 			<whatItDoes />
 			<impact />
-			<status>compliant</status>
+			<status>enforced</status>
 			<enforced>1</enforced>
 			<toggleable>1</toggleable>
 			<section>settings</section>

--- a/plugins/PrivacyManager/tests/System/expected/test_granularPolicyEnforced__PrivacyManager.getCompliancePolicySettings.xml
+++ b/plugins/PrivacyManager/tests/System/expected/test_granularPolicyEnforced__PrivacyManager.getCompliancePolicySettings.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<policy>cnil_v1</policy>
+	<title>CNIL Website Analytics Compliance</title>
+	<description>This table shows how specific Matomo configuration settings align with &lt;a href=&quot;https://matomo.org/faq/how-to/how-do-i-configure-matomo-without-tracking-consent-for-french-visitors-cnil-exemption/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;CNIL guidance&lt;/a&gt; on consent-exempt audience measurement. It is provided for &lt;b&gt;informational purposes only&lt;/b&gt; and does not constitute legal advice or guarantee full compliance. To rely on CNIL's consent exemption, &lt;b&gt;all&lt;/b&gt; required configurations must be correctly implemented.&lt;br/&gt;&lt;br/&gt;&lt;ul class='browser-default'&gt;&lt;li&gt;If a setting is marked &lt;b&gt;non-compliant&lt;/b&gt;, the exemption conditions are not satisfied and valid user consent must be obtained.&lt;/li&gt;&lt;li&gt;If a setting is marked &lt;b&gt;unknown&lt;/b&gt;, Matomo cannot determine whether the requirement has been met; these items must be verified manually by you, the publisher/controller.&lt;/li&gt;&lt;/ul&gt;&lt;br/&gt;To assess your overall compliance make sure you consult your legal advisors for a definitive compliance assessment.&lt;br/&gt;Click &lt;a href=&quot;https://matomo.org/faq/how-to/how-do-i-configure-matomo-without-tracking-consent-for-french-visitors-cnil-exemption/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;here&lt;/a&gt; to access the Matomo Self-Assessment, learn more about the CNIL criteria for consent-exempt analytics and understand how to configure Matomo for CNIL exemption.&lt;br/&gt;&lt;b&gt;Compliance cannot be guaranteed with the use of third-party plugins.&lt;/b&gt;</description>
+	<configControlled>0</configControlled>
+	<policyEnforced>1</policyEnforced>
+	<settings>
+		<row>
+			<id>DevicesDetection.DeviceModelDetectionDisabled</id>
+			<name>Device model detection disabled</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>DevicesDetection.OnlyMajorVersions</id>
+			<name>Only Major versions</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Ecommerce.EcommerceRestricted</id>
+			<name>Ecommerce Restricted</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Ecommerce.OrderIdAnonymization</id>
+			<name>Ecommerce - Order ID anonymisation</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>SitesManager.FilterPIIParameters</id>
+			<name>PII data filtered</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Live.VisitorLogDisabled</id>
+			<name>Turn off Visits log and Visitor profiles</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.CampaignParameterValuesMasked</id>
+			<name>Campaign parameter values masked</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.DataRoundingEnabled</id>
+			<name>Segmented data rounding enabled</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.IPAnonymisation</id>
+			<name>IP Anonymisation Enabled</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.IpAddressMaskLength</id>
+			<name>IP Address Mask Length</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.ReferrerAnonymisation</id>
+			<name>Referrer Anonymisation</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>PrivacyManager.ReportRetention</id>
+			<name>Data retention period</name>
+			<whatItDoes />
+			<impact />
+			<status>compliant</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>SegmentEditor.LimitSegments</id>
+			<name>Limit available segments</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Resolution.ScreenResolutionDetectionDisabled</id>
+			<name>Screen resolution detection disabled</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>UserId.UserIdDisabled</id>
+			<name>User ID disabled</name>
+			<whatItDoes />
+			<impact />
+			<status>enforced</status>
+			<enforced>1</enforced>
+			<toggleable>1</toggleable>
+			<section>settings</section>
+		</row>
+		<row>
+			<id>Core.ThirdPartyCookies</id>
+			<name>Third-party cookies</name>
+			<whatItDoes />
+			<impact />
+			<status>on_by_default</status>
+			<enforced />
+			<toggleable>0</toggleable>
+			<section>external</section>
+		</row>
+		<row>
+			<id>cnil_v1.optOut</id>
+			<name>Opt out</name>
+			<whatItDoes>Opt out must be manually set up and configured. &lt;a href=&quot;https://matomo.org/faq/general/faq_20000/?mtm_campaign=Matomo_App&amp;mtm_source=Matomo_App_OnPremise&amp;mtm_medium=App.PrivacyManager.compliance&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Learn more&lt;/a&gt;</whatItDoes>
+			<impact />
+			<status>manual</status>
+			<enforced />
+			<toggleable>0</toggleable>
+			<section>external</section>
+		</row>
+	</settings>
+</result>


### PR DESCRIPTION
Part of DEV-20349. The CNIL compliance page is moving from one enforce checkbox that switches every requirement on at once to a switch per setting, because customers want to adopt the requirements one at a time and see where they stand on each. For that the new dashboard needs to ask a question the current API can't answer: for this site, what is the state of each individual requirement?

This PR adds that read API. `PrivacyManager.getCompliancePolicySettings` returns one row per setting with its stable id, translated name and explanation, whether enforcement is switched on, and a status. The status distinguishes two ways of meeting a requirement: `compliant` means your own Matomo configuration already satisfies it, `enforced` means it's only met because the compliance switch is holding it in place. To tell them apart the provider computes each setting's value twice, once normally and once with enforcement bypassed, using the read model from the previous PR.

The endpoint is super user only and gated behind a new `GranularPrivacyCompliance` feature flag that defaults to off, so nothing changes for anyone yet. It ships `@internal` but is shaped as the future public API for granular configuration (DEV-20350), so we don't have to break it later.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
