### PR TITLE
[automatic composer updates]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -770,12 +770,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/referrer-spam-list.git",
-                "reference": "4f1c7a8d99be37b0aa19ff93fcd8bd7f2d0bf27e"
+                "reference": "b1c66b3cbbd8fe243ff028a8932788da187b9934"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/4f1c7a8d99be37b0aa19ff93fcd8bd7f2d0bf27e",
-                "reference": "4f1c7a8d99be37b0aa19ff93fcd8bd7f2d0bf27e",
+                "url": "https://api.github.com/repos/matomo-org/referrer-spam-list/zipball/b1c66b3cbbd8fe243ff028a8932788da187b9934",
+                "reference": "b1c66b3cbbd8fe243ff028a8932788da187b9934",
                 "shasum": ""
             },
             "replace": {
@@ -793,7 +793,7 @@
                 "issues": "https://github.com/matomo-org/referrer-spam-list/issues",
                 "source": "https://github.com/matomo-org/referrer-spam-list/tree/master"
             },
-            "time": "2026-07-01T13:51:06+00:00"
+            "time": "2026-08-20T14:26:27+00:00"
         },
         {
             "name": "matomo/searchengine-and-social-list",
@@ -1099,21 +1099,21 @@
         },
         {
             "name": "pear/archive_tar",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Archive_Tar.git",
-                "reference": "dc3285537f1832da8ddbbe45f5a007248b6cc00e"
+                "reference": "a0d2c458a2ff6ee8943ac4271b7f57d613529ae0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/dc3285537f1832da8ddbbe45f5a007248b6cc00e",
-                "reference": "dc3285537f1832da8ddbbe45f5a007248b6cc00e",
+                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/a0d2c458a2ff6ee8943ac4271b7f57d613529ae0",
+                "reference": "a0d2c458a2ff6ee8943ac4271b7f57d613529ae0",
                 "shasum": ""
             },
             "require": {
                 "pear/pear-core-minimal": "^1.10.0alpha2",
-                "php": ">=5.4.0"
+                "php": ">=5.6.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "*"
@@ -1126,7 +1126,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -1165,7 +1165,7 @@
                 "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Archive_Tar",
                 "source": "https://github.com/pear/Archive_Tar"
             },
-            "time": "2025-07-19T14:49:16+00:00"
+            "time": "2026-08-19T17:37:49+00:00"
         },
         {
             "name": "pear/console_getopt",


### PR DESCRIPTION
composer update log:
```
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 2 updates, 0 removals
  - Upgrading matomo/referrer-spam-list (dev-master 4f1c7a8 => dev-master b1c66b3)
  - Upgrading pear/archive_tar (1.6.0 => 1.6.1)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 2 updates, 0 removals
  - Downloading pear/archive_tar (1.6.1)
  - Downloading matomo/referrer-spam-list (dev-master b1c66b3)
  - Upgrading pear/archive_tar (1.6.0 => 1.6.1): Extracting archive
  - Upgrading matomo/referrer-spam-list (dev-master 4f1c7a8 => dev-master b1c66b3): Extracting archive
Package lox/xhprof is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
59 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.
```
