### PR TITLE
Adding google tracking and hubspot ids to our exclude list

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -573,7 +573,7 @@ auth_token_rotation_notification_days = 180
 auth_token_default_expiration_days = 180
 
 ; Number of days before the expiration date of a personal auth token, where an email notification is sent to the user.
-; If set to 0 days, notifications won't be sent. 
+; If set to 0 days, notifications won't be sent.
 ; Recommended to keep enabled for best security.
 auth_token_expiration_notification_days = 30
 
@@ -677,7 +677,7 @@ live_widget_visitor_count_last_minutes = 3
 live_visitor_profile_max_visits_to_aggregate = 100
 
 ; maximum number of AI chatbots listed in the real-time AI Chatbots reports
-live_ai_chatbots_maximum_rows = 100 
+live_ai_chatbots_maximum_rows = 100
 ; maximum number of page URLs listed in the real-time AI Chatbots top page URL reports
 live_ai_chatbots_top_page_urls_maximum_rows = 100
 
@@ -1033,8 +1033,12 @@ window_look_back_for_visitor = 0
 default_time_one_page_visit = 0
 
 ; Comma separated list of URL query string variable names that will be removed from your tracked URLs
-; By default, Matomo will remove the most common parameters which are known to change often (eg. session ID parameters)
-url_query_parameter_to_exclude_from_url = "gclid,fbclid,msclkid,twclid,wbraid,gbraid,yclid,fb_xd_fragment,fb_comment_id,phpsessid,jsessionid,sessionid,aspsessionid,doing_wp_cron,sid,pk_vid,li_fat_id,token_auth,token"
+; By default, Matomo will remove the most common parameters which are known to change often (eg. session ID parameters
+; and advertising/attribution tracking parameters)
+; An entry can either be a parameter name (eg. gclid) or a regular expression including its delimiters, as used below.
+; As this list is split on commas, a regular expression must not contain a
+; comma. Matching is case insensitive, so entries should always be written in lower case.
+url_query_parameter_to_exclude_from_url = "gclid,fbclid,msclkid,twclid,wbraid,gbraid,yclid,fb_xd_fragment,fb_comment_id,phpsessid,jsessionid,sessionid,aspsessionid,doing_wp_cron,sid,pk_vid,li_fat_id,token_auth,token,gad_source,gad_campaignid,/^hsa_(acc|ad|cam|grp|kw|la|mt|net|ol|src|tgt|ver)$/"
 
 ; If set to 1, Matomo will use the default provider if no other provider is configured.
 ; In addition the default provider will be used as a fallback when the configure provider does not return any results.

--- a/tests/PHPUnit/Integration/Tracker/ActionTest.php
+++ b/tests/PHPUnit/Integration/Tracker/ActionTest.php
@@ -231,6 +231,67 @@ class ActionTest extends IntegrationTestCase
         $this->assertEquals($filteredUrl, PageUrl::excludeQueryParametersFromUrl($url, $idSite));
     }
 
+    public function getTestHubspotGoogleAdUrls()
+    {
+        return [
+            // HubSpot hsa_*
+            ['https://www.example.com?hsa_acc=1', 'https://www.example.com'],
+            ['https://www.example.com?hsa_cam=1', 'https://www.example.com'],
+            ['https://www.example.com?hsa_grp=1', 'https://www.example.com'],
+            ['https://www.example.com?hsa_ad=1', 'https://www.example.com'],
+            ['https://www.example.com?hsa_src=1', 'https://www.example.com'],
+            ['https://www.example.com?hsa_tgt=1', 'https://www.example.com'],
+            ['https://www.example.com?hsa_kw=1', 'https://www.example.com'],
+            ['https://www.example.com?hsa_mt=1', 'https://www.example.com'],
+            ['https://www.example.com?hsa_net=adwords', 'https://www.example.com'],
+            ['https://www.example.com?hsa_ver=3', 'https://www.example.com'],
+            // only added by HubSpot's Facebook/Instagram tracking template
+            ['https://www.example.com?hsa_la=true', 'https://www.example.com'],
+            ['https://www.example.com?hsa_ol=true', 'https://www.example.com'],
+            [
+                'https://www.example.com/path?hsa_acc=1234534242&hsa_cam=4567895464&hsa_net=adwords&hsa_ver=3',
+                'https://www.example.com/path',
+            ],
+            // Google Ads
+            ['https://www.example.com?gad_source=1', 'https://www.example.com'],
+            ['https://www.example.com?gad_campaignid=321321231', 'https://www.example.com'],
+            ['https://www.example.com?random=1&hsa_acc=2', 'https://www.example.com?random=1'],
+            ['https://www.example.com?HSA_ACC=1', 'https://www.example.com'],
+            // similar looking parameters that are not HubSpot ad parameters are kept
+            ['https://www.example.com?hsalt=1', 'https://www.example.com?hsalt=1'],
+            ['https://www.example.com?hsa_id=1', 'https://www.example.com?hsa_id=1'],
+            ['https://www.example.com?hsa_accx=1', 'https://www.example.com?hsa_accx=1'],
+            ['https://www.example.com?xhsa_acc=1', 'https://www.example.com?xhsa_acc=1'],
+        ];
+    }
+
+    /**
+     * HubSpot and Google Ads tracking parameters are excluded by the shipped default config
+     *
+     * @dataProvider getTestHubspotGoogleAdUrls
+     */
+    public function testExcludeQueryParametersHubspotGoogleAds($url, $filteredUrl)
+    {
+        $this->setUpRootAccess();
+        $idSite = API::getInstance()->addSite(
+            "site1",
+            array('http://example.org'),
+            $ecommerce = 0,
+            $siteSearch = 1,
+            $searchKeywordParameters = null,
+            $searchCategoryParameters = null,
+            $excludedIps = '',
+            $excludedQueryParameters = '',
+            $timezone = null,
+            $currency = null,
+            $group = null,
+            $startDate = null,
+            $excludedUserAgents = null,
+            $keepURLFragments = 1
+        );
+        $this->assertEquals($filteredUrl, PageUrl::excludeQueryParametersFromUrl($url, $idSite));
+    }
+
     public function getTestSensitiveTokenUrls()
     {
         return [

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ab0e6bf1b5335966da58467f1d7ac274022f2800659c639604840823d56845a3
-size 4895954
+oid sha256:fa8fcce71aacc2bb55e5ff67e0e0d3dc34ea4008549e457a61424643af3febab
+size 4919110


### PR DESCRIPTION
### Description

Ticket: DEV-20462

HubSpot and Google Ads append ad-tracking parameters to landing page URLs, which fragments Page URL reports so one page shows up as many rows. This adds them to the shipped `[Tracker] url_query_parameter_to_exclude_from_url` default:

- Google Ads: `gad_source`, `gad_campaignid`
- HubSpot: `/^hsa_(acc|ad|cam|grp|kw|la|mt|net|ol|src|tgt|ver)$/`

The HubSpot pattern is anchored to the 12 parameters their Google, Facebook/Instagram and LinkedIn tracking templates actually use, rather than a broad `/^hsa_/`, so unrelated `hsa_`-prefixed parameters on other sites (`hsa_id`, `hsa_plan`) are left alone. The setting has always accepted regex entries via `UrlHelper::inArrayMatchesRegex()`, but this is the first shipped default to use one — so the comment above the setting now documents that and lists the parameter names so they stay greppable.

Notes for review:

- Campaign attribution is unaffected: HubSpot's templates carry `utm_source`/`utm_medium`/`utm_campaign` alongside the `hsa_*` parameters, and campaign detection reads the raw request URL.
- Forward-only. Already-stored URLs are unchanged, and installations overriding this setting keep their own value.

`ActionTest` covers all 12 parameters, case-insensitivity, and the near-miss cases (`hsa_id`, `hsa_accx`, `xhsa_acc`, `hsalt`) that pin the pattern's anchoring.

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
