### PR TITLE
Check if plugin is in file system before updating it

### DIFF
--- a/plugins/Marketplace/Controller.php
+++ b/plugins/Marketplace/Controller.php
@@ -14,6 +14,7 @@ use Piwik\Common;
 use Piwik\Config\GeneralConfig;
 use Piwik\Container\StaticContainer;
 use Piwik\DataTable\Renderer\Json;
+use Piwik\Exception\PluginNotFoundException;
 use Piwik\Date;
 use Piwik\Filesystem;
 use Piwik\Log;
@@ -473,6 +474,14 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $this->displayWarningIfConfigFileNotWritable();
 
         $plugins = $this->getPluginNameIfNonceValid($nonceName);
+
+        if ($nonceName === static::UPDATE_NONCE) {
+            foreach ($plugins as $pluginName) {
+                if (!$this->pluginManager->isPluginInFilesystem($pluginName)) {
+                    throw new PluginNotFoundException($pluginName);
+                }
+            }
+        }
 
         $view = new View('@Marketplace/' . $template);
         $this->setBasicVariablesView($view);


### PR DESCRIPTION
### Description

Check if plugin is in file system before updating it, #AS-676

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)



Backport of #25070.
