### PR TITLE
Migrate whole-policy compliance flags to per-setting enforcement state, DEV-20349

### DIFF
--- a/core/Policy/CompliancePolicy.php
+++ b/core/Policy/CompliancePolicy.php
@@ -190,9 +190,9 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
      * this function will return true for all sites.
      *
      * @deprecated since Matomo 6.0, enforcement is now stored per setting — use
-     *             {@link isEnforcedForSetting()} instead. This flag remains as the
-     *             whole-policy state written by {@link setActiveStatus()} and as the
-     *             fallback for scopes without per-setting enforcement state.
+     *             {@link isEnforcedForSetting()} instead. This flag only reflects the
+     *             whole-policy state written by {@link setActiveStatus()}; it no longer
+     *             participates in enforcement resolution.
      */
     public static function isActive(?int $idSite): bool
     {
@@ -228,8 +228,6 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
      *  1. config-level enforcement of the whole policy
      *  2. explicit per-setting enforcement state; an enabled instance-wide state
      *     applies to all sites, like {@link isActive()} does for the whole policy
-     *  3. the whole-policy enforcement flag, for scopes where no per-setting
-     *     state has been stored yet
      *
      * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
      */
@@ -251,11 +249,7 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
             }
         }
 
-        if (!is_null($systemValue)) {
-            return false;
-        }
-
-        return static::isActive($idSite);
+        return false;
     }
 
     /**

--- a/core/Updates/6.0.0-b2.php
+++ b/core/Updates/6.0.0-b2.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Plugins\CoreAdminHome\Commands\MigrateCompliancePolicyEnforcement;
+use Piwik\Updater;
+use Piwik\Updater\Migration\Custom as CustomMigration;
+use Piwik\Updates;
+
+class Updates_6_0_0_b2 extends Updates
+{
+    public function getMigrations(Updater $updater)
+    {
+        if (!MigrateCompliancePolicyEnforcement::hasLegacyPolicyFlags()) {
+            return [];
+        }
+
+        return [
+            new CustomMigration(
+                [MigrateCompliancePolicyEnforcement::class, 'migrate'],
+                './console core:matomo600-migrate-compliance-policy-enforcement'
+            ),
+        ];
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
+    }
+}

--- a/core/Version.php
+++ b/core/Version.php
@@ -22,7 +22,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    public const VERSION = '6.0.0-b1';
+    public const VERSION = '6.0.0-b2';
 
     public const MAJOR_VERSION = 6;
 

--- a/plugins/CoreAdminHome/Commands/MigrateCompliancePolicyEnforcement.php
+++ b/plugins/CoreAdminHome/Commands/MigrateCompliancePolicyEnforcement.php
@@ -1,0 +1,306 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\Commands;
+
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\Option;
+use Piwik\Piwik;
+use Piwik\Plugin\ConsoleCommand;
+use Piwik\Policy\PolicyManager;
+use Piwik\Tracker\Cache;
+
+class MigrateCompliancePolicyEnforcement extends ConsoleCommand
+{
+    protected function configure()
+    {
+        $this->setName('core:matomo600-migrate-compliance-policy-enforcement');
+        $this->setDescription(
+            'Only needed for Matomo 6.0.0-b2 upgrade. '
+            . 'Converts the whole-policy compliance enforcement flags into per-setting enforcement state '
+            . 'and removes the legacy flags (a JSON backup is kept in the option table for one release).'
+        );
+    }
+
+    protected function doExecute(): int
+    {
+        $result = self::migrate();
+
+        $this->getOutput()->writeln('Done');
+        foreach ($result as $key => $value) {
+            $this->getOutput()->writeln(sprintf('%s: %d', $key, $value));
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Whether any policy still stores the legacy whole-policy enforcement flag.
+     */
+    public static function hasLegacyPolicyFlags(): bool
+    {
+        foreach (PolicyManager::getAllPolicies() as $policyClass) {
+            [$systemValue, $siteRows] = self::fetchLegacyPolicyFlags($policyClass);
+            if ($systemValue !== false || !empty($siteRows)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public static function migrate(): array
+    {
+        $stats = ['policiesMigrated' => 0, 'instanceFlagsConverted' => 0, 'siteFlagsConverted' => 0];
+
+        foreach (PolicyManager::getAllPolicies() as $policyClass) {
+            [$systemValue, $siteRows] = self::fetchLegacyPolicyFlags($policyClass);
+
+            if ($systemValue === false && empty($siteRows)) {
+                continue;
+            }
+
+            $toggleableSettings = [];
+            foreach (PolicyManager::getAllControlledSettings($policyClass) as $settingClass) {
+                if (!$settingClass::isExternallyManagedByPolicyPage()) {
+                    $toggleableSettings[] = $settingClass;
+                }
+            }
+
+            if (!empty($systemValue)) {
+                $existingSystemState = self::fetchExistingEnforcementSettingNames($policyClass);
+                foreach ($toggleableSettings as $settingClass) {
+                    // per-setting choices made before the migration keep their effective state
+                    if (in_array($policyClass::getSettingEnforcementName($settingClass), $existingSystemState, true)) {
+                        continue;
+                    }
+                    self::insertEnforcementRow($policyClass, $settingClass, null);
+                }
+                $stats['instanceFlagsConverted']++;
+            }
+
+            $affectedSites = [];
+            foreach ($siteRows as $row) {
+                $idSite = (int) $row['idsite'];
+                $affectedSites[] = $idSite;
+
+                if (empty($row['setting_value'])) {
+                    continue;
+                }
+
+                $existingSiteState = self::fetchExistingEnforcementSettingNames($policyClass, $idSite);
+                foreach ($toggleableSettings as $settingClass) {
+                    if (in_array($policyClass::getSettingEnforcementName($settingClass), $existingSiteState, true)) {
+                        continue;
+                    }
+                    self::insertEnforcementRow($policyClass, $settingClass, $idSite);
+                }
+                $stats['siteFlagsConverted']++;
+            }
+
+            self::backupAndDeleteLegacyPolicyFlags($policyClass, $systemValue, $siteRows);
+
+            foreach (array_unique($affectedSites) as $idSite) {
+                Cache::deleteCacheWebsiteAttributes($idSite);
+            }
+            Cache::deleteTrackerCache();
+            \Piwik\Settings\Storage\Backend\Cache::clearCache();
+
+            $stats['policiesMigrated']++;
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Reads the legacy flag rows directly from the database: the setting objects
+     * fold in config file values, and config-controlled instances must not have
+     * per-setting state written for them.
+     *
+     * @param class-string<\Piwik\Policy\CompliancePolicy> $policyClass
+     * @return array{0: string|false, 1: array<int, array<string, string>>}
+     */
+    private static function fetchLegacyPolicyFlags(string $policyClass): array
+    {
+        $pluginName = Piwik::getPluginNameOfMatomoClass($policyClass);
+        $flagName = $policyClass::getSystemSettingShortName();
+
+        $systemValue = Db::fetchOne(
+            'SELECT setting_value FROM ' . Common::prefixTable('plugin_setting')
+            . ' WHERE plugin_name = ? AND setting_name = ? AND user_login = ?',
+            [$pluginName, $flagName, '']
+        );
+
+        $siteRows = Db::fetchAll(
+            'SELECT idsite, setting_value FROM ' . Common::prefixTable('site_setting')
+            . ' WHERE plugin_name = ? AND setting_name = ?',
+            [$pluginName, $flagName]
+        );
+
+        return [$systemValue, $siteRows];
+    }
+
+    /**
+     * Rows are written directly: the migration must not run plugin event listeners
+     * or setting permission checks while the instance is half-upgraded.
+     *
+     * @param class-string<\Piwik\Policy\CompliancePolicy> $policyClass
+     * @param class-string<\Piwik\Settings\Interfaces\PolicyComparisonInterface<mixed>> $settingClass
+     */
+    private static function insertEnforcementRow(string $policyClass, string $settingClass, ?int $idSite): void
+    {
+        $pluginName = Piwik::getPluginNameOfMatomoClass($policyClass);
+        $settingName = $policyClass::getSettingEnforcementName($settingClass);
+
+        if (is_null($idSite)) {
+            Db::query(
+                'INSERT INTO ' . Common::prefixTable('plugin_setting')
+                . ' (plugin_name, setting_name, setting_value, json_encoded, user_login) VALUES (?, ?, ?, 0, ?)',
+                [$pluginName, $settingName, '1', '']
+            );
+        } else {
+            Db::query(
+                'INSERT INTO ' . Common::prefixTable('site_setting')
+                . ' (idsite, plugin_name, setting_name, setting_value, json_encoded) VALUES (?, ?, ?, ?, 0)',
+                [$idSite, $pluginName, $settingName, '1']
+            );
+        }
+    }
+
+    /**
+     * Removes the migration backup for the given policy. Called when the
+     * whole-policy state changes after the migration; the backup is only kept
+     * as a one-release safety net for support and for reconciling plugins that
+     * were deactivated while the migration ran.
+     *
+     * Deliberately removes the ENTIRE backup on any whole-policy change, even a
+     * site-scoped one: once an admin has actively managed the policy after
+     * upgrading, replaying any part of the pre-migration state would be more
+     * surprising than asking them to toggle a reactivated plugin's settings.
+     *
+     * @param class-string<\Piwik\Policy\CompliancePolicy> $policyClass
+     */
+    public static function deleteLegacyBackup(string $policyClass): void
+    {
+        Option::delete(Piwik::getPluginNameOfMatomoClass($policyClass) . '_legacy_policy_flag_backup');
+    }
+
+    /**
+     * Writes the enforcement state a (re)activated plugin's settings would have
+     * received from the migration, based on the legacy-flag backup. Settings of
+     * plugins that were deactivated while the migration ran are not discoverable
+     * then, so their enforcement is reconciled here instead of being lost.
+     */
+    public static function reconcileEnforcementForPlugin(string $pluginName): void
+    {
+        foreach (PolicyManager::getAllPolicies() as $policyClass) {
+            $backupJson = Option::get(Piwik::getPluginNameOfMatomoClass($policyClass) . '_legacy_policy_flag_backup');
+            if (empty($backupJson)) {
+                continue;
+            }
+
+            $backup = json_decode($backupJson, true);
+            if (empty($backup)) {
+                continue;
+            }
+
+            $existingSystemState = self::fetchExistingEnforcementSettingNames($policyClass);
+
+            foreach (PolicyManager::getAllControlledSettings($policyClass) as $settingClass) {
+                if (
+                    $settingClass::isExternallyManagedByPolicyPage()
+                    || Piwik::getPluginNameOfMatomoClass($settingClass) !== $pluginName
+                ) {
+                    continue;
+                }
+
+                $settingName = $policyClass::getSettingEnforcementName($settingClass);
+
+                if (!empty($backup['system']) && !in_array($settingName, $existingSystemState, true)) {
+                    self::insertEnforcementRow($policyClass, $settingClass, null);
+                }
+
+                foreach ($backup['sites'] ?? [] as $idSite => $value) {
+                    if (
+                        !empty($value)
+                        && !in_array($settingName, self::fetchExistingEnforcementSettingNames($policyClass, (int) $idSite), true)
+                    ) {
+                        self::insertEnforcementRow($policyClass, $settingClass, (int) $idSite);
+                    }
+                }
+            }
+        }
+
+        Cache::deleteTrackerCache();
+        \Piwik\Settings\Storage\Backend\Cache::clearCache();
+    }
+
+    /**
+     * Names of the per-setting enforcement rows the given policy already stores.
+     *
+     * @param class-string<\Piwik\Policy\CompliancePolicy> $policyClass
+     * @return array<int, string>
+     */
+    private static function fetchExistingEnforcementSettingNames(string $policyClass, ?int $idSite = null): array
+    {
+        $pluginName = Piwik::getPluginNameOfMatomoClass($policyClass);
+
+        if (is_null($idSite)) {
+            $rows = Db::fetchAll(
+                'SELECT setting_name FROM ' . Common::prefixTable('plugin_setting')
+                . ' WHERE plugin_name = ? AND setting_name LIKE ? AND user_login = ?',
+                [$pluginName, '%\_enforce\_\_%', '']
+            );
+        } else {
+            $rows = Db::fetchAll(
+                'SELECT setting_name FROM ' . Common::prefixTable('site_setting')
+                . ' WHERE idsite = ? AND plugin_name = ? AND setting_name LIKE ?',
+                [$idSite, $pluginName, '%\_enforce\_\_%']
+            );
+        }
+
+        return array_column($rows, 'setting_name');
+    }
+
+    /**
+     * @param class-string<\Piwik\Policy\CompliancePolicy> $policyClass
+     * @param string|false $systemValue
+     * @param array<int, array<string, string>> $siteRows
+     */
+    private static function backupAndDeleteLegacyPolicyFlags(string $policyClass, $systemValue, array $siteRows): void
+    {
+        $pluginName = Piwik::getPluginNameOfMatomoClass($policyClass);
+        $flagName = $policyClass::getSystemSettingShortName();
+
+        $backup = [
+            'system' => $systemValue === false ? null : $systemValue,
+            'sites' => [],
+        ];
+        foreach ($siteRows as $row) {
+            $backup['sites'][(int) $row['idsite']] = $row['setting_value'];
+        }
+
+        Option::set($pluginName . '_legacy_policy_flag_backup', json_encode($backup));
+
+        Db::query(
+            'DELETE FROM ' . Common::prefixTable('plugin_setting')
+            . ' WHERE plugin_name = ? AND setting_name = ?',
+            [$pluginName, $flagName]
+        );
+        Db::query(
+            'DELETE FROM ' . Common::prefixTable('site_setting')
+            . ' WHERE plugin_name = ? AND setting_name = ?',
+            [$pluginName, $flagName]
+        );
+    }
+}

--- a/plugins/CoreAdminHome/Commands/MigrateCompliancePolicyEnforcement.php
+++ b/plugins/CoreAdminHome/Commands/MigrateCompliancePolicyEnforcement.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\CoreAdminHome\Commands;
 
 use Piwik\Common;
 use Piwik\Db;
+use Piwik\DbHelper;
 use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugin\ConsoleCommand;
@@ -132,6 +133,16 @@ class MigrateCompliancePolicyEnforcement extends ConsoleCommand
      */
     private static function fetchLegacyPolicyFlags(string $policyClass): array
     {
+        // The legacy flags live in the plugin_setting / site_setting tables. When the
+        // instance is upgraded from a schema that predates them there is nothing to
+        // migrate, and the updater must not fail while listing the pending migrations.
+        if (
+            !DbHelper::tableExists(Common::prefixTable('plugin_setting'))
+            || !DbHelper::tableExists(Common::prefixTable('site_setting'))
+        ) {
+            return [false, []];
+        }
+
         $pluginName = Piwik::getPluginNameOfMatomoClass($policyClass);
         $flagName = $policyClass::getSystemSettingShortName();
 

--- a/plugins/CoreAdminHome/CoreAdminHome.php
+++ b/plugins/CoreAdminHome/CoreAdminHome.php
@@ -34,6 +34,8 @@ class CoreAdminHome extends \Piwik\Plugin
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
             'System.addSystemSummaryItems' => 'addSystemSummaryItems',
             'FrontController.modifyErrorPage' => 'onModifyErrorPage',
+            'PluginManager.pluginActivated' => 'reconcileCompliancePolicyEnforcement',
+            'CompliancePolicy.setActiveStatus' => 'invalidateCompliancePolicyLegacyBackup',
         );
     }
 
@@ -113,6 +115,26 @@ class CoreAdminHome extends \Piwik\Plugin
         }
 
         return $output;
+    }
+
+    /**
+     * Settings of plugins that were deactivated while the 6.0.0-b2 compliance
+     * migration ran could not receive their per-setting enforcement state; give
+     * it to them when the plugin comes back.
+     */
+    public function reconcileCompliancePolicyEnforcement($pluginName)
+    {
+        Commands\MigrateCompliancePolicyEnforcement::reconcileEnforcementForPlugin($pluginName);
+    }
+
+    /**
+     * Once the whole-policy state is changed deliberately after the migration,
+     * the migration backup no longer reflects the intended enforcement and must
+     * not be replayed onto plugins activated later.
+     */
+    public function invalidateCompliancePolicyLegacyBackup($isActive, $idSite, $policyClass)
+    {
+        Commands\MigrateCompliancePolicyEnforcement::deleteLegacyBackup($policyClass);
     }
 
     public function addSystemSummaryItems(&$systemSummary)

--- a/plugins/CoreAdminHome/tests/Integration/Commands/MigrateCompliancePolicyEnforcementTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/MigrateCompliancePolicyEnforcementTest.php
@@ -1,0 +1,234 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Integration\Commands;
+
+use Piwik\Common;
+use Piwik\Container\StaticContainer;
+use Piwik\Db;
+use Piwik\Option;
+use Piwik\Plugins\CoreAdminHome\Commands\MigrateCompliancePolicyEnforcement;
+use Piwik\Plugins\DevicesDetection\Settings\DeviceModelDetectionDisabled;
+use Piwik\Plugins\PrivacyManager\Settings\DataRoundingEnabled;
+use Piwik\Plugins\PrivacyManager\Settings\IPAnonymisation;
+use Piwik\Policy\CnilPolicy;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Tracker\Config\ThirdPartyCookies;
+
+/**
+ * @group CoreAdminHome
+ * @group Commands
+ * @group MigrateCompliancePolicyEnforcement
+ */
+class MigrateCompliancePolicyEnforcementTest extends IntegrationTestCase
+{
+    /**
+     * @var int
+     */
+    private $siteId;
+
+    /**
+     * @var int
+     */
+    private $otherSiteId;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createSuperUser();
+        $this->siteId = Fixture::createWebsite('2024-01-01 01:02:03');
+        $this->otherSiteId = Fixture::createWebsite('2024-01-01 01:02:03');
+    }
+
+    public function testHasLegacyPolicyFlagsIsFalseWithoutFlags(): void
+    {
+        $this->assertFalse(MigrateCompliancePolicyEnforcement::hasLegacyPolicyFlags());
+    }
+
+    public function testMigrateIsANoOpWithoutLegacyFlags(): void
+    {
+        $stats = MigrateCompliancePolicyEnforcement::migrate();
+        $this->clearSettingsCaches();
+
+        $this->assertSame(0, $stats['policiesMigrated']);
+        $this->assertFalse(CnilPolicy::isEnforcedForSetting(IPAnonymisation::class));
+    }
+
+    public function testMigrateConvertsInstanceWideLegacyFlag(): void
+    {
+        $this->insertLegacySystemFlag('1');
+
+        $this->assertTrue(MigrateCompliancePolicyEnforcement::hasLegacyPolicyFlags());
+
+        $stats = MigrateCompliancePolicyEnforcement::migrate();
+        $this->clearSettingsCaches();
+
+        $this->assertSame(1, $stats['policiesMigrated']);
+        $this->assertSame(1, $stats['instanceFlagsConverted']);
+        $this->assertSame(0, $stats['siteFlagsConverted']);
+
+        // enforcement carries over for every toggleable setting, for all sites
+        $this->assertTrue(CnilPolicy::isEnforcedForSetting(IPAnonymisation::class));
+        $this->assertTrue(CnilPolicy::isEnforcedForSetting(DataRoundingEnabled::class, $this->siteId));
+
+        // externally managed settings do not get enforcement state
+        $this->assertFalse(CnilPolicy::isEnforcedForSetting(ThirdPartyCookies::class));
+
+        // the legacy flag is gone, a backup remains
+        $this->assertFalse(MigrateCompliancePolicyEnforcement::hasLegacyPolicyFlags());
+        $backup = json_decode(Option::get('CnilPolicy_legacy_policy_flag_backup'), true);
+        $this->assertSame('1', $backup['system']);
+        $this->assertSame([], $backup['sites']);
+    }
+
+    public function testMigrateConvertsPerSiteLegacyFlags(): void
+    {
+        $this->insertLegacySiteFlag($this->siteId, '1');
+        $this->insertLegacySiteFlag($this->otherSiteId, '0');
+
+        $stats = MigrateCompliancePolicyEnforcement::migrate();
+        $this->clearSettingsCaches();
+
+        $this->assertSame(1, $stats['policiesMigrated']);
+        $this->assertSame(0, $stats['instanceFlagsConverted']);
+        $this->assertSame(1, $stats['siteFlagsConverted']);
+
+        $this->assertTrue(CnilPolicy::isEnforcedForSetting(IPAnonymisation::class, $this->siteId));
+        $this->assertFalse(CnilPolicy::isEnforcedForSetting(IPAnonymisation::class, $this->otherSiteId));
+        $this->assertFalse(CnilPolicy::isEnforcedForSetting(IPAnonymisation::class));
+
+        $backup = json_decode(Option::get('CnilPolicy_legacy_policy_flag_backup'), true);
+        $this->assertNull($backup['system']);
+        $this->assertSame(['1', '0'], [
+            $backup['sites'][$this->siteId],
+            $backup['sites'][$this->otherSiteId],
+        ]);
+    }
+
+    public function testMigrateIsIdempotent(): void
+    {
+        $this->insertLegacySystemFlag('1');
+
+        MigrateCompliancePolicyEnforcement::migrate();
+        $secondRun = MigrateCompliancePolicyEnforcement::migrate();
+        $this->clearSettingsCaches();
+
+        $this->assertSame(0, $secondRun['policiesMigrated']);
+        $this->assertTrue(CnilPolicy::isEnforcedForSetting(IPAnonymisation::class));
+    }
+
+    public function testMigrateKeepsExplicitPerSettingStateWrittenBeforehand(): void
+    {
+        $this->insertLegacySystemFlag('1');
+
+        // the user already disabled one setting individually before updating
+        CnilPolicy::setEnforcedForSetting(IPAnonymisation::class, false);
+
+        MigrateCompliancePolicyEnforcement::migrate();
+        $this->clearSettingsCaches();
+
+        // the explicit choice keeps its effective state, everything else is enforced
+        $this->assertFalse(CnilPolicy::isEnforcedForSetting(IPAnonymisation::class));
+        $this->assertTrue(CnilPolicy::isEnforcedForSetting(DataRoundingEnabled::class));
+    }
+
+    public function testReconcileEnforcementForPluginRestoresStateOfPluginsDeactivatedDuringMigration(): void
+    {
+        $this->insertLegacySystemFlag('1');
+        MigrateCompliancePolicyEnforcement::migrate();
+        $this->clearSettingsCaches();
+
+        // simulate a plugin that was deactivated while the migration ran: its rows are missing
+        Db::query(
+            'DELETE FROM ' . Common::prefixTable('plugin_setting')
+            . " WHERE plugin_name = 'CnilPolicy' AND setting_name LIKE '%DevicesDetection%'"
+        );
+        $this->clearSettingsCaches();
+        $this->assertFalse(CnilPolicy::isEnforcedForSetting(DeviceModelDetectionDisabled::class));
+
+        MigrateCompliancePolicyEnforcement::reconcileEnforcementForPlugin('DevicesDetection');
+        $this->clearSettingsCaches();
+
+        $this->assertTrue(CnilPolicy::isEnforcedForSetting(DeviceModelDetectionDisabled::class));
+        // settings of other plugins keep their state, no duplicates are created
+        $this->assertTrue(CnilPolicy::isEnforcedForSetting(IPAnonymisation::class));
+        MigrateCompliancePolicyEnforcement::reconcileEnforcementForPlugin('DevicesDetection');
+        $count = Db::fetchOne(
+            'SELECT COUNT(*) FROM ' . Common::prefixTable('plugin_setting')
+            . " WHERE plugin_name = 'CnilPolicy' AND setting_name = ?",
+            [CnilPolicy::getSettingEnforcementName(DeviceModelDetectionDisabled::class)]
+        );
+        $this->assertEquals(1, $count);
+    }
+
+    public function testReconcileDoesNotReplayBackupAfterWholePolicyWasChanged(): void
+    {
+        $this->insertLegacySystemFlag('1');
+        MigrateCompliancePolicyEnforcement::migrate();
+        $this->clearSettingsCaches();
+
+        // simulate a plugin deactivated during migration
+        Db::query(
+            'DELETE FROM ' . Common::prefixTable('plugin_setting')
+            . " WHERE plugin_name = 'CnilPolicy' AND setting_name LIKE '%DevicesDetection%'"
+        );
+        $this->clearSettingsCaches();
+
+        // the user deliberately disables the whole policy after migrating;
+        // the event listener invalidates the backup
+        CnilPolicy::setActiveStatus(null, false);
+        $this->assertFalse((bool) Option::get('CnilPolicy_legacy_policy_flag_backup'));
+
+        MigrateCompliancePolicyEnforcement::reconcileEnforcementForPlugin('DevicesDetection');
+        $this->clearSettingsCaches();
+
+        $this->assertFalse(CnilPolicy::isEnforcedForSetting(DeviceModelDetectionDisabled::class));
+    }
+
+    private function insertLegacySystemFlag(string $value): void
+    {
+        Db::query(
+            'INSERT INTO ' . Common::prefixTable('plugin_setting')
+            . ' (plugin_name, setting_name, setting_value, json_encoded, user_login)'
+            . ' VALUES (?, ?, ?, 0, ?)',
+            ['CnilPolicy', 'cnil_v1_policy_enabled', $value, '']
+        );
+
+        $this->clearSettingsCaches();
+    }
+
+    private function insertLegacySiteFlag(int $idSite, string $value): void
+    {
+        Db::query(
+            'INSERT INTO ' . Common::prefixTable('site_setting')
+            . ' (idsite, plugin_name, setting_name, setting_value, json_encoded)'
+            . ' VALUES (?, ?, ?, ?, 0)',
+            [$idSite, 'CnilPolicy', 'cnil_v1_policy_enabled', $value]
+        );
+
+        $this->clearSettingsCaches();
+    }
+
+    /**
+     * Setting storages cache loaded values; inserting rows directly requires
+     * clearing those caches so the next settings write does not persist a stale
+     * state without the inserted rows.
+     */
+    private function clearSettingsCaches(): void
+    {
+        \Piwik\Settings\Storage\Backend\Cache::clearCache();
+
+        $factory = StaticContainer::get('Piwik\Settings\Storage\Factory');
+        $cacheProperty = new \ReflectionProperty($factory, 'cache');
+        $cacheProperty->setAccessible(true);
+        $cacheProperty->setValue($factory, []);
+    }
+}

--- a/plugins/PrivacyManager/tests/System/APITest.php
+++ b/plugins/PrivacyManager/tests/System/APITest.php
@@ -276,13 +276,19 @@ class APITest extends SystemTestCase
 
     public function testGetCompliancePolicySettingsReturnsErrorWhenFeatureNotEnabled(): void
     {
-        $this->runApiTests('PrivacyManager.getCompliancePolicySettings', [
-            'testSuffix' => 'granularFeatureDisabled',
-            'otherRequestParameters' => [
-                'idSite' => '1',
-                'compliancePolicy' => 'cnil_v1',
-            ],
-        ]);
+        Config::getInstance()->FeatureFlags = ['GranularPrivacyCompliance_feature' => 'disabled'];
+
+        try {
+            $this->runApiTests('PrivacyManager.getCompliancePolicySettings', [
+                'testSuffix' => 'granularFeatureDisabled',
+                'otherRequestParameters' => [
+                    'idSite' => '1',
+                    'compliancePolicy' => 'cnil_v1',
+                ],
+            ]);
+        } finally {
+            Config::getInstance()->FeatureFlags = null;
+        }
     }
 
     public function testGetCompliancePolicySettingsReturnsAllSettings(): void

--- a/tests/PHPUnit/Integration/Policy/CompliancePolicyTest.php
+++ b/tests/PHPUnit/Integration/Policy/CompliancePolicyTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Policy;
+
+use Piwik\Tests\Framework\Mock\Policy\TestPolicy;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * Exercises the whole-policy active flag, which fans out to the per-setting
+ * enforcement state. {@link \Piwik\Policy\CompliancePolicy::setActiveStatus()}
+ * enumerates the policy-controlled settings via the plugin manager, so a
+ * database is required and this case cannot live in the unit suite.
+ *
+ * @group Core
+ */
+class CompliancePolicyTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        TestPolicy::reset();
+    }
+
+    /**
+     * @dataProvider possibleStatesForPolicyActive
+     */
+    public function testSetActiveStatusInstanceLevel(
+        $idSite,
+        $newActiveState,
+        $currentInstanceState,
+        $currentSiteState,
+        $expectedInstanceState,
+        $expectedSiteState
+    ): void {
+        TestPolicy::setState($currentInstanceState, $currentSiteState ? 99 : false);
+        TestPolicy::setActiveStatus($idSite, $newActiveState);
+        $this->assertSame(TestPolicy::isActive(null), $expectedInstanceState, "Instance status $expectedInstanceState is incorrect");
+        $this->assertSame(TestPolicy::isActive(99), $expectedSiteState, "Site status $expectedSiteState is incorrect");
+    }
+
+    public function possibleStatesForPolicyActive()
+    {
+        /*
+            [
+                idSite,
+                newActiveState,
+                currentInstanceState,
+                currentSiteState,
+                expectedInstanceState,
+                expectedSiteState
+            ]
+         */
+        yield [null, true, true, true, true, true];
+        yield [null, true, true, false, true, true];
+        yield [null, true, false, true, true, true];
+        yield [null, true, false, false, true, true];
+        yield [null, false, true, true, false, true];
+        yield [null, false, true, false, false, false];
+        yield [null, false, false, true, false, true];
+        yield [null, false, false, false, false, false];
+        yield [99, true, true, true, true, true];
+        yield [99, true, true, false, true, true];
+        yield [99, true, false, true, false, true];
+        yield [99, true, false, false, false, true];
+        yield [99, false, true, true, false, false];
+        yield [99, false, true, false, false, false];
+        yield [99, false, false, true, false, false];
+        yield [99, false, false, false, false, false];
+    }
+}

--- a/tests/PHPUnit/Integration/Settings/PolicyComparisonTraitTest.php
+++ b/tests/PHPUnit/Integration/Settings/PolicyComparisonTraitTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Settings;
+
+use Piwik\Policy\PolicyManager;
+use Piwik\Tests\Framework\Mock\Policy\TestPolicy;
+use Piwik\Tests\Framework\Mock\Settings\TraitImpls\PolicyComparisonTraitImpl;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * Covers the policy-value resolution paths that flip the whole-policy active
+ * flag via {@link PolicyManager::setPolicyActiveStatus()}. That fans out to the
+ * per-setting enforcement state and enumerates the policy-controlled settings,
+ * so a database is required and these cases cannot live in the unit suite.
+ *
+ * @group Core
+ */
+class PolicyComparisonTraitTest extends IntegrationTestCase
+{
+    public function testGetPolicyValuesPolicyInactive()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, false);
+        $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
+        $this->assertCount(1, $values);
+        $this->assertArrayHasKey(TestPolicy::class, $values);
+        $this->assertNull($values[TestPolicy::class]);
+    }
+
+    public function testGetPolicyValuesPresentWhenSettingEnforcementIsEnabledWithoutPolicyFlag()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, false);
+        TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, true);
+
+        try {
+            $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
+            $this->assertNotNull($values[TestPolicy::class]);
+        } finally {
+            TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, null);
+        }
+    }
+
+    public function testGetPolicyValuesNulledWhenSettingEnforcementIsDisabledDespiteActivePolicyFlag()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+        TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, false);
+
+        try {
+            $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
+            $this->assertNull($values[TestPolicy::class]);
+        } finally {
+            TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, null);
+        }
+    }
+}

--- a/tests/PHPUnit/Unit/Policy/CompliancePolicyTest.php
+++ b/tests/PHPUnit/Unit/Policy/CompliancePolicyTest.php
@@ -115,20 +115,9 @@ class CompliancePolicyTest extends TestCase
         $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 100));
     }
 
-    public function testIsEnforcedForSettingExplicitSystemOffSuppressesLegacyFlag(): void
+    public function testIsEnforcedForSettingIsFalseWithoutAnyState(): void
     {
-        TestPolicy::setState(true, 99);
-        TestPolicy::setSettingEnforcementSystemValue(FakePolicySetting::class, false);
-
         $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
-        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
-    }
-
-    public function testIsEnforcedForSettingExplicitSiteOffSuppressesLegacyFlag(): void
-    {
-        TestPolicy::setState(false, 99);
-        TestPolicy::setSettingEnforcementMeasurableValue(FakePolicySetting::class, 99, false);
-
         $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
     }
 
@@ -173,28 +162,12 @@ class CompliancePolicyTest extends TestCase
         $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 100));
     }
 
-    /**
-     * @dataProvider possibleStatesForPolicyActive
-     */
-    public function testIsEnforcedForSettingFallsBackToLegacyPolicyFlag(
-        $idSite,
-        $newActiveState,
-        $currentInstanceState,
-        $currentSiteState,
-        $expectedInstanceState,
-        $expectedSiteState
-    ): void {
-        // without any per-setting state, enforcement must exactly mirror the legacy whole-policy flag
-        TestPolicy::setState($currentInstanceState, $currentSiteState ? 99 : false);
-        TestPolicy::setActiveStatus($idSite, $newActiveState);
+    public function testIsEnforcedForSettingIgnoresTheLegacyWholePolicyFlag(): void
+    {
+        // the legacy flag is converted to per-setting state by a migration and no longer resolves
+        TestPolicy::setState(true, 99);
 
-        $this->assertSame(
-            $expectedInstanceState,
-            TestPolicy::isEnforcedForSetting(FakePolicySetting::class)
-        );
-        $this->assertSame(
-            $expectedSiteState,
-            TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99)
-        );
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
+        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
     }
 }

--- a/tests/PHPUnit/Unit/Policy/CompliancePolicyTest.php
+++ b/tests/PHPUnit/Unit/Policy/CompliancePolicyTest.php
@@ -23,53 +23,6 @@ class CompliancePolicyTest extends TestCase
         $this->assertSame('Test policy description', $details['description']);
     }
 
-    /**
-     * @dataProvider possibleStatesForPolicyActive
-     */
-    public function testSetActiveStatusInstanceLevel(
-        $idSite,
-        $newActiveState,
-        $currentInstanceState,
-        $currentSiteState,
-        $expectedInstanceState,
-        $expectedSiteState
-    ): void {
-        TestPolicy::setState($currentInstanceState, $currentSiteState ? 99 : false);
-        TestPolicy::setActiveStatus($idSite, $newActiveState);
-        $this->assertSame(TestPolicy::isActive(null), $expectedInstanceState, "Instance status $expectedInstanceState is incorrect");
-        $this->assertSame(TestPolicy::isActive(99), $expectedSiteState, "Site status $expectedSiteState is incorrect");
-    }
-
-    public function possibleStatesForPolicyActive()
-    {
-        /*
-            [
-                idSite,
-                newActiveState,
-                currentInstanceState,
-                currentSiteState,
-                expectedInstanceState,
-                expectedSiteState
-            ]
-         */
-        yield [null, true, true, true, true, true];
-        yield [null, true, true, false, true, true];
-        yield [null, true, false, true, true, true];
-        yield [null, true, false, false, true, true];
-        yield [null, false, true, true, false, true];
-        yield [null, false, true, false, false, false];
-        yield [null, false, false, true, false, true];
-        yield [null, false, false, false, false, false];
-        yield [99, true, true, true, true, true];
-        yield [99, true, true, false, true, true];
-        yield [99, true, false, true, false, true];
-        yield [99, true, false, false, false, true];
-        yield [99, false, true, true, false, false];
-        yield [99, false, true, false, false, false];
-        yield [99, false, false, true, false, false];
-        yield [99, false, false, false, false, false];
-    }
-
     public function testGetSettingEnforcementNameCombinesPolicyAndSettingId(): void
     {
         $this->assertSame(

--- a/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
+++ b/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
@@ -17,11 +17,16 @@ class PolicyComparisonTraitTest extends TestCase
 
     public function testGetPolicyValuesPolicyActive()
     {
-        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
-        $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
-        $this->assertCount(1, $values);
-        $this->assertArrayHasKey(TestPolicy::class, $values);
-        $this->assertNotNull($values[TestPolicy::class]);
+        TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, true);
+
+        try {
+            $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
+            $this->assertCount(1, $values);
+            $this->assertArrayHasKey(TestPolicy::class, $values);
+            $this->assertNotNull($values[TestPolicy::class]);
+        } finally {
+            TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, null);
+        }
     }
 
     public function testGetPolicyValuesPolicyInactive()
@@ -68,19 +73,23 @@ class PolicyComparisonTraitTest extends TestCase
 
     public function testGetPolicyValuesNulledWhileEnforcementIsBypassed()
     {
-        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+        TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, true);
 
-        $values = PolicyEnforcementBypass::run(function () {
-            return PolicyComparisonTraitImpl::getPolicyRequiredValues();
-        });
+        try {
+            $values = PolicyEnforcementBypass::run(function () {
+                return PolicyComparisonTraitImpl::getPolicyRequiredValues();
+            });
 
-        $this->assertCount(1, $values);
-        $this->assertArrayHasKey(TestPolicy::class, $values);
-        $this->assertNull($values[TestPolicy::class]);
+            $this->assertCount(1, $values);
+            $this->assertArrayHasKey(TestPolicy::class, $values);
+            $this->assertNull($values[TestPolicy::class]);
 
-        // the bypass must not leak outside of the callable
-        $valuesAfterBypass = PolicyComparisonTraitImpl::getPolicyRequiredValues();
-        $this->assertNotNull($valuesAfterBypass[TestPolicy::class]);
+            // the bypass must not leak outside of the callable
+            $valuesAfterBypass = PolicyComparisonTraitImpl::getPolicyRequiredValues();
+            $this->assertNotNull($valuesAfterBypass[TestPolicy::class]);
+        } finally {
+            TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, null);
+        }
     }
 
     public function testBypassIsClearedWhenCallableThrows()

--- a/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
+++ b/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
@@ -4,7 +4,6 @@ namespace Piwik\Tests\Unit\Settings;
 
 use PHPUnit\Framework\TestCase;
 use Piwik\Policy\PolicyEnforcementBypass;
-use Piwik\Policy\PolicyManager;
 use Piwik\Tests\Framework\Mock\Policy\TestPolicy;
 use Piwik\Tests\Framework\Mock\Settings\TraitImpls\PolicyComparisonTraitImpl;
 
@@ -29,46 +28,11 @@ class PolicyComparisonTraitTest extends TestCase
         }
     }
 
-    public function testGetPolicyValuesPolicyInactive()
-    {
-        PolicyManager::setPolicyActiveStatus(TestPolicy::class, false);
-        $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
-        $this->assertCount(1, $values);
-        $this->assertArrayHasKey(TestPolicy::class, $values);
-        $this->assertNull($values[TestPolicy::class]);
-    }
-
     public function testIsControlledBySpecificPolicy()
     {
         $this->assertTrue(
             PolicyComparisonTraitImpl::isControlledBySpecificPolicy(TestPolicy::class)
         );
-    }
-
-    public function testGetPolicyValuesPresentWhenSettingEnforcementIsEnabledWithoutPolicyFlag()
-    {
-        PolicyManager::setPolicyActiveStatus(TestPolicy::class, false);
-        TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, true);
-
-        try {
-            $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
-            $this->assertNotNull($values[TestPolicy::class]);
-        } finally {
-            TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, null);
-        }
-    }
-
-    public function testGetPolicyValuesNulledWhenSettingEnforcementIsDisabledDespiteActivePolicyFlag()
-    {
-        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
-        TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, false);
-
-        try {
-            $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
-            $this->assertNull($values[TestPolicy::class]);
-        } finally {
-            TestPolicy::setSettingEnforcementSystemValue(PolicyComparisonTraitImpl::class, null);
-        }
     }
 
     public function testGetPolicyValuesNulledWhileEnforcementIsBypassed()


### PR DESCRIPTION
Adds the 6.0.0-b2 update with a command-backed migration (`core:matomo600-migrate-compliance-policy-enforcement`) that:

- converts the legacy whole-policy enforcement flag (instance-wide and per-site) into per-setting enforcement state for every toggleable setting
- **keeps the effective state of settings that already have explicit per-setting choices** (made through the granular UI/API before updating)
- reads the legacy rows directly from the database so config-controlled instances are not given database state (the config key keeps enforcing through the resolution short-circuit)
- deletes the legacy flag rows and keeps a one-release JSON backup in the option table (`CnilPolicy_legacy_policy_flag_backup`)
- is idempotent and skipped entirely when no legacy flags exist

With the migration in place, the legacy-flag fallback is removed from `isEnforcedForSetting()`.

### Review focus
The preserve-explicit-state semantics. Verified end-to-end via `core:update` on a snapshot instance with per-site legacy flags and one explicit per-setting choice: both sites converted, the explicit choice preserved, legacy rows removed, backup written.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
