### PR TITLE
Overlay: JS-encode handshake parameters in inline scripts

### DIFF
--- a/plugins/Overlay/templates/index.twig
+++ b/plugins/Overlay/templates/index.twig
@@ -72,7 +72,7 @@
 
             // The startOverlaySession URL is matched by piwik.js::isOverlaySession(). Only the
             // canonical handshake parameters (module, action, idSite, period, date, segment) belong here.
-            var iframeSrc = 'index.php?module=Overlay&action=startOverlaySession&idSite={{ idSite }}&period={{ period }}&date={{ rawDate }}&segment={{ segment }}';
+            var iframeSrc = 'index.php?module=Overlay&action=startOverlaySession&idSite={{ idSite|e('js') }}&period={{ period|e('js') }}&date={{ rawDate|e('js') }}&segment={{ segment|e('js') }}';
             var iframePostParams = null;
             if (piwik.shouldPropagateTokenAuth) {
                 iframePostParams = {
@@ -83,7 +83,7 @@
                 }
             }
 
-            Piwik_Overlay.init(iframeSrc, '{{ idSite }}', '{{ period }}', '{{ rawDate }}', '{{ segment }}', iframePostParams);
+            Piwik_Overlay.init(iframeSrc, '{{ idSite|e('js') }}', '{{ period|e('js') }}', '{{ rawDate|e('js') }}', '{{ segment|e('js') }}', iframePostParams);
 
             window.Piwik_Overlay_Translations = {
                 domain: "{{ 'Overlay_Domain'|translate }}"

--- a/plugins/Overlay/templates/index_noframe.twig
+++ b/plugins/Overlay/templates/index_noframe.twig
@@ -8,7 +8,7 @@
     <script type="text/javascript">
         // The startOverlaySession URL is matched by piwik.js::isOverlaySession(). Only the
         // canonical handshake parameters (module, action, idSite, period, date, segment) belong here.
-        var newLocation = 'index.php?module=Overlay&action=startOverlaySession&idSite={{ idSite }}&period={{ period }}&date={{ date }}&segment={{ segment }}';
+        var newLocation = 'index.php?module=Overlay&action=startOverlaySession&idSite={{ idSite|e('js') }}&period={{ period|e('js') }}&date={{ date|e('js') }}&segment={{ segment|e('js') }}';
 
         function submitPostNavigation(action, params) {
             var form = document.createElement('form');

--- a/plugins/Overlay/tests/Unit/TemplateEncodingTest.php
+++ b/plugins/Overlay/tests/Unit/TemplateEncodingTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Overlay\tests\Unit;
+
+/**
+ * The Overlay handshake parameters (idSite, period, date, segment) are written into
+ * inline JavaScript string literals. They must always be JS-encoded there, so a change
+ * that drops the encoding is caught before it ships.
+ */
+class TemplateEncodingTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider getHandshakeTemplates
+     */
+    public function testHandshakeParametersAreJavascriptEncoded(string $templateFile, array $params)
+    {
+        $contents = file_get_contents(dirname(__DIR__, 2) . '/templates/' . $templateFile);
+        $this->assertNotFalse($contents, "Could not read template $templateFile");
+
+        foreach ($params as $param) {
+            $this->assertStringContainsString(
+                "{{ $param|e('js') }}",
+                $contents,
+                "$templateFile must JS-encode the '$param' handshake parameter"
+            );
+
+            $this->assertStringNotContainsString(
+                "{{ $param }}",
+                $contents,
+                "$templateFile must not write '$param' into JavaScript without JS-encoding"
+            );
+        }
+    }
+
+    public function getHandshakeTemplates(): array
+    {
+        return [
+            ['index.twig', ['idSite', 'period', 'rawDate', 'segment']],
+            ['index_noframe.twig', ['idSite', 'period', 'date', 'segment']],
+        ];
+    }
+}


### PR DESCRIPTION
The Overlay index templates write the handshake parameters (idSite/period/date/segment) straight into inline JavaScript strings. This encodes them with the Twig js escaper so those values stay as data.

Runtime output is unchanged for normal input, so the session handshake URL still matches `isOverlaySession()`. Tested in both framed and non-framed mode locally, added a small test to guard the encoding.

Ref DEV-20636

Checklist
[✔] I have understood, reviewed, and tested all AI outputs before use
[✔] All AI instructions respect security, IP, and privacy rules