### PR TITLE
Show the percentage of the report total in the AI Chatbot reports

### DIFF
--- a/plugins/BotTracking/Reports/AbstractAIChatbotContentUrlReport.php
+++ b/plugins/BotTracking/Reports/AbstractAIChatbotContentUrlReport.php
@@ -49,6 +49,21 @@ abstract class AbstractAIChatbotContentUrlReport extends Report
         $this->defaultSortColumn = Metrics::COLUMN_REQUESTS;
     }
 
+    /**
+     * The average server time and response size are left out, as a percentage of their summed up
+     * report total says nothing about a row.
+     *
+     * @return array<string, string>
+     */
+    public function getMetricNamesToProcessReportTotals()
+    {
+        return [
+            Metrics::COLUMN_REQUESTS                    => Metrics::COLUMN_REQUESTS,
+            Metrics::COLUMN_SERVER_ERROR_5XX_REQUESTS   => Metrics::COLUMN_SERVER_ERROR_5XX_REQUESTS,
+            Metrics::COLUMN_PAGE_NOT_FOUND_404_REQUESTS => Metrics::COLUMN_PAGE_NOT_FOUND_404_REQUESTS,
+        ];
+    }
+
     public function configureView(ViewDataTable $view): void
     {
         parent::configureView($view);

--- a/plugins/BotTracking/Reports/AbstractAIChatbotFavouredPagesReport.php
+++ b/plugins/BotTracking/Reports/AbstractAIChatbotFavouredPagesReport.php
@@ -64,6 +64,20 @@ abstract class AbstractAIChatbotFavouredPagesReport extends Report
     }
 
     /**
+     * The discrepancy score is left out, as it weights the two traffic columns against each other
+     * per page — a percentage of the summed up scores of the report would be meaningless.
+     *
+     * @return array<string, string>
+     */
+    public function getMetricNamesToProcessReportTotals()
+    {
+        return [
+            Metrics::COLUMN_UNIQUE_HUMAN_PAGEVIEWS => Metrics::COLUMN_UNIQUE_HUMAN_PAGEVIEWS,
+            Metrics::COLUMN_AI_CHATBOT_REQUESTS    => Metrics::COLUMN_AI_CHATBOT_REQUESTS,
+        ];
+    }
+
+    /**
      * @return DiscrepancyScore::VARIANT_HUMAN_FAVOURED|DiscrepancyScore::VARIANT_AI_FAVOURED
      */
     abstract protected function getDiscrepancyScoreVariant(): string;

--- a/plugins/BotTracking/Reports/GetAIChatbotBrokenContent.php
+++ b/plugins/BotTracking/Reports/GetAIChatbotBrokenContent.php
@@ -40,6 +40,18 @@ class GetAIChatbotBrokenContent extends Report
         $this->defaultSortColumn = Metrics::COLUMN_TOTAL_BROKEN_REQUESTS;
     }
 
+    /**
+     * @return array<string, string>
+     */
+    public function getMetricNamesToProcessReportTotals()
+    {
+        return [
+            Metrics::COLUMN_TOTAL_BROKEN_REQUESTS       => Metrics::COLUMN_TOTAL_BROKEN_REQUESTS,
+            Metrics::COLUMN_SERVER_ERROR_5XX_REQUESTS   => Metrics::COLUMN_SERVER_ERROR_5XX_REQUESTS,
+            Metrics::COLUMN_PAGE_NOT_FOUND_404_REQUESTS => Metrics::COLUMN_PAGE_NOT_FOUND_404_REQUESTS,
+        ];
+    }
+
     public function configureView(ViewDataTable $view): void
     {
         parent::configureView($view);

--- a/plugins/BotTracking/Reports/GetAIChatbotRequests.php
+++ b/plugins/BotTracking/Reports/GetAIChatbotRequests.php
@@ -51,6 +51,19 @@ class GetAIChatbotRequests extends Report
         }
     }
 
+    /**
+     * @return array<string, string>
+     */
+    public function getMetricNamesToProcessReportTotals()
+    {
+        return [
+            Metrics::COLUMN_REQUESTS          => Metrics::COLUMN_REQUESTS,
+            Metrics::COLUMN_PAGE_REQUESTS     => Metrics::COLUMN_PAGE_REQUESTS,
+            Metrics::COLUMN_DOCUMENT_REQUESTS => Metrics::COLUMN_DOCUMENT_REQUESTS,
+            Metrics::COLUMN_ACQUIRED_VISITS   => Metrics::COLUMN_ACQUIRED_VISITS,
+        ];
+    }
+
     public function configureView(ViewDataTable $view): void
     {
         parent::configureView($view);

--- a/plugins/BotTracking/Reports/GetDocumentUrlsForAIChatbot.php
+++ b/plugins/BotTracking/Reports/GetDocumentUrlsForAIChatbot.php
@@ -15,6 +15,7 @@ use Piwik\Piwik;
 use Piwik\Plugin\Report;
 use Piwik\Plugins\BotTracking\Columns\DocumentUrl;
 use Piwik\Plugins\BotTracking\Columns\Metrics\Requests;
+use Piwik\Plugins\BotTracking\Metrics;
 
 class GetDocumentUrlsForAIChatbot extends Report
 {
@@ -28,5 +29,13 @@ class GetDocumentUrlsForAIChatbot extends Report
         $this->processedMetrics = [];
         $this->dimension        = new DocumentUrl();
         $this->isSubtableReport = true;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getMetricNamesToProcessReportTotals()
+    {
+        return [Metrics::COLUMN_REQUESTS => Metrics::COLUMN_REQUESTS];
     }
 }

--- a/plugins/BotTracking/Reports/GetPageUrlsForAIChatbot.php
+++ b/plugins/BotTracking/Reports/GetPageUrlsForAIChatbot.php
@@ -15,6 +15,7 @@ use Piwik\Piwik;
 use Piwik\Plugin\Report;
 use Piwik\Plugins\BotTracking\Columns\Metrics\Requests;
 use Piwik\Plugins\BotTracking\Columns\PageUrl;
+use Piwik\Plugins\BotTracking\Metrics;
 
 class GetPageUrlsForAIChatbot extends Report
 {
@@ -28,5 +29,13 @@ class GetPageUrlsForAIChatbot extends Report
         $this->processedMetrics = [];
         $this->dimension        = new PageUrl();
         $this->isSubtableReport = true;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getMetricNamesToProcessReportTotals()
+    {
+        return [Metrics::COLUMN_REQUESTS => Metrics::COLUMN_REQUESTS];
     }
 }

--- a/plugins/BotTracking/tests/Integration/ReportTotalsTest.php
+++ b/plugins/BotTracking/tests/Integration/ReportTotalsTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace Piwik\Plugins\BotTracking\tests\Integration;
+
+use Piwik\Plugin\Report;
+use Piwik\Plugin\ReportsProvider;
+use Piwik\Plugins\BotTracking\Metrics;
+use Piwik\Plugins\BotTracking\Reports\AbstractAIChatbotsRealTimeReport;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * The HTML table visualization only shows the percentage of the report total on hover for the
+ * columns a report registers through Report::getMetricNamesToProcessReportTotals().
+ *
+ * @group BotTracking
+ * @group BotTrackingReportTotals
+ * @group Plugins
+ */
+class ReportTotalsTest extends IntegrationTestCase
+{
+    /**
+     * Columns whose values do not add up over the rows of a report, so a percentage of the summed
+     * up report total would be meaningless for them.
+     */
+    private const NON_ADDITIVE_COLUMNS = [
+        Metrics::COLUMN_AVG_SERVER_TIME,
+        Metrics::COLUMN_AVG_RESPONSE_SIZE,
+        Metrics::COLUMN_DISCREPANCY_SCORE,
+    ];
+
+    public function testEveryAdditiveColumnOfAReportIsRegisteredToProcessReportTotals(): void
+    {
+        $reports = $this->getReportsWithProcessableTotals();
+
+        $this->assertNotEmpty($reports);
+
+        foreach ($reports as $report) {
+            $reportName = $report->getModule() . '.' . $report->getAction();
+            $additiveColumns = array_diff($report->getAllMetrics(), self::NON_ADDITIVE_COLUMNS);
+
+            $this->assertEqualsCanonicalizing(
+                array_values($additiveColumns),
+                array_values($report->getMetricNamesToProcessReportTotals()),
+                'Report ' . $reportName . ' registers the wrong columns to process report totals for.'
+                    . ' Every column that adds up over the rows of the report has to be registered, so its'
+                    . ' percentage of the report total is shown on hover, and no other column may be.'
+            );
+        }
+    }
+
+    public function testRealTimeReportsDoNotProcessReportTotals(): void
+    {
+        $reports = $this->getRealTimeReports();
+
+        $this->assertNotEmpty($reports);
+
+        foreach ($reports as $report) {
+            $this->assertSame(
+                [],
+                $report->getMetricNamesToProcessReportTotals(),
+                'Report ' . $report->getModule() . '.' . $report->getAction() . ' must not process report totals.'
+            );
+        }
+    }
+
+    /**
+     * Reports without a dimension have a single row, so no report total is calculated for them.
+     *
+     * Real-time reports are left out as well: their rows are a live lookback window capped by the
+     * DAO without a summary row for the remainder, and they carry neither the period nor the segment
+     * metadata the ratio tooltip describes them with, so a percentage of their total would relate a
+     * row to a population the report does not show.
+     *
+     * @return Report[]
+     */
+    private function getReportsWithProcessableTotals(): array
+    {
+        $reports = [];
+
+        foreach ($this->getBotTrackingReports() as $report) {
+            if ($report->getDimension() && !$report instanceof AbstractAIChatbotsRealTimeReport) {
+                $reports[] = $report;
+            }
+        }
+
+        return $reports;
+    }
+
+    /**
+     * @return Report[]
+     */
+    private function getRealTimeReports(): array
+    {
+        $reports = [];
+
+        foreach ($this->getBotTrackingReports() as $report) {
+            if ($report instanceof AbstractAIChatbotsRealTimeReport) {
+                $reports[] = $report;
+            }
+        }
+
+        return $reports;
+    }
+
+    /**
+     * @return Report[]
+     */
+    private function getBotTrackingReports(): array
+    {
+        $reports = [];
+
+        foreach ((new ReportsProvider())->getAllReports() as $report) {
+            if ($report->getModule() === 'BotTracking') {
+                $reports[] = $report;
+            }
+        }
+
+        return $reports;
+    }
+}

--- a/plugins/BotTracking/tests/System/expected/test__ai_favoured__BotTracking.getAIChatbotAIFavouredPages_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test__ai_favoured__BotTracking.getAIChatbotAIFavouredPages_day.xml
@@ -5,23 +5,31 @@
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>79.2</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>33.3%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/2</label>
 		<unique_human_pageviews>2</unique_human_pageviews>
 		<ai_chatbot_requests>3</ai_chatbot_requests>
 		<discrepancy_score>20</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>50%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>50%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/3</label>
 		<unique_human_pageviews>1</unique_human_pageviews>
 		<ai_chatbot_requests>1</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>25%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>16.7%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article-1</label>
 		<unique_human_pageviews>1</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>25%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test__ai_favoured__BotTracking.getAIChatbotAIFavouredPages_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test__ai_favoured__BotTracking.getAIChatbotAIFavouredPages_week.xml
@@ -5,65 +5,87 @@
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>3</ai_chatbot_requests>
 		<discrepancy_score>86.1</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>16.7%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/1/page/2</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>68.3</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>11.1%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/4/page/2</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>68.3</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>11.1%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/overview</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>68.3</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>11.1%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/3</label>
 		<unique_human_pageviews>1</unique_human_pageviews>
 		<ai_chatbot_requests>4</ai_chatbot_requests>
 		<discrepancy_score>60</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>6.3%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>22.2%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/1/page/1</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>1</ai_chatbot_requests>
 		<discrepancy_score>43.1</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>5.6%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/2</label>
 		<unique_human_pageviews>5</unique_human_pageviews>
 		<ai_chatbot_requests>4</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>31.3%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>22.2%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article-1</label>
 		<unique_human_pageviews>1</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>6.3%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article-2</label>
 		<unique_human_pageviews>2</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>12.5%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article-3</label>
 		<unique_human_pageviews>3</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>18.8%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article-4</label>
 		<unique_human_pageviews>4</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>25%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test__ai_favoured_filtered__BotTracking.getAIChatbotAIFavouredPages_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test__ai_favoured_filtered__BotTracking.getAIChatbotAIFavouredPages_day.xml
@@ -5,11 +5,15 @@
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>79.2</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>33.3%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/2</label>
 		<unique_human_pageviews>2</unique_human_pageviews>
 		<ai_chatbot_requests>3</ai_chatbot_requests>
 		<discrepancy_score>20</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>50%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>50%</ai_chatbot_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test__ai_favoured_filtered__BotTracking.getAIChatbotAIFavouredPages_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test__ai_favoured_filtered__BotTracking.getAIChatbotAIFavouredPages_week.xml
@@ -5,35 +5,47 @@
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>3</ai_chatbot_requests>
 		<discrepancy_score>86.1</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>16.7%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/1/page/2</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>68.3</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>11.1%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/4/page/2</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>68.3</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>11.1%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/overview</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>68.3</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>11.1%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/3</label>
 		<unique_human_pageviews>1</unique_human_pageviews>
 		<ai_chatbot_requests>4</ai_chatbot_requests>
 		<discrepancy_score>60</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>6.3%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>22.2%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/1/page/1</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>1</ai_chatbot_requests>
 		<discrepancy_score>43.1</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>5.6%</ai_chatbot_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test__broken_content__BotTracking.getAIChatbotBrokenContent_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test__broken_content__BotTracking.getAIChatbotBrokenContent_day.xml
@@ -5,17 +5,26 @@
 		<total_broken_requests>1</total_broken_requests>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<total_broken_requests_percent_of_total>33.3%</total_broken_requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>50%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/resources/doc.pdf</label>
 		<total_broken_requests>1</total_broken_requests>
 		<page_not_found_404_requests>1</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<total_broken_requests_percent_of_total>33.3%</total_broken_requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>100%</page_not_found_404_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/resources/guide.pdf</label>
 		<total_broken_requests>1</total_broken_requests>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<total_broken_requests_percent_of_total>33.3%</total_broken_requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>50%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test__broken_content__BotTracking.getAIChatbotBrokenContent_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test__broken_content__BotTracking.getAIChatbotBrokenContent_week.xml
@@ -5,29 +5,44 @@
 		<total_broken_requests>1</total_broken_requests>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<total_broken_requests_percent_of_total>20%</total_broken_requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>33.3%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/4/page/2</label>
 		<total_broken_requests>1</total_broken_requests>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<total_broken_requests_percent_of_total>20%</total_broken_requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>33.3%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/resources/case-study.pdf</label>
 		<total_broken_requests>1</total_broken_requests>
 		<page_not_found_404_requests>1</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<total_broken_requests_percent_of_total>20%</total_broken_requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>50%</page_not_found_404_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/resources/doc.pdf</label>
 		<total_broken_requests>1</total_broken_requests>
 		<page_not_found_404_requests>1</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<total_broken_requests_percent_of_total>20%</total_broken_requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>50%</page_not_found_404_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/resources/guide.pdf</label>
 		<total_broken_requests>1</total_broken_requests>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<total_broken_requests_percent_of_total>20%</total_broken_requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>33.3%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test__content_documents__BotTracking.getAIChatbotContentDocuments_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test__content_documents__BotTracking.getAIChatbotContentDocuments_day.xml
@@ -9,6 +9,9 @@
 		<nb_response_size>1</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<requests_percent_of_total>50%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>100%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>0.45</avg_server_time>
 		<avg_response_size>33658</avg_response_size>
 	</row>
@@ -21,6 +24,9 @@
 		<nb_response_size>0</nb_response_size>
 		<page_not_found_404_requests>1</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>25%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>100%</page_not_found_404_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/resources/whitepaper.pdf</label>
@@ -31,6 +37,9 @@
 		<nb_response_size>1</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>25%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>4.5</avg_server_time>
 		<avg_response_size>123456</avg_response_size>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test__content_documents__BotTracking.getAIChatbotContentDocuments_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test__content_documents__BotTracking.getAIChatbotContentDocuments_week.xml
@@ -9,6 +9,9 @@
 		<nb_response_size>3</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<requests_percent_of_total>30.8%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>100%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>1.07</avg_server_time>
 		<avg_response_size>109794.66666667</avg_response_size>
 	</row>
@@ -21,6 +24,9 @@
 		<nb_response_size>3</nb_response_size>
 		<page_not_found_404_requests>1</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>23.1%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>50%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>1.45</avg_server_time>
 		<avg_response_size>69007</avg_response_size>
 	</row>
@@ -33,6 +39,9 @@
 		<nb_response_size>2</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>15.4%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>0.75</avg_server_time>
 		<avg_response_size>48362.5</avg_response_size>
 	</row>
@@ -45,6 +54,9 @@
 		<nb_response_size>1</nb_response_size>
 		<page_not_found_404_requests>1</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>15.4%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>50%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>5</avg_server_time>
 		<avg_response_size>225445</avg_response_size>
 	</row>
@@ -57,6 +69,9 @@
 		<nb_response_size>2</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>15.4%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>3.35</avg_server_time>
 		<avg_response_size>96656</avg_response_size>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test__content_pages__BotTracking.getAIChatbotContentPages_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test__content_pages__BotTracking.getAIChatbotContentPages_day.xml
@@ -9,6 +9,9 @@
 		<nb_response_size>3</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>50%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>2.5666666666667</avg_server_time>
 		<avg_response_size>35485</avg_response_size>
 	</row>
@@ -21,6 +24,9 @@
 		<nb_response_size>1</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<requests_percent_of_total>33.3%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>100%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>0.76</avg_server_time>
 		<avg_response_size>29658</avg_response_size>
 	</row>
@@ -33,6 +39,9 @@
 		<nb_response_size>1</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>16.7%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_response_size>85236</avg_response_size>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test__content_pages__BotTracking.getAIChatbotContentPages_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test__content_pages__BotTracking.getAIChatbotContentPages_week.xml
@@ -9,6 +9,9 @@
 		<nb_response_size>4</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>22.2%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>2.3375</avg_server_time>
 		<avg_response_size>29727.75</avg_response_size>
 	</row>
@@ -21,6 +24,9 @@
 		<nb_response_size>4</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>22.2%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>0.4</avg_server_time>
 		<avg_response_size>32735</avg_response_size>
 	</row>
@@ -33,6 +39,9 @@
 		<nb_response_size>3</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>16.7%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>1.9566666666667</avg_server_time>
 		<avg_response_size>29457.333333333</avg_response_size>
 	</row>
@@ -45,6 +54,9 @@
 		<nb_response_size>1</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<requests_percent_of_total>11.1%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>50%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>0.76</avg_server_time>
 		<avg_response_size>29658</avg_response_size>
 	</row>
@@ -57,6 +69,9 @@
 		<nb_response_size>1</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<requests_percent_of_total>11.1%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>50%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>1.75</avg_server_time>
 		<avg_response_size>95147</avg_response_size>
 	</row>
@@ -69,6 +84,9 @@
 		<nb_response_size>2</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>11.1%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>0.975</avg_server_time>
 		<avg_response_size>29426</avg_response_size>
 	</row>
@@ -81,6 +99,9 @@
 		<nb_response_size>1</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>5.6%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>0.21</avg_server_time>
 		<avg_response_size>25412</avg_response_size>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test__documents__BotTracking.getAIChatbotRequests_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test__documents__BotTracking.getAIChatbotRequests_day.xml
@@ -6,12 +6,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>1</visits_acquired>
+		<requests_percent_of_total>30%</requests_percent_of_total>
+		<page_requests_percent_of_total>33.3%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>100%</visits_acquired_percent_of_total>
 		<url>perplexity.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/perplexity.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/guide.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>10%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -21,12 +26,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>1</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>20%</requests_percent_of_total>
+		<page_requests_percent_of_total>16.7%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>chatgpt.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chatgpt.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/guide.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>10%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -36,12 +46,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>0</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>10%</requests_percent_of_total>
+		<page_requests_percent_of_total>0%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>claude.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/claude.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/whitepaper.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>10%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -51,6 +66,10 @@
 		<document_requests>0</document_requests>
 		<page_requests>1</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>10%</requests_percent_of_total>
+		<page_requests_percent_of_total>16.7%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>0%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>gemini.google.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/gemini.google.com.png</logo>
 	</row>
@@ -60,12 +79,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>30%</requests_percent_of_total>
+		<page_requests_percent_of_total>33.3%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>chat.mistral.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chat.mistral.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/doc.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>10%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test__documents__BotTracking.getAIChatbotRequests_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test__documents__BotTracking.getAIChatbotRequests_week.xml
@@ -6,12 +6,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>4</page_requests>
 		<visits_acquired>2</visits_acquired>
+		<requests_percent_of_total>16.1%</requests_percent_of_total>
+		<page_requests_percent_of_total>22.2%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>7.7%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>33.3%</visits_acquired_percent_of_total>
 		<url>chatgpt.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chatgpt.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/guide.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -21,20 +26,27 @@
 		<document_requests>3</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>2</visits_acquired>
+		<requests_percent_of_total>16.1%</requests_percent_of_total>
+		<page_requests_percent_of_total>11.1%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>23.1%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>33.3%</visits_acquired_percent_of_total>
 		<url>claude.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/claude.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/case-study.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/resources/datasheet.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/resources/whitepaper.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -44,28 +56,37 @@
 		<document_requests>6</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>2</visits_acquired>
+		<requests_percent_of_total>25.8%</requests_percent_of_total>
+		<page_requests_percent_of_total>11.1%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>46.2%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>33.3%</visits_acquired_percent_of_total>
 		<url>perplexity.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/perplexity.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/case-study.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/resources/datasheet.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/resources/doc.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/resources/guide.pdf</label>
 				<requests>2</requests>
+				<requests_percent_of_total>6.5%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/resources/whitepaper.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -75,6 +96,10 @@
 		<document_requests>0</document_requests>
 		<page_requests>4</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>12.9%</requests_percent_of_total>
+		<page_requests_percent_of_total>22.2%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>0%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>gemini.google.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/gemini.google.com.png</logo>
 	</row>
@@ -84,12 +109,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>4</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>16.1%</requests_percent_of_total>
+		<page_requests_percent_of_total>22.2%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>7.7%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>chat.mistral.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chat.mistral.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/doc.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -99,16 +129,22 @@
 		<document_requests>2</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>12.9%</requests_percent_of_total>
+		<page_requests_percent_of_total>11.1%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>15.4%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>notebooklm.google.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/notebooklm.google.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/case-study.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/resources/guide.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test__flat__BotTracking.getAIChatbotRequests_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test__flat__BotTracking.getAIChatbotRequests_day.xml
@@ -3,6 +3,7 @@
 	<row>
 		<label>ChatGPT - example.com/article/1/page/2</label>
 		<requests>1</requests>
+		<requests_percent_of_total>11.1%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>ChatGPT</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/1/page/2</BotTracking_PageUrl>
 		<url />
@@ -11,6 +12,7 @@
 	<row>
 		<label>Gemini - example.com/article/1/page/2</label>
 		<requests>1</requests>
+		<requests_percent_of_total>11.1%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Gemini</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/1/page/2</BotTracking_PageUrl>
 		<url />
@@ -19,6 +21,7 @@
 	<row>
 		<label>Le Chat - example.com/article/2</label>
 		<requests>1</requests>
+		<requests_percent_of_total>11.1%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Le Chat</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/2</BotTracking_PageUrl>
 		<url />
@@ -27,6 +30,7 @@
 	<row>
 		<label>Le Chat - example.com/article/3</label>
 		<requests>1</requests>
+		<requests_percent_of_total>11.1%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Le Chat</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/3</BotTracking_PageUrl>
 		<url />
@@ -35,6 +39,7 @@
 	<row>
 		<label>Perplexity - example.com/article/2</label>
 		<requests>2</requests>
+		<requests_percent_of_total>22.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Perplexity</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/2</BotTracking_PageUrl>
 		<url />

--- a/plugins/BotTracking/tests/System/expected/test__flat__BotTracking.getAIChatbotRequests_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test__flat__BotTracking.getAIChatbotRequests_week.xml
@@ -3,6 +3,7 @@
 	<row>
 		<label>ChatGPT - example.com/article/1/page/1</label>
 		<requests>1</requests>
+		<requests_percent_of_total>3.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>ChatGPT</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/1/page/1</BotTracking_PageUrl>
 		<url />
@@ -11,6 +12,7 @@
 	<row>
 		<label>ChatGPT - example.com/article/1/page/2</label>
 		<requests>1</requests>
+		<requests_percent_of_total>3.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>ChatGPT</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/1/page/2</BotTracking_PageUrl>
 		<url />
@@ -19,6 +21,7 @@
 	<row>
 		<label>ChatGPT - example.com/article/3</label>
 		<requests>1</requests>
+		<requests_percent_of_total>3.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>ChatGPT</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/3</BotTracking_PageUrl>
 		<url />
@@ -27,6 +30,7 @@
 	<row>
 		<label>ChatGPT - example.com/article/4/page/1</label>
 		<requests>1</requests>
+		<requests_percent_of_total>3.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>ChatGPT</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/4/page/1</BotTracking_PageUrl>
 		<url />
@@ -35,6 +39,7 @@
 	<row>
 		<label>Claude - example.com/article/3</label>
 		<requests>1</requests>
+		<requests_percent_of_total>3.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Claude</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/3</BotTracking_PageUrl>
 		<url />
@@ -43,6 +48,7 @@
 	<row>
 		<label>Claude - example.com/article/4/page/2</label>
 		<requests>1</requests>
+		<requests_percent_of_total>3.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Claude</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/4/page/2</BotTracking_PageUrl>
 		<url />
@@ -51,6 +57,7 @@
 	<row>
 		<label>Gemini - example.com/article/1/page/2</label>
 		<requests>1</requests>
+		<requests_percent_of_total>3.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Gemini</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/1/page/2</BotTracking_PageUrl>
 		<url />
@@ -59,6 +66,7 @@
 	<row>
 		<label>Gemini - example.com/article/3</label>
 		<requests>1</requests>
+		<requests_percent_of_total>3.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Gemini</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/3</BotTracking_PageUrl>
 		<url />
@@ -67,6 +75,7 @@
 	<row>
 		<label>Gemini - example.com/article/4/page/1</label>
 		<requests>1</requests>
+		<requests_percent_of_total>3.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Gemini</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/4/page/1</BotTracking_PageUrl>
 		<url />
@@ -75,6 +84,7 @@
 	<row>
 		<label>Gemini - example.com/article/4/page/2</label>
 		<requests>1</requests>
+		<requests_percent_of_total>3.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Gemini</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/4/page/2</BotTracking_PageUrl>
 		<url />
@@ -83,6 +93,7 @@
 	<row>
 		<label>Le Chat - example.com/article/2</label>
 		<requests>2</requests>
+		<requests_percent_of_total>6.5%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Le Chat</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/2</BotTracking_PageUrl>
 		<url />
@@ -91,6 +102,7 @@
 	<row>
 		<label>Le Chat - example.com/article/3</label>
 		<requests>1</requests>
+		<requests_percent_of_total>3.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Le Chat</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/3</BotTracking_PageUrl>
 		<url />
@@ -99,6 +111,7 @@
 	<row>
 		<label>Le Chat - example.com/article/4/page/1</label>
 		<requests>1</requests>
+		<requests_percent_of_total>3.2%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Le Chat</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/4/page/1</BotTracking_PageUrl>
 		<url />
@@ -107,6 +120,7 @@
 	<row>
 		<label>NotebookLM - example.com/overview</label>
 		<requests>2</requests>
+		<requests_percent_of_total>6.5%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>NotebookLM</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/overview</BotTracking_PageUrl>
 		<url />
@@ -115,6 +129,7 @@
 	<row>
 		<label>Perplexity - example.com/article/2</label>
 		<requests>2</requests>
+		<requests_percent_of_total>6.5%</requests_percent_of_total>
 		<BotTracking_AIChatbotName>Perplexity</BotTracking_AIChatbotName>
 		<BotTracking_PageUrl>example.com/article/2</BotTracking_PageUrl>
 		<url />

--- a/plugins/BotTracking/tests/System/expected/test__human_favoured__BotTracking.getAIChatbotHumanFavouredPages_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test__human_favoured__BotTracking.getAIChatbotHumanFavouredPages_day.xml
@@ -5,23 +5,31 @@
 		<unique_human_pageviews>1</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>63.1</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>25%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/2</label>
 		<unique_human_pageviews>2</unique_human_pageviews>
 		<ai_chatbot_requests>3</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>50%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>50%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/3</label>
 		<unique_human_pageviews>1</unique_human_pageviews>
 		<ai_chatbot_requests>1</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>25%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>16.7%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/1/page/2</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>33.3%</ai_chatbot_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test__human_favoured__BotTracking.getAIChatbotHumanFavouredPages_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test__human_favoured__BotTracking.getAIChatbotHumanFavouredPages_week.xml
@@ -5,65 +5,87 @@
 		<unique_human_pageviews>4</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>89.8</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>25%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article-3</label>
 		<unique_human_pageviews>3</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>77.4</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>18.8%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article-2</label>
 		<unique_human_pageviews>2</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>61.3</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>12.5%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article-1</label>
 		<unique_human_pageviews>1</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>38.7</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>6.3%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/2</label>
 		<unique_human_pageviews>5</unique_human_pageviews>
 		<ai_chatbot_requests>4</ai_chatbot_requests>
 		<discrepancy_score>11.1</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>31.3%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>22.2%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/3</label>
 		<unique_human_pageviews>1</unique_human_pageviews>
 		<ai_chatbot_requests>4</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>6.3%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>22.2%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/1/page/1</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>1</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>5.6%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/1/page/2</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>11.1%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/4/page/1</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>3</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>16.7%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/4/page/2</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>11.1%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/overview</label>
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>0</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>11.1%</ai_chatbot_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test__human_favoured_filtered__BotTracking.getAIChatbotHumanFavouredPages_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test__human_favoured_filtered__BotTracking.getAIChatbotHumanFavouredPages_day.xml
@@ -5,5 +5,7 @@
 		<unique_human_pageviews>1</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>63.1</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>25%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test__human_favoured_filtered__BotTracking.getAIChatbotHumanFavouredPages_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test__human_favoured_filtered__BotTracking.getAIChatbotHumanFavouredPages_week.xml
@@ -5,29 +5,39 @@
 		<unique_human_pageviews>4</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>89.8</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>25%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article-3</label>
 		<unique_human_pageviews>3</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>77.4</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>18.8%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article-2</label>
 		<unique_human_pageviews>2</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>61.3</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>12.5%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article-1</label>
 		<unique_human_pageviews>1</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>38.7</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>6.3%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>example.com/article/2</label>
 		<unique_human_pageviews>5</unique_human_pageviews>
 		<ai_chatbot_requests>4</ai_chatbot_requests>
 		<discrepancy_score>11.1</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>31.3%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>22.2%</ai_chatbot_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test__pages__BotTracking.getAIChatbotRequests_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test__pages__BotTracking.getAIChatbotRequests_day.xml
@@ -6,12 +6,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>1</visits_acquired>
+		<requests_percent_of_total>30%</requests_percent_of_total>
+		<page_requests_percent_of_total>33.3%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>100%</visits_acquired_percent_of_total>
 		<url>perplexity.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/perplexity.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/2</label>
 				<requests>2</requests>
+				<requests_percent_of_total>20%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -21,12 +26,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>1</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>20%</requests_percent_of_total>
+		<page_requests_percent_of_total>16.7%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>chatgpt.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chatgpt.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/1/page/2</label>
 				<requests>1</requests>
+				<requests_percent_of_total>10%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -36,6 +46,10 @@
 		<document_requests>1</document_requests>
 		<page_requests>0</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>10%</requests_percent_of_total>
+		<page_requests_percent_of_total>0%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>claude.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/claude.ai.png</logo>
 	</row>
@@ -45,12 +59,17 @@
 		<document_requests>0</document_requests>
 		<page_requests>1</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>10%</requests_percent_of_total>
+		<page_requests_percent_of_total>16.7%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>0%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>gemini.google.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/gemini.google.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/1/page/2</label>
 				<requests>1</requests>
+				<requests_percent_of_total>10%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -60,16 +79,22 @@
 		<document_requests>1</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>30%</requests_percent_of_total>
+		<page_requests_percent_of_total>33.3%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>chat.mistral.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chat.mistral.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/2</label>
 				<requests>1</requests>
+				<requests_percent_of_total>10%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/article/3</label>
 				<requests>1</requests>
+				<requests_percent_of_total>10%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test__pages__BotTracking.getAIChatbotRequests_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test__pages__BotTracking.getAIChatbotRequests_week.xml
@@ -6,24 +6,32 @@
 		<document_requests>1</document_requests>
 		<page_requests>4</page_requests>
 		<visits_acquired>2</visits_acquired>
+		<requests_percent_of_total>16.1%</requests_percent_of_total>
+		<page_requests_percent_of_total>22.2%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>7.7%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>33.3%</visits_acquired_percent_of_total>
 		<url>chatgpt.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chatgpt.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/1/page/1</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/article/1/page/2</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/article/3</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/article/4/page/1</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -33,16 +41,22 @@
 		<document_requests>3</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>2</visits_acquired>
+		<requests_percent_of_total>16.1%</requests_percent_of_total>
+		<page_requests_percent_of_total>11.1%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>23.1%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>33.3%</visits_acquired_percent_of_total>
 		<url>claude.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/claude.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/3</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/article/4/page/2</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -52,12 +66,17 @@
 		<document_requests>6</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>2</visits_acquired>
+		<requests_percent_of_total>25.8%</requests_percent_of_total>
+		<page_requests_percent_of_total>11.1%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>46.2%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>33.3%</visits_acquired_percent_of_total>
 		<url>perplexity.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/perplexity.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/2</label>
 				<requests>2</requests>
+				<requests_percent_of_total>6.5%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -67,24 +86,32 @@
 		<document_requests>0</document_requests>
 		<page_requests>4</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>12.9%</requests_percent_of_total>
+		<page_requests_percent_of_total>22.2%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>0%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>gemini.google.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/gemini.google.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/1/page/2</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/article/3</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/article/4/page/1</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/article/4/page/2</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -94,20 +121,27 @@
 		<document_requests>1</document_requests>
 		<page_requests>4</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>16.1%</requests_percent_of_total>
+		<page_requests_percent_of_total>22.2%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>7.7%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>chat.mistral.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chat.mistral.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/2</label>
 				<requests>2</requests>
+				<requests_percent_of_total>6.5%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/article/3</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/article/4/page/1</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -117,12 +151,17 @@
 		<document_requests>2</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>12.9%</requests_percent_of_total>
+		<page_requests_percent_of_total>11.1%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>15.4%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>notebooklm.google.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/notebooklm.google.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/overview</label>
 				<requests>2</requests>
+				<requests_percent_of_total>6.5%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_ai_favoured_pages__BotTracking.getAIChatbotAIFavouredPages_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_ai_favoured_pages__BotTracking.getAIChatbotAIFavouredPages_day.xml
@@ -5,11 +5,15 @@
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>79.2</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>33.3%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>Others</label>
 		<unique_human_pageviews>4</unique_human_pageviews>
 		<ai_chatbot_requests>4</ai_chatbot_requests>
 		<discrepancy_score />
+		<unique_human_pageviews_percent_of_total>100%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>66.7%</ai_chatbot_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_ai_favoured_pages__BotTracking.getAIChatbotAIFavouredPages_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_ai_favoured_pages__BotTracking.getAIChatbotAIFavouredPages_week.xml
@@ -5,11 +5,15 @@
 		<unique_human_pageviews>0</unique_human_pageviews>
 		<ai_chatbot_requests>2</ai_chatbot_requests>
 		<discrepancy_score>100</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>0%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>11.1%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>Others</label>
 		<unique_human_pageviews>16</unique_human_pageviews>
 		<ai_chatbot_requests>16</ai_chatbot_requests>
 		<discrepancy_score />
+		<unique_human_pageviews_percent_of_total>100%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>88.9%</ai_chatbot_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_broken_content__BotTracking.getAIChatbotBrokenContent_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_broken_content__BotTracking.getAIChatbotBrokenContent_day.xml
@@ -5,11 +5,17 @@
 		<total_broken_requests>1</total_broken_requests>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<total_broken_requests_percent_of_total>33.3%</total_broken_requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>50%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 	</row>
 	<row>
 		<label>Others</label>
 		<total_broken_requests>2</total_broken_requests>
 		<page_not_found_404_requests>1</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<total_broken_requests_percent_of_total>66.7%</total_broken_requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>50%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>100%</page_not_found_404_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_broken_content__BotTracking.getAIChatbotBrokenContent_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_broken_content__BotTracking.getAIChatbotBrokenContent_week.xml
@@ -5,11 +5,17 @@
 		<total_broken_requests>1</total_broken_requests>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<total_broken_requests_percent_of_total>20%</total_broken_requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>33.3%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 	</row>
 	<row>
 		<label>Others</label>
 		<total_broken_requests>4</total_broken_requests>
 		<page_not_found_404_requests>2</page_not_found_404_requests>
 		<server_error_5xx_requests>2</server_error_5xx_requests>
+		<total_broken_requests_percent_of_total>80%</total_broken_requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>66.7%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>100%</page_not_found_404_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_content_documents__BotTracking.getAIChatbotContentDocuments_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_content_documents__BotTracking.getAIChatbotContentDocuments_day.xml
@@ -9,6 +9,9 @@
 		<nb_response_size>1</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<requests_percent_of_total>50%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>100%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>0.45</avg_server_time>
 		<avg_response_size>33658</avg_response_size>
 	</row>
@@ -21,6 +24,9 @@
 		<nb_response_size>1</nb_response_size>
 		<page_not_found_404_requests>1</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>50%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>100%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>4.5</avg_server_time>
 		<avg_response_size>123456</avg_response_size>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_content_documents__BotTracking.getAIChatbotContentDocuments_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_content_documents__BotTracking.getAIChatbotContentDocuments_week.xml
@@ -9,6 +9,9 @@
 		<nb_response_size>2</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<requests_percent_of_total>23.1%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>100%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>0.46</avg_server_time>
 		<avg_response_size>35321.5</avg_response_size>
 	</row>
@@ -21,6 +24,9 @@
 		<nb_response_size>9</nb_response_size>
 		<page_not_found_404_requests>2</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>76.9%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>100%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>2.375</avg_server_time>
 		<avg_response_size>109027.11111111</avg_response_size>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_content_pages__BotTracking.getAIChatbotContentPages_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_content_pages__BotTracking.getAIChatbotContentPages_day.xml
@@ -9,6 +9,9 @@
 		<nb_response_size>3</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>50%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>2.5666666666667</avg_server_time>
 		<avg_response_size>35485</avg_response_size>
 	</row>
@@ -21,6 +24,9 @@
 		<nb_response_size>2</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>1</server_error_5xx_requests>
+		<requests_percent_of_total>50%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>100%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>0.76</avg_server_time>
 		<avg_response_size>57447</avg_response_size>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_content_pages__BotTracking.getAIChatbotContentPages_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_content_pages__BotTracking.getAIChatbotContentPages_week.xml
@@ -9,6 +9,9 @@
 		<nb_response_size>3</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>0</server_error_5xx_requests>
+		<requests_percent_of_total>16.7%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>0%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>2.5666666666667</avg_server_time>
 		<avg_response_size>35485</avg_response_size>
 	</row>
@@ -21,6 +24,9 @@
 		<nb_response_size>13</nb_response_size>
 		<page_not_found_404_requests>0</page_not_found_404_requests>
 		<server_error_5xx_requests>2</server_error_5xx_requests>
+		<requests_percent_of_total>83.3%</requests_percent_of_total>
+		<server_error_5xx_requests_percent_of_total>100%</server_error_5xx_requests_percent_of_total>
+		<page_not_found_404_requests_percent_of_total>0%</page_not_found_404_requests_percent_of_total>
 		<avg_server_time>1.2583333333333</avg_server_time>
 		<avg_response_size>33910.538461538</avg_response_size>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_documents__BotTracking.getAIChatbotRequests_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_documents__BotTracking.getAIChatbotRequests_day.xml
@@ -6,12 +6,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>1</visits_acquired>
+		<requests_percent_of_total>30%</requests_percent_of_total>
+		<page_requests_percent_of_total>33.3%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>100%</visits_acquired_percent_of_total>
 		<url>perplexity.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/perplexity.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/guide.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>10%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -21,12 +26,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>1</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>20%</requests_percent_of_total>
+		<page_requests_percent_of_total>16.7%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>chatgpt.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chatgpt.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/guide.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>10%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -36,12 +46,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>30%</requests_percent_of_total>
+		<page_requests_percent_of_total>33.3%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>chat.mistral.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chat.mistral.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/doc.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>10%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -51,6 +66,10 @@
 		<document_requests>1</document_requests>
 		<page_requests>1</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>20%</requests_percent_of_total>
+		<page_requests_percent_of_total>16.7%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url />
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/xx.png</logo>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_documents__BotTracking.getAIChatbotRequests_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_documents__BotTracking.getAIChatbotRequests_week.xml
@@ -6,12 +6,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>3</page_requests>
 		<visits_acquired>2</visits_acquired>
+		<requests_percent_of_total>12.9%</requests_percent_of_total>
+		<page_requests_percent_of_total>16.7%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>7.7%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>33.3%</visits_acquired_percent_of_total>
 		<url>chatgpt.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chatgpt.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/guide.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -21,16 +26,22 @@
 		<document_requests>3</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>2</visits_acquired>
+		<requests_percent_of_total>16.1%</requests_percent_of_total>
+		<page_requests_percent_of_total>11.1%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>23.1%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>33.3%</visits_acquired_percent_of_total>
 		<url>perplexity.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/perplexity.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/case-study.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/resources/guide.pdf</label>
 				<requests>2</requests>
+				<requests_percent_of_total>6.5%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -40,12 +51,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>4</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>16.1%</requests_percent_of_total>
+		<page_requests_percent_of_total>22.2%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>7.7%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>chat.mistral.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chat.mistral.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/resources/doc.pdf</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -55,6 +71,10 @@
 		<document_requests>8</document_requests>
 		<page_requests>9</page_requests>
 		<visits_acquired>2</visits_acquired>
+		<requests_percent_of_total>54.8%</requests_percent_of_total>
+		<page_requests_percent_of_total>50%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>61.5%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>33.3%</visits_acquired_percent_of_total>
 		<url />
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/xx.png</logo>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_human_favoured_pages__BotTracking.getAIChatbotHumanFavouredPages_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_human_favoured_pages__BotTracking.getAIChatbotHumanFavouredPages_day.xml
@@ -5,11 +5,15 @@
 		<unique_human_pageviews>1</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>63.1</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>25%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>Others</label>
 		<unique_human_pageviews>3</unique_human_pageviews>
 		<ai_chatbot_requests>6</ai_chatbot_requests>
 		<discrepancy_score />
+		<unique_human_pageviews_percent_of_total>75%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>100%</ai_chatbot_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_human_favoured_pages__BotTracking.getAIChatbotHumanFavouredPages_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_human_favoured_pages__BotTracking.getAIChatbotHumanFavouredPages_week.xml
@@ -5,11 +5,15 @@
 		<unique_human_pageviews>4</unique_human_pageviews>
 		<ai_chatbot_requests>0</ai_chatbot_requests>
 		<discrepancy_score>100</discrepancy_score>
+		<unique_human_pageviews_percent_of_total>25%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>0%</ai_chatbot_requests_percent_of_total>
 	</row>
 	<row>
 		<label>Others</label>
 		<unique_human_pageviews>12</unique_human_pageviews>
 		<ai_chatbot_requests>18</ai_chatbot_requests>
 		<discrepancy_score />
+		<unique_human_pageviews_percent_of_total>75%</unique_human_pageviews_percent_of_total>
+		<ai_chatbot_requests_percent_of_total>100%</ai_chatbot_requests_percent_of_total>
 	</row>
 </result>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_pages__BotTracking.getAIChatbotRequests_day.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_pages__BotTracking.getAIChatbotRequests_day.xml
@@ -6,12 +6,17 @@
 		<document_requests>0</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>1</visits_acquired>
+		<requests_percent_of_total>20%</requests_percent_of_total>
+		<page_requests_percent_of_total>33.3%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>0%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>100%</visits_acquired_percent_of_total>
 		<url>perplexity.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/perplexity.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/2</label>
 				<requests>2</requests>
+				<requests_percent_of_total>20%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -21,12 +26,17 @@
 		<document_requests>1</document_requests>
 		<page_requests>1</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>20%</requests_percent_of_total>
+		<page_requests_percent_of_total>16.7%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>chatgpt.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chatgpt.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/1/page/2</label>
 				<requests>1</requests>
+				<requests_percent_of_total>10%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -36,6 +46,10 @@
 		<document_requests>1</document_requests>
 		<page_requests>0</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>10%</requests_percent_of_total>
+		<page_requests_percent_of_total>0%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>claude.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/claude.ai.png</logo>
 	</row>
@@ -45,6 +59,10 @@
 		<document_requests>1</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>30%</requests_percent_of_total>
+		<page_requests_percent_of_total>33.3%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>chat.mistral.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chat.mistral.ai.png</logo>
 	</row>
@@ -54,6 +72,10 @@
 		<document_requests>1</document_requests>
 		<page_requests>1</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>20%</requests_percent_of_total>
+		<page_requests_percent_of_total>16.7%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>25%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url />
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/xx.png</logo>
 	</row>

--- a/plugins/BotTracking/tests/System/expected/test_ranking_limit_pages__BotTracking.getAIChatbotRequests_week.xml
+++ b/plugins/BotTracking/tests/System/expected/test_ranking_limit_pages__BotTracking.getAIChatbotRequests_week.xml
@@ -6,16 +6,22 @@
 		<document_requests>1</document_requests>
 		<page_requests>4</page_requests>
 		<visits_acquired>2</visits_acquired>
+		<requests_percent_of_total>16.1%</requests_percent_of_total>
+		<page_requests_percent_of_total>22.2%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>7.7%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>33.3%</visits_acquired_percent_of_total>
 		<url>chatgpt.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chatgpt.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/1/page/1</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>Others</label>
 				<requests>3</requests>
+				<requests_percent_of_total>9.7%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -25,16 +31,22 @@
 		<document_requests>3</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>2</visits_acquired>
+		<requests_percent_of_total>16.1%</requests_percent_of_total>
+		<page_requests_percent_of_total>11.1%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>23.1%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>33.3%</visits_acquired_percent_of_total>
 		<url>claude.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/claude.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/3</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>example.com/article/4/page/2</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -44,12 +56,17 @@
 		<document_requests>5</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>2</visits_acquired>
+		<requests_percent_of_total>22.6%</requests_percent_of_total>
+		<page_requests_percent_of_total>11.1%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>38.5%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>33.3%</visits_acquired_percent_of_total>
 		<url>perplexity.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/perplexity.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/2</label>
 				<requests>2</requests>
+				<requests_percent_of_total>6.5%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -59,16 +76,22 @@
 		<document_requests>0</document_requests>
 		<page_requests>3</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>9.7%</requests_percent_of_total>
+		<page_requests_percent_of_total>16.7%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>0%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>gemini.google.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/gemini.google.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/3</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>Others</label>
 				<requests>2</requests>
+				<requests_percent_of_total>6.5%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -78,16 +101,22 @@
 		<document_requests>1</document_requests>
 		<page_requests>4</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>16.1%</requests_percent_of_total>
+		<page_requests_percent_of_total>22.2%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>7.7%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>chat.mistral.ai</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/chat.mistral.ai.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/article/2</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 			<row>
 				<label>Others</label>
 				<requests>1</requests>
+				<requests_percent_of_total>3.2%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -97,12 +126,17 @@
 		<document_requests>2</document_requests>
 		<page_requests>2</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>12.9%</requests_percent_of_total>
+		<page_requests_percent_of_total>11.1%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>15.4%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url>notebooklm.google.com</url>
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/notebooklm.google.com.png</logo>
 		<subtable>
 			<row>
 				<label>example.com/overview</label>
 				<requests>2</requests>
+				<requests_percent_of_total>6.5%</requests_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -112,6 +146,10 @@
 		<document_requests>1</document_requests>
 		<page_requests>1</page_requests>
 		<visits_acquired>0</visits_acquired>
+		<requests_percent_of_total>6.5%</requests_percent_of_total>
+		<page_requests_percent_of_total>5.6%</page_requests_percent_of_total>
+		<document_requests_percent_of_total>7.7%</document_requests_percent_of_total>
+		<visits_acquired_percent_of_total>0%</visits_acquired_percent_of_total>
 		<url />
 		<logo>plugins/Morpheus/icons/dist/aiAssistants/xx.png</logo>
 	</row>

--- a/plugins/BotTracking/tests/UI/BotTracking_spec.js
+++ b/plugins/BotTracking/tests/UI/BotTracking_spec.js
@@ -32,6 +32,32 @@ describe("BotTracking", function () {
         expect(headers).to.deep.equal(expectedHeaders);
     }
 
+    /**
+     * The ratio percentages are always rendered, but stay `visibility: hidden` until their column
+     * is hovered, so counting the visible ones tells whether they are actually shown.
+     */
+    async function ratiosVisible(cellSelector) {
+        return await page.evaluate(function (selector) {
+            return jQuery(selector + ' .ratio').filter(function () {
+                return jQuery(this).css('visibility') === 'visible';
+            }).length;
+        }, cellSelector);
+    }
+
+    /**
+     * The tooltip text as the user reads it. The title attribute holds it HTML encoded, as the
+     * tooltip is rendered as HTML by the jQuery UI tooltip the data table sets up for these spans
+     * — which also takes the attribute over once it has shown the tooltip.
+     */
+    async function tooltipText(ratioSelector) {
+        return await page.evaluate(function (selector) {
+            var $ratio = jQuery(selector);
+            var title = $ratio.attr('title') || $ratio.data('ui-tooltip-title');
+
+            return jQuery('<div>').html(title).text().trim();
+        }, ratioSelector);
+    }
+
     async function assertMetricDocumentation(widgetId, expectedCount) {
         const docs = await page.$$eval(widgetId + ' thead th .columnDocumentation', function (nodes) {
             return nodes.map(function (node) { return (node.textContent || '').trim(); });
@@ -407,4 +433,66 @@ describe("BotTracking", function () {
 
         expect(matchingFooterMessages).to.be.at.least(3);
     });
+
+    // The hover tests come last: hovering a column leaves it highlighted, and that state survives
+    // the navigation of a following test, which would then capture the percentages as well.
+    it('should show the percentage of the report total when hovering a metric column', async function () {
+        await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_AIAssistants&subcategory=BotTracking_AIChatbotsOverview");
+        await page.waitForNetworkIdle();
+
+        const widgetId = '#widgetBotTrackinggetAIChatbotRequests';
+        const requestsColumn = widgetId + ' tbody tr td.column:nth-child(2)';
+
+        await page.waitForSelector(requestsColumn, { visible: true });
+
+        // the percentages are in the DOM from the start but hidden, hovering any cell of a metric
+        // column highlights the whole column and reveals them
+        expect(await ratiosVisible(requestsColumn)).to.equal(0);
+
+        const cell = await page.jQuery(requestsColumn + ':first');
+        await cell.hover();
+        await page.waitForFunction('$("' + requestsColumn + ':first").hasClass("highlight")');
+
+        const percentages = await page.$$eval(requestsColumn + ' .ratio', function (spans) {
+            return spans.map(function (span) { return (span.textContent || '').trim(); });
+        });
+        expect(percentages.length).to.equal(await page.$$eval(requestsColumn, function (tds) { return tds.length; }));
+        percentages.forEach(function (percentage) {
+            expect(percentage).to.match(/^\d+(\.\d+)?%$/);
+        });
+        expect(await ratiosVisible(requestsColumn)).to.equal(percentages.length);
+
+        // the tooltip relates the row to the report total. It must not add the sentence relating it
+        // to the site total as well, as API.get does not know this report's columns
+        const tooltip = await tooltipText(requestsColumn + ':first .ratio');
+        expect(tooltip).to.match(/^'.+' represents \d+(\.\d+)?% of \d+ Requests in segment ".+" with AI Chatbot Name\.$/);
+
+        var elem = await page.$(widgetId);
+        expect(await elem.screenshot()).to.matchImage('bot_requests_ratio');
+    });
+
+    it('should not show a percentage for a column that has no meaningful report total', async function () {
+        await page.goto("?" + urlBase + "#?" + generalParams + "&category=General_AIAssistants&subcategory=BotTracking_AIChatbotsContentRequests");
+        await page.waitForNetworkIdle();
+
+        const widgetId = '#widgetBotTrackinggetAIChatbotHumanFavouredPages';
+        const pageviewsColumn = widgetId + ' tbody tr td.column:nth-child(2)';
+        const scoreColumn = widgetId + ' tbody tr td.column:nth-child(4)';
+
+        await page.waitForSelector(scoreColumn, { visible: true });
+
+        // the two traffic columns add up over the rows of the report, so they carry a percentage
+        const pageviews = await page.jQuery(pageviewsColumn + ':first');
+        await pageviews.hover();
+        await page.waitForFunction('$("' + pageviewsColumn + ':first").hasClass("highlight")');
+        expect(await ratiosVisible(pageviewsColumn)).to.be.above(0);
+
+        // the discrepancy score weights those two columns against each other per page, so summing
+        // it up over the report says nothing about a row and it gets no percentage at all
+        const score = await page.jQuery(scoreColumn + ':first');
+        await score.hover();
+        await page.waitForFunction('$("' + scoreColumn + ':first").hasClass("highlight")');
+        expect(await page.$$eval(scoreColumn + ' .ratio', function (spans) { return spans.length; })).to.equal(0);
+    });
+
 });

--- a/plugins/BotTracking/tests/UI/expected-screenshots/BotTracking_bot_overview.png
+++ b/plugins/BotTracking/tests/UI/expected-screenshots/BotTracking_bot_overview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e36a1dc377236b3a571479d1fe86df4c45abf52dce98045994fc16a78e4c12d
-size 80431
+oid sha256:11d91ca8a42711371c0fd26d003631e43eab44ac643974b002bbccb0a3b09857
+size 80161

--- a/plugins/BotTracking/tests/UI/expected-screenshots/BotTracking_bot_requests.png
+++ b/plugins/BotTracking/tests/UI/expected-screenshots/BotTracking_bot_requests.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3dec4501c4b8bc1b23b6d347559bd37bfc9fcfd1ff87b3a868f981ea2bc6c918
-size 36393
+oid sha256:90d0aede5387e780870eca18fb1472c0e406a4026d44fa47e618a8d7c6515fa4
+size 36103

--- a/plugins/BotTracking/tests/UI/expected-screenshots/BotTracking_bot_requests_documents.png
+++ b/plugins/BotTracking/tests/UI/expected-screenshots/BotTracking_bot_requests_documents.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9730e0653a9095cb8b32704c094e1a2cac59c6d705498f89e3d56babd12c0570
-size 36252
+oid sha256:7d9a06bd9bd5a7a3aa0dc71f0f103cf0a71f4940e4be847e1639350faed1df98
+size 35954

--- a/plugins/BotTracking/tests/UI/expected-screenshots/BotTracking_bot_requests_ratio.png
+++ b/plugins/BotTracking/tests/UI/expected-screenshots/BotTracking_bot_requests_ratio.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:405f08cdfab5aca24ec7aabd5c502fd587a508de8c7760a3996fed4ced3fe716
+size 32579

--- a/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_ratio.twig
+++ b/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable_ratio.twig
@@ -24,7 +24,8 @@
     {% if totalPercentage|default is empty %}
         {% if row.getMetadata(column ~ '_site_total_percentage') != false %}
             {% set totalPercentage = row.getMetadata(column ~ '_site_total_percentage') %}
-        {% elseif row.getColumn(column)|default(0) is numeric and siteTotal is numeric %}
+        {#- without a site summary row siteTotal falls back to 0, which is no total to relate a row to -#}
+        {% elseif row.getColumn(column)|default(0) is numeric and siteTotal is numeric and siteTotal > 0 %}
             {% set totalPercentage = row.getColumn(column)|percentage(siteTotal, 1) %}
         {% endif %}
     {% endif %}


### PR DESCRIPTION
Fixes #25076

The HTML table shows the percentage of the report total on hover only for the columns a report registers through `Report::getMetricNamesToProcessReportTotals()`. The BotTracking reports registered none, so their tables only ever showed absolute values.

### Changes

- Every BotTracking report now registers the columns that add up over its rows, which restores the hover percentages and adds the matching `{metric}_percent_of_total` columns to the Reporting API.
- Left out are the columns where a percentage of the summed report total means nothing: `avg_server_time`, `avg_response_size` and `discrepancy_score`.
- The real-time reports are left out entirely. They carry neither `period` nor `segment` metadata, so the tooltip degrades to `in segment ""` and `in .`, and their rows are capped in the DAO without a summary row for the remainder.
- `_dataTableViz_htmlTable_ratio.twig` no longer appends the site total sentence when there is no site total. `HtmlTable::getSiteSummary()` asks `API.get` for the report's own columns, so a report built on columns `API.get` does not know got an empty summary row and every tooltip claimed *"This is 0% of all 0 Requests in Sun, Feb 2."*

### Tests

`ReportTotalsTest` walks every BotTracking report and fails until a new column is classified as additive-and-registered or explicitly not. Two UI tests hover a metric column and assert the revealed percentages and the tooltip text, and that the discrepancy score gets none.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
