### PR TITLE
Let policy-controlled settings own their enforcement state, DEV-20349

### DIFF
--- a/core/Policy/CompliancePolicy.php
+++ b/core/Policy/CompliancePolicy.php
@@ -14,13 +14,10 @@ use Piwik\Plugin\Manager;
 use Piwik\Settings\FieldConfig;
 use Piwik\Settings\Interfaces\ConfigSettingInterface;
 use Piwik\Settings\Interfaces\MeasurableSettingInterface;
-use Piwik\Settings\Interfaces\PolicyComparisonInterface;
 use Piwik\Settings\Interfaces\SystemSettingInterface;
 use Piwik\Settings\Interfaces\Traits\Getters\ConfigGetterTrait;
 use Piwik\Settings\Interfaces\Traits\Setters\MeasurableSetterTrait;
 use Piwik\Settings\Interfaces\Traits\Setters\SystemSetterTrait;
-use Piwik\Settings\Measurable\MeasurableSetting;
-use Piwik\Settings\Plugin\SystemSetting;
 
 /**
  * @implements SystemSettingInterface<bool>
@@ -187,95 +184,5 @@ abstract class CompliancePolicy implements SystemSettingInterface, MeasurableSet
     public static function isConfigControlled()
     {
         return !is_null(static::getConfigValue());
-    }
-
-    /**
-     * Name under which the per-setting enforcement state of the given
-     * policy-controlled setting is stored, at system and measurable scope.
-     *
-     * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
-     */
-    public static function getSettingEnforcementName(string $settingClass): string
-    {
-        $settingId = str_replace('.', '_', $settingClass::getPolicySettingId());
-        return preg_replace('/\s+/', '', static::getName()) . '_enforce__' . $settingId;
-    }
-
-    /**
-     * Returns whether this policy currently enforces the given policy-controlled
-     * setting for the given scope (instance-wide when $idSite is null).
-     *
-     * Resolution order:
-     *  1. config-level enforcement of the whole policy
-     *  2. explicit per-setting enforcement state; an enabled instance-wide state
-     *     applies to all sites, like {@link isActive()} does for the whole policy
-     *  3. the whole-policy enforcement flag, for scopes where no per-setting
-     *     state has been stored yet
-     *
-     * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
-     */
-    public static function isEnforcedForSetting(string $settingClass, ?int $idSite = null): bool
-    {
-        if (static::isConfigControlled()) {
-            return (bool) static::getConfigValue();
-        }
-
-        $systemValue = static::getSettingEnforcementSystemValue($settingClass);
-        if ($systemValue === true) {
-            return true;
-        }
-
-        if (!is_null($idSite)) {
-            $measurableValue = static::getSettingEnforcementMeasurableValue($settingClass, $idSite);
-            if (!is_null($measurableValue)) {
-                return $measurableValue;
-            }
-        }
-
-        if (!is_null($systemValue)) {
-            return false;
-        }
-
-        return static::isActive($idSite);
-    }
-
-    /**
-     * Instance-wide enforcement state of the given setting, or null when no state was ever stored.
-     *
-     * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
-     */
-    protected static function getSettingEnforcementSystemValue(string $settingClass): ?bool
-    {
-        // a null default value allows distinguishing "never stored" from an explicit value
-        $setting = new SystemSetting(
-            static::getSettingEnforcementName($settingClass),
-            null,
-            FieldConfig::TYPE_BOOL,
-            Piwik::getPluginNameOfMatomoClass(static::class)
-        );
-
-        $value = $setting->getValue();
-
-        return is_null($value) ? null : (bool) $value;
-    }
-
-    /**
-     * Per-site enforcement state of the given setting, or null when no state was ever stored.
-     *
-     * @param class-string<PolicyComparisonInterface<mixed>> $settingClass
-     */
-    protected static function getSettingEnforcementMeasurableValue(string $settingClass, int $idSite): ?bool
-    {
-        $setting = new MeasurableSetting(
-            static::getSettingEnforcementName($settingClass),
-            null,
-            FieldConfig::TYPE_BOOL,
-            Piwik::getPluginNameOfMatomoClass(static::class),
-            $idSite
-        );
-
-        $value = $setting->getValue();
-
-        return is_null($value) ? null : (bool) $value;
     }
 }

--- a/core/Policy/PolicyManager.php
+++ b/core/Policy/PolicyManager.php
@@ -246,17 +246,18 @@ class PolicyManager
         $settings = [];
 
         foreach ($policies as $policyClass) {
-            if (false === $policyClass::isActive($idSite)) {
-                continue;
-            }
             $controlledSettings = self::getAllControlledSettings($policyClass, $idSite, $settingType);
 
             foreach ($controlledSettings as $controlledSetting) {
-                if ($settingName === call_user_func([$controlledSetting, self::$settingTypesMap[$settingType]['method']])) {
-                    $settings[$policyClass::getName()] = [
-                        'requiredValue' => $controlledSetting::getPolicyRequirements()[$policyClass],
-                    ];
+                if ($settingName !== call_user_func([$controlledSetting, self::$settingTypesMap[$settingType]['method']])) {
+                    continue;
                 }
+                if (!$controlledSetting::isEnforced($idSite)) {
+                    continue;
+                }
+                $settings[$policyClass::getName()] = [
+                    'requiredValue' => $controlledSetting::getPolicyRequirements()[$policyClass],
+                ];
             }
         }
 

--- a/core/Settings/Interfaces/PolicyComparisonInterface.php
+++ b/core/Settings/Interfaces/PolicyComparisonInterface.php
@@ -12,16 +12,25 @@ namespace Piwik\Settings\Interfaces;
 use Piwik\Policy\CompliancePolicy;
 
 /**
+ * Implemented by settings that a compliance policy can control.
+ *
+ * A setting subscribes to the policies it forms a requirement of via
+ * {@link getPolicyRequirements()}, and separately owns the state that records whether
+ * it is currently being enforced. That state is not tied to any single policy: a
+ * setting has one enforcement state per scope, not one per policy it subscribes to.
+ *
  * Implement this interface via {@link \Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait},
- * which provides default implementations for all dashboard-metadata methods.
- * Methods may be added to this interface in major releases; the trait always
- * ships matching defaults, so trait users are unaffected.
+ * which provides default implementations for the enforcement state and dashboard
+ * metadata methods. Methods may be added to this interface in major releases; the
+ * trait always ships matching defaults, so trait users are unaffected.
  *
  * @template T of mixed
  */
 interface PolicyComparisonInterface
 {
     /**
+     * The policies this setting is a requirement of, and the value each of them requires.
+     *
      * @return array<class-string<CompliancePolicy>, T>
      */
     public static function getPolicyRequirements(): array;
@@ -72,4 +81,40 @@ interface PolicyComparisonInterface
      * @since Matomo 6.0.0 — {@link PolicyComparisonTrait} provides a default.
      */
     public static function getImpact(): string;
+
+    /**
+     * Whether this setting is currently being enforced for the given scope, so that the
+     * values required by the policies it subscribes to override the underlying Matomo
+     * setting when its value is resolved.
+     *
+     * @param int|null $idSite The website to check, or null for the instance wide state.
+     * @since Matomo 6.0.0 — {@link PolicyComparisonTrait} provides a default.
+     */
+    public static function isEnforced(?int $idSite = null): bool;
+
+    /**
+     * Changes whether this setting is being enforced for the given scope.
+     *
+     * @param bool|null $isEnforced Null makes the setting follow the enforcement state of its policies again.
+     * @param int|null $idSite The website to update, or null for the instance wide state.
+     * @since Matomo 6.0.0 — {@link PolicyComparisonTrait} provides a default.
+     */
+    public static function setEnforced(?bool $isEnforced, ?int $idSite = null): void;
+
+    /**
+     * The enforcement state explicitly stored for the given scope, or null when none was
+     * stored and the setting therefore follows the policies it subscribes to.
+     *
+     * @param int|null $idSite The website to read, or null for the instance wide state.
+     * @since Matomo 6.0.0 — {@link PolicyComparisonTrait} provides a default.
+     */
+    public static function getStoredEnforcementState(?int $idSite = null): ?bool;
+
+    /**
+     * Whether the enforcement state of this setting can be changed for the given scope.
+     *
+     * @param int|null $idSite The website to check, or null for the instance wide state.
+     * @since Matomo 6.0.0 — {@link PolicyComparisonTrait} provides a default.
+     */
+    public static function isEnforcementWritable(?int $idSite = null): bool;
 }

--- a/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
+++ b/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
@@ -12,6 +12,7 @@ namespace Piwik\Settings\Interfaces\Traits;
 use Piwik\Piwik;
 use Piwik\Policy\CompliancePolicy;
 use Piwik\Policy\PolicyEnforcementBypass;
+use Piwik\Settings\PolicyEnforcementState;
 
 /**
  * @template T of mixed
@@ -21,20 +22,192 @@ use Piwik\Policy\PolicyEnforcementBypass;
 trait PolicyComparisonTrait
 {
     /**
+     * The values required of this setting that currently apply.
+     *
+     * The requirements only apply while the setting is being enforced. When it is not,
+     * every requirement is nulled out and the underlying Matomo setting decides the value
+     * on its own. The policy keys are always present, so callers can still tell which
+     * policies this setting is a requirement of.
+     *
      * @return array<class-string<CompliancePolicy>, T|null>
      */
     public static function getPolicyRequiredValues(?int $idSite = null): array
     {
         $policyValues = static::getPolicyRequirements();
 
-        /** @var class-string<CompliancePolicy> $policy */
-        foreach (array_keys($policyValues) as $policy) {
-            if (PolicyEnforcementBypass::isActive() || !$policy::isActive($idSite)) {
-                $policyValues[$policy] = null;
-            }
+        if (PolicyEnforcementBypass::isActive() || !static::isEnforced($idSite)) {
+            return array_fill_keys(array_keys($policyValues), null);
         }
 
         return $policyValues;
+    }
+
+    public static function isEnforced(?int $idSite = null): bool
+    {
+        $configEnforcement = static::getConfigControlledEnforcement();
+
+        if (!is_null($configEnforcement)) {
+            // a policy pinned in config.ini.php cannot be overridden from the dashboard
+            return $configEnforcement;
+        }
+
+        if (static::isExternallyManagedByPolicyPage()) {
+            // no enforcement state is stored for these, they follow their policies directly
+            return static::isEnforcedByPolicies($idSite);
+        }
+
+        $instanceState = static::getStoredEnforcementState(null);
+
+        // mirrors CompliancePolicy::isActive(): an instance wide state applies to every site
+        if (true === $instanceState) {
+            return true;
+        }
+
+        if (!is_null($idSite)) {
+            $siteState = static::getStoredEnforcementState($idSite);
+
+            if (!is_null($siteState)) {
+                return $siteState;
+            }
+        }
+
+        if (!is_null($instanceState)) {
+            return false;
+        }
+
+        return static::isEnforcedByPolicies($idSite);
+    }
+
+    public static function setEnforced(?bool $isEnforced, ?int $idSite = null): void
+    {
+        if (static::isExternallyManagedByPolicyPage()) {
+            throw new \Exception(sprintf(
+                'The enforcement state of "%s" is managed outside of the compliance page and cannot be changed',
+                static::getPolicySettingId()
+            ));
+        }
+
+        if (!is_null($idSite) && false === $isEnforced && true === static::getStoredEnforcementState(null)) {
+            // mirrors CompliancePolicy::setActiveStatus(): an instance wide state applies to
+            // every site, so it has to give way before a single site can opt out of it
+            static::writeEnforcementState(null, static::reduceToDeviation(false, null));
+        }
+
+        static::writeEnforcementState($idSite, static::reduceToDeviation($isEnforced, $idSite));
+
+        /**
+         * Triggered when the enforcement state of a policy-controlled setting changes, to
+         * allow performing extra actions when a setting starts or stops being enforced.
+         *
+         * The enforcement state cannot be changed via this event.
+         *
+         * @param bool|null $isEnforced Whether the setting is being enforced, or null when it
+         *                              was reset to follow the policies it subscribes to
+         * @param int|null $idSite The website the state was changed for, or null for the instance
+         * @param class-string<\Piwik\Settings\Interfaces\PolicyComparisonInterface<mixed>> The setting in question
+         */
+        Piwik::postEvent('CompliancePolicy.setSettingEnforcedStatus', [$isEnforced, $idSite, static::class]);
+    }
+
+    public static function getStoredEnforcementState(?int $idSite = null): ?bool
+    {
+        return static::getPolicyEnforcementState()->get($idSite);
+    }
+
+    public static function isEnforcementWritable(?int $idSite = null): bool
+    {
+        if (static::isExternallyManagedByPolicyPage()) {
+            return false;
+        }
+
+        if (!is_null(static::getConfigControlledEnforcement())) {
+            return false;
+        }
+
+        return static::getPolicyEnforcementState()->isWritableByCurrentUser($idSite);
+    }
+
+    /**
+     * Only states that deviate from what would otherwise be inherited are worth storing.
+     * Resetting a setting back to what its policies already say removes the stored state,
+     * so a stored row always represents a deliberate deviation and never merely pins the
+     * value a policy happened to have at the time.
+     */
+    protected static function reduceToDeviation(?bool $isEnforced, ?int $idSite): ?bool
+    {
+        if (is_null($isEnforced)) {
+            return null;
+        }
+
+        return $isEnforced === static::getInheritedEnforcement($idSite) ? null : $isEnforced;
+    }
+
+    /**
+     * The enforcement state this setting would have for the given scope if no state was
+     * stored for that scope.
+     */
+    protected static function getInheritedEnforcement(?int $idSite): bool
+    {
+        if (!is_null($idSite)) {
+            $instanceState = static::getStoredEnforcementState(null);
+
+            if (!is_null($instanceState)) {
+                return $instanceState;
+            }
+        }
+
+        return static::isEnforcedByPolicies($idSite);
+    }
+
+    /**
+     * Whether any of the policies this setting subscribes to is currently active. This is
+     * the state a setting follows until its own enforcement state is set, which is what
+     * keeps installs that enforced a whole policy enforced without having to convert
+     * anything.
+     */
+    protected static function isEnforcedByPolicies(?int $idSite = null): bool
+    {
+        /** @var class-string<CompliancePolicy> $policy */
+        foreach (array_keys(static::getPolicyRequirements()) as $policy) {
+            if ($policy::isActive($idSite)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The enforcement state dictated by a policy that is pinned in `config.ini.php`, or
+     * null when none of the policies this setting subscribes to is config controlled.
+     */
+    protected static function getConfigControlledEnforcement(): ?bool
+    {
+        $isEnforced = null;
+
+        /** @var class-string<CompliancePolicy> $policy */
+        foreach (array_keys(static::getPolicyRequirements()) as $policy) {
+            if (!$policy::isConfigControlled()) {
+                continue;
+            }
+
+            $isEnforced = ($isEnforced ?? false) || (bool) $policy::getConfigValue();
+        }
+
+        return $isEnforced;
+    }
+
+    protected static function writeEnforcementState(?int $idSite, ?bool $isEnforced): void
+    {
+        static::getPolicyEnforcementState()->set($idSite, $isEnforced);
+    }
+
+    protected static function getPolicyEnforcementState(): PolicyEnforcementState
+    {
+        return new PolicyEnforcementState(
+            static::getPolicySettingPluginName(),
+            static::getPolicySettingShortName() . PolicyEnforcementState::SETTING_NAME_SUFFIX
+        );
     }
 
     /**
@@ -80,13 +253,15 @@ trait PolicyComparisonTrait
 
     public static function isControlledBySpecificPolicy(string $policy, ?int $idSite = null): bool
     {
-        return array_key_exists($policy, self::getPolicyRequiredValues($idSite));
+        // whether the setting subscribed to the policy is all that matters here, and is
+        // deliberately independent of the enforcement state: this is called for every
+        // discovered setting, so it must not read the enforcement state from storage
+        return array_key_exists($policy, static::getPolicyRequirements());
     }
 
     public static function getPolicySettingId(): string
     {
-        $shortClassName = substr(strrchr(static::class, '\\'), 1);
-        return Piwik::getPluginNameOfMatomoClass(static::class) . '.' . $shortClassName;
+        return static::getPolicySettingPluginName() . '.' . static::getPolicySettingShortName();
     }
 
     public static function isExternallyManagedByPolicyPage(): bool
@@ -102,6 +277,22 @@ trait PolicyComparisonTrait
     public static function getImpact(): string
     {
         return '';
+    }
+
+    /**
+     * The plugin the enforcement state of this setting is stored under, which is the plugin
+     * owning the setting itself.
+     */
+    protected static function getPolicySettingPluginName(): string
+    {
+        return Piwik::getPluginNameOfMatomoClass(static::class);
+    }
+
+    protected static function getPolicySettingShortName(): string
+    {
+        $parts = explode('\\', static::class);
+
+        return (string) end($parts);
     }
 
     /**

--- a/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
+++ b/core/Settings/Interfaces/Traits/PolicyComparisonTrait.php
@@ -10,6 +10,7 @@
 namespace Piwik\Settings\Interfaces\Traits;
 
 use Piwik\Piwik;
+use Piwik\Plugins\SitesManager\Model as SitesManagerModel;
 use Piwik\Policy\CompliancePolicy;
 use Piwik\Policy\PolicyEnforcementBypass;
 use Piwik\Settings\PolicyEnforcementState;
@@ -57,21 +58,18 @@ trait PolicyComparisonTrait
         }
 
         $instanceState = static::getStoredEnforcementState(null);
+        $siteState = is_null($idSite) ? null : static::getStoredEnforcementState($idSite);
 
-        // mirrors CompliancePolicy::isActive(): an instance wide state applies to every site
-        if (true === $instanceState) {
+        // enforcement is additive across scopes: the setting is enforced as soon as any
+        // scope enforces it, so an instance wide state cannot un-enforce a site that
+        // enforces itself, and a site cannot un-enforce itself while the instance does
+        if (true === $instanceState || true === $siteState) {
             return true;
         }
 
-        if (!is_null($idSite)) {
-            $siteState = static::getStoredEnforcementState($idSite);
-
-            if (!is_null($siteState)) {
-                return $siteState;
-            }
-        }
-
-        if (!is_null($instanceState)) {
+        // an explicit "not enforced" is a deliberate answer and suppresses the policies,
+        // which is what allows a single site to opt out of an otherwise active policy
+        if (false === $instanceState || false === $siteState) {
             return false;
         }
 
@@ -88,12 +86,12 @@ trait PolicyComparisonTrait
         }
 
         if (!is_null($idSite) && false === $isEnforced && true === static::getStoredEnforcementState(null)) {
-            // mirrors CompliancePolicy::setActiveStatus(): an instance wide state applies to
-            // every site, so it has to give way before a single site can opt out of it
-            static::writeEnforcementState(null, static::reduceToDeviation(false, null));
+            // an instance wide state enforces every site, so it has to give way before a
+            // single site can opt out of it
+            static::demoteInstanceWideEnforcement();
         }
 
-        static::writeEnforcementState($idSite, static::reduceToDeviation($isEnforced, $idSite));
+        static::writeEnforcementState($idSite, $isEnforced);
 
         /**
          * Triggered when the enforcement state of a policy-controlled setting changes, to
@@ -124,39 +122,67 @@ trait PolicyComparisonTrait
             return false;
         }
 
-        return static::getPolicyEnforcementState()->isWritableByCurrentUser($idSite);
+        $state = static::getPolicyEnforcementState();
+
+        // changing a site while the instance wide state enforces it demotes that state,
+        // which rewrites every site as well, so it needs instance wide write access even
+        // though the caller only named one site
+        if (!is_null($idSite) && true === static::getStoredEnforcementState(null)) {
+            return $state->isWritableByCurrentUser(null) && $state->isWritableByCurrentUser($idSite);
+        }
+
+        return $state->isWritableByCurrentUser($idSite);
     }
 
     /**
-     * Only states that deviate from what would otherwise be inherited are worth storing.
-     * Resetting a setting back to what its policies already say removes the stored state,
-     * so a stored row always represents a deliberate deviation and never merely pins the
-     * value a policy happened to have at the time.
+     * Turns the instance wide enforcement state off without changing whether any site is
+     * enforced: every site is first given the state it currently resolves to, so that the
+     * sites which were only enforced through the instance wide state keep their
+     * enforcement once it is gone.
+     *
+     * The sites are written before the instance wide state, so an interrupted demotion
+     * leaves everything enforced rather than silently un-enforcing the sites it did not
+     * reach yet.
+     *
+     * @throws \Exception when the current user may not change the instance wide state
      */
-    protected static function reduceToDeviation(?bool $isEnforced, ?int $idSite): ?bool
+    protected static function demoteInstanceWideEnforcement(): void
     {
-        if (is_null($isEnforced)) {
-            return null;
+        $state = static::getPolicyEnforcementState();
+
+        // rewriting every site is an instance wide change whichever site triggered it,
+        // so refuse it upfront rather than part way through
+        $state->assertWritableByCurrentUser(null);
+
+        // resolve every site before writing anything, so each one is given back exactly
+        // what it resolves to today rather than a copy of the instance wide state. Note
+        // this does overwrite a site's own stored "not enforced" with the enforcement it
+        // currently inherits, which is the state that was actually in effect for it.
+        $resolvedStates = [];
+
+        foreach (static::getAllIdSites() as $id) {
+            $idSite = (int) $id;
+            $resolvedStates[$idSite] = static::isEnforced($idSite);
         }
 
-        return $isEnforced === static::getInheritedEnforcement($idSite) ? null : $isEnforced;
+        foreach ($resolvedStates as $id => $isEnforced) {
+            static::writeEnforcementState($id, $isEnforced);
+        }
+
+        // the instance can no longer claim to be enforced as a whole, and recording that
+        // explicitly also keeps sites created later out of the demoted enforcement
+        static::writeEnforcementState(null, false);
     }
 
     /**
-     * The enforcement state this setting would have for the given scope if no state was
-     * stored for that scope.
+     * The websites the instance wide enforcement state has to be materialised onto when
+     * it is demoted.
+     *
+     * @return array<int, int|string>
      */
-    protected static function getInheritedEnforcement(?int $idSite): bool
+    protected static function getAllIdSites(): array
     {
-        if (!is_null($idSite)) {
-            $instanceState = static::getStoredEnforcementState(null);
-
-            if (!is_null($instanceState)) {
-                return $instanceState;
-            }
-        }
-
-        return static::isEnforcedByPolicies($idSite);
+        return (new SitesManagerModel())->getSitesId();
     }
 
     /**

--- a/core/Settings/PolicyEnforcementState.php
+++ b/core/Settings/PolicyEnforcementState.php
@@ -88,14 +88,7 @@ class PolicyEnforcementState
      */
     public function set(?int $idSite, ?bool $isEnforced): void
     {
-        $setting = $this->makeSetting($idSite);
-
-        if (!$setting->isWritableByCurrentUser()) {
-            throw new Exception(Piwik::translate(
-                'CoreAdminHome_PluginSettingChangeNotAllowed',
-                [$this->settingName, $this->pluginName]
-            ));
-        }
+        $this->assertWritableByCurrentUser($idSite);
 
         // Setting::setValue() cannot express the removal of a state, as its boolean
         // validation rejects null. The state is therefore written through the very storage
@@ -119,6 +112,26 @@ class PolicyEnforcementState
     public function isWritableByCurrentUser(?int $idSite = null): bool
     {
         return $this->makeSetting($idSite)->isWritableByCurrentUser();
+    }
+
+    /**
+     * Fails unless the current user may change the enforcement state of the given scope.
+     * Callers that write more than one scope use this to reject the whole change before
+     * any of it is written.
+     *
+     * @param int|null $idSite The website to check, or null for the instance wide state.
+     * @throws Exception when the state cannot be written by the current user
+     */
+    public function assertWritableByCurrentUser(?int $idSite = null): void
+    {
+        if ($this->isWritableByCurrentUser($idSite)) {
+            return;
+        }
+
+        throw new Exception(Piwik::translate(
+            'CoreAdminHome_PluginSettingChangeNotAllowed',
+            [$this->settingName, $this->pluginName]
+        ));
     }
 
     private function makeSetting(?int $idSite): Setting

--- a/core/Settings/PolicyEnforcementState.php
+++ b/core/Settings/PolicyEnforcementState.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Settings;
+
+use Exception;
+use Piwik\Container\StaticContainer;
+use Piwik\Piwik;
+use Piwik\Settings\Measurable\MeasurableSetting;
+use Piwik\Settings\Plugin\SystemSetting;
+use Piwik\Settings\Storage\Factory;
+use Piwik\Settings\Storage\Storage;
+
+/**
+ * Stored enforcement state of a single policy-controlled setting.
+ *
+ * A policy-controlled setting has two separate storage areas:
+ *
+ *  1. The value of the underlying Matomo setting, written from whichever settings
+ *     page owns it and read through the setting's own getter trait. Compliance
+ *     never writes to it, and only reads it to judge whether the underlying
+ *     configuration already satisfies a policy requirement on its own.
+ *  2. The enforcement state handled by this class, which records whether the
+ *     setting is being forced on, in the same way a compliance policy as a whole
+ *     can be turned on or off.
+ *
+ * The state is deliberately independent of any compliance policy: a setting has one
+ * enforcement state per scope, not one per policy it subscribes to. Storing it under
+ * the setting's own plugin means it is reachable from the setting, is removed along
+ * with the plugin's other settings when the plugin is uninstalled, and can be pinned
+ * from `config.ini.php` like any other system setting.
+ *
+ * Three states are distinguished:
+ *
+ *  - `true` / `false` — the state was set explicitly for this scope
+ *  - `null` — no state was ever stored, so the setting follows the enforcement
+ *    state of the policies it subscribes to
+ */
+class PolicyEnforcementState
+{
+    /**
+     * Suffix of the setting name the enforcement state is stored under. It intentionally
+     * carries no policy name: the state belongs to the setting, not to a policy.
+     */
+    public const SETTING_NAME_SUFFIX = '_policy_enforced';
+
+    /**
+     * @var string
+     */
+    private $pluginName;
+
+    /**
+     * @var string
+     */
+    private $settingName;
+
+    public function __construct(string $pluginName, string $settingName)
+    {
+        $this->pluginName = $pluginName;
+        $this->settingName = $settingName;
+    }
+
+    /**
+     * Returns the stored enforcement state for the given scope, or null when no state
+     * was ever stored and the setting therefore follows its policies.
+     *
+     * @param int|null $idSite The website to read the state of, or null for the instance wide state.
+     */
+    public function get(?int $idSite = null): ?bool
+    {
+        $value = $this->makeSetting($idSite)->getValue();
+
+        return is_null($value) ? null : (bool) $value;
+    }
+
+    /**
+     * Stores the enforcement state for the given scope.
+     *
+     * @param int|null $idSite The website to write the state of, or null for the instance wide state.
+     * @param bool|null $isEnforced Null removes the stored state, making the setting follow its policies again.
+     * @throws Exception when the state cannot be written by the current user
+     */
+    public function set(?int $idSite, ?bool $isEnforced): void
+    {
+        $setting = $this->makeSetting($idSite);
+
+        if (!$setting->isWritableByCurrentUser()) {
+            throw new Exception(Piwik::translate(
+                'CoreAdminHome_PluginSettingChangeNotAllowed',
+                [$this->settingName, $this->pluginName]
+            ));
+        }
+
+        // Setting::setValue() cannot express the removal of a state, as its boolean
+        // validation rejects null. The state is therefore written through the very storage
+        // the setting reads from, which both persists it and keeps the request cached
+        // values coherent with what was just written.
+        $storage = $this->getStorage($idSite);
+
+        if (is_null($isEnforced)) {
+            $storage->unsetValue($this->settingName);
+        } else {
+            $storage->setValue($this->settingName, $isEnforced);
+        }
+
+        $storage->save();
+    }
+
+    /**
+     * Whether the current user is allowed to change the enforcement state of this
+     * setting. Returns false when the state is pinned in `config.ini.php`.
+     */
+    public function isWritableByCurrentUser(?int $idSite = null): bool
+    {
+        return $this->makeSetting($idSite)->isWritableByCurrentUser();
+    }
+
+    private function makeSetting(?int $idSite): Setting
+    {
+        if (is_null($idSite)) {
+            return new SystemSetting($this->settingName, null, FieldConfig::TYPE_BOOL, $this->pluginName);
+        }
+
+        return new MeasurableSetting($this->settingName, null, FieldConfig::TYPE_BOOL, $this->pluginName, $idSite);
+    }
+
+    private function getStorage(?int $idSite): Storage
+    {
+        /** @var Factory $factory */
+        $factory = StaticContainer::get(Factory::class);
+
+        if (is_null($idSite)) {
+            return $factory->getPluginStorage($this->pluginName, '');
+        }
+
+        return $factory->getMeasurableSettingsStorage($idSite, $this->pluginName);
+    }
+}

--- a/core/Settings/PolicyEnforcementState.php
+++ b/core/Settings/PolicyEnforcementState.php
@@ -41,6 +41,10 @@ use Piwik\Settings\Storage\Storage;
  *  - `true` / `false` — the state was set explicitly for this scope
  *  - `null` — no state was ever stored, so the setting follows the enforcement
  *    state of the policies it subscribes to
+ *
+ * The state is consumed during setting-value resolution via
+ * {@link \Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait::getPolicyRequiredValues()},
+ * which only applies the policy-required values while the setting is enforced.
  */
 class PolicyEnforcementState
 {

--- a/core/Settings/Storage/Storage.php
+++ b/core/Settings/Storage/Storage.php
@@ -101,6 +101,29 @@ class Storage
         $this->settingsValues[$key] = $value;
     }
 
+    /**
+     * Removes the value of a setting in memory. To persist the change across requests,
+     * {@link save()} must be called.
+     *
+     * This differs from setting a value to null: a removed value makes {@link getValue()}
+     * return the given default value again, whereas a null value would still be found and
+     * converted to the setting's type. Settings that need to distinguish "no value stored"
+     * from a stored falsy value therefore have to remove the value rather than null it.
+     *
+     * @param string $key The name / key of a setting
+     */
+    public function unsetValue($key)
+    {
+        $this->loadSettingsIfNotDoneYet();
+
+        if (!array_key_exists($key, $this->settingsValues)) {
+            return;
+        }
+
+        $this->isDirty = true;
+        unset($this->settingsValues[$key]);
+    }
+
     private function loadSettingsIfNotDoneYet()
     {
         if ($this->settingValuesLoaded) {

--- a/plugins/DevicesDetection/Reports/GetModel.php
+++ b/plugins/DevicesDetection/Reports/GetModel.php
@@ -11,9 +11,8 @@ namespace Piwik\Plugins\DevicesDetection\Reports;
 
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
-use Piwik\Policy\CnilPolicy;
 use Piwik\Plugins\DevicesDetection\Columns\DeviceModel;
-use Piwik\Policy\PolicyManager;
+use Piwik\Plugins\DevicesDetection\Settings\DeviceModelDetectionDisabled;
 
 class GetModel extends Base
 {
@@ -37,7 +36,7 @@ class GetModel extends Base
 
     public function isEnabled()
     {
-        // Metadata visibility is global-only here, so check the policy state directly.
-        return !PolicyManager::isPolicyActive(CnilPolicy::class, $idSite = null);
+        // Metadata visibility is global-only here, so check the instance-wide setting state.
+        return !DeviceModelDetectionDisabled::getInstance()->getValue();
     }
 }

--- a/plugins/Resolution/Reports/GetResolution.php
+++ b/plugins/Resolution/Reports/GetResolution.php
@@ -11,10 +11,9 @@ namespace Piwik\Plugins\Resolution\Reports;
 
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
-use Piwik\Policy\CnilPolicy;
 use Piwik\Plugins\Resolution\Columns\Resolution;
 use Piwik\Plugin\ReportsProvider;
-use Piwik\Policy\PolicyManager;
+use Piwik\Plugins\Resolution\Settings\ScreenResolutionDetectionDisabled;
 
 class GetResolution extends Base
 {
@@ -43,7 +42,7 @@ class GetResolution extends Base
 
     public function isEnabled()
     {
-        // Metadata visibility is global-only here, so check the policy state directly.
-        return !PolicyManager::isPolicyActive(CnilPolicy::class, $idSite = null);
+        // Metadata visibility is global-only here, so check the instance-wide setting state.
+        return !ScreenResolutionDetectionDisabled::getInstance()->getValue();
     }
 }

--- a/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
+++ b/tests/PHPUnit/Framework/Mock/Policy/TestPolicy.php
@@ -13,12 +13,6 @@ class TestPolicy extends \Piwik\Policy\CompliancePolicy
     /** @var array<int,bool> */
     private static $perSite = [];
 
-    /** @var array<string,bool> */
-    private static $settingEnforcementSystem = [];
-
-    /** @var array<int,array<string,bool>> */
-    private static $settingEnforcementPerSite = [];
-
     /** @var bool|null */
     private static $configValue = null;
 
@@ -26,8 +20,6 @@ class TestPolicy extends \Piwik\Policy\CompliancePolicy
     {
         self::$system = false;
         self::$perSite = [];
-        self::$settingEnforcementSystem = [];
-        self::$settingEnforcementPerSite = [];
         self::$configValue = null;
     }
 
@@ -86,34 +78,6 @@ class TestPolicy extends \Piwik\Policy\CompliancePolicy
     public static function setConfigValue(?bool $value): void
     {
         self::$configValue = $value;
-    }
-
-    protected static function getSettingEnforcementSystemValue(string $settingClass): ?bool
-    {
-        return self::$settingEnforcementSystem[$settingClass] ?? null;
-    }
-
-    protected static function getSettingEnforcementMeasurableValue(string $settingClass, int $idSite): ?bool
-    {
-        return self::$settingEnforcementPerSite[$idSite][$settingClass] ?? null;
-    }
-
-    public static function setSettingEnforcementSystemValue(string $settingClass, ?bool $value): void
-    {
-        if (is_null($value)) {
-            unset(self::$settingEnforcementSystem[$settingClass]);
-        } else {
-            self::$settingEnforcementSystem[$settingClass] = $value;
-        }
-    }
-
-    public static function setSettingEnforcementMeasurableValue(string $settingClass, int $idSite, ?bool $value): void
-    {
-        if (is_null($value)) {
-            unset(self::$settingEnforcementPerSite[$idSite][$settingClass]);
-        } else {
-            self::$settingEnforcementPerSite[$idSite][$settingClass] = $value;
-        }
     }
 
     public static function setState($instanceLevel, $siteLevel)

--- a/tests/PHPUnit/Framework/Mock/Settings/FakePolicySetting.php
+++ b/tests/PHPUnit/Framework/Mock/Settings/FakePolicySetting.php
@@ -13,9 +13,21 @@ class FakePolicySetting implements PolicyComparisonInterface, SettingValueInterf
      */
     private $value;
 
+    /**
+     * Enforcement states per scope, the instance wide scope being stored under ''.
+     *
+     * @var array<string, bool>
+     */
+    private static $enforcementStates = [];
+
     private function __construct(bool $value)
     {
         $this->value = $value;
+    }
+
+    public static function reset(): void
+    {
+        self::$enforcementStates = [];
     }
 
     public static function getPolicyRequirements(): array
@@ -90,5 +102,34 @@ class FakePolicySetting implements PolicyComparisonInterface, SettingValueInterf
     public static function getInlineHelp(): string
     {
         return 'Fake policy setting inline help text';
+    }
+
+    public static function isEnforced(?int $idSite = null): bool
+    {
+        return self::getStoredEnforcementState($idSite)
+            ?? self::getStoredEnforcementState(null)
+            ?? TestPolicy::isActive($idSite);
+    }
+
+    public static function setEnforced(?bool $isEnforced, ?int $idSite = null): void
+    {
+        $scope = is_null($idSite) ? '' : (string) $idSite;
+
+        if (is_null($isEnforced)) {
+            unset(self::$enforcementStates[$scope]);
+            return;
+        }
+
+        self::$enforcementStates[$scope] = $isEnforced;
+    }
+
+    public static function getStoredEnforcementState(?int $idSite = null): ?bool
+    {
+        return self::$enforcementStates[is_null($idSite) ? '' : (string) $idSite] ?? null;
+    }
+
+    public static function isEnforcementWritable(?int $idSite = null): bool
+    {
+        return true;
     }
 }

--- a/tests/PHPUnit/Framework/Mock/Settings/InMemoryPolicyEnforcementState.php
+++ b/tests/PHPUnit/Framework/Mock/Settings/InMemoryPolicyEnforcementState.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Framework\Mock\Settings;
+
+use Piwik\Settings\PolicyEnforcementState;
+
+/**
+ * Enforcement state kept in memory, so that the resolution rules of
+ * {@link \Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait} can be unit tested
+ * without a database.
+ */
+class InMemoryPolicyEnforcementState extends PolicyEnforcementState
+{
+    /**
+     * States per storage key, of [scope => bool]. The instance wide scope is stored under ''.
+     *
+     * @var array<string, array<string, bool>>
+     */
+    private static $states = [];
+
+    /**
+     * @var bool
+     */
+    private static $isWritable = true;
+
+    /**
+     * @var string
+     */
+    private $key;
+
+    public function __construct(string $pluginName, string $settingName)
+    {
+        parent::__construct($pluginName, $settingName);
+
+        $this->key = $pluginName . '.' . $settingName;
+    }
+
+    public static function reset(): void
+    {
+        self::$states = [];
+        self::$isWritable = true;
+    }
+
+    public static function setIsWritable(bool $isWritable): void
+    {
+        self::$isWritable = $isWritable;
+    }
+
+    public function get(?int $idSite = null): ?bool
+    {
+        return self::$states[$this->key][$this->scope($idSite)] ?? null;
+    }
+
+    public function set(?int $idSite, ?bool $isEnforced): void
+    {
+        if (is_null($isEnforced)) {
+            // the real storage drops null values when persisting, removing the row entirely
+            unset(self::$states[$this->key][$this->scope($idSite)]);
+
+            if (empty(self::$states[$this->key])) {
+                unset(self::$states[$this->key]);
+            }
+
+            return;
+        }
+
+        self::$states[$this->key][$this->scope($idSite)] = $isEnforced;
+    }
+
+    public function isWritableByCurrentUser(?int $idSite = null): bool
+    {
+        return self::$isWritable;
+    }
+
+    /**
+     * All stored states, for asserting that nothing was written.
+     *
+     * @return array<string, array<string, bool>>
+     */
+    public static function getAllStates(): array
+    {
+        return self::$states;
+    }
+
+    private function scope(?int $idSite): string
+    {
+        return is_null($idSite) ? '' : (string) $idSite;
+    }
+}

--- a/tests/PHPUnit/Framework/Mock/Settings/TraitImpls/ExternallyManagedPolicyComparisonTraitImpl.php
+++ b/tests/PHPUnit/Framework/Mock/Settings/TraitImpls/ExternallyManagedPolicyComparisonTraitImpl.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Piwik\Tests\Framework\Mock\Settings\TraitImpls;
+
+/**
+ * A policy setting that is managed outside of the compliance page, and therefore stores no
+ * enforcement state of its own.
+ */
+class ExternallyManagedPolicyComparisonTraitImpl extends PolicyComparisonTraitImpl
+{
+    public static function isExternallyManagedByPolicyPage(): bool
+    {
+        return true;
+    }
+}

--- a/tests/PHPUnit/Framework/Mock/Settings/TraitImpls/PolicyComparisonTraitImpl.php
+++ b/tests/PHPUnit/Framework/Mock/Settings/TraitImpls/PolicyComparisonTraitImpl.php
@@ -4,7 +4,9 @@ namespace Piwik\Tests\Framework\Mock\Settings\TraitImpls;
 
 use Piwik\Settings\Interfaces\PolicyComparisonInterface;
 use Piwik\Settings\Interfaces\Traits\PolicyComparisonTrait;
+use Piwik\Settings\PolicyEnforcementState;
 use Piwik\Tests\Framework\Mock\Policy\TestPolicy;
+use Piwik\Tests\Framework\Mock\Settings\InMemoryPolicyEnforcementState;
 
 class PolicyComparisonTraitImpl implements PolicyComparisonInterface
 {
@@ -33,5 +35,19 @@ class PolicyComparisonTraitImpl implements PolicyComparisonInterface
     public static function getComplianceRequirementNote(?int $idSite = null): string
     {
         return 'test PolicyComparisonTrait';
+    }
+
+    protected static function getPolicySettingPluginName(): string
+    {
+        // the mock does not live in a plugin, so the name cannot be derived from its namespace
+        return 'TestPlugin';
+    }
+
+    protected static function getPolicyEnforcementState(): PolicyEnforcementState
+    {
+        return new InMemoryPolicyEnforcementState(
+            static::getPolicySettingPluginName(),
+            static::getPolicySettingShortName() . PolicyEnforcementState::SETTING_NAME_SUFFIX
+        );
     }
 }

--- a/tests/PHPUnit/Framework/Mock/Settings/TraitImpls/PolicyComparisonTraitImpl.php
+++ b/tests/PHPUnit/Framework/Mock/Settings/TraitImpls/PolicyComparisonTraitImpl.php
@@ -15,6 +15,27 @@ class PolicyComparisonTraitImpl implements PolicyComparisonInterface
      */
     use PolicyComparisonTrait;
 
+    /**
+     * Websites the mock pretends the instance has, so that demoting the instance wide
+     * enforcement state can be tested without a database.
+     *
+     * @var array<int, int>
+     */
+    private static $idSites = [];
+
+    /**
+     * @param array<int, int> $idSites
+     */
+    public static function setAllIdSites(array $idSites): void
+    {
+        self::$idSites = $idSites;
+    }
+
+    protected static function getAllIdSites(): array
+    {
+        return self::$idSites;
+    }
+
     protected static function compareStrictness($value1, $value2)
     {
         return $value1;

--- a/tests/PHPUnit/Integration/Settings/PolicyEnforcementInheritanceTest.php
+++ b/tests/PHPUnit/Integration/Settings/PolicyEnforcementInheritanceTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Settings;
+
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\Policy\CnilPolicy;
+use Piwik\Policy\PolicyManager;
+use Piwik\Plugins\PrivacyManager\Settings\IPAnonymisation;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * Until a setting's own enforcement state is set, it follows the enforcement state of the
+ * policies it subscribes to. That is what keeps installs which enforced a whole policy
+ * before per-setting enforcement existed enforced afterwards, without any of their stored
+ * state having to be converted.
+ *
+ * @group PolicySettings
+ */
+class PolicyEnforcementInheritanceTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createWebsite('2020-01-01 00:00:00');
+        Fixture::createWebsite('2020-01-01 00:00:00');
+    }
+
+    public function testEveryControlledSettingIsEnforcedWhenOnlyTheWholePolicyFlagIsSet()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, true);
+
+        $settings = $this->getControlledSettings();
+        $this->assertNotEmpty($settings);
+
+        foreach ($settings as $setting) {
+            $this->assertTrue(
+                $setting::isEnforced(),
+                sprintf('%s should be enforced by the active policy', $setting::getPolicySettingId())
+            );
+        }
+    }
+
+    public function testNoEnforcementStateIsStoredWhenTheWholePolicyIsEnforced()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, true);
+
+        foreach ($this->getControlledSettings() as $setting) {
+            $this->assertNull(
+                $setting::getStoredEnforcementState(),
+                sprintf('%s should not have stored an enforcement state', $setting::getPolicySettingId())
+            );
+        }
+
+        $this->assertSame(0, $this->countStoredEnforcementRows());
+    }
+
+    public function testNoControlledSettingIsEnforcedWhileThePolicyIsInactive()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, false);
+
+        foreach ($this->getControlledSettings() as $setting) {
+            $this->assertFalse(
+                $setting::isEnforced(),
+                sprintf('%s should not be enforced by an inactive policy', $setting::getPolicySettingId())
+            );
+        }
+    }
+
+    public function testSettingsFollowThePolicyPerSite()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, true, 1);
+
+        foreach ($this->getControlledSettings(1) as $setting) {
+            $this->assertTrue($setting::isEnforced(1), $setting::getPolicySettingId());
+            $this->assertFalse($setting::isEnforced(2), $setting::getPolicySettingId());
+        }
+
+        $this->assertSame(0, $this->countStoredEnforcementRows());
+    }
+
+    public function testASingleSettingCanOptOutWhileTheRestKeepFollowingThePolicy()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, true);
+
+        IPAnonymisation::setEnforced(false);
+
+        $this->assertFalse(IPAnonymisation::isEnforced());
+        $this->assertFalse(IPAnonymisation::getStoredEnforcementState());
+
+        foreach ($this->getControlledSettings() as $setting) {
+            if ($setting === IPAnonymisation::class) {
+                continue;
+            }
+
+            $this->assertTrue($setting::isEnforced(), $setting::getPolicySettingId());
+            $this->assertNull($setting::getStoredEnforcementState(), $setting::getPolicySettingId());
+        }
+    }
+
+    public function testASingleSettingCanBeEnforcedWhileThePolicyStaysInactive()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, false);
+
+        IPAnonymisation::setEnforced(true);
+
+        $this->assertTrue(IPAnonymisation::isEnforced());
+
+        foreach ($this->getControlledSettings() as $setting) {
+            if ($setting === IPAnonymisation::class) {
+                continue;
+            }
+
+            $this->assertFalse($setting::isEnforced(), $setting::getPolicySettingId());
+        }
+    }
+
+    public function testEnforcingASingleSettingAppliesItsRequiredValue()
+    {
+        PolicyManager::setPolicyActiveStatus(CnilPolicy::class, false);
+
+        $required = IPAnonymisation::getPolicyRequirements()[CnilPolicy::class];
+
+        IPAnonymisation::setEnforced(true);
+        $this->assertGreaterThanOrEqual($required, IPAnonymisation::getInstance()->getValue());
+        $this->assertTrue(IPAnonymisation::isCompliant(CnilPolicy::class));
+
+        IPAnonymisation::setEnforced(false);
+        $this->assertNull(IPAnonymisation::getPolicyRequiredValues()[CnilPolicy::class]);
+    }
+
+    /**
+     * @return array<class-string<\Piwik\Settings\Interfaces\PolicyComparisonInterface<mixed>>>
+     */
+    private function getControlledSettings(?int $idSite = null): array
+    {
+        return PolicyManager::getAllControlledSettings(CnilPolicy::class, $idSite);
+    }
+
+    private function countStoredEnforcementRows(): int
+    {
+        $pluginRows = (int) Db::fetchOne(
+            'SELECT COUNT(*) FROM ' . Common::prefixTable('plugin_setting')
+            . " WHERE setting_name LIKE '%\_policy\_enforced'"
+        );
+
+        $siteRows = (int) Db::fetchOne(
+            'SELECT COUNT(*) FROM ' . Common::prefixTable('site_setting')
+            . " WHERE setting_name LIKE '%\_policy\_enforced'"
+        );
+
+        return $pluginRows + $siteRows;
+    }
+}

--- a/tests/PHPUnit/Integration/Settings/PolicyEnforcementStateTest.php
+++ b/tests/PHPUnit/Integration/Settings/PolicyEnforcementStateTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Settings;
+
+use Piwik\Common;
+use Piwik\Config;
+use Piwik\Db;
+use Piwik\Settings\PolicyEnforcementState;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * The enforcement state of a policy-controlled setting needs three states: enforced, not
+ * enforced, and "no state stored, so follow the policy". These tests cover that the storage
+ * really distinguishes them, in particular that removing a state removes the row rather than
+ * storing a falsy value.
+ *
+ * @group PolicySettings
+ */
+class PolicyEnforcementStateTest extends IntegrationTestCase
+{
+    private const PLUGIN_NAME = 'PrivacyManager';
+    private const SETTING_NAME = 'FakeSetting_policy_enforced';
+
+    /**
+     * @var PolicyEnforcementState
+     */
+    private $state;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createWebsite('2020-01-01 00:00:00');
+        Fixture::createWebsite('2020-01-01 00:00:00');
+
+        $this->state = new PolicyEnforcementState(self::PLUGIN_NAME, self::SETTING_NAME);
+    }
+
+    public function testNoStateIsStoredInitially()
+    {
+        $this->assertNull($this->state->get());
+        $this->assertNull($this->state->get(1));
+    }
+
+    public function testStoresAndReadsBackTheInstanceWideState()
+    {
+        $this->state->set(null, true);
+        $this->assertTrue($this->state->get());
+
+        $this->state->set(null, false);
+        $this->assertFalse($this->state->get());
+    }
+
+    public function testStoresAndReadsBackASiteState()
+    {
+        $this->state->set(1, true);
+
+        $this->assertTrue($this->state->get(1));
+        $this->assertNull($this->state->get(2));
+        $this->assertNull($this->state->get());
+    }
+
+    public function testInstanceAndSiteStatesAreStoredIndependently()
+    {
+        $this->state->set(null, true);
+        $this->state->set(1, false);
+
+        $this->assertTrue($this->state->get());
+        $this->assertFalse($this->state->get(1));
+        $this->assertNull($this->state->get(2));
+    }
+
+    public function testStoringFalseIsDistinguishableFromNoStateAtAll()
+    {
+        $this->state->set(null, false);
+
+        $this->assertFalse($this->state->get());
+        $this->assertNotNull($this->state->get());
+        $this->assertSame(1, $this->countStoredInstanceRows());
+    }
+
+    public function testRemovingTheInstanceWideStateRemovesTheRow()
+    {
+        $this->state->set(null, true);
+        $this->assertSame(1, $this->countStoredInstanceRows());
+
+        $this->state->set(null, null);
+
+        $this->assertNull($this->state->get());
+        $this->assertSame(0, $this->countStoredInstanceRows());
+    }
+
+    public function testRemovingASiteStateRemovesTheRow()
+    {
+        $this->state->set(1, true);
+        $this->assertSame(1, $this->countStoredSiteRows(1));
+
+        $this->state->set(1, null);
+
+        $this->assertNull($this->state->get(1));
+        $this->assertSame(0, $this->countStoredSiteRows(1));
+    }
+
+    public function testRemovingAStateKeepsOtherScopesIntact()
+    {
+        $this->state->set(null, true);
+        $this->state->set(1, false);
+
+        $this->state->set(1, null);
+
+        $this->assertTrue($this->state->get());
+        $this->assertNull($this->state->get(1));
+    }
+
+    public function testRemovingAStateThatWasNeverStoredIsHarmless()
+    {
+        $this->state->set(null, null);
+
+        $this->assertNull($this->state->get());
+        $this->assertSame(0, $this->countStoredInstanceRows());
+    }
+
+    public function testDoesNotCollideWithTheEnforcementStateOfAnotherSetting()
+    {
+        $other = new PolicyEnforcementState(self::PLUGIN_NAME, 'OtherFakeSetting_policy_enforced');
+
+        $this->state->set(null, true);
+
+        $this->assertNull($other->get());
+
+        $other->set(null, false);
+
+        $this->assertTrue($this->state->get());
+        $this->assertFalse($other->get());
+    }
+
+    public function testDoesNotCollideWithTheSameSettingInAnotherPlugin()
+    {
+        $other = new PolicyEnforcementState('Live', self::SETTING_NAME);
+
+        $this->state->set(null, true);
+
+        $this->assertNull($other->get());
+    }
+
+    public function testStateCanBePinnedInTheConfigFile()
+    {
+        $this->assertNull($this->state->get());
+        $this->assertTrue($this->state->isWritableByCurrentUser());
+
+        Config::getInstance()->{self::PLUGIN_NAME} = [self::SETTING_NAME => 1];
+
+        $this->assertTrue($this->state->get());
+        $this->assertFalse($this->state->isWritableByCurrentUser());
+    }
+
+    public function testWritingAPinnedStateIsRejected()
+    {
+        Config::getInstance()->{self::PLUGIN_NAME} = [self::SETTING_NAME => 1];
+
+        $this->expectExceptionMessage('CoreAdminHome_PluginSettingChangeNotAllowed');
+
+        $this->state->set(null, false);
+    }
+
+    private function countStoredInstanceRows(): int
+    {
+        return (int) Db::fetchOne(
+            'SELECT COUNT(*) FROM ' . Common::prefixTable('plugin_setting')
+            . ' WHERE plugin_name = ? AND user_login = ? AND setting_name = ?',
+            [self::PLUGIN_NAME, '', self::SETTING_NAME]
+        );
+    }
+
+    private function countStoredSiteRows(int $idSite): int
+    {
+        return (int) Db::fetchOne(
+            'SELECT COUNT(*) FROM ' . Common::prefixTable('site_setting')
+            . ' WHERE idsite = ? AND plugin_name = ? AND setting_name = ?',
+            [$idSite, self::PLUGIN_NAME, self::SETTING_NAME]
+        );
+    }
+}

--- a/tests/PHPUnit/Integration/Settings/Storage/StorageTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/StorageTest.php
@@ -91,6 +91,55 @@ class StorageTest extends IntegrationTestCase
         $this->assertSame($loaded, $this->loadValuesFromBackend());
     }
 
+    public function testUnsetValueShouldMakeGetValueReturnTheDefaultValueAgain()
+    {
+        $this->storage->setValue($this->settingName, false);
+        $this->assertFalse($this->storage->getValue($this->settingName, null, FieldConfig::TYPE_BOOL));
+
+        $this->storage->unsetValue($this->settingName);
+
+        $this->assertNull($this->storage->getValue($this->settingName, null, FieldConfig::TYPE_BOOL));
+    }
+
+    public function testUnsetValueShouldDistinguishARemovedValueFromANullValue()
+    {
+        // a null value is still found and cast to the requested type, a removed one is not
+        $this->storage->setValue($this->settingName, null);
+        $this->assertFalse($this->storage->getValue($this->settingName, null, FieldConfig::TYPE_BOOL));
+
+        $this->storage->unsetValue($this->settingName);
+        $this->assertNull($this->storage->getValue($this->settingName, null, FieldConfig::TYPE_BOOL));
+    }
+
+    public function testUnsetValueShouldNotRemoveItFromDatabaseBeforeSaving()
+    {
+        $loaded = $this->backend->load();
+        $this->storage->unsetValue($this->settingName);
+
+        $this->assertSame($loaded, $this->loadValuesFromBackend());
+    }
+
+    public function testSaveShouldRemoveAnUnsetValueFromDatabase()
+    {
+        $this->storage->setValue('mySecondName', 'keepMe');
+        $this->storage->save();
+
+        $this->storage->unsetValue($this->settingName);
+        $this->storage->save();
+
+        $this->assertEquals(array('mySecondName' => 'keepMe'), $this->loadValuesFromBackend());
+    }
+
+    public function testUnsetValueShouldBeHarmlessWhenNoValueWasStored()
+    {
+        $loaded = $this->loadValuesFromBackend();
+
+        $this->storage->unsetValue('UnkNownFielD');
+        $this->storage->save();
+
+        $this->assertSame($loaded, $this->loadValuesFromBackend());
+    }
+
     public function testSaveShouldPersistValueInDatabase()
     {
         $this->storage->setValue($this->settingName, 'myRandomVal');

--- a/tests/PHPUnit/Unit/Policy/CompliancePolicyTest.php
+++ b/tests/PHPUnit/Unit/Policy/CompliancePolicyTest.php
@@ -4,7 +4,6 @@ namespace Piwik\Tests\Unit\Policy;
 
 use PHPUnit\Framework\TestCase;
 use Piwik\Tests\Framework\Mock\Policy\TestPolicy;
-use Piwik\Tests\Framework\Mock\Settings\FakePolicySetting;
 
 class CompliancePolicyTest extends TestCase
 {
@@ -68,92 +67,5 @@ class CompliancePolicyTest extends TestCase
         yield [99, false, true, false, false, false];
         yield [99, false, false, true, false, false];
         yield [99, false, false, false, false, false];
-    }
-
-    public function testGetSettingEnforcementNameCombinesPolicyAndSettingId(): void
-    {
-        $this->assertSame(
-            'test_policy_v1_enforce__Fake_FakePolicySetting',
-            TestPolicy::getSettingEnforcementName(FakePolicySetting::class)
-        );
-    }
-
-    public function testIsEnforcedForSettingConfigValueShortCircuitsEverything(): void
-    {
-        // per-setting state says "off", config says "on"
-        TestPolicy::setSettingEnforcementSystemValue(FakePolicySetting::class, false);
-        TestPolicy::setConfigValue(true);
-
-        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
-        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
-
-        // per-setting and legacy state say "on", config says "off"
-        TestPolicy::setSettingEnforcementSystemValue(FakePolicySetting::class, true);
-        TestPolicy::setState(true, 99);
-        TestPolicy::setConfigValue(false);
-
-        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
-        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
-    }
-
-    public function testIsEnforcedForSettingSystemStateAppliesToAllSites(): void
-    {
-        TestPolicy::setSettingEnforcementSystemValue(FakePolicySetting::class, true);
-        TestPolicy::setSettingEnforcementMeasurableValue(FakePolicySetting::class, 99, false);
-
-        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
-        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
-    }
-
-    public function testIsEnforcedForSettingSiteStateWinsWhenSystemStateIsOff(): void
-    {
-        TestPolicy::setSettingEnforcementSystemValue(FakePolicySetting::class, false);
-        TestPolicy::setSettingEnforcementMeasurableValue(FakePolicySetting::class, 99, true);
-
-        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
-        $this->assertTrue(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
-        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 100));
-    }
-
-    public function testIsEnforcedForSettingExplicitSystemOffSuppressesLegacyFlag(): void
-    {
-        TestPolicy::setState(true, 99);
-        TestPolicy::setSettingEnforcementSystemValue(FakePolicySetting::class, false);
-
-        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class));
-        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
-    }
-
-    public function testIsEnforcedForSettingExplicitSiteOffSuppressesLegacyFlag(): void
-    {
-        TestPolicy::setState(false, 99);
-        TestPolicy::setSettingEnforcementMeasurableValue(FakePolicySetting::class, 99, false);
-
-        $this->assertFalse(TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99));
-    }
-
-    /**
-     * @dataProvider possibleStatesForPolicyActive
-     */
-    public function testIsEnforcedForSettingFallsBackToLegacyPolicyFlag(
-        $idSite,
-        $newActiveState,
-        $currentInstanceState,
-        $currentSiteState,
-        $expectedInstanceState,
-        $expectedSiteState
-    ): void {
-        // without any per-setting state, enforcement must exactly mirror the legacy whole-policy flag
-        TestPolicy::setState($currentInstanceState, $currentSiteState ? 99 : false);
-        TestPolicy::setActiveStatus($idSite, $newActiveState);
-
-        $this->assertSame(
-            $expectedInstanceState,
-            TestPolicy::isEnforcedForSetting(FakePolicySetting::class)
-        );
-        $this->assertSame(
-            $expectedSiteState,
-            TestPolicy::isEnforcedForSetting(FakePolicySetting::class, 99)
-        );
     }
 }

--- a/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
+++ b/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
@@ -21,12 +21,14 @@ class PolicyComparisonTraitTest extends TestCase
 
         TestPolicy::reset();
         InMemoryPolicyEnforcementState::reset();
+        PolicyComparisonTraitImpl::setAllIdSites([self::IDSITE, self::OTHER_IDSITE]);
     }
 
     public function tearDown(): void
     {
         TestPolicy::reset();
         InMemoryPolicyEnforcementState::reset();
+        PolicyComparisonTraitImpl::setAllIdSites([]);
 
         parent::tearDown();
     }
@@ -178,6 +180,20 @@ class PolicyComparisonTraitTest extends TestCase
         $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
     }
 
+    /**
+     * Enforcement is additive: a site that enforces the setting stays enforced even while
+     * the instance wide state does not enforce it.
+     */
+    public function testIsEnforcedLetsASiteEnforceOverAnInstanceWideOptOut()
+    {
+        PolicyComparisonTraitImpl::setEnforced(false);
+        PolicyComparisonTraitImpl::setEnforced(true, self::IDSITE);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+    }
+
     public function testIsEnforcedIsPinnedOnByAConfigControlledPolicy()
     {
         TestPolicy::setConfigValue(true);
@@ -197,31 +213,38 @@ class PolicyComparisonTraitTest extends TestCase
 
     // storing the enforcement state
 
-    public function testSetEnforcedOnlyStoresAStateThatDeviatesFromThePolicy()
+    public function testSetEnforcedStoresTheRequestedStateVerbatim()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::getStoredEnforcementState());
+    }
+
+    /**
+     * The stored state records what was asked for, not how it differed from the policies
+     * at the time, so the same intent survives a later policy change.
+     */
+    public function testSetEnforcedStoresAStateThatMatchesThePolicy()
     {
         PolicyComparisonTraitImpl::setEnforced(false);
 
-        $this->assertSame([], InMemoryPolicyEnforcementState::getAllStates());
-        $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState());
+        $this->assertFalse(PolicyComparisonTraitImpl::getStoredEnforcementState());
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+
         $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
     }
 
-    public function testSetEnforcedStoresAStateThatDeviatesFromThePolicy()
+    public function testSetEnforcedKeepsAnExplicitlyEnforcedStateWhenThePolicyIsDeactivated()
     {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
         PolicyComparisonTraitImpl::setEnforced(true);
 
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, false);
+
         $this->assertTrue(PolicyComparisonTraitImpl::getStoredEnforcementState());
-    }
-
-    public function testSetEnforcedRemovesAStoredStateWhenItMatchesThePolicyAgain()
-    {
-        PolicyComparisonTraitImpl::setEnforced(true);
-        $this->assertTrue(PolicyComparisonTraitImpl::getStoredEnforcementState());
-
-        PolicyComparisonTraitImpl::setEnforced(false);
-
-        $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState());
-        $this->assertSame([], InMemoryPolicyEnforcementState::getAllStates());
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced());
     }
 
     public function testSetEnforcedWithNullResetsTheSettingToFollowItsPolicies()
@@ -236,15 +259,69 @@ class PolicyComparisonTraitTest extends TestCase
         $this->assertTrue(PolicyComparisonTraitImpl::isEnforced());
     }
 
-    public function testSetEnforcedGivesWayForASiteOptOutOfAnInstanceWideState()
+    public function testSetEnforcedDemotesInstanceWideEnforcementSoOtherSitesKeepTheirs()
     {
         PolicyComparisonTraitImpl::setEnforced(true);
 
         PolicyComparisonTraitImpl::setEnforced(false, self::IDSITE);
 
+        // the site that opted out is the only one that stops being enforced
         $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+
+        // the other site keeps its enforcement through a state of its own, not through
+        // the instance wide one it used to inherit
+        $this->assertTrue(PolicyComparisonTraitImpl::getStoredEnforcementState(self::OTHER_IDSITE));
+
+        // the instance can no longer claim to be enforced as a whole
+        $this->assertFalse(PolicyComparisonTraitImpl::getStoredEnforcementState());
         $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
-        $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState());
+    }
+
+    public function testSetEnforcedDemotesInstanceWideEnforcementWhileThePolicyIsActive()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        PolicyComparisonTraitImpl::setEnforced(false, self::IDSITE);
+
+        // the explicit instance wide "not enforced" must not leak into the other site,
+        // and must not be overridden by the still active policy either
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    public function testSetEnforcedIsRefusedWhenTheInstanceWideStateCannotBeDemoted()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        InMemoryPolicyEnforcementState::setIsWritable(false);
+
+        try {
+            PolicyComparisonTraitImpl::setEnforced(false, self::IDSITE);
+            $this->fail('Expected the demotion to be refused');
+        } catch (\Exception $e) {
+            // nothing may have been written before the refusal
+            InMemoryPolicyEnforcementState::setIsWritable(true);
+
+            $this->assertTrue(PolicyComparisonTraitImpl::getStoredEnforcementState());
+            $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState(self::IDSITE));
+            $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState(self::OTHER_IDSITE));
+        }
+    }
+
+    public function testIsEnforcementNotWritableForASiteWhenTheInstanceWideStateIsNot()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforcementWritable(self::IDSITE));
+
+        InMemoryPolicyEnforcementState::setIsWritable(false);
+
+        // changing the site would demote the instance wide state, so it needs the same
+        // access as an instance wide change
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforcementWritable(self::IDSITE));
     }
 
     public function testSetEnforcedPinsASiteOptOutWhileThePolicyStaysActive()

--- a/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
+++ b/tests/PHPUnit/Unit/Settings/PolicyComparisonTraitTest.php
@@ -6,13 +6,29 @@ use PHPUnit\Framework\TestCase;
 use Piwik\Policy\PolicyEnforcementBypass;
 use Piwik\Policy\PolicyManager;
 use Piwik\Tests\Framework\Mock\Policy\TestPolicy;
+use Piwik\Tests\Framework\Mock\Settings\InMemoryPolicyEnforcementState;
+use Piwik\Tests\Framework\Mock\Settings\TraitImpls\ExternallyManagedPolicyComparisonTraitImpl;
 use Piwik\Tests\Framework\Mock\Settings\TraitImpls\PolicyComparisonTraitImpl;
 
 class PolicyComparisonTraitTest extends TestCase
 {
+    private const IDSITE = 1;
+    private const OTHER_IDSITE = 2;
+
     public function setUp(): void
     {
         parent::setUp();
+
+        TestPolicy::reset();
+        InMemoryPolicyEnforcementState::reset();
+    }
+
+    public function tearDown(): void
+    {
+        TestPolicy::reset();
+        InMemoryPolicyEnforcementState::reset();
+
+        parent::tearDown();
     }
 
     public function testGetPolicyValuesPolicyActive()
@@ -33,8 +49,37 @@ class PolicyComparisonTraitTest extends TestCase
         $this->assertNull($values[TestPolicy::class]);
     }
 
+    public function testGetPolicyValuesAppliesRequirementWhenTheSettingIsEnforcedWhileThePolicyIsNot()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, false);
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
+
+        $this->assertSame([TestPolicy::class => true], $values);
+    }
+
+    public function testGetPolicyValuesDropsRequirementWhenTheSettingIsNotEnforcedWhileThePolicyIs()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $values = PolicyComparisonTraitImpl::getPolicyRequiredValues();
+
+        $this->assertSame([TestPolicy::class => null], $values);
+    }
+
     public function testIsControlledBySpecificPolicy()
     {
+        $this->assertTrue(
+            PolicyComparisonTraitImpl::isControlledBySpecificPolicy(TestPolicy::class)
+        );
+    }
+
+    public function testIsControlledBySpecificPolicyDoesNotDependOnTheEnforcementState()
+    {
+        PolicyComparisonTraitImpl::setEnforced(false);
+
         $this->assertTrue(
             PolicyComparisonTraitImpl::isControlledBySpecificPolicy(TestPolicy::class)
         );
@@ -71,10 +116,178 @@ class PolicyComparisonTraitTest extends TestCase
         $this->assertFalse(PolicyEnforcementBypass::isActive());
     }
 
+    // enforcement state resolution
+
+    public function testIsEnforcedFollowsThePolicyWhenNoStateWasStored()
+    {
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    public function testIsEnforcedFollowsThePolicyPerSiteWhenNoStateWasStored()
+    {
+        TestPolicy::setMeasurableValue(self::IDSITE, true);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    public function testIsEnforcedUsesTheStoredInstanceStateOverAnInactivePolicy()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced());
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+    }
+
+    public function testIsEnforcedUsesTheStoredInstanceStateOverAnActivePolicy()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+    }
+
+    public function testIsEnforcedUsesTheStoredSiteStateOverThePolicy()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true, self::IDSITE);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    public function testIsEnforcedLetsAnInstanceWideStateApplyToEverySite()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+    }
+
+    public function testIsEnforcedAppliesAnInstanceWideOptOutToSitesWithoutTheirOwnState()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+    }
+
+    public function testIsEnforcedIsPinnedOnByAConfigControlledPolicy()
+    {
+        TestPolicy::setConfigValue(true);
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced());
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+    }
+
+    public function testIsEnforcedIsPinnedOffByAConfigControlledPolicy()
+    {
+        TestPolicy::setConfigValue(false);
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    // storing the enforcement state
+
+    public function testSetEnforcedOnlyStoresAStateThatDeviatesFromThePolicy()
+    {
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $this->assertSame([], InMemoryPolicyEnforcementState::getAllStates());
+        $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState());
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    public function testSetEnforcedStoresAStateThatDeviatesFromThePolicy()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        $this->assertTrue(PolicyComparisonTraitImpl::getStoredEnforcementState());
+    }
+
+    public function testSetEnforcedRemovesAStoredStateWhenItMatchesThePolicyAgain()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+        $this->assertTrue(PolicyComparisonTraitImpl::getStoredEnforcementState());
+
+        PolicyComparisonTraitImpl::setEnforced(false);
+
+        $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState());
+        $this->assertSame([], InMemoryPolicyEnforcementState::getAllStates());
+    }
+
+    public function testSetEnforcedWithNullResetsTheSettingToFollowItsPolicies()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        PolicyComparisonTraitImpl::setEnforced(null);
+
+        $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState());
+
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced());
+    }
+
+    public function testSetEnforcedGivesWayForASiteOptOutOfAnInstanceWideState()
+    {
+        PolicyComparisonTraitImpl::setEnforced(true);
+
+        PolicyComparisonTraitImpl::setEnforced(false, self::IDSITE);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced());
+        $this->assertNull(PolicyComparisonTraitImpl::getStoredEnforcementState());
+    }
+
+    public function testSetEnforcedPinsASiteOptOutWhileThePolicyStaysActive()
+    {
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+
+        PolicyComparisonTraitImpl::setEnforced(false, self::IDSITE);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforced(self::IDSITE));
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforced(self::OTHER_IDSITE));
+        $this->assertFalse(PolicyComparisonTraitImpl::getStoredEnforcementState(self::IDSITE));
+    }
+
+    // externally managed settings
+
+    public function testExternallyManagedSettingFollowsItsPoliciesOnly()
+    {
+        $this->assertFalse(ExternallyManagedPolicyComparisonTraitImpl::isEnforced());
+
+        PolicyManager::setPolicyActiveStatus(TestPolicy::class, true);
+
+        $this->assertTrue(ExternallyManagedPolicyComparisonTraitImpl::isEnforced());
+        $this->assertSame([], InMemoryPolicyEnforcementState::getAllStates());
+    }
+
+    public function testExternallyManagedSettingCannotBeEnforcedDirectly()
+    {
+        $this->expectExceptionMessage('cannot be changed');
+
+        ExternallyManagedPolicyComparisonTraitImpl::setEnforced(true);
+    }
+
+    public function testExternallyManagedSettingIsNotWritable()
+    {
+        $this->assertFalse(ExternallyManagedPolicyComparisonTraitImpl::isEnforcementWritable());
+    }
+
+    // identity and writability
+
     public function testGetPolicySettingIdDefaultsToPluginAndShortClassName()
     {
         $this->assertSame(
-            'Framework.PolicyComparisonTraitImpl',
+            'TestPlugin.PolicyComparisonTraitImpl',
             PolicyComparisonTraitImpl::getPolicySettingId()
         );
     }
@@ -84,5 +297,21 @@ class PolicyComparisonTraitTest extends TestCase
         $this->assertFalse(PolicyComparisonTraitImpl::isExternallyManagedByPolicyPage());
         $this->assertSame('', PolicyComparisonTraitImpl::getWhatItDoes());
         $this->assertSame('', PolicyComparisonTraitImpl::getImpact());
+    }
+
+    public function testIsEnforcementWritable()
+    {
+        $this->assertTrue(PolicyComparisonTraitImpl::isEnforcementWritable());
+
+        InMemoryPolicyEnforcementState::setIsWritable(false);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforcementWritable());
+    }
+
+    public function testIsEnforcementNotWritableWhenThePolicyIsConfigControlled()
+    {
+        TestPolicy::setConfigValue(true);
+
+        $this->assertFalse(PolicyComparisonTraitImpl::isEnforcementWritable());
     }
 }


### PR DESCRIPTION
Reworks compliance enforcement so a policy-controlled setting owns its own enforcement state, rather than the state living on the policy.

A setting has one enforcement state per scope, not one per policy it subscribes to, so the stored name carries no policy name and lives under the setting's own plugin. Three states are distinguished: `true`/`false` for a deliberate deviation, and `null` (nothing stored) meaning the setting follows the policies it subscribes to. Only deviations from the inherited state are stored, so a stored row always represents a deliberate choice. Value resolution now asks whether the setting itself is enforced (`isEnforced()`) instead of whether the policy is active.

Because an unset state inherits from whichever policies are currently active, installs that enforced a whole policy stay enforced with no data migration needed.

New API on the trait/interface: `isEnforced()`, `setEnforced()` (null resets to inherit), `getStoredEnforcementState()`, `isEnforcementWritable()`. `getPolicyRequiredValues()` now gates on `isEnforced()`; `isControlledBySpecificPolicy()` reads `getPolicyRequirements()` directly and never touches storage. `Storage::unsetValue()` is added so a stored `false` is distinguishable from "no value".

Also decouples `PolicyManager::getCompliancePoliciesControllingASetting()` from the whole-policy flag (it now checks the setting's own enforcement state), so the generic Settings-admin "locked by policy" indicator agrees with the compliance dashboard once a setting can be individually overridden; and points the Resolution/DeviceModel report-visibility checks at the concrete setting instead of the whole policy.

### Description

The design here is Nathan's, from #25060 — this rebases it onto current `6.x-dev` and closes three gaps from that branch: it de-duplicates the identity methods that merged separately in #25006, restores the `PolicyEnforcementBypass` check that #25060 had dropped from `getPolicyRequiredValues()`, and removes the now-dead per-policy read model that #25007 had added. #25060 can be closed in favour of this. Bottom of the DEV-20349 stack.

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
