### PR TITLE
Make the preview release build a selectable target branch

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -47,6 +47,14 @@ on:
   schedule:
     - cron: '0 1 * * *' # 1am daily
 
+# Two builds for the same target would force-push the same preview branch and
+# race for the same version number, so they are queued instead of cancelled.
+# The default needs to be repeated here, as the concurrency group cannot access
+# the env context.
+concurrency:
+  group: preview-${{ inputs.target_branch || '5.x-dev' }}
+  cancel-in-progress: false
+
 env:
   RELEASE_PASSWORD: ${{ secrets.RELEASE_PASSWORD }}
 jobs:

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -82,14 +82,16 @@ jobs:
             core.setFailed('User is not allowed to release.')
       # The target branch ends up as a checkout ref, as the force-push target
       # and as the ref the release workflow builds from, so validate it here
-      # instead of relying on the input staying a restricted choice.
+      # instead of relying on the input staying a restricted choice. Each
+      # supported branch also needs a test job below, so failing early is
+      # better than skipping the release later on.
       - name: Determine preview branch
         id: target
         run: |
-          if ! [[ $TARGET_BRANCH =~ ^[0-9]+\.x-dev$ ]]; then
-            echo "Unsupported target branch: $TARGET_BRANCH"
-            exit 1
-          fi
+          case "$TARGET_BRANCH" in
+            5.x-dev|6.x-dev) ;;
+            *) echo "Unsupported target branch: $TARGET_BRANCH"; exit 1 ;;
+          esac
 
           echo "PREVIEW_BRANCH=${TARGET_BRANCH%-dev}-preview" >> "$GITHUB_ENV"
           echo "preview_branch=${TARGET_BRANCH%-dev}-preview" >> "$GITHUB_OUTPUT"
@@ -202,14 +204,35 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  run_matomo_tests:
+  # A workflow started from a branch always calls the reusable workflows of that
+  # same branch, which would test the code of the target branch with the PHP,
+  # MySQL and Node versions of the branch this workflow was started from. As the
+  # called workflow can not be chosen dynamically, there is one job per target
+  # branch, so the tests always run with the matching versions.
+  run_matomo_tests_5x:
+    needs: [prepare_preview_version]
+    uses: matomo-org/matomo/.github/workflows/matomo-tests.yml@5.x-dev
+    if: |
+      always() &&
+      needs.prepare_preview_version.result == 'success' &&
+      needs.prepare_preview_version.outputs.do_release == '1' &&
+      needs.prepare_preview_version.outputs.has_new_version == '1' &&
+      needs.prepare_preview_version.outputs.preview_branch == '5.x-preview'
+    with:
+      is_preview: true
+      ref: ${{ needs.prepare_preview_version.outputs.preview_branch }}
+    secrets:
+      ARTIFACTS_PASS: ${{ secrets.ARTIFACTS_PASS }}
+
+  run_matomo_tests_6x:
     needs: [prepare_preview_version]
     uses: ./.github/workflows/matomo-tests.yml
     if: |
-      always() && 
-      needs.prepare_preview_version.result == 'success' && 
-      needs.prepare_preview_version.outputs.do_release == '1' && 
-      needs.prepare_preview_version.outputs.has_new_version == '1'
+      always() &&
+      needs.prepare_preview_version.result == 'success' &&
+      needs.prepare_preview_version.outputs.do_release == '1' &&
+      needs.prepare_preview_version.outputs.has_new_version == '1' &&
+      needs.prepare_preview_version.outputs.preview_branch == '6.x-preview'
     with:
       is_preview: true
       ref: ${{ needs.prepare_preview_version.outputs.preview_branch }}
@@ -217,13 +240,17 @@ jobs:
       ARTIFACTS_PASS: ${{ secrets.ARTIFACTS_PASS }}
 
   release_preview_version:
-    needs: [prepare_preview_version, run_matomo_tests]
+    needs: [prepare_preview_version, run_matomo_tests_5x, run_matomo_tests_6x]
     uses: ./.github/workflows/release.yml
+    # exactly one of the test jobs runs, the other one is always skipped
     if: |
-      always() && 
-      needs.prepare_preview_version.result == 'success' && 
-      needs.run_matomo_tests.result == 'success' && 
-      needs.prepare_preview_version.outputs.do_release == '1' && 
+      always() &&
+      needs.prepare_preview_version.result == 'success' &&
+      (
+        (needs.run_matomo_tests_5x.result == 'success' && needs.run_matomo_tests_6x.result == 'skipped') ||
+        (needs.run_matomo_tests_6x.result == 'success' && needs.run_matomo_tests_5x.result == 'skipped')
+      ) &&
+      needs.prepare_preview_version.outputs.do_release == '1' &&
       needs.prepare_preview_version.outputs.has_new_version == '1'
     with:
       is_preview: true

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,5 +1,11 @@
 # Matomo release action for automated PREVIEW releases
 #
+# The branch to build a preview from is selectable. Scheduled runs always use
+# the default (5.x-dev), because Matomo Cloud is still on Matomo 5 and needs to
+# keep receiving 5.x previews even though the repository's default branch is
+# switching to 6.x-dev. Previews for another major can be built by dispatching
+# this workflow manually with a different target branch.
+#
 # Slack notifications on failure and automatic retries live in the
 # separate preview-retry-handler.yml workflow, which reacts to this
 # workflow's completion. Attempts 1 and 2 get rerun automatically;
@@ -26,22 +32,33 @@ permissions:
   statuses: none
 
 on:
-  # TODO: remove manual dispatch after testing and enable cron
   workflow_dispatch:
     inputs:
       password:
         description: 'Release password'
         required: true
+      target_branch:
+        description: 'Branch to build the preview from'
+        type: choice
+        default: '5.x-dev'
+        options:
+          - '5.x-dev'
+          - '6.x-dev'
   schedule:
     - cron: '0 1 * * *' # 1am daily
+
 env:
   RELEASE_PASSWORD: ${{ secrets.RELEASE_PASSWORD }}
 jobs:
   prepare_preview_version:
     runs-on: ubuntu-24.04
+    # inputs is empty for scheduled runs, so the default has to be repeated here
+    env:
+      TARGET_BRANCH: ${{ inputs.target_branch || '5.x-dev' }}
     outputs:
       do_release: ${{ steps.changes.outputs.do_release }}
       has_new_version: ${{ steps.version.outputs.has_new_version }}
+      preview_branch: ${{ steps.target.outputs.preview_branch }}
     steps:
       - name: "Check release password"
         if: ${{ github.event_name != 'schedule' && github.event.inputs.password != env.RELEASE_PASSWORD }}
@@ -55,12 +72,27 @@ jobs:
         with:
           script: |
             core.setFailed('User is not allowed to release.')
+      # The target branch ends up as a checkout ref, as the force-push target
+      # and as the ref the release workflow builds from, so validate it here
+      # instead of relying on the input staying a restricted choice.
+      - name: Determine preview branch
+        id: target
+        run: |
+          if ! [[ $TARGET_BRANCH =~ ^[0-9]+\.x-dev$ ]]; then
+            echo "Unsupported target branch: $TARGET_BRANCH"
+            exit 1
+          fi
+
+          echo "PREVIEW_BRANCH=${TARGET_BRANCH%-dev}-preview" >> "$GITHUB_ENV"
+          echo "preview_branch=${TARGET_BRANCH%-dev}-preview" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v7
         with:
           lfs: false
           fetch-tags: true
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ env.TARGET_BRANCH }}
 
       - name: Prepare git config
         run: |
@@ -70,21 +102,40 @@ jobs:
       - name: Check if there are any changes to create a preview release for
         id: changes
         run: |
-          LATEST_PREVIEW=$(git tag --sort=-creatordate | grep -E '\.[0-9]{14}$' | head -n 1)
-          
-          DIFF=""
-          if [ -n "$LATEST_PREVIEW" ]; then
-            # using || true to always exit either with a diff or a success exit code to not fail the whole workflow
-            DIFF=$(git diff "$LATEST_PREVIEW..6.x-dev" --unified=0 | grep -vE "^\+\+\+|---" | grep "^[+-]" | grep -v "public const VERSION = '.*';" || true)
+          MAJOR=$(php -r "include_once 'core/Version.php'; echo \Piwik\Version::MAJOR_VERSION;")
+
+          if [ "$MAJOR" != "${TARGET_BRANCH%%.*}" ]; then
+            echo "core/Version.php on ${TARGET_BRANCH} reports major version ${MAJOR}."
+            exit 1
           fi
-          
-          if [ -z "$DIFF" ]; then
-            echo "No changes in 6.x-dev since last preview version was created."
-            DO_RELEASE=0
-          else
+
+          PREVIEW_TAGS=$(git tag --sort=-creatordate | grep -E '\.[0-9]{14}$' || true)
+
+          # not finding any preview tag at all means they were not fetched correctly,
+          # which must not be mistaken for a major that has no previews yet
+          if [ -z "$PREVIEW_TAGS" ]; then
+            echo "No preview tags found at all."
+            exit 1
+          fi
+
+          # previews of another major are no valid base to compare against
+          LATEST_PREVIEW=$(printf '%s\n' "$PREVIEW_TAGS" | grep -E "^${MAJOR}\." | head -n 1 || true)
+
+          if [ -z "$LATEST_PREVIEW" ]; then
+            echo "No preview version has been created for Matomo ${MAJOR} yet."
             DO_RELEASE=1
+          else
+            # using || true to always exit either with a diff or a success exit code to not fail the whole workflow
+            DIFF=$(git diff "$LATEST_PREVIEW..HEAD" --unified=0 | grep -vE "^\+\+\+|---" | grep "^[+-]" | grep -v "public const VERSION = '.*';" || true)
+
+            if [ -z "$DIFF" ]; then
+              echo "No changes in ${TARGET_BRANCH} since last preview version was created."
+              DO_RELEASE=0
+            else
+              DO_RELEASE=1
+            fi
           fi
-          
+
           echo "do_release=$DO_RELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Determine new preview version number
@@ -110,7 +161,7 @@ jobs:
         if: steps.changes.outputs.do_release == '1' && steps.version.outputs.has_new_version == '1'
         run: |
           if [[ $OLD_VERSION =~ -rc[0-9]+$ ]]; then
-            echo "Preview releases are skipped while VERSION is an RC ($OLD_VERSION). Set VERSION to the next -alpha on 6.x-dev."
+            echo "Preview releases are skipped while VERSION is an RC ($OLD_VERSION). Set VERSION to the next -alpha on ${TARGET_BRANCH}."
             exit 1
           fi
 
@@ -125,11 +176,6 @@ jobs:
             exit 1
           fi
 
-      - name: Update 6.x-preview branch to latest 6.x-dev
-        if: steps.changes.outputs.do_release == '1' && steps.version.outputs.has_new_version == '1'
-        run: |
-          git checkout -B 6.x-preview
-
       - name: Update version file with new version
         if: steps.changes.outputs.do_release == '1' && steps.version.outputs.has_new_version == '1'
         run: |
@@ -141,10 +187,10 @@ jobs:
           git add core/Version.php
           git commit -m "Update version to ${NEW_VERSION}"
 
-      - name: Push changes to 5.x-preview
+      - name: Push changes to ${{ steps.target.outputs.preview_branch }}
         if: steps.changes.outputs.do_release == '1' && steps.version.outputs.has_new_version == '1'
         run: |
-          git push -f "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}" 5.x-preview
+          git push -f "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}" "HEAD:refs/heads/${PREVIEW_BRANCH}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -158,7 +204,7 @@ jobs:
       needs.prepare_preview_version.outputs.has_new_version == '1'
     with:
       is_preview: true
-      ref: 5.x-preview
+      ref: ${{ needs.prepare_preview_version.outputs.preview_branch }}
     secrets:
       ARTIFACTS_PASS: ${{ secrets.ARTIFACTS_PASS }}
 
@@ -173,7 +219,7 @@ jobs:
       needs.prepare_preview_version.outputs.has_new_version == '1'
     with:
       is_preview: true
-      ref: 5.x-preview
+      ref: ${{ needs.prepare_preview_version.outputs.preview_branch }}
     secrets:
       RELEASE_PASSWORD: ${{ secrets.RELEASE_PASSWORD }}
       GPG_CERTIFICATE: ${{ secrets.GPG_CERTIFICATE }}


### PR DESCRIPTION
### Description

Scheduled workflows only ever run from the repository's default branch. Once the default switches from `5.x-dev` to `6.x-dev`, the nightly *Build preview release* would start cutting Matomo 6 previews — but Matomo Cloud is still on Matomo 5 and needs to keep receiving 5.x previews.

The branch to build a preview from is now an explicit input:

```yaml
target_branch:
  description: 'Branch to build the preview from'
  type: choice
  default: '5.x-dev'
  options: ['5.x-dev', '6.x-dev']
```

Scheduled runs get the same default (the `inputs` context is empty for `schedule`, so the fallback is repeated where needed), and a manual dispatch can pick `6.x-dev` to build a Matomo 6 preview. Everything downstream is derived from it: the checkout ref, the base tag to compare against, the preview branch name, the push refspec, and the `ref:` handed to `matomo-tests.yml` and `release.yml`.

Three things beyond the plain parameterisation:

* **The tests run with the test matrix of the target branch.** A workflow started from a branch always calls the reusable workflows of that same branch, so after the switch the nightly would have tested Matomo 5 code with 6.x's PHP, MySQL and Node versions — dropping the PHP 7.2 and MySQL 5.7 coverage and running the JS, Client and UI suites on Node 24 instead of 12/16, which the 5.x toolchain is unlikely to survive. Since `uses:` accepts no expressions, there is one test job per target branch and only the matching one runs; the release job requires exactly one success and one skip. `release.yml` needs no equivalent treatment — it differs only in an error message between the branches and builds the package from the code of the tag it creates.
* **The base tag lookup is scoped to the major version of the target branch.** It previously took the newest preview tag repo-wide, so the first manually built 6.x preview would have become the comparison base for the nightly 5.x run, which would then release a preview every night regardless of changes. When a major has no preview yet, a release is triggered rather than silently skipped, and not finding *any* preview tag now fails the build — a broken checkout must not look like a major without previews.
* **Preview builds are serialised per target branch.** Making the target selectable adds a second way to start a build, and two builds for the same target would force-push the same preview branch and race for the same version number. They are queued rather than cancelled, so a running build always finishes.

This also fixes leftovers of the partial 6.x rename in 05d2e1d318d, which created the preview branch as `6.x-preview` but pushed and released `5.x-preview`. Since `5.x-preview` does not exist locally in a fresh checkout, the push had no source ref — the nightly build on `6.x-dev` is broken as it stands today.

### Rollout

1. **Merge before the default branch is switched.** Flipping first leaves the nightly running the current `6.x-dev` file, whose `git push -f … 5.x-preview` has no local source ref and fails.
2. **Optionally dispatch manually on `6.x-dev` with `target_branch=5.x-dev` afterwards.** That is a faithful rehearsal of the post-switch nightly — same workflow file, same reusable-workflow resolution, same `GITHUB_REF` — and confirms the wiring end to end. It publishes a normal extra preview if it succeeds.

Worth checking as part of the branch switch itself, outside this PR: `composer-update.yml` and `update-intl.yml` are also `schedule`-triggered and hardcode `6.x-dev`, so they change what they operate on the moment the default flips too.

### Notes

* **A 6.x preview cannot be built until `6.0.0-b1` is tagged** — it is not an `-alpha`, so the existing "previous version has been released" guard requires a matching tag. The dispatch fails cleanly before anything is pushed, and that guard is deliberately left alone: it is what stops a preview being cut from an unreleased base.
* **`release.yml`'s branch guard stays caller-scoped.** It validates `GITHUB_REF` (the branch the workflow was started from) rather than `inputs.ref` (the preview branch it checks out and tags). Traced for the post-switch case and it still passes, but it can no longer tell a 5.x preview from a 6.x one. Anyone fixing that must also fix the inverted condition at `release.yml:136`, which today rejects exactly the combination it claims to allow — doing one without the other breaks every preview release.
* **Artifact branch labels** need a `github-branch` input in `matomo-org/github-action-tests`, which hardcodes `github.head_ref || github.ref_name` at both upload sites. Patching only the one upload done directly in `matomo-tests.yml` would split a single run across two labels, so it is left out here.

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
