### PR TITLE
UsersManager - Remove deprecated Common::getRequestVar() usage - 5x

### DIFF
--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -388,7 +388,7 @@ class Controller extends ControllerAdmin
     {
         Piwik::checkUserIsNotAnonymous();
 
-        $idTokenAuth = Common::getRequestVar('idtokenauth', '', 'string');
+        $idTokenAuth = \Piwik\Request::fromPost()->getStringParameter('idtokenauth', '');
 
         if (!empty($idTokenAuth)) {
             $params = array(
@@ -617,13 +617,14 @@ class Controller extends ControllerAdmin
      */
     public function recordAnonymousUserSettings()
     {
-        $response = new ResponseBuilder(Common::getRequestVar('format'));
+        $response = new ResponseBuilder(\Piwik\Request::fromRequest()->getStringParameter('format'));
         try {
             Piwik::checkUserHasSuperUserAccess();
             $this->checkTokenInUrl();
 
-            $anonymousDefaultReport = Common::getRequestVar('anonymousDefaultReport');
-            $anonymousDefaultDate = Common::getRequestVar('anonymousDefaultDate');
+            $request = \Piwik\Request::fromPost();
+            $anonymousDefaultReport = $request->getStringParameter('anonymousDefaultReport');
+            $anonymousDefaultDate = $request->getStringParameter('anonymousDefaultDate');
             $userLogin = 'anonymous';
             APIUsersManager::getInstance()->setUserPreference(
                 $userLogin,
@@ -649,15 +650,16 @@ class Controller extends ControllerAdmin
      */
     public function recordUserSettings()
     {
-        $response = new ResponseBuilder(Common::getRequestVar('format'));
+        $response = new ResponseBuilder(\Piwik\Request::fromRequest()->getStringParameter('format'));
         try {
             $this->checkTokenInUrl();
 
-            $themeMode = $this->getValidatedThemeMode(Common::getRequestVar('themeMode'));
-            $defaultReport = Common::getRequestVar('defaultReport');
-            $defaultDate = Common::getRequestVar('defaultDate');
-            $language = Common::getRequestVar('language');
-            $timeFormat = Common::getRequestVar('timeformat');
+            $request = \Piwik\Request::fromPost();
+            $themeMode = $this->getValidatedThemeMode($request->getStringParameter('themeMode'));
+            $defaultReport = $request->getStringParameter('defaultReport');
+            $defaultDate = $request->getStringParameter('defaultDate');
+            $language = $request->getStringParameter('language');
+            $timeFormat = $request->getStringParameter('timeformat');
             $userLogin = Piwik::getCurrentUserLogin();
 
             Piwik::checkUserHasSuperUserAccessOrIsTheUser($userLogin);
@@ -759,7 +761,7 @@ class Controller extends ControllerAdmin
             throw new Exception("Cannot change email with untrusted hostname!");
         }
 
-        $request = \Piwik\Request::fromRequest();
+        $request = \Piwik\Request::fromPost();
         $email = $request->getStringParameter('email');
         $passwordCurrent = $request->getStringParameter('passwordConfirmation', '');
 
@@ -782,7 +784,7 @@ class Controller extends ControllerAdmin
             throw new Exception("Cannot change password with untrusted hostname!");
         }
 
-        $request = \Piwik\Request::fromRequest();
+        $request = \Piwik\Request::fromPost();
         $newPassword = $request->getStringParameter('password', '');
         $passwordBis = $request->getStringParameter('passwordBis', '');
         $passwordCurrent = $request->getStringParameter('passwordConfirmation', '');

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -388,7 +388,12 @@ class Controller extends ControllerAdmin
     {
         Piwik::checkUserIsNotAnonymous();
 
-        $idTokenAuth = \Piwik\Request::fromPost()->getStringParameter('idtokenauth', '');
+        // the form submits via POST, but after a password confirmation the action is re-dispatched
+        // as a GET request carrying the parameters below
+        $idTokenAuth = \Piwik\Request::fromPost()->getStringParameter(
+            'idtokenauth',
+            \Piwik\Request::fromGet()->getStringParameter('idtokenauth', '')
+        );
 
         if (!empty($idTokenAuth)) {
             $params = array(

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -184,13 +184,11 @@ class Controller extends ControllerAdmin
     }
 
     /**
-     * Returns the enabled dates that users can select,
+     * Returns the dates that users can select,
      * in their User Settings page "Report date to load by default"
      *
-     * @param bool $includeDisabledPeriods whether to also return the dates whose period is not
-     *                                     enabled in [General] enabled_periods_UI. The forms must
-     *                                     not offer those, but a date stored before an admin
-     *                                     narrowed that setting is still submitted back by them.
+     * @param bool $includeDisabledPeriods whether to include dates whose period is disabled in
+     *                                     [General] enabled_periods_UI
      * @return array
      */
     protected function getDefaultDates(bool $includeDisabledPeriods = false)
@@ -746,16 +744,17 @@ class Controller extends ControllerAdmin
     }
 
     /**
-     * The unfiltered list is used on purpose: the forms pre-fill the stored date, which does not
-     * have to belong to a period that is still enabled in the UI. Rejecting it would leave the
-     * whole form unsavable. Storing it stays harmless, as UserPreferences falls back to the system
-     * default when it reads a date whose period is disabled.
+     * The forms pre-fill the stored date, which is not always one they offer: its period may be
+     * disabled in the UI, and [General] default_day accepts any lastN or previousN.
      *
-     * @throws Exception if the date is not one of the known default dates
+     * @throws Exception if the date is neither a known default date nor a lastN/previousN range
      */
     private function getValidatedDefaultDate(string $defaultDate): string
     {
-        if (!array_key_exists($defaultDate, $this->getDefaultDates(true))) {
+        if (
+            !array_key_exists($defaultDate, $this->getDefaultDates(true))
+            && !preg_match('/^(last|previous)[0-9]+$/', $defaultDate)
+        ) {
             throw new Exception('Invalid default date');
         }
 
@@ -776,7 +775,7 @@ class Controller extends ControllerAdmin
             $idSite = (int) $defaultReport;
 
             if ($this->isSiteViewableByUser($idSite, $userLogin)) {
-                // normalised, so that a padded id such as '007' is not stored verbatim
+                // normalised, so '007' is not stored verbatim
                 return (string) $idSite;
             }
         }

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -17,6 +17,7 @@ use Piwik\Common;
 use Piwik\Config\GeneralConfig;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
+use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Nonce;
 use Piwik\Notification;
 use Piwik\Option;
@@ -186,9 +187,13 @@ class Controller extends ControllerAdmin
      * Returns the enabled dates that users can select,
      * in their User Settings page "Report date to load by default"
      *
+     * @param bool $includeDisabledPeriods whether to also return the dates whose period is not
+     *                                     enabled in [General] enabled_periods_UI. The forms must
+     *                                     not offer those, but a date stored before an admin
+     *                                     narrowed that setting is still submitted back by them.
      * @return array
      */
-    protected function getDefaultDates()
+    protected function getDefaultDates(bool $includeDisabledPeriods = false)
     {
         $dates = array(
             'today'      => $this->translator->translate('Intl_Today'),
@@ -219,9 +224,11 @@ class Controller extends ControllerAdmin
             throw new Exception("some metadata is missing in getDefaultDates()");
         }
 
-        $allowedPeriods = self::getEnabledPeriodsInUI();
-        $allowedDates = array_intersect($mappingDatesToPeriods, $allowedPeriods);
-        $dates = array_intersect_key($dates, $allowedDates);
+        if (!$includeDisabledPeriods) {
+            $allowedPeriods = self::getEnabledPeriodsInUI();
+            $allowedDates = array_intersect($mappingDatesToPeriods, $allowedPeriods);
+            $dates = array_intersect_key($dates, $allowedDates);
+        }
 
         /**
          * Triggered when the list of available dates is requested, for example for the
@@ -388,11 +395,13 @@ class Controller extends ControllerAdmin
     {
         Piwik::checkUserIsNotAnonymous();
 
-        // after a password confirmation the action arrives as a GET
-        $idTokenAuth = \Piwik\Request::fromPost()->getStringParameter(
-            'idtokenauth',
-            \Piwik\Request::fromGet()->getStringParameter('idtokenauth', '')
-        );
+        $postRequest = \Piwik\Request::fromPost();
+        $postRequestHasData = count($postRequest->getParameters());
+
+        // after a password confirmation the action arrives as a GET, without a post body
+        $idTokenAuth = $postRequestHasData
+            ? $postRequest->getStringParameter('idtokenauth', '')
+            : \Piwik\Request::fromGet()->getStringParameter('idtokenauth', '');
 
         if (!empty($idTokenAuth)) {
             // the forms only submit 'all' or a token id
@@ -737,11 +746,16 @@ class Controller extends ControllerAdmin
     }
 
     /**
-     * @throws Exception if the date is not one the settings forms offer
+     * The unfiltered list is used on purpose: the forms pre-fill the stored date, which does not
+     * have to belong to a period that is still enabled in the UI. Rejecting it would leave the
+     * whole form unsavable. Storing it stays harmless, as UserPreferences falls back to the system
+     * default when it reads a date whose period is disabled.
+     *
+     * @throws Exception if the date is not one of the known default dates
      */
     private function getValidatedDefaultDate(string $defaultDate): string
     {
-        if (!array_key_exists($defaultDate, $this->getDefaultDates())) {
+        if (!array_key_exists($defaultDate, $this->getDefaultDates(true))) {
             throw new Exception('Invalid default date');
         }
 
@@ -758,8 +772,13 @@ class Controller extends ControllerAdmin
             return $defaultReport;
         }
 
-        if (ctype_digit($defaultReport) && $this->isSiteViewableByUser((int) $defaultReport, $userLogin)) {
-            return $defaultReport;
+        if (ctype_digit($defaultReport)) {
+            $idSite = (int) $defaultReport;
+
+            if ($this->isSiteViewableByUser($idSite, $userLogin)) {
+                // normalised, so that a padded id such as '007' is not stored verbatim
+                return (string) $idSite;
+            }
         }
 
         throw new Exception('Invalid default report');
@@ -768,7 +787,18 @@ class Controller extends ControllerAdmin
     private function isSiteViewableByUser(int $idSite, string $userLogin): bool
     {
         if ($userLogin === Piwik::getCurrentUserLogin()) {
-            return Piwik::isUserHasViewAccess($idSite);
+            if (!Piwik::isUserHasViewAccess($idSite)) {
+                return false;
+            }
+
+            try {
+                // view access short-circuits for super users, so confirm the site still exists
+                new Site($idSite);
+            } catch (UnexpectedWebsiteFoundException $e) {
+                return false;
+            }
+
+            return true;
         }
 
         // a super user may record settings for another login, whose access has to be looked up directly

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -396,7 +396,7 @@ class Controller extends ControllerAdmin
 
         if (!empty($idTokenAuth)) {
             // the forms only submit 'all' or a token id
-            if ($idTokenAuth !== 'all' && !is_numeric($idTokenAuth)) {
+            if ($idTokenAuth !== 'all' && !ctype_digit($idTokenAuth)) {
                 throw new Exception('Invalid idtokenauth');
             }
 
@@ -428,7 +428,7 @@ class Controller extends ControllerAdmin
                     'all' => true,
                 ));
                 $email->safeSend();
-            } elseif (is_numeric($idTokenAuth)) {
+            } else {
                 $description = $this->userModel->getUserTokenDescriptionByIdTokenAuth($idTokenAuth, Piwik::getCurrentUserLogin());
                 $this->userModel->deleteToken($idTokenAuth, Piwik::getCurrentUserLogin());
 
@@ -631,10 +631,15 @@ class Controller extends ControllerAdmin
             Piwik::checkUserHasSuperUserAccess();
             $this->checkTokenInUrl();
 
-            $request = \Piwik\Request::fromPost();
-            $anonymousDefaultReport = $request->getStringParameter('anonymousDefaultReport');
-            $anonymousDefaultDate = $request->getStringParameter('anonymousDefaultDate');
             $userLogin = 'anonymous';
+            $request = \Piwik\Request::fromPost();
+            $anonymousDefaultReport = $this->getValidatedDefaultReport(
+                $request->getStringParameter('anonymousDefaultReport'),
+                $userLogin
+            );
+            $anonymousDefaultDate = $this->getValidatedDefaultDate(
+                $request->getStringParameter('anonymousDefaultDate')
+            );
             APIUsersManager::getInstance()->setUserPreference(
                 $userLogin,
                 APIUsersManager::PREFERENCE_DEFAULT_REPORT,
@@ -663,13 +668,16 @@ class Controller extends ControllerAdmin
         try {
             $this->checkTokenInUrl();
 
+            $userLogin = Piwik::getCurrentUserLogin();
             $request = \Piwik\Request::fromPost();
             $themeMode = $this->getValidatedThemeMode($request->getStringParameter('themeMode'));
-            $defaultReport = $request->getStringParameter('defaultReport');
-            $defaultDate = $request->getStringParameter('defaultDate');
+            $defaultReport = $this->getValidatedDefaultReport(
+                $request->getStringParameter('defaultReport'),
+                $userLogin
+            );
+            $defaultDate = $this->getValidatedDefaultDate($request->getStringParameter('defaultDate'));
             $language = $request->getStringParameter('language');
             $timeFormat = $request->getStringParameter('timeformat');
-            $userLogin = Piwik::getCurrentUserLogin();
 
             Piwik::checkUserHasSuperUserAccessOrIsTheUser($userLogin);
 
@@ -726,6 +734,47 @@ class Controller extends ControllerAdmin
         }
 
         return $themeMode;
+    }
+
+    /**
+     * @throws Exception if the date is not one the settings forms offer
+     */
+    private function getValidatedDefaultDate(string $defaultDate): string
+    {
+        if (!array_key_exists($defaultDate, $this->getDefaultDates())) {
+            throw new Exception('Invalid default date');
+        }
+
+        return $defaultDate;
+    }
+
+    /**
+     * @param string $userLogin the user the report is stored for, which is not necessarily the current user
+     * @throws Exception if the report is neither a known screen nor a site the user may view
+     */
+    private function getValidatedDefaultReport(string $defaultReport, string $userLogin): string
+    {
+        if (in_array($defaultReport, ['MultiSites', Piwik::getLoginPluginName()], true)) {
+            return $defaultReport;
+        }
+
+        if (ctype_digit($defaultReport) && $this->isSiteViewableByUser((int) $defaultReport, $userLogin)) {
+            return $defaultReport;
+        }
+
+        throw new Exception('Invalid default report');
+    }
+
+    private function isSiteViewableByUser(int $idSite, string $userLogin): bool
+    {
+        if ($userLogin === Piwik::getCurrentUserLogin()) {
+            return Piwik::isUserHasViewAccess($idSite);
+        }
+
+        // a super user may record settings for another login, whose access has to be looked up directly
+        $idSites = array_column($this->userModel->getSitesAccessFromUser($userLogin), 'site');
+
+        return in_array($idSite, array_map('intval', $idSites), true);
     }
 
 

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -388,14 +388,18 @@ class Controller extends ControllerAdmin
     {
         Piwik::checkUserIsNotAnonymous();
 
-        // the form submits via POST, but after a password confirmation the action is re-dispatched
-        // as a GET request carrying the parameters below
+        // after a password confirmation the action arrives as a GET
         $idTokenAuth = \Piwik\Request::fromPost()->getStringParameter(
             'idtokenauth',
             \Piwik\Request::fromGet()->getStringParameter('idtokenauth', '')
         );
 
         if (!empty($idTokenAuth)) {
+            // the forms only submit 'all' or a token id
+            if ($idTokenAuth !== 'all' && !is_numeric($idTokenAuth)) {
+                throw new Exception('Invalid idtokenauth');
+            }
+
             $params = array(
                 'module' => 'UsersManager',
                 'action' => 'deleteToken',

--- a/plugins/UsersManager/tests/Integration/ControllerTest.php
+++ b/plugins/UsersManager/tests/Integration/ControllerTest.php
@@ -57,6 +57,7 @@ class ControllerTest extends IntegrationTestCase
     private $request;
     private $session;
     private $enableUsersAdmin;
+    private $enabledPeriodsUi;
     private $superUser;
     private $identity;
     private $superUserLogin;
@@ -78,6 +79,7 @@ class ControllerTest extends IntegrationTestCase
         $this->request = $_REQUEST;
         $this->session = $_SESSION ?? null;
         $this->enableUsersAdmin = Config::getInstance()->General['enable_users_admin'];
+        $this->enabledPeriodsUi = Config::getInstance()->General['enabled_periods_UI'];
         $this->superUser = FakeAccess::$superUser;
         $this->identity = FakeAccess::$identity;
         $this->superUserLogin = FakeAccess::$superUserLogin;
@@ -108,6 +110,7 @@ class ControllerTest extends IntegrationTestCase
         }
 
         Config::getInstance()->General['enable_users_admin'] = $this->enableUsersAdmin;
+        Config::getInstance()->General['enabled_periods_UI'] = $this->enabledPeriodsUi;
         FakeAccess::$superUser = $this->superUser;
         FakeAccess::$identity = $this->identity;
         FakeAccess::$superUserLogin = $this->superUserLogin;
@@ -180,6 +183,7 @@ class ControllerTest extends IntegrationTestCase
 
     public function testRecordUserSettingsReadsSettingsFromPost()
     {
+        $idSite = $this->createSiteWithUser();
         Config::getInstance()->General['enable_users_admin'] = 0;
 
         // settings are read from the post body, not the query string
@@ -189,7 +193,7 @@ class ControllerTest extends IntegrationTestCase
         ];
         $_POST = [
             'themeMode' => ThemeStyles::DARK_MODE,
-            'defaultReport' => '1',
+            'defaultReport' => (string) $idSite,
             'defaultDate' => 'today',
             'language' => 'en',
             'timeformat' => '0',
@@ -288,6 +292,97 @@ class ControllerTest extends IntegrationTestCase
 
         $this->assertStringContainsString('Invalid default date', $response);
         $this->assertFalse($this->getStoredPreference(UsersManagerAPI::PREFERENCE_DEFAULT_REPORT_DATE));
+    }
+
+    public function testRecordUserSettingsRejectsDefaultReportForSiteThatDoesNotExist()
+    {
+        Config::getInstance()->General['enable_users_admin'] = 0;
+
+        // the current user is a super user, for whom the view access check passes for any site id
+        $_GET = ['format' => 'json'];
+        $_POST = [
+            'themeMode' => ThemeStyles::LIGHT_MODE,
+            'defaultReport' => '999999',
+            'defaultDate' => 'today',
+            'language' => 'en',
+            'timeformat' => '0',
+        ];
+
+        $response = $this->controller->recordUserSettings();
+
+        $this->assertStringContainsString('Invalid default report', $response);
+        $this->assertFalse($this->getStoredPreference(UsersManagerAPI::PREFERENCE_DEFAULT_REPORT));
+    }
+
+    public function testRecordUserSettingsStoresNormalisedDefaultReport()
+    {
+        $idSite = $this->createSiteWithUser();
+        Config::getInstance()->General['enable_users_admin'] = 0;
+
+        $_GET = ['format' => 'json'];
+        $_POST = [
+            'themeMode' => ThemeStyles::LIGHT_MODE,
+            // a padded id passes ctype_digit() and must not reach storage verbatim
+            'defaultReport' => '0' . $idSite,
+            'defaultDate' => 'today',
+            'language' => 'en',
+            'timeformat' => '0',
+        ];
+
+        $response = $this->controller->recordUserSettings();
+
+        $this->assertStringContainsString('"result":"success"', $response);
+        $this->assertSame(
+            (string) $idSite,
+            (string) $this->getStoredPreference(UsersManagerAPI::PREFERENCE_DEFAULT_REPORT)
+        );
+    }
+
+    public function testRecordUserSettingsAcceptsStoredDefaultDateOfPeriodDisabledInTheUi()
+    {
+        $idSite = $this->createSiteWithUser();
+        Config::getInstance()->General['enable_users_admin'] = 0;
+
+        UsersManagerAPI::getInstance()->setUserPreference(
+            self::CURRENT_USER_LOGIN,
+            UsersManagerAPI::PREFERENCE_DEFAULT_REPORT_DATE,
+            'last30'
+        );
+
+        // an admin has since dropped the range period the stored date belongs to
+        Config::getInstance()->General['enabled_periods_UI'] = 'day,week,month,year';
+
+        // the form still pre-fills the stored date, so it is posted back along with everything else
+        $_GET = ['format' => 'json'];
+        $_POST = [
+            'themeMode' => ThemeStyles::DARK_MODE,
+            'defaultReport' => (string) $idSite,
+            'defaultDate' => 'last30',
+            'language' => 'en',
+            'timeformat' => '0',
+        ];
+
+        $response = $this->controller->recordUserSettings();
+
+        $this->assertStringContainsString('"result":"success"', $response);
+        $this->assertSame(
+            'last30',
+            (string) $this->getStoredPreference(UsersManagerAPI::PREFERENCE_DEFAULT_REPORT_DATE)
+        );
+        // the rest of the form was saved rather than lost to the rejected date
+        $this->assertSame(ThemeStyles::DARK_MODE, (new UserPreferences())->getThemeMode());
+    }
+
+    public function testUserSettingsShouldNotOfferDatesOfPeriodsDisabledInTheUi()
+    {
+        Config::getInstance()->General['enabled_periods_UI'] = 'day,week,month,year';
+        $this->createSiteWithUser();
+
+        $response = $this->controller->userSettings();
+
+        // the dates the form offers are json encoded into an attribute
+        $this->assertStringNotContainsString('&quot;last30&quot;', $response);
+        $this->assertStringContainsString('&quot;yesterday&quot;', $response);
     }
 
     public function testRecordAnonymousUserSettingsReadsSettingsFromPost()

--- a/plugins/UsersManager/tests/Integration/ControllerTest.php
+++ b/plugins/UsersManager/tests/Integration/ControllerTest.php
@@ -42,6 +42,10 @@ class ControllerTest extends IntegrationTestCase
      * @var Controller
      */
     private $controller;
+    /**
+     * @var PasswordVerifier
+     */
+    private $passwordVerify;
     private $post;
     private $get;
     private $request;
@@ -54,9 +58,10 @@ class ControllerTest extends IntegrationTestCase
     {
         parent::setUp();
 
+        $this->passwordVerify = new PasswordVerifier();
         $this->controller = new Controller(
             $translator = new Translator(new DevelopmentLoader(new JsonFileLoader())),
-            $passwordVerify = new PasswordVerifier(),
+            $this->passwordVerify,
             $userModel = new Model(),
             $passwordStrength = new PasswordStrength(true)
         );
@@ -141,19 +146,110 @@ class ControllerTest extends IntegrationTestCase
 
         $_GET = [
             'format' => 'json',
+        ];
+        $_POST = [
             'themeMode' => 'invalid',
             'defaultReport' => '1',
             'defaultDate' => 'today',
             'language' => 'en',
             'timeformat' => '0',
         ];
-        $_POST = [];
-        $_REQUEST = $_GET;
+        $_REQUEST = $_GET + $_POST;
 
         $response = $this->controller->recordUserSettings();
 
         $this->assertStringContainsString('Invalid theme mode', $response);
         $this->assertSame(ThemeStyles::LIGHT_MODE, (new UserPreferences())->getThemeMode());
+    }
+
+    public function testRecordUserSettingsReadsSettingsFromPost()
+    {
+        Config::getInstance()->General['enable_users_admin'] = 0;
+
+        // settings are read from the post body, not the query string
+        $_GET = [
+            'format' => 'json',
+            'themeMode' => 'invalid',
+        ];
+        $_POST = [
+            'themeMode' => ThemeStyles::LIGHT_MODE,
+            'defaultReport' => '1',
+            'defaultDate' => 'today',
+            'language' => 'en',
+            'timeformat' => '0',
+        ];
+        $_REQUEST = $_GET + $_POST;
+
+        $response = $this->controller->recordUserSettings();
+
+        $this->assertStringNotContainsString('Invalid theme mode', $response);
+    }
+
+    public function testRecordAnonymousUserSettingsReadsSettingsFromPost()
+    {
+        (new Model())->addUser('anonymous', '', 'anonymous@example.com', Date::now()->getDatetime());
+
+        // settings are read from the post body, not the query string
+        $_GET = [
+            'format' => 'json',
+            'anonymousDefaultReport' => 'MultiSites',
+            'anonymousDefaultDate' => 'week',
+        ];
+        $_POST = [
+            'anonymousDefaultReport' => '1',
+            'anonymousDefaultDate' => 'today',
+        ];
+        $_REQUEST = $_GET + $_POST;
+
+        $this->controller->recordAnonymousUserSettings();
+
+        $storedReport = UsersManagerAPI::getInstance()->getUserPreference(
+            UsersManagerAPI::PREFERENCE_DEFAULT_REPORT,
+            'anonymous'
+        );
+        $storedDate = UsersManagerAPI::getInstance()->getUserPreference(
+            UsersManagerAPI::PREFERENCE_DEFAULT_REPORT_DATE,
+            'anonymous'
+        );
+
+        $this->assertSame('1', (string) $storedReport);
+        $this->assertSame('today', (string) $storedDate);
+    }
+
+    public function testRecordPasswordChangeReadsPasswordFromPost()
+    {
+        // password is read from the post body, not the query string
+        $this->setupPostStateWithPassword('Password111!');
+        $_GET['password'] = 'weak';
+        $_GET['passwordBis'] = 'weak';
+
+        // create user to get test in a repeatable state
+        $userLogin = 'super user was set';
+        $userEmail = 'test@test.com';
+        $usersModel = new Model();
+        $usersModel->addUser($userLogin, $passwordHash = '', $userEmail, Date::now()->getDatetime());
+
+        // expect test to get past strength check and fail when checking existing password
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ConfirmWithReAuthentication');
+        $this->controller->recordPasswordChange();
+    }
+
+    public function testDeleteTokenReadsIdTokenAuthFromPost()
+    {
+        // don't redirect to the password confirmation, so the failed verification throws
+        $this->passwordVerify->setDisableRedirect();
+
+        $_POST = [
+            'idtokenauth' => '1',
+            'nonce' => Nonce::getNonce('deleteTokenNonce'),
+        ];
+        $_GET = [];
+        $_REQUEST = $_POST;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Not allowed');
+        $this->controller->deleteToken();
     }
 
     public function testUserSettingsShouldExposeMatchBrowserThemeModeOption()

--- a/plugins/UsersManager/tests/Integration/ControllerTest.php
+++ b/plugins/UsersManager/tests/Integration/ControllerTest.php
@@ -9,7 +9,9 @@
 
 namespace Piwik\Plugins\UsersManager\tests\Integration;
 
+use Piwik\Common;
 use Piwik\Config;
+use Piwik\Exception\NoWebsiteFoundException;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Plugins\UsersManager\Controller;
 use Piwik\Nonce;
@@ -46,9 +48,14 @@ class ControllerTest extends IntegrationTestCase
      * @var PasswordVerifier
      */
     private $passwordVerify;
+    /**
+     * @var Model
+     */
+    private $userModel;
     private $post;
     private $get;
     private $request;
+    private $session;
     private $enableUsersAdmin;
     private $superUser;
     private $identity;
@@ -59,22 +66,24 @@ class ControllerTest extends IntegrationTestCase
         parent::setUp();
 
         $this->passwordVerify = new PasswordVerifier();
+        $this->userModel = new Model();
         $this->controller = new Controller(
             $translator = new Translator(new DevelopmentLoader(new JsonFileLoader())),
             $this->passwordVerify,
-            $userModel = new Model(),
+            $this->userModel,
             $passwordStrength = new PasswordStrength(true)
         );
         $this->post = $_POST;
         $this->get = $_GET;
         $this->request = $_REQUEST;
+        $this->session = $_SESSION ?? [];
         $this->enableUsersAdmin = Config::getInstance()->General['enable_users_admin'];
         $this->superUser = FakeAccess::$superUser;
         $this->identity = FakeAccess::$identity;
         $this->superUserLogin = FakeAccess::$superUserLogin;
 
         FakeAccess::$superUser = true;
-        $userModel->deleteUser(self::CURRENT_USER_LOGIN);
+        $this->userModel->deleteUser(self::CURRENT_USER_LOGIN);
         UsersManagerAPI::getInstance()->addUser(
             self::CURRENT_USER_LOGIN,
             'Password111!',
@@ -90,6 +99,7 @@ class ControllerTest extends IntegrationTestCase
         $_POST = $this->post;
         $_GET = $this->get;
         $_REQUEST = $this->request;
+        $_SESSION = $this->session;
         Config::getInstance()->General['enable_users_admin'] = $this->enableUsersAdmin;
         FakeAccess::$superUser = $this->superUser;
         FakeAccess::$identity = $this->identity;
@@ -235,14 +245,14 @@ class ControllerTest extends IntegrationTestCase
         $this->controller->recordPasswordChange();
     }
 
-    public function testDeleteTokenReadsIdTokenAuthFromPost()
+    public function testDeleteTokenRequiresRecentPasswordVerification()
     {
         // don't redirect to the password confirmation, so the failed verification throws
         $this->passwordVerify->setDisableRedirect();
 
         $_POST = [
             'idtokenauth' => '1',
-            'nonce' => Nonce::getNonce('deleteTokenNonce'),
+            'nonce' => Nonce::getNonce(Controller::NONCE_DELETE_AUTH_TOKEN),
         ];
         $_GET = [];
         $_REQUEST = $_POST;
@@ -250,6 +260,78 @@ class ControllerTest extends IntegrationTestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Not allowed');
         $this->controller->deleteToken();
+    }
+
+    public function testDeleteTokenDeletesTokenAfterPasswordConfirmationRedirect()
+    {
+        $idTokenAuth = $this->addTokenForCurrentUser('token submitted for deletion');
+
+        $_POST = [
+            'idtokenauth' => (string) $idTokenAuth,
+            'nonce' => Nonce::getNonce(Controller::NONCE_DELETE_AUTH_TOKEN),
+        ];
+        $_GET = ['module' => 'UsersManager', 'action' => 'deleteToken'];
+        $_REQUEST = $_GET + $_POST;
+
+        // the password has not been confirmed yet, so the action redirects to the confirmation form
+        $redirectUrl = $this->captureRedirect(function () {
+            $this->controller->deleteToken();
+        });
+        $this->assertStringContainsString('action=confirmPassword', $redirectUrl);
+
+        // confirming the password redirects back to the action with the stored parameters
+        $redirectUrl = $this->captureRedirect(function () {
+            $this->passwordVerify->setPasswordVerifiedCorrectly(self::CURRENT_USER_LOGIN);
+        });
+        $this->assertStringContainsString('action=deleteToken', $redirectUrl);
+        $this->assertStringContainsString('idtokenauth=' . $idTokenAuth, $redirectUrl);
+
+        // that redirect is a GET request, so the parameters arrive without a post body
+        parse_str((string) parse_url($redirectUrl, PHP_URL_QUERY), $_GET);
+        $_POST = [];
+        $_REQUEST = $_GET;
+
+        $this->callDeleteTokenIgnoringFinalRedirect();
+
+        $this->assertSame([], $this->getTokenIdsForCurrentUser());
+    }
+
+    public function testDeleteTokenPrefersPostedIdTokenAuth()
+    {
+        $idTokenAuthInPost = $this->addTokenForCurrentUser('token named in the post body');
+        $idTokenAuthInQuery = $this->addTokenForCurrentUser('token named in the query string');
+
+        $this->markPasswordAsVerified();
+
+        $_POST = [
+            'idtokenauth' => (string) $idTokenAuthInPost,
+            'nonce' => Nonce::getNonce(Controller::NONCE_DELETE_AUTH_TOKEN),
+        ];
+        $_GET = ['idtokenauth' => (string) $idTokenAuthInQuery];
+        $_REQUEST = $_GET + $_POST;
+
+        $this->callDeleteTokenIgnoringFinalRedirect();
+
+        $this->assertSame([(string) $idTokenAuthInQuery], $this->getTokenIdsForCurrentUser());
+    }
+
+    public function testDeleteTokenIgnoresEmptyPostedIdTokenAuth()
+    {
+        $idTokenAuthInQuery = $this->addTokenForCurrentUser('token named in the query string');
+
+        $this->markPasswordAsVerified();
+
+        // an empty posted value is a value, so the query string is not consulted for it
+        $_POST = [
+            'idtokenauth' => '',
+            'nonce' => Nonce::getNonce(Controller::NONCE_DELETE_AUTH_TOKEN),
+        ];
+        $_GET = ['idtokenauth' => (string) $idTokenAuthInQuery];
+        $_REQUEST = $_GET + $_POST;
+
+        $this->callDeleteTokenIgnoringFinalRedirect();
+
+        $this->assertSame([(string) $idTokenAuthInQuery], $this->getTokenIdsForCurrentUser());
     }
 
     public function testUserSettingsShouldExposeMatchBrowserThemeModeOption()
@@ -293,6 +375,66 @@ class ControllerTest extends IntegrationTestCase
     public function testThemeModeShouldDefaultToLightForNewUsers()
     {
         $this->assertSame(ThemeStyles::LIGHT_MODE, (new UserPreferences())->getThemeMode());
+    }
+
+    private function addTokenForCurrentUser(string $description): string
+    {
+        return (string) $this->userModel->addTokenAuth(
+            self::CURRENT_USER_LOGIN,
+            'token' . Common::generateUniqId(),
+            $description,
+            Date::now()->getDatetime()
+        );
+    }
+
+    private function getTokenIdsForCurrentUser(): array
+    {
+        $tokens = $this->userModel->getAllNonSystemTokensForLogin(self::CURRENT_USER_LOGIN);
+
+        return array_map('strval', array_column($tokens, 'idusertokenauth'));
+    }
+
+    private function markPasswordAsVerified(): void
+    {
+        // the password only counts as verified while a verification is pending, so the redirect has
+        // to be initiated first
+        $this->passwordVerify->setDisableRedirect();
+        $this->passwordVerify->requirePasswordVerifiedRecently([
+            'module' => 'UsersManager',
+            'action' => 'deleteToken',
+        ]);
+        $this->passwordVerify->setPasswordVerifiedCorrectly(self::CURRENT_USER_LOGIN);
+    }
+
+    /**
+     * Runs a callable that is expected to redirect and returns the url it redirected to. Redirects
+     * throw instead of sending a header when running on the command line.
+     */
+    private function captureRedirect(callable $callable): string
+    {
+        unset(Common::$headersSentInTests['Location']);
+
+        try {
+            $callable();
+        } catch (\Exception $e) {
+            $this->assertStringContainsString('would redirect you to this URL', $e->getMessage());
+
+            return trim(Common::$headersSentInTests['Location'] ?? '');
+        }
+
+        $this->fail('the call was expected to redirect');
+    }
+
+    private function callDeleteTokenIgnoringFinalRedirect(): void
+    {
+        // the action ends by redirecting to the user security page, which cannot be followed here as
+        // no site exists to build the url from
+        try {
+            $this->controller->deleteToken();
+            $this->fail('deleteToken() was expected to end in a redirect');
+        } catch (NoWebsiteFoundException $e) {
+            // expected
+        }
     }
 
     private function setupPostStateWithPassword(string $password)

--- a/plugins/UsersManager/tests/Integration/ControllerTest.php
+++ b/plugins/UsersManager/tests/Integration/ControllerTest.php
@@ -164,7 +164,6 @@ class ControllerTest extends IntegrationTestCase
             'language' => 'en',
             'timeformat' => '0',
         ];
-        $_REQUEST = $_GET + $_POST;
 
         $response = $this->controller->recordUserSettings();
 
@@ -182,22 +181,21 @@ class ControllerTest extends IntegrationTestCase
             'themeMode' => 'invalid',
         ];
         $_POST = [
-            'themeMode' => ThemeStyles::LIGHT_MODE,
+            'themeMode' => ThemeStyles::DARK_MODE,
             'defaultReport' => '1',
             'defaultDate' => 'today',
             'language' => 'en',
             'timeformat' => '0',
         ];
-        $_REQUEST = $_GET + $_POST;
 
-        $response = $this->controller->recordUserSettings();
+        $this->controller->recordUserSettings();
 
-        $this->assertStringNotContainsString('Invalid theme mode', $response);
+        $this->assertSame(ThemeStyles::DARK_MODE, (new UserPreferences())->getThemeMode());
     }
 
     public function testRecordAnonymousUserSettingsReadsSettingsFromPost()
     {
-        (new Model())->addUser('anonymous', '', 'anonymous@example.com', Date::now()->getDatetime());
+        $this->userModel->addUser('anonymous', '', 'anonymous@example.com', Date::now()->getDatetime());
 
         // settings are read from the post body, not the query string
         $_GET = [
@@ -209,7 +207,6 @@ class ControllerTest extends IntegrationTestCase
             'anonymousDefaultReport' => '1',
             'anonymousDefaultDate' => 'today',
         ];
-        $_REQUEST = $_GET + $_POST;
 
         $this->controller->recordAnonymousUserSettings();
 
@@ -233,12 +230,6 @@ class ControllerTest extends IntegrationTestCase
         $_GET['password'] = 'weak';
         $_GET['passwordBis'] = 'weak';
 
-        // create user to get test in a repeatable state
-        $userLogin = 'super user was set';
-        $userEmail = 'test@test.com';
-        $usersModel = new Model();
-        $usersModel->addUser($userLogin, $passwordHash = '', $userEmail, Date::now()->getDatetime());
-
         // expect test to get past strength check and fail when checking existing password
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('UsersManager_ConfirmWithReAuthentication');
@@ -255,7 +246,6 @@ class ControllerTest extends IntegrationTestCase
             'nonce' => Nonce::getNonce(Controller::NONCE_DELETE_AUTH_TOKEN),
         ];
         $_GET = [];
-        $_REQUEST = $_POST;
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Not allowed');
@@ -271,7 +261,6 @@ class ControllerTest extends IntegrationTestCase
             'nonce' => Nonce::getNonce(Controller::NONCE_DELETE_AUTH_TOKEN),
         ];
         $_GET = ['module' => 'UsersManager', 'action' => 'deleteToken'];
-        $_REQUEST = $_GET + $_POST;
 
         // the password has not been confirmed yet, so the action redirects to the confirmation form
         $redirectUrl = $this->captureRedirect(function () {
@@ -289,7 +278,6 @@ class ControllerTest extends IntegrationTestCase
         // that redirect is a GET request, so the parameters arrive without a post body
         parse_str((string) parse_url($redirectUrl, PHP_URL_QUERY), $_GET);
         $_POST = [];
-        $_REQUEST = $_GET;
 
         $this->callDeleteTokenIgnoringFinalRedirect();
 
@@ -308,30 +296,33 @@ class ControllerTest extends IntegrationTestCase
             'nonce' => Nonce::getNonce(Controller::NONCE_DELETE_AUTH_TOKEN),
         ];
         $_GET = ['idtokenauth' => (string) $idTokenAuthInQuery];
-        $_REQUEST = $_GET + $_POST;
 
         $this->callDeleteTokenIgnoringFinalRedirect();
 
         $this->assertSame([(string) $idTokenAuthInQuery], $this->getTokenIdsForCurrentUser());
     }
 
-    public function testDeleteTokenIgnoresEmptyPostedIdTokenAuth()
+    public function testDeleteTokenDeletesNothingWhenPostedIdTokenAuthIsEmpty()
     {
         $idTokenAuthInQuery = $this->addTokenForCurrentUser('token named in the query string');
 
-        $this->markPasswordAsVerified();
-
         // an empty posted value is a value, so the query string is not consulted for it
-        $_POST = [
-            'idtokenauth' => '',
-            'nonce' => Nonce::getNonce(Controller::NONCE_DELETE_AUTH_TOKEN),
-        ];
+        $_POST = ['idtokenauth' => ''];
         $_GET = ['idtokenauth' => (string) $idTokenAuthInQuery];
-        $_REQUEST = $_GET + $_POST;
 
         $this->callDeleteTokenIgnoringFinalRedirect();
 
         $this->assertSame([(string) $idTokenAuthInQuery], $this->getTokenIdsForCurrentUser());
+    }
+
+    public function testDeleteTokenRejectsInvalidIdTokenAuth()
+    {
+        $_POST = ['idtokenauth' => '1&2'];
+        $_GET = [];
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid idtokenauth');
+        $this->controller->deleteToken();
     }
 
     public function testUserSettingsShouldExposeMatchBrowserThemeModeOption()

--- a/plugins/UsersManager/tests/Integration/ControllerTest.php
+++ b/plugins/UsersManager/tests/Integration/ControllerTest.php
@@ -58,7 +58,9 @@ class ControllerTest extends IntegrationTestCase
     private $session;
     private $enableUsersAdmin;
     private $enabledPeriodsUi;
+    private $defaultDay;
     private $superUser;
+    private $idSitesView;
     private $identity;
     private $superUserLogin;
 
@@ -80,7 +82,9 @@ class ControllerTest extends IntegrationTestCase
         $this->session = $_SESSION ?? null;
         $this->enableUsersAdmin = Config::getInstance()->General['enable_users_admin'];
         $this->enabledPeriodsUi = Config::getInstance()->General['enabled_periods_UI'];
+        $this->defaultDay = Config::getInstance()->General['default_day'];
         $this->superUser = FakeAccess::$superUser;
+        $this->idSitesView = FakeAccess::$idSitesView;
         $this->identity = FakeAccess::$identity;
         $this->superUserLogin = FakeAccess::$superUserLogin;
 
@@ -111,7 +115,9 @@ class ControllerTest extends IntegrationTestCase
 
         Config::getInstance()->General['enable_users_admin'] = $this->enableUsersAdmin;
         Config::getInstance()->General['enabled_periods_UI'] = $this->enabledPeriodsUi;
+        Config::getInstance()->General['default_day'] = $this->defaultDay;
         FakeAccess::$superUser = $this->superUser;
+        FakeAccess::$idSitesView = $this->idSitesView;
         FakeAccess::$identity = $this->identity;
         FakeAccess::$superUserLogin = $this->superUserLogin;
     }
@@ -298,7 +304,7 @@ class ControllerTest extends IntegrationTestCase
     {
         Config::getInstance()->General['enable_users_admin'] = 0;
 
-        // the current user is a super user, for whom the view access check passes for any site id
+        // a super user passes the view access check for any site id
         $_GET = ['format' => 'json'];
         $_POST = [
             'themeMode' => ThemeStyles::LIGHT_MODE,
@@ -352,7 +358,7 @@ class ControllerTest extends IntegrationTestCase
         // an admin has since dropped the range period the stored date belongs to
         Config::getInstance()->General['enabled_periods_UI'] = 'day,week,month,year';
 
-        // the form still pre-fills the stored date, so it is posted back along with everything else
+        // the form pre-fills the stored date, so it is posted back with everything else
         $_GET = ['format' => 'json'];
         $_POST = [
             'themeMode' => ThemeStyles::DARK_MODE,
@@ -369,8 +375,35 @@ class ControllerTest extends IntegrationTestCase
             'last30',
             (string) $this->getStoredPreference(UsersManagerAPI::PREFERENCE_DEFAULT_REPORT_DATE)
         );
-        // the rest of the form was saved rather than lost to the rejected date
+        // the rest of the form was saved too
         $this->assertSame(ThemeStyles::DARK_MODE, (new UserPreferences())->getThemeMode());
+    }
+
+    public function testRecordUserSettingsAcceptsConfiguredLastNDefaultDay()
+    {
+        $idSite = $this->createSiteWithUser();
+        Config::getInstance()->General['enable_users_admin'] = 0;
+
+        // an admin may configure any lastN or previousN
+        Config::getInstance()->General['default_day'] = 'last14';
+
+        // with no stored date the form pre-fills the configured default and posts it back
+        $_GET = ['format' => 'json'];
+        $_POST = [
+            'themeMode' => ThemeStyles::DARK_MODE,
+            'defaultReport' => (string) $idSite,
+            'defaultDate' => 'last14',
+            'language' => 'en',
+            'timeformat' => '0',
+        ];
+
+        $response = $this->controller->recordUserSettings();
+
+        $this->assertStringContainsString('"result":"success"', $response);
+        $this->assertSame(
+            'last14',
+            (string) $this->getStoredPreference(UsersManagerAPI::PREFERENCE_DEFAULT_REPORT_DATE)
+        );
     }
 
     public function testUserSettingsShouldNotOfferDatesOfPeriodsDisabledInTheUi()
@@ -380,9 +413,9 @@ class ControllerTest extends IntegrationTestCase
 
         $response = $this->controller->userSettings();
 
-        // the dates the form offers are json encoded into an attribute
-        $this->assertStringNotContainsString('&quot;last30&quot;', $response);
-        $this->assertStringContainsString('&quot;yesterday&quot;', $response);
+        // the offered dates are key/label pairs, the pre-filled date is a bare string
+        $this->assertStringNotContainsString('&quot;last30&quot;:', $response);
+        $this->assertStringContainsString('&quot;yesterday&quot;:', $response);
     }
 
     public function testRecordAnonymousUserSettingsReadsSettingsFromPost()

--- a/plugins/UsersManager/tests/Integration/ControllerTest.php
+++ b/plugins/UsersManager/tests/Integration/ControllerTest.php
@@ -76,7 +76,7 @@ class ControllerTest extends IntegrationTestCase
         $this->post = $_POST;
         $this->get = $_GET;
         $this->request = $_REQUEST;
-        $this->session = $_SESSION ?? [];
+        $this->session = $_SESSION ?? null;
         $this->enableUsersAdmin = Config::getInstance()->General['enable_users_admin'];
         $this->superUser = FakeAccess::$superUser;
         $this->identity = FakeAccess::$identity;
@@ -99,7 +99,14 @@ class ControllerTest extends IntegrationTestCase
         $_POST = $this->post;
         $_GET = $this->get;
         $_REQUEST = $this->request;
-        $_SESSION = $this->session;
+
+        // leave $_SESSION undefined for later tests if it was not defined before
+        if (isset($this->session)) {
+            $_SESSION = $this->session;
+        } else {
+            unset($_SESSION);
+        }
+
         Config::getInstance()->General['enable_users_admin'] = $this->enableUsersAdmin;
         FakeAccess::$superUser = $this->superUser;
         FakeAccess::$identity = $this->identity;
@@ -193,9 +200,99 @@ class ControllerTest extends IntegrationTestCase
         $this->assertSame(ThemeStyles::DARK_MODE, (new UserPreferences())->getThemeMode());
     }
 
+    public function testRecordUserSettingsReadsEmailFromPost()
+    {
+        // the email is only processed while the users admin is enabled
+        Config::getInstance()->General['enable_users_admin'] = 1;
+        $idSite = $this->createSiteWithUser();
+
+        // the email is read from the post body, not the query string
+        $_GET = [
+            'format' => 'json',
+            'email' => 'from-the-query-string@example.com',
+        ];
+        $_POST = [
+            'email' => self::CURRENT_USER_EMAIL,
+            'themeMode' => ThemeStyles::LIGHT_MODE,
+            'defaultReport' => (string) $idSite,
+            'defaultDate' => 'today',
+            'language' => 'en',
+            'timeformat' => '0',
+        ];
+
+        $response = $this->controller->recordUserSettings();
+
+        $this->assertStringContainsString('"result":"success"', $response);
+        $this->assertSame(
+            self::CURRENT_USER_EMAIL,
+            $this->userModel->getUser(self::CURRENT_USER_LOGIN)['email']
+        );
+    }
+
+    public function testRecordUserSettingsRejectsEmptyDefaultReport()
+    {
+        Config::getInstance()->General['enable_users_admin'] = 0;
+
+        $_GET = ['format' => 'json'];
+        $_POST = [
+            'themeMode' => ThemeStyles::LIGHT_MODE,
+            'defaultReport' => '',
+            'defaultDate' => 'today',
+            'language' => 'en',
+            'timeformat' => '0',
+        ];
+
+        $response = $this->controller->recordUserSettings();
+
+        // an empty default report would leave the user settings page unable to render
+        $this->assertStringContainsString('Invalid default report', $response);
+        $this->assertFalse($this->getStoredPreference(UsersManagerAPI::PREFERENCE_DEFAULT_REPORT));
+    }
+
+    public function testRecordUserSettingsRejectsDefaultReportForSiteWithoutViewAccess()
+    {
+        FakeAccess::$superUser = false;
+        FakeAccess::$idSitesView = [];
+
+        $_GET = ['format' => 'json'];
+        $_POST = [
+            'themeMode' => ThemeStyles::LIGHT_MODE,
+            'defaultReport' => '1',
+            'defaultDate' => 'today',
+            'language' => 'en',
+            'timeformat' => '0',
+        ];
+
+        $response = $this->controller->recordUserSettings();
+
+        $this->assertStringContainsString('Invalid default report', $response);
+        $this->assertFalse($this->getStoredPreference(UsersManagerAPI::PREFERENCE_DEFAULT_REPORT));
+    }
+
+    public function testRecordUserSettingsRejectsInvalidDefaultDate()
+    {
+        $idSite = $this->createSiteWithUser();
+        Config::getInstance()->General['enable_users_admin'] = 0;
+
+        $_GET = ['format' => 'json'];
+        $_POST = [
+            'themeMode' => ThemeStyles::LIGHT_MODE,
+            'defaultReport' => (string) $idSite,
+            // survives getDefaultDateWithoutValidation() verbatim and would end up in menu urls
+            'defaultDate' => 'last7&module=CoreAdminHome',
+            'language' => 'en',
+            'timeformat' => '0',
+        ];
+
+        $response = $this->controller->recordUserSettings();
+
+        $this->assertStringContainsString('Invalid default date', $response);
+        $this->assertFalse($this->getStoredPreference(UsersManagerAPI::PREFERENCE_DEFAULT_REPORT_DATE));
+    }
+
     public function testRecordAnonymousUserSettingsReadsSettingsFromPost()
     {
-        $this->userModel->addUser('anonymous', '', 'anonymous@example.com', Date::now()->getDatetime());
+        $idSite = $this->addSiteAnonymousCanView();
 
         // settings are read from the post body, not the query string
         $_GET = [
@@ -204,7 +301,7 @@ class ControllerTest extends IntegrationTestCase
             'anonymousDefaultDate' => 'week',
         ];
         $_POST = [
-            'anonymousDefaultReport' => '1',
+            'anonymousDefaultReport' => (string) $idSite,
             'anonymousDefaultDate' => 'today',
         ];
 
@@ -219,8 +316,45 @@ class ControllerTest extends IntegrationTestCase
             'anonymous'
         );
 
-        $this->assertSame('1', (string) $storedReport);
+        $this->assertSame((string) $idSite, (string) $storedReport);
         $this->assertSame('today', (string) $storedDate);
+    }
+
+    public function testRecordAnonymousUserSettingsRejectsSiteOnlyTheCurrentUserCanView()
+    {
+        $this->userModel->addUser('anonymous', '', 'anonymous@example.com', Date::now()->getDatetime());
+
+        // the site is viewable by the super user recording the settings, but not by anonymous
+        $idSite = $this->createSiteWithUser();
+
+        $_GET = ['format' => 'json'];
+        $_POST = [
+            'anonymousDefaultReport' => (string) $idSite,
+            'anonymousDefaultDate' => 'today',
+        ];
+
+        $response = $this->controller->recordAnonymousUserSettings();
+
+        $this->assertStringContainsString('Invalid default report', $response);
+        $this->assertFalse($this->getStoredPreference(UsersManagerAPI::PREFERENCE_DEFAULT_REPORT, 'anonymous'));
+    }
+
+    public function testRecordAnonymousUserSettingsRejectsInvalidDefaultDate()
+    {
+        $idSite = $this->addSiteAnonymousCanView();
+
+        $_GET = ['format' => 'json'];
+        $_POST = [
+            'anonymousDefaultReport' => (string) $idSite,
+            'anonymousDefaultDate' => 'last7&module=CoreAdminHome',
+        ];
+
+        $response = $this->controller->recordAnonymousUserSettings();
+
+        $this->assertStringContainsString('Invalid default date', $response);
+        $this->assertFalse(
+            $this->getStoredPreference(UsersManagerAPI::PREFERENCE_DEFAULT_REPORT_DATE, 'anonymous')
+        );
     }
 
     public function testRecordPasswordChangeReadsPasswordFromPost()
@@ -302,6 +436,25 @@ class ControllerTest extends IntegrationTestCase
         $this->assertSame([(string) $idTokenAuthInQuery], $this->getTokenIdsForCurrentUser());
     }
 
+    public function testDeleteTokenDeletesAllTokens()
+    {
+        $this->addTokenForCurrentUser('first token');
+        $this->addTokenForCurrentUser('second token');
+
+        $this->markPasswordAsVerified();
+
+        // what the "delete all tokens" form submits
+        $_POST = [
+            'idtokenauth' => 'all',
+            'nonce' => Nonce::getNonce(Controller::NONCE_DELETE_AUTH_TOKEN),
+        ];
+        $_GET = [];
+
+        $this->callDeleteTokenIgnoringFinalRedirect();
+
+        $this->assertSame([], $this->getTokenIdsForCurrentUser());
+    }
+
     public function testDeleteTokenDeletesNothingWhenPostedIdTokenAuthIsEmpty()
     {
         $idTokenAuthInQuery = $this->addTokenForCurrentUser('token named in the query string');
@@ -366,6 +519,32 @@ class ControllerTest extends IntegrationTestCase
     public function testThemeModeShouldDefaultToLightForNewUsers()
     {
         $this->assertSame(ThemeStyles::LIGHT_MODE, (new UserPreferences())->getThemeMode());
+    }
+
+    private function addSiteAnonymousCanView(): int
+    {
+        $this->userModel->addUser('anonymous', '', 'anonymous@example.com', Date::now()->getDatetime());
+
+        $idSite = SitesManagerAPI::getInstance()->addSite(
+            'Anonymous site',
+            ['https://anonymous.example.test']
+        );
+        UsersManagerAPI::getInstance()->setUserAccess('anonymous', 'view', [$idSite]);
+
+        return $idSite;
+    }
+
+    /**
+     * @return mixed the stored value, or false when nothing was stored
+     */
+    private function getStoredPreference(string $preferenceName, string $userLogin = self::CURRENT_USER_LOGIN)
+    {
+        return StaticContainer::get(UserScopedSettingsAccessManager::class)->get(
+            'UsersManager',
+            $userLogin,
+            $preferenceName,
+            false
+        );
     }
 
     private function addTokenForCurrentUser(string $description): string


### PR DESCRIPTION
### Description

We want to remove the use of the deprecated `Common::getRequestVar()` in User Manager Controller. 

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
