### PR TITLE
Fix weekly scheduled reports crossing timezone day boundaries

### DIFF
--- a/plugins/ScheduledReports/Model.php
+++ b/plugins/ScheduledReports/Model.php
@@ -52,6 +52,33 @@ class Model
         return $nextId;
     }
 
+    /**
+     * @param list<int> $idSites
+     * @return array<int, string>
+     */
+    public function getSiteTimezones(array $idSites): array
+    {
+        $idSites = array_values(array_unique(array_map('intval', $idSites)));
+        if (empty($idSites)) {
+            return [];
+        }
+
+        $siteTable = Common::prefixTable('site');
+        $rows = Db::fetchAll(
+            "SELECT idsite, timezone
+                FROM {$siteTable}
+                WHERE idsite IN (" . Common::getSqlStringFieldsArray($idSites) . ')',
+            $idSites
+        );
+
+        $timezones = [];
+        foreach ($rows as $row) {
+            $timezones[(int) $row['idsite']] = $row['timezone'];
+        }
+
+        return $timezones;
+    }
+
     private function getNextReportId()
     {
         $db = $this->getDb();

--- a/plugins/ScheduledReports/Tasks.php
+++ b/plugins/ScheduledReports/Tasks.php
@@ -9,20 +9,55 @@
 
 namespace Piwik\Plugins\ScheduledReports;
 
+use Piwik\Date;
 use Piwik\Scheduler\Schedule\Schedule;
+use Piwik\Scheduler\Schedule\Weekly;
 
 class Tasks extends \Piwik\Plugin\Tasks
 {
+    /**
+     * @var Model
+     */
+    private $model;
+
+    public function __construct(Model $model)
+    {
+        $this->model = $model;
+    }
+
     public function schedule()
     {
-        foreach (API::getInstance()->getReports() as $report) {
+        $reports = API::getInstance()->getReports();
+        $idSites = array_values(array_unique(array_map('intval', array_column($reports, 'idsite'))));
+        $siteTimezones = $this->model->getSiteTimezones($idSites);
+
+        foreach ($reports as $report) {
             if (!$report['deleted'] && $report['period'] != Schedule::PERIOD_NEVER) {
                 $schedule = Schedule::getScheduledTimeForPeriod($report['period']);
                 $schedule->setHour($report['hour']);
                 $schedule->setTimezone('UTC'); // saved hour is UTC always
 
+                if ($schedule instanceof Weekly) {
+                    $siteTimezone = $siteTimezones[(int) $report['idsite']] ?? 'UTC';
+                    $this->alignWeeklyScheduleWithSiteTimezone($schedule, $siteTimezone);
+                }
+
                 $this->custom(API::getInstance(), 'sendReport', $report['idreport'], $schedule);
             }
+        }
+    }
+
+    private function alignWeeklyScheduleWithSiteTimezone(Weekly $schedule, string $timezone): void
+    {
+        $nextMondayUtc = $schedule->getRescheduledTime();
+        $timezoneOffset = Date::adjustForTimezone($nextMondayUtc, $timezone) - $nextMondayUtc;
+        $localHour = (int) gmdate('G', $nextMondayUtc) + ($timezoneOffset / 3600);
+
+        // Keep the report on local Monday when its saved UTC hour crosses a calendar-day boundary.
+        if ($localHour >= 24) {
+            $schedule->setDay(7);
+        } elseif ($localHour < 0) {
+            $schedule->setDay(2);
         }
     }
 }

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -17,6 +17,7 @@ use Piwik\Date;
 use Piwik\Piwik;
 use Piwik\Plugins\ScheduledReports\API as APIScheduledReports;
 use Piwik\Plugins\ScheduledReports\GeneratedReport;
+use Piwik\Plugins\ScheduledReports\Model as ScheduledReportsModel;
 use Piwik\Plugins\ScheduledReports\ScheduledReports;
 use Piwik\Plugins\ScheduledReports\Tasks;
 use Piwik\Plugins\ScheduledReports\WidgetReportMapper;
@@ -28,8 +29,8 @@ use Piwik\NoAccessException;
 use Piwik\ReportRenderer;
 use Piwik\Scheduler\Schedule\Monthly;
 use Piwik\Scheduler\Schedule\Schedule;
+use Piwik\Scheduler\Schedule\Weekly;
 use Piwik\Scheduler\Task;
-use Piwik\Site;
 use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Widget\WidgetsList;
@@ -510,7 +511,7 @@ class ApiTest extends IntegrationTestCase
      */
     public function testGetScheduledTasks()
     {
-        // stub API to control getReports() return values
+        // stub the scheduling model to control the registered tasks
         $report1 = self::getDailyPDFReportData($this->idSite);
         $report1['idreport'] = 1;
         $report1['hour'] = 0;
@@ -544,20 +545,44 @@ class ApiTest extends IntegrationTestCase
         $report6['period'] = Schedule::PERIOD_NEVER;
         $report6['deleted'] = 0;
 
+        $report7 = self::getMonthlyEmailReportData($this->idSite);
+        $report7['idreport'] = 7;
+        $report7['idsite'] = 3;
+        $report7['period'] = Schedule::PERIOD_WEEK;
+        $report7['hour'] = 21;
+        $report7['deleted'] = 0;
+
+        $report8 = self::getMonthlyEmailReportData($this->idSite);
+        $report8['idreport'] = 8;
+        $report8['idsite'] = 2;
+        $report8['period'] = Schedule::PERIOD_WEEK;
+        $report8['hour'] = 2;
+        $report8['deleted'] = 0;
+
+        $report9 = self::getMonthlyEmailReportData($this->idSite);
+        $report9['idreport'] = 9;
+        $report9['idsite'] = 3;
+        $report9['period'] = Schedule::PERIOD_WEEK;
+        $report9['hour'] = 8;
+        $report9['deleted'] = 0;
+
         $stubbedAPIScheduledReports = $this->getMockBuilder('\\Piwik\\Plugins\\ScheduledReports\\API')
-                                           ->setMethods(array('getReports', 'getInstance'))
+                                           ->setMethods(array('getReports'))
                                            ->disableOriginalConstructor()
                                            ->getMock();
-        $stubbedAPIScheduledReports->expects($this->any())->method('getReports')->will($this->returnValue(
-            array($report1, $report2, $report3, $report4, $report5, $report6)
-        ));
+        $stubbedAPIScheduledReports->expects($this->once())->method('getReports')->willReturn(
+            array($report1, $report2, $report3, $report4, $report5, $report6, $report7, $report8, $report9)
+        );
         \Piwik\Plugins\ScheduledReports\API::setSingletonInstance($stubbedAPIScheduledReports);
 
-        // initialize sites 1 and 2
-        Site::setSites(array(
-            1 => array('timezone' => 'Europe/Paris'),
-            2 => array('timezone' => 'UTC-6.5'),
-        ));
+        $stubbedModel = $this->getMockBuilder(ScheduledReportsModel::class)
+            ->setMethods(array('getSiteTimezones'))
+            ->getMock();
+        $stubbedModel->expects($this->once())->method('getSiteTimezones')->with(
+            array(1, 2, 3)
+        )->willReturn(
+            array(1 => 'Europe/Paris', 2 => 'UTC-6.5', 3 => 'Asia/Shanghai')
+        );
 
         // expected tasks
         // NOTE: scheduled reports are always saved with UTC, to avoid daylight saving issues
@@ -577,19 +602,61 @@ class ApiTest extends IntegrationTestCase
         $scheduleTask4->setHour(8);
         $scheduleTask4->setTimezone('UTC');
 
+        $scheduleTask5 = new Weekly();
+        $scheduleTask5->setDay(7);
+        $scheduleTask5->setHour(21);
+        $scheduleTask5->setTimezone('UTC');
+
+        $scheduleTask6 = new Weekly();
+        $scheduleTask6->setDay(2);
+        $scheduleTask6->setHour(2);
+        $scheduleTask6->setTimezone('UTC');
+
+        $scheduleTask7 = new Weekly();
+        $scheduleTask7->setHour(8);
+        $scheduleTask7->setTimezone('UTC');
+
         $expectedTasks = array(
             new Task(APIScheduledReports::getInstance(), 'sendReport', 1, $scheduleTask1),
             new Task(APIScheduledReports::getInstance(), 'sendReport', 2, $scheduleTask2),
             new Task(APIScheduledReports::getInstance(), 'sendReport', 4, $scheduleTask3),
             new Task(APIScheduledReports::getInstance(), 'sendReport', 5, $scheduleTask4),
+            new Task(APIScheduledReports::getInstance(), 'sendReport', 7, $scheduleTask5),
+            new Task(APIScheduledReports::getInstance(), 'sendReport', 8, $scheduleTask6),
+            new Task(APIScheduledReports::getInstance(), 'sendReport', 9, $scheduleTask7),
         );
 
-        $pdfReportPlugin = new Tasks();
+        $pdfReportPlugin = new Tasks($stubbedModel);
         $pdfReportPlugin->schedule();
         $tasks = $pdfReportPlugin->getScheduledTasks();
         $this->assertEquals($expectedTasks, $tasks);
 
+        $expectedLocalTimes = array(
+            7 => array('Asia/Shanghai', '05:00'),
+            8 => array('UTC-6.5', '19:30'),
+            9 => array('Asia/Shanghai', '16:00'),
+        );
+        foreach ($tasks as $task) {
+            $reportId = $task->getMethodParameter();
+            if (!isset($expectedLocalTimes[$reportId])) {
+                continue;
+            }
+
+            [$timezone, $expectedLocalTime] = $expectedLocalTimes[$reportId];
+            $localTimestamp = Date::adjustForTimezone($task->getRescheduledTime(), $timezone);
+            $this->assertSame('1', gmdate('N', $localTimestamp));
+            $this->assertSame($expectedLocalTime, gmdate('H:i', $localTimestamp));
+        }
+
         \Piwik\Plugins\ScheduledReports\API::unsetInstance();
+    }
+
+    public function testGetSiteTimezonesReturnsRequestedSites()
+    {
+        $site = APISitesManager::getInstance()->getSiteFromId($this->idSite);
+        $timezones = (new ScheduledReportsModel())->getSiteTimezones(array($this->idSite));
+
+        $this->assertSame(array($this->idSite => $site['timezone']), $timezones);
     }
 
     /**


### PR DESCRIPTION
## Description

Weekly reports store their selected hour in UTC, but the scheduler always used Monday in UTC as well. When the site timezone moves that hour across midnight, the report arrives on Tuesday or Sunday locally.

This keeps the existing UTC-hour storage contract, loads the relevant site timezones in one batch query, and adjusts only the UTC weekday when needed so weekly reports still arrive on local Monday. It covers positive, negative, and fractional timezone offsets without changing the public API, schema, or frontend.

Fixes #24980.

## Testing

- Added regressions for `Asia/Shanghai` (`Sunday 21:00 UTC` → `Monday 05:00` local), negative fractional `UTC-6.5`, and a no-rollover case.
- `vendor/bin/phpunit -c tests/PHPUnit/phpunit.xml.dist plugins/ScheduledReports/tests/Integration` — 90 tests, 277 assertions.
- `vendor/bin/phpcs --standard=phpcs.xml plugins/ScheduledReports/Model.php plugins/ScheduledReports/Tasks.php plugins/ScheduledReports/tests/Integration/ApiTest.php`
- `vendor/bin/phpstan analyse -c phpstan.neon --no-progress plugins/ScheduledReports/Model.php plugins/ScheduledReports/Tasks.php`

Existing persisted timetable entries are not cleared globally; they adopt the corrected weekday when that report is next rescheduled.
