### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -633,16 +633,16 @@
         },
         {
             "name": "matomo/ini",
-            "version": "3.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/component-ini.git",
-                "reference": "b55c55da943f4ccd564d48fe6b218fbdada98c1a"
+                "reference": "8bd472309dbb742404deabd2bd86d060fb42219e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/component-ini/zipball/b55c55da943f4ccd564d48fe6b218fbdada98c1a",
-                "reference": "b55c55da943f4ccd564d48fe6b218fbdada98c1a",
+                "url": "https://api.github.com/repos/matomo-org/component-ini/zipball/8bd472309dbb742404deabd2bd86d060fb42219e",
+                "reference": "8bd472309dbb742404deabd2bd86d060fb42219e",
                 "shasum": ""
             },
             "require": {
@@ -664,9 +664,9 @@
             ],
             "support": {
                 "issues": "https://github.com/matomo-org/component-ini/issues",
-                "source": "https://github.com/matomo-org/component-ini/tree/3.0.1"
+                "source": "https://github.com/matomo-org/component-ini/tree/3.0.3"
             },
-            "time": "2022-11-09T08:19:54+00:00"
+            "time": "2026-08-17T08:38:26+00:00"
         },
         {
             "name": "matomo/matomo-php-tracker",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading matomo/ini (3.0.1 => 3.0.3)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downloading matomo/ini (3.0.3)
  - Upgrading matomo/ini (3.0.1 => 3.0.3): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
59 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.
```
