### PR TITLE
TwoFactorAuth: validate preconditions in the login-only setup action

### DIFF
--- a/plugins/TwoFactorAuth/Controller.php
+++ b/plugins/TwoFactorAuth/Controller.php
@@ -186,7 +186,11 @@ class Controller extends \Piwik\Plugin\Controller
 
     public function onLoginSetupTwoFactorAuth()
     {
-        // called when 2fa is required, but user has not yet set up 2fa
+        // login-only setup screen: available only while 2fa is enforced and the user has not enrolled yet
+        $this->validator->checkCanUseTwoFa();
+        $this->validator->checkCurrentUserMatchesSessionUser();
+        $this->validator->check2FaIsRequired();
+        $this->validator->check2FaNotEnabled();
 
         return $this->setupTwoFactorAuth($standalone = true);
     }

--- a/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
@@ -13,7 +13,9 @@ use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\Auth;
 use Piwik\AuthResult;
+use Piwik\Nonce;
 use Piwik\Session\SessionFingerprint;
+use Piwik\Session\SessionNamespace;
 use Piwik\Container\StaticContainer;
 use Piwik\Plugins\Login\Security\BruteForceDetection;
 use Piwik\Plugins\TwoFactorAuth\Dao\RecoveryCodeDao;
@@ -24,6 +26,7 @@ use Piwik\Plugins\TwoFactorAuth\Controller;
 use Piwik\Plugins\TwoFactorAuth\TwoFactorAuth;
 use Piwik\Plugins\TwoFactorAuth\Validator;
 use Piwik\Plugins\UsersManager\API;
+use Piwik\Plugins\UsersManager\Model;
 use Piwik\Plugins\UsersManager\UserUpdater;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -93,7 +96,9 @@ class TwoFactorAuthTest extends IntegrationTestCase
     public function tearDown(): void
     {
         $this->bruteForceDetection->deleteAll();
-        unset($_GET['authCode'], $_GET['module'], $_GET['action']);
+        unset($_GET['authCode'], $_GET['authCodeNonce'], $_GET['module'], $_GET['action']);
+        // the session is not reset between tests, so leftover fingerprints or setup secrets would leak
+        $_SESSION = [];
     }
 
     public function testLoginTwoFactorAuthRequiresFreshLoginWhenCurrentUserDoesNotMatchPendingSessionUser()
@@ -119,6 +124,134 @@ class TwoFactorAuthTest extends IntegrationTestCase
 
         $result = StaticContainer::get(Controller::class)->loginTwoFactorAuth();
         $this->assertStringContainsString('form_authcode', $result);
+    }
+
+    public function testOnLoginSetupTwoFactorAuthRendersWhenEnforcedAndUserNotEnrolled()
+    {
+        $this->setTwoFaRequired(true);
+        $this->setCurrentUser($this->userWithout2Fa);
+
+        $sessionFingerprint = new SessionFingerprint();
+        $sessionFingerprint->initialize($this->userWithout2Fa, 'pending-session-token');
+
+        $result = StaticContainer::get(Controller::class)->onLoginSetupTwoFactorAuth();
+
+        // standalone="true" is only rendered by the login-only template
+        $this->assertStringContainsString('standalone="true"', $result);
+        $this->assertStringContainsString('auth-code-nonce', $result);
+    }
+
+    public function testOnLoginSetupTwoFactorAuthRendersWhenTwoFactorAuthWasResetDuringAVerifiedSession()
+    {
+        $this->setTwoFaRequired(true);
+        $this->setCurrentUser($this->userWithout2Fa);
+
+        // a superuser may reset a user's 2fa while that user has an already verified session, which leaves
+        // them unenrolled but still verified - they have to be able to enroll again
+        $sessionFingerprint = new SessionFingerprint();
+        $sessionFingerprint->initialize($this->userWithout2Fa, 'pending-session-token');
+        $sessionFingerprint->setTwoFactorAuthenticationVerified($this->userWithout2Fa);
+
+        $result = StaticContainer::get(Controller::class)->onLoginSetupTwoFactorAuth();
+
+        $this->assertStringContainsString('standalone="true"', $result);
+    }
+
+    public function testOnLoginSetupTwoFactorAuthEnrollsUserWhenEnforcedAndCodeIsValid()
+    {
+        $this->setTwoFaRequired(true);
+        $this->setCurrentUser($this->userWithout2Fa);
+
+        $sessionFingerprint = new SessionFingerprint();
+        $sessionFingerprint->initialize($this->userWithout2Fa, 'pending-session-token');
+
+        $this->dao->createRecoveryCodesForLogin($this->userWithout2Fa);
+
+        $newSecret = $this->twoFa->generateSecret();
+        $session = new SessionNamespace('TwoFactorAuthenticator');
+        $session->secret = $newSecret;
+        $_GET['authCode'] = $this->generateValidAuthCode($newSecret);
+        $_GET['authCodeNonce'] = Nonce::getNonce(Controller::AUTH_CODE_NONCE);
+
+        try {
+            StaticContainer::get(Controller::class)->onLoginSetupTwoFactorAuth();
+        } catch (\Exception $e) {
+            // the setup redirects once finished, which cannot complete outside of a web request
+        }
+
+        $user = (new Model())->getUser($this->userWithout2Fa);
+        $this->assertSame($newSecret, $user['twofactor_secret']);
+        $this->assertTrue($sessionFingerprint->hasVerifiedTwoFactor());
+    }
+
+    public function testOnLoginSetupTwoFactorAuthNotAvailableWhenUserAlreadyUsesTwoFactorAuth()
+    {
+        $this->setTwoFaRequired(true);
+        $this->setCurrentUser($this->userWith2Fa);
+
+        $sessionFingerprint = new SessionFingerprint();
+        $sessionFingerprint->initialize($this->userWith2Fa, 'pending-session-token');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('not available');
+
+        StaticContainer::get(Controller::class)->onLoginSetupTwoFactorAuth();
+    }
+
+    public function testOnLoginSetupTwoFactorAuthNotAvailableWhenTwoFactorAuthIsNotEnforced()
+    {
+        $this->setCurrentUser($this->userWithout2Fa);
+
+        $sessionFingerprint = new SessionFingerprint();
+        $sessionFingerprint->initialize($this->userWithout2Fa, 'pending-session-token');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('not available');
+
+        StaticContainer::get(Controller::class)->onLoginSetupTwoFactorAuth();
+    }
+
+    public function testOnLoginSetupTwoFactorAuthNotAvailableWhenSessionUserDoesNotMatchCurrentUser()
+    {
+        $this->setTwoFaRequired(true);
+        $this->setCurrentUser($this->userWithout2Fa);
+
+        $sessionFingerprint = new SessionFingerprint();
+        $sessionFingerprint->initialize($this->otherUserWith2Fa, 'pending-session-token');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('not available');
+
+        StaticContainer::get(Controller::class)->onLoginSetupTwoFactorAuth();
+    }
+
+    public function testOnLoginSetupTwoFactorAuthKeepsExistingSecretWhenNotAvailable()
+    {
+        $this->setTwoFaRequired(true);
+        $this->setCurrentUser($this->userWith2Fa);
+
+        $sessionFingerprint = new SessionFingerprint();
+        $sessionFingerprint->initialize($this->userWith2Fa, 'pending-session-token');
+
+        // simulate a submitted setup form holding a valid code for a freshly generated secret
+        $replacementSecret = $this->twoFa->generateSecret();
+        $session = new SessionNamespace('TwoFactorAuthenticator');
+        $session->secret = $replacementSecret;
+        $_GET['authCode'] = $this->generateValidAuthCode($replacementSecret);
+        $_GET['authCodeNonce'] = Nonce::getNonce(Controller::AUTH_CODE_NONCE);
+
+        $exception = null;
+
+        try {
+            StaticContainer::get(Controller::class)->onLoginSetupTwoFactorAuth();
+        } catch (\Exception $e) {
+            $exception = $e;
+        }
+
+        $user = (new Model())->getUser($this->userWith2Fa);
+        $this->assertSame($this->user2faSecret, $user['twofactor_secret']);
+        $this->assertNotNull($exception, 'An exception should have been thrown');
+        $this->assertSame('not available', $exception->getMessage());
     }
 
     public function testOnRequestDispatchRequiresFreshLoginWhenDifferentUserIsAuthenticatedDuringPendingSession()
@@ -357,6 +490,15 @@ class TwoFactorAuthTest extends IntegrationTestCase
         Request::processRequest('UsersManager.deleteUser', array(
             'userLogin' => $this->userWithout2Fa,
         ));
+    }
+
+    private function setTwoFaRequired(bool $isRequired): void
+    {
+        // must go through the container: resolving it applies the test config decoration, which would
+        // otherwise reset the value afterwards
+        Access::doAsSuperUser(function () use ($isRequired) {
+            StaticContainer::get(SystemSettings::class)->twoFactorAuthRequired->setValue($isRequired ? 1 : 0);
+        });
     }
 
     private function generateValidAuthCode($secret)


### PR DESCRIPTION
### Description

`TwoFactorAuth.onLoginSetupTwoFactorAuth` renders the enrollment screen shown when two-factor authentication is enforced for all users and the current user has not enrolled yet. It is reached from exactly one place — the `!$isUsing2FA && $twoFa->isUserRequiredToHaveTwoFactorEnabled()` branch in `TwoFactorAuth::onRequestDispatch()`.

The action never asserted that state itself, though: the only check it reached was `Validator::checkCanUseTwoFa()`, i.e. "not anonymous and Matomo is installed". The dispatcher was the only thing keeping the action in scope. Every neighbouring action in the plugin declares its preconditions explicitly — `loginTwoFactorAuth()`, `disableTwoFactorAuth()` and `showRecoveryCodes()` all do — so this brings the login-only action in line with them.

The preconditions are asserted with the `Validator` methods the plugin already provides, so there is no new validation logic:

- `checkCurrentUserMatchesSessionUser()` — the request belongs to the session's own user
- `check2FaIsRequired()` — enforcement is actually on (this method had no callers before)
- `check2FaNotEnabled()` — the user has not enrolled yet

They fail the same way as elsewhere in the plugin, via the generic `not available` exception.

### Coverage

`onLoginSetupTwoFactorAuth()` previously had no PHP-level test at all. Added to `plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php`:

- the screen renders in the enforced, not-yet-enrolled state
- completing the enrollment persists the secret and marks the session verified
- a user whose 2FA was reset by a superuser while their session is already verified can still enroll again — this case is why `checkNotVerified2FAYet()` must *not* be added here, and the test fails if it is
- each precondition is rejected when violated, and a submitted setup form does not change a stored secret when the action is not available

I verified the negative tests fail without the added checks, and that the enrollment tests fail if a check wrongly blocks the flow.

The teardown now also resets `$_SESSION` between tests, since these tests store a setup secret there and it would otherwise leak into any test added later.

### Notes for reviewers

- No behaviour change for the enforced enrollment flow: a session login always initialises the fingerprint with the authenticated identity, so the session-user check holds, and the user is still unenrolled when the completing form is submitted (the secret is saved after the checks run).
- `plugins/TwoFactorAuth/tests/UI/TwoFactorAuth_spec.js:341`'s `requireTwoFa()` before the confirming POST is now load-bearing rather than defensive, because `afterEach` deletes the flag. Please keep it.
- I could not run `tests:run-ui --plugin=TwoFactorAuth` locally (the screenshot harness in my checkout has puppeteer 8 installed while it requires ^24, so both specs fail in `before all`). No screenshot changes are expected — the specs authenticate through real `Login.logme`, so the enforced enrollment flow satisfies all of the checks — but this needs CI to confirm.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)



Backport of #24995.
