### PR TITLE
Align PDF report label linking with the HTML report renderer

### DIFF
--- a/core/ReportRenderer/Pdf.php
+++ b/core/ReportRenderer/Pdf.php
@@ -16,6 +16,7 @@ use Piwik\Piwik;
 use Piwik\Plugins\CoreAdminHome\CustomLogo;
 use Piwik\ReportRenderer;
 use Piwik\TCPDF;
+use Piwik\UrlHelper;
 use TCPDF_FONTS;
 
 /**
@@ -490,7 +491,7 @@ class Pdf extends ReportRenderer
         if (isset($rowMetrics['label'])) {
             $labelText = trim($rowMetrics['label']);
             $urlString = $this->isUrl($labelText);
-            if (!$url && $urlString !== false) {
+            if (!$url && $urlString !== null) {
                 $url = $urlString;
             }
             $labelText = $this->limitTextLength($labelText, $this->maxLabelCharacter);
@@ -598,6 +599,9 @@ class Pdf extends ReportRenderer
     }
 
     /**
+     * Renders the clickable label link (when the row carries a linkable URL) and,
+     * when available, the row's logo image.
+     *
      * @param false|string $url
      * @param array<string, mixed> $rowMetadata
      */
@@ -611,8 +615,9 @@ class Pdf extends ReportRenderer
         float &$logoWidth,
         float &$logoHeight
     ): void {
-        if ($url) {
-            $this->TCPDF->Link($posX, $posY, $this->labelCellWidth, $rowHeight, $url);
+        $linkUrl = $url ? $this->getRenderableLabelLinkUrl($url) : null;
+        if ($linkUrl !== null) {
+            $this->TCPDF->Link($posX, $posY, $this->labelCellWidth, $rowHeight, $linkUrl);
         }
         $this->TCPDF->SetXY($posX + $this->labelCellWidth, $posY);
 
@@ -643,11 +648,29 @@ class Pdf extends ReportRenderer
     }
 
     /**
-     * Checks if a string might be a url or not
-     * Will return the string with an 'https' protocol if it is a valid url
-     * @return false|string
+     * Returns the URL a row's label should link to, or null to render it as plain text.
+     *
+     * Scheme-less values are completed with https, so bare domain rows stay clickable.
+     * Schemes outside the link allowlist are not linked.
      */
-    private function isUrl(string $value)
+    private function getRenderableLabelLinkUrl(string $url): ?string
+    {
+        // parse_url(), not a regex: example.com:8080/path is a host and port, not a scheme.
+        if (!parse_url($url, PHP_URL_SCHEME)) {
+            $url = $this->isUrl($url);
+            if ($url === null) {
+                return null;
+            }
+        }
+
+        return UrlHelper::isLookLikeSafeUrl($url) ? $url : null;
+    }
+
+    /**
+     * Checks if a string might be a url or not
+     * Will return the string with an 'https' protocol if it is a valid url, null otherwise
+     */
+    private function isUrl(string $value): ?string
     {
         $candidate = $value;
         if (!preg_match('~^[a-z][a-z0-9+.-]*://~i', $candidate)) {
@@ -656,7 +679,7 @@ class Pdf extends ReportRenderer
         $host = parse_url($candidate, PHP_URL_HOST);
         $isValidHost = $host && strpos($host, '.') !== false;
         $isValidUrl = filter_var($candidate, FILTER_VALIDATE_URL) !== false && $isValidHost;
-        return $isValidUrl ? $candidate : false;
+        return $isValidUrl ? $candidate : null;
     }
 
     /**

--- a/tests/PHPUnit/Unit/ReportRenderer/PdfTest.php
+++ b/tests/PHPUnit/Unit/ReportRenderer/PdfTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\ReportRenderer;
+
+use Piwik\ReportRenderer\Pdf;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * @group Core
+ */
+class PdfTest extends TestCase
+{
+    private function getRenderableLabelLinkUrl(string $url): ?string
+    {
+        $method = new ReflectionMethod(Pdf::class, 'getRenderableLabelLinkUrl');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->newRenderer(), $url);
+    }
+
+    public function getTestDataForGetRenderableLabelLinkUrl(): array
+    {
+        return [
+            // Values already carrying a web or contact scheme are linked as they are.
+            ['http://example.com/report', 'http://example.com/report'],
+            ['https://example.com/report', 'https://example.com/report'],
+            ['https://example.com/quarterly-report.pdf', 'https://example.com/quarterly-report.pdf'],
+            ['mailto:someone@example.com', 'mailto:someone@example.com'],
+            ['tel:+123456789', 'tel:+123456789'],
+            ['sms:+123456789', 'sms:+123456789'],
+            ['callto:someone', 'callto:someone'],
+
+            // Scheme-less values are completed, so bare domain rows stay clickable.
+            ['example.com/report', 'https://example.com/report'],
+            ['example.com/quarterly-report.pdf', 'https://example.com/quarterly-report.pdf'],
+            ['example.com', 'https://example.com'],
+            ['example.com:8080/report', 'https://example.com:8080/report'],
+
+            // A token that only looks like a scheme is a host and port, so it is completed
+            // like any other scheme-less value and then dropped for not naming a domain.
+            ['http:8080/report', null],
+
+            // Other schemes are not linkable, they render as plain label text.
+            ['ftp://example.com/quarterly-report.pdf', null],
+            ['webcal://example.com/calendar.ics', null],
+
+            // Values that cannot form a usable link render as plain label text.
+            ['//example.com/report', null],
+            ['/relative/path', null],
+            ['', null],
+        ];
+    }
+
+    /**
+     * @dataProvider getTestDataForGetRenderableLabelLinkUrl
+     */
+    public function testGetRenderableLabelLinkUrl(string $url, ?string $expected): void
+    {
+        self::assertSame($expected, $this->getRenderableLabelLinkUrl($url));
+    }
+
+    public function getTestDataForRenderLabelLinkAndLogo(): array
+    {
+        return [
+            ['example.com/report', ['https://example.com/report']],
+            ['http://example.com/report', ['http://example.com/report']],
+            ['ftp://example.com/quarterly-report.pdf', []],
+            [false, []],
+        ];
+    }
+
+    /**
+     * @dataProvider getTestDataForRenderLabelLinkAndLogo
+     * @param false|string $url
+     * @param string[] $expectedLinks
+     */
+    public function testRenderLabelLinkAndLogoLinksTheRenderableUrlOnly($url, array $expectedLinks): void
+    {
+        $tcpdf = new class {
+            /**
+             * @var string[]
+             */
+            public $links = [];
+
+            // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+            public function Link($posX, $posY, $width, $height, $link): void
+            {
+                $this->links[] = $link;
+            }
+
+            // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+            public function SetXY($posX, $posY): void
+            {
+            }
+        };
+
+        $renderer = $this->newRenderer();
+        $this->setPrivateProperty($renderer, 'TCPDF', $tcpdf);
+        $this->setPrivateProperty($renderer, 'labelCellWidth', 80.0);
+
+        $logoWidth = 16.0;
+        $logoHeight = 16.0;
+        $method = new ReflectionMethod(Pdf::class, 'renderLabelLinkAndLogo');
+        $method->setAccessible(true);
+        $method->invokeArgs($renderer, [$url, 10.0, 20.0, 6.0, [], false, &$logoWidth, &$logoHeight]);
+
+        self::assertSame($expectedLinks, $tcpdf->links);
+    }
+
+    /**
+     * Exercises the label rendering in isolation, without building a TCPDF document.
+     */
+    private function newRenderer(): Pdf
+    {
+        return (new ReflectionClass(Pdf::class))->newInstanceWithoutConstructor();
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function setPrivateProperty(Pdf $renderer, string $name, $value): void
+    {
+        $property = new ReflectionProperty(Pdf::class, $name);
+        $property->setAccessible(true);
+        $property->setValue($renderer, $value);
+    }
+}


### PR DESCRIPTION
### Description
DEV-20627

### Problem

The PDF and HTML report renderers disagree on which report rows get a usable clickable label.

The HTML renderer completes a scheme-less URL before it uses it, so a bare-domain row value like `facebook.com` becomes a real link. The PDF renderer used the stored value as-is, so bare-domain rows — Socials, AI Assistants — produced a link target of `facebook.com`, which is not a location a PDF viewer can open. Rows whose stored URL is not a link at all were made clickable too.

The PDF renderer now completes a scheme-less value the same way before deciding whether the label gets a link.

Two differences from the HTML renderer are deliberate:

- scheme-less values are completed with `https`, not `http`
- the label link is kept only for the link types Matomo already allows elsewhere in the UI, and a completed value has to name a domain — anything else renders as plain label text rather than as a dead link

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)



Backport of #25055.
