### PR TITLE
Add internal APIs to write granular compliance policy settings, DEV-20349

### DIFF
--- a/core/Policy/PolicyManager.php
+++ b/core/Policy/PolicyManager.php
@@ -163,7 +163,7 @@ class PolicyManager
 
     /**
      * @param class-string<CompliancePolicy> $policyClass
-     * @return array<array<string>> of [['title' => (string) 'TITLE', 'note' => (string) 'NOTE']]
+     * @return array<array<string>> of [['id' => (string) 'ID', 'title' => (string) 'TITLE', 'note' => (string) 'NOTE']]
      * @throws CompliancePolicyNotFoundException when $policyClass is not a valid policy
      */
     public static function getAllUnknownSettings(string $policyClass): array
@@ -192,6 +192,51 @@ class PolicyManager
     {
         self::checkPolicyIsValid($policyClass);
         $policyClass::setActiveStatus($idSite, $isActive);
+        if (!is_null($idSite)) {
+            Cache::deleteCacheWebsiteAttributes($idSite);
+        }
+        Cache::deleteTrackerCache();
+    }
+
+    /**
+     * Sets the enforcement state of multiple policy-controlled settings at once.
+     *
+     * @param class-string<CompliancePolicy> $policyClass
+     * @param array<string, bool|int|string> $settingIdToEnforced Map of policy setting id => whether to enforce it
+     * @throws CompliancePolicyNotFoundException when $policyClass is not a valid policy
+     * @throws Exception when a setting id is unknown or the setting cannot be toggled
+     */
+    public static function setPolicySettingEnforcedStatuses(string $policyClass, array $settingIdToEnforced, ?int $idSite = null): void
+    {
+        self::checkPolicyIsValid($policyClass);
+
+        $toggleableSettingsById = [];
+        foreach (self::getAllControlledSettings($policyClass, $idSite) as $settingClass) {
+            if (!$settingClass::isExternallyManagedByPolicyPage()) {
+                $toggleableSettingsById[$settingClass::getPolicySettingId()] = $settingClass;
+            }
+        }
+
+        // validate everything upfront: a failure mid-write would leave a partial
+        // change behind without the tracker caches ever being invalidated
+        $normalised = [];
+        foreach ($settingIdToEnforced as $settingId => $enforced) {
+            if (!array_key_exists($settingId, $toggleableSettingsById)) {
+                throw new Exception(sprintf('The setting "%s" is unknown or cannot be toggled', $settingId));
+            }
+
+            $enforced = filter_var($enforced, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            if (is_null($enforced)) {
+                throw new Exception(sprintf('Invalid enforcement value for the setting "%s"', $settingId));
+            }
+
+            $normalised[$settingId] = $enforced;
+        }
+
+        foreach ($normalised as $settingId => $enforced) {
+            $toggleableSettingsById[$settingId]::setEnforced($enforced, $idSite);
+        }
+
         if (!is_null($idSite)) {
             Cache::deleteCacheWebsiteAttributes($idSite);
         }

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -655,6 +655,7 @@ class API extends \Piwik\Plugin\API
      * @param string $complianceType Compliance policy name to inspect.
      * @return array<string, bool|array<int, array<string, string>>> Compliance status including enforcement state,
      *                                                               config control flag, and requirement details.
+     * @deprecated since Matomo 6.0, use {@link getCompliancePolicySettings()} instead.
      * @internal
      *
      */
@@ -722,13 +723,123 @@ class API extends \Piwik\Plugin\API
             throw new Exception('Invalid compliance policy');
         }
 
-        if ($idSite === 'all') {
-            $idSite = null;
-        } else {
-            $idSite = intval($idSite);
-        }
+        $idSite = $this->resolveCompliancePolicyIdSite($idSite);
 
         return $this->complianceSettingsProvider->getPolicySettings($policy, $idSite);
+    }
+
+    /**
+     * @param int|string $idSite
+     * @throws Exception when the site does not exist
+     */
+    private function resolveCompliancePolicyIdSite($idSite): ?int
+    {
+        if ($idSite === 'all') {
+            return null;
+        }
+
+        $idSite = intval($idSite);
+        new Site($idSite); // throws for unknown site ids
+
+        return $idSite;
+    }
+
+    /**
+     * Sets the enforcement state of individual compliance policy settings.
+     *
+     * Only the settings present in `settingValues` are changed; all other settings keep
+     * their current enforcement state. Enforcing a setting overrides the underlying Matomo
+     * setting at read time, the underlying configuration itself is never modified.
+     *
+     * @param int|string $idSite Site ID to update, or `all` for the instance-wide state.
+     * @param string $compliancePolicy Compliance policy id to update, e.g. `cnil_v1`.
+     * @param array<string, int|string|bool> $settingValues Map of policy setting id => whether to
+     *                                                      enforce it, e.g. settingValues[PrivacyManager.IPAnonymisation]=1
+     * @param string|null $passwordConfirmation Current user password confirmation when required.
+     * @return array<string, mixed> The updated payload, as returned by {@link getCompliancePolicySettings()}.
+     * @internal
+     *
+     */
+    public function setCompliancePolicySettings(
+        $idSite,
+        string $compliancePolicy,
+        array $settingValues,
+        #[\SensitiveParameter]
+        ?string $passwordConfirmation = null
+    ): array {
+        $policy = $this->checkCompliancePolicySettingsWriteAccess($compliancePolicy, $passwordConfirmation);
+
+        $idSite = $this->resolveCompliancePolicyIdSite($idSite);
+
+        PolicyManager::setPolicySettingEnforcedStatuses($policy, $settingValues, $idSite);
+
+        return $this->complianceSettingsProvider->getPolicySettings($policy, $idSite);
+    }
+
+    /**
+     * Enables enforcement of every toggleable setting of a compliance policy at once.
+     *
+     * This enforces each of the policy's toggleable settings individually; every setting
+     * stays individually toggleable afterwards. Settings managed outside the compliance
+     * page are left untouched.
+     *
+     * @param int|string $idSite Site ID to update, or `all` for the instance-wide state.
+     * @param string $compliancePolicy Compliance policy id to enforce, e.g. `cnil_v1`.
+     * @param string|null $passwordConfirmation Current user password confirmation when required.
+     * @return array<string, mixed> The updated payload, as returned by {@link getCompliancePolicySettings()}.
+     * @internal
+     *
+     */
+    public function enforceCompliancePolicySettings(
+        $idSite,
+        string $compliancePolicy,
+        #[\SensitiveParameter]
+        ?string $passwordConfirmation = null
+    ): array {
+        $policy = $this->checkCompliancePolicySettingsWriteAccess($compliancePolicy, $passwordConfirmation);
+
+        $idSite = $this->resolveCompliancePolicyIdSite($idSite);
+
+        $settingValues = [];
+        foreach (PolicyManager::getAllControlledSettings($policy, $idSite) as $settingClass) {
+            if ($settingClass::isExternallyManagedByPolicyPage()) {
+                continue;
+            }
+            $settingValues[$settingClass::getPolicySettingId()] = true;
+        }
+
+        PolicyManager::setPolicySettingEnforcedStatuses($policy, $settingValues, $idSite);
+
+        return $this->complianceSettingsProvider->getPolicySettings($policy, $idSite);
+    }
+
+    /**
+     * @return class-string<CompliancePolicy>
+     */
+    private function checkCompliancePolicySettingsWriteAccess(
+        string $compliancePolicy,
+        #[\SensitiveParameter]
+        ?string $passwordConfirmation
+    ): string {
+        Piwik::checkUserHasSuperUserAccess();
+
+        $this->checkGranularComplianceFeatureIsEnabled();
+
+        if (StaticContainer::get(AuthenticationToken::class)->isSessionToken()) {
+            $this->confirmCurrentUserPassword($passwordConfirmation);
+        }
+
+        $policy = PolicyManager::getPolicyByName($compliancePolicy);
+
+        if (is_null($policy)) {
+            throw new Exception('Invalid compliance policy');
+        }
+
+        if (PolicyManager::isPolicyConfigControlled($policy)) {
+            throw new Exception('The compliance policy is controlled by the config file and cannot be changed');
+        }
+
+        return $policy;
     }
 
     private function checkGranularComplianceFeatureIsEnabled(): void
@@ -746,6 +857,8 @@ class API extends \Piwik\Plugin\API
      * @param bool $enforce `true` to enforce the selected policy, `false` to disable enforcement.
      * @param string|null $passwordConfirmation Current user password confirmation when required.
      * @return bool `true` if the policy is enabled after the update, `false` otherwise.
+     * @deprecated since Matomo 6.0, use {@link setCompliancePolicySettings()} or
+     *             {@link enforceCompliancePolicySettings()} instead.
      * @internal
      *
      */

--- a/plugins/PrivacyManager/tests/Integration/ApiTest.php
+++ b/plugins/PrivacyManager/tests/Integration/ApiTest.php
@@ -16,6 +16,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\NoAccessException;
 use Piwik\Policy\CnilPolicy;
 use Piwik\Plugins\PrivacyManager\API;
+use Piwik\Plugins\PrivacyManager\Settings\IPAnonymisation;
 use Piwik\Plugins\PrivacyManager\Settings\IpAddressMaskLength;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
@@ -155,6 +156,8 @@ class ApiTest extends IntegrationTestCase
 
     public function testGetCompliancePolicySettingsThrowsWhenFeatureIsNotEnabled(): void
     {
+        $this->disableGranularComplianceFeature();
+
         $this->expectExceptionMessage('Granular compliance configuration is not enabled');
 
         $this->api->getCompliancePolicySettings($this->siteId, 'cnil_v1');
@@ -280,9 +283,181 @@ class ApiTest extends IntegrationTestCase
         $this->assertSame('non_compliant', $thirdPartyCookies['status']);
     }
 
+    public function testSetCompliancePolicySettingsThrowsWhenFeatureIsNotEnabled(): void
+    {
+        $this->disableGranularComplianceFeature();
+
+        $this->expectExceptionMessage('Granular compliance configuration is not enabled');
+
+        $this->api->setCompliancePolicySettings($this->siteId, 'cnil_v1', ['PrivacyManager.IPAnonymisation' => 1]);
+    }
+
+    public function testSetCompliancePolicySettingsThrowsForUnknownSettingId(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        $this->expectExceptionMessage('The setting "PrivacyManager.Egg" is unknown or cannot be toggled');
+
+        $this->api->setCompliancePolicySettings($this->siteId, 'cnil_v1', ['PrivacyManager.Egg' => 1]);
+    }
+
+    public function testSetCompliancePolicySettingsThrowsForExternallyManagedSetting(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        $this->expectExceptionMessage('The setting "Core.ThirdPartyCookies" is unknown or cannot be toggled');
+
+        $this->api->setCompliancePolicySettings($this->siteId, 'cnil_v1', ['Core.ThirdPartyCookies' => 1]);
+    }
+
+    public function testSetCompliancePolicySettingsThrowsWhenPolicyIsConfigControlled(): void
+    {
+        $this->enableGranularComplianceFeature();
+        Config::getInstance()->CnilPolicy = ['cnil_v1_policy_enabled' => 1];
+
+        $this->expectExceptionMessage('The compliance policy is controlled by the config file and cannot be changed');
+
+        $this->api->setCompliancePolicySettings($this->siteId, 'cnil_v1', ['PrivacyManager.IPAnonymisation' => 1]);
+    }
+
+    public function testSetCompliancePolicySettingsRequiresPasswordWhenUsingSessionToken(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('UsersManager_ConfirmWithReAuthentication');
+
+        $_GET['force_api_session'] = 0;
+        $_POST['token_auth'] = 'postToken';
+        $_POST['force_api_session'] = 1;
+
+        try {
+            $this->api->setCompliancePolicySettings($this->siteId, 'cnil_v1', ['PrivacyManager.IPAnonymisation' => 1]);
+        } finally {
+            unset($_GET['force_api_session']);
+            unset($_POST['token_auth']);
+            unset($_POST['force_api_session']);
+        }
+    }
+
+    public function testSetCompliancePolicySettingsEnforcesAndReleasesIndividualSettings(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        // make the underlying setting non-compliant so enforcement is observable
+        $this->api->setAnonymizeIpSettings(false, 2, true);
+
+        $payload = $this->api->setCompliancePolicySettings(
+            $this->siteId,
+            'cnil_v1',
+            ['PrivacyManager.IPAnonymisation' => 1]
+        );
+
+        $settings = $this->getSettingsById($payload);
+        $this->assertTrue($settings['PrivacyManager.IPAnonymisation']['enforced']);
+        $this->assertSame('enforced', $settings['PrivacyManager.IPAnonymisation']['status']);
+        $this->assertFalse($payload['policyEnforced']);
+
+        // settings not present in the request keep their state
+        $this->assertFalse($settings['PrivacyManager.DataRoundingEnabled']['enforced']);
+        $this->assertSame('non_compliant', $settings['PrivacyManager.DataRoundingEnabled']['status']);
+
+        // the enforced value is applied at read time
+        $this->assertGreaterThanOrEqual(1, IPAnonymisation::getInstance($this->siteId)->getValue());
+
+        $payload = $this->api->setCompliancePolicySettings(
+            $this->siteId,
+            'cnil_v1',
+            ['PrivacyManager.IPAnonymisation' => 0]
+        );
+
+        $settings = $this->getSettingsById($payload);
+        $this->assertFalse($settings['PrivacyManager.IPAnonymisation']['enforced']);
+        $this->assertSame('non_compliant', $settings['PrivacyManager.IPAnonymisation']['status']);
+    }
+
+    public function testEnforceCompliancePolicySettingsEnforcesAllToggleableSettings(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        $payload = $this->api->enforceCompliancePolicySettings($this->siteId, 'cnil_v1');
+
+        $this->assertTrue($payload['policyEnforced']);
+        foreach ($payload['settings'] as $setting) {
+            if ($setting['toggleable']) {
+                $this->assertTrue($setting['enforced'], "setting {$setting['id']} should be enforced");
+            }
+        }
+
+        // enforcement is written per setting: the legacy whole-policy flag is left untouched,
+        // it is only an inheritance default and no longer the source of truth
+        $complianceStatus = $this->api->getComplianceStatus($this->siteId, 'cnil_v1');
+        $this->assertFalse($complianceStatus['complianceModeEnforced']);
+    }
+
+    public function testSetCompliancePolicySettingsCanDisableSingleSettingAfterPolicyWasEnforced(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        $this->api->enforceCompliancePolicySettings($this->siteId, 'cnil_v1');
+
+        $payload = $this->api->setCompliancePolicySettings(
+            $this->siteId,
+            'cnil_v1',
+            ['PrivacyManager.DataRoundingEnabled' => 0]
+        );
+
+        $settings = $this->getSettingsById($payload);
+        $this->assertFalse($settings['PrivacyManager.DataRoundingEnabled']['enforced']);
+        $this->assertSame('non_compliant', $settings['PrivacyManager.DataRoundingEnabled']['status']);
+        $this->assertTrue($settings['PrivacyManager.CampaignParameterValuesMasked']['enforced']);
+        $this->assertFalse($payload['policyEnforced']);
+    }
+
+    public function testSetCompliancePolicySettingsCanDisableSingleSettingAfterLegacyPolicyFlagWasSet(): void
+    {
+        // enforce via the deprecated whole-policy API first
+        $this->api->setComplianceStatus((string) $this->siteId, 'cnil_v1', true);
+
+        $this->enableGranularComplianceFeature();
+
+        $payload = $this->api->setCompliancePolicySettings(
+            $this->siteId,
+            'cnil_v1',
+            ['PrivacyManager.DataRoundingEnabled' => 0]
+        );
+
+        $settings = $this->getSettingsById($payload);
+        $this->assertFalse($settings['PrivacyManager.DataRoundingEnabled']['enforced']);
+        $this->assertTrue($settings['PrivacyManager.CampaignParameterValuesMasked']['enforced']);
+    }
+
+    public function testSetCompliancePolicySettingsThrowsForUnknownSite(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        $this->expectException(\Piwik\Exception\UnexpectedWebsiteFoundException::class);
+
+        $this->api->setCompliancePolicySettings(99999, 'cnil_v1', ['PrivacyManager.IPAnonymisation' => 1]);
+    }
+
+    public function testSetCompliancePolicySettingsThrowsForGarbageEnforcementValue(): void
+    {
+        $this->enableGranularComplianceFeature();
+
+        $this->expectExceptionMessage('Invalid enforcement value for the setting "PrivacyManager.IPAnonymisation"');
+
+        $this->api->setCompliancePolicySettings($this->siteId, 'cnil_v1', ['PrivacyManager.IPAnonymisation' => 'banana']);
+    }
+
     private function enableGranularComplianceFeature(): void
     {
         Config::getInstance()->FeatureFlags = ['GranularPrivacyCompliance_feature' => 'enabled'];
+    }
+
+    private function disableGranularComplianceFeature(): void
+    {
+        Config::getInstance()->FeatureFlags = ['GranularPrivacyCompliance_feature' => 'disabled'];
     }
 
     /**


### PR DESCRIPTION
Part of DEV-20349. The CNIL compliance page is moving from one enforce checkbox to a switch per setting, because customers want to enforce individual requirements without switching on the whole policy. With the read side and resolution in place, this PR adds the write APIs the new dashboard will save through.

`PrivacyManager.setCompliancePolicySettings` takes a map of setting id to on or off and stores each choice, for one site or instance wide. Unknown or non toggleable ids are rejected, writes are refused when enforcement is controlled from the config file, and saves need password confirmation for session authenticated requests. It returns the fresh payload so the dashboard can re-render straight from the response. `enforceCompliancePolicySettings` switches every requirement on in one call, mainly for automation. Underneath, `PolicyManager` gets a batch method that validates the ids and clears the tracker caches once per save rather than per setting.

Everything is gated behind the `GranularPrivacyCompliance` feature flag and super user only, so there is no visible change yet. The existing endpoints keep working unchanged. Like the read API, these are shipped `@internal` but shaped as the future public contract (DEV-20350).

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
