### PR TITLE
Restrict report streaming to the top-level request and serve API array output as text/plain

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -393,6 +393,19 @@ class Request
     }
 
     /**
+     * Checks if the currently executing API request is running inside another API request.
+     *
+     * This is true only for "child" API requests, i.e. requests that were dispatched
+     * programmatically from within another API method (for example the sub-requests run by
+     * {@link \Piwik\Plugins\API\API::getBulkRequest()}). It is false for the root request and
+     * when no API request is currently being processed.
+     */
+    public static function isCurrentApiRequestNestedInAnotherApiRequest(): bool
+    {
+        return self::$nestedApiInvocationCount > 1;
+    }
+
+    /**
      * Detect if request is an API request. Meaning the module is 'API' and an API method having a valid format was
      * specified. Note that this method will return true even if the actual request is for example a regular UI
      * reporting page request but within this request we are currently processing an API request (eg a

--- a/core/ReportRenderer.php
+++ b/core/ReportRenderer.php
@@ -201,8 +201,24 @@ abstract class ReportRenderer extends BaseFactory
         return $outputFilename;
     }
 
+    /**
+     * Streaming a report writes response headers and body directly, so it is reserved for the
+     * top-level request. A report generated as a nested API sub-request must be returned to the
+     * calling request instead.
+     *
+     * @throws Exception
+     */
+    public static function checkStreamingToBrowserIsAllowed(): void
+    {
+        if (Request::isCurrentApiRequestNestedInAnotherApiRequest()) {
+            throw new Exception('A report can only be sent to the browser by the top-level request.');
+        }
+    }
+
     protected static function sendToBrowser($filename, $extension, $contentType, $content)
     {
+        self::checkStreamingToBrowserIsAllowed();
+
         $filename = ReportRenderer::makeFilenameWithExtension($filename, $extension);
 
         ProxyHttp::overrideCacheControlHeaders();
@@ -216,6 +232,8 @@ abstract class ReportRenderer extends BaseFactory
 
     protected static function inlineToBrowser($contentType, $content)
     {
+        self::checkStreamingToBrowserIsAllowed();
+
         Common::sendHeader('Content-Type: ' . $contentType);
         echo $content;
     }

--- a/core/ReportRenderer/Pdf.php
+++ b/core/ReportRenderer/Pdf.php
@@ -165,12 +165,16 @@ class Pdf extends ReportRenderer
 
     public function sendToBrowserDownload($filename)
     {
+        self::checkStreamingToBrowserIsAllowed();
+
         $filename = ReportRenderer::makeFilenameWithExtension($filename, self::PDF_CONTENT_TYPE);
         $this->TCPDF->Output($filename, 'D');
     }
 
     public function sendToBrowserInline($filename)
     {
+        self::checkStreamingToBrowserIsAllowed();
+
         $filename = ReportRenderer::makeFilenameWithExtension($filename, self::PDF_CONTENT_TYPE);
         $this->TCPDF->Output($filename, 'I');
     }

--- a/plugins/API/Controller.php
+++ b/plugins/API/Controller.php
@@ -27,8 +27,6 @@ class Controller extends \Piwik\Plugin\Controller
     public function index()
     {
         $tokenAuth = StaticContainer::get(AuthenticationToken::class)->getAuthToken() ?: 'anonymous';
-        $format = Common::getRequestVar('format', false);
-        $serialize = Common::getRequestVar('serialize', false);
 
         // when calling the API through http, we limit the number of returned results
         if (!isset($_GET['filter_limit'])) {
@@ -45,12 +43,8 @@ class Controller extends \Piwik\Plugin\Controller
         $response = $request->process();
 
         if (is_array($response)) {
-            if (
-                $format == 'original'
-                && $serialize != 1
-            ) {
-                Original::sendPlainTextHeader();
-            }
+            // var_export() output is a plain-text PHP structure dump and is always served as such
+            Original::sendPlainTextHeader();
 
             $response = var_export($response, true);
         }

--- a/plugins/API/tests/Integration/ControllerTest.php
+++ b/plugins/API/tests/Integration/ControllerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\API\tests\Integration;
+
+use Piwik\Common;
+use Piwik\Plugins\API\Controller;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group API
+ * @group Plugins
+ */
+class ControllerTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Common::$headersSentInTests = [];
+    }
+
+    public function tearDown(): void
+    {
+        $_GET = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider getFormatSpellings
+     */
+    public function testIndexServesArrayOutputAsPlainText(string $format)
+    {
+        $_GET = [
+            'module' => 'API',
+            'method' => 'API.getBulkRequest',
+            'format' => $format,
+            'serialize' => '0',
+            'urls' => [],
+        ];
+
+        $response = (new Controller())->index();
+
+        self::assertSame(var_export([], true), $response);
+        self::assertSame(
+            'text/plain; charset=utf-8',
+            trim(Common::$headersSentInTests['Content-Type'] ?? '')
+        );
+    }
+
+    public function getFormatSpellings(): array
+    {
+        return [
+            ['original'],
+            ['ORIGINAL'],
+            ['Original'],
+        ];
+    }
+}

--- a/plugins/ImageGraph/API.php
+++ b/plugins/ImageGraph/API.php
@@ -171,6 +171,12 @@ class API extends \Piwik\Plugin\API
     ) {
         Piwik::checkUserHasViewAccess($idSite);
 
+        // a graph may only be streamed to the browser by the top-level request, so it is checked
+        // upfront and no graph is rendered for an output mode that will be refused anyway
+        if (self::isStreamingOutputType($outputType) && Request::isCurrentApiRequestNestedInAnotherApiRequest()) {
+            throw new Exception('A graph can only be sent to the browser by the top-level request.');
+        }
+
         // Health check - should we also test for GD2 only?
         if (!SettingsServer::isGdExtensionEnabled()) {
             throw new Exception('Error: To create graphs in Matomo, please enable GD php extension (with Freetype support) in php.ini,
@@ -585,6 +591,15 @@ class API extends \Piwik\Plugin\API
                 $graph->sendToBrowser();
                 exit;
         }
+    }
+
+    /**
+     * Whether the given output mode streams the graph to the browser. Mirrors the output modes
+     * handled by the switch in {@see get()}, where any unknown mode means inline.
+     */
+    private static function isStreamingOutputType(int $outputType): bool
+    {
+        return !in_array($outputType, [self::GRAPH_OUTPUT_FILE, self::GRAPH_OUTPUT_PHP], true);
     }
 
     private function setFilterTruncate(int $default): void

--- a/plugins/ImageGraph/tests/Integration/APITest.php
+++ b/plugins/ImageGraph/tests/Integration/APITest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\ImageGraph\tests\Integration;
+
+use Exception;
+use Piwik\API\Request;
+use Piwik\Plugins\ImageGraph\API;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use ReflectionProperty;
+
+/**
+ * @group ImageGraph
+ * @group Plugins
+ */
+class APITest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        FakeAccess::$superUser = true;
+    }
+
+    public function tearDown(): void
+    {
+        $this->setNestedApiInvocationCount(0);
+
+        parent::tearDown();
+    }
+
+    public function testGetRefusesStreamingOutputInsideNestedApiRequest()
+    {
+        $this->setNestedApiInvocationCount(2);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('A graph can only be sent to the browser by the top-level request.');
+
+        API::getInstance()->get(1, 'day', 'today', 'VisitsSummary', 'get');
+    }
+
+    public function provideContainerConfig()
+    {
+        return [
+            'Piwik\Access' => new FakeAccess(),
+        ];
+    }
+
+    private function setNestedApiInvocationCount(int $count): void
+    {
+        $reflectionProperty = new ReflectionProperty(Request::class, 'nestedApiInvocationCount');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue(null, $count);
+    }
+}

--- a/plugins/ImageGraph/tests/Unit/APITest.php
+++ b/plugins/ImageGraph/tests/Unit/APITest.php
@@ -34,4 +34,24 @@ class APITest extends \PHPUnit\Framework\TestCase
             ['', 0.0],
         ];
     }
+
+    /**
+     * @dataProvider getOutputTypes
+     */
+    public function testIsStreamingOutputTypeDetectsBrowserOutput(int $outputType, bool $expected): void
+    {
+        $method = new ReflectionMethod(API::class, 'isStreamingOutputType');
+
+        $this->assertSame($expected, $method->invoke(null, $outputType));
+    }
+
+    public function getOutputTypes(): array
+    {
+        return [
+            [API::GRAPH_OUTPUT_INLINE, true],
+            [API::GRAPH_OUTPUT_FILE, false],
+            [API::GRAPH_OUTPUT_PHP, false],
+            [99, true],
+        ];
+    }
 }

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -558,6 +558,11 @@ class API extends \Piwik\Plugin\API
             $outputType = self::OUTPUT_DOWNLOAD;
         }
 
+        // checked upfront so no report is rendered for an output mode that will be refused anyway
+        if (self::isStreamingOutputType($outputType)) {
+            ReportRenderer::checkStreamingToBrowserIsAllowed();
+        }
+
         /** @var Translator $translator */
         $translator = StaticContainer::get('Piwik\Translation\Translator');
 
@@ -834,6 +839,17 @@ class API extends \Piwik\Plugin\API
                 $reportRenderer->sendToBrowserDownload($filename);
                 break;
         }
+    }
+
+    /**
+     * Whether the given output mode streams the report to the browser. Mirrors the output modes
+     * handled by the switch in {@see generateReport()}, where any unknown mode means download.
+     *
+     * @param int|false $outputType
+     */
+    private static function isStreamingOutputType($outputType): bool
+    {
+        return !in_array($outputType, [self::OUTPUT_SAVE_ON_DISK, self::OUTPUT_RETURN]);
     }
 
     /**

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -35,6 +35,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Widget\WidgetsList;
 use Exception;
 use ReflectionMethod;
+use ReflectionProperty;
 
 require_once PIWIK_INCLUDE_PATH . '/plugins/ScheduledReports/ScheduledReports.php';
 
@@ -809,6 +810,45 @@ class ApiTest extends IntegrationTestCase
         self::assertSame('Weekly traffic overview', $renderedReport['frontPageDescription']);
     }
 
+    public function testGenerateReportRefusesStreamingOutputInsideNestedApiRequest()
+    {
+        $this->setNestedApiInvocationCount(2);
+
+        try {
+            $this->expectException(Exception::class);
+            $this->expectExceptionMessage('A report can only be sent to the browser by the top-level request.');
+
+            APIScheduledReports::getInstance()->generateReport(
+                1,
+                '2024-01-01',
+                false,
+                APIScheduledReports::OUTPUT_DOWNLOAD
+            );
+        } finally {
+            $this->setNestedApiInvocationCount(0);
+        }
+    }
+
+    public function testGenerateReportAllowsNonStreamingOutputInsideNestedApiRequest()
+    {
+        $this->setNestedApiInvocationCount(2);
+
+        try {
+            // the report lookup is only reached when the output mode is not refused upfront
+            $this->expectException(Exception::class);
+            $this->expectExceptionMessage("Requested report couldn't be found.");
+
+            APIScheduledReports::getInstance()->generateReport(
+                1,
+                '2024-01-01',
+                false,
+                APIScheduledReports::OUTPUT_RETURN
+            );
+        } finally {
+            $this->setNestedApiInvocationCount(0);
+        }
+    }
+
     public function testGetDisplayDescriptionFallsBackToNameForLegacyReports()
     {
         $report = new GeneratedReport([
@@ -1414,5 +1454,12 @@ class ApiTest extends IntegrationTestCase
     {
         FakeAccess::clearAccess();
         FakeAccess::$identity = 'anonymous';
+    }
+
+    private function setNestedApiInvocationCount(int $count): void
+    {
+        $reflectionProperty = new ReflectionProperty(Request::class, 'nestedApiInvocationCount');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue(null, $count);
     }
 }

--- a/tests/PHPUnit/Integration/API/RequestTest.php
+++ b/tests/PHPUnit/Integration/API/RequestTest.php
@@ -407,6 +407,22 @@ class RequestTest extends IntegrationTestCase
         }
     }
 
+    public function testIsCurrentApiRequestNestedInAnotherApiRequestReflectsInvocationDepth()
+    {
+        try {
+            $this->setNestedApiInvocationCount(0);
+            $this->assertFalse(Request::isCurrentApiRequestNestedInAnotherApiRequest());
+
+            $this->setNestedApiInvocationCount(1);
+            $this->assertFalse(Request::isCurrentApiRequestNestedInAnotherApiRequest());
+
+            $this->setNestedApiInvocationCount(2);
+            $this->assertTrue(Request::isCurrentApiRequestNestedInAnotherApiRequest());
+        } finally {
+            $this->setNestedApiInvocationCount(0);
+        }
+    }
+
     private function assertSameUserAsBeforeIsAuthenticated()
     {
         $this->assertEquals($this->userAuthToken, $this->access->getTokenAuth());

--- a/tests/PHPUnit/Integration/ReportRendererNestedApiRequestTest.php
+++ b/tests/PHPUnit/Integration/ReportRendererNestedApiRequestTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration;
+
+use Exception;
+use Piwik\API\Request;
+use Piwik\ReportRenderer;
+use Piwik\ReportRenderer\Pdf;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * A report may only be streamed to the browser by the top-level request. A report generated as a
+ * nested API sub-request must be returned to the calling request instead.
+ *
+ * @group Core
+ * @group ReportRenderer
+ */
+class ReportRendererNestedApiRequestTest extends IntegrationTestCase
+{
+    private const REFUSED_MESSAGE = 'A report can only be sent to the browser by the top-level request.';
+
+    public function tearDown(): void
+    {
+        $this->setNestedApiInvocationCount(0);
+        parent::tearDown();
+    }
+
+    public function testInlineToBrowserIsRefusedInsideNestedApiRequest()
+    {
+        $this->setNestedApiInvocationCount(2);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(self::REFUSED_MESSAGE);
+
+        $this->invokeReportRendererStatic('inlineToBrowser', ['text/html', 'report body']);
+    }
+
+    public function testSendToBrowserIsRefusedInsideNestedApiRequest()
+    {
+        $this->setNestedApiInvocationCount(2);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(self::REFUSED_MESSAGE);
+
+        $this->invokeReportRendererStatic('sendToBrowser', ['report', 'html', 'text/html', 'report body']);
+    }
+
+    public function testPdfSendToBrowserInlineIsRefusedInsideNestedApiRequest()
+    {
+        $this->setNestedApiInvocationCount(2);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(self::REFUSED_MESSAGE);
+
+        (new Pdf())->sendToBrowserInline('report');
+    }
+
+    public function testPdfSendToBrowserDownloadIsRefusedInsideNestedApiRequest()
+    {
+        $this->setNestedApiInvocationCount(2);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(self::REFUSED_MESSAGE);
+
+        (new Pdf())->sendToBrowserDownload('report');
+    }
+
+    public function testInlineToBrowserIsAllowedForTheRootApiRequest()
+    {
+        $this->setNestedApiInvocationCount(1);
+
+        $this->expectOutputString('report body');
+        $this->invokeReportRendererStatic('inlineToBrowser', ['text/html', 'report body']);
+    }
+
+    private function invokeReportRendererStatic(string $method, array $args): void
+    {
+        $reflectionMethod = new ReflectionMethod(ReportRenderer::class, $method);
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invokeArgs(null, $args);
+    }
+
+    private function setNestedApiInvocationCount(int $count): void
+    {
+        $reflection = new ReflectionClass(Request::class);
+        $reflectionProperty = $reflection->getProperty('nestedApiInvocationCount');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue(null, $count);
+    }
+}


### PR DESCRIPTION
### Summary

Report renderers (`ReportRenderer::sendToBrowser` / `inlineToBrowser` and the PDF renderer) send their own HTTP headers and body straight to the browser. When a report is generated programmatically as a **nested API sub-request** — for example a sub-request of `API.getBulkRequest` — its result is meant to be consumed by the calling request, so it should not be written to the shared HTTP response of the outer request.

This PR:

- Adds `Request::isCurrentApiRequestNestedInAnotherApiRequest()` (a precise "am I running inside another API request" check, complementing the existing root-request check).
- Uses it in `ReportRenderer` (and the PDF renderer) to refuse report streaming while the current API request is nested inside another one. The refusal is a normal API exception, so a bulk request completes with an error entry for that sub-request rather than aborting.
- Always serves the `plugins/API` Controller `var_export()` array output as `text/plain`, since that output is a plain-text PHP structure dump.

### Tests

- `tests/PHPUnit/Integration/ReportRendererNestedApiRequestTest.php` — the streaming guard refuses when nested and allows the top-level request.
- `RequestTest::testIsCurrentApiRequestNestedInAnotherApiRequestReflectsInvocationDepth` — the new nesting helper.
- Existing `API` bulk-request suite (27 tests) and report-rendering / renderer tests pass unchanged.

### Review notes

Ref DEV-20629

Checklist
[✔] I have understood, reviewed, and tested all AI outputs before use
[✔] All AI instructions respect security, IP, and privacy rules