### PR TITLE
Resolve compliance enforcement per setting instead of per policy, DEV-20349

### DIFF
--- a/core/Policy/CompliancePolicy.php
+++ b/core/Policy/CompliancePolicy.php
@@ -9,6 +9,8 @@
 
 namespace Piwik\Policy;
 
+use Piwik\Common;
+use Piwik\Db;
 use Piwik\Piwik;
 use Piwik\Plugin\Manager;
 use Piwik\Settings\FieldConfig;
@@ -146,6 +148,9 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
      * If the policy is active at the instance level,
      * disabling the policy for a site will also disable it
      * for the instance.
+     *
+     * Additionally sets the enforcement state of every toggleable setting the
+     * policy controls, so whole-policy and per-setting enforcement stay in sync.
      */
     public static function setActiveStatus(?int $idSite, bool $isActive): void
     {
@@ -157,6 +162,15 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
         } else {
             static::setSystemValue($isActive);
         }
+
+        foreach (PolicyManager::getAllControlledSettings(static::class, $idSite) as $settingClass) {
+            if ($settingClass::isExternallyManagedByPolicyPage()) {
+                continue;
+            }
+            static::setEnforcedForSetting($settingClass, $isActive, $idSite);
+        }
+
+        static::alignStoredSettingEnforcementRows($idSite, $isActive);
 
         /**
          * This event is triggered when the status of a compliance policy changes, and
@@ -174,6 +188,11 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
     /**
      * If the policy is active at the instance level, then
      * this function will return true for all sites.
+     *
+     * @deprecated since Matomo 6.0, enforcement is now stored per setting — use
+     *             {@link isEnforcedForSetting()} instead. This flag remains as the
+     *             whole-policy state written by {@link setActiveStatus()} and as the
+     *             fallback for scopes without per-setting enforcement state.
      */
     public static function isActive(?int $idSite): bool
     {
@@ -315,6 +334,76 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
         $value = $setting->getValue();
 
         return is_null($value) ? null : (bool) $value;
+    }
+
+    /**
+     * Aligns every stored per-setting enforcement row of this policy with the
+     * whole-policy state, including rows of settings whose plugin is currently
+     * deactivated and therefore not discoverable — otherwise stale enforcement
+     * would survive a whole-policy toggle and resurface on plugin reactivation.
+     *
+     * Rows are enumerated directly but written through the settings storage, so
+     * request-cached storage instances stay coherent with the aligned values.
+     */
+    protected static function alignStoredSettingEnforcementRows(?int $idSite, bool $isActive): void
+    {
+        if (is_null($idSite)) {
+            foreach (self::fetchStoredSettingEnforcementNames(null) as $settingName) {
+                self::writeSettingEnforcementValue($settingName, null, $isActive);
+            }
+            return;
+        }
+
+        foreach (self::fetchStoredSettingEnforcementNames($idSite) as $settingName) {
+            self::writeSettingEnforcementValue($settingName, $idSite, $isActive);
+        }
+
+        if (!$isActive) {
+            // mirror the explicit-clear rule: disabling for one site also clears
+            // instance-wide enforcement, including rows of undiscoverable settings
+            foreach (self::fetchStoredSettingEnforcementNames(null) as $settingName) {
+                self::writeSettingEnforcementValue($settingName, null, false);
+            }
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function fetchStoredSettingEnforcementNames(?int $idSite): array
+    {
+        $namePrefix = str_replace('_', '\_', preg_replace('/\s+/', '', static::getName()) . '_enforce__') . '%';
+        $pluginName = Piwik::getPluginNameOfMatomoClass(static::class);
+
+        if (is_null($idSite)) {
+            $rows = Db::fetchAll(
+                'SELECT setting_name FROM ' . Common::prefixTable('plugin_setting')
+                . ' WHERE plugin_name = ? AND user_login = ? AND setting_name LIKE ?',
+                [$pluginName, '', $namePrefix]
+            );
+        } else {
+            $rows = Db::fetchAll(
+                'SELECT setting_name FROM ' . Common::prefixTable('site_setting')
+                . ' WHERE idsite = ? AND plugin_name = ? AND setting_name LIKE ?',
+                [$idSite, $pluginName, $namePrefix]
+            );
+        }
+
+        return array_column($rows, 'setting_name');
+    }
+
+    private static function writeSettingEnforcementValue(string $settingName, ?int $idSite, bool $value): void
+    {
+        $pluginName = Piwik::getPluginNameOfMatomoClass(static::class);
+
+        if (is_null($idSite)) {
+            $setting = new SystemSetting($settingName, null, FieldConfig::TYPE_BOOL, $pluginName);
+        } else {
+            $setting = new MeasurableSetting($settingName, null, FieldConfig::TYPE_BOOL, $pluginName, $idSite);
+        }
+
+        $setting->setValue($value);
+        $setting->save();
     }
 
     /**

--- a/core/Policy/PolicyManager.php
+++ b/core/Policy/PolicyManager.php
@@ -246,17 +246,18 @@ class PolicyManager
         $settings = [];
 
         foreach ($policies as $policyClass) {
-            if (false === $policyClass::isActive($idSite)) {
-                continue;
-            }
             $controlledSettings = self::getAllControlledSettings($policyClass, $idSite, $settingType);
 
             foreach ($controlledSettings as $controlledSetting) {
-                if ($settingName === call_user_func([$controlledSetting, self::$settingTypesMap[$settingType]['method']])) {
-                    $settings[$policyClass::getName()] = [
-                        'requiredValue' => $controlledSetting::getPolicyRequirements()[$policyClass],
-                    ];
+                if ($settingName !== call_user_func([$controlledSetting, self::$settingTypesMap[$settingType]['method']])) {
+                    continue;
                 }
+                if (!$policyClass::isEnforcedForSetting($controlledSetting, $idSite)) {
+                    continue;
+                }
+                $settings[$policyClass::getName()] = [
+                    'requiredValue' => $controlledSetting::getPolicyRequirements()[$policyClass],
+                ];
             }
         }
 

--- a/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
+++ b/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
@@ -29,7 +29,10 @@ trait PolicyComparisonTrait
 
         /** @var class-string<CompliancePolicy> $policy */
         foreach (array_keys($policyValues) as $policy) {
-            if (PolicyEnforcementBypass::isActive() || !$policy::isActive($idSite)) {
+            if (
+                PolicyEnforcementBypass::isActive()
+                || !$policy::isEnforcedForSetting(static::class, $idSite)
+            ) {
                 $policyValues[$policy] = null;
             }
         }
@@ -80,7 +83,9 @@ trait PolicyComparisonTrait
 
     public static function isControlledBySpecificPolicy(string $policy, ?int $idSite = null): bool
     {
-        return array_key_exists($policy, self::getPolicyRequiredValues($idSite));
+        // key existence is all that matters here; evaluating the enforcement
+        // state would query storage for every discovered setting
+        return array_key_exists($policy, static::getPolicyRequirements());
     }
 
     public static function getPolicySettingId(): string

--- a/plugins/DevicesDetection/Reports/GetModel.php
+++ b/plugins/DevicesDetection/Reports/GetModel.php
@@ -11,9 +11,8 @@ namespace Piwik\Plugins\DevicesDetection\Reports;
 
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
-use Piwik\Policy\CnilPolicy;
 use Piwik\Plugins\DevicesDetection\Columns\DeviceModel;
-use Piwik\Policy\PolicyManager;
+use Piwik\Plugins\DevicesDetection\Settings\DeviceModelDetectionDisabled;
 
 class GetModel extends Base
 {
@@ -37,7 +36,7 @@ class GetModel extends Base
 
     public function isEnabled()
     {
-        // Metadata visibility is global-only here, so check the policy state directly.
-        return !PolicyManager::isPolicyActive(CnilPolicy::class, $idSite = null);
+        // Metadata visibility is global-only here, so check the instance-wide setting state.
+        return !DeviceModelDetectionDisabled::getInstance()->getValue();
     }
 }

--- a/plugins/Resolution/Reports/GetResolution.php
+++ b/plugins/Resolution/Reports/GetResolution.php
@@ -11,10 +11,9 @@ namespace Piwik\Plugins\Resolution\Reports;
 
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
-use Piwik\Policy\CnilPolicy;
 use Piwik\Plugins\Resolution\Columns\Resolution;
 use Piwik\Plugin\ReportsProvider;
-use Piwik\Policy\PolicyManager;
+use Piwik\Plugins\Resolution\Settings\ScreenResolutionDetectionDisabled;
 
 class GetResolution extends Base
 {
@@ -43,7 +42,7 @@ class GetResolution extends Base
 
     public function isEnabled()
     {
-        // Metadata visibility is global-only here, so check the policy state directly.
-        return !PolicyManager::isPolicyActive(CnilPolicy::class, $idSite = null);
+        // Metadata visibility is global-only here, so check the instance-wide setting state.
+        return !ScreenResolutionDetectionDisabled::getInstance()->getValue();
     }
 }

--- a/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
+++ b/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
@@ -88,6 +88,11 @@ class TestPolicy extends \Piwik\Policy\CompliancePolicy
         self::$configValue = $value;
     }
 
+    protected static function alignStoredSettingEnforcementRows(?int $idSite, bool $isActive): void
+    {
+        // no database in unit tests; the in-memory state is fully covered by the fan-out
+    }
+
     protected static function getSettingEnforcementSystemValue(string $settingClass): ?bool
     {
         return self::$settingEnforcementSystem[$settingClass] ?? null;

--- a/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
+++ b/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
@@ -40,6 +40,32 @@ class PolicyComparisonTraitTest extends TestCase
         );
     }
 
+    public function testGetPolicyValuesPresentWhenSettingEnforcementIsEnabledWithoutPolicyFlag()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, false);
+        TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, true);
+
+        try {
+            $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
+            $this->assertNotNull($values[TestPolicy::class]);
+        } finally {
+            TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, null);
+        }
+    }
+
+    public function testGetPolicyValuesNulledWhenSettingEnforcementIsDisabledDespiteActivePolicyFlag()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+        TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, false);
+
+        try {
+            $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
+            $this->assertNull($values[TestPolicy::class]);
+        } finally {
+            TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, null);
+        }
+    }
+
     public function testGetPolicyValuesNulledWhileEnforcementIsBypassed()
     {
         PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);


### PR DESCRIPTION
Part of DEV-20349. The CNIL compliance page is moving from one enforce checkbox to a switch per setting, because customers want to enforce individual requirements without switching on the whole policy. The previous PRs added the per setting state and the APIs to read it; this is the PR where enforcement actually starts using it.

Until now the value override asked one question: is the policy active? This changes the resolution in `PolicyComparisonTrait` to ask whether enforcement is switched on for that specific setting, so each requirement can be held in place on its own. The same shift applies to the read only lock on the underlying settings pages, which now only locks a setting whose own switch is on rather than everything at once, and to the two reports (screen resolution and device model) that used to check the whole policy.

Existing installs behave identically: when a setting has no per setting state, resolution falls back to the old whole policy flag, so anyone who had the policy enforced stays fully enforced. That fallback is removed later by the migration PR once the old flag is converted into per setting values. The production change is small, most of the diff is tests for the new resolution behaviour.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
