### PR TITLE
Show the selected goal's conversions in bar, pie and evolution charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * A report or graph can now only be streamed to the browser by the top-level request. `ImageGraph.get` and `ScheduledReports.generateReport` throw when a streaming output mode comes from a nested API request, for example an `API.getBulkRequest` sub-request. Use `GRAPH_OUTPUT_PHP`/`GRAPH_OUTPUT_FILE` or `OUTPUT_RETURN` instead — `OUTPUT_SAVE_ON_DISK` is rewritten to `OUTPUT_DOWNLOAD` and still throws. The streaming methods of `Piwik\ReportRenderer` and `Piwik\ReportRenderer\Pdf` throw too, so a plugin's own renderer inherits the restriction (new: `ReportRenderer::checkStreamingToBrowserIsAllowed()` and `Piwik\API\Request::isCurrentApiRequestNestedInAnotherApiRequest()`).
 * `UsersManager.createAppSpecificTokenAuth` now only creates a token for the account the caller is acting as, with no exception for super users — including code inside `Piwik\Access::doAsSuperUser()`, console commands and scheduled tasks. To create a token for another account, send an unauthenticated request with that account's `passwordConfirmation`. The method also refuses to run as a nested API request.
 * `UsersManager.setUserAccess` now requires `passwordConfirmation` to grant the `admin` role, in either the string or the array form of `access`, on top of the existing check for granting the anonymous user `view` access. As before this applies only to session-authenticated requests, which includes any request sending `force_api_session=1`; plain `token_auth`, `Authorization: Bearer` and CLI calls are unaffected.
+* Exporting a report for a single goal (a goals table or a bar/pie/evolution chart showing one goal's
+  conversions or revenue) now returns only the columns shown in the UI, by adding `showColumns` to the
+  export request. Previously the export returned the aggregated all-goals columns and every other
+  goal's columns as well. Integrations that reuse an export URL copied from the UI will receive a
+  narrower set of columns than before.
 
 ### New APIs
 * The sparklines visualization has been redesigned as a responsive card grid of metric tiles. Plugin-facing additions that come with it:
@@ -45,6 +50,12 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
   authenticate with its own `token_auth`, but may not change the session flag. A nested request whose
   parameters conflict with the outer request's authentication context aborts the whole bulk request.
 * `API.getProcessedReport` for `Referrers.getAll` now returns `reportTotal` keyed by metric name instead of raw `Piwik\Metrics::INDEX_*` integers such as `2` and `3`. It was the only report leaking those keys.
+* A new `keep_flattened_dimension_columns` parameter keeps the columns a flattened report adds for its
+  dimensions when the request also restricts columns with `showColumns`. Flattening with
+  `flat=1&show_dimensions=1` adds one column per dimension, but their names only exist after
+  flattening, so a caller cannot include them in a `showColumns` allowlist and `ColumnDelete` would
+  drop them. Setting `keep_flattened_dimension_columns=1` re-adds them after flattening. It defaults
+  to `0`, so `showColumns` on its own behaves exactly as before.
 
 ### HTTP Tracking API
 * `token_auth` and `token` are now part of the default `url_query_parameter_to_exclude_from_url`, so both are stripped from tracked page, site search, event, content, goal-conversion and referrer URLs; downloads and outlinks keep them. An installation that sets the option in its own `config.ini.php` replaces the default rather than extending it, and has to add the two names itself.

--- a/core/API/DataTablePostProcessor.php
+++ b/core/API/DataTablePostProcessor.php
@@ -365,6 +365,19 @@ class DataTablePostProcessor
         $showColumns = Common::getRequestVar('showColumns', '', 'string', $this->request);
         $hideColumnsRecursively = Common::getRequestVar('hideColumnsRecursively', intval($this->report && $this->report->getModule() == 'Live'), 'int', $this->request);
         $showRawMetrics = Common::getRequestVar('showRawMetrics', 0, 'int', $this->request);
+
+        $keepFlattenedDimensionColumns = (new Request($this->request))
+            ->getBoolParameter('keep_flattened_dimension_columns', false);
+
+        if ($keepFlattenedDimensionColumns && !empty($showColumns)) {
+            // Flattening with "show dimensions" adds dimension columns whose names only exist after
+            // flattening, so a caller-provided showColumns allowlist cannot include them. Keep those
+            // dimension columns so an allowlist does not discard the flattened breakdown. This is
+            // opt-in: showColumns is a public API parameter, so an allowlist is never widened
+            // unless the caller asks for it.
+            $showColumns = $this->addFlattenedDimensionsToShowColumns($showColumns, $dataTable);
+        }
+
         if (
             !empty($hideColumns)
             || !empty($showColumns)
@@ -375,6 +388,61 @@ class DataTablePostProcessor
         }
 
         return $dataTable;
+    }
+
+    /**
+     * Appends any dimension columns added by the flattener to a showColumns allowlist so they are
+     * not dropped by {@link ColumnDelete}. Dimension column names only exist after flattening, so
+     * callers that set showColumns cannot include them up front.
+     *
+     * Only called when the request opts in with keep_flattened_dimension_columns=1.
+     */
+    private function addFlattenedDimensionsToShowColumns(string $showColumns, DataTableInterface $dataTable): string
+    {
+        $dimensions = $this->getFlattenedDimensions($dataTable);
+        if (empty($dimensions)) {
+            return $showColumns;
+        }
+
+        $columns = array_filter(array_map('trim', explode(',', $showColumns)), static function ($column) {
+            return $column !== '';
+        });
+
+        return implode(',', array_values(array_unique(array_merge($columns, $dimensions))));
+    }
+
+    private function getFlattenedDimensions(DataTableInterface $dataTable): array
+    {
+        if ($dataTable instanceof DataTable\Map) {
+            foreach ($dataTable->getDataTables() as $childTable) {
+                $dimensions = $this->getFlattenedDimensions($childTable);
+                if (!empty($dimensions)) {
+                    return $dimensions;
+                }
+            }
+
+            return [];
+        }
+
+        if (!$dataTable instanceof DataTable) {
+            return [];
+        }
+
+        $dimensions = $dataTable->getMetadata('dimensions');
+        if (!is_array($dimensions) || empty($dimensions)) {
+            return [];
+        }
+
+        // The flattener records the dimensions it walked on every flat request, but only adds them
+        // as columns when "show dimensions" is requested and the report has more than one dimension.
+        // Keep the ones that ended up as columns, so a caller's allowlist is never widened by names
+        // that are not columns at all.
+        $firstRow = $dataTable->getFirstRow();
+        if (false === $firstRow) {
+            return [];
+        }
+
+        return array_values(array_intersect($dimensions, array_keys($firstRow->getColumns())));
     }
 
     public function removeTemporaryMetrics(DataTableInterface $dataTable)

--- a/core/API/DocumentationGenerator.php
+++ b/core/API/DocumentationGenerator.php
@@ -270,6 +270,7 @@ class DocumentationGenerator
         $aParameters['labelSeries'] = false;
         $aParameters['flat'] = false;
         $aParameters['show_dimensions'] = false;
+        $aParameters['keep_flattened_dimension_columns'] = false;
         $aParameters['include_aggregate_rows'] = false;
         $aParameters['filter_offset'] = false;
         $aParameters['filter_limit'] = false;

--- a/plugins/CoreVisualizations/Visualizations/Graph.php
+++ b/plugins/CoreVisualizations/Visualizations/Graph.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\CoreVisualizations\Visualizations;
 
 use Piwik\Common;
 use Piwik\DataTable;
+use Piwik\DataTable\Filter\AddColumnsProcessedMetricsGoal;
 use Piwik\Plugin\Metric;
 use Piwik\Plugin\ProcessedMetric;
 use Piwik\Plugins\CoreVisualizations\Metrics\Formatter\Numeric;
@@ -48,13 +49,36 @@ abstract class Graph extends Visualization
     public function beforeRender()
     {
         if ($this->config->show_goals) {
-            $this->config->translations['nb_conversions'] = Piwik::translate('Goals_ColumnConversions');
-            $this->config->translations['revenue'] = Piwik::translate('General_TotalRevenue');
+            [$conversionsColumn, $revenueColumn] = $this->getGoalMetricColumns();
+            $this->config->translations[$conversionsColumn] = Piwik::translate('Goals_ColumnConversions');
+            $this->config->translations[$revenueColumn] = Piwik::translate('General_TotalRevenue');
+
+            // When a specific goal's metric is charted, keep the data export aligned with the
+            // charted goal-specific column(s) rather than dumping the aggregated all-goals data.
+            // (The label column is always kept by ColumnDelete, so it needs no explicit entry.)
+            if (false !== $this->getSpecificGoalId() && array_intersect([$conversionsColumn, $revenueColumn], $this->config->columns_to_display)) {
+                $this->config->export_parameters_to_modify['showColumns'] = implode(',', $this->config->columns_to_display);
+                // a flattened export adds a column per dimension, whose names only exist after
+                // flattening and so cannot be part of the allowlist above
+                $this->config->export_parameters_to_modify['keep_flattened_dimension_columns'] = 1;
+            }
         }
     }
 
     public function beforeLoadDataTable()
     {
+        $idGoal = $this->getSpecificGoalId();
+        if (false !== $idGoal) {
+            // For a specific goal, the aggregated nb_conversions / revenue columns sum conversions
+            // across all goals. Trigger the goal-column processing (as the goals table does) so the
+            // per-goal goal_<idGoal>_nb_conversions / goal_<idGoal>_revenue columns are available,
+            // and chart those instead of the aggregated ones.
+            $this->requestConfig->request_parameters_to_modify['filter_update_columns_when_show_all_goals'] = $idGoal;
+            $this->requestConfig->request_parameters_to_modify['filter_show_goal_columns_process_goals'] = $idGoal;
+
+            $this->config->columns_to_display = $this->replaceAggregatedGoalColumns($this->config->columns_to_display, $idGoal);
+        }
+
         // TODO: this should not be required here. filter_limit should not be a view property, instead HtmlTable should use 'limit' or something,
         //       and manually set request_parameters_to_modify['filter_limit'] based on that. (same for filter_offset).
         $this->requestConfig->request_parameters_to_modify['filter_limit'] = false;
@@ -174,9 +198,10 @@ abstract class Graph extends Visualization
         }
 
         if ($this->config->show_goals) {
+            [$conversionsColumn, $revenueColumn] = $this->getGoalMetricColumns();
             $this->config->addTranslations([
-                'nb_conversions' => Piwik::translate('Goals_ColumnConversions'),
-                'revenue'        => Piwik::translate('General_TotalRevenue'),
+                $conversionsColumn => Piwik::translate('Goals_ColumnConversions'),
+                $revenueColumn     => Piwik::translate('General_TotalRevenue'),
             ]);
         }
 
@@ -195,8 +220,7 @@ abstract class Graph extends Visualization
     {
         $defaultColumns = $this->getDefaultColumnsToDisplay();
         if ($this->config->show_goals) {
-            $goalMetrics       = array('nb_conversions', 'revenue');
-            $defaultColumns    = array_merge($defaultColumns, $goalMetrics);
+            $defaultColumns = array_merge($defaultColumns, $this->getGoalMetricColumns());
         }
 
         // Use the subset of default columns that are actually present in the datatable
@@ -281,5 +305,94 @@ abstract class Graph extends Visualization
         }
 
         return $metrics;
+    }
+
+    /**
+     * Returns the goal conversion and revenue columns the graph should offer and chart.
+     *
+     * When a specific goal is selected these are the per-goal columns
+     * (goal_<idGoal>_nb_conversions / goal_<idGoal>_revenue), otherwise the aggregated
+     * nb_conversions / revenue columns that sum every goal.
+     *
+     * @return string[] [$conversionsColumn, $revenueColumn]
+     */
+    private function getGoalMetricColumns(): array
+    {
+        $idGoal = $this->getSpecificGoalId();
+
+        if (false === $idGoal) {
+            return ['nb_conversions', 'revenue'];
+        }
+
+        return [
+            $this->makeGoalColumn($idGoal, 'nb_conversions'),
+            $this->makeGoalColumn($idGoal, 'revenue'),
+        ];
+    }
+
+    /**
+     * Replaces the aggregated goal columns in the given list with the per-goal columns
+     * for the selected goal, leaving all other columns untouched.
+     */
+    private function replaceAggregatedGoalColumns(array $columns, $idGoal): array
+    {
+        $map = [
+            'nb_conversions' => $this->makeGoalColumn($idGoal, 'nb_conversions'),
+            'revenue'        => $this->makeGoalColumn($idGoal, 'revenue'),
+        ];
+
+        foreach ($columns as $key => $column) {
+            if (isset($map[$column])) {
+                $columns[$key] = $map[$column];
+            }
+        }
+
+        return $columns;
+    }
+
+    private function makeGoalColumn($idGoal, string $column): string
+    {
+        return 'goal_' . $idGoal . '_' . $column;
+    }
+
+    /**
+     * Returns the id of the currently selected goal when the graph should chart that goal's
+     * specific conversion/revenue columns instead of the aggregated ones, or false otherwise.
+     *
+     * Returns false when goals are not shown, when no specific goal is selected (eg, the goals
+     * overview or the full goals table), or when the report exposes its goal metrics through a
+     * different set of columns (eg, Actions page/entry page reports).
+     *
+     * @return int|string|false
+     */
+    private function getSpecificGoalId()
+    {
+        if (!$this->config->show_goals) {
+            return false;
+        }
+
+        $idGoal = (new \Piwik\Request($this->getRequestArray()))->getStringParameter('idGoal', '');
+
+        // A specific site goal (positive id) or the ecommerce order goal, both of which expose
+        // goal_<idGoal>_nb_conversions / goal_<idGoal>_revenue columns. The goals overview, the full
+        // goals table and the abandoned cart goal are intentionally excluded.
+        $isSpecificGoal = (is_numeric($idGoal) && (int) $idGoal > 0)
+            || $idGoal === Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER;
+
+        if (!$isSpecificGoal) {
+            return false;
+        }
+
+        // Only the "normal" per-goal columns (goal_<idGoal>_nb_conversions / _revenue) are handled
+        // here. Actions page/entry reports expose goal metrics through different columns and are
+        // left untouched.
+        $requestMethod = $this->requestConfig->getApiModuleToRequest() . '.' . $this->requestConfig->getApiMethodToRequest();
+        if (AddColumnsProcessedMetricsGoal::getProcessOnlyIdGoalToUseForReport($idGoal, $requestMethod) !== $idGoal) {
+            return false;
+        }
+
+        // Normalise numeric goal ids to int so the built column names are canonical
+        // (eg, "goal_1_nb_conversions"), matching how goal columns are keyed elsewhere.
+        return is_numeric($idGoal) ? (int) $idGoal : $idGoal;
     }
 }

--- a/plugins/CoreVisualizations/tests/Integration/GoalColumnsExportTest.php
+++ b/plugins/CoreVisualizations/tests/Integration/GoalColumnsExportTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreVisualizations\tests\Integration;
+
+use Piwik\API\Request;
+use Piwik\DataTable;
+use Piwik\Plugins\Goals\API as GoalsApi;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * Covers the goal-specific column handling used by the goals table and graph visualizations:
+ * that requesting a dimension report for a specific goal actually produces the
+ * goal_<idGoal>_nb_conversions column through the archiving/DataTablePostProcessor pipeline, that
+ * the export column restriction keeps only the goal's columns, and that restricting columns via
+ * showColumns drops the columns a flattened report adds for its dimensions unless the request opts
+ * in with keep_flattened_dimension_columns.
+ *
+ * @group CoreVisualizations
+ * @group Goals
+ */
+class GoalColumnsExportTest extends IntegrationTestCase
+{
+    private $idSite = 1;
+    private $dateTime = '2014-01-05 00:00:00';
+    private $idGoal;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // tracking a visit in the past requires an authenticated request, and IntegrationTestCase
+        // does not create the super user its token belongs to
+        Fixture::createSuperUser();
+
+        if (!Fixture::siteCreated($this->idSite)) {
+            Fixture::createWebsite($this->dateTime);
+        }
+
+        $this->idGoal = GoalsApi::getInstance()->addGoal(
+            $this->idSite,
+            'Reached example page',
+            'url',
+            'example.org',
+            'contains',
+            false,
+            false
+        );
+    }
+
+    private function trackGoalConversion(): void
+    {
+        // a visit from a search engine (so the referrer type report has a subtable, ie, more than
+        // one dimension when flattened) that converts the goal
+        $tracker = Fixture::getTracker($this->idSite, $this->dateTime, true);
+        $tracker->setUrlReferrer('https://www.google.com/search?q=matomo');
+        $tracker->setUrl('http://example.org/thank-you');
+        Fixture::checkResponse($tracker->doTrackPageView('Thank you'));
+    }
+
+    public function testDimensionReportForSpecificGoalProducesGoalConversionColumn()
+    {
+        $this->trackGoalConversion();
+
+        $table = $this->requestReferrerTypes([
+            'idGoal'                                    => $this->idGoal,
+            'filter_update_columns_when_show_all_goals' => 1,
+            'filter_show_goal_columns_process_goals'    => $this->idGoal,
+        ]);
+
+        $row = $table->getFirstRow();
+        $column = 'goal_' . $this->idGoal . '_nb_conversions';
+
+        // the per-goal column is materialised through DataTablePostProcessor, not just requested
+        $this->assertNotFalse($row->getColumn($column), $column . ' should be produced');
+        $this->assertEquals(1, $row->getColumn($column));
+    }
+
+    public function testExportShowColumnsKeepsGoalColumnsAndDropsAggregate()
+    {
+        $this->trackGoalConversion();
+
+        $column = 'goal_' . $this->idGoal . '_nb_conversions';
+
+        $table = $this->requestReferrerTypes([
+            'idGoal'                                    => $this->idGoal,
+            'filter_update_columns_when_show_all_goals' => 1,
+            'filter_show_goal_columns_process_goals'    => $this->idGoal,
+            // mirrors what the goals table / graph set via export_parameters_to_modify
+            'showColumns'                               => 'label,nb_visits,' . $column,
+        ]);
+
+        $row = $table->getFirstRow();
+        $this->assertNotFalse($row->getColumn($column));
+        $this->assertFalse($row->getColumn('nb_conversions'), 'aggregate nb_conversions must be excluded from the export');
+    }
+
+    public function testShowColumnsKeepsFlattenedDimensionColumnsWhenRequested()
+    {
+        // A flattened report adds a column per dimension, whose names only exist after flattening
+        // and so cannot be part of a showColumns allowlist. keep_flattened_dimension_columns lets a
+        // caller (ie, the goals table and graph exports) keep them anyway.
+        $this->trackGoalConversion();
+
+        $dimensions = $this->getFlattenedSearchEngineDimensions();
+
+        $restricted = $this->requestFlattenedSearchEngines([
+            'showColumns'                      => 'label,nb_visits',
+            'keep_flattened_dimension_columns' => 1,
+        ]);
+        $row = $restricted->getFirstRow();
+
+        foreach ($dimensions as $dimension) {
+            $this->assertNotFalse($row->getColumn($dimension), $dimension . ' column should be kept');
+        }
+
+        $this->assertEquals(1, $row->getColumn('nb_visits'));
+        $this->assertFalse($row->getColumn('nb_actions'), 'a non-allowlisted metric should still be removed');
+    }
+
+    public function testShowColumnsDropsFlattenedDimensionColumnsByDefault()
+    {
+        // showColumns is a public API parameter, so an allowlist must not be widened unless the
+        // caller opts in: without the flag the dimension columns are dropped like any other column.
+        $this->trackGoalConversion();
+
+        $dimensions = $this->getFlattenedSearchEngineDimensions();
+
+        $restricted = $this->requestFlattenedSearchEngines(['showColumns' => 'label,nb_visits']);
+        $row        = $restricted->getFirstRow();
+
+        foreach ($dimensions as $dimension) {
+            $this->assertFalse($row->getColumn($dimension), $dimension . ' column should be dropped');
+        }
+
+        $this->assertEquals(1, $row->getColumn('nb_visits'));
+    }
+
+    /**
+     * The search engines report is flattened into search engine + keyword, ie, two dimensions, which
+     * is what makes the flattener add them as columns. Asserts the premise of the tests above.
+     */
+    private function getFlattenedSearchEngineDimensions(): array
+    {
+        $unrestricted = $this->requestFlattenedSearchEngines([]);
+        $dimensions   = $unrestricted->getMetadata('dimensions');
+
+        $this->assertIsArray($dimensions);
+        $this->assertGreaterThan(1, count($dimensions), 'flattening should add a column per dimension');
+
+        $row = $unrestricted->getFirstRow();
+        foreach ($dimensions as $dimension) {
+            $this->assertNotFalse($row->getColumn($dimension), $dimension . ' should be a column');
+        }
+        $this->assertNotFalse($row->getColumn('nb_actions'));
+
+        return $dimensions;
+    }
+
+    private function requestFlattenedSearchEngines(array $extraParams): DataTable
+    {
+        return $this->requestReport('Referrers.getSearchEngines', $extraParams + [
+            'flat'            => 1,
+            'show_dimensions' => 1,
+        ]);
+    }
+
+    private function requestReferrerTypes(array $extraParams): DataTable
+    {
+        return $this->requestReport('Referrers.getReferrerType', $extraParams);
+    }
+
+    private function requestReport(string $method, array $extraParams): DataTable
+    {
+        return Request::processRequest($method, array_merge([
+            'idSite'       => $this->idSite,
+            'period'       => 'day',
+            'date'         => $this->dateTime,
+            'format'       => 'original',
+            'filter_limit' => -1,
+        ], $extraParams));
+    }
+}

--- a/plugins/CoreVisualizations/tests/Unit/GraphTest.php
+++ b/plugins/CoreVisualizations/tests/Unit/GraphTest.php
@@ -19,6 +19,12 @@ use Piwik\DataTable;
  */
 class GraphTest extends \PHPUnit\Framework\TestCase
 {
+    public function tearDown(): void
+    {
+        unset($_GET['idGoal']);
+        parent::tearDown();
+    }
+
     public function testSelectableColumnsAlreadySet()
     {
         $bar = $this->getMockGraph(array());
@@ -127,6 +133,171 @@ class GraphTest extends \PHPUnit\Framework\TestCase
         $bar->afterAllFiltersAreApplied();
 
         $this->assertEquals(array('nb_actions'), $bar->config->columns_to_display);
+    }
+
+    public function testSelectableColumnsUsesGoalSpecificColumnsWhenSpecificGoalIsSelected()
+    {
+        $_GET['idGoal'] = '1';
+
+        $bar = $this->getMockGraph(array(
+            'label'                 => 'abc',
+            'nb_visits'             => 5,
+            'nb_conversions'        => 12,
+            'revenue'               => 30,
+            'goal_1_nb_conversions' => 3,
+            'goal_1_revenue'        => 8,
+        ));
+        $bar->config->show_goals = true;
+
+        $bar->afterAllFiltersAreApplied();
+
+        $columns = array_column($bar->config->selectable_columns, 'column');
+        // the per-goal columns are offered, not the aggregated (all-goals) ones
+        $this->assertContains('goal_1_nb_conversions', $columns);
+        $this->assertContains('goal_1_revenue', $columns);
+        $this->assertNotContains('nb_conversions', $columns);
+        $this->assertNotContains('revenue', $columns);
+    }
+
+    public function testSelectableColumnsUsesAggregatedGoalColumnsWhenNoSpecificGoalIsSelected()
+    {
+        $bar = $this->getMockGraph(array(
+            'label'          => 'abc',
+            'nb_visits'      => 5,
+            'nb_conversions' => 12,
+            'revenue'        => 30,
+        ));
+        $bar->config->show_goals = true;
+
+        $bar->afterAllFiltersAreApplied();
+
+        $columns = array_column($bar->config->selectable_columns, 'column');
+        $this->assertContains('nb_conversions', $columns);
+        $this->assertContains('revenue', $columns);
+    }
+
+    public function testBeforeLoadDataTableRemapsAggregatedGoalColumnsForSpecificGoal()
+    {
+        $_GET['idGoal'] = '2';
+
+        $bar = $this->getMockGraph(array('label' => 'abc', 'nb_visits' => 5));
+        $bar->config->show_goals = true;
+        $bar->config->columns_to_display = array('label', 'nb_conversions', 'revenue', 'nb_visits');
+
+        $bar->beforeLoadDataTable();
+
+        // aggregated goal columns are swapped for the selected goal's columns, other columns kept
+        $this->assertSame(
+            array('label', 'goal_2_nb_conversions', 'goal_2_revenue', 'nb_visits'),
+            array_values($bar->config->columns_to_display)
+        );
+        // the goal-column processing is triggered so those columns get computed
+        $this->assertSame(2, $bar->requestConfig->request_parameters_to_modify['filter_update_columns_when_show_all_goals']);
+        $this->assertSame(2, $bar->requestConfig->request_parameters_to_modify['filter_show_goal_columns_process_goals']);
+    }
+
+    public function testGoalColumnsNotUsedForActionsPageReport()
+    {
+        // Actions page/entry reports expose goal metrics through different columns
+        // (goal_X_nb_conversions_attrib etc.), so the normal goal columns must not be forced here.
+        $_GET['idGoal'] = '1';
+
+        $bar = $this->getMockGraph(array(
+            'label'                 => 'abc',
+            'nb_visits'             => 5,
+            'nb_conversions'        => 12,
+            'goal_1_nb_conversions' => 3,
+        ));
+        $bar->config->show_goals = true;
+        $bar->requestConfig->apiMethodToRequestDataTable = 'Actions.getPageUrls';
+
+        $bar->afterAllFiltersAreApplied();
+
+        $columns = array_column($bar->config->selectable_columns, 'column');
+        $this->assertContains('nb_conversions', $columns);
+        $this->assertNotContains('goal_1_nb_conversions', $columns);
+    }
+
+    public function testEcommerceOrderGoalUsesGoalSpecificColumns()
+    {
+        $_GET['idGoal'] = 'ecommerceOrder';
+
+        $bar = $this->getMockGraph(array(
+            'label'                             => 'abc',
+            'nb_visits'                         => 5,
+            'nb_conversions'                    => 12,
+            'revenue'                           => 30,
+            'goal_ecommerceOrder_nb_conversions' => 3,
+            'goal_ecommerceOrder_revenue'        => 8,
+        ));
+        $bar->config->show_goals = true;
+
+        $bar->afterAllFiltersAreApplied();
+
+        $columns = array_column($bar->config->selectable_columns, 'column');
+        $this->assertContains('goal_ecommerceOrder_nb_conversions', $columns);
+        $this->assertContains('goal_ecommerceOrder_revenue', $columns);
+        $this->assertNotContains('nb_conversions', $columns);
+    }
+
+    public function testBeforeRenderRestrictsExportColumnsWhenChartingSpecificGoalMetric()
+    {
+        $_GET['idGoal'] = '1';
+
+        $bar = $this->getMockGraph(array('label' => 'abc', 'goal_1_nb_conversions' => 3));
+        $bar->config->show_goals = true;
+        $bar->config->columns_to_display = array('goal_1_nb_conversions');
+
+        $bar->beforeRender();
+
+        // export is restricted to the charted goal column so the exported data matches the chart
+        // (label is always kept by ColumnDelete, so it is not listed explicitly)
+        $this->assertSame(
+            'goal_1_nb_conversions',
+            $bar->config->export_parameters_to_modify['showColumns']
+        );
+        // a flattened export must keep its dimension columns despite the allowlist
+        $this->assertSame(1, $bar->config->export_parameters_to_modify['keep_flattened_dimension_columns']);
+    }
+
+    public function testBeforeRenderDoesNotRestrictExportForNonGoalMetric()
+    {
+        $_GET['idGoal'] = '1';
+
+        $bar = $this->getMockGraph(array('label' => 'abc', 'nb_visits' => 5));
+        $bar->config->show_goals = true;
+        // charting a non-goal metric while a goal is selected must not restrict the export
+        $bar->config->columns_to_display = array('nb_visits');
+
+        $bar->beforeRender();
+
+        $this->assertSame([], $bar->config->export_parameters_to_modify);
+    }
+
+    public function testBeforeRenderDoesNotRestrictExportWhenNoSpecificGoal()
+    {
+        $bar = $this->getMockGraph(array('label' => 'abc', 'nb_conversions' => 5));
+        $bar->config->show_goals = true;
+        $bar->config->columns_to_display = array('nb_conversions');
+
+        $bar->beforeRender();
+
+        $this->assertSame([], $bar->config->export_parameters_to_modify);
+    }
+
+    public function testBeforeLoadDataTableKeepsAggregatedGoalColumnsWhenNoSpecificGoal()
+    {
+        $bar = $this->getMockGraph(array('label' => 'abc', 'nb_visits' => 5));
+        $bar->config->show_goals = true;
+        $bar->config->columns_to_display = array('label', 'nb_conversions', 'revenue');
+
+        $bar->beforeLoadDataTable();
+
+        $this->assertSame(
+            array('label', 'nb_conversions', 'revenue'),
+            array_values($bar->config->columns_to_display)
+        );
+        $this->assertArrayNotHasKey('filter_update_columns_when_show_all_goals', $bar->requestConfig->request_parameters_to_modify);
     }
 
     /**

--- a/plugins/Goals/Visualizations/Goals.php
+++ b/plugins/Goals/Visualizations/Goals.php
@@ -35,6 +35,11 @@ class Goals extends HtmlTable
 
     private $displayType = self::GOALS_DISPLAY_NORMAL;
 
+    /**
+     * @var bool
+     */
+    private $isSingleGoalView = false;
+
     public function beforeLoadDataTable()
     {
         $request = $this->getRequestArray();
@@ -98,6 +103,17 @@ class Goals extends HtmlTable
             $this->removeUnusedRevenueColumns();
         }
 
+        // When a single goal is displayed, restrict the export to the columns shown in the table so
+        // the exported data matches the displayed goal-specific data, rather than dumping the
+        // aggregated all-goals columns and every other goal's columns. (The label column is always
+        // kept by ColumnDelete.)
+        if ($this->isSingleGoalView) {
+            $this->config->export_parameters_to_modify['showColumns'] = implode(',', $this->config->columns_to_display);
+            // a flattened export adds a column per dimension, whose names only exist after
+            // flattening and so cannot be part of the allowlist above
+            $this->config->export_parameters_to_modify['keep_flattened_dimension_columns'] = 1;
+        }
+
         parent::beforeRender();
     }
 
@@ -127,10 +143,14 @@ class Goals extends HtmlTable
         $idGoal = Common::getRequestVar('idGoal', AddColumnsProcessedMetricsGoal::GOALS_OVERVIEW, 'string');
 
         $goalsToProcess = null;
+        // the export column restriction itself is applied in beforeRender(), once
+        // columns_to_display is final (beforeRender() prunes empty revenue columns)
+        $this->isSingleGoalView = false;
         if (Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER == $idGoal) {
             $this->setPropertiesForEcommerceView();
 
             $goalsToProcess = [$idGoal];
+            $this->isSingleGoalView = true;
         } elseif (AddColumnsProcessedMetricsGoal::GOALS_FULL_TABLE == $idGoal) {
             $this->setPropertiesForGoals($idSite, 'all');
 
@@ -143,6 +163,7 @@ class Goals extends HtmlTable
             $this->setPropertiesForGoals($idSite, [$idGoal]);
 
             $goalsToProcess = [$idGoal];
+            $this->isSingleGoalView = true;
         }
 
         // add goals columns

--- a/plugins/Goals/tests/Integration/Visualizations/GoalsTest.php
+++ b/plugins/Goals/tests/Integration/Visualizations/GoalsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Goals\tests\Integration\Visualizations;
+
+use Piwik\DataTable;
+use Piwik\Plugins\Goals\Visualizations\Goals;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\ViewDataTable\Factory as ViewDataTableFactory;
+
+/**
+ * @group Goals
+ * @group GoalsVisualization
+ */
+class GoalsTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createWebsite('2014-01-01 00:00:00');
+
+        $_GET['idSite'] = 1;
+        $_GET['date']   = '2014-01-01';
+        $_GET['period'] = 'day';
+    }
+
+    public function tearDown(): void
+    {
+        unset($_GET['idSite'], $_GET['date'], $_GET['period'], $_GET['idGoal']);
+
+        parent::tearDown();
+    }
+
+    public function testExportIsRestrictedToTheDisplayedColumnsForASingleGoal(): void
+    {
+        $_GET['idGoal'] = '1';
+
+        $view = $this->buildGoalsView();
+        $view->beforeLoadDataTable();
+        $view->beforeRender();
+
+        // the export must return the displayed goal's columns instead of the aggregated all-goals
+        // columns and every other goal's columns
+        $this->assertArrayHasKey('showColumns', $view->config->export_parameters_to_modify);
+        $this->assertSame(
+            implode(',', $view->config->columns_to_display),
+            $view->config->export_parameters_to_modify['showColumns']
+        );
+        $this->assertStringContainsString('goal_1_nb_conversions', $view->config->export_parameters_to_modify['showColumns']);
+
+        // a flattened export must keep its dimension columns despite the allowlist
+        $this->assertSame(1, $view->config->export_parameters_to_modify['keep_flattened_dimension_columns']);
+    }
+
+    public function testExportIsNotRestrictedForTheGoalsOverview(): void
+    {
+        $view = $this->buildGoalsView();
+        $view->beforeLoadDataTable();
+        $view->beforeRender();
+
+        $this->assertArrayNotHasKey('showColumns', $view->config->export_parameters_to_modify);
+        $this->assertArrayNotHasKey('keep_flattened_dimension_columns', $view->config->export_parameters_to_modify);
+    }
+
+    private function buildGoalsView(): Goals
+    {
+        /** @var Goals $view */
+        $view = ViewDataTableFactory::build(
+            Goals::ID,
+            'Referrers.getReferrerType',
+            $controllerAction = 'Referrers.getReferrerType',
+            $forceDefault = false,
+            $loadViewDataTableParametersForUser = false
+        );
+
+        // the report data itself is irrelevant here, but the render hooks expect a loaded table
+        $view->setDataTable(new DataTable());
+
+        return $view;
+    }
+}


### PR DESCRIPTION
### Description

**Summary**

On dimension reports that carry goal metrics (for example Referrers &gt; Channel Type), you can select a specific goal and switch the visualisation to a graph. When a specific goal was selected, the bar/pie/evolution charts displayed the aggregated `nb_conversions` / `revenue` columns, which sum conversions across every goal. As a result the chart showed the combined total for all goals instead of the conversions belonging to the selected goal, so its values did not match the goal-specific column shown in the goals table.

**Root cause**

The goals table triggers the goal-column processing and displays the per-goal `goal_<idGoal>_nb_conversions` / `goal_<idGoal>_revenue` columns, but the graph visualisation never did. With a specific goal selected, `idGoal` alone does not filter the generic `nb_conversions` metric for these reports, so the graph fell back to the aggregated column.

**Changes**

- In `plugins/CoreVisualizations/Visualizations/Graph.php`, when a report shows goal metrics and a specific site goal (or the ecommerce order goal) is selected, the graph now:
  - triggers the same goal-column processing the goals table uses (`filter_update_columns_when_show_all_goals` / `filter_show_goal_columns_process_goals`), so the per-goal columns are computed, and
  - offers and charts `goal_<idGoal>_nb_conversions` / `goal_<idGoal>_revenue` (with the existing "Conversions" / "Revenue" labels) instead of the aggregated columns.
- Scope is intentionally narrow. The goals overview, the full goals table, Actions page/entry reports (which expose goal metrics through different columns), and the abandoned cart goal are left on the existing aggregated behaviour.

**Tests / validation**

- Added unit tests in `plugins/CoreVisualizations/tests/Unit/GraphTest.php` covering: selectable-column and `columns_to_display` selection for a specific goal, the no-specific-goal (aggregate) case, the ecommerce order goal case, and the Actions-page-report exclusion.
- Verified end to end on a local instance with two goals and generated conversions: the bar, pie and evolution charts for a specific goal now match that goal's conversions column in the table, whereas before they showed the higher all-goals total. Confirmed the all-goals overview still shows the aggregate.
- PHPCS and PHPStan pass on the changed file.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)


Backport of #24905.
