### PR TITLE
Add a "What's New" panel to the login layout - 5x

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -85,6 +85,11 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
     private $passwordStrength;
 
     /**
+     * @var WhatsNewProvider
+     */
+    private $whatsNewProvider;
+
+    /**
      * @param PasswordResetter $passwordResetter
      * @param \Piwik\Auth $auth
      * @param SessionInitializer $sessionInitializer
@@ -92,6 +97,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
      * @param BruteForceDetection $bruteForceDetection
      * @param SystemSettings $systemSettings
      * @param PasswordStrength $passwordStrength
+     * @param WhatsNewProvider $whatsNewProvider
      */
     public function __construct(
         $passwordResetter = null,
@@ -100,7 +106,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $passwordVerify = null,
         $bruteForceDetection = null,
         $systemSettings = null,
-        $passwordStrength = null
+        $passwordStrength = null,
+        $whatsNewProvider = null
     ) {
         parent::__construct();
 
@@ -138,6 +145,11 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             $passwordStrength = StaticContainer::get('Piwik\Auth\PasswordStrength');
         }
         $this->passwordStrength = $passwordStrength;
+
+        if (empty($whatsNewProvider)) {
+            $whatsNewProvider = StaticContainer::get(WhatsNewProvider::class);
+        }
+        $this->whatsNewProvider = $whatsNewProvider;
     }
 
     /**
@@ -210,6 +222,18 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
         // crsf token: don't trust the submitted value; generate/fetch it from session data
         $view->nonce = Nonce::getNonce('Login.login');
+
+        $view->whatsNewChanges = $this->getWhatsNewChanges();
+    }
+
+    /**
+     * The "What's New" entries shown by the shared login layout.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function getWhatsNewChanges(): array
+    {
+        return $this->whatsNewProvider->getChanges();
     }
 
     public function confirmPassword()
@@ -246,6 +270,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
           'nonce'             => Nonce::getNonce($nonceKey),
           'AccessErrorString' => $messageNoAccess,
           'loginPlugin'       => Piwik::getLoginPluginName(),
+          'whatsNewChanges'   => $this->getWhatsNewChanges(),
         ]);
     }
 
@@ -516,6 +541,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             'loginPlugin' => Piwik::getLoginPluginName(),
             'login' => $login,
             'resetToken' => $resetToken,
+            'whatsNewChanges' => $this->getWhatsNewChanges(),
         ], 'basic');
     }
 
@@ -558,7 +584,10 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
         return $this->renderTemplateAs(
             '@Login/cancelResetPassword',
-            ['cancelResetPasswordContent' => $cancelResetPasswordContent],
+            [
+                'cancelResetPasswordContent' => $cancelResetPasswordContent,
+                'whatsNewChanges' => $this->getWhatsNewChanges(),
+            ],
             'basic'
         );
     }
@@ -621,6 +650,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
           'nonce'        => $nonce,
           'errorMessage' => $errorMessage,
           'loginPlugin' => Piwik::getLoginPluginName(),
+          'whatsNewChanges' => $this->getWhatsNewChanges(),
         ], 'basic');
     }
 

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -272,6 +272,7 @@ class Login extends \Piwik\Plugin
         $stylesheetFiles[] = "plugins/Login/stylesheets/variables.less";
         $stylesheetFiles[] = "plugins/Login/stylesheets/loginLayout.less";
         $stylesheetFiles[] = "plugins/Login/stylesheets/loginForm.less";
+        $stylesheetFiles[] = "plugins/Login/stylesheets/loginWhatsNew.less";
     }
 
     /**

--- a/plugins/Login/WhatsNewProvider.php
+++ b/plugins/Login/WhatsNewProvider.php
@@ -1,0 +1,234 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Login;
+
+use Piwik\Cache;
+use Piwik\CacheId;
+use Piwik\Changes\Model as ChangesModel;
+use Piwik\Common;
+use Piwik\Log\LoggerInterface;
+use Piwik\Piwik;
+use Piwik\Plugin\Manager as PluginManager;
+
+/**
+ * The "What's New" entries shown on the login layout (`@Login/loginLayout.twig`, shared by Login
+ * and TwoFactorAuth).
+ *
+ * Takes the three most recent changes and keeps a link only when a logged out visitor could follow
+ * it. An entry always keeps its title and description; only the link goes. Any failure is logged
+ * and returns an empty list, so the login page always renders.
+ */
+class WhatsNewProvider
+{
+    private const MAX_ENTRIES = 3;
+
+    /**
+     * Hosts whose links may show a call to action, subdomains included. Anything else keeps its
+     * entry and loses the link - including an absolute link back to this instance, which a logged
+     * out visitor could not follow either.
+     */
+    private const ALLOWED_LINK_HOSTS = ['matomo.org'];
+
+    private const CACHE_KEY = 'Login.whatsNewPanel';
+
+    /**
+     * Lifetime of the cached entries, in seconds.
+     */
+    private const CACHE_TTL = 3600;
+
+    /**
+     * @var ChangesModel
+     */
+    private $changesModel;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Per-request cache of the processed entries.
+     *
+     * @var array<int, array<string, mixed>>|null
+     */
+    private $changes = null;
+
+    public function __construct(ChangesModel $changesModel, LoggerInterface $logger)
+    {
+        $this->changesModel = $changesModel;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Returns the processed What's New entries for the login layout.
+     *
+     * @return array<int, array<string, mixed>> Each entry has: title, description, plugin_name,
+     *                                           showPluginPrefix, link, link_name. Empty on any failure.
+     */
+    public function getChanges(): array
+    {
+        if ($this->changes !== null) {
+            return $this->changes;
+        }
+
+        try {
+            $this->changes = $this->loadChanges();
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'Unable to build the login What\'s New panel entries: {message}',
+                ['message' => $e->getMessage(), 'exception' => $e]
+            );
+            $this->changes = [];
+        }
+
+        return $this->changes;
+    }
+
+    /**
+     * The finished entries, cached across requests for logged out visitors so this public page
+     * doesn't query on every hit.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function loadChanges(): array
+    {
+        $cache = Cache::getLazyCache();
+
+        // The plugin list and language are part of the id, so activating a plugin invalidates it.
+        $cacheKey = CacheId::pluginAware(self::CACHE_KEY);
+
+        // Only a logged out visitor may read or fill this. `Changes.filterChanges` can rewrite the
+        // list per user, so an authenticated request builds its own instead of inheriting somebody
+        // else's.
+        $isAnonymous = Piwik::isUserIsAnonymous();
+
+        if ($isAnonymous) {
+            $cached = $cache->fetch($cacheKey);
+
+            if (is_array($cached) && !empty($cached)) {
+                return $cached;
+            }
+        }
+
+        $changes = $this->buildChanges();
+
+        // Never pin an empty result: a fresh install records its first change eventually, and the
+        // panel should show it without waiting out the TTL.
+        if ($isAnonymous && !empty($changes)) {
+            $cache->save($cacheKey, $changes, self::CACHE_TTL);
+        }
+
+        return $changes;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildChanges(): array
+    {
+        // WhiteLabel installs must not reveal any Matomo name, announcement or link.
+        if ($this->isWhiteLabelActive()) {
+            return [];
+        }
+
+        // The model already orders the entries by recency.
+        $selected = array_slice($this->changesModel->getChangeItems(), 0, self::MAX_ENTRIES);
+
+        if (empty($selected)) {
+            return [];
+        }
+
+        $pluginManager = PluginManager::getInstance();
+
+        $result = [];
+
+        foreach ($selected as $change) {
+            $pluginName = is_string($change['plugin_name'] ?? null) ? $change['plugin_name'] : '';
+
+            $entry = [
+                'title'            => is_string($change['title'] ?? null) ? $change['title'] : '',
+                'description'      => is_string($change['description'] ?? null) ? $change['description'] : '',
+                'plugin_name'      => $pluginName,
+                'showPluginPrefix' => $pluginName !== '' && !$pluginManager->isPluginBundledWithCore($pluginName),
+                'link'             => '',
+                'link_name'        => '',
+            ];
+
+            $link = $change['link'] ?? '';
+            $linkName = $change['link_name'] ?? '';
+
+            // Store the trimmed URL: that is what was checked, and `|safelink` rejects a padded one.
+            if ($this->isDisplayableExternalLink($link, $linkName)) {
+                $entry['link'] = trim($link);
+                $entry['link_name'] = trim($linkName);
+            }
+
+            $result[] = $entry;
+        }
+
+        return $result;
+    }
+
+    private function isWhiteLabelActive(): bool
+    {
+        return PluginManager::getInstance()->isPluginActivated('WhiteLabel');
+    }
+
+    /**
+     * A link keeps its call to action only when it is an absolute http/https URL on an allowed host
+     * and has a label. This is a product filter rather than a security boundary: links come from
+     * each plugin's own `changes.json`, so nothing a visitor sends can reach it.
+     *
+     * @param mixed $link
+     * @param mixed $linkName
+     */
+    private function isDisplayableExternalLink($link, $linkName): bool
+    {
+        if (!is_string($link) || !is_string($linkName) || trim($linkName) === '') {
+            return false;
+        }
+
+        // No host means empty or relative; no scheme means protocol-relative.
+        $parsed = parse_url(trim($link));
+
+        if (!is_array($parsed) || empty($parsed['host'])) {
+            return false;
+        }
+
+        if (!in_array(strtolower($parsed['scheme'] ?? ''), ['http', 'https'], true)) {
+            return false;
+        }
+
+        // Reject userinfo: PHP splits the authority on the last `@`, browsers end the host at the
+        // first `\`, so `https://evil.example\@matomo.org/` is matomo.org here and evil.example
+        // there. Announcement links never carry credentials.
+        if (isset($parsed['user']) || isset($parsed['pass'])) {
+            return false;
+        }
+
+        // parse_url() already split the port off; just fold case and drop a trailing root dot.
+        return $this->isAllowedLinkHost(rtrim(strtolower($parsed['host']), '.'));
+    }
+
+    /**
+     * An exact match on an allowed host or one of its subdomains. Anchoring the suffix on a dot is
+     * what keeps `evil-matomo.org` and `matomo.org.example.com` out.
+     */
+    private function isAllowedLinkHost(string $host): bool
+    {
+        foreach (self::ALLOWED_LINK_HOSTS as $allowedHost) {
+            if ($host === $allowedHost || Common::stringEndsWith($host, '.' . $allowedHost)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/plugins/Login/stylesheets/loginLayout.less
+++ b/plugins/Login/stylesheets/loginLayout.less
@@ -31,7 +31,8 @@
 }
 
 /* REFRESHED LOGIN LAYOUT
-   Logo + login form centred in the primary column, which fills the page on its own.
+   Logo + login form centred in the primary column, "What's New" panel on a rounded,
+   brand-tinted surface filling the secondary column. Columns stack on tablet/mobile.
 ***********************/
 .loginLayout {
     display: flex;
@@ -66,6 +67,24 @@
         margin-top: 24px;
     }
 
+    .loginLayout__secondary {
+        display: flex;
+        flex-direction: column;
+        justify-content: safe center;
+        /* Stretch rather than centre: the panel fills the padding box, so the padding itself is
+           the teal frame around it - hence uniform on all four sides. */
+        align-items: stretch;
+        flex: none;
+        box-sizing: border-box;
+        width: 50%;
+        /* Same 24px inset the primary column uses, but not on the side facing it. */
+        margin: 24px 24px 24px 0;
+        padding: 40px;
+        border-radius: 24px;
+        /* Decorative brand surface, layered radial highlights over a vertical base wash. */
+        background-image: ~"radial-gradient(166.67% 208.33% at 258.33% 66.67%, rgba(229, 255, 252, 0.60) 0%, rgba(229, 255, 252, 0.00) 100%), radial-gradient(192.31% 138.89% at 63.89% -111.54%, rgba(209, 255, 247, 0.60) 0%, rgba(209, 255, 247, 0.00) 100%), radial-gradient(142.86% 178.57% at -85.71% 50%, rgba(204, 252, 255, 0.65) 0%, rgba(204, 255, 245, 0.00) 100%), radial-gradient(166.67% 156.25% at 75% 210%, rgba(224, 255, 250, 0.70) 0%, rgba(224, 255, 250, 0.00) 100%), radial-gradient(125% 113.64% at 145.45% -20%, rgba(154, 255, 241, 0.55) 0%, rgba(51, 204, 184, 0.00) 100%), radial-gradient(113.64% 125% at -12.5% 113.64%, rgba(102, 242, 229, 0.55) 0%, rgba(102, 242, 229, 0.00) 100%), radial-gradient(90.91% 90.91% at -8.18% -13.64%, rgba(0, 180, 190, 0.60) 0%, rgba(0, 190, 174, 0.00) 100%), radial-gradient(104.17% 86.21% at 127.59% 141.67%, rgba(49, 238, 241, 0.65) 0%, rgba(77, 224, 204, 0.00) 100%), linear-gradient(183deg, #F2FFFF 17.92%, #5DC7CD 132.86%)";
+    }
+
     /* override: the sign-in form reads as a plain column in the refreshed design, so strip
        the Morpheus/Materialize card chrome that contentBlock.twig wraps it in. */
     .card {
@@ -96,5 +115,13 @@
 
     .input-field.col label {
         left: 0;
+    }
+
+    /* Tablet and below: drop the secondary column so the sign in form has the page to
+       itself. Any narrower and the two columns fight over the width. */
+    @media (max-width: 1040px) {
+        .loginLayout__secondary {
+            display: none;
+        }
     }
 }

--- a/plugins/Login/stylesheets/loginWhatsNew.less
+++ b/plugins/Login/stylesheets/loginWhatsNew.less
@@ -1,0 +1,53 @@
+/* WHAT'S NEW PANEL
+***********************/
+.loginWhatsNew {
+    display: flex;
+    flex-direction: column;
+    justify-content: safe center;
+    gap: 8px;
+    box-sizing: border-box;
+    width: 100%;
+    padding: 32px;
+    border-radius: 16px;
+    background-color: @theme-color-background-contrast;
+
+    .loginWhatsNew__heading {
+        margin-bottom: 9px;
+        padding: 0;
+        font-size: 24px;
+        font-weight: 600;
+        color: @theme-color-text;
+    }
+
+    .loginWhatsNew__entry {
+        padding: 20px;
+        border: 1px solid @theme-color-border-alternative;
+        border-radius: 8px;
+    }
+
+    .loginWhatsNew__title {
+        margin: 0 0 8px;
+        font-size: 18px;
+        font-weight: 400;
+        line-height: 24px;
+        color: @theme-color-text;
+        overflow-wrap: anywhere;
+    }
+
+    .loginWhatsNew__description {
+        font-size: 14px;
+        line-height: 20px;
+        color: @theme-color-text-light;
+        overflow-wrap: anywhere;
+    }
+
+    .loginWhatsNew__link {
+        display: inline-block;
+        margin-top: 12px;
+        font-size: 13px;
+        font-weight: 400;
+        line-height: 18px;
+        color: @theme-color-link;
+        overflow-wrap: anywhere;
+    }
+}

--- a/plugins/Login/templates/_whatsNewPanel.twig
+++ b/plugins/Login/templates/_whatsNewPanel.twig
@@ -1,0 +1,21 @@
+<div class="loginWhatsNew">
+    <h2 class="loginWhatsNew__heading">{{ 'CoreAdminHome_WhatIsNewTitle'|translate }}</h2>
+
+    {% for change in changes %}
+        <div class="loginWhatsNew__entry">
+            <h3 class="loginWhatsNew__title">
+                {% if change.showPluginPrefix %}{{ change.plugin_name }} - {% endif %}{{ change.title }}
+            </h3>
+
+            {# Escaped, unlike the admin popover — this page is public. #}
+            <div class="loginWhatsNew__description">{{ change.description }}</div>
+
+            {% if change.link is not empty and change.link_name is not empty %}
+                <a class="loginWhatsNew__link"
+                   href="{{ change.link|safelink|e('html_attr') }}"
+                   target="_blank"
+                   rel="noreferrer noopener">{{ change.link_name }}</a>
+            {% endif %}
+        </div>
+    {% endfor %}
+</div>

--- a/plugins/Login/templates/loginLayout.twig
+++ b/plugins/Login/templates/loginLayout.twig
@@ -52,6 +52,13 @@
                 <div class="loginLayout__footerLinks">{{ footerLinks }}</div>
             {% endif %}
         </div>
+
+        {# The secondary column is dropped entirely when there is nothing to show in it. #}
+        {% if whatsNewChanges is defined and whatsNewChanges is not empty %}
+            <div class="loginLayout__secondary">
+                {% include '@Login/_whatsNewPanel.twig' with { 'changes': whatsNewChanges } %}
+            </div>
+        {% endif %}
     </div>
 
 {% endblock %}

--- a/plugins/Login/tests/Fixtures/PendingUsers.php
+++ b/plugins/Login/tests/Fixtures/PendingUsers.php
@@ -35,6 +35,10 @@ class PendingUsers extends Fixture
         $this->setUpWebsite();
         $this->setUpUser();
         $this->setUpTermsAndPrivacy();
+
+        // Lets the invite specs take one What's New baseline. Inert for every other test, which
+        // sees FakeChangesModel and reads nothing back.
+        WhatsNewChanges::recordPanelChanges();
     }
 
     public function tearDown(): void

--- a/plugins/Login/tests/Fixtures/WhatsNewChanges.php
+++ b/plugins/Login/tests/Fixtures/WhatsNewChanges.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Login\tests\Fixtures;
+
+use Piwik\Changes\Model as ChangesModel;
+use Piwik\Plugins\PrivacyManager\SystemSettings;
+use Piwik\Tests\Framework\Fixture;
+
+/**
+ * Records four changes, oldest first, so the login "What's New" panel has something to render -
+ * the installation itself never records any. The provider keeps the three most recent, so the
+ * first is deliberately left out, and the three that show cover each link outcome: external
+ * (kept), internal (stripped), none.
+ */
+class WhatsNewChanges extends Fixture
+{
+    public $dateTime = '2013-01-23 01:23:45';
+    public $idSite = 1;
+
+    public function setUp(): void
+    {
+        $this->setUpWebsite();
+        self::recordPanelChanges();
+        $this->setUpTermsAndPrivacy();
+    }
+
+    public function tearDown(): void
+    {
+        // empty
+    }
+
+    private function setUpWebsite(): void
+    {
+        if (!self::siteCreated($this->idSite)) {
+            $idSite = self::createWebsite($this->dateTime);
+            $this->assertSame($this->idSite, $idSite);
+        }
+    }
+
+    /**
+     * Static so other fixtures can reuse these entries. Inert until a spec sets
+     * `testEnvironment.loadChanges`, which is what swaps FakeChangesModel back for the real one.
+     */
+    public static function recordPanelChanges(): void
+    {
+        // Not resolved through the container: FakeChangesModel::addChange() is a no-op.
+        $model = new ChangesModel();
+
+        // Oldest first, so this one falls outside the three most recent.
+        $model->addChange('CoreHome', [
+            'version'     => '5.0.0',
+            'title'       => 'This entry is left out of the panel',
+            'description' => 'Only the three most recent entries are shown on the login page.',
+        ]);
+
+        $model->addChange('CoreHome', [
+            'version'     => '5.0.1',
+            'title'       => 'An entry without a call to action',
+            'description' => 'Entries stay visible even when they carry no link at all.',
+        ]);
+
+        $model->addChange('CoreHome', [
+            'version'     => '5.0.2',
+            'title'       => 'An entry linking back to this instance',
+            'description' => 'The call to action is stripped, the entry itself is kept.',
+            'link_name'   => 'Open the dashboard',
+            'link'        => 'index.php?module=CoreHome&action=index',
+        ]);
+
+        $model->addChange('CoreHome', [
+            'version'     => '5.0.3',
+            'title'       => 'An entry with an external call to action',
+            'description' => 'Only genuinely external links keep their call to action.',
+            'link_name'   => 'Read the announcement',
+            'link'        => 'https://matomo.org/changelog/',
+        ]);
+    }
+
+    /**
+     * The footer links only render for anonymous visitors once these are set, so the panel
+     * baseline covers them too.
+     */
+    private function setUpTermsAndPrivacy(): void
+    {
+        $settings = new SystemSettings();
+        $settings->privacyPolicyUrl->setValue('matomo.org');
+        $settings->termsAndConditionUrl->setValue('matomo.org');
+        $settings->save();
+    }
+}

--- a/plugins/Login/tests/Integration/WhatsNewPanelRenderTest.php
+++ b/plugins/Login/tests/Integration/WhatsNewPanelRenderTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Login\tests\Integration;
+
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\View;
+
+/**
+ * Output-safety checks for the What's New panel rendered on the shared login layout.
+ *
+ * @group Login
+ * @group WhatsNewProvider
+ * @group Plugins
+ */
+class WhatsNewPanelRenderTest extends IntegrationTestCase
+{
+    public function testEscapesHtmlInTitleDescriptionAndPluginName(): void
+    {
+        $html = $this->render([
+            [
+                'title'            => 'Title <script>alert(1)</script>',
+                'description'      => 'Body <img src=x onerror=alert(1)>',
+                'plugin_name'      => 'Evil<script>',
+                'showPluginPrefix' => true,
+                'link'             => '',
+                'link_name'        => '',
+            ],
+        ]);
+
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $html);
+        $this->assertStringNotContainsString('<img src=x onerror=alert(1)>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testRendersExternalLinkWithRelAndTargetAttributes(): void
+    {
+        $html = $this->render([
+            [
+                'title'            => 'A change',
+                'description'      => 'Body',
+                'plugin_name'      => 'CoreHome',
+                'showPluginPrefix' => false,
+                'link'             => 'https://matomo.org/blog',
+                'link_name'        => 'Read more',
+            ],
+        ]);
+
+        // The href is passed through safelink + html_attr escaping (the established Matomo pattern),
+        // so ":" and "/" are rendered as numeric entities. Assert on the parts that survive escaping.
+        $this->assertStringContainsString('class="loginWhatsNew__link"', $html);
+        $this->assertStringContainsString('matomo.org', $html);
+        $this->assertStringContainsString('rel="noreferrer noopener"', $html);
+        $this->assertStringContainsString('target="_blank"', $html);
+        $this->assertStringContainsString('Read more', $html);
+        // Ensure the unsafe-scheme guard leaves nothing executable behind.
+        $this->assertStringNotContainsString('javascript:', $html);
+    }
+
+    public function testDoesNotRenderCtaWhenLinkIsEmpty(): void
+    {
+        $html = $this->render([
+            [
+                'title'            => 'A change',
+                'description'      => 'Body',
+                'plugin_name'      => 'CoreHome',
+                'showPluginPrefix' => false,
+                'link'             => '',
+                'link_name'        => '',
+            ],
+        ]);
+
+        $this->assertStringContainsString('A change', $html);
+        $this->assertStringNotContainsString('loginWhatsNew__link', $html);
+    }
+
+    public function testRendersPluginPrefixOnlyWhenFlagged(): void
+    {
+        $html = $this->render([
+            [
+                'title'            => 'A change',
+                'description'      => 'Body',
+                'plugin_name'      => 'SomeMarketplacePlugin',
+                'showPluginPrefix' => true,
+                'link'             => '',
+                'link_name'        => '',
+            ],
+        ]);
+
+        $this->assertStringContainsString('SomeMarketplacePlugin - ', $html);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $changes
+     */
+    private function render(array $changes): string
+    {
+        $view = new View('@Login/_whatsNewPanel');
+        $view->changes = $changes;
+
+        return $view->render();
+    }
+}

--- a/plugins/Login/tests/Integration/WhatsNewProviderTest.php
+++ b/plugins/Login/tests/Integration/WhatsNewProviderTest.php
@@ -1,0 +1,393 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Login\tests\Integration;
+
+use Piwik\Access;
+use Piwik\Cache;
+use Piwik\Changes\Model as ChangesModel;
+use Piwik\Container\StaticContainer;
+use Piwik\Log\LoggerInterface;
+use Piwik\Piwik;
+use Piwik\Plugin\Manager as PluginManager;
+use Piwik\Plugins\Login\WhatsNewProvider;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Login
+ * @group WhatsNewProvider
+ * @group Plugins
+ */
+class WhatsNewProviderTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // The cache id is fixed, so an entry left behind by another test would be picked up here.
+        Cache::flushAll();
+    }
+
+    public function tearDown(): void
+    {
+        Cache::flushAll();
+
+        parent::tearDown();
+    }
+
+    public function testReturnsOnlyTheThreeMostRecentEntriesPreservingModelOrder(): void
+    {
+        $provider = $this->makeProvider([
+            $this->change(['title' => 'First']),
+            $this->change(['title' => 'Second']),
+            $this->change(['title' => 'Third']),
+            $this->change(['title' => 'Fourth']),
+        ]);
+
+        $changes = $provider->getChanges();
+
+        $this->assertCount(3, $changes);
+        $this->assertSame('First', $changes[0]['title']);
+        $this->assertSame('Second', $changes[1]['title']);
+        $this->assertSame('Third', $changes[2]['title']);
+    }
+
+    public function testCachesResultForTheRequest(): void
+    {
+        $model = $this->createMock(ChangesModel::class);
+        $model->expects($this->once())->method('getChangeItems')->willReturn([$this->change([])]);
+
+        $provider = $this->provider($model);
+
+        $provider->getChanges();
+        $provider->getChanges();
+    }
+
+    public function testCachesProcessedEntriesAcrossRequestsForLoggedOutVisitors(): void
+    {
+        $model = $this->createMock(ChangesModel::class);
+        $model->expects($this->once())->method('getChangeItems')->willReturn([$this->change([])]);
+
+        // Two providers stand in for two requests; only the first may read the changes table.
+        $this->assertCount(1, $this->getChangesAsLoggedOutVisitor($this->provider($model)));
+        $this->assertCount(1, $this->getChangesAsLoggedOutVisitor($this->provider($model)));
+    }
+
+    /**
+     * A logged in request must never fill the cache a logged out visitor reads, since
+     * `Changes.filterChanges` may have filtered its list for that one user.
+     */
+    public function testALoggedInRequestDoesNotFillTheCacheALoggedOutVisitorReads(): void
+    {
+        $model = $this->createMock(ChangesModel::class);
+        // Both build their own: the logged in one may not save, the logged out one finds nothing.
+        $model->expects($this->exactly(2))->method('getChangeItems')->willReturn([$this->change([])]);
+
+        $this->assertFalse(Piwik::isUserIsAnonymous(), 'this only means anything as a logged in request');
+        $this->assertCount(1, $this->provider($model)->getChanges());
+
+        $this->assertCount(1, $this->getChangesAsLoggedOutVisitor($this->provider($model)));
+    }
+
+    /**
+     * A logged in request saves nothing, so two users can never serve each other a filtered list.
+     */
+    public function testNeverFillsTheCacheForALoggedInRequest(): void
+    {
+        $model = $this->createMock(ChangesModel::class);
+        $model->expects($this->exactly(2))->method('getChangeItems')->willReturn([$this->change([])]);
+
+        $this->assertFalse(Piwik::isUserIsAnonymous(), 'this only means anything as a logged in request');
+
+        $this->assertCount(1, $this->provider($model)->getChanges());
+        $this->assertCount(1, $this->provider($model)->getChanges());
+    }
+
+    /**
+     * `Changes.filterChanges` runs inside the model, so an authenticated request that reused the
+     * cache would never filter for its own user.
+     */
+    public function testALoggedInRequestIgnoresWhatALoggedOutVisitorCached(): void
+    {
+        $model = $this->createMock(ChangesModel::class);
+        $model->expects($this->exactly(2))->method('getChangeItems')->willReturn([$this->change([])]);
+
+        $this->assertCount(1, $this->getChangesAsLoggedOutVisitor($this->provider($model)));
+        $this->assertCount(1, $this->provider($model)->getChanges());
+    }
+
+    /**
+     * End to end against the real model and table, which the mocked tests above cannot cover.
+     * Mirrors what the WhatsNewChanges UI fixture records.
+     */
+    public function testReturnsTheThreeMostRecentEntriesFromTheRealChangesTable(): void
+    {
+        $model = new ChangesModel();
+        $model->addChange('CoreHome', ['version' => '5.0.0', 'title' => 'Left out', 'description' => 'd']);
+        $model->addChange('CoreHome', ['version' => '5.0.1', 'title' => 'No link', 'description' => 'd']);
+        $model->addChange('CoreHome', [
+            'version'     => '5.0.2',
+            'title'       => 'Internal link',
+            'description' => 'd',
+            'link_name'   => 'Dashboard',
+            'link'        => 'index.php?module=CoreHome&action=index',
+        ]);
+        $model->addChange('CoreHome', [
+            'version'     => '5.0.3',
+            'title'       => 'External link',
+            'description' => 'd',
+            'link_name'   => 'Announcement',
+            'link'        => 'https://matomo.org/changelog/',
+        ]);
+
+        $changes = $this->provider(new ChangesModel())->getChanges();
+
+        $this->assertSame(
+            ['External link', 'Internal link', 'No link'],
+            array_column($changes, 'title'),
+            'the three most recent entries, newest first'
+        );
+        $this->assertSame('https://matomo.org/changelog/', $changes[0]['link']);
+        $this->assertSame('', $changes[1]['link'], 'the internal link must be stripped');
+        $this->assertSame('', $changes[2]['link']);
+    }
+
+    public function testDoesNotCacheAnEmptyResult(): void
+    {
+        $model = $this->createMock(ChangesModel::class);
+        // A fresh install reaches the login page before recording anything, and the panel has to
+        // appear as soon as the first change arrives. Checked logged out, the only request that saves.
+        $model->expects($this->exactly(2))->method('getChangeItems')->willReturn([]);
+
+        $this->assertSame([], $this->getChangesAsLoggedOutVisitor($this->provider($model)));
+        $this->assertSame([], $this->getChangesAsLoggedOutVisitor($this->provider($model)));
+    }
+
+    /**
+     * One link per case: seeding several at once would let MAX_ENTRIES silently drop everything
+     * past the third, so those cases would never be exercised.
+     *
+     * @dataProvider getAllowedHostLinks
+     */
+    public function testKeepsLinksOnTheAllowedHostAndItsSubdomains(string $link): void
+    {
+        $provider = $this->makeProvider([
+            $this->change(['link' => $link, 'link_name' => 'Read more']),
+        ]);
+
+        $changes = $provider->getChanges();
+
+        $this->assertCount(1, $changes);
+        $this->assertSame($link, $changes[0]['link'], 'the call to action should have been kept');
+        $this->assertSame('Read more', $changes[0]['link_name']);
+    }
+
+    public function getAllowedHostLinks(): array
+    {
+        return [
+            'apex host'          => ['https://matomo.org/changelog/'],
+            'subdomain'          => ['https://plugins.matomo.org/SomePlugin'],
+            'www subdomain'      => ['https://www.matomo.org'],
+            'different casing'   => ['https://MATOMO.org/faq/'],
+            'trailing root dot'  => ['https://matomo.org./faq/'],
+            'explicit port'      => ['https://matomo.org:8443/faq/'],
+            'plain http'         => ['http://matomo.org/news'],
+        ];
+    }
+
+    public function testKeepsEntryWithoutAnyLink(): void
+    {
+        $provider = $this->makeProvider([
+            $this->change(['title' => 'No link', 'link' => null, 'link_name' => null]),
+        ]);
+
+        $changes = $provider->getChanges();
+
+        $this->assertCount(1, $changes);
+        $this->assertSame('No link', $changes[0]['title']);
+        $this->assertSame('', $changes[0]['link']);
+        $this->assertSame('', $changes[0]['link_name']);
+    }
+
+    /**
+     * @dataProvider getUnsafeOrInternalLinks
+     */
+    public function testStripsUnsafeOrInternalLinkButKeepsEntry(?string $link): void
+    {
+        $provider = $this->makeProvider([
+            $this->change(['title' => 'Kept', 'description' => 'Body', 'link' => $link, 'link_name' => 'Go here']),
+        ]);
+
+        $changes = $provider->getChanges();
+
+        $this->assertCount(1, $changes, 'the entry itself must always stay visible');
+        $this->assertSame('Kept', $changes[0]['title']);
+        $this->assertSame('Body', $changes[0]['description']);
+        $this->assertSame('', $changes[0]['link'], 'the CTA link must be stripped');
+        $this->assertSame('', $changes[0]['link_name']);
+    }
+
+    public function getUnsafeOrInternalLinks(): array
+    {
+        return [
+            'internal index.php'          => ['index.php?module=CoreHome&action=index'],
+            'root-relative index.php'     => ['/index.php?module=CoreHome'],
+            'other relative url'          => ['some/relative/path'],
+            'absolute url on this instance' => ['https://analytics.example.com/index.php?module=CoreHome'],
+            'any other external host'     => ['https://example.org/news'],
+            // Look-alikes: neither is a subdomain of an allowed host.
+            'allowed host as a suffix'    => ['https://evil-matomo.org/phishing'],
+            'allowed host as a prefix'    => ['https://matomo.org.example.com/phishing'],
+            // parse_url() splits the authority on the last `@` and reads matomo.org as the host;
+            // browsers end it at the first `\` and go to evil.example instead.
+            'userinfo hides the real host' => ['https://evil.example\@matomo.org/path'],
+            'userinfo percent-encoded'     => ['https://evil.example%5C@matomo.org/path'],
+            'userinfo credentials'         => ['https://user:pw@matomo.org/changelog/'],
+            'protocol-relative url'       => ['//evil.example.org/path'],
+            'invalid url'                 => ['http://'],
+            'javascript scheme'           => ['javascript:alert(1)'],
+            'data scheme'                 => ['data:text/html,<script>alert(1)</script>'],
+            'file scheme'                 => ['file:///etc/passwd'],
+            'empty link'                  => [''],
+            'null link'                   => [null],
+        ];
+    }
+
+    public function testStoresTheTrimmedLinkSoTheHrefStaysUsable(): void
+    {
+        $provider = $this->makeProvider([
+            $this->change(['link' => '  https://matomo.org/changelog/  ', 'link_name' => '  Read more  ']),
+        ]);
+
+        $changes = $provider->getChanges();
+
+        // The check runs on the trimmed URL, so storing the raw one would leave `|safelink` to
+        // reject it and the template to render an empty href.
+        $this->assertSame('https://matomo.org/changelog/', $changes[0]['link']);
+        $this->assertSame('Read more', $changes[0]['link_name']);
+    }
+
+    public function testStripsCtaWhenLinkNameIsMissingEvenIfUrlIsValid(): void
+    {
+        $provider = $this->makeProvider([
+            $this->change(['link' => 'https://matomo.org', 'link_name' => null]),
+        ]);
+
+        $changes = $provider->getChanges();
+
+        $this->assertCount(1, $changes);
+        $this->assertSame('', $changes[0]['link']);
+    }
+
+    public function testAddsPluginPrefixForNonCoreBundledPluginOnly(): void
+    {
+        $provider = $this->makeProvider([
+            $this->change(['title' => 'Marketplace', 'plugin_name' => 'SomeMarketplacePlugin']),
+            $this->change(['title' => 'Core', 'plugin_name' => 'CoreHome']),
+        ]);
+
+        $changes = $provider->getChanges();
+
+        $this->assertTrue($changes[0]['showPluginPrefix']);
+        $this->assertSame('SomeMarketplacePlugin', $changes[0]['plugin_name']);
+        $this->assertFalse($changes[1]['showPluginPrefix']);
+    }
+
+    public function testReturnsEmptyWhenModelHasNoChanges(): void
+    {
+        $provider = $this->makeProvider([]);
+
+        $this->assertSame([], $provider->getChanges());
+    }
+
+    public function testReturnsEmptyWhenModelThrowsSoLoginStillRenders(): void
+    {
+        $model = $this->createMock(ChangesModel::class);
+        $model->method('getChangeItems')->willThrowException(new \Exception('db down'));
+
+        $provider = $this->provider($model);
+
+        $this->assertSame([], $provider->getChanges());
+    }
+
+    public function testReturnsEmptyWhenWhiteLabelIsActive(): void
+    {
+        $manager = PluginManager::getInstance();
+
+        $reflection = new \ReflectionProperty(PluginManager::class, 'pluginsToLoad');
+        $reflection->setAccessible(true);
+        $original = $reflection->getValue($manager);
+
+        try {
+            $reflection->setValue($manager, array_merge($original, ['WhiteLabel']));
+            $this->assertTrue($manager->isPluginActivated('WhiteLabel'));
+
+            $provider = $this->makeProvider([$this->change(['title' => 'Should be hidden'])]);
+
+            $this->assertSame([], $provider->getChanges());
+        } finally {
+            $reflection->setValue($manager, $original);
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $items
+     */
+    private function makeProvider(array $items): WhatsNewProvider
+    {
+        $model = $this->createMock(ChangesModel::class);
+        $model->method('getChangeItems')->willReturn($items);
+
+        return $this->provider($model);
+    }
+
+    private function provider(ChangesModel $model): WhatsNewProvider
+    {
+        return new WhatsNewProvider($model, StaticContainer::get(LoggerInterface::class));
+    }
+
+    /**
+     * Runs the provider as a logged out visitor, which is what a login page hit looks like -
+     * IntegrationTestCase grants super user access in setUp(). Undone in a finally.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function getChangesAsLoggedOutVisitor(WhatsNewProvider $provider): array
+    {
+        $realAccess = Access::getInstance();
+        $anonymous = new FakeAccess($superUser = false, $idSitesAdmin = [], $idSitesView = [], $identity = 'anonymous');
+        StaticContainer::getContainer()->set('Piwik\Access', $anonymous);
+
+        try {
+            $this->assertTrue(Piwik::isUserIsAnonymous(), 'the swap should have made this logged out');
+
+            return $provider->getChanges();
+        } finally {
+            StaticContainer::getContainer()->set('Piwik\Access', $realAccess);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function change(array $overrides): array
+    {
+        return array_merge([
+            'idchange'    => 1,
+            'plugin_name' => 'CoreHome',
+            'version'     => '5.0.0',
+            'title'       => 'A change',
+            'description' => 'A description',
+            'link_name'   => null,
+            'link'        => null,
+        ], $overrides);
+    }
+}

--- a/plugins/Login/tests/UI/Decline_spec.js
+++ b/plugins/Login/tests/UI/Decline_spec.js
@@ -15,6 +15,46 @@ describe('Decline', function () {
 
   var pendingUserUrl = '?module=Login&action=declineInvitation&token=13cb9dcef6cc70b02a640cee30dc8ce9';
 
+  // Swaps FakeChangesModel for the real one, so only this test sees the panel. Restored in a
+  // finally so a failure here cannot leak it into the baselines below.
+  async function withWhatsNewPanel(assertions) {
+    testEnvironment.loadChanges = 1;
+    testEnvironment.save();
+
+    try {
+      await assertions();
+    } finally {
+      delete testEnvironment.loadChanges;
+      testEnvironment.save();
+    }
+  }
+
+  function measurePanelBesideForm() {
+    const de = document.documentElement;
+    const primary = document.querySelector('.loginLayout__primary').getBoundingClientRect();
+    const panel = document.querySelector('.loginWhatsNew').getBoundingClientRect();
+
+    return {
+      entries: document.querySelectorAll('.loginWhatsNew__entry').length,
+      panelRightOfForm: panel.left >= primary.right,
+      panelVisible: panel.width > 0 && panel.height > 0,
+      noOverflow: de.scrollWidth <= de.clientWidth,
+    };
+  }
+
+  // Runs before the test below spends the token. Geometry only - the panel has its own baseline in
+  // LoginWhatsNew. The viewport is left alone: setViewport would persist into the baselines below.
+  it('should display decline invite page beside the What\'s New panel', async function () {
+    await withWhatsNewPanel(async function () {
+      await page.goto(pendingUserUrl);
+      await page.waitForSelector('.loginWhatsNew__entry');
+
+      expect(await page.evaluate(measurePanelBesideForm)).to.deep.equal({
+        entries: 3, panelRightOfForm: true, panelVisible: true, noOverflow: true,
+      });
+    });
+  });
+
   it('should display decline invite page', async function () {
     await page.goto(pendingUserUrl);
     expect(await page.screenshot({ fullPage: true })).to.matchImage('default');

--- a/plugins/Login/tests/UI/Invite_spec.js
+++ b/plugins/Login/tests/UI/Invite_spec.js
@@ -16,9 +16,37 @@ describe('Invite', function () {
   var pendingUserUrl = '?module=Login&action=acceptInvitation&token=13cb9dcef6cc70b02a640cee30dc8ce9';
   var wrongUserUrl = '?module=Login&action=acceptInvitation&token=123';
 
+  // Swaps FakeChangesModel for the real one, so only this test sees the panel. Restored in a
+  // finally so a failure here cannot leak it into the baselines below.
+  async function withWhatsNewPanel(assertions) {
+    testEnvironment.loadChanges = 1;
+    testEnvironment.save();
+
+    try {
+      await assertions();
+    } finally {
+      delete testEnvironment.loadChanges;
+      testEnvironment.save();
+    }
+  }
+
   it('should display error page', async function (){
     await page.goto(wrongUserUrl);
     expect(await page.screenshot({ fullPage: true })).to.matchImage('error');
+  });
+
+  // Runs before the tests below consume the token. The tallest form sharing the login layout, so
+  // the one worth a baseline next to the panel.
+  it('should display set password page beside the What\'s New panel', async function () {
+    await withWhatsNewPanel(async function () {
+      // The error page above leaves a 3s redirect timer pending, which would abort the navigation
+      // below. Same guard loginUser() uses in the TwoFactorAuth spec.
+      await page.goto('about:blank');
+
+      await page.goto(pendingUserUrl);
+      await page.waitForSelector('.loginWhatsNew__entry');
+      expect(await page.screenshot({ fullPage: true })).to.matchImage('set_password_whats_new');
+    });
   });
 
   it('should display set password page', async function () {

--- a/plugins/Login/tests/UI/WhatsNew_spec.js
+++ b/plugins/Login/tests/UI/WhatsNew_spec.js
@@ -1,0 +1,216 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * "What's New" panel on the refreshed login layout: mostly DOM/security invariants, plus one
+ * baseline of the panel itself. Entries come from the WhatsNewChanges fixture, so they are stable.
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+describe("LoginWhatsNew", function () {
+    this.fixture = 'Piwik\\Plugins\\Login\\tests\\Fixtures\\WhatsNewChanges';
+
+    const loginUrl = "?module=Login&action=login";
+
+    // Pages that only need to show the layout holds assert geometry instead of taking a baseline.
+    const panelBesideForm = { entries: 3, panelRightOfForm: true, panelVisible: true, noOverflow: true };
+
+    function measurePanelBesideForm() {
+        const de = document.documentElement;
+        const primary = document.querySelector('.loginLayout__primary').getBoundingClientRect();
+        const panel = document.querySelector('.loginWhatsNew').getBoundingClientRect();
+
+        return {
+            entries: document.querySelectorAll('.loginWhatsNew__entry').length,
+            panelRightOfForm: panel.left >= primary.right,
+            panelVisible: panel.width > 0 && panel.height > 0,
+            noOverflow: de.scrollWidth <= de.clientWidth,
+        };
+    }
+
+    before(function () {
+        testEnvironment.testUseMockAuth = 0;
+        // Swaps FakeChangesModel, which reads back nothing, for the real one.
+        testEnvironment.loadChanges = 1;
+        testEnvironment.save();
+    });
+
+    after(function () {
+        testEnvironment.testUseMockAuth = 1;
+        delete testEnvironment.loadChanges;
+        testEnvironment.save();
+    });
+
+    it("should render the login page with the What's New panel", async function () {
+        await page.webpage.setViewport({ width: 1440, height: 900 });
+        await page.goto(loginUrl);
+        await page.waitForSelector('.loginWhatsNew__entry');
+
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('panel');
+    });
+
+    it("should show the three most recent entries and drop the older one", async function () {
+        const titles = await page.$$eval('.loginWhatsNew__title', els => els.map(el => el.innerText.trim()));
+
+        expect(titles).to.deep.equal([
+            'An entry with an external call to action',
+            'An entry linking back to this instance',
+            'An entry without a call to action',
+        ]);
+    });
+
+    it("should keep the external call to action and strip the internal one", async function () {
+        const entries = await page.$$eval('.loginWhatsNew__entry', els => els.map(el => {
+            const link = el.querySelector('.loginWhatsNew__link');
+            return link === null ? null : link.getAttribute('href');
+        }));
+
+        expect(entries[0]).to.match(/^https:(&#x2F;|\/){2}matomo\.org(&#x2F;|\/)changelog/);
+        expect(entries[1]).to.equal(null, 'the internal link must not render a call to action');
+        expect(entries[2]).to.equal(null);
+    });
+
+    it("should render the What's New panel beside the login form on desktop", async function () {
+        await page.webpage.setViewport({ width: 1440, height: 900 });
+        await page.goto(loginUrl);
+        await page.waitForSelector('.loginLayout__primary');
+
+        const panelIsRightOfForm = await page.evaluate(function () {
+            const form = document.querySelector('#login_form_login').getBoundingClientRect();
+            const panel = document.querySelector('.loginWhatsNew').getBoundingClientRect();
+
+            return panel.left >= form.right;
+        });
+
+        expect(panelIsRightOfForm).to.be.true;
+    });
+
+    // Same invariants LoginLayout_spec asserts without the panel, re-checked against the narrower
+    // primary column the secondary one leaves behind.
+    it("should keep the sign in form flush with the logo with the panel beside it", async function () {
+        const form = await page.evaluate(function () {
+            const styles = getComputedStyle(document.querySelector('.loginLayout__content .card'));
+            const leftOf = function (selector) {
+                return document.querySelector(selector).getBoundingClientRect().left;
+            };
+
+            return {
+                borderTopWidth: styles.borderTopWidth,
+                borderLeftWidth: styles.borderLeftWidth,
+                // Logo, heading, labels and every field share one left edge — no Materialize gutter.
+                offsets: [
+                    '.loginLayout__content .card-title',
+                    'label[for="login_form_login"]',
+                    '#login_form_login',
+                    'label[for="login_form_password"]',
+                    '#login_form_password',
+                    '#login_form_submit',
+                ].map(function (selector) {
+                    return Math.abs(leftOf(selector) - leftOf('.loginLayout__logo'));
+                }),
+            };
+        });
+
+        expect(form.borderTopWidth).to.equal('0px');
+        expect(form.borderLeftWidth).to.equal('0px');
+        form.offsets.forEach(function (offset) {
+            expect(offset).to.be.below(1);
+        });
+    });
+
+    it("should show at most the three most recent entries", async function () {
+        const count = await page.$$eval('.loginWhatsNew__entry', els => els.length);
+
+        expect(count).to.be.above(0);
+        expect(count).to.be.at.most(3);
+    });
+
+    it("should only render call-to-action links on an allowed host", async function () {
+        const hrefs = await page.$$eval('.loginWhatsNew__link', els => els.map(el => el.getAttribute('href')));
+
+        hrefs.forEach(function (href) {
+            // Only absolute http(s) links on matomo.org (or a subdomain of it) may render a CTA.
+            expect(href).to.match(/^https?:(&#x2F;|\/){2}([a-z0-9-]+\.)*matomo\.org([:/]|$)/);
+            expect(href.toLowerCase()).to.not.contain('index.php');
+        });
+    });
+
+    it("should open external call-to-action links safely in a new tab", async function () {
+        const links = await page.$$eval('.loginWhatsNew__link', els => els.map(el => ({
+            target: el.getAttribute('target'),
+            rel: el.getAttribute('rel'),
+        })));
+
+        links.forEach(function (link) {
+            expect(link.target).to.equal('_blank');
+            expect(link.rel).to.contain('noreferrer');
+            expect(link.rel).to.contain('noopener');
+        });
+    });
+
+    // The other shape the primary column takes for a logged out visitor. Kept ahead of the
+    // responsive test below, which shrinks the viewport.
+    it("should render the forgot password form beside the panel", async function () {
+        await page.webpage.setViewport({ width: 1440, height: 900 });
+        await page.goto(loginUrl);
+        await page.waitForSelector('a#login_form_nav');
+        await page.click('a#login_form_nav');
+        await page.waitForNetworkIdle();
+        await page.waitForSelector('.loginWhatsNew__entry');
+
+        expect(await page.evaluate(measurePanelBesideForm)).to.deep.equal(panelBesideForm);
+    });
+
+    it("should hide the panel and leave the form alone on tablet and mobile", async function () {
+        const measure = function () {
+            const de = document.documentElement;
+
+            return {
+                noOverflow: de.scrollWidth <= de.clientWidth,
+                panelHidden: document.querySelector('.loginWhatsNew').offsetParent === null,
+                formVisible: document.querySelector('#login_form_login').offsetParent !== null,
+            };
+        };
+
+        // The panel is dropped at `max-width: 1040px` (loginLayout.less), so 960 is inside that range.
+        const results = [];
+
+        for (const width of [960, 720, 380]) {
+            await page.webpage.setViewport({ width: width, height: 820 });
+            await page.goto(loginUrl);
+            await page.waitForSelector('#login_form_login');
+            results.push(await page.evaluate(measure));
+        }
+
+        results.forEach(function (result) {
+            expect(result.noOverflow).to.be.true;
+            expect(result.panelHidden).to.be.true;
+            expect(result.formVisible).to.be.true;
+        });
+    });
+
+    // The other way round: where the panel does show, the form must still be full width.
+    // 1120 leaves room above the breakpoint so a scrollbar can't push us under it.
+    it("should keep the sign in form at its full width wherever the panel shows", async function () {
+        await page.webpage.setViewport({ width: 1120, height: 900 });
+        await page.goto(loginUrl);
+        await page.waitForSelector('.loginWhatsNew__entry');
+
+        const layout = await page.evaluate(function () {
+            const de = document.documentElement;
+
+            return {
+                panelVisible: document.querySelector('.loginWhatsNew').offsetParent !== null,
+                formWidth: Math.round(
+                    document.querySelector('.loginLayout__content').getBoundingClientRect().width
+                ),
+                noOverflow: de.scrollWidth <= de.clientWidth,
+            };
+        });
+
+        expect(layout.panelVisible).to.be.true;
+        expect(layout.noOverflow).to.be.true;
+        expect(layout.formWidth).to.equal(450);
+    });
+});

--- a/plugins/Login/tests/UI/expected-screenshots/Invite_set_password_whats_new.png
+++ b/plugins/Login/tests/UI/expected-screenshots/Invite_set_password_whats_new.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27191ce7a88cb40712c2bd65b7ccd400ce7e16e6acd6c83b29011de0b41bc00c
+size 280257

--- a/plugins/Login/tests/UI/expected-screenshots/LoginWhatsNew_panel.png
+++ b/plugins/Login/tests/UI/expected-screenshots/LoginWhatsNew_panel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cd96ecd35b49e0943259f86657734e8a19df70b6eb7ef686d018f412fff6ec8
+size 355741

--- a/plugins/TwoFactorAuth/Controller.php
+++ b/plugins/TwoFactorAuth/Controller.php
@@ -16,6 +16,7 @@ use Piwik\IP;
 use Piwik\Nonce;
 use Piwik\Piwik;
 use Piwik\Plugins\Login\PasswordVerifier;
+use Piwik\Plugins\Login\WhatsNewProvider;
 use Piwik\Plugins\TwoFactorAuth\Dao\RecoveryCodeDao;
 use Piwik\Session\SessionFingerprint;
 use Piwik\Session\SessionNamespace;
@@ -60,15 +61,38 @@ class Controller extends \Piwik\Plugin\Controller
      */
     private $validator;
 
-    public function __construct(SystemSettings $systemSettings, RecoveryCodeDao $recoveryCodeDao, PasswordVerifier $passwordVerify, TwoFactorAuthentication $twoFa, Validator $validator)
-    {
+    /**
+     * @var WhatsNewProvider
+     */
+    private $whatsNewProvider;
+
+    public function __construct(
+        SystemSettings $systemSettings,
+        RecoveryCodeDao $recoveryCodeDao,
+        PasswordVerifier $passwordVerify,
+        TwoFactorAuthentication $twoFa,
+        Validator $validator,
+        WhatsNewProvider $whatsNewProvider
+    ) {
         $this->settings = $systemSettings;
         $this->recoveryCodeDao = $recoveryCodeDao;
         $this->passwordVerify = $passwordVerify;
         $this->twoFa = $twoFa;
         $this->validator = $validator;
+        $this->whatsNewProvider = $whatsNewProvider;
 
         parent::__construct();
+    }
+
+    /**
+     * The "What's New" entries shown by the shared login layout. Reuses Login's provider, since
+     * these screens already extend Login's layout.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function getWhatsNewChanges(): array
+    {
+        return $this->whatsNewProvider->getChanges();
     }
 
     public function loginTwoFactorAuth()
@@ -120,6 +144,7 @@ class Controller extends \Piwik\Plugin\Controller
         $view->AccessErrorString = $messageNoAccess;
         $view->addForm($form);
         $this->setBasicVariablesView($view);
+        $view->whatsNewChanges = $this->getWhatsNewChanges();
         $view->nonce = Nonce::getNonce(self::LOGIN_2FA_NONCE);
 
         return $view->render();
@@ -208,6 +233,7 @@ class Controller extends \Piwik\Plugin\Controller
         if ($standalone) {
             $view = new View('@TwoFactorAuth/setupTwoFactorAuthStandalone');
             $this->setBasicVariablesView($view);
+            $view->whatsNewChanges = $this->getWhatsNewChanges();
             $view->submitAction = 'onLoginSetupTwoFactorAuth';
         } else {
             $view = new View('@TwoFactorAuth/setupTwoFactorAuth');

--- a/plugins/TwoFactorAuth/tests/Fixtures/TwoFactorFixture.php
+++ b/plugins/TwoFactorAuth/tests/Fixtures/TwoFactorFixture.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\TwoFactorAuth\tests\Fixtures;
 
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
+use Piwik\Plugins\Login\tests\Fixtures\WhatsNewChanges;
 use Piwik\Plugins\TwoFactorAuth\Dao\RecoveryCodeDao;
 use Piwik\Plugins\TwoFactorAuth\TwoFactorAuthentication;
 use Piwik\Plugins\UsersManager\Model;
@@ -52,6 +53,10 @@ class TwoFactorFixture extends Fixture
         $this->setUpWebsite();
         $this->setUpUsers();
         $this->trackFirstVisit();
+
+        // Lets the 2FA spec assert against the What's New panel, since its login screens extend
+        // the same @Login/loginLayout.twig. Inert for every other test, which reads nothing back.
+        WhatsNewChanges::recordPanelChanges();
     }
 
     public function tearDown(): void

--- a/plugins/TwoFactorAuth/tests/UI/TwoFactorAuth_spec.js
+++ b/plugins/TwoFactorAuth/tests/UI/TwoFactorAuth_spec.js
@@ -110,6 +110,39 @@ describe("TwoFactorAuth", function () {
         expect(widgetsCount).to.equal(1);
     });
 
+    // The 2FA screens extend @Login/loginLayout.twig, so they get the panel too. Geometry only -
+    // it has its own baseline in the Login specs. The finally only clears the flag: the panel
+    // itself stays cached for the tests below, which is fine as they all crop to .loginSection.
+    it('should show the auth code screen beside the What\'s New panel', async function () {
+        testEnvironment.loadChanges = 1;
+        testEnvironment.save();
+
+        try {
+            await loginUser('with2FA', false);
+            await page.waitForSelector('.loginWhatsNew__entry');
+
+            const layout = await page.evaluate(function () {
+                const de = document.documentElement;
+                const primary = document.querySelector('.loginLayout__primary').getBoundingClientRect();
+                const panel = document.querySelector('.loginWhatsNew').getBoundingClientRect();
+
+                return {
+                    entries: document.querySelectorAll('.loginWhatsNew__entry').length,
+                    panelRightOfForm: panel.left >= primary.right,
+                    panelVisible: panel.width > 0 && panel.height > 0,
+                    noOverflow: de.scrollWidth <= de.clientWidth,
+                };
+            });
+
+            expect(layout).to.deep.equal({
+                entries: 3, panelRightOfForm: true, panelVisible: true, noOverflow: true,
+            });
+        } finally {
+            delete testEnvironment.loadChanges;
+            testEnvironment.save();
+        }
+    });
+
     it('when logging in through logme and not providing auth code it should show auth code screen', async function () {
         await loginUser('with2FA', false);
         const section = await page.waitForSelector('.loginSection');


### PR DESCRIPTION
Backport of #24999.

Stacked on #25057 — retarget to `5.x-dev` once that merges.

### Companion PRs

The premium plugin companions cover the whole login stack (#25056 → #25057 → this one), so they are listed here rather than split per PR:

- WhiteLabel — https://github.com/innocraft/plugin-WhiteLabel/pull/113
- RollUpReporting — https://github.com/innocraft/plugin-RollUpReporting/pull/175
- LoginSaml — https://github.com/innocraft/plugin-LoginSaml/pull/238

### Note

`WhatsNewProvider` and `TwoFactorAuth\Controller` use PHPDoc `@var` properties instead of 6.x's typed properties, since 5.x still supports PHP 7.2.

### Checklist
[✔] I have understood, reviewed, and tested all AI outputs before use
[✔] All AI instructions respect security, IP, and privacy rules
### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
