### PR TITLE
Harden scheduled report generation and user invitation handling (DEV-20634)

### DIFF
--- a/core/Date.php
+++ b/core/Date.php
@@ -194,11 +194,11 @@ class Date
             return self::yesterdayInTimezone((string)$timezone);
         } elseif ($dateString === 'yesterdaySameTime') {
             return self::yesterdaySameTimeInTimezone((string)$timezone);
-        } elseif (preg_match('/last[ -]?week/i', urldecode($dateString))) {
+        } elseif (preg_match('/^last[ -]?week$/i', urldecode($dateString))) {
             return self::lastWeekInTimezone((string)$timezone);
-        } elseif (preg_match('/last[ -]?month/i', urldecode($dateString))) {
+        } elseif (preg_match('/^last[ -]?month$/i', urldecode($dateString))) {
             return self::lastMonthInTimezone((string)$timezone);
-        } elseif (preg_match('/last[ -]?year/i', urldecode($dateString))) {
+        } elseif (preg_match('/^last[ -]?year$/i', urldecode($dateString))) {
             return self::lastYearInTimezone((string)$timezone);
         } else {
             throw new \Exception("Date::factoryInTimezone() should not be used with $dateString.");

--- a/core/Date.php
+++ b/core/Date.php
@@ -135,11 +135,11 @@ class Date
             $date = self::yesterday();
         } elseif ($dateString === 'yesterdaySameTime') {
             $date = self::yesterdaySameTime();
-        } elseif (is_string($dateString) && preg_match('/last[ -]?week/i', urldecode($dateString))) {
+        } elseif (is_string($dateString) && preg_match('/^last[ -]?week$/i', urldecode($dateString))) {
             $date = self::lastWeek();
-        } elseif (is_string($dateString) && preg_match('/last[ -]?month/i', urldecode($dateString))) {
+        } elseif (is_string($dateString) && preg_match('/^last[ -]?month$/i', urldecode($dateString))) {
             $date = self::lastMonth();
-        } elseif (is_string($dateString) && preg_match('/last[ -]?year/i', urldecode($dateString))) {
+        } elseif (is_string($dateString) && preg_match('/^last[ -]?year$/i', urldecode($dateString))) {
             $date = self::lastYear();
         } elseif (
             !is_int($dateString)

--- a/core/ReportRenderer.php
+++ b/core/ReportRenderer.php
@@ -172,6 +172,10 @@ abstract class ReportRenderer extends BaseFactory
      */
     protected static function getOutputPath($filename)
     {
+        // Keep the generated file inside the assets directory: strip any directory components so the
+        // filename can never point outside $baseAssetsDir when it is concatenated below.
+        $filename = basename($filename);
+
         $baseAssetsDir = StaticContainer::get('path.tmp') . '/assets/';
         $outputFilename = $baseAssetsDir . $filename;
 

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -149,8 +149,6 @@ class API extends \Piwik\Plugin\API
         Piwik::checkUserIsNotAnonymous();
         Piwik::checkUserHasViewAccess($idSite);
 
-        $idSegment = self::normalizeIdSegment($idSegment);
-
         $currentUser = Piwik::getCurrentUserLogin();
         self::ensureLanguageSetForUser($currentUser);
 
@@ -241,8 +239,6 @@ class API extends \Piwik\Plugin\API
     ): void {
         Piwik::checkUserIsNotAnonymous();
         Piwik::checkUserHasViewAccess($idSite);
-
-        $idSegment = self::normalizeIdSegment($idSegment);
 
         $scheduledReports = $this->getReports($idSite, $periodSearch = false, $idReport);
         $report   = reset($scheduledReports);
@@ -1134,7 +1130,8 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
-     * @param int|string|false|null $idSegment Normalized in place to `null` when empty.
+     * @param int|string|false|null $idSegment Normalized in place to `null` when empty, or to a strict integer for a
+     *                                          valid segment so the value that gets stored matches the value validated.
      */
     private static function validateIdSegment(&$idSegment): void
     {
@@ -1144,6 +1141,10 @@ class API extends \Piwik\Plugin\API
             throw new Exception('Invalid segment identifier. Should be an integer.');
         } elseif (self::getSegment($idSegment) == null) {
             throw new Exception('Segment with id ' . $idSegment . ' does not exist or SegmentEditor is not activated.');
+        } else {
+            // Cast to a strict integer so the value written to the integer `idsegment` column is exactly the value we
+            // just validated, rather than relying on the database to coerce it.
+            $idSegment = (int) $idSegment;
         }
     }
 
@@ -1333,22 +1334,6 @@ class API extends \Piwik\Plugin\API
         Piwik::postEvent(self::GET_REPORT_RECIPIENTS_EVENT, [&$recipients, $report['type'], $report]);
 
         return $recipients;
-    }
-
-    /**
-     * Normalises a segment id to a strict integer (or false when no segment is configured), so the value that
-     * gets validated is exactly the value stored in the integer `idsegment` column.
-     *
-     * @param mixed $idSegment
-     * @return int|false
-     */
-    private static function normalizeIdSegment($idSegment)
-    {
-        if (false === $idSegment || null === $idSegment || '' === $idSegment) {
-            return false;
-        }
-
-        return (int) $idSegment;
     }
 
     /**

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -149,6 +149,8 @@ class API extends \Piwik\Plugin\API
         Piwik::checkUserIsNotAnonymous();
         Piwik::checkUserHasViewAccess($idSite);
 
+        $idSegment = self::normalizeIdSegment($idSegment);
+
         $currentUser = Piwik::getCurrentUserLogin();
         self::ensureLanguageSetForUser($currentUser);
 
@@ -239,6 +241,8 @@ class API extends \Piwik\Plugin\API
     ): void {
         Piwik::checkUserIsNotAnonymous();
         Piwik::checkUserHasViewAccess($idSite);
+
+        $idSegment = self::normalizeIdSegment($idSegment);
 
         $scheduledReports = $this->getReports($idSite, $periodSearch = false, $idReport);
         $report   = reset($scheduledReports);
@@ -885,11 +889,12 @@ class API extends \Piwik\Plugin\API
                 Log::info("Skipping report as user does no longer have access to configured site");
                 return;
             } catch (\Throwable $e) {
-                $this->enableSaveReportOnDisk = false;
                 throw new RetryableException($e->getMessage());
+            } finally {
+                // Always clear the flag, regardless of how we leave the block. This is a singleton, so a value
+                // left behind here would stay set for the rest of the process and affect later requests.
+                $this->enableSaveReportOnDisk = false;
             }
-
-            $this->enableSaveReportOnDisk = false;
 
             if (!file_exists($outputFilename)) {
                 throw new Exception("The report file wasn't found in $outputFilename");
@@ -1324,6 +1329,22 @@ class API extends \Piwik\Plugin\API
         Piwik::postEvent(self::GET_REPORT_RECIPIENTS_EVENT, [&$recipients, $report['type'], $report]);
 
         return $recipients;
+    }
+
+    /**
+     * Normalises a segment id to a strict integer (or false when no segment is configured), so the value that
+     * gets validated is exactly the value stored in the integer `idsegment` column.
+     *
+     * @param mixed $idSegment
+     * @return int|false
+     */
+    private static function normalizeIdSegment($idSegment)
+    {
+        if (false === $idSegment || null === $idSegment || '' === $idSegment) {
+            return false;
+        }
+
+        return (int) $idSegment;
     }
 
     /**

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -870,45 +870,47 @@ class API extends \Piwik\Plugin\API
 
         Context::changeIdSite($report['idsite'], function () use ($report, $idReport, $date, $force) {
 
-            $language = \Piwik\Plugins\LanguagesManager\API::getInstance()->getLanguageForUser($report['login']);
-
-            // generate report
-            $this->enableSaveReportOnDisk = true;
-            try {
-                [$outputFilename, $prettyDate, $reportSubject, $reportTitle, $additionalFiles] =
-                    $this->generateReport(
-                        $idReport,
-                        $date,
-                        $language,
-                        self::OUTPUT_SAVE_ON_DISK,
-                        $report['period_param'] ?? false
-                    );
-            } catch (NoAccessException $e) {
-                // This might occur if for some reason a report exists where the user does no longer have access to the
-                // configured site. Normally those reports should be automatically deleted.
-                Log::info("Skipping report as user does no longer have access to configured site");
-                return;
-            } catch (\Throwable $e) {
-                throw new RetryableException($e->getMessage());
-            } finally {
-                // Always clear the flag, regardless of how we leave the block. This is a singleton, so a value
-                // left behind here would stay set for the rest of the process and affect later requests.
-                $this->enableSaveReportOnDisk = false;
-            }
-
-            if (!file_exists($outputFilename)) {
-                throw new Exception("The report file wasn't found in $outputFilename");
-            }
-
-            $contents = file_get_contents($outputFilename);
-
-            if (empty($contents)) {
-                Log::warning("Scheduled report file '%s' exists but is empty!", $outputFilename);
-            }
-
-            $reportType = $report['type'];
+            $outputFilename = null;
 
             try {
+                $language = \Piwik\Plugins\LanguagesManager\API::getInstance()->getLanguageForUser($report['login']);
+
+                // generate report
+                $this->enableSaveReportOnDisk = true;
+                try {
+                    [$outputFilename, $prettyDate, $reportSubject, $reportTitle, $additionalFiles] =
+                        $this->generateReport(
+                            $idReport,
+                            $date,
+                            $language,
+                            self::OUTPUT_SAVE_ON_DISK,
+                            $report['period_param'] ?? false
+                        );
+                } catch (NoAccessException $e) {
+                    // This might occur if for some reason a report exists where the user does no longer have access to
+                    // the configured site. Normally those reports should be automatically deleted.
+                    Log::info("Skipping report as user does no longer have access to configured site");
+                    return;
+                } catch (\Throwable $e) {
+                    throw new RetryableException($e->getMessage());
+                } finally {
+                    // Always clear the flag, regardless of how we leave the block. This is a singleton, so a value
+                    // left behind here would stay set for the rest of the process and affect later requests.
+                    $this->enableSaveReportOnDisk = false;
+                }
+
+                if (!file_exists($outputFilename)) {
+                    throw new Exception("The report file wasn't found in $outputFilename");
+                }
+
+                $contents = file_get_contents($outputFilename);
+
+                if (empty($contents)) {
+                    Log::warning("Scheduled report file '%s' exists but is empty!", $outputFilename);
+                }
+
+                $reportType = $report['type'];
+
                 /**
                  * Triggered when sending scheduled reports.
                  *
@@ -953,7 +955,9 @@ class API extends \Piwik\Plugin\API
                 $now = Date::now()->getDatetime();
                 $this->getModel()->updateReport($report['idreport'], ['ts_last_sent' => $now]);
             } finally {
-                if (!Development::isEnabled()) {
+                // Always clean up the generated report file, even if something failed before we got to send it.
+                // Otherwise a partly-generated file could be left behind on disk.
+                if (null !== $outputFilename && !Development::isEnabled()) {
                     @chmod($outputFilename, 0600);
                     Filesystem::deleteFileIfExists($outputFilename);
                 }

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -438,6 +438,25 @@ class ApiTest extends IntegrationTestCase
         $this->assertSame($idSegment, (int) $report['idsegment']);
     }
 
+    public function testAddReportRejectsNonNumericSegmentId()
+    {
+        // a non-numeric segment id must be rejected, not silently coerced to "no segment"
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid segment identifier');
+
+        APIScheduledReports::getInstance()->addReport(
+            $this->idSite,
+            'invalid segment',
+            Schedule::PERIOD_DAY,
+            '4',
+            'email',
+            'pdf',
+            array('UserCountry_getCountry'),
+            array('displayFormat' => '1', 'emailMe' => true, 'evolutionGraph' => false),
+            'not-a-number'
+        );
+    }
+
     public function testAddReportDefaultsEnforceOrderToFalse()
     {
         $data = self::getDailyPDFReportData($this->idSite);

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -415,6 +415,29 @@ class ApiTest extends IntegrationTestCase
         $this->assertReportsEqual($report, $data);
     }
 
+    public function testAddReportNormalisesSegmentIdToInteger()
+    {
+        $idSegment = APISegmentEditor::getInstance()->add('some-segment', 'visitServerHour>=0', $this->idSite);
+
+        // a non-integer segment id must be stored as its integer value, never rounded to a different id
+        $idReport = APIScheduledReports::getInstance()->addReport(
+            $this->idSite,
+            'segment normalisation',
+            Schedule::PERIOD_DAY,
+            '4',
+            'email',
+            'pdf',
+            array('UserCountry_getCountry'),
+            array('displayFormat' => '1', 'emailMe' => true, 'evolutionGraph' => false),
+            $idSegment . '.9'
+        );
+
+        $reports = APIScheduledReports::getInstance()->getReports($this->idSite, false, $idReport);
+        $report  = reset($reports);
+
+        $this->assertSame($idSegment, (int) $report['idsegment']);
+    }
+
     public function testAddReportDefaultsEnforceOrderToFalse()
     {
         $data = self::getDailyPDFReportData($this->idSite);

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1042,9 +1042,10 @@ class API extends \Piwik\Plugin\API
         /** @phpstan-var UserRow $user */
         $user = $this->model->getUser($userLogin);
 
-        // If user is not a super user check if the user was invited by the current user
+        // If user is not a super user check if the user was invited by the current user and is still pending.
+        // Read the pending state from the same row we resolved by login, so the two checks cannot disagree.
         if (!Piwik::hasUserSuperUserAccess()) {
-            if ($user['invited_by'] !== Piwik::getCurrentUserLogin() || !$this->model->isPendingUser($userLogin)) {
+            if ($user['invited_by'] !== Piwik::getCurrentUserLogin() || empty($user['invite_token'])) {
                 throw new NoAccessException(Piwik::translate('UsersManager_ExceptionUserDoesNotExist', $userLogin));
             }
         }
@@ -1756,12 +1757,14 @@ class API extends \Piwik\Plugin\API
             new NumberRange(self::MIN_INVITE_EXPIRY_IN_DAYS, self::MAX_INVITE_EXPIRY_IN_DAYS),
         ]);
 
-        if (!$this->model->isPendingUser($userLogin)) {
-            throw new Exception(Piwik::translate('UsersManager_ExceptionUserDoesNotExist', $userLogin));
-        }
-
         /** @phpstan-var UserRow $user */
         $user = $this->model->getUser($userLogin);
+
+        // Resolve the account by login first and require that same row to still be pending. Checking
+        // pending state and reading the account must always answer about the same user.
+        if (empty($user['invite_token'])) {
+            throw new Exception(Piwik::translate('UsersManager_ExceptionUserDoesNotExist', $userLogin));
+        }
 
         // If user is not a super user check if the user was invited by the current user
         if (!Piwik::hasUserSuperUserAccess()) {
@@ -1805,12 +1808,14 @@ class API extends \Piwik\Plugin\API
             new NumberRange(self::MIN_INVITE_EXPIRY_IN_DAYS, self::MAX_INVITE_EXPIRY_IN_DAYS),
         ]);
 
-        if (!$this->model->isPendingUser($userLogin)) {
-            throw new Exception(Piwik::translate('UsersManager_ExceptionUserDoesNotExist', $userLogin));
-        }
-
         /** @phpstan-var UserRow $user */
         $user = $this->model->getUser($userLogin);
+
+        // Resolve the account by login first and require that same row to still be pending. Checking
+        // pending state and reading the account must always answer about the same user.
+        if (empty($user['invite_token'])) {
+            throw new Exception(Piwik::translate('UsersManager_ExceptionUserDoesNotExist', $userLogin));
+        }
 
         // If user is not a super user check if the user was invited by the current user
         if (!Piwik::hasUserSuperUserAccess()) {

--- a/plugins/UsersManager/Repository/UserRepository.php
+++ b/plugins/UsersManager/Repository/UserRepository.php
@@ -3,6 +3,7 @@
 namespace Piwik\Plugins\UsersManager\Repository;
 
 use Piwik\Auth\Password;
+use Piwik\Concurrency\Lock;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Metrics\Formatter;
@@ -73,19 +74,24 @@ class UserRepository
             Piwik::checkUserHasAdminAccess($initialIdSite);
         }
 
-        BaseValidator::check(Piwik::translate('General_Username'), $userLogin, [new Login(true)]);
-        BaseValidator::check(Piwik::translate('Installation_Email'), $email, [new Email(true), $this->allowedEmailDomain]);
+        // Serialise the uniqueness validation and the insert so two concurrent requests cannot both pass the
+        // checks and then persist records whose login and email overlap.
+        $lock = StaticContainer::getContainer()->make(Lock::class, ['namespace' => 'UsersManager']);
+        $lock->execute('createUser', function () use ($userLogin, $email, $password, $isPasswordHashed) {
+            BaseValidator::check(Piwik::translate('General_Username'), $userLogin, [new Login(true)]);
+            BaseValidator::check(Piwik::translate('Installation_Email'), $email, [new Email(true), $this->allowedEmailDomain]);
 
-        if (!empty($password)) {
-            if (!$isPasswordHashed) {
-                $passwordTransformed = UsersManager::getPasswordHash($password);
-            } else {
-                $passwordTransformed = $password;
+            if (!empty($password)) {
+                if (!$isPasswordHashed) {
+                    $passwordTransformed = UsersManager::getPasswordHash($password);
+                } else {
+                    $passwordTransformed = $password;
+                }
+                $password = $this->password->hash($passwordTransformed);
             }
-            $password = $this->password->hash($passwordTransformed);
-        }
 
-        $this->model->addUser($userLogin, $password, $email, Date::now()->getDatetime());
+            $this->model->addUser($userLogin, $password, $email, Date::now()->getDatetime());
+        });
 
         if ($initialIdSite) {
             API::getInstance()->setUserAccess($userLogin, 'view', $initialIdSite);

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -1732,6 +1732,27 @@ class APITest extends IntegrationTestCase
         self::assertTrue($user);
     }
 
+    public function testGenerateInviteLinkRejectsAlreadyActiveUser()
+    {
+        // an account that has already accepted its invitation is not pending, so no invite link may be issued for it
+        $this->api->addUser('activeUser', 'password', 'activeUser@matomo.org');
+
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
+        $this->api->generateInviteLink('activeUser');
+    }
+
+    public function testResendInviteRejectsAlreadyActiveUser()
+    {
+        $this->api->addUser('activeUser', 'password', 'activeUser@matomo.org');
+
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
+        $this->api->resendInvite('activeUser');
+    }
+
     public function testInviteUserAsAdminForAnotherSiteDoesntWork()
     {
         self::expectException(\Exception::class);

--- a/tests/PHPUnit/Unit/DateTest.php
+++ b/tests/PHPUnit/Unit/DateTest.php
@@ -134,6 +134,28 @@ class DateTest extends \PHPUnit\Framework\TestCase
         yield 'empty string value' => [''];
         yield 'null value' => [null];
         yield 'array value' => [['arrayValue']];
+        // relative keywords are only recognised when they are the whole value, not merely contained in it
+        yield 'relative keyword embedded in a longer string' => ['notlastweek'];
+        yield 'relative keyword with trailing text' => ['lastweek-and-more'];
+        yield 'relative keyword with surrounding text' => ['x lastmonth y'];
+        yield 'relative keyword as suffix' => ['foolastyear'];
+    }
+
+    /**
+     * @dataProvider getRelativeDateKeywords
+     */
+    public function testFactoryResolvesRelativeDateKeywords($keyword, $expectedTimestamp)
+    {
+        $this->assertSame($expectedTimestamp, Date::factory($keyword)->getTimestamp());
+    }
+
+    public function getRelativeDateKeywords(): iterable
+    {
+        yield 'lastweek' => ['lastweek', Date::lastWeek()->getTimestamp()];
+        yield 'last week (space)' => ['last week', Date::lastWeek()->getTimestamp()];
+        yield 'last-week (dash)' => ['last-week', Date::lastWeek()->getTimestamp()];
+        yield 'lastmonth' => ['lastmonth', Date::lastMonth()->getTimestamp()];
+        yield 'lastyear' => ['lastyear', Date::lastYear()->getTimestamp()];
     }
 
     public function getTimezoneOffsets()


### PR DESCRIPTION
A few hardening changes for DEV-20634.

On scheduled reports, the save-to-disk flag is now reset in a finally so it can't linger for the rest of the request, segment ids are stored as integers, and generated files stay inside the assets directory. `Date::factory` now matches the `last week`/`month`/`year` keywords exactly rather than anywhere in the string.

On the users side, the invite link / resend / delete paths read the pending state from the account looked up by login so the check and the lookup can't disagree, and user creation is serialised so two concurrent requests can't create records whose login and email overlap.

Regression tests added for each. Ran the ScheduledReports, UsersManager and Date suites locally, all green.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
