### PR TITLE
Modernize the example plugins

### DIFF
--- a/core/Columns/Dimension.php
+++ b/core/Columns/Dimension.php
@@ -105,6 +105,7 @@ abstract class Dimension
     /**
      * By defining a segment name a user will be able to filter their visitors by this column. If you do not want to
      * define a segment for this dimension, simply leave the name empty.
+     * @var string
      * @api since Piwik 3.2.0
      */
     protected $segmentName = '';

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -494,6 +494,9 @@ class Request
         return isset($this->params[$name]);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getParams()
     {
         return $this->params;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3067,30 +3067,6 @@ parameters:
 			path: plugins/Events/Reports/Base.php
 
 		-
-			message: '#^Parameter \#3 \$escapeComment of static method Piwik\\Plugins\\Diagnostics\\Diagnostic\\DiagnosticResult\:\:informationalResult\(\) expects bool, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: plugins/ExamplePlugin/Diagnostic/ExampleCheck.php
-
-		-
-			message: '#^Parameter \#2 \$value of static method Piwik\\Option\:\:set\(\) expects string, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: plugins/ExamplePlugin/RecordBuilders/ExampleMetric2.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between false and string will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: plugins/ExampleTracker/Columns/ExampleActionDimension.php
-
-		-
-			message: '#^Property Piwik\\Notification\:\:\$flags \(int\) does not accept null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: plugins/ExampleUI/Controller.php
-
-		-
 			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
 			identifier: catch.neverThrown
 			count: 1

--- a/plugins/ExampleAPI/API.php
+++ b/plugins/ExampleAPI/API.php
@@ -88,11 +88,11 @@ class API extends \Piwik\Plugin\API
      * When called from the Web API, you see that simple arrays like this one
      * are automatically converted in the various formats (xml, csv, etc.)
      *
-     * @return array
+     * @return list<string>
      */
     public function getDescriptionArray(): array
     {
-        return array('piwik', 'free/libre', 'web analytics', 'free', 'Strong message: Свободный Тибет');
+        return ['piwik', 'free/libre', 'web analytics', 'free', 'Strong message: Свободный Тибет'];
     }
 
     /**
@@ -105,14 +105,14 @@ class API extends \Piwik\Plugin\API
         $dataTable = new DataTable();
 
         $row1 = new Row();
-        $row1->setColumns(array('name' => 'piwik', 'license' => 'GPL'));
+        $row1->setColumns(['name' => 'piwik', 'license' => 'GPL']);
 
         // Rows Metadata is useful to store non stats data for example (logos, urls, etc.)
         // When printed out, they are simply merged with columns
         $row1->setMetadata('logo', 'logo.png');
         $dataTable->addRow($row1);
 
-        $dataTable->addRowFromSimpleArray(array('name' => 'google analytics', 'license' => 'commercial'));
+        $dataTable->addRowFromSimpleArray(['name' => 'google analytics', 'license' => 'commercial']);
 
         return $dataTable;
     }
@@ -129,17 +129,16 @@ class API extends \Piwik\Plugin\API
      * Returns a Multidimensional Array
      * Only supported in JSON
      *
-     * @return array
+     * @return array<string, array<mixed>>
      */
     public function getMultiArray(): array
     {
-        $return = array(
-            'Limitation'       => array(
+        return [
+            'Limitation'       => [
                 "Multi dimensional arrays is only supported by format=JSON",
                 "Known limitation",
-            ),
-            'Second Dimension' => array(true, false, 1, 0, 152, 'test', array(42 => 'end')),
-        );
-        return $return;
+            ],
+            'Second Dimension' => [true, false, 1, 0, 152, 'test', [42 => 'end']],
+        ];
     }
 }

--- a/plugins/ExampleAPI/ExampleAPI.php
+++ b/plugins/ExampleAPI/ExampleAPI.php
@@ -11,7 +11,6 @@ namespace Piwik\Plugins\ExampleAPI;
 
 /**
  * This plugin only provides an API.php file, so we leave the plugin class empty
- *
  */
 class ExampleAPI extends \Piwik\Plugin
 {

--- a/plugins/ExampleAPI/MagicObject.php
+++ b/plugins/ExampleAPI/MagicObject.php
@@ -11,15 +11,15 @@ namespace Piwik\Plugins\ExampleAPI;
 
 /**
  * Magic Object
- *
  */
 class MagicObject
 {
-    public function incredible()
+    public string $great = 'formidable';
+
+    protected string $wonderful = 'magnifique';
+
+    public function incredible(): string
     {
         return 'Incroyable';
     }
-
-    protected $wonderful = 'magnifique';
-    public $great = 'formidable';
 }

--- a/plugins/ExampleAPI/config/config.php
+++ b/plugins/ExampleAPI/config/config.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleAPI/config/tracker.php
+++ b/plugins/ExampleAPI/config/tracker.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleCommand/Commands/HelloWorld.php
+++ b/plugins/ExampleCommand/Commands/HelloWorld.php
@@ -71,9 +71,11 @@ class HelloWorld extends ConsoleCommand
 
         $name = $input->getOption('name');
 
-        $message = sprintf('<info>HelloWorld: %s</info>', $name);
+        if (!is_string($name)) {
+            $name = '';
+        }
 
-        $output->writeln($message);
+        $output->writeln(sprintf('<info>HelloWorld: %s</info>', $name));
 
         return self::SUCCESS;
     }

--- a/plugins/ExampleCommand/config/config.php
+++ b/plugins/ExampleCommand/config/config.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleCommand/config/tracker.php
+++ b/plugins/ExampleCommand/config/tracker.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleLogTables/Columns/GroupAttributeAdmin.php
+++ b/plugins/ExampleLogTables/Columns/GroupAttributeAdmin.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
 namespace Piwik\Plugins\ExampleLogTables\Columns;
 
 use Piwik\Columns\Dimension;

--- a/plugins/ExampleLogTables/Columns/UserAttributeGender.php
+++ b/plugins/ExampleLogTables/Columns/UserAttributeGender.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
 namespace Piwik\Plugins\ExampleLogTables\Columns;
 
 use Piwik\Columns\Dimension;

--- a/plugins/ExampleLogTables/Dao/CustomGroupLog.php
+++ b/plugins/ExampleLogTables/Dao/CustomGroupLog.php
@@ -15,56 +15,50 @@ use Piwik\DbHelper;
 
 class CustomGroupLog
 {
-    private $table = 'log_group';
-    private $tablePrefixed = '';
+    private const TABLE = 'log_group';
+
+    private readonly string $tablePrefixed;
 
     public function __construct()
     {
-        $this->tablePrefixed = Common::prefixTable($this->table);
+        $this->tablePrefixed = Common::prefixTable(self::TABLE);
     }
 
-    public function install()
+    public function install(): void
     {
-        DbHelper::createTable($this->table, "
+        DbHelper::createTable(self::TABLE, "
                   `group` VARCHAR(30) NOT NULL,
                   `is_admin` TINYINT(1) NOT NULL,
                   PRIMARY KEY (`group`)");
     }
 
-    public function uninstall()
+    public function uninstall(): void
     {
         Db::query(sprintf('DROP TABLE IF EXISTS `%s`', $this->tablePrefixed));
     }
 
-    private function getDb()
+    /**
+     * @return list<array<array-key, string|int|float|null>>
+     */
+    public function getAllRecords(): array
     {
-        return Db::get();
+        return Db::fetchAll('SELECT * FROM ' . $this->tablePrefixed);
     }
 
-    public function getAllRecords()
+    public function addGroupInformation(string $group, bool $isAdmin): void
     {
-        return $this->getDb()->fetchAll('SELECT * FROM ' . $this->tablePrefixed);
-    }
-
-    public function addGroupInformation($group, $isAdmin)
-    {
-        $columns = array(
+        $columns = [
             'group' => $group,
-            'is_admin' => $isAdmin,
-        );
-
-        $bind = array_values($columns);
-        $placeholder = Common::getSqlStringFieldsArray($columns);
+            'is_admin' => (int) $isAdmin,
+        ];
 
         $sql = sprintf(
             'INSERT INTO `%s` (`%s`) VALUES(%s)',
             $this->tablePrefixed,
             implode('`,`', array_keys($columns)),
-            $placeholder
+            Common::getSqlStringFieldsArray($columns)
         );
 
-        $db = $this->getDb();
-
-        $db->query($sql, $bind);
+        Db::query($sql, array_values($columns));
     }
 }

--- a/plugins/ExampleLogTables/Dao/CustomUserLog.php
+++ b/plugins/ExampleLogTables/Dao/CustomUserLog.php
@@ -15,58 +15,52 @@ use Piwik\DbHelper;
 
 class CustomUserLog
 {
-    private $table = 'log_custom';
-    private $tablePrefixed = '';
+    private const TABLE = 'log_custom';
+
+    private readonly string $tablePrefixed;
 
     public function __construct()
     {
-        $this->tablePrefixed = Common::prefixTable($this->table);
+        $this->tablePrefixed = Common::prefixTable(self::TABLE);
     }
 
-    public function install()
+    public function install(): void
     {
-        DbHelper::createTable($this->table, "
+        DbHelper::createTable(self::TABLE, "
                   `user_id` VARCHAR(191) NOT NULL,
                   `gender` VARCHAR(30) NOT NULL,
                   `group` VARCHAR(30) NOT NULL,
                   PRIMARY KEY (user_id)");
     }
 
-    public function uninstall()
+    public function uninstall(): void
     {
         Db::query(sprintf('DROP TABLE IF EXISTS `%s`', $this->tablePrefixed));
     }
 
-    private function getDb()
+    /**
+     * @return list<array<array-key, string|int|float|null>>
+     */
+    public function getAllRecords(): array
     {
-        return Db::get();
+        return Db::fetchAll('SELECT * FROM ' . $this->tablePrefixed);
     }
 
-    public function getAllRecords()
+    public function addUserInformation(string $userId, string $group, string $gender): void
     {
-        return $this->getDb()->fetchAll('SELECT * FROM ' . $this->tablePrefixed);
-    }
-
-    public function addUserInformation($userId, $group, $gender)
-    {
-        $columns = array(
+        $columns = [
             'user_id' => $userId,
             'group' => $group,
             'gender' => $gender,
-        );
-
-        $bind = array_values($columns);
-        $placeholder = Common::getSqlStringFieldsArray($columns);
+        ];
 
         $sql = sprintf(
             'INSERT INTO `%s` (`%s`) VALUES(%s)',
             $this->tablePrefixed,
             implode('`,`', array_keys($columns)),
-            $placeholder
+            Common::getSqlStringFieldsArray($columns)
         );
 
-        $db = $this->getDb();
-
-        $db->query($sql, $bind);
+        Db::query($sql, array_values($columns));
     }
 }

--- a/plugins/ExampleLogTables/ExampleLogTables.php
+++ b/plugins/ExampleLogTables/ExampleLogTables.php
@@ -34,9 +34,9 @@ class ExampleLogTables extends \Piwik\Plugin
     /**
      * Register the new tables, so Matomo knows about them.
      *
-     * @param array $allTablesInstalled
+     * @param string[] $allTablesInstalled
      */
-    public function getTablesInstalled(&$allTablesInstalled)
+    public function getTablesInstalled(array &$allTablesInstalled): void
     {
         $allTablesInstalled[] = Common::prefixTable('log_group');
         $allTablesInstalled[] = Common::prefixTable('log_custom');

--- a/plugins/ExampleLogTables/Tracker/LogTable/CustomGroupLog.php
+++ b/plugins/ExampleLogTables/Tracker/LogTable/CustomGroupLog.php
@@ -23,11 +23,17 @@ class CustomGroupLog extends LogTable
         return 'group';
     }
 
+    /**
+     * @return string[]
+     */
     public function getPrimaryKey()
     {
         return ['group'];
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function getWaysToJoinToOtherLogTables()
     {
         return ['log_custom' => 'group'];

--- a/plugins/ExampleLogTables/Tracker/LogTable/CustomUserLog.php
+++ b/plugins/ExampleLogTables/Tracker/LogTable/CustomUserLog.php
@@ -23,11 +23,17 @@ class CustomUserLog extends LogTable
         return 'user_id';
     }
 
+    /**
+     * @return string[]
+     */
     public function getPrimaryKey()
     {
         return ['user_id'];
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function getWaysToJoinToOtherLogTables()
     {
         return ['log_visit' => 'user_id'];

--- a/plugins/ExampleLogTables/config/config.php
+++ b/plugins/ExampleLogTables/config/config.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleLogTables/config/tracker.php
+++ b/plugins/ExampleLogTables/config/tracker.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleLogTables/tests/Fixtures/VisitsWithUserIdAndCustomData.php
+++ b/plugins/ExampleLogTables/tests/Fixtures/VisitsWithUserIdAndCustomData.php
@@ -19,11 +19,14 @@ class VisitsWithUserIdAndCustomData extends Fixture
     public $dateTime = '2018-02-01 11:22:33';
     public $idSite = 1;
 
-    private static $countryCodes = ['CA', 'CN', 'DE', 'ES', 'FR', 'IE', 'IN', 'IT', 'MX', 'PT', 'RU', 'GB', 'US'];
+    /**
+     * @var string[]
+     */
+    private static array $countryCodes = ['CA', 'CN', 'DE', 'ES', 'FR', 'IE', 'IN', 'IT', 'MX', 'PT', 'RU', 'GB', 'US'];
 
     public function setUp(): void
     {
-        if (!self::siteCreated($idSite = 1)) {
+        if (!self::siteCreated($this->idSite)) {
             self::createWebsite($this->dateTime);
         }
 
@@ -38,13 +41,13 @@ class VisitsWithUserIdAndCustomData extends Fixture
         $this->insertCustomGroupLogData();
     }
 
-    private function trackVisits()
+    private function trackVisits(): void
     {
-        $t = self::getTracker($this->idSite, $this->dateTime, $defaultInit = true);
+        $t = self::getTracker($this->idSite, $this->dateTime, defaultInit: true);
         $t->setTokenAuth(self::getTokenAuth());
         $t->enableBulkTracking();
 
-        foreach (array('user1', 'user2', 'user3', 'user4', null) as $key => $userId) {
+        foreach (['user1', 'user2', 'user3', 'user4', null] as $key => $userId) {
             for ($numVisits = 0; $numVisits < ($key + 1) * 10; $numVisits++) {
                 $visitDateTime = Date::factory($this->dateTime)->addHour($numVisits)->getDatetime();
                 $t->setForceVisitDateTime($visitDateTime);
@@ -95,7 +98,7 @@ class VisitsWithUserIdAndCustomData extends Fixture
         self::checkBulkTrackingResponse($t->doBulkTrack());
     }
 
-    private function insertCustomUserLogData()
+    private function insertCustomUserLogData(): void
     {
         $customLog = new CustomUserLog();
         $customLog->addUserInformation('user1', 'admin', 'men');
@@ -104,10 +107,10 @@ class VisitsWithUserIdAndCustomData extends Fixture
         $customLog->addUserInformation('user4', '', 'men');
     }
 
-    private function insertCustomGroupLogData()
+    private function insertCustomGroupLogData(): void
     {
         $customGroup = new CustomGroupLog();
-        $customGroup->addGroupInformation('admin', 1);
-        $customGroup->addGroupInformation('user', 0);
+        $customGroup->addGroupInformation('admin', true);
+        $customGroup->addGroupInformation('user', false);
     }
 }

--- a/plugins/ExampleLogTables/tests/System/CustomLogTablesTest.php
+++ b/plugins/ExampleLogTables/tests/System/CustomLogTablesTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
 namespace Piwik\Plugins\ExampleLogTables\tests\System;
 
 use Piwik\Plugins\ExampleLogTables\tests\Fixtures\VisitsWithUserIdAndCustomData;
@@ -23,7 +30,7 @@ class CustomLogTablesTest extends SystemTestCase
     /**
      * @dataProvider getApiForTesting
      */
-    public function testApi($api, $params)
+    public function testApi($api, $params): void
     {
         $this->runApiTests($api, $params);
     }
@@ -31,7 +38,7 @@ class CustomLogTablesTest extends SystemTestCase
     /**
      * @dataProvider getSegmentsToTest
      */
-    public function testNoApiReturnsError($segment)
+    public function testNoApiReturnsError(string $segment): void
     {
         self::expectNotToPerformAssertions();
 
@@ -61,7 +68,7 @@ class CustomLogTablesTest extends SystemTestCase
         }
     }
 
-    public function getSegmentsToTest()
+    public function getSegmentsToTest(): array
     {
         return [
             ['attrgender==men'],
@@ -74,7 +81,7 @@ class CustomLogTablesTest extends SystemTestCase
         $dateTime = self::$fixture->dateTime;
         $idSite1 = self::$fixture->idSite;
 
-        $result = [
+        return [
             [[
                 'Actions.get',
                 'UserId.getUsers',
@@ -123,8 +130,6 @@ class CustomLogTablesTest extends SystemTestCase
                 'testSuffix'   => '_all'],
             ],
         ];
-
-        return $result;
     }
 
     public static function getOutputPrefix()
@@ -134,7 +139,7 @@ class CustomLogTablesTest extends SystemTestCase
 
     public static function getPathToTestDirectory()
     {
-        return dirname(__FILE__);
+        return __DIR__;
     }
 }
 

--- a/plugins/ExamplePlugin/API.php
+++ b/plugins/ExamplePlugin/API.php
@@ -46,12 +46,10 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $table = DataTable::makeFromSimpleArray(array(
-            array('label' => 'My Label 1', 'nb_visits' => '1'),
-            array('label' => 'My Label 2', 'nb_visits' => '5'),
-        ));
-
-        return $table;
+        return DataTable::makeFromSimpleArray([
+            ['label' => 'My Label 1', 'nb_visits' => '1'],
+            ['label' => 'My Label 2', 'nb_visits' => '5'],
+        ]);
     }
 
     /**
@@ -66,11 +64,10 @@ class API extends \Piwik\Plugin\API
         return $archive->getDataTableFromNumeric([ExampleMetric::EXAMPLEPLUGIN_METRIC_NAME, ExampleMetric2::EXAMPLEPLUGIN_CONST_METRIC_NAME]);
     }
 
-    public function getSegmentHash(string $idSite, string $segment)
+    public function getSegmentHash(string $idSite, string $segment): string
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $segment = new Segment($segment, [$idSite]);
-        return $segment->getHash();
+        return (new Segment($segment, [$idSite]))->getHash();
     }
 }

--- a/plugins/ExamplePlugin/Controller.php
+++ b/plugins/ExamplePlugin/Controller.php
@@ -17,11 +17,11 @@ namespace Piwik\Plugins\ExamplePlugin;
  */
 class Controller extends \Piwik\Plugin\Controller
 {
-    public function index()
+    public function index(): string
     {
         // Render the Twig template templates/index.twig and assign the view variable answerToLife to the view.
-        return $this->renderTemplate('index', array(
+        return $this->renderTemplate('index', [
             'answerToLife' => 42,
-        ));
+        ]);
     }
 }

--- a/plugins/ExamplePlugin/Diagnostic/ExampleCheck.php
+++ b/plugins/ExamplePlugin/Diagnostic/ExampleCheck.php
@@ -14,19 +14,16 @@ use Piwik\Plugins\Diagnostics\Diagnostic\DiagnosticResult;
 
 class ExampleCheck implements Diagnostic
 {
+    /**
+     * @return DiagnosticResult[]
+     */
     public function execute()
     {
-        $result = [];
-
-        $label = 'Example Check';
         $status = DiagnosticResult::STATUS_OK; // can be ok, error, warning or informational
-        $comment = 'A comment for this check';
-        $result[] = DiagnosticResult::singleResult($label, $status, $comment);
 
-        $label = 'Example Information';
-        $comment = 'The PHP version is ' . PHP_VERSION;
-        $result[] = DiagnosticResult::informationalResult($label, $status, $comment);
-
-        return $result;
+        return [
+            DiagnosticResult::singleResult('Example Check', $status, 'A comment for this check'),
+            DiagnosticResult::informationalResult('Example Information', 'The PHP version is ' . PHP_VERSION),
+        ];
     }
 }

--- a/plugins/ExamplePlugin/ExamplePlugin.php
+++ b/plugins/ExamplePlugin/ExamplePlugin.php
@@ -9,20 +9,10 @@
 
 namespace Piwik\Plugins\ExamplePlugin;
 
+/**
+ * This plugin does not need to hook into any event, so the plugin class stays empty. Have a look at
+ * ExampleLogTables or ExampleTheme to see how events are registered via `registerEvents()`.
+ */
 class ExamplePlugin extends \Piwik\Plugin
 {
-    public function registerEvents()
-    {
-        return [
-            'CronArchive.getArchivingAPIMethodForPlugin' => 'getArchivingAPIMethodForPlugin',
-        ];
-    }
-
-    // support archiving just this plugin via core:archive
-    public function getArchivingAPIMethodForPlugin(&$method, $plugin)
-    {
-        if ($plugin == 'ExamplePlugin') {
-            $method = 'ExamplePlugin.getExampleArchivedMetric';
-        }
-    }
 }

--- a/plugins/ExamplePlugin/Menu.php
+++ b/plugins/ExamplePlugin/Menu.php
@@ -19,11 +19,17 @@ use Piwik\Menu\MenuTop;
  */
 class Menu extends \Piwik\Plugin\Menu
 {
+    /**
+     * @return void
+     */
     public function configureTopMenu(MenuTop $menu)
     {
         // $menu->addItem('ExamplePlugin_MyTopItem', null, $this->urlForDefaultAction(), $orderId = 30);
     }
 
+    /**
+     * @return void
+     */
     public function configureAdminMenu(MenuAdmin $menu)
     {
         // reuse an existing category. Execute the showList() method within the controller when menu item was clicked

--- a/plugins/ExamplePlugin/RecordBuilders/ExampleBlob.php
+++ b/plugins/ExamplePlugin/RecordBuilders/ExampleBlob.php
@@ -64,9 +64,12 @@ class ExampleBlob extends RecordBuilder
     {
         $record = new DataTable();
 
+        /** @var \Zend_Db_Statement $query */
         $query = $archiveProcessor->getLogAggregator()->queryVisitsByDimension(['idvisitor']);
+
         while ($row = $query->fetch()) {
-            $label = $row['idvisitor'];
+            /** @var array<string, string|int|float|null> $row */
+            $label = (string) $row['idvisitor'];
             unset($row['idvisitor']);
             $record->sumRowWithLabel($label, $row);
         }

--- a/plugins/ExamplePlugin/RecordBuilders/ExampleMetric.php
+++ b/plugins/ExamplePlugin/RecordBuilders/ExampleMetric.php
@@ -40,7 +40,7 @@ class ExampleMetric extends RecordBuilder
     public const EXAMPLEPLUGIN_ARCHIVE_RECORD = "ExamplePlugin_archive_record";
     public const EXAMPLEPLUGIN_METRIC_NAME = 'ExamplePlugin_example_metric';
 
-    private $daysFrom = '2016-07-08';
+    private const DAYS_FROM = '2016-07-08';
 
     /**
      * This method should return the list of records this RecordBuilder creates. This example
@@ -79,8 +79,8 @@ class ExampleMetric extends RecordBuilder
         $records = [];
 
         // insert a test numeric metric that is the difference in days between the day we're archiving and
-        // $this->daysFrom.
-        $daysFrom = Date::factory($this->daysFrom);
+        // self::DAYS_FROM.
+        $daysFrom = Date::factory(self::DAYS_FROM);
         $date = $params->getPeriod()->getDateStart();
 
         $differenceInSeconds = $daysFrom->getTimestamp() - $date->getTimestamp();

--- a/plugins/ExamplePlugin/RecordBuilders/ExampleMetric2.php
+++ b/plugins/ExamplePlugin/RecordBuilders/ExampleMetric2.php
@@ -72,13 +72,13 @@ class ExampleMetric2 extends RecordBuilder
         return $records;
     }
 
-    private function getAndIncrementArchiveCallCount(ArchiveProcessor $archiveProcessor)
+    private function getAndIncrementArchiveCallCount(ArchiveProcessor $archiveProcessor): int
     {
         $params = $archiveProcessor->getParams();
         $optionName = 'ExamplePlugin.metricValue.' . md5($params->getSite()->getId() . '.' . $params->getPeriod()->getRangeString()
                 . '.' . $params->getPeriod()->getLabel() . '.' . $params->getSegment()->getHash());
         $value = (int) Option::get($optionName);
-        Option::set($optionName, $value + 1);
+        Option::set($optionName, (string) ($value + 1));
         return $value;
     }
 }

--- a/plugins/ExamplePlugin/Tasks.php
+++ b/plugins/ExamplePlugin/Tasks.php
@@ -11,6 +11,9 @@ namespace Piwik\Plugins\ExamplePlugin;
 
 class Tasks extends \Piwik\Plugin\Tasks
 {
+    /**
+     * @return void
+     */
     public function schedule()
     {
         $this->hourly('myTask');  // method will be executed once every hour
@@ -26,12 +29,12 @@ class Tasks extends \Piwik\Plugin\Tasks
         $this->monthly('myTaskWithParam', 'anystring', self::HIGH_PRIORITY);
     }
 
-    public function myTask()
+    public function myTask(): void
     {
         // do something
     }
 
-    public function myTaskWithParam($param)
+    public function myTaskWithParam(string $param): void
     {
         // do something
     }

--- a/plugins/ExamplePlugin/Updates/0.0.2.php
+++ b/plugins/ExamplePlugin/Updates/0.0.2.php
@@ -19,11 +19,8 @@ use Piwik\Updater\Migration\Factory as MigrationFactory;
  */
 class Updates_0_0_2 extends PiwikUpdates
 {
-    private MigrationFactory $migration;
-
-    public function __construct(MigrationFactory $factory)
+    public function __construct(private readonly MigrationFactory $migration)
     {
-        $this->migration = $factory;
     }
 
     /**
@@ -41,12 +38,12 @@ class Updates_0_0_2 extends PiwikUpdates
         // many different migrations are available to be used via $this->migration factory
         $migration1 = $this->migration->db->changeColumnType('log_visit', 'example', 'BOOLEAN NOT NULL');
         // you can also define custom SQL migrations. If you need to bind parameters, use `->boundSql()`
-        $migration2 = $this->migration->db->sql($sqlQuery = 'SELECT 1');
+        $migration2 = $this->migration->db->sql('SELECT 1');
 
-        return array(
+        return [
             // $migration1,
-            // $migration2
-        );
+            // $migration2,
+        ];
     }
 
     /**
@@ -54,6 +51,8 @@ class Updates_0_0_2 extends PiwikUpdates
      *
      * This method should perform all updating logic. If you define queries in the `getMigrations()` method,
      * you must call {@link Updater::executeMigrations()} here.
+     *
+     * @return void
      */
     public function doUpdate(Updater $updater)
     {

--- a/plugins/ExamplePlugin/Widgets/MyExampleWidget.php
+++ b/plugins/ExamplePlugin/Widgets/MyExampleWidget.php
@@ -45,7 +45,7 @@ class MyExampleWidget extends Widget
 
         /**
          * Optionally set URL parameters that will be used when this widget is requested.
-         * $config->setParameters(array('myparam' => 'myvalue'));
+         * $config->setParameters(['myparam' => 'myvalue']);
          */
 
         /**
@@ -71,7 +71,7 @@ class MyExampleWidget extends Widget
      */
     public function render()
     {
-        // or: return $this->renderTemplate('myViewTemplate', array(...view variables...));
+        // or: return $this->renderTemplate('myViewTemplate', [...view variables...]);
 
         return '<div class="widgetBody">My Widget Text</div>';
     }

--- a/plugins/ExamplePlugin/config/config.php
+++ b/plugins/ExamplePlugin/config/config.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExamplePlugin/config/tracker.php
+++ b/plugins/ExamplePlugin/config/tracker.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExamplePlugin/tests/Fixtures/SimpleFixtureTrackFewVisits.php
+++ b/plugins/ExamplePlugin/tests/Fixtures/SimpleFixtureTrackFewVisits.php
@@ -34,17 +34,17 @@ class SimpleFixtureTrackFewVisits extends Fixture
         // empty
     }
 
-    private function setUpWebsite()
+    private function setUpWebsite(): void
     {
         if (!self::siteCreated($this->idSite)) {
-            $idSite = self::createWebsite($this->dateTime, $ecommerce = 1);
+            $idSite = self::createWebsite($this->dateTime, ecommerce: 1);
             $this->assertSame($this->idSite, $idSite);
         }
     }
 
-    protected function trackFirstVisit()
+    protected function trackFirstVisit(): void
     {
-        $t = self::getTracker($this->idSite, $this->dateTime, $defaultInit = true);
+        $t = self::getTracker($this->idSite, $this->dateTime, defaultInit: true);
 
         $t->setForceVisitDateTime(Date::factory($this->dateTime)->addHour(0.1)->getDatetime());
         $t->setUrl('http://example.com/');
@@ -55,13 +55,13 @@ class SimpleFixtureTrackFewVisits extends Fixture
         self::checkResponse($t->doTrackPageView('Second page view'));
 
         $t->setForceVisitDateTime(Date::factory($this->dateTime)->addHour(0.25)->getDatetime());
-        $t->addEcommerceItem($sku = 'SKU_ID', $name = 'Test item!', $category = 'Test & Category', $price = 777, $quantity = 33);
-        self::checkResponse($t->doTrackEcommerceOrder('TestingOrder', $grandTotal = 33 * 77));
+        $t->addEcommerceItem(sku: 'SKU_ID', name: 'Test item!', category: 'Test & Category', price: 777, quantity: 33);
+        self::checkResponse($t->doTrackEcommerceOrder('TestingOrder', grandTotal: 33 * 77));
     }
 
-    protected function trackSecondVisit()
+    protected function trackSecondVisit(): void
     {
-        $t = self::getTracker($this->idSite, $this->dateTime, $defaultInit = true);
+        $t = self::getTracker($this->idSite, $this->dateTime, defaultInit: true);
         $t->setIp('56.11.55.73');
 
         $t->setForceVisitDateTime(Date::factory($this->dateTime)->addHour(0.1)->getDatetime());
@@ -73,7 +73,7 @@ class SimpleFixtureTrackFewVisits extends Fixture
         self::checkResponse($t->doTrackPageView('Site search query'));
 
         $t->setForceVisitDateTime(Date::factory($this->dateTime)->addHour(0.3)->getDatetime());
-        $t->addEcommerceItem($sku = 'SKU_ID2', $name = 'A durable item', $category = 'Best seller', $price = 321);
-        self::checkResponse($t->doTrackEcommerceCartUpdate($grandTotal = 33 * 77));
+        $t->addEcommerceItem(sku: 'SKU_ID2', name: 'A durable item', category: 'Best seller', price: 321);
+        self::checkResponse($t->doTrackEcommerceCartUpdate(33 * 77));
     }
 }

--- a/plugins/ExamplePlugin/tests/Integration/SimpleTest.php
+++ b/plugins/ExamplePlugin/tests/Integration/SimpleTest.php
@@ -35,7 +35,7 @@ class SimpleTest extends IntegrationTestCase
     /**
      * All your actual test methods should start with the name "test"
      */
-    public function testSimpleAddition()
+    public function testSimpleAddition(): void
     {
         $this->assertEquals(2, 1 + 1);
     }

--- a/plugins/ExamplePlugin/tests/System/SimpleSystemTest.php
+++ b/plugins/ExamplePlugin/tests/System/SimpleSystemTest.php
@@ -27,29 +27,29 @@ class SimpleSystemTest extends SystemTestCase
     /**
      * @dataProvider getApiForTesting
      */
-    public function testApi($api, $params)
+    public function testApi($api, $params): void
     {
         $this->runApiTests($api, $params);
     }
 
     public function getApiForTesting()
     {
-        $api = array(
+        $api = [
             'API.get',
             'Goals.getItemsSku',
-        );
+        ];
 
-        $apiToTest   = array();
-        $apiToTest[] = array($api,
-            array(
-                'idSite'     => 1,
-                'date'       => self::$fixture->dateTime,
-                'periods'    => array('day'),
-                'testSuffix' => '',
-            ),
-        );
-
-        return $apiToTest;
+        return [
+            [
+                $api,
+                [
+                    'idSite'     => 1,
+                    'date'       => self::$fixture->dateTime,
+                    'periods'    => ['day'],
+                    'testSuffix' => '',
+                ],
+            ],
+        ];
     }
 
     public static function getOutputPrefix()
@@ -59,7 +59,7 @@ class SimpleSystemTest extends SystemTestCase
 
     public static function getPathToTestDirectory()
     {
-        return dirname(__FILE__);
+        return __DIR__;
     }
 }
 

--- a/plugins/ExamplePlugin/tests/Unit/SimpleTest.php
+++ b/plugins/ExamplePlugin/tests/Unit/SimpleTest.php
@@ -29,7 +29,7 @@ class SimpleTest extends \PHPUnit\Framework\TestCase
     /**
      * All your actual test methods should start with the name "test"
      */
-    public function testSimpleAddition()
+    public function testSimpleAddition(): void
     {
         $this->assertEquals(2, 1 + 1);
     }

--- a/plugins/ExampleReport/API.php
+++ b/plugins/ExampleReport/API.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\ExampleReport;
 
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
+use Piwik\Piwik;
 
 /**
  * API for plugin ExampleReport
@@ -21,17 +22,16 @@ class API extends \Piwik\Plugin\API
 {
     /**
      * Another example method that returns a data table.
-     * @param int    $idSite
-     * @param string $period
-     * @param string $date
-     * @param bool|string $segment
-     * @return DataTable
+     *
+     * @param string $idSite (might be a number, or the string all)
      */
-    public function getExampleReport($idSite, $period, $date, $segment = false)
+    public function getExampleReport(string $idSite, string $period, string $date, ?string $segment = null): DataTable
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $table = new DataTable();
 
-        $table->addRowFromArray(array(Row::COLUMNS => array('nb_visits' => 5)));
+        $table->addRowFromArray([Row::COLUMNS => ['nb_visits' => 5]]);
 
         return $table;
     }

--- a/plugins/ExampleReport/Reports/Base.php
+++ b/plugins/ExampleReport/Reports/Base.php
@@ -13,6 +13,9 @@ use Piwik\Plugin\Report;
 
 abstract class Base extends Report
 {
+    /**
+     * @return void
+     */
     protected function init()
     {
         $this->categoryId = 'ExampleCategory';

--- a/plugins/ExampleReport/Reports/GetExampleReport.php
+++ b/plugins/ExampleReport/Reports/GetExampleReport.php
@@ -20,6 +20,9 @@ use Piwik\Plugins\Actions\Columns\ExitPageUrl;
  */
 class GetExampleReport extends Base
 {
+    /**
+     * @return void
+     */
     protected function init()
     {
         parent::init();
@@ -32,11 +35,11 @@ class GetExampleReport extends Base
         $this->order = 999;
 
         // By default standard metrics are defined but you can customize them by defining an array of metric names
-        // $this->metrics       = array('nb_visits', 'nb_hits');
+        // $this->metrics       = ['nb_visits', 'nb_hits'];
 
         // Uncomment the next line if your report does not contain any processed metrics, otherwise default
         // processed metrics will be assigned
-        // $this->processedMetrics = array();
+        // $this->processedMetrics = [];
 
         // Uncomment the next line if your report defines goal metrics
         // $this->hasGoalMetrics = true;
@@ -55,6 +58,8 @@ class GetExampleReport extends Base
     /**
      * Here you can configure how your report should be displayed. For instance whether your report supports a search
      * etc. You can also change the default request config. For instance change how many rows are displayed by default.
+     *
+     * @return void
      */
     public function configureView(ViewDataTable $view)
     {
@@ -62,7 +67,7 @@ class GetExampleReport extends Base
         // $view->requestConfig->filter_sort_column = 'nb_visits';
         // $view->requestConfig->filter_limit = 10';
 
-        $view->config->columns_to_display = array_merge(array('label'), $this->metrics);
+        $view->config->columns_to_display = array_merge(['label'], $this->metrics);
     }
 
     /**
@@ -73,7 +78,7 @@ class GetExampleReport extends Base
      */
     public function getRelatedReports()
     {
-        return array(); // eg return array(new XyzReport());
+        return []; // eg return [new XyzReport()];
     }
 
     /**
@@ -86,7 +91,7 @@ class GetExampleReport extends Base
     public function render()
     {
         $view = new View('@ExampleReport/getExampleReport');
-        $view->myData = array();
+        $view->myData = [];
 
         return $view->render();
     }

--- a/plugins/ExampleReport/config/config.php
+++ b/plugins/ExampleReport/config/config.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleReport/config/tracker.php
+++ b/plugins/ExampleReport/config/tracker.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleSettingsPlugin/MeasurableSettings.php
+++ b/plugins/ExampleSettingsPlugin/MeasurableSettings.php
@@ -10,8 +10,8 @@
 namespace Piwik\Plugins\ExampleSettingsPlugin;
 
 use Piwik\Plugins\MobileAppMeasurable\Type as MobileAppType;
-use Piwik\Settings\Setting;
 use Piwik\Settings\FieldConfig;
+use Piwik\Settings\Measurable\MeasurableSetting;
 
 /**
  * Defines Settings for ExampleSettingsPlugin.
@@ -24,12 +24,13 @@ use Piwik\Settings\FieldConfig;
  */
 class MeasurableSettings extends \Piwik\Settings\Measurable\MeasurableSettings
 {
-    /** @var Setting|null */
-    public $appId;
+    public ?MeasurableSetting $appId = null;
 
-    /** @var Setting */
-    public $contactEmails;
+    public MeasurableSetting $contactEmails;
 
+    /**
+     * @return void
+     */
     protected function init()
     {
         if ($this->hasMeasurableType(MobileAppType::ID)) {
@@ -40,7 +41,7 @@ class MeasurableSettings extends \Piwik\Settings\Measurable\MeasurableSettings
         $this->contactEmails = $this->makeContactEmailsSetting();
     }
 
-    private function makeAppIdSetting()
+    private function makeAppIdSetting(): MeasurableSetting
     {
         $defaultValue = '';
         $type = FieldConfig::TYPE_STRING;
@@ -52,9 +53,9 @@ class MeasurableSettings extends \Piwik\Settings\Measurable\MeasurableSettings
         });
     }
 
-    private function makeContactEmailsSetting()
+    private function makeContactEmailsSetting(): MeasurableSetting
     {
-        $defaultValue = array();
+        $defaultValue = [];
         $type = FieldConfig::TYPE_ARRAY;
 
         return $this->makeSetting('contact_email', $defaultValue, $type, function (FieldConfig $field) {

--- a/plugins/ExampleSettingsPlugin/SystemSettings.php
+++ b/plugins/ExampleSettingsPlugin/SystemSettings.php
@@ -9,8 +9,8 @@
 
 namespace Piwik\Plugins\ExampleSettingsPlugin;
 
-use Piwik\Settings\Setting;
 use Piwik\Settings\FieldConfig;
+use Piwik\Settings\Plugin\SystemSetting;
 use Piwik\Validators\NotEmpty;
 
 /**
@@ -23,18 +23,17 @@ use Piwik\Validators\NotEmpty;
  */
 class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
 {
-    /** @var Setting */
-    public $metric;
+    public SystemSetting $metric;
 
-    /** @var Setting */
-    public $browsers;
+    public SystemSetting $browsers;
 
-    /** @var Setting */
-    public $description;
+    public SystemSetting $description;
 
-    /** @var Setting */
-    public $password;
+    public SystemSetting $password;
 
+    /**
+     * @return void
+     */
     protected function init()
     {
         // System setting --> allows selection of a single value
@@ -50,30 +49,30 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         $this->password = $this->createPasswordSetting();
     }
 
-    private function createMetricSetting()
+    private function createMetricSetting(): SystemSetting
     {
-        return $this->makeSetting('metric', $default = 'nb_visits', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+        return $this->makeSetting('metric', 'nb_visits', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
             $field->title = 'Metric to display';
             $field->uiControl = FieldConfig::UI_CONTROL_SINGLE_SELECT;
-            $field->availableValues = array('nb_visits' => 'Visits', 'nb_actions' => 'Actions', 'visitors' => 'Visitors');
+            $field->availableValues = ['nb_visits' => 'Visits', 'nb_actions' => 'Actions', 'visitors' => 'Visitors'];
             $field->description = 'Choose the metric that should be displayed in the browser tab';
             $field->validators[] = new NotEmpty();
         });
     }
 
-    private function createBrowsersSetting()
+    private function createBrowsersSetting(): SystemSetting
     {
-        $default = array('firefox', 'chromium', 'safari');
+        $default = ['firefox', 'chromium', 'safari'];
 
         return $this->makeSetting('browsers', $default, FieldConfig::TYPE_ARRAY, function (FieldConfig $field) {
             $field->title = 'Supported Browsers';
             $field->uiControl = FieldConfig::UI_CONTROL_MULTI_SELECT;
-            $field->availableValues = array('firefox' => 'Firefox', 'chromium' => 'Chromium', 'safari' => 'safari');
+            $field->availableValues = ['firefox' => 'Firefox', 'chromium' => 'Chromium', 'safari' => 'safari'];
             $field->description = 'The value will be only displayed in the following browsers';
         });
     }
 
-    private function createDescriptionSetting()
+    private function createDescriptionSetting(): SystemSetting
     {
         $default = "This is the value: \nAnother line";
 
@@ -85,15 +84,14 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         });
     }
 
-    private function createPasswordSetting()
+    private function createPasswordSetting(): SystemSetting
     {
-        return $this->makeSetting('password', $default = null, FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+        return $this->makeSetting('password', null, FieldConfig::TYPE_STRING, function (FieldConfig $field) {
             $field->title = 'API password';
             $field->uiControl = FieldConfig::UI_CONTROL_PASSWORD;
             $field->description = 'Password for the 3rd API where we fetch the value';
-            $field->transform = function ($value) {
-                return password_hash($value, PASSWORD_DEFAULT);
-            };
+            // the transform callback receives the raw, not yet type casted request value
+            $field->transform = fn ($value) => password_hash(is_string($value) ? $value : '', PASSWORD_DEFAULT);
         });
     }
 }

--- a/plugins/ExampleSettingsPlugin/UserSettings.php
+++ b/plugins/ExampleSettingsPlugin/UserSettings.php
@@ -9,8 +9,9 @@
 
 namespace Piwik\Plugins\ExampleSettingsPlugin;
 
-use Piwik\Settings\Setting;
 use Piwik\Settings\FieldConfig;
+use Piwik\Settings\Plugin\UserSetting;
+use Piwik\Settings\Setting;
 
 /**
  * Defines Settings for ExampleSettingsPlugin.
@@ -22,15 +23,15 @@ use Piwik\Settings\FieldConfig;
  */
 class UserSettings extends \Piwik\Settings\Plugin\UserSettings
 {
-    /** @var Setting */
-    public $autoRefresh;
+    public UserSetting $autoRefresh;
 
-    /** @var Setting */
-    public $refreshInterval;
+    public UserSetting $refreshInterval;
 
-    /** @var Setting */
-    public $color;
+    public UserSetting $color;
 
+    /**
+     * @return void
+     */
     protected function init()
     {
         // User setting --> checkbox converted to bool
@@ -43,38 +44,39 @@ class UserSettings extends \Piwik\Settings\Plugin\UserSettings
         $this->color = $this->createColorSetting();
     }
 
-    private function createAutoRefreshSetting()
+    private function createAutoRefreshSetting(): UserSetting
     {
-        return $this->makeSetting('autoRefresh', $default = false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
+        return $this->makeSetting('autoRefresh', false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
             $field->title = 'Auto refresh';
             $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
             $field->description = 'If enabled, the value will be automatically refreshed depending on the specified interval';
         });
     }
 
-    private function createRefreshIntervalSetting()
+    private function createRefreshIntervalSetting(): UserSetting
     {
-        return $this->makeSetting('refreshInterval', $default = '30', FieldConfig::TYPE_INT, function (FieldConfig $field) {
+        return $this->makeSetting('refreshInterval', '30', FieldConfig::TYPE_INT, function (FieldConfig $field) {
             $field->title = 'Refresh Interval';
             $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
-            $field->uiControlAttributes = array('size' => 3);
+            $field->uiControlAttributes = ['size' => 3];
             $field->description = 'Defines how often the value should be updated';
             $field->inlineHelp  = 'Enter a number which is >= 15';
-            $field->validate = function ($value, $setting) {
-                if ($value < 15) {
+            // the validate callback receives the raw, not yet type casted request value
+            $field->validate = function ($value, Setting $setting) {
+                if (!is_numeric($value) || (int) $value < 15) {
                     throw new \Exception('Value is invalid');
                 }
             };
         });
     }
 
-    private function createColorSetting()
+    private function createColorSetting(): UserSetting
     {
-        return $this->makeSetting('color', $default = 'red', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+        return $this->makeSetting('color', 'red', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
             $field->title = 'Color';
             $field->uiControl = FieldConfig::UI_CONTROL_RADIO;
             $field->description = 'Pick your favourite color';
-            $field->availableValues = array('red' => 'Red', 'blue' => 'Blue', 'green' => 'Green');
+            $field->availableValues = ['red' => 'Red', 'blue' => 'Blue', 'green' => 'Green'];
         });
     }
 }

--- a/plugins/ExampleSettingsPlugin/config/config.php
+++ b/plugins/ExampleSettingsPlugin/config/config.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleSettingsPlugin/config/tracker.php
+++ b/plugins/ExampleSettingsPlugin/config/tracker.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleTheme/ExampleTheme.php
+++ b/plugins/ExampleTheme/ExampleTheme.php
@@ -20,7 +20,7 @@ class ExampleTheme extends Plugin
         ];
     }
 
-    public function configureThemeVariables(Plugin\ThemeStyles $vars)
+    public function configureThemeVariables(Plugin\ThemeStyles $vars): void
     {
         $vars->fontFamilyBase = 'Arial, Verdana, sans-serif';
         $vars->colorBrand = ['#5793d4', '#5793d4'];

--- a/plugins/ExampleTheme/config/config.php
+++ b/plugins/ExampleTheme/config/config.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleTheme/config/tracker.php
+++ b/plugins/ExampleTheme/config/tracker.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleTracker/Columns/ExampleActionDimension.php
+++ b/plugins/ExampleTracker/Columns/ExampleActionDimension.php
@@ -27,7 +27,7 @@ class ExampleActionDimension extends ActionDimension
 {
     /**
      * The name of the dimension which will be visible for instance in the UI of a related report and in the mobile app.
-     * @return string
+     * @var string
      */
     protected $nameSingular = 'ExampleTracker_DimensionName';
 
@@ -65,9 +65,9 @@ class ExampleActionDimension extends ActionDimension
     /**
      * This event is triggered before a new action is logged to the log_link_visit_action table. It overwrites any
      * looked up action so it makes usually no sense to implement both methods but it sometimes does. You can assign
-     * any value to the column or return boolan false in case you do not want to save any value.
+     * any value to the column or return boolean false in case you do not want to save any value.
      *
-     * @return mixed|false
+     * @return string|false
      */
     public function onNewAction(Request $request, Visitor $visitor, Action $action)
     {
@@ -76,13 +76,12 @@ class ExampleActionDimension extends ActionDimension
             return false;
         }
 
-        $value = Common::getRequestVar('my_page_keywords', false, 'string', $request->getParams());
+        $value = trim(Common::getRequestVar('my_page_keywords', '', 'string', $request->getParams()));
 
-        if (false === $value) {
-            return $value;
+        if ('' === $value) {
+            // nothing was tracked for this action, so do not save any value.
+            return false;
         }
-
-        $value = trim($value);
 
         return substr($value, 0, 255);
     }
@@ -96,10 +95,9 @@ class ExampleActionDimension extends ActionDimension
      * "onNewAction" the value will be probably overwritten by the other event. So make sure to implement only one of
      * those.
      *
-     * @param Request $request
-     * @param Action $action
+     * Uncomment the following method to enable this behaviour:
      *
-     * @return false|mixed
+     * @return string|false
     public function onLookupAction(Request $request, Action $action)
     {
         if (!($action instanceof ActionPageview)) {
@@ -107,13 +105,12 @@ class ExampleActionDimension extends ActionDimension
             return false;
         }
 
-        $value = Common::getRequestVar('my_page_keywords', false, 'string', $request->getParams());
+        $value = trim(Common::getRequestVar('my_page_keywords', '', 'string', $request->getParams()));
 
-        if (false === $value) {
-            return $value;
+        if ('' === $value) {
+            // nothing was tracked for this action, so do not save any value.
+            return false;
         }
-
-        $value = trim($value);
 
         return substr($value, 0, 255);
     }
@@ -121,6 +118,7 @@ class ExampleActionDimension extends ActionDimension
 
     /**
      * An action id. The value returned by the lookup action will be associated with this id in the log_action table.
+     *
      * @return int
     public function getActionId()
     {

--- a/plugins/ExampleTracker/Columns/ExampleConversionDimension.php
+++ b/plugins/ExampleTracker/Columns/ExampleConversionDimension.php
@@ -51,7 +51,7 @@ class ExampleConversionDimension extends ConversionDimension
 
     /**
      * The name of the dimension which will be visible for instance in the UI of a related report and in the mobile app.
-     * @return string
+     * @var string
      */
     protected $nameSingular = 'ExampleTracker_DimensionName';
 
@@ -71,16 +71,11 @@ class ExampleConversionDimension extends ConversionDimension
      * action on an ecommerce order at all it is recommended to just remove this method.
      *
      * @param Action|null $action
-     *
-     * @return mixed|false
+     * @return int
      */
     public function onEcommerceOrderConversion(Request $request, Visitor $visitor, $action, GoalManager $goalManager)
     {
-        if ($visitor->isVisitorKnown()) {
-            return 1;
-        }
-
-        return 0;
+        return $visitor->isVisitorKnown() ? 1 : 0;
     }
 
     /**
@@ -90,12 +85,11 @@ class ExampleConversionDimension extends ConversionDimension
      * action on an ecommerce order at all it is recommended to just remove this method.
      *
      * @param Action|null $action
-     *
-     * @return mixed|false
+     * @return int
      */
     public function onEcommerceCartUpdateConversion(Request $request, Visitor $visitor, $action, GoalManager $goalManager)
     {
-        return Common::getRequestVar('myCustomParam', $default = false, 'int', $request->getParams());
+        return Common::getRequestVar('myCustomParam', 0, 'int', $request->getParams());
     }
 
     /**
@@ -110,12 +104,10 @@ class ExampleConversionDimension extends ConversionDimension
      */
     public function onGoalConversion(Request $request, Visitor $visitor, $action, GoalManager $goalManager)
     {
-        $goalId = $goalManager->getGoalColumn('idgoal');
-
-        if ($visitor->isVisitorKnown()) {
-            return $goalId;
+        if (!$visitor->isVisitorKnown()) {
+            return false;
         }
 
-        return false;
+        return $goalManager->getGoalColumn('idgoal');
     }
 }

--- a/plugins/ExampleTracker/Columns/ExampleDimension.php
+++ b/plugins/ExampleTracker/Columns/ExampleDimension.php
@@ -20,7 +20,7 @@ class ExampleDimension extends Dimension
 {
     /**
      * The name of the dimension which will be visible for instance in the UI of a related report and in the mobile app.
-     * @return string
+     * @var string
      */
     protected $nameSingular = 'ExampleTracker_DimensionName';
 }

--- a/plugins/ExampleTracker/Columns/ExampleVisitDimension.php
+++ b/plugins/ExampleTracker/Columns/ExampleVisitDimension.php
@@ -50,7 +50,7 @@ class ExampleVisitDimension extends VisitDimension
 
     /**
      * The name of the dimension which will be visible for instance in the UI of a related report and in the mobile app.
-     * @return string
+     * @var string
      */
     protected $nameSingular = 'ExampleTracker_DimensionName';
 
@@ -70,7 +70,7 @@ class ExampleVisitDimension extends VisitDimension
      * to perform any action on a new visit you can just remove this method.
      *
      * @param Action|null $action
-     * @return mixed|false
+     * @return string|int
      */
     public function onNewVisit(Request $request, Visitor $visitor, $action)
     {
@@ -96,8 +96,7 @@ class ExampleVisitDimension extends VisitDimension
      * will be updated. If you do not want to perform any action on a new visit you can just remove this method.
      *
      * @param Action|null $action
-     *
-     * @return mixed|false
+     * @return string|int|false
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {
@@ -110,7 +109,7 @@ class ExampleVisitDimension extends VisitDimension
             return false; // Do not change an already persisted value
         }
 
-        return $visitor->getVisitorColumn($this->columnName) + 1;
+        return $this->getAchievementPoints($visitor) + 1;
     }
 
     /**
@@ -120,12 +119,11 @@ class ExampleVisitDimension extends VisitDimension
      * action url. Return boolean false if you do not want to change the current value.
      *
      * @param Action|null $action
-     *
-     * @return mixed|false
+     * @return int
      */
     public function onConvertedVisit(Request $request, Visitor $visitor, $action)
     {
-        return $visitor->getVisitorColumn($this->columnName) + 5;  // give this visitor 5 extra achievement points
+        return $this->getAchievementPoints($visitor) + 5;  // give this visitor 5 extra achievement points
     }
 
     /**
@@ -135,11 +133,9 @@ class ExampleVisitDimension extends VisitDimension
      * conversion. Once you implement this event and a $columnType is defined a column in the log_conversion MySQL table
      * will be created automatically.
      *
-     * @param Request $request
-     * @param Visitor $visitor
      * @param Action|null $action
-     *
      * @return mixed
+     *
     public function onAnyGoalConversion(Request $request, Visitor $visitor, $action)
     {
         return $visitor->getVisitorColumn($this->columnName);
@@ -151,10 +147,22 @@ class ExampleVisitDimension extends VisitDimension
      * a value depending on the value of other dimensions. You can do this by defining an array of dimension names.
      * If you access any value of any other column within your events, you should require them here. Otherwise those
      * values may not be available.
-     * @return array
+     *
+     * @return string[]
     public function getRequiredVisitFields()
     {
-        return array('idsite', 'server_time');
+        return ['idsite', 'server_time'];
     }
     */
+
+    /**
+     * Reads the currently persisted value for this dimension. A visitor column is not guaranteed to hold a number,
+     * so the raw value needs to be checked before it is used in a calculation.
+     */
+    private function getAchievementPoints(Visitor $visitor): int
+    {
+        $points = $visitor->getVisitorColumn($this->columnName);
+
+        return is_numeric($points) ? (int) $points : 0;
+    }
 }

--- a/plugins/ExampleTracker/VisitorDetails.php
+++ b/plugins/ExampleTracker/VisitorDetails.php
@@ -14,11 +14,18 @@ use Piwik\View;
 
 class VisitorDetails extends VisitorDetailsAbstract
 {
+    /**
+     * @param array<string, mixed> $visitor
+     * @return void
+     */
     public function extendVisitorDetails(&$visitor)
     {
-        $visitor['myCustomVisitParam'] = isset($this->details['example_visit_dimension']) ? $this->details['example_visit_dimension'] : 'no-value';
+        $visitor['myCustomVisitParam'] = $this->details['example_visit_dimension'] ?? 'no-value';
     }
 
+    /**
+     * @param array<string, mixed> $visitorDetails
+     */
     public function renderIcons($visitorDetails)
     {
         if (empty($visitorDetails['myCustomVisitParam'])) {

--- a/plugins/ExampleTracker/config/config.php
+++ b/plugins/ExampleTracker/config/config.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleTracker/config/tracker.php
+++ b/plugins/ExampleTracker/config/tracker.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleUI/API.php
+++ b/plugins/ExampleUI/API.php
@@ -23,17 +23,17 @@ use Piwik\Period\Range;
  */
 class API extends \Piwik\Plugin\API
 {
-    public static $disableRandomness = false;
+    public static bool $disableRandomness = false;
 
-    public function getTemperaturesEvolution(string $date, string $period)
+    public function getTemperaturesEvolution(string $date, string $period): DataTable
     {
-        $temperatures = array();
+        $temperatures = [];
 
-        $date   = Date::factory('2013-10-10', 'UTC');
-        $period = new Range($period, 'last30');
-        $period->setDefaultEndDate($date);
+        $endDate = Date::factory('2013-10-10', 'UTC');
+        $range   = new Range($period, 'last30');
+        $range->setDefaultEndDate($endDate);
 
-        foreach ($period->getSubperiods() as $subPeriod) {
+        foreach ($range->getSubperiods() as $subPeriod) {
             if (self::$disableRandomness) {
                 $server1 = 50;
                 $server2 = 40;
@@ -42,27 +42,25 @@ class API extends \Piwik\Plugin\API
                 $server2 = mt_rand(40, 110);
             }
 
-            $value = array('server1' => $server1, 'server2' => $server2);
-
-            $temperatures[$subPeriod->getLocalizedShortString()] = $value;
+            $temperatures[$subPeriod->getLocalizedShortString()] = ['server1' => $server1, 'server2' => $server2];
         }
 
         return DataTable::makeFromIndexedArray($temperatures);
     }
 
-    public function getTemperatures()
+    public function getTemperatures(): DataTable
     {
-        $xAxis = array(
+        $xAxis = [
             '0h', '1h', '2h', '3h', '4h', '5h', '6h', '7h', '8h', '9h', '10h', '11h',
             '12h', '13h', '14h', '15h', '16h', '17h', '18h', '19h', '20h', '21h', '22h', '23h',
-        );
+        ];
 
         $temperatureValues = array_slice(range(50, 90), 0, count($xAxis));
         if (!self::$disableRandomness) {
             shuffle($temperatureValues);
         }
 
-        $temperatures = array();
+        $temperatures = [];
         foreach ($xAxis as $i => $xAxisLabel) {
             $temperatures[$xAxisLabel] = $temperatureValues[$i];
         }
@@ -70,9 +68,9 @@ class API extends \Piwik\Plugin\API
         return DataTable::makeFromIndexedArray($temperatures);
     }
 
-    public function getPlanetRatios()
+    public function getPlanetRatios(): DataTable
     {
-        $planetRatios = array(
+        $planetRatios = [
             'Mercury' => 0.382,
             'Venus'   => 0.949,
             'Earth'   => 1.00,
@@ -81,21 +79,24 @@ class API extends \Piwik\Plugin\API
             'Saturn'  => 9.449,
             'Uranus'  => 4.007,
             'Neptune' => 3.883,
-        );
+        ];
 
         return DataTable::makeFromIndexedArray($planetRatios);
     }
 
-    public function getPlanetRatiosWithLogos()
+    public function getPlanetRatiosWithLogos(): DataTable
     {
         $planetsDataTable = $this->getPlanetRatios();
 
         foreach ($planetsDataTable->getRows() as $row) {
-            $logo = sprintf('plugins/ExampleUI/images/icons-planet/%s.png', strtolower($row->getColumn('label')));
-            $url = sprintf('http://en.wikipedia.org/wiki/%s', $row->getColumn('label'));
+            $label = $row->getColumn('label');
 
-            $row->addMetadata('logo', $logo);
-            $row->addMetadata('url', $url);
+            if (!is_string($label)) {
+                continue;
+            }
+
+            $row->addMetadata('logo', sprintf('plugins/ExampleUI/images/icons-planet/%s.png', strtolower($label)));
+            $row->addMetadata('url', sprintf('http://en.wikipedia.org/wiki/%s', $label));
         }
 
         return $planetsDataTable;

--- a/plugins/ExampleUI/Controller.php
+++ b/plugins/ExampleUI/Controller.php
@@ -14,7 +14,7 @@ use Piwik\View;
 
 class Controller extends \Piwik\Plugin\Controller
 {
-    public function notifications()
+    public function notifications(): string
     {
         $notification = new Notification('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
         Notification\Manager::notify('ExampleUI_InfoSimple', $notification);
@@ -22,7 +22,7 @@ class Controller extends \Piwik\Plugin\Controller
         $notification = new Notification('Neque porro quisquam est qui dolorem ipsum quia dolor sit amet.');
         $notification->title   = 'Warning:';
         $notification->context = Notification::CONTEXT_WARNING;
-        $notification->flags   = null;
+        $notification->flags   = Notification::FLAG_CLEAR;
         Notification\Manager::notify('ExampleUI_warningWithClose', $notification);
 
         $notification = new Notification('Phasellus tincidunt arcu at justo faucibus, et lacinia est accumsan. ');

--- a/plugins/ExampleUI/Menu.php
+++ b/plugins/ExampleUI/Menu.php
@@ -13,8 +13,11 @@ use Piwik\Menu\MenuAdmin;
 
 class Menu extends \Piwik\Plugin\Menu
 {
+    /**
+     * @return void
+     */
     public function configureAdminMenu(MenuAdmin $menu)
     {
-        $menu->addPlatformItem('ExampleUI_UiNotifications', $this->urlForAction('notifications'), $order = 10);
+        $menu->addPlatformItem('ExampleUI_UiNotifications', $this->urlForAction('notifications'), 10);
     }
 }

--- a/plugins/ExampleUI/Reports/Base.php
+++ b/plugins/ExampleUI/Reports/Base.php
@@ -13,6 +13,9 @@ use Piwik\Plugin\Report;
 
 abstract class Base extends Report
 {
+    /**
+     * @return void
+     */
     protected function init()
     {
         $this->categoryId = 'ExampleUI_UiFramework';

--- a/plugins/ExampleUI/Reports/GetPlanetRatios.php
+++ b/plugins/ExampleUI/Reports/GetPlanetRatios.php
@@ -22,6 +22,9 @@ use Piwik\Widget\WidgetsList;
  */
 class GetPlanetRatios extends Base
 {
+    /**
+     * @return void
+     */
     protected function init()
     {
         parent::init();
@@ -37,6 +40,9 @@ class GetPlanetRatios extends Base
         return Pie::ID;
     }
 
+    /**
+     * @return void
+     */
     public function configureWidgets(WidgetsList $widgetsList, ReportWidgetFactory $factory)
     {
         $widgetsList->addWidgetConfig(
@@ -53,17 +59,20 @@ class GetPlanetRatios extends Base
         );
     }
 
+    /**
+     * @return void
+     */
     public function configureView(ViewDataTable $view)
     {
         $view->config->addTranslation('value', 'times the diameter of Earth');
 
         if ($view->isViewDataTableId(Pie::ID)) {
-            $view->config->columns_to_display = array('value');
-            $view->config->selectable_columns = array('value');
+            $view->config->columns_to_display = ['value'];
+            $view->config->selectable_columns = ['value'];
             $view->config->show_footer_icons = false;
             $view->config->max_graph_elements = 10;
         } elseif ($view->isViewDataTableId(Cloud::ID)) {
-            $view->config->columns_to_display = array('label', 'value');
+            $view->config->columns_to_display = ['label', 'value'];
             $view->config->show_footer = false;
         }
     }

--- a/plugins/ExampleUI/Reports/GetPlanetRatiosWithLogos.php
+++ b/plugins/ExampleUI/Reports/GetPlanetRatiosWithLogos.php
@@ -20,6 +20,9 @@ use Piwik\Plugins\CoreVisualizations\Visualizations\Cloud;
  */
 class GetPlanetRatiosWithLogos extends Base
 {
+    /**
+     * @return void
+     */
     protected function init()
     {
         parent::init();
@@ -35,10 +38,13 @@ class GetPlanetRatiosWithLogos extends Base
         return Cloud::ID;
     }
 
+    /**
+     * @return void
+     */
     public function configureView(ViewDataTable $view)
     {
         $view->config->display_logo_instead_of_label = true;
-        $view->config->columns_to_display = array('label', 'value');
+        $view->config->columns_to_display = ['label', 'value'];
         $view->config->addTranslation('value', 'times the diameter of Earth');
     }
 }

--- a/plugins/ExampleUI/Reports/GetTemperatures.php
+++ b/plugins/ExampleUI/Reports/GetTemperatures.php
@@ -23,6 +23,9 @@ use Piwik\Widget\WidgetsList;
  */
 class GetTemperatures extends Base
 {
+    /**
+     * @return void
+     */
     protected function init()
     {
         parent::init();
@@ -33,6 +36,9 @@ class GetTemperatures extends Base
         $this->order = 110;
     }
 
+    /**
+     * @return void
+     */
     public function configureWidgets(WidgetsList $widgetsList, ReportWidgetFactory $factory)
     {
         // this will render the default view, in this case an Html Table
@@ -54,34 +60,39 @@ class GetTemperatures extends Base
         }
     }
 
+    /**
+     * @return void
+     */
     public function configureView(ViewDataTable $view)
     {
         if ($view->isViewDataTableId(Bar::ID)) {
             $view->config->y_axis_unit = '°C';
             $view->config->show_footer = false;
-            $view->config->translations['value'] = "Temperature";
-            $view->config->selectable_columns = array("value");
+            $view->config->addTranslation('value', 'Temperature');
+            $view->config->selectable_columns = ['value'];
             $view->config->max_graph_elements = 24;
         } elseif ($view->isViewDataTableId('infoviz-treemap')) {
-            $view->config->translations['value'] = "Temperature";
-            $view->config->columns_to_display = array("label", "value");
-            $view->config->selectable_columns = array("value");
+            $view->config->addTranslation('value', 'Temperature');
+            $view->config->columns_to_display = ['label', 'value'];
+            $view->config->selectable_columns = ['value'];
             $view->config->show_evolution_values = 0;
         } else {
             // for default view datatable, eg HtmlTable
 
-            $view->config->translations['value'] = 'Temperature in °C';
-            $view->config->translations['label'] = 'Hour of day';
+            $view->config->addTranslations([
+                'value' => 'Temperature in °C',
+                'label' => 'Hour of day',
+            ]);
             $view->requestConfig->filter_sort_column = 'label';
             $view->requestConfig->filter_sort_order = 'asc';
             $view->requestConfig->filter_limit = 24;
-            $view->config->columns_to_display  = array('label', 'value');
+            $view->config->columns_to_display  = ['label', 'value'];
             $view->config->y_axis_unit = '°C'; // useful if the user requests the bar graph
             $view->config->show_exclude_low_population = false;
             $view->config->show_table_all_columns = false;
             $view->config->disable_row_evolution  = true;
             $view->config->max_graph_elements = 24;
-            $view->config->metrics_documentation = array('value' => 'Documentation for temperature metric');
+            $view->config->metrics_documentation = ['value' => 'Documentation for temperature metric'];
         }
     }
 }

--- a/plugins/ExampleUI/Reports/GetTemperaturesEvolution.php
+++ b/plugins/ExampleUI/Reports/GetTemperaturesEvolution.php
@@ -24,6 +24,9 @@ use Piwik\Widget\WidgetsList;
  */
 class GetTemperaturesEvolution extends Base
 {
+    /**
+     * @return void
+     */
     protected function init()
     {
         parent::init();
@@ -33,6 +36,9 @@ class GetTemperaturesEvolution extends Base
         $this->order = 111;
     }
 
+    /**
+     * @return void
+     */
     public function configureWidgets(WidgetsList $widgetsList, ReportWidgetFactory $factory)
     {
         $widgetsList->addWidgetConfig(
@@ -46,36 +52,42 @@ class GetTemperaturesEvolution extends Base
                     ->setName('ExampleUI_TemperaturesEvolution')
                     ->setSubcategoryId('Evolution Graph')
                     ->forceViewDataTable(Evolution::ID)
-                    ->setParameters(array('columns' => array('server1', 'server2')))
+                    ->setParameters(['columns' => ['server1', 'server2']])
         );
     }
 
     /**
      * Here you can configure how your report should be displayed. For instance whether your report supports a search
      * etc. You can also change the default request config. For instance change how many rows are displayed by default.
+     *
+     * @return void
      */
     public function configureView(ViewDataTable $view)
     {
         if ($view->isViewDataTableId(Sparklines::ID)) {
-
             /** @var Sparklines $view */
-            $view->config->addSparklineMetric(array('server1'));
-            $view->config->addSparklineMetric(array('server2'));
-            $view->config->addTranslations(array('server1' => 'Evolution of temperature for server piwik.org'));
-            $view->config->addTranslations(array('server2' => 'Evolution of temperature for server dev.piwik.org'));
+            $view->config->addSparklineMetric(['server1']);
+            $view->config->addSparklineMetric(['server2']);
+            $view->config->addTranslations([
+                'server1' => 'Evolution of temperature for server piwik.org',
+                'server2' => 'Evolution of temperature for server dev.piwik.org',
+            ]);
         } elseif ($view->isViewDataTableId(Evolution::ID)) {
-
             /** @var Evolution $view */
-            $selectableColumns = array('server1', 'server2');
+            $selectableColumns = ['server1', 'server2'];
 
-            $columns = Common::getRequestVar('columns', false);
-            if (!empty($columns)) {
-                $columns = Piwik::getArrayFromApiParameter($columns);
+            // the requested columns may be sent as a comma separated string or as an array
+            $requestedColumns = Common::getRequestVar('columns', '');
+
+            if (is_string($requestedColumns)) {
+                $requestedColumns = Piwik::getArrayFromApiParameter($requestedColumns);
+            } elseif (!is_array($requestedColumns)) {
+                $requestedColumns = [];
             }
 
-            $columns = array_merge($columns ? $columns : array(), $selectableColumns);
-            $view->config->columns_to_display = $columns;
+            $columns = array_merge(array_filter($requestedColumns, 'is_string'), $selectableColumns);
 
+            $view->config->columns_to_display = $columns;
             $view->config->addTranslations(array_combine($columns, $columns));
             $view->config->selectable_columns = $selectableColumns;
             $view->requestConfig->filter_sort_column = 'label';

--- a/plugins/ExampleUI/config/config.php
+++ b/plugins/ExampleUI/config/config.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleUI/config/tracker.php
+++ b/plugins/ExampleUI/config/tracker.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleVisualization/Visualizations/SimpleTable.php
+++ b/plugins/ExampleVisualization/Visualizations/SimpleTable.php
@@ -22,12 +22,18 @@ class SimpleTable extends Visualization
     public const FOOTER_ICON_TITLE = 'Simple Table';
     public const FOOTER_ICON       = 'plugins/ExampleVisualization/images/table.png';
 
+    /**
+     * @return void
+     */
     public function beforeLoadDataTable()
     {
         // Here you can change the request that is sent to the API, for instance
         // $this->requestConfig->filter_sort_order = 'desc';
     }
 
+    /**
+     * @return void
+     */
     public function beforeGenericFiltersAreAppliedToLoadedDataTable()
     {
         // this hook is executed before generic filters like "filter_limit" and "filter_offset" are applied
@@ -35,6 +41,9 @@ class SimpleTable extends Visualization
         // $this->dateTable->filter($nameOrClosure);
     }
 
+    /**
+     * @return void
+     */
     public function afterGenericFiltersAreAppliedToLoadedDataTable()
     {
         // this hook is executed after generic filters like "filter_limit" and "filter_offset" are applied
@@ -42,6 +51,9 @@ class SimpleTable extends Visualization
         // $this->dateTable->filter($nameOrClosure, $parameters);
     }
 
+    /**
+     * @return void
+     */
     public function afterAllFiltersAreApplied()
     {
         // this hook is executed after the data table is loaded and after all filteres are applied.
@@ -50,6 +62,9 @@ class SimpleTable extends Visualization
         $this->assignTemplateVar('vizTitle', 'MyAwesomeTitle');
     }
 
+    /**
+     * @return void
+     */
     public function beforeRender()
     {
         // Configure how your visualization should look like, for instance you can disable search

--- a/plugins/ExampleVisualization/config/config.php
+++ b/plugins/ExampleVisualization/config/config.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];

--- a/plugins/ExampleVisualization/config/tracker.php
+++ b/plugins/ExampleVisualization/config/tracker.php
@@ -1,3 +1,3 @@
 <?php
 
-return array();
+return [];


### PR DESCRIPTION
### Description

The `Example*` plugins are what plugin developers (and increasingly AI tooling) copy as the starting point for a new plugin, but they had not been maintained for a while. This is a first pass to bring them up to the standard we want them to demonstrate. Nothing about *what* they illustrate changes.

Improvement categories applied across all eleven plugins:

- **Type information** — return and parameter types on everything the plugins declare themselves, plus annotations where a native type cannot be used. Inherited framework hooks stay untyped on purpose, so a later signature change in core cannot break them.
- **Modern PHP** — short array syntax, `readonly` and promoted constructor properties, class constants, named arguments, null coalescing, arrow functions.
- **Correct API usage** — a handful of calls passed arguments in the wrong slot or of the wrong type, one condition could never match, one API method was missing its access check, and one event handler was registered for an event core never posts.
- **Consistency** — documented setters instead of writing to config arrays directly, core `Db` helpers instead of hand-rolled ones, missing license headers.

Two core additions were needed so the examples could be analysed strictly. Both are docblock-only, deliberately: a native return type on `Piwik\Tracker\Request::getParams()` would be an unexpected breaking change for plugins that subclass it.

The plugins are clean at PHPStan's maximum level and under PHP_CodeSniffer. I did not wire that up as a standing check, so this is a one-off.

Follow-ups left for a later pass: some example docblocks still describe code that no longer matches the method body, and `ExampleVue`'s frontend side is untouched.

### Review

- [ ] Functional review
- [ ] Code review
- [ ] Tests were added if useful/possible
- [ ] Reviewed for security

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules