### PR TITLE
Let policy-controlled settings own their enforcement state

### DIFF
--- a/core/Settings/Interfaces/PolicyComparisonInterface.php
+++ b/core/Settings/Interfaces/PolicyComparisonInterface.php
@@ -12,11 +12,25 @@ namespace Piwik\Settings\Interfaces;
 use Piwik\Policy\CompliancePolicy;
 
 /**
+ * Implemented by settings that a compliance policy can control.
+ *
+ * A setting subscribes to the policies it forms a requirement of via
+ * {@link getPolicyRequirements()}, and separately owns the state that records whether
+ * it is currently being enforced. That state is not tied to any single policy: a
+ * setting has one enforcement state per scope, not one per policy it subscribes to.
+ *
+ * Implement this interface via {@link \Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait},
+ * which provides default implementations for the enforcement state and dashboard
+ * metadata methods. Methods may be added to this interface in major releases; the
+ * trait always ships matching defaults, so trait users are unaffected.
+ *
  * @template T of mixed
  */
 interface PolicyComparisonInterface
 {
     /**
+     * The policies this setting is a requirement of, and the value each of them requires.
+     *
      * @return array<class-string<CompliancePolicy>, T>
      */
     public static function getPolicyRequirements(): array;
@@ -37,4 +51,57 @@ interface PolicyComparisonInterface
     public static function isControlledBySpecificPolicy(string $policy, ?int $idSite = null): bool;
 
     public static function getComplianceRequirementNote(?int $idSite = null): string;
+
+    /**
+     * Stable identifier of this policy-controlled setting, used to address it from the
+     * compliance dashboard and its APIs, eg `PrivacyManager.IPAnonymisation`.
+     *
+     * @since Matomo 6.0.0 — {@link \Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait} provides a default.
+     */
+    public static function getPolicySettingId(): string;
+
+    /**
+     * Whether the enforcement state of this setting cannot be changed from the compliance
+     * dashboard because it is managed elsewhere, eg in `config.ini.php`. Such settings
+     * store no enforcement state of their own and follow their policies directly.
+     *
+     * @since Matomo 6.0.0 — {@link \Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait} provides a default.
+     */
+    public static function isExternallyManagedByPolicyPage(): bool;
+
+    /**
+     * Whether this setting is currently being enforced for the given scope, so that the
+     * values required by the policies it subscribes to override the underlying Matomo
+     * setting when its value is resolved.
+     *
+     * @param int|null $idSite The website to check, or null for the instance wide state.
+     * @since Matomo 6.0.0 — {@link \Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait} provides a default.
+     */
+    public static function isEnforced(?int $idSite = null): bool;
+
+    /**
+     * Changes whether this setting is being enforced for the given scope.
+     *
+     * @param bool|null $isEnforced Null makes the setting follow the enforcement state of its policies again.
+     * @param int|null $idSite The website to update, or null for the instance wide state.
+     * @since Matomo 6.0.0 — {@link \Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait} provides a default.
+     */
+    public static function setEnforced(?bool $isEnforced, ?int $idSite = null): void;
+
+    /**
+     * The enforcement state explicitly stored for the given scope, or null when none was
+     * stored and the setting therefore follows the policies it subscribes to.
+     *
+     * @param int|null $idSite The website to read, or null for the instance wide state.
+     * @since Matomo 6.0.0 — {@link \Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait} provides a default.
+     */
+    public static function getStoredEnforcementState(?int $idSite = null): ?bool;
+
+    /**
+     * Whether the enforcement state of this setting can be changed for the given scope.
+     *
+     * @param int|null $idSite The website to check, or null for the instance wide state.
+     * @since Matomo 6.0.0 — {@link \Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait} provides a default.
+     */
+    public static function isEnforcementWritable(?int $idSite = null): bool;
 }

--- a/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
+++ b/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
@@ -9,7 +9,9 @@
 
 namespace Piwik\Settings\Interfaces\Traits;
 
+use Piwik\Piwik;
 use Piwik\Policy\CompliancePolicy;
+use Piwik\Settings\PolicyEnforcementState;
 
 /**
  * @template T of mixed
@@ -19,20 +21,218 @@ use Piwik\Policy\CompliancePolicy;
 trait PolicyComparisonTrait
 {
     /**
+     * The values required of this setting that currently apply.
+     *
+     * The requirements only apply while the setting is being enforced. When it is not,
+     * every requirement is nulled out and the underlying Matomo setting decides the value
+     * on its own. The policy keys are always present, so callers can still tell which
+     * policies this setting is a requirement of.
+     *
      * @return array<class-string<CompliancePolicy>, T|null>
      */
     public static function getPolicyRequiredValues(?int $idSite = null): array
     {
         $policyValues = static::getPolicyRequirements();
 
-        /** @var class-string<CompliancePolicy> $policy */
-        foreach (array_keys($policyValues) as $policy) {
-            if (!$policy::isActive($idSite)) {
-                $policyValues[$policy] = null;
-            }
+        if (!static::isEnforced($idSite)) {
+            return array_fill_keys(array_keys($policyValues), null);
         }
 
         return $policyValues;
+    }
+
+    public static function isEnforced(?int $idSite = null): bool
+    {
+        $configEnforcement = static::getConfigControlledEnforcement();
+
+        if (!is_null($configEnforcement)) {
+            // a policy pinned in config.ini.php cannot be overridden from the dashboard
+            return $configEnforcement;
+        }
+
+        if (static::isExternallyManagedByPolicyPage()) {
+            // no enforcement state is stored for these, they follow their policies directly
+            return static::isEnforcedByPolicies($idSite);
+        }
+
+        $instanceState = static::getStoredEnforcementState(null);
+
+        // mirrors CompliancePolicy::isActive(): an instance wide state applies to every site
+        if (true === $instanceState) {
+            return true;
+        }
+
+        if (!is_null($idSite)) {
+            $siteState = static::getStoredEnforcementState($idSite);
+
+            if (!is_null($siteState)) {
+                return $siteState;
+            }
+        }
+
+        if (!is_null($instanceState)) {
+            return false;
+        }
+
+        return static::isEnforcedByPolicies($idSite);
+    }
+
+    public static function setEnforced(?bool $isEnforced, ?int $idSite = null): void
+    {
+        if (static::isExternallyManagedByPolicyPage()) {
+            throw new \Exception(sprintf(
+                'The enforcement state of "%s" is managed outside of the compliance page and cannot be changed',
+                static::getPolicySettingId()
+            ));
+        }
+
+        if (!is_null($idSite) && false === $isEnforced && true === static::getStoredEnforcementState(null)) {
+            // mirrors CompliancePolicy::setActiveStatus(): an instance wide state applies to
+            // every site, so it has to give way before a single site can opt out of it
+            static::writeEnforcementState(null, static::reduceToDeviation(false, null));
+        }
+
+        static::writeEnforcementState($idSite, static::reduceToDeviation($isEnforced, $idSite));
+
+        /**
+         * Triggered when the enforcement state of a policy-controlled setting changes, to
+         * allow performing extra actions when a setting starts or stops being enforced.
+         *
+         * The enforcement state cannot be changed via this event.
+         *
+         * @param bool|null $isEnforced Whether the setting is being enforced, or null when it
+         *                              was reset to follow the policies it subscribes to
+         * @param int|null $idSite The website the state was changed for, or null for the instance
+         * @param class-string<\Piwik\Settings\Interfaces\PolicyComparisonInterface<mixed>> The setting in question
+         */
+        Piwik::postEvent('CompliancePolicy.setSettingEnforcedStatus', [$isEnforced, $idSite, static::class]);
+    }
+
+    public static function getStoredEnforcementState(?int $idSite = null): ?bool
+    {
+        return static::getPolicyEnforcementState()->get($idSite);
+    }
+
+    public static function isEnforcementWritable(?int $idSite = null): bool
+    {
+        if (static::isExternallyManagedByPolicyPage()) {
+            return false;
+        }
+
+        if (!is_null(static::getConfigControlledEnforcement())) {
+            return false;
+        }
+
+        return static::getPolicyEnforcementState()->isWritableByCurrentUser($idSite);
+    }
+
+    /**
+     * Only states that deviate from what would otherwise be inherited are worth storing.
+     * Resetting a setting back to what its policies already say removes the stored state,
+     * so a stored row always represents a deliberate deviation and never merely pins the
+     * value a policy happened to have at the time.
+     */
+    protected static function reduceToDeviation(?bool $isEnforced, ?int $idSite): ?bool
+    {
+        if (is_null($isEnforced)) {
+            return null;
+        }
+
+        return $isEnforced === static::getInheritedEnforcement($idSite) ? null : $isEnforced;
+    }
+
+    /**
+     * The enforcement state this setting would have for the given scope if no state was
+     * stored for that scope.
+     */
+    protected static function getInheritedEnforcement(?int $idSite): bool
+    {
+        if (!is_null($idSite)) {
+            $instanceState = static::getStoredEnforcementState(null);
+
+            if (!is_null($instanceState)) {
+                return $instanceState;
+            }
+        }
+
+        return static::isEnforcedByPolicies($idSite);
+    }
+
+    /**
+     * Whether any of the policies this setting subscribes to is currently active. This is
+     * the state a setting follows until its own enforcement state is set, which is what
+     * keeps installs that enforced a whole policy enforced without having to convert
+     * anything.
+     */
+    protected static function isEnforcedByPolicies(?int $idSite = null): bool
+    {
+        /** @var class-string<CompliancePolicy> $policy */
+        foreach (array_keys(static::getPolicyRequirements()) as $policy) {
+            if ($policy::isActive($idSite)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The enforcement state dictated by a policy that is pinned in `config.ini.php`, or
+     * null when none of the policies this setting subscribes to is config controlled.
+     */
+    protected static function getConfigControlledEnforcement(): ?bool
+    {
+        $isEnforced = null;
+
+        /** @var class-string<CompliancePolicy> $policy */
+        foreach (array_keys(static::getPolicyRequirements()) as $policy) {
+            if (!$policy::isConfigControlled()) {
+                continue;
+            }
+
+            $isEnforced = ($isEnforced ?? false) || (bool) $policy::getConfigValue();
+        }
+
+        return $isEnforced;
+    }
+
+    protected static function writeEnforcementState(?int $idSite, ?bool $isEnforced): void
+    {
+        static::getPolicyEnforcementState()->set($idSite, $isEnforced);
+    }
+
+    protected static function getPolicyEnforcementState(): PolicyEnforcementState
+    {
+        return new PolicyEnforcementState(
+            static::getPolicySettingPluginName(),
+            static::getPolicySettingShortName() . PolicyEnforcementState::SETTING_NAME_SUFFIX
+        );
+    }
+
+    public static function getPolicySettingId(): string
+    {
+        return static::getPolicySettingPluginName() . '.' . static::getPolicySettingShortName();
+    }
+
+    public static function isExternallyManagedByPolicyPage(): bool
+    {
+        return false;
+    }
+
+    /**
+     * The plugin the enforcement state of this setting is stored under, which is the plugin
+     * owning the setting itself.
+     */
+    protected static function getPolicySettingPluginName(): string
+    {
+        return Piwik::getPluginNameOfMatomoClass(static::class);
+    }
+
+    protected static function getPolicySettingShortName(): string
+    {
+        $parts = explode('\\', static::class);
+
+        return (string) end($parts);
     }
 
     /**
@@ -78,7 +278,10 @@ trait PolicyComparisonTrait
 
     public static function isControlledBySpecificPolicy(string $policy, ?int $idSite = null): bool
     {
-        return array_key_exists($policy, self::getPolicyRequiredValues($idSite));
+        // whether the setting subscribed to the policy is all that matters here, and is
+        // deliberately independent of the enforcement state: this is called for every
+        // discovered setting, so it must not read the enforcement state from storage
+        return array_key_exists($policy, static::getPolicyRequirements());
     }
 
     /**

--- a/core/Settings/PolicyEnforcementState.php
+++ b/core/Settings/PolicyEnforcementState.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Settings;
+
+use Exception;
+use Piwik\Container\StaticContainer;
+use Piwik\Piwik;
+use Piwik\Settings\Measurable\MeasurableSetting;
+use Piwik\Settings\Plugin\SystemSetting;
+use Piwik\Settings\Storage\Factory;
+use Piwik\Settings\Storage\Storage;
+
+/**
+ * Stored enforcement state of a single policy-controlled setting.
+ *
+ * A policy-controlled setting has two separate storage areas:
+ *
+ *  1. The value of the underlying Matomo setting, written from whichever settings
+ *     page owns it and read through the setting's own getter trait. Compliance
+ *     never writes to it, and only reads it to judge whether the underlying
+ *     configuration already satisfies a policy requirement on its own.
+ *  2. The enforcement state handled by this class, which records whether the
+ *     setting is being forced on, in the same way a compliance policy as a whole
+ *     can be turned on or off.
+ *
+ * The state is deliberately independent of any compliance policy: a setting has one
+ * enforcement state per scope, not one per policy it subscribes to. Storing it under
+ * the setting's own plugin means it is reachable from the setting, is removed along
+ * with the plugin's other settings when the plugin is uninstalled, and can be pinned
+ * from `config.ini.php` like any other system setting.
+ *
+ * Three states are distinguished:
+ *
+ *  - `true` / `false` — the state was set explicitly for this scope
+ *  - `null` — no state was ever stored, so the setting follows the enforcement
+ *    state of the policies it subscribes to
+ */
+class PolicyEnforcementState
+{
+    /**
+     * Suffix of the setting name the enforcement state is stored under. It intentionally
+     * carries no policy name: the state belongs to the setting, not to a policy.
+     */
+    public const SETTING_NAME_SUFFIX = '_policy_enforced';
+
+    /**
+     * @var string
+     */
+    private $pluginName;
+
+    /**
+     * @var string
+     */
+    private $settingName;
+
+    public function __construct(string $pluginName, string $settingName)
+    {
+        $this->pluginName = $pluginName;
+        $this->settingName = $settingName;
+    }
+
+    /**
+     * Returns the stored enforcement state for the given scope, or null when no state
+     * was ever stored and the setting therefore follows its policies.
+     *
+     * @param int|null $idSite The website to read the state of, or null for the instance wide state.
+     */
+    public function get(?int $idSite = null): ?bool
+    {
+        $value = $this->makeSetting($idSite)->getValue();
+
+        return is_null($value) ? null : (bool) $value;
+    }
+
+    /**
+     * Stores the enforcement state for the given scope.
+     *
+     * @param int|null $idSite The website to write the state of, or null for the instance wide state.
+     * @param bool|null $isEnforced Null removes the stored state, making the setting follow its policies again.
+     * @throws Exception when the state cannot be written by the current user
+     */
+    public function set(?int $idSite, ?bool $isEnforced): void
+    {
+        $setting = $this->makeSetting($idSite);
+
+        if (!$setting->isWritableByCurrentUser()) {
+            throw new Exception(Piwik::translate(
+                'CoreAdminHome_PluginSettingChangeNotAllowed',
+                [$this->settingName, $this->pluginName]
+            ));
+        }
+
+        // Setting::setValue() cannot express the removal of a state, as its boolean
+        // validation rejects null. The state is therefore written through the very storage
+        // the setting reads from, which both persists it and keeps the request cached
+        // values coherent with what was just written.
+        $storage = $this->getStorage($idSite);
+
+        if (is_null($isEnforced)) {
+            $storage->unsetValue($this->settingName);
+        } else {
+            $storage->setValue($this->settingName, $isEnforced);
+        }
+
+        $storage->save();
+    }
+
+    /**
+     * Whether the current user is allowed to change the enforcement state of this
+     * setting. Returns false when the state is pinned in `config.ini.php`.
+     */
+    public function isWritableByCurrentUser(?int $idSite = null): bool
+    {
+        return $this->makeSetting($idSite)->isWritableByCurrentUser();
+    }
+
+    private function makeSetting(?int $idSite): Setting
+    {
+        if (is_null($idSite)) {
+            return new SystemSetting($this->settingName, null, FieldConfig::TYPE_BOOL, $this->pluginName);
+        }
+
+        return new MeasurableSetting($this->settingName, null, FieldConfig::TYPE_BOOL, $this->pluginName, $idSite);
+    }
+
+    private function getStorage(?int $idSite): Storage
+    {
+        /** @var Factory $factory */
+        $factory = StaticContainer::get(Factory::class);
+
+        if (is_null($idSite)) {
+            return $factory->getPluginStorage($this->pluginName, '');
+        }
+
+        return $factory->getMeasurableSettingsStorage($idSite, $this->pluginName);
+    }
+}

--- a/core/Settings/Storage/Storage.php
+++ b/core/Settings/Storage/Storage.php
@@ -105,6 +105,29 @@ class Storage
         $this->settingsValues[$key] = $value;
     }
 
+    /**
+     * Removes the value of a setting in memory. To persist the change across requests,
+     * {@link save()} must be called.
+     *
+     * This differs from setting a value to null: a removed value makes {@link getValue()}
+     * return the given default value again, whereas a null value would still be found and
+     * converted to the setting's type. Settings that need to distinguish "no value stored"
+     * from a stored falsy value therefore have to remove the value rather than null it.
+     *
+     * @param string $key The name / key of a setting
+     */
+    public function unsetValue($key)
+    {
+        $this->loadSettingsIfNotDoneYet();
+
+        if (!array_key_exists($key, $this->settingsValues)) {
+            return;
+        }
+
+        $this->isDirty = true;
+        unset($this->settingsValues[$key]);
+    }
+
     private function loadSettingsIfNotDoneYet()
     {
         if ($this->settingValuesLoaded) {

--- a/core/Tracker/Config/ThirdPartyCookies.php
+++ b/core/Tracker/Config/ThirdPartyCookies.php
@@ -75,6 +75,20 @@ class ThirdPartyCookies implements
         return Piwik::translate('General_ThirdPartyCookieSettingNote');
     }
 
+    public static function getPolicySettingId(): string
+    {
+        // this setting lives in core rather than in a plugin, so the plugin name cannot be
+        // derived from its namespace the way it can be for every other policy setting
+        return 'Core.ThirdPartyCookies';
+    }
+
+    public static function isExternallyManagedByPolicyPage(): bool
+    {
+        // this setting can only be configured in config.ini.php, so its enforcement state
+        // is not toggleable from the compliance page and is never stored
+        return true;
+    }
+
     protected static function compareStrictness($value1, $value2): bool
     {
         if ($value1 === true && $value2 === true) {

--- a/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
+++ b/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
@@ -13,10 +13,27 @@ class TestPolicy extends \Piwik\Policy\CompliancePolicy
     /** @var array<int,bool> */
     private static $perSite = [];
 
+    /** @var bool|null */
+    private static $configValue = null;
+
     public static function reset(): void
     {
         self::$system = false;
         self::$perSite = [];
+        self::$configValue = null;
+    }
+
+    /**
+     * @param bool|null $value Null means the policy is not controlled by the config file.
+     */
+    public static function setConfigValue(?bool $value): void
+    {
+        self::$configValue = $value;
+    }
+
+    public static function getConfigValue(?int $idSite = null)
+    {
+        return self::$configValue;
     }
 
     public static function getName(): string

--- a/tests/PHPUnit/Framework/Mock/Settings/FakePolicySetting.php
+++ b/tests/PHPUnit/Framework/Mock/Settings/FakePolicySetting.php
@@ -13,9 +13,21 @@ class FakePolicySetting implements PolicyComparisonInterface, SettingValueInterf
      */
     private $value;
 
+    /**
+     * Enforcement states per scope, the instance wide scope being stored under ''.
+     *
+     * @var array<string, bool>
+     */
+    private static $enforcementStates = [];
+
     private function __construct(bool $value)
     {
         $this->value = $value;
+    }
+
+    public static function reset(): void
+    {
+        self::$enforcementStates = [];
     }
 
     public static function getPolicyRequirements(): array
@@ -70,5 +82,44 @@ class FakePolicySetting implements PolicyComparisonInterface, SettingValueInterf
     public static function getInlineHelp(): string
     {
         return 'Fake policy setting inline help text';
+    }
+
+    public static function getPolicySettingId(): string
+    {
+        return 'Fake.FakePolicySetting';
+    }
+
+    public static function isExternallyManagedByPolicyPage(): bool
+    {
+        return false;
+    }
+
+    public static function isEnforced(?int $idSite = null): bool
+    {
+        return self::getStoredEnforcementState($idSite)
+            ?? self::getStoredEnforcementState(null)
+            ?? TestPolicy::isActive($idSite);
+    }
+
+    public static function setEnforced(?bool $isEnforced, ?int $idSite = null): void
+    {
+        $scope = is_null($idSite) ? '' : (string) $idSite;
+
+        if (is_null($isEnforced)) {
+            unset(self::$enforcementStates[$scope]);
+            return;
+        }
+
+        self::$enforcementStates[$scope] = $isEnforced;
+    }
+
+    public static function getStoredEnforcementState(?int $idSite = null): ?bool
+    {
+        return self::$enforcementStates[is_null($idSite) ? '' : (string) $idSite] ?? null;
+    }
+
+    public static function isEnforcementWritable(?int $idSite = null): bool
+    {
+        return true;
     }
 }

--- a/tests/PHPUnit/Framework/Mock/Settings/InMemoryPolicyEnforcementState.php
+++ b/tests/PHPUnit/Framework/Mock/Settings/InMemoryPolicyEnforcementState.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Framework\Mock\Settings;
+
+use Piwik\Settings\PolicyEnforcementState;
+
+/**
+ * Enforcement state kept in memory, so that the resolution rules of
+ * {@link \Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait} can be unit tested
+ * without a database.
+ */
+class InMemoryPolicyEnforcementState extends PolicyEnforcementState
+{
+    /**
+     * States per storage key, of [scope => bool]. The instance wide scope is stored under ''.
+     *
+     * @var array<string, array<string, bool>>
+     */
+    private static $states = [];
+
+    /**
+     * @var bool
+     */
+    private static $isWritable = true;
+
+    /**
+     * @var string
+     */
+    private $key;
+
+    public function __construct(string $pluginName, string $settingName)
+    {
+        parent::__construct($pluginName, $settingName);
+
+        $this->key = $pluginName . '.' . $settingName;
+    }
+
+    public static function reset(): void
+    {
+        self::$states = [];
+        self::$isWritable = true;
+    }
+
+    public static function setIsWritable(bool $isWritable): void
+    {
+        self::$isWritable = $isWritable;
+    }
+
+    public function get(?int $idSite = null): ?bool
+    {
+        return self::$states[$this->key][$this->scope($idSite)] ?? null;
+    }
+
+    public function set(?int $idSite, ?bool $isEnforced): void
+    {
+        if (is_null($isEnforced)) {
+            // the real storage drops null values when persisting, removing the row entirely
+            unset(self::$states[$this->key][$this->scope($idSite)]);
+
+            if (empty(self::$states[$this->key])) {
+                unset(self::$states[$this->key]);
+            }
+
+            return;
+        }
+
+        self::$states[$this->key][$this->scope($idSite)] = $isEnforced;
+    }
+
+    public function isWritableByCurrentUser(?int $idSite = null): bool
+    {
+        return self::$isWritable;
+    }
+
+    /**
+     * All stored states, for asserting that nothing was written.
+     *
+     * @return array<string, array<string, bool>>
+     */
+    public static function getAllStates(): array
+    {
+        return self::$states;
+    }
+
+    private function scope(?int $idSite): string
+    {
+        return is_null($idSite) ? '' : (string) $idSite;
+    }
+}

--- a/tests/PHPUnit/Framework/Mock/Settings/TraitImpls/ExternallyManagedPolicyComparisonTraitImpl.php
+++ b/tests/PHPUnit/Framework/Mock/Settings/TraitImpls/ExternallyManagedPolicyComparisonTraitImpl.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Piwik\Tests\Framework\Mock\Settings\TraitImpls;
+
+/**
+ * A policy setting that is managed outside of the compliance page, and therefore stores no
+ * enforcement state of its own.
+ */
+class ExternallyManagedPolicyComparisonTraitImpl extends PolicyComparisonTraitImpl
+{
+    public static function isExternallyManagedByPolicyPage(): bool
+    {
+        return true;
+    }
+}

--- a/tests/PHPUnit/Framework/Mock/Settings/TraitImpls/PolicyComparisonTraitImpl.php
+++ b/tests/PHPUnit/Framework/Mock/Settings/TraitImpls/PolicyComparisonTraitImpl.php
@@ -4,7 +4,9 @@ namespace Piwik\Tests\Framework\Mock\Settings\TraitImpls;
 
 use Piwik\Settings\Interfaces\PolicyComparisonInterface;
 use Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait;
+use Piwik\Settings\PolicyEnforcementState;
 use Piwik\Tests\Framework\Mock\Policy\TestPolicy;
+use Piwik\Tests\Framework\Mock\Settings\InMemoryPolicyEnforcementState;
 
 class PolicyComparisonTraitImpl implements PolicyComparisonInterface
 {
@@ -33,5 +35,19 @@ class PolicyComparisonTraitImpl implements PolicyComparisonInterface
     public static function getComplianceRequirementNote(?int $idSite = null): string
     {
         return 'test PolicyComparisonTrait';
+    }
+
+    protected static function getPolicySettingPluginName(): string
+    {
+        // the mock does not live in a plugin, so the name cannot be derived from its namespace
+        return 'TestPlugin';
+    }
+
+    protected static function getPolicyEnforcementState(): PolicyEnforcementState
+    {
+        return new InMemoryPolicyEnforcementState(
+            static::getPolicySettingPluginName(),
+            static::getPolicySettingShortName() . PolicyEnforcementState::SETTING_NAME_SUFFIX
+        );
     }
 }

--- a/tests/PHPUnit/Integration/Settings/PolicyEnforcementInheritanceTest.php
+++ b/tests/PHPUnit/Integration/Settings/PolicyEnforcementInheritanceTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Settings;
+
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\Policy\CnilPolicy;
+use Piwik\Policy\PolicyManager;
+use Piwik\Plugins\PrivacyManager\Settings\IPAnonymisation;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * Until a setting's own enforcement state is set, it follows the enforcement state of the
+ * policies it subscribes to. That is what keeps installs which enforced a whole policy
+ * before per-setting enforcement existed enforced afterwards, without any of their stored
+ * state having to be converted.
+ *
+ * @group PolicySettings
+ */
+class PolicyEnforcementInheritanceTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createWebsite('2020-01-01 00:00:00');
+        Fixture::createWebsite('2020-01-01 00:00:00');
+    }
+
+    public function testEveryControlledSettingIsEnforcedWhenOnlyTheWholePolicyFlagIsSet()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, true);
+
+        $settings = $this->getControlledSettings();
+        $this->assertNotEmpty($settings);
+
+        foreach ($settings as $setting) {
+            $this->assertTrue(
+                $setting::isEnforced(),
+                sprintf('%s should be enforced by the active policy', $setting::getPolicySettingId())
+            );
+        }
+    }
+
+    public function testNoEnforcementStateIsStoredWhenTheWholePolicyIsEnforced()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, true);
+
+        foreach ($this->getControlledSettings() as $setting) {
+            $this->assertNull(
+                $setting::getStoredEnforcementState(),
+                sprintf('%s should not have stored an enforcement state', $setting::getPolicySettingId())
+            );
+        }
+
+        $this->assertSame(0, $this->countStoredEnforcementRows());
+    }
+
+    public function testNoControlledSettingIsEnforcedWhileThePolicyIsInactive()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, false);
+
+        foreach ($this->getControlledSettings() as $setting) {
+            $this->assertFalse(
+                $setting::isEnforced(),
+                sprintf('%s should not be enforced by an inactive policy', $setting::getPolicySettingId())
+            );
+        }
+    }
+
+    public function testSettingsFollowThePolicyPerSite()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, true, 1);
+
+        foreach ($this->getControlledSettings(1) as $setting) {
+            $this->assertTrue($setting::isEnforced(1), $setting::getPolicySettingId());
+            $this->assertFalse($setting::isEnforced(2), $setting::getPolicySettingId());
+        }
+
+        $this->assertSame(0, $this->countStoredEnforcementRows());
+    }
+
+    public function testASingleSettingCanOptOutWhileTheRestKeepFollowingThePolicy()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, true);
+
+        IPAnonymisation::setEnforced(false);
+
+        $this->assertFalse(IPAnonymisation::isEnforced());
+        $this->assertFalse(IPAnonymisation::getStoredEnforcementState());
+
+        foreach ($this->getControlledSettings() as $setting) {
+            if ($setting === IPAnonymisation::class) {
+                continue;
+            }
+
+            $this->assertTrue($setting::isEnforced(), $setting::getPolicySettingId());
+            $this->assertNull($setting::getStoredEnforcementState(), $setting::getPolicySettingId());
+        }
+    }
+
+    public function testASingleSettingCanBeEnforcedWhileThePolicyStaysInactive()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, false);
+
+        IPAnonymisation::setEnforced(true);
+
+        $this->assertTrue(IPAnonymisation::isEnforced());
+
+        foreach ($this->getControlledSettings() as $setting) {
+            if ($setting === IPAnonymisation::class) {
+                continue;
+            }
+
+            $this->assertFalse($setting::isEnforced(), $setting::getPolicySettingId());
+        }
+    }
+
+    public function testEnforcingASingleSettingAppliesItsRequiredValue()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, false);
+
+        $required = IPAnonymisation::getPolicyRequirements()[CnilPolicy::class];
+
+        IPAnonymisation::setEnforced(true);
+        $this->assertGreaterThanOrEqual($required, IPAnonymisation::getInstance()->getValue());
+        $this->assertTrue(IPAnonymisation::isCompliant(CnilPolicy::class));
+
+        IPAnonymisation::setEnforced(false);
+        $this->assertNull(IPAnonymisation::getPolicyRequiredValues()[CnilPolicy::class]);
+    }
+
+    /**
+     * @return array<class-string<\Piwik\Settings\Interfaces\PolicyComparisonInterface<mixed>>>
+     */
+    private function getControlledSettings(?int $idSite = null): array
+    {
+        return PolicyManager::getAllControlledSettings(CnilPolicy::class, $idSite);
+    }
+
+    private function countStoredEnforcementRows(): int
+    {
+        $pluginRows = (int) Db::fetchOne(
+            'SELECT COUNT(*) FROM ' . Common::prefixTable('plugin_setting')
+            . " WHERE setting_name LIKE '%\_policy\_enforced'"
+        );
+
+        $siteRows = (int) Db::fetchOne(
+            'SELECT COUNT(*) FROM ' . Common::prefixTable('site_setting')
+            . " WHERE setting_name LIKE '%\_policy\_enforced'"
+        );
+
+        return $pluginRows + $siteRows;
+    }
+}

--- a/tests/PHPUnit/Integration/Settings/PolicyEnforcementStateTest.php
+++ b/tests/PHPUnit/Integration/Settings/PolicyEnforcementStateTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Settings;
+
+use Piwik\Common;
+use Piwik\Config;
+use Piwik\Db;
+use Piwik\Settings\PolicyEnforcementState;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * The enforcement state of a policy-controlled setting needs three states: enforced, not
+ * enforced, and "no state stored, so follow the policy". These tests cover that the storage
+ * really distinguishes them, in particular that removing a state removes the row rather than
+ * storing a falsy value.
+ *
+ * @group PolicySettings
+ */
+class PolicyEnforcementStateTest extends IntegrationTestCase
+{
+    private const PLUGIN_NAME = 'PrivacyManager';
+    private const SETTING_NAME = 'FakeSetting_policy_enforced';
+
+    /**
+     * @var PolicyEnforcementState
+     */
+    private $state;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createWebsite('2020-01-01 00:00:00');
+        Fixture::createWebsite('2020-01-01 00:00:00');
+
+        $this->state = new PolicyEnforcementState(self::PLUGIN_NAME, self::SETTING_NAME);
+    }
+
+    public function testNoStateIsStoredInitially()
+    {
+        $this->assertNull($this->state->get());
+        $this->assertNull($this->state->get(1));
+    }
+
+    public function testStoresAndReadsBackTheInstanceWideState()
+    {
+        $this->state->set(null, true);
+        $this->assertTrue($this->state->get());
+
+        $this->state->set(null, false);
+        $this->assertFalse($this->state->get());
+    }
+
+    public function testStoresAndReadsBackASiteState()
+    {
+        $this->state->set(1, true);
+
+        $this->assertTrue($this->state->get(1));
+        $this->assertNull($this->state->get(2));
+        $this->assertNull($this->state->get());
+    }
+
+    public function testInstanceAndSiteStatesAreStoredIndependently()
+    {
+        $this->state->set(null, true);
+        $this->state->set(1, false);
+
+        $this->assertTrue($this->state->get());
+        $this->assertFalse($this->state->get(1));
+        $this->assertNull($this->state->get(2));
+    }
+
+    public function testStoringFalseIsDistinguishableFromNoStateAtAll()
+    {
+        $this->state->set(null, false);
+
+        $this->assertFalse($this->state->get());
+        $this->assertNotNull($this->state->get());
+        $this->assertSame(1, $this->countStoredInstanceRows());
+    }
+
+    public function testRemovingTheInstanceWideStateRemovesTheRow()
+    {
+        $this->state->set(null, true);
+        $this->assertSame(1, $this->countStoredInstanceRows());
+
+        $this->state->set(null, null);
+
+        $this->assertNull($this->state->get());
+        $this->assertSame(0, $this->countStoredInstanceRows());
+    }
+
+    public function testRemovingASiteStateRemovesTheRow()
+    {
+        $this->state->set(1, true);
+        $this->assertSame(1, $this->countStoredSiteRows(1));
+
+        $this->state->set(1, null);
+
+        $this->assertNull($this->state->get(1));
+        $this->assertSame(0, $this->countStoredSiteRows(1));
+    }
+
+    public function testRemovingAStateKeepsOtherScopesIntact()
+    {
+        $this->state->set(null, true);
+        $this->state->set(1, false);
+
+        $this->state->set(1, null);
+
+        $this->assertTrue($this->state->get());
+        $this->assertNull($this->state->get(1));
+    }
+
+    public function testRemovingAStateThatWasNeverStoredIsHarmless()
+    {
+        $this->state->set(null, null);
+
+        $this->assertNull($this->state->get());
+        $this->assertSame(0, $this->countStoredInstanceRows());
+    }
+
+    public function testDoesNotCollideWithTheEnforcementStateOfAnotherSetting()
+    {
+        $other = new PolicyEnforcementState(self::PLUGIN_NAME, 'OtherFakeSetting_policy_enforced');
+
+        $this->state->set(null, true);
+
+        $this->assertNull($other->get());
+
+        $other->set(null, false);
+
+        $this->assertTrue($this->state->get());
+        $this->assertFalse($other->get());
+    }
+
+    public function testDoesNotCollideWithTheSameSettingInAnotherPlugin()
+    {
+        $other = new PolicyEnforcementState('Live', self::SETTING_NAME);
+
+        $this->state->set(null, true);
+
+        $this->assertNull($other->get());
+    }
+
+    public function testStateCanBePinnedInTheConfigFile()
+    {
+        $this->assertNull($this->state->get());
+        $this->assertTrue($this->state->isWritableByCurrentUser());
+
+        Config::getInstance()->{self::PLUGIN_NAME} = [self::SETTING_NAME => 1];
+
+        $this->assertTrue($this->state->get());
+        $this->assertFalse($this->state->isWritableByCurrentUser());
+    }
+
+    public function testWritingAPinnedStateIsRejected()
+    {
+        Config::getInstance()->{self::PLUGIN_NAME} = [self::SETTING_NAME => 1];
+
+        $this->expectExceptionMessage('CoreAdminHome_PluginSettingChangeNotAllowed');
+
+        $this->state->set(null, false);
+    }
+
+    private function countStoredInstanceRows(): int
+    {
+        return (int) Db::fetchOne(
+            'SELECT COUNT(*) FROM ' . Common::prefixTable('plugin_setting')
+            . ' WHERE plugin_name = ? AND user_login = ? AND setting_name = ?',
+            [self::PLUGIN_NAME, '', self::SETTING_NAME]
+        );
+    }
+
+    private function countStoredSiteRows(int $idSite): int
+    {
+        return (int) Db::fetchOne(
+            'SELECT COUNT(*) FROM ' . Common::prefixTable('site_setting')
+            . ' WHERE idsite = ? AND plugin_name = ? AND setting_name = ?',
+            [$idSite, self::PLUGIN_NAME, self::SETTING_NAME]
+        );
+    }
+}

--- a/tests/PHPUnit/Integration/Settings/Storage/StorageTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/StorageTest.php
@@ -91,6 +91,55 @@ class StorageTest extends IntegrationTestCase
         $this->assertSame($loaded, $this->loadValuesFromBackend());
     }
 
+    public function testUnsetValueShouldMakeGetValueReturnTheDefaultValueAgain()
+    {
+        $this->storage->setValue($this->settingName, false);
+        $this->assertFalse($this->storage->getValue($this->settingName, null, FieldConfig::TYPE_BOOL));
+
+        $this->storage->unsetValue($this->settingName);
+
+        $this->assertNull($this->storage->getValue($this->settingName, null, FieldConfig::TYPE_BOOL));
+    }
+
+    public function testUnsetValueShouldDistinguishARemovedValueFromANullValue()
+    {
+        // a null value is still found and cast to the requested type, a removed one is not
+        $this->storage->setValue($this->settingName, null);
+        $this->assertFalse($this->storage->getValue($this->settingName, null, FieldConfig::TYPE_BOOL));
+
+        $this->storage->unsetValue($this->settingName);
+        $this->assertNull($this->storage->getValue($this->settingName, null, FieldConfig::TYPE_BOOL));
+    }
+
+    public function testUnsetValueShouldNotRemoveItFromDatabaseBeforeSaving()
+    {
+        $loaded = $this->backend->load();
+        $this->storage->unsetValue($this->settingName);
+
+        $this->assertSame($loaded, $this->loadValuesFromBackend());
+    }
+
+    public function testSaveShouldRemoveAnUnsetValueFromDatabase()
+    {
+        $this->storage->setValue('mySecondName', 'keepMe');
+        $this->storage->save();
+
+        $this->storage->unsetValue($this->settingName);
+        $this->storage->save();
+
+        $this->assertEquals(array('mySecondName' => 'keepMe'), $this->loadValuesFromBackend());
+    }
+
+    public function testUnsetValueShouldBeHarmlessWhenNoValueWasStored()
+    {
+        $loaded = $this->loadValuesFromBackend();
+
+        $this->storage->unsetValue('UnkNownFielD');
+        $this->storage->save();
+
+        $this->assertSame($loaded, $this->loadValuesFromBackend());
+    }
+
     public function testSaveShouldPersistValueInDatabase()
     {
         $this->storage->setValue($this->settingName, 'myRandomVal');

--- a/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
+++ b/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
@@ -5,13 +5,29 @@ namespace Piwik\Tests\Unit\Settings;
 use PHPUnit\Framework\TestCase;
 use Piwik\Policy\PolicyManager;
 use Piwik\Tests\Framework\Mock\Policy\TestPolicy;
+use Piwik\Tests\Framework\Mock\Settings\InMemoryPolicyEnforcementState;
+use Piwik\Tests\Framework\Mock\Settings\TraitImpls\ExternallyManagedPolicyComparisonTraitImpl;
 use Piwik\Tests\Framework\Mock\Settings\TraitImpls\PolicyComparisonTraitImpl;
 
 class PolicyComparisonTraitTest extends TestCase
 {
+    private const IDSITE = 1;
+    private const OTHER_IDSITE = 2;
+
     public function setUp(): void
     {
         parent::setUp();
+
+        TestPolicy::reset();
+        InMemoryPolicyEnforcementState::reset();
+    }
+
+    public function tearDown(): void
+    {
+        TestPolicy::reset();
+        InMemoryPolicyEnforcementState::reset();
+
+        parent::tearDown();
     }
 
     public function testGetPolicyValuesPolicyActive()
@@ -32,10 +48,228 @@ class PolicyComparisonTraitTest extends TestCase
         $this->assertNull($values[TestPolicy::class]);
     }
 
+    public function testGetPolicyValuesAppliesRequirementWhenTheSettingIsEnforcedWhileThePolicyIsNot()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, false);
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
+
+        $this->assertSame([TestPolicy::class => true], $values);
+    }
+
+    public function testGetPolicyValuesDropsRequirementWhenTheSettingIsNotEnforcedWhileThePolicyIs()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
+
+        $this->assertSame([TestPolicy::class => null], $values);
+    }
+
     public function testIsControlledBySpecificPolicy()
     {
         $this->assertTrue(
             PolicyComparisonTraitImpl::isControlledBySpecificPolicy(TestPolicy::class)
         );
+    }
+
+    public function testIsControlledBySpecificPolicyDoesNotDependOnTheEnforcementState()
+    {
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $this->assertTrue(
+            PolicyComparisonTraitImpl::isControlledBySpecificPolicy(TestPolicy::class)
+        );
+    }
+
+    // enforcement state resolution
+
+    public function testIsEnforcedFollowsThePolicyWhenNoStateWasStored()
+    {
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    public function testIsEnforcedFollowsThePolicyPerSiteWhenNoStateWasStored()
+    {
+        TestPolicy::setMeasurableValue(self::IDSITE, true);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    public function testIsEnforcedUsesTheStoredInstanceStateOverAnInactivePolicy()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced());
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+    }
+
+    public function testIsEnforcedUsesTheStoredInstanceStateOverAnActivePolicy()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+    }
+
+    public function testIsEnforcedUsesTheStoredSiteStateOverThePolicy()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true, self::IDSITE);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    public function testIsEnforcedLetsAnInstanceWideStateApplyToEverySite()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+    }
+
+    public function testIsEnforcedAppliesAnInstanceWideOptOutToSitesWithoutTheirOwnState()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+    }
+
+    public function testIsEnforcedIsPinnedOnByAConfigControlledPolicy()
+    {
+        TestPolicy::setConfigValue(true);
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced());
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+    }
+
+    public function testIsEnforcedIsPinnedOffByAConfigControlledPolicy()
+    {
+        TestPolicy::setConfigValue(false);
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    // storing the enforcement state
+
+    public function testSetEnforcedOnlyStoresAStateThatDeviatesFromThePolicy()
+    {
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $this->assertSame([], InMemoryPolicyEnforcementState::getAllStates());
+        $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState());
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    public function testSetEnforcedStoresAStateThatDeviatesFromThePolicy()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::getStoredEnforcementState());
+    }
+
+    public function testSetEnforcedRemovesAStoredStateWhenItMatchesThePolicyAgain()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+        $this->assertTrue(PolicyComparisonTraitImpl::getStoredEnforcementState());
+
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState());
+        $this->assertSame([], InMemoryPolicyEnforcementState::getAllStates());
+    }
+
+    public function testSetEnforcedWithNullResetsTheSettingToFollowItsPolicies()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        PolicyComparisonTraitImpl::setEnforced(null);
+
+        $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState());
+
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    public function testSetEnforcedGivesWayForASiteOptOutOfAnInstanceWideState()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        PolicyComparisonTraitImpl::setEnforced(false, self::IDSITE);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+        $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState());
+    }
+
+    public function testSetEnforcedPinsASiteOptOutWhileThePolicyStaysActive()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+
+        PolicyComparisonTraitImpl::setEnforced(false, self::IDSITE);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::getStoredEnforcementState(self::IDSITE));
+    }
+
+    // externally managed settings
+
+    public function testExternallyManagedSettingFollowsItsPoliciesOnly()
+    {
+        $this->assertFalse(ExternallyManagedPolicyComparisonTraitImpl::isEnforced());
+
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+
+        $this->assertTrue(ExternallyManagedPolicyComparisonTraitImpl::isEnforced());
+        $this->assertSame([], InMemoryPolicyEnforcementState::getAllStates());
+    }
+
+    public function testExternallyManagedSettingCannotBeEnforcedDirectly()
+    {
+        $this->expectExceptionMessage('cannot be changed');
+
+        ExternallyManagedPolicyComparisonTraitImpl::setEnforced(true);
+    }
+
+    public function testExternallyManagedSettingIsNotWritable()
+    {
+        $this->assertFalse(ExternallyManagedPolicyComparisonTraitImpl::isEnforcementWritable());
+    }
+
+    // identity and writability
+
+    public function testGetPolicySettingId()
+    {
+        $this->assertSame('TestPlugin.PolicyComparisonTraitImpl', PolicyComparisonTraitImpl::getPolicySettingId());
+    }
+
+    public function testIsEnforcementWritable()
+    {
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforcementWritable());
+
+        InMemoryPolicyEnforcementState::setIsWritable(false);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforcementWritable());
+    }
+
+    public function testIsEnforcementNotWritableWhenThePolicyIsConfigControlled()
+    {
+        TestPolicy::setConfigValue(true);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforcementWritable());
     }
 }


### PR DESCRIPTION
A policy-controlled setting has two separate storage areas. The first holds the value of the underlying Matomo setting, written from whichever settings page owns it; compliance only reads it, to judge whether that configuration already satisfies a policy requirement on its own. This adds the second: whether the setting is being forced on, in the same way a compliance policy as a whole can be turned on or off, stored per instance and per website.

That state belongs to the setting rather than to a policy. A setting has one enforcement state per scope, not one per policy it subscribes to, so the stored name carries no policy name and lives under the setting's own plugin. Value resolution now asks whether the setting itself is enforced instead of whether the policy is active.

Until a setting's own state is set it follows the policies it subscribes to, so installs that enforced a whole policy stay enforced without any stored state having to be converted. Only states deviating from what would be inherited are stored, which means a stored row always represents a deliberate choice rather than a pinned copy of whatever a policy happened to say at the time.

Storage gained unsetValue(), as it previously had no way to express the removal of a value: nulling one leaves the key in place, where it is found and cast to the setting's type, so a three-state setting could not tell a stored false from no value at all.

### Description

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
