### PR TITLE
Add hidden release channel for Matomo 5 preview releases

### DIFF
--- a/plugins/CoreUpdater/ReleaseChannel/Latest5XPreview.php
+++ b/plugins/CoreUpdater/ReleaseChannel/Latest5XPreview.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreUpdater\ReleaseChannel;
+
+use Piwik\Plugins\CoreUpdater\ReleaseChannel;
+
+class Latest5XPreview extends ReleaseChannel
+{
+    public function getId()
+    {
+        return 'latest_5x_preview';
+    }
+
+    public function getName()
+    {
+        return 'latest_5x_preview';
+    }
+
+    public function doesPreferStable()
+    {
+        return false;
+    }
+
+    public function getOrder()
+    {
+        return 31;
+    }
+
+    public function isSelectableInSettings(): bool
+    {
+        return false;
+    }
+}

--- a/plugins/CoreUpdater/tests/Integration/ReleaseChannelTest.php
+++ b/plugins/CoreUpdater/tests/Integration/ReleaseChannelTest.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\CoreUpdater\tests\ReleaseChannel;
 
 use Piwik\Db;
 use Piwik\Plugins\CoreUpdater\ReleaseChannel;
+use Piwik\Plugins\CoreUpdater\ReleaseChannel\Latest5XPreview;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Url;
 use Piwik\Version;
@@ -67,5 +68,18 @@ class ReleaseChannelTest extends IntegrationTestCase
     public function testDoesPreferStable()
     {
         $this->assertTrue($this->channel->doesPreferStable());
+    }
+
+    public function testLatest5XPreviewIsHiddenAndChecksForPreviewVersions()
+    {
+        $channel = new Latest5XPreview();
+
+        $this->assertSame('latest_5x_preview', $channel->getId());
+        $this->assertFalse($channel->isSelectableInSettings());
+        $this->assertFalse($channel->doesPreferStable());
+        $this->assertStringContainsString(
+            'release_channel=latest_5x_preview',
+            $channel->getUrlToCheckForLatestAvailableVersion()
+        );
     }
 }

--- a/tests/PHPUnit/Integration/Plugin/ReleaseChannelsTest.php
+++ b/tests/PHPUnit/Integration/Plugin/ReleaseChannelsTest.php
@@ -42,7 +42,7 @@ class ReleaseChannelsTest extends IntegrationTestCase
     {
         $channels = $this->channels->getAllReleaseChannels();
 
-        $this->assertCount(5, $channels);
+        $this->assertCount(6, $channels);
 
         foreach ($channels as $channel) {
             $this->assertTrue($channel instanceof ReleaseChannel);
@@ -78,6 +78,7 @@ class ReleaseChannelsTest extends IntegrationTestCase
             array($exists = true, $id = 'latest_beta'),
             array($exists = true, $id = 'latest_5x_stable'),
             array($exists = true, $id = 'latest_preview'),
+            array($exists = true, $id = 'latest_5x_preview'),
             array($exists = true, $id = 'laTest_stable'), // we do not check for exact match
             array($exists = false, $id = ''),
             array($exists = false, $id = 'latest'),


### PR DESCRIPTION
### Description

Adds a second hidden release channel, `latest_5x_preview`, that pins updates to the **Matomo 5** preview line.

We already have a hidden `latest_preview` channel (#22205), but it is not pinned to a major version — the update
service returns the newest preview regardless of the installed version (a `6.0.0-b1` install is offered the 5.x
preview today). Once previews for Matomo 6 start being produced, everyone on `latest_preview` would be pulled onto
Matomo 6. Cloud and internal testers need to stay on Matomo 5 previews, which is the same need #25029 covers on the
build side.

Like `latest_preview`, the channel is not offered in *Administration → General settings* and can only be enabled
through `[General] release_channel` in `config.ini.php`. `getName()` is deliberately left untranslated, since the
string is never rendered.

issue dev-20631

### ⚠️ Server side dependency

`api.matomo.org` has to learn the new `release_channel` id. Until it does, the unknown id falls back to the latest
stable release:

| request | response today |
|---|---|
| `getLatestVersion/?release_channel=latest_preview` | `5.13.0-alpha.20260810013519` |
| `getLatestVersion/?release_channel=latest_5x_preview` | `5.12.0` (unknown id → stable fallback) |

So on a `5.13.0-alpha.<ts>` install the channel is inert rather than harmful (`version_compare()` reports no
update), but it does nothing useful until the update service is updated. Please confirm the exact id string before
merging, since it is the whole contract.

### Impact

* **New hidden channel** `latest_5x_preview`, order `31` (right after `latest_preview`, which is `30`).
* **Nothing changes by default** — the channel is invisible in the UI and no existing channel behaviour is touched.
* **No registration needed** — `Piwik\Plugin\ReleaseChannels` discovers it by globbing `plugins/*/ReleaseChannel/*.php`.
* **Check and download URLs** come from the shared `Piwik\Plugins\CoreUpdater\ReleaseChannel` base, so previews
  resolve to `builds.matomo.org/matomo-<version>.zip`, which is where preview archives already live.
* **Marketplace** is queried with `prefer_stable=0` on this channel, same as `latest_preview`.
* **Not forward-ported to 6.x-dev on purpose** — a Matomo 6 install has no `Latest5XPreview` class, so a config
  still holding the id resolves to `null` in `ReleaseChannels::factory()` and falls back to `latest_stable`. The
  channel is designed never to lead to Matomo 6 anyway.

### Step by step tests

1. Add `release_channel = "latest_5x_preview"` to the `[General]` section of `config/config.ini.php`.
2. Go to *Administration → System → General settings*.
  👁️ The page loads without error and the *Release channel* radio still offers only the four selectable channels
  (`latest_stable`, `latest_beta`, `latest_5x_stable`, `latest_5x_beta`), with none preselected — the existing
  behaviour whenever a hidden channel is active, identical to `latest_preview`.
3. Go to *Administration → Diagnostic → System Check → Informational*.
  👁️ `Release Channel` reads `latest_5x_preview`, which proves the id resolved instead of silently falling back.
4. Run `./console diagnostics:run`.
  👁️ No release-channel related error.
5. Remove the setting again.
  👁️ *General settings* shows *Latest stable release (Recommended)* selected as before.

#### Edge cases

1. Set `release_channel = "LATEST_5X_PREVIEW"`.
  👁️ Still resolves — `ReleaseChannels::factory()` matches case-insensitively.
2. Set `release_channel = "latest_5x_previews"` (typo).
  👁️ Falls back to `latest_stable` (lowest order), no error.
3. With the channel active, open *Administration → Marketplace*.
  👁️ Plugin listings still load; the requests carry `prefer_stable=0`.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
