### PR TITLE
Add per-setting compliance enforcement write path, DEV-20349

### DIFF
--- a/core/Policy/CompliancePolicy.php
+++ b/core/Policy/CompliancePolicy.php
@@ -240,6 +240,44 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
     }
 
     /**
+     * Sets the enforcement state of the given policy-controlled setting.
+     *
+     * Mirrors the scope rules of {@link setActiveStatus()}: disabling a setting
+     * for one site while it has explicit instance-wide enforcement state also
+     * clears that instance-wide state. Enforcement that is only inherited from
+     * the legacy whole-policy flag is not modified here; the migration
+     * materialises that state into explicit per-setting values.
+     *
+     * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
+     */
+    public static function setEnforcedForSetting(string $settingClass, bool $enforced, ?int $idSite = null): void
+    {
+        if (isset($idSite)) {
+            static::setSettingEnforcementMeasurableValue($settingClass, $idSite, $enforced);
+            if (!$enforced && static::getSettingEnforcementSystemValue($settingClass) === true) {
+                static::setSettingEnforcementSystemValue($settingClass, false);
+            }
+        } else {
+            static::setSettingEnforcementSystemValue($settingClass, $enforced);
+        }
+
+        /**
+         * This event is triggered when the enforcement state of a single policy-controlled
+         * setting changes, and is to be used to perform extra actions when the enforcement
+         * of a setting is enabled/disabled. It is also posted for every toggleable setting
+         * when a whole policy is activated/deactivated.
+         *
+         * The enforcement state cannot be changed via this event.
+         *
+         * @param bool $enforced Whether enforcement of the setting is being enabled or disabled
+         * @param int|null $idSite
+         * @param class-string<CompliancePolicy> The compliance policy in question
+         * @param class-string<PolicyComparisonInterface<mixed>> The policy-controlled setting in question
+         */
+        Piwik::postEvent('CompliancePolicy.setSettingEnforcedStatus', [$enforced, $idSite, static::class, $settingClass]);
+    }
+
+    /**
      * Instance-wide enforcement state of the given setting, or null when no state was ever stored.
      *
      * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
@@ -277,5 +315,38 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
         $value = $setting->getValue();
 
         return is_null($value) ? null : (bool) $value;
+    }
+
+    /**
+     * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
+     */
+    protected static function setSettingEnforcementSystemValue(string $settingClass, bool $value): void
+    {
+        $setting = new SystemSetting(
+            static::getSettingEnforcementName($settingClass),
+            null,
+            FieldConfig::TYPE_BOOL,
+            Piwik::getPluginNameOfMatomoClass(static::class)
+        );
+
+        $setting->setValue($value);
+        $setting->save();
+    }
+
+    /**
+     * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
+     */
+    protected static function setSettingEnforcementMeasurableValue(string $settingClass, int $idSite, bool $value): void
+    {
+        $setting = new MeasurableSetting(
+            static::getSettingEnforcementName($settingClass),
+            null,
+            FieldConfig::TYPE_BOOL,
+            Piwik::getPluginNameOfMatomoClass(static::class),
+            $idSite
+        );
+
+        $setting->setValue($value);
+        $setting->save();
     }
 }

--- a/tests/PHPUnit/Unit/Policy/CompliancePolicyTest.php
+++ b/tests/PHPUnit/Unit/Policy/CompliancePolicyTest.php
@@ -132,6 +132,47 @@ class CompliancePolicyTest extends TestCase
         $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
     }
 
+    public function testSetEnforcedForSettingInstanceLevelAppliesToAllSites(): void
+    {
+        TestPolicy::setEnforcedForSetting(FakePolicySetting::class, true);
+
+        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
+        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
+
+        TestPolicy::setEnforcedForSetting(FakePolicySetting::class, false);
+
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
+    }
+
+    public function testSetEnforcedForSettingSiteLevelOnlyAffectsTheSite(): void
+    {
+        TestPolicy::setEnforcedForSetting(FakePolicySetting::class, true, 99);
+
+        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 100));
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
+    }
+
+    public function testSetEnforcedForSettingDisablingForSiteClearsInstanceLevelState(): void
+    {
+        TestPolicy::setEnforcedForSetting(FakePolicySetting::class, true);
+        TestPolicy::setEnforcedForSetting(FakePolicySetting::class, false, 99);
+
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 100));
+    }
+
+    public function testSetEnforcedForSettingEnablingForSiteKeepsInstanceLevelState(): void
+    {
+        TestPolicy::setEnforcedForSetting(FakePolicySetting::class, true);
+        TestPolicy::setEnforcedForSetting(FakePolicySetting::class, true, 99);
+
+        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
+        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 100));
+    }
+
     /**
      * @dataProvider possibleStatesForPolicyActive
      */


### PR DESCRIPTION
Part of DEV-20349. The CNIL compliance page is moving from one enforce checkbox to a switch per setting, because customers want to enforce individual requirements without switching on the whole policy. The previous PRs added the read side; this one adds the ability to store a choice.

`CompliancePolicy::setEnforcedForSetting()` records whether a single requirement is enforced, either for the whole instance or for one site. Turning a setting off for one site while it's enforced instance wide clears the instance level state, which mirrors exactly how the existing whole policy switch behaves, so per setting and whole policy writes stay consistent. Each change posts a `CompliancePolicy.setSettingEnforcedStatus` event so plugins can react to individual toggles the same way they react to the policy switch today.

Nothing reads this state when resolving setting values yet, that flip comes in the next PR, so there is no behaviour change. The diff is small: the write method plus the unit tests covering both scopes and the demotion rule.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
