### PR TITLE
Use a single encoding for row labels in HTML reports

### DIFF
--- a/core/ReportRenderer.php
+++ b/core/ReportRenderer.php
@@ -243,6 +243,19 @@ abstract class ReportRenderer extends BaseFactory
     }
 
     /**
+     * Whether the report aggregates its rows by a dimension.
+     *
+     * A report without a dimension has a single row of metrics rather than one row per
+     * dimension value.
+     *
+     * @param array $reportMetadata
+     */
+    protected static function isAggregateReport($reportMetadata): bool
+    {
+        return !empty($reportMetadata['dimension']);
+    }
+
+    /**
      * Convert a dimension-less report to a multi-row two-column data table
      *
      * @static
@@ -254,7 +267,7 @@ abstract class ReportRenderer extends BaseFactory
     protected static function processTableFormat($reportMetadata, $report, $reportColumns)
     {
         $finalReport = $report;
-        if (empty($reportMetadata['dimension'])) {
+        if (!self::isAggregateReport($reportMetadata)) {
             $simpleReportMetrics = $report->getFirstRow();
             if ($simpleReportMetrics) {
                 $finalReport = new Simple();

--- a/core/ReportRenderer/Html.php
+++ b/core/ReportRenderer/Html.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\ReportRenderer;
 
+use Piwik\Common;
 use Piwik\Piwik;
 use Piwik\ReportRenderer;
 use Piwik\View;
@@ -104,6 +105,13 @@ class Html extends ReportRenderer
         $reportMetadata = $processedReport['metadata'];
         $reportData = $processedReport['reportData'];
         $columns = $processedReport['columns'];
+
+        // processTableFormat() builds row labels from the metric names when a report has no
+        // dimension, so encode them like SafeDecodeLabel encodes the data table's own labels.
+        if (empty($reportMetadata['dimension'])) {
+            $columns = array_map(array(Common::class, 'sanitizeInputValue'), $columns);
+        }
+
         list($reportData, $columns) = self::processTableFormat($reportMetadata, $reportData, $columns);
 
         $reportView->assign("reportName", $reportMetadata['name']);

--- a/core/ReportRenderer/Html.php
+++ b/core/ReportRenderer/Html.php
@@ -107,9 +107,11 @@ class Html extends ReportRenderer
         $columns = $processedReport['columns'];
 
         // processTableFormat() builds row labels from the metric names when a report has no
-        // dimension, so encode them like SafeDecodeLabel encodes the data table's own labels.
-        if (empty($reportMetadata['dimension'])) {
-            $columns = array_map(array(Common::class, 'sanitizeInputValue'), $columns);
+        // dimension, so encode them to match the encoding the data table's own labels carry.
+        // sanitizeInputValue() rather than decodeLabelSafe(), because metric names are not
+        // URL-encoded and so must not be urldecode()d on the way through.
+        if (!self::isAggregateReport($reportMetadata)) {
+            $columns = array_map([Common::class, 'sanitizeInputValue'], $columns);
         }
 
         list($reportData, $columns) = self::processTableFormat($reportMetadata, $reportData, $columns);

--- a/core/ReportRenderer/Html.php
+++ b/core/ReportRenderer/Html.php
@@ -108,10 +108,8 @@ class Html extends ReportRenderer
 
         // processTableFormat() builds row labels from the metric names when a report has no
         // dimension, so encode them to match the encoding the data table's own labels carry.
-        // sanitizeInputValue() rather than decodeLabelSafe(), because metric names are not
-        // URL-encoded and so must not be urldecode()d on the way through.
         if (!self::isAggregateReport($reportMetadata)) {
-            $columns = array_map([Common::class, 'sanitizeInputValue'], $columns);
+            $columns = Common::sanitizeInputValues($columns);
         }
 
         list($reportData, $columns) = self::processTableFormat($reportMetadata, $reportData, $columns);

--- a/core/ReportRenderer/Pdf.php
+++ b/core/ReportRenderer/Pdf.php
@@ -244,7 +244,7 @@ class Pdf extends ReportRenderer
      */
     private function paintReportHeader()
     {
-        $isAggregateReport = !empty($this->reportMetadata['dimension']);
+        $isAggregateReport = self::isAggregateReport($this->reportMetadata);
 
         // Graph-only report
         static $graphOnlyReportCount = 0;

--- a/plugins/CoreHome/templates/ReportRenderer/_htmlReportBody.twig
+++ b/plugins/CoreHome/templates/ReportRenderer/_htmlReportBody.twig
@@ -63,7 +63,7 @@
                                     {% if rowMetadata.url is defined %}
                                         <a style="color: {{ emailStyles.reportTextColor }};" href='{% if rowMetadata.url|slice(0,4) not in ['http','ftp:'] %}http://{% endif %}{{ rowMetadata.url }}'>
                                     {% endif %}
-                                    {{ rowMetrics[columnId] | raw }}{# labels are escaped by SafeDecodeLabel filter in core/API/Response.php #}
+                                    {{ rowMetrics[columnId] | raw }}{# labels are escaped before they reach the template #}
                                     {% if rowMetadata.url is defined %}
                                         </a>
                                     {% endif %}

--- a/tests/PHPUnit/Integration/ReportRendererLabelEncodingTest.php
+++ b/tests/PHPUnit/Integration/ReportRendererLabelEncodingTest.php
@@ -15,11 +15,8 @@ use Piwik\ReportRenderer\Html;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 /**
- * Row labels reach the HTML report body in one representation: encoded. Labels taken from the data
- * table are encoded by the SafeDecodeLabel filter, and the ones built from metric names for reports
- * without a dimension are encoded by the renderer.
- *
- * Both sides are covered here, because a mismatch either way is silent.
+ * Row labels reach the HTML report body encoded, whether they come from the data table or are
+ * built from metric names. Both are covered here, because a mismatch either way is silent.
  *
  * @group Core
  * @group ReportRenderer
@@ -27,39 +24,36 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 class ReportRendererLabelEncodingTest extends IntegrationTestCase
 {
     /**
-     * Metric names are free text and can contain markup characters, so they need encoding before
-     * they are used as labels.
+     * Metric names become row labels, so they are encoded like labels.
      */
     public function testMetricNamesUsedAsRowLabelsAreEncoded()
     {
         $reportData = new Simple();
-        $reportData->addRowFromSimpleArray(['nb_conversions' => 5]);
+        $reportData->addRowFromSimpleArray(['nb_visits' => 5]);
 
         $rendered = $this->renderReport([
-            'metadata' => ['name' => 'Goals', 'uniqueId' => 'Goals_get'],
+            'metadata' => ['name' => 'Visits Summary', 'uniqueId' => 'VisitsSummary_get'],
             'reportData' => $reportData,
-            'columns' => ['nb_conversions' => 'Conversions goal "<b>Sale</b> & Co" (ID 1 )'],
+            'columns' => ['nb_visits' => 'Custom <metric> & "name"'],
         ]);
 
-        self::assertStringNotContainsString('<b>', $rendered);
-        self::assertStringContainsString('Conversions goal &quot;&lt;b&gt;Sale&lt;/b&gt; &amp; Co&quot; (ID 1 )', $rendered);
+        self::assertStringContainsString('Custom &lt;metric&gt; &amp; &quot;name&quot;', $rendered);
+        self::assertStringNotContainsString('Custom <metric>', $rendered);
     }
 
     /**
-     * Metric names do not all arrive in the same shape: some are plain text, others are already
-     * encoded by the time they get here. Encoding has to be idempotent so the second kind is not
-     * shown with its entities, and it has to leave + and %XX alone, which is why this uses
-     * Common::sanitizeInputValue() rather than the label filter's decodeLabelSafe().
+     * Metric names do not all arrive in the same shape, so the encoding has to be idempotent and
+     * has to leave + and %XX alone - which is why this is sanitizeInputValue(), not decodeLabelSafe().
      */
     public function testMetricNamesAreNotDoubleEncodedOrDecoded()
     {
         $reportData = new Simple();
-        $reportData->addRowFromSimpleArray(['nb_conversions' => 5]);
+        $reportData->addRowFromSimpleArray(['nb_visits' => 5]);
 
         $rendered = $this->renderReport([
-            'metadata' => ['name' => 'Goals', 'uniqueId' => 'Goals_get'],
+            'metadata' => ['name' => 'Visits Summary', 'uniqueId' => 'VisitsSummary_get'],
             'reportData' => $reportData,
-            'columns' => ['nb_conversions' => 'Custom &amp; Metric + 50%2F'],
+            'columns' => ['nb_visits' => 'Custom &amp; Metric + 50%2F'],
         ]);
 
         self::assertStringContainsString('Custom &amp; Metric + 50%2F', $rendered);
@@ -67,8 +61,7 @@ class ReportRendererLabelEncodingTest extends IntegrationTestCase
     }
 
     /**
-     * Labels that come from the data table are encoded before they reach the template, so they are
-     * printed as they are. Encoding them a second time would show the entities to the reader.
+     * Labels from the data table are already encoded, so the renderer must not encode them again.
      */
     public function testDataTableLabelsAreNotDoubleEncoded()
     {
@@ -82,6 +75,24 @@ class ReportRendererLabelEncodingTest extends IntegrationTestCase
         ]);
 
         self::assertStringContainsString('Electronics &amp; Cameras', $rendered);
+        self::assertStringNotContainsString('&amp;amp;', $rendered);
+    }
+
+    /**
+     * Column headers are escaped by Twig, so encoding them here as well would show the entities.
+     */
+    public function testColumnHeadersAreNotDoubleEncoded()
+    {
+        $reportData = new DataTable();
+        $reportData->addRowFromSimpleArray(['label' => 'Downloads', 'nb_visits' => 5]);
+
+        $rendered = $this->renderReport([
+            'metadata' => ['name' => 'Pages', 'uniqueId' => 'Actions_getPageUrls', 'dimension' => 'Page URL'],
+            'reportData' => $reportData,
+            'columns' => ['label' => 'Page URL', 'nb_visits' => 'Visits & Views'],
+        ]);
+
+        self::assertStringContainsString('Visits &amp; Views', $rendered);
         self::assertStringNotContainsString('&amp;amp;', $rendered);
     }
 

--- a/tests/PHPUnit/Integration/ReportRendererLabelEncodingTest.php
+++ b/tests/PHPUnit/Integration/ReportRendererLabelEncodingTest.php
@@ -43,7 +43,7 @@ class ReportRendererLabelEncodingTest extends IntegrationTestCase
 
     /**
      * Metric names do not all arrive in the same shape, so the encoding has to be idempotent and
-     * has to leave + and %XX alone - which is why this is sanitizeInputValue(), not decodeLabelSafe().
+     * has to leave + and %XX alone - which is why this is sanitizeInputValues(), not decodeLabelSafe().
      */
     public function testMetricNamesAreNotDoubleEncodedOrDecoded()
     {
@@ -58,6 +58,25 @@ class ReportRendererLabelEncodingTest extends IntegrationTestCase
 
         self::assertStringContainsString('Custom &amp; Metric + 50%2F', $rendered);
         self::assertStringNotContainsString('&amp;amp;', $rendered);
+    }
+
+    /**
+     * A line break inside a metric name has to reach the template, where the HTML collapses it to
+     * a space. sanitizeInputValue() would delete it instead and run the words either side together.
+     */
+    public function testLineBreaksInMetricNamesAreNotStripped()
+    {
+        $reportData = new Simple();
+        $reportData->addRowFromSimpleArray(['nb_visits' => 5]);
+
+        $rendered = $this->renderReport([
+            'metadata' => ['name' => 'Visits Summary', 'uniqueId' => 'VisitsSummary_get'],
+            'reportData' => $reportData,
+            'columns' => ['nb_visits' => "Custom metric\nname"],
+        ]);
+
+        self::assertStringContainsString("metric\nname", $rendered);
+        self::assertStringNotContainsString('metricname', $rendered);
     }
 
     /**

--- a/tests/PHPUnit/Integration/ReportRendererLabelEncodingTest.php
+++ b/tests/PHPUnit/Integration/ReportRendererLabelEncodingTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration;
+
+use Piwik\DataTable;
+use Piwik\DataTable\Simple;
+use Piwik\ReportRenderer\Html;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * Row labels reach the HTML report body in one representation: encoded. Labels taken from the data
+ * table are encoded by the SafeDecodeLabel filter, and the ones built from metric names for reports
+ * without a dimension are encoded by the renderer.
+ *
+ * Both sides are covered here, because a mismatch either way is silent.
+ *
+ * @group Core
+ * @group ReportRenderer
+ */
+class ReportRendererLabelEncodingTest extends IntegrationTestCase
+{
+    /**
+     * Metric names are free text and can contain markup characters, so they need encoding before
+     * they are used as labels.
+     */
+    public function testMetricNamesUsedAsRowLabelsAreEncoded()
+    {
+        $reportData = new Simple();
+        $reportData->addRowFromSimpleArray(['nb_conversions' => 5]);
+
+        $rendered = $this->renderReport([
+            'metadata' => ['name' => 'Goals', 'uniqueId' => 'Goals_get'],
+            'reportData' => $reportData,
+            'columns' => ['nb_conversions' => 'Conversions goal "<b>Sale</b> & Co" (ID 1 )'],
+        ]);
+
+        self::assertStringNotContainsString('<b>', $rendered);
+        self::assertStringContainsString('Conversions goal &quot;&lt;b&gt;Sale&lt;/b&gt; &amp; Co&quot; (ID 1 )', $rendered);
+    }
+
+    /**
+     * Metric names do not all arrive in the same shape: some are plain text, others are already
+     * encoded by the time they get here. Encoding has to be idempotent so the second kind is not
+     * shown with its entities, and it has to leave + and %XX alone, which is why this uses
+     * Common::sanitizeInputValue() rather than the label filter's decodeLabelSafe().
+     */
+    public function testMetricNamesAreNotDoubleEncodedOrDecoded()
+    {
+        $reportData = new Simple();
+        $reportData->addRowFromSimpleArray(['nb_conversions' => 5]);
+
+        $rendered = $this->renderReport([
+            'metadata' => ['name' => 'Goals', 'uniqueId' => 'Goals_get'],
+            'reportData' => $reportData,
+            'columns' => ['nb_conversions' => 'Custom &amp; Metric + 50%2F'],
+        ]);
+
+        self::assertStringContainsString('Custom &amp; Metric + 50%2F', $rendered);
+        self::assertStringNotContainsString('&amp;amp;', $rendered);
+    }
+
+    /**
+     * Labels that come from the data table are encoded before they reach the template, so they are
+     * printed as they are. Encoding them a second time would show the entities to the reader.
+     */
+    public function testDataTableLabelsAreNotDoubleEncoded()
+    {
+        $reportData = new DataTable();
+        $reportData->addRowFromSimpleArray(['label' => 'Electronics &amp; Cameras', 'nb_visits' => 5]);
+
+        $rendered = $this->renderReport([
+            'metadata' => ['name' => 'Products', 'uniqueId' => 'Ecommerce_getItemCategory', 'dimension' => 'Product'],
+            'reportData' => $reportData,
+            'columns' => ['label' => 'Product', 'nb_visits' => 'Visits'],
+        ]);
+
+        self::assertStringContainsString('Electronics &amp; Cameras', $rendered);
+        self::assertStringNotContainsString('&amp;amp;', $rendered);
+    }
+
+    private function renderReport(array $processedReport): string
+    {
+        $renderer = new Html();
+        $renderer->renderReport($processedReport + [
+            'reportMetadata' => new DataTable(),
+            'displayTable' => true,
+            'displayGraph' => false,
+            'evolutionGraph' => false,
+            'segment' => null,
+        ]);
+
+        return $renderer->getRenderedReport();
+    }
+}


### PR DESCRIPTION
DEV-20673
## Summary

Reports without a dimension have no row labels of their own, so `ReportRenderer::processTableFormat()` builds them from the metrics' translated names. This encodes them in the HTML renderer so they match the labels that come from the data table.

## Review

- [ ] Functional review done
- [ ] Potential edge cases considered
- [ ] Usable, i.e. no confusing behaviour

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules



Backport of #25103.
