### PR TITLE
Add store and table component for the granular compliance dashboard, DEV-20349

### DIFF
--- a/plugins/PrivacyManager/vue/src/Compliance/GranularCompliance.store.spec.ts
+++ b/plugins/PrivacyManager/vue/src/Compliance/GranularCompliance.store.spec.ts
@@ -1,0 +1,200 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+vi.mock('CoreHome', () => ({
+  AjaxHelper: {
+    fetch: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+import { AjaxHelper } from 'CoreHome';
+import {
+  createGranularComplianceStore,
+  PolicySetting,
+  PolicySettingsPayload,
+} from './GranularCompliance.store';
+
+const fetchMock = vi.mocked(AjaxHelper.fetch);
+const postMock = vi.mocked(AjaxHelper.post);
+
+function setting(overrides: Partial<PolicySetting> = {}): PolicySetting {
+  return {
+    id: 'PrivacyManager.IPAnonymisation',
+    name: 'IP Anonymisation Enabled',
+    whatItDoes: 'what it does',
+    impact: 'impact',
+    status: 'non_compliant',
+    enforced: false,
+    toggleable: true,
+    section: 'settings',
+    ...overrides,
+  };
+}
+
+function payload(settings: PolicySetting[], overrides: Partial<PolicySettingsPayload> = {}): PolicySettingsPayload {
+  return {
+    policy: 'cnil_v1',
+    title: 'CNIL',
+    description: 'desc',
+    configControlled: false,
+    policyEnforced: false,
+    settings,
+    ...overrides,
+  };
+}
+
+async function createLoadedStore(settings: PolicySetting[], overrides: Partial<PolicySettingsPayload> = {}) {
+  fetchMock.mockResolvedValueOnce(payload(settings, overrides));
+  const store = createGranularComplianceStore('cnil_v1');
+  store.setIdSite('1');
+  await new Promise(process.nextTick);
+  return store;
+}
+
+describe('PrivacyManager/GranularCompliance.store', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    postMock.mockReset();
+  });
+
+  it('fetches the payload for the site and mirrors toggle state', async () => {
+    const store = await createLoadedStore([
+      setting({ enforced: true, status: 'enforced' }),
+      setting({ id: 'Core.ThirdPartyCookies', toggleable: false, enforced: null, section: 'external' }),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'PrivacyManager.getCompliancePolicySettings',
+        idSite: '1',
+        compliancePolicy: 'cnil_v1',
+      }),
+      expect.anything(),
+    );
+    expect(store.state.settings).toHaveLength(2);
+    expect(store.state.localEnforced['PrivacyManager.IPAnonymisation']).toBe(true);
+    // non-toggleable settings never get local toggle state
+    expect('Core.ThirdPartyCookies' in store.state.localEnforced).toBe(false);
+    expect(store.dirtySettingIds.value).toEqual([]);
+  });
+
+  it('tracks dirty settings when a toggle differs from the persisted state', async () => {
+    const store = await createLoadedStore([setting({ enforced: false })]);
+
+    store.toggleSetting('PrivacyManager.IPAnonymisation');
+    expect(store.dirtySettingIds.value).toEqual(['PrivacyManager.IPAnonymisation']);
+
+    // toggling back clears the dirty state
+    store.toggleSetting('PrivacyManager.IPAnonymisation');
+    expect(store.dirtySettingIds.value).toEqual([]);
+  });
+
+  it('ignores toggles for unknown settings and when config controlled', async () => {
+    const store = await createLoadedStore(
+      [setting({ enforced: true })],
+      { configControlled: true, policyEnforced: true },
+    );
+
+    store.toggleSetting('PrivacyManager.IPAnonymisation');
+    store.toggleSetting('PrivacyManager.DoesNotExist');
+
+    expect(store.dirtySettingIds.value).toEqual([]);
+  });
+
+  it('enforceAll only flips local toggles and does not call the API', async () => {
+    const store = await createLoadedStore([
+      setting({ id: 'A.One', enforced: false }),
+      setting({ id: 'B.Two', enforced: false }),
+      setting({ id: 'C.External', toggleable: false, enforced: null, section: 'external' }),
+    ]);
+
+    store.enforceAll();
+
+    expect(store.state.localEnforced['A.One']).toBe(true);
+    expect(store.state.localEnforced['B.Two']).toBe(true);
+    expect(store.dirtySettingIds.value).toEqual(['A.One', 'B.Two']);
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('save submits only the dirty settings and replaces state from the response', async () => {
+    const store = await createLoadedStore([
+      setting({ id: 'A.One', enforced: false }),
+      setting({ id: 'B.Two', enforced: true }),
+    ]);
+
+    store.toggleSetting('A.One');
+    postMock.mockResolvedValueOnce(payload([
+      setting({ id: 'A.One', enforced: true, status: 'enforced' }),
+      setting({ id: 'B.Two', enforced: true, status: 'enforced' }),
+    ], { policyEnforced: true }));
+
+    store.save('secret');
+    await new Promise(process.nextTick);
+
+    expect(postMock).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'PrivacyManager.setCompliancePolicySettings' }),
+      expect.objectContaining({
+        settingValues: { 'A.One': 1 },
+        passwordConfirmation: 'secret',
+      }),
+      expect.anything(),
+    );
+    expect(store.state.policyEnforced).toBe(true);
+    expect(store.state.localEnforced['A.One']).toBe(true);
+    expect(store.dirtySettingIds.value).toEqual([]);
+  });
+
+  it('save without dirty settings is a no-op', async () => {
+    const store = await createLoadedStore([setting()]);
+
+    store.save('secret');
+
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps local state and records the error when saving fails', async () => {
+    const store = await createLoadedStore([setting({ id: 'A.One', enforced: false })]);
+
+    store.toggleSetting('A.One');
+    postMock.mockRejectedValueOnce(new Error('nope'));
+
+    store.save('secret');
+    await new Promise(process.nextTick);
+
+    expect(store.state.saveError).toBe('nope');
+    expect(store.dirtySettingIds.value).toEqual(['A.One']);
+  });
+
+  it('discards stale fetch responses after the site changed', async () => {
+    let resolveFirst!: (p: PolicySettingsPayload) => void;
+    fetchMock.mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }));
+    fetchMock.mockResolvedValueOnce(payload([setting({ id: 'B.Two', enforced: true })]));
+
+    const store = createGranularComplianceStore('cnil_v1');
+    store.setIdSite('1');
+    store.setIdSite('2');
+    await new Promise(process.nextTick);
+
+    // the slow response for site 1 arrives last and must be ignored
+    resolveFirst(payload([setting({ id: 'A.One' })]));
+    await new Promise(process.nextTick);
+
+    expect(store.state.settings[0].id).toBe('B.Two');
+  });
+
+  it('records the error when fetching fails', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('offline'));
+    const store = createGranularComplianceStore('cnil_v1');
+
+    store.setIdSite('1');
+    await new Promise(process.nextTick);
+
+    expect(store.state.fetchError).toBe('offline');
+    expect(store.state.loading).toBe(false);
+  });
+});

--- a/plugins/PrivacyManager/vue/src/Compliance/GranularCompliance.store.spec.ts
+++ b/plugins/PrivacyManager/vue/src/Compliance/GranularCompliance.store.spec.ts
@@ -147,6 +147,25 @@ describe('PrivacyManager/GranularCompliance.store', () => {
     expect(store.state.policyEnforced).toBe(true);
     expect(store.state.localEnforced['A.One']).toBe(true);
     expect(store.dirtySettingIds.value).toEqual([]);
+    expect(store.state.saveSuccess).toBe(true);
+  });
+
+  it('clears the save success notification on the next toggle', async () => {
+    const store = await createLoadedStore([
+      setting({ id: 'A.One', enforced: false }),
+    ]);
+
+    store.toggleSetting('A.One');
+    postMock.mockResolvedValueOnce(payload([
+      setting({ id: 'A.One', enforced: true, status: 'enforced' }),
+    ], { policyEnforced: true }));
+
+    store.save('secret');
+    await new Promise(process.nextTick);
+    expect(store.state.saveSuccess).toBe(true);
+
+    store.toggleSetting('A.One');
+    expect(store.state.saveSuccess).toBe(false);
   });
 
   it('save without dirty settings is a no-op', async () => {
@@ -167,6 +186,7 @@ describe('PrivacyManager/GranularCompliance.store', () => {
     await new Promise(process.nextTick);
 
     expect(store.state.saveError).toBe('nope');
+    expect(store.state.saveSuccess).toBe(false);
     expect(store.dirtySettingIds.value).toEqual(['A.One']);
   });
 

--- a/plugins/PrivacyManager/vue/src/Compliance/GranularCompliance.store.ts
+++ b/plugins/PrivacyManager/vue/src/Compliance/GranularCompliance.store.ts
@@ -1,0 +1,201 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+import {
+  computed,
+  ComputedRef,
+  DeepReadonly,
+  reactive,
+  readonly,
+} from 'vue';
+import { AjaxHelper } from 'CoreHome';
+
+export interface PolicySetting {
+  id: string;
+  name: string;
+  whatItDoes: string;
+  impact: string;
+  status: string;
+  enforced: boolean | null;
+  toggleable: boolean;
+  section: string;
+}
+
+export interface PolicySettingsPayload {
+  policy: string;
+  title: string;
+  description: string;
+  configControlled: boolean;
+  policyEnforced: boolean;
+  settings: PolicySetting[];
+}
+
+interface GranularComplianceStoreState {
+  idSite: string | null;
+  loading: boolean;
+  saving: boolean;
+  configControlled: boolean;
+  policyEnforced: boolean;
+  settings: PolicySetting[];
+  localEnforced: Record<string, boolean>;
+  fetchError: string | null;
+  saveError: string | null;
+}
+
+export interface GranularComplianceStore {
+  state: DeepReadonly<GranularComplianceStoreState>;
+  dirtySettingIds: ComputedRef<string[]>;
+  setIdSite: (idSite: string) => void;
+  toggleSetting: (settingId: string) => void;
+  enforceAll: () => void;
+  save: (password: string) => void;
+}
+
+export function createGranularComplianceStore(policy: string): GranularComplianceStore {
+  const state = reactive<GranularComplianceStoreState>({
+    idSite: null,
+    loading: false,
+    saving: false,
+    configControlled: false,
+    policyEnforced: false,
+    settings: [],
+    localEnforced: {},
+    fetchError: null,
+    saveError: null,
+  });
+
+  function applyPayload(payload: PolicySettingsPayload) {
+    state.configControlled = payload.configControlled;
+    state.policyEnforced = payload.policyEnforced;
+    state.settings = payload.settings;
+
+    const localEnforced: Record<string, boolean> = {};
+    payload.settings.forEach((setting) => {
+      if (setting.toggleable) {
+        localEnforced[setting.id] = !!setting.enforced;
+      }
+    });
+    state.localEnforced = localEnforced;
+  }
+
+  const dirtySettingIds = computed(
+    () => state.settings
+      .filter((s) => s.toggleable && state.localEnforced[s.id] !== !!s.enforced)
+      .map((s) => s.id),
+  );
+
+  function fetchSettings() {
+    if (!state.idSite) {
+      return;
+    }
+
+    // guard against out-of-order responses when the site changes mid-request
+    const requestedIdSite = state.idSite;
+
+    state.loading = true;
+    state.fetchError = null;
+    AjaxHelper.fetch<PolicySettingsPayload>(
+      {
+        idSite: requestedIdSite,
+        compliancePolicy: policy,
+        method: 'PrivacyManager.getCompliancePolicySettings',
+      },
+      {
+        createErrorNotification: false,
+      },
+    ).then((payload) => {
+      if (state.idSite === requestedIdSite) {
+        applyPayload(payload);
+      }
+    }).catch((error) => {
+      if (state.idSite === requestedIdSite) {
+        state.fetchError = error.message || error;
+      }
+    }).finally(() => {
+      if (state.idSite === requestedIdSite) {
+        state.loading = false;
+      }
+    });
+  }
+
+  function setIdSite(idSite: string) {
+    state.idSite = idSite;
+    fetchSettings();
+  }
+
+  function toggleSetting(settingId: string) {
+    if (state.configControlled || !(settingId in state.localEnforced)) {
+      return;
+    }
+
+    state.localEnforced[settingId] = !state.localEnforced[settingId];
+  }
+
+  function enforceAll() {
+    if (state.configControlled) {
+      return;
+    }
+
+    state.settings.forEach((setting) => {
+      if (setting.toggleable) {
+        state.localEnforced[setting.id] = true;
+      }
+    });
+  }
+
+  function save(password: string) {
+    const settingValues: Record<string, number> = {};
+    dirtySettingIds.value.forEach((settingId) => {
+      settingValues[settingId] = state.localEnforced[settingId] ? 1 : 0;
+    });
+
+    if (!Object.keys(settingValues).length) {
+      return;
+    }
+
+    // guard against applying a save response after the site changed mid-request
+    const requestedIdSite = state.idSite;
+
+    state.saving = true;
+    state.saveError = null;
+    AjaxHelper.post<PolicySettingsPayload>(
+      {
+        idSite: requestedIdSite,
+        compliancePolicy: policy,
+        method: 'PrivacyManager.setCompliancePolicySettings',
+      },
+      {
+        settingValues,
+        passwordConfirmation: password,
+      },
+      {
+        createErrorNotification: false,
+      },
+    ).then((payload) => {
+      if (state.idSite === requestedIdSite) {
+        applyPayload(payload);
+      }
+    }).catch((error) => {
+      if (state.idSite === requestedIdSite) {
+        state.saveError = error.message || error;
+      }
+    }).finally(() => {
+      state.saving = false;
+    });
+  }
+
+  const publicState = readonly(state) as DeepReadonly<GranularComplianceStoreState>;
+
+  return {
+    state: publicState,
+    dirtySettingIds,
+    setIdSite,
+    toggleSetting,
+    enforceAll,
+    save,
+  };
+}

--- a/plugins/PrivacyManager/vue/src/Compliance/GranularCompliance.store.ts
+++ b/plugins/PrivacyManager/vue/src/Compliance/GranularCompliance.store.ts
@@ -44,6 +44,7 @@ interface GranularComplianceStoreState {
   localEnforced: Record<string, boolean>;
   fetchError: string | null;
   saveError: string | null;
+  saveSuccess: boolean;
 }
 
 export interface GranularComplianceStore {
@@ -66,6 +67,7 @@ export function createGranularComplianceStore(policy: string): GranularComplianc
     localEnforced: {},
     fetchError: null,
     saveError: null,
+    saveSuccess: false,
   });
 
   function applyPayload(payload: PolicySettingsPayload) {
@@ -124,6 +126,8 @@ export function createGranularComplianceStore(policy: string): GranularComplianc
 
   function setIdSite(idSite: string) {
     state.idSite = idSite;
+    state.saveError = null;
+    state.saveSuccess = false;
     fetchSettings();
   }
 
@@ -133,6 +137,7 @@ export function createGranularComplianceStore(policy: string): GranularComplianc
     }
 
     state.localEnforced[settingId] = !state.localEnforced[settingId];
+    state.saveSuccess = false;
   }
 
   function enforceAll() {
@@ -162,6 +167,7 @@ export function createGranularComplianceStore(policy: string): GranularComplianc
 
     state.saving = true;
     state.saveError = null;
+    state.saveSuccess = false;
     AjaxHelper.post<PolicySettingsPayload>(
       {
         idSite: requestedIdSite,
@@ -178,6 +184,7 @@ export function createGranularComplianceStore(policy: string): GranularComplianc
     ).then((payload) => {
       if (state.idSite === requestedIdSite) {
         applyPayload(payload);
+        state.saveSuccess = true;
       }
     }).catch((error) => {
       if (state.idSite === requestedIdSite) {

--- a/plugins/PrivacyManager/vue/src/Compliance/GranularComplianceTable.spec.ts
+++ b/plugins/PrivacyManager/vue/src/Compliance/GranularComplianceTable.spec.ts
@@ -54,7 +54,7 @@ describe('PrivacyManager/GranularComplianceTable', () => {
     expect(rows[0].find('.settingName').text()).toBe('IP Anonymisation Enabled');
     expect(rows[0].find('.status').text()).toContain('PrivacyManager_ComplianceCompliant');
     expect(rows[0].find('.status .icon-ok').exists()).toBe(true);
-    expect(rows[1].find('.status').text()).toContain('PrivacyManager_ComplianceStatusEnforced');
+    expect(rows[1].find('.status').text()).toContain('PrivacyManager_ComplianceStatusCompliantEnforced');
     expect(rows[1].find('input[type=checkbox]').element as HTMLInputElement).toHaveProperty('checked', true);
   });
 

--- a/plugins/PrivacyManager/vue/src/Compliance/GranularComplianceTable.spec.ts
+++ b/plugins/PrivacyManager/vue/src/Compliance/GranularComplianceTable.spec.ts
@@ -1,0 +1,125 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+import { mount } from '@vue/test-utils';
+import GranularComplianceTable from './GranularComplianceTable.vue';
+import { PolicySetting } from './GranularCompliance.store';
+
+function setting(overrides: Partial<PolicySetting> = {}): PolicySetting {
+  return {
+    id: 'PrivacyManager.IPAnonymisation',
+    name: 'IP Anonymisation Enabled',
+    whatItDoes: 'what it does',
+    impact: 'impact',
+    status: 'non_compliant',
+    enforced: false,
+    toggleable: true,
+    section: 'settings',
+    ...overrides,
+  };
+}
+
+function createWrapper(props = {}) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return mount(GranularComplianceTable as any, {
+    props: {
+      settings: [setting()],
+      ...props,
+    },
+    global: {
+      mocks: {
+        translate: (key: string) => key,
+        $sanitize: (html: string) => html,
+      },
+    },
+  });
+}
+
+describe('PrivacyManager/GranularComplianceTable', () => {
+  it('renders one row per setting with name, texts and status', () => {
+    const wrapper = createWrapper({
+      settings: [
+        setting({ status: 'compliant' }),
+        setting({ id: 'B.Two', name: 'Second', status: 'enforced', enforced: true }),
+      ],
+      localEnforced: { 'PrivacyManager.IPAnonymisation': false, 'B.Two': true },
+    });
+
+    const rows = wrapper.findAll('tbody tr');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].find('.settingName').text()).toBe('IP Anonymisation Enabled');
+    expect(rows[0].find('.status').text()).toContain('PrivacyManager_ComplianceCompliant');
+    expect(rows[0].find('.status .icon-ok').exists()).toBe(true);
+    expect(rows[1].find('.status').text()).toContain('PrivacyManager_ComplianceStatusEnforced');
+    expect(rows[1].find('input[type=checkbox]').element as HTMLInputElement).toHaveProperty('checked', true);
+  });
+
+  it('renders non-compliant status without an icon', () => {
+    const wrapper = createWrapper({ settings: [setting({ status: 'non_compliant' })] });
+
+    const status = wrapper.find('.status');
+    expect(status.text()).toContain('PrivacyManager_ComplianceNonCompliant');
+    expect(status.find('.icon').exists()).toBe(false);
+  });
+
+  it('overlays applies-on-save for dirty toggleable settings', () => {
+    const wrapper = createWrapper({
+      settings: [setting({ status: 'non_compliant' })],
+      localEnforced: { 'PrivacyManager.IPAnonymisation': true },
+      dirtySettingIds: ['PrivacyManager.IPAnonymisation'],
+    });
+
+    const status = wrapper.find('.status');
+    expect(status.classes()).toContain('applies-on-save');
+    expect(status.text()).toContain('PrivacyManager_ComplianceStatusAppliesOnSave');
+    expect(status.find('.icon-warning').exists()).toBe(true);
+  });
+
+  it('gives each toggle an accessible name', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.find('input[type=checkbox]').attributes('aria-label'))
+      .toBe('PrivacyManager_ComplianceStatusEnforced: IP Anonymisation Enabled');
+  });
+
+  it('emits toggle with the setting id when the switch changes', async () => {
+    const wrapper = createWrapper();
+
+    await wrapper.find('input[type=checkbox]').trigger('change');
+
+    expect(wrapper.emitted('toggle')).toEqual([['PrivacyManager.IPAnonymisation']]);
+  });
+
+  it('disables switches when the table is disabled', () => {
+    const wrapper = createWrapper({ disabled: true });
+
+    expect((wrapper.find('input[type=checkbox]').element as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it('renders lock statuses and no switch for non-toggleable settings', () => {
+    const wrapper = createWrapper({
+      settings: [setting({
+        id: 'Core.ThirdPartyCookies',
+        toggleable: false,
+        enforced: null,
+        status: 'on_by_default',
+        section: 'external',
+      })],
+    });
+
+    expect(wrapper.find('.status').text()).toContain('PrivacyManager_ComplianceStatusOnByDefault');
+    expect(wrapper.find('.status .icon-locked').exists()).toBe(true);
+    expect(wrapper.find('input[type=checkbox]').exists()).toBe(false);
+  });
+
+  it('hides the whole toggle column when showToggles is off', () => {
+    const wrapper = createWrapper({ showToggles: false });
+
+    expect(wrapper.findAll('thead th')).toHaveLength(4);
+    expect(wrapper.find('.toggleColumn').exists()).toBe(false);
+  });
+});

--- a/plugins/PrivacyManager/vue/src/Compliance/GranularComplianceTable.vue
+++ b/plugins/PrivacyManager/vue/src/Compliance/GranularComplianceTable.vue
@@ -13,7 +13,7 @@
           {{ translate('PrivacyManager_ComplianceTableSettingName') }}
         </th>
         <th class="label">
-          {{ translate('PrivacyManager_ComplianceTableWhatItDoes') }}
+          {{ translate('General_Description') }}
         </th>
         <th class="label">
           {{ translate('PrivacyManager_ComplianceTableImpact') }}

--- a/plugins/PrivacyManager/vue/src/Compliance/GranularComplianceTable.vue
+++ b/plugins/PrivacyManager/vue/src/Compliance/GranularComplianceTable.vue
@@ -85,7 +85,7 @@ const iconClassMap: Record<string, string> = {
 
 const statusTextMap: Record<string, string> = {
   compliant: 'PrivacyManager_ComplianceCompliant',
-  enforced: 'PrivacyManager_ComplianceStatusEnforced',
+  enforced: 'PrivacyManager_ComplianceStatusCompliantEnforced',
   non_compliant: 'PrivacyManager_ComplianceNonCompliant',
   on_by_default: 'PrivacyManager_ComplianceStatusOnByDefault',
   manual: 'PrivacyManager_ComplianceStatusManual',

--- a/plugins/PrivacyManager/vue/src/Compliance/GranularComplianceTable.vue
+++ b/plugins/PrivacyManager/vue/src/Compliance/GranularComplianceTable.vue
@@ -1,0 +1,142 @@
+<!--
+  Matomo - free/libre analytics platform
+
+  @link    https://matomo.org
+  @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+-->
+
+<template>
+  <table class="card-table dataTable compliance granularCompliance">
+    <thead>
+      <tr>
+        <th class="label">
+          {{ translate('PrivacyManager_ComplianceTableSettingName') }}
+        </th>
+        <th class="label">
+          {{ translate('PrivacyManager_ComplianceTableWhatItDoes') }}
+        </th>
+        <th class="label">
+          {{ translate('PrivacyManager_ComplianceTableImpact') }}
+        </th>
+        <th class="label">
+          {{ translate('PrivacyManager_ComplianceTableSettingStatus') }}
+        </th>
+        <th class="label toggleColumn" v-if="showToggles">
+          <span class="sr-only">{{ translate('PrivacyManager_ComplianceStatusEnforced') }}</span>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="setting in settings" :key="setting.id">
+        <td class="settingName">{{ setting.name }}</td>
+        <td v-html="$sanitize(setting.whatItDoes)" />
+        <td v-html="$sanitize(setting.impact)" />
+        <td :class="['status', getStatusClass(setting)]">
+          <span
+            v-if="getIconClass(setting)"
+            :class="['icon', getIconClass(setting)]"
+          ></span>
+          {{ translate(getStatusText(setting)) }}
+        </td>
+        <td class="toggleColumn" v-if="showToggles">
+          <div
+            :class="['switch', 'switch-' + setting.id.replace('.', '-')]"
+            v-if="setting.toggleable"
+          >
+            <label>
+              <input
+                type="checkbox"
+                :id="'toggle-' + setting.id"
+                :checked="isToggledOn(setting)"
+                :disabled="disabled"
+                :aria-label="translate('PrivacyManager_ComplianceStatusEnforced') + ': ' + setting.name"
+                @change="$emit('toggle', setting.id)"
+              />
+              <span class="lever"></span>
+            </label>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import { PolicySetting } from './GranularCompliance.store';
+
+const statusClassMap: Record<string, string> = {
+  compliant: 'compliant',
+  enforced: 'enforced',
+  non_compliant: 'non-compliant',
+  on_by_default: 'on-by-default',
+  manual: 'manual',
+  applies_on_save: 'applies-on-save',
+};
+
+const iconClassMap: Record<string, string> = {
+  compliant: 'icon-ok',
+  enforced: 'icon-ok',
+  non_compliant: '',
+  on_by_default: 'icon-locked',
+  manual: 'icon-locked',
+  applies_on_save: 'icon-warning',
+};
+
+const statusTextMap: Record<string, string> = {
+  compliant: 'PrivacyManager_ComplianceCompliant',
+  enforced: 'PrivacyManager_ComplianceStatusEnforced',
+  non_compliant: 'PrivacyManager_ComplianceNonCompliant',
+  on_by_default: 'PrivacyManager_ComplianceStatusOnByDefault',
+  manual: 'PrivacyManager_ComplianceStatusManual',
+  applies_on_save: 'PrivacyManager_ComplianceStatusAppliesOnSave',
+};
+
+export default defineComponent({
+  props: {
+    settings: {
+      type: Array as PropType<readonly PolicySetting[]>,
+      required: true,
+    },
+    localEnforced: {
+      type: Object as PropType<Readonly<Record<string, boolean>>>,
+      default: () => ({}),
+    },
+    dirtySettingIds: {
+      type: Array as PropType<readonly string[]>,
+      default: () => [],
+    },
+    showToggles: {
+      type: Boolean,
+      default: true,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['toggle'],
+  methods: {
+    getEffectiveStatus(setting: PolicySetting): string {
+      if (setting.toggleable && this.dirtySettingIds.indexOf(setting.id) !== -1) {
+        return 'applies_on_save';
+      }
+      return setting.status;
+    },
+    getStatusClass(setting: PolicySetting): string {
+      return statusClassMap[this.getEffectiveStatus(setting)] || 'unknown';
+    },
+    getIconClass(setting: PolicySetting): string {
+      const status = this.getEffectiveStatus(setting);
+      return status in iconClassMap ? iconClassMap[status] : 'icon-circle';
+    },
+    getStatusText(setting: PolicySetting): string {
+      return statusTextMap[this.getEffectiveStatus(setting)]
+        || 'PrivacyManager_ComplianceComplianceUnknown';
+    },
+    isToggledOn(setting: PolicySetting): boolean {
+      return !!this.localEnforced[setting.id];
+    },
+  },
+});
+</script>


### PR DESCRIPTION
`GranularCompliance.store.ts` owns the dashboard state: fetching the per-setting payload, local toggle state with dirty tracking (the *Applies on Save* overlay), a client-side enforce-all that only flips toggles, and a batch save that submits dirty rows through password confirmation and replaces state from the response. `GranularComplianceTable.vue` renders the Setting / What it does / Impact / Status / toggle columns with neutral status text and icon accents.

**Not yet wired into the page** — the dashboard lands in the next PR, so this one is pure logic without layout noise.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
